### PR TITLE
fix: flaky test `Create token, approve token and approve token without gas approves an already created token and displays the token approval data @no-mmi`

### DIFF
--- a/test/e2e/tests/tokens/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/tokens/custom-token-add-approve.spec.js
@@ -18,7 +18,6 @@ describe('Create token, approve token and approve token without gas', function (
   it('imports and renders the balance for the new token', async function () {
     await withFixtures(
       {
-        dapp: true,
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/tokens/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/tokens/custom-token-add-approve.spec.js
@@ -32,14 +32,7 @@ describe('Create token, approve token and approve token without gas', function (
         );
         await unlockWallet(driver);
 
-        // create token
-        await openDapp(driver, contractAddress);
-
-        const windowHandles = await driver.getAllWindowHandles();
-        const extension = windowHandles[0];
-
         // imports custom token from extension
-        await driver.switchToWindow(extension);
         await driver.clickElement(`[data-testid="home__asset-tab"]`);
         await clickNestedButton(driver, 'Tokens');
 
@@ -52,14 +45,12 @@ describe('Create token, approve token and approve token without gas', function (
         await driver.waitForSelector(
           '[data-testid="import-tokens-modal-custom-decimals"]',
         );
-        await driver.delay(2000);
 
         await driver.clickElement({
           text: 'Next',
           tag: 'button',
         });
 
-        await driver.delay(2000);
         await driver.clickElement(
           '[data-testid="import-tokens-modal-import-button"]',
         );

--- a/test/e2e/tests/tokens/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/tokens/custom-token-add-approve.spec.js
@@ -18,8 +18,7 @@ describe('Create token, approve token and approve token without gas', function (
   it('imports and renders the balance for the new token', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder()
-          .build(),
+        fixtures: new FixtureBuilder().build(),
         ganacheOptions: defaultGanacheOptions,
         smartContract,
         title: this.test.fullTitle(),

--- a/test/e2e/tests/tokens/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/tokens/custom-token-add-approve.spec.js
@@ -19,7 +19,6 @@ describe('Create token, approve token and approve token without gas', function (
     await withFixtures(
       {
         fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
           .build(),
         ganacheOptions: defaultGanacheOptions,
         smartContract,


### PR DESCRIPTION
## **Description**
This PR fixes the flaky test `Create token, approve token and approve token without gas approves an already created token and displays the token approval data @no-mmi`.

The problem seems to be that we are first going to the test dapp, and right after, going to the Extension full view, and we try to click on a the token tab, but the element cannot be located: `TimeoutError: Waiting for element to be located By(css selector, [data-testid="home__asset-tab"])`

After looking into the code, we see that there is no reason on why are we going to the test dapp in the first place, since we are not using the test dapp in this test.

The solution is to remove the first steps of going to the test dapp, this removes any point of flakiness in the window switch, as there is no window switch needed anymore.

https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/84207/workflows/b324f068-a209-4c13-9ee4-74ce464966e5/jobs/3027291/parallel-runs/8

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24937?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci
2. Run the test multiple times `yarn test:e2e:single test/e2e/tests/tokens/custom-token-add-approve.spec.js --browser=chrome --leave-running --retryUntilFailure --retries=10`

## **Screenshots/Recordings**

![Screenshot from 2024-05-31 11-35-47](https://github.com/MetaMask/metamask-extension/assets/54408225/672622ba-447d-42fa-bda0-f04520255322)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
