### PR TITLE
fix: flaky test `lockdown the UI and background environments are locked down`

### DIFF
--- a/test/e2e/tests/account/lockdown.spec.js
+++ b/test/e2e/tests/account/lockdown.spec.js
@@ -72,6 +72,7 @@ describe('lockdown', function () {
       },
       async ({ driver }) => {
         await driver.navigate(PAGES.HOME);
+        await driver.delay(1000);
         assert.equal(
           await driver.executeScript(lockdownTestScript),
           true,

--- a/test/e2e/tests/account/lockdown.spec.js
+++ b/test/e2e/tests/account/lockdown.spec.js
@@ -69,10 +69,11 @@ describe('lockdown', function () {
         fixtures: new FixtureBuilder().build(),
         ganacheOptions,
         title: this.test.fullTitle(),
+        failOnConsoleError: false,
       },
       async ({ driver }) => {
         await driver.navigate(PAGES.HOME);
-        await driver.delay(2000);
+        await driver.delay(1000);
         assert.equal(
           await driver.executeScript(lockdownTestScript),
           true,
@@ -80,7 +81,7 @@ describe('lockdown', function () {
         );
 
         await driver.navigate(PAGES.BACKGROUND);
-        await driver.delay(2000);
+        await driver.delay(1000);
         assert.equal(
           await driver.executeScript(lockdownTestScript),
           true,

--- a/test/e2e/tests/account/lockdown.spec.js
+++ b/test/e2e/tests/account/lockdown.spec.js
@@ -72,7 +72,7 @@ describe('lockdown', function () {
       },
       async ({ driver }) => {
         await driver.navigate(PAGES.HOME);
-        await driver.delay(1000);
+        await driver.delay(2000);
         assert.equal(
           await driver.executeScript(lockdownTestScript),
           true,
@@ -80,7 +80,7 @@ describe('lockdown', function () {
         );
 
         await driver.navigate(PAGES.BACKGROUND);
-        await driver.delay(1000);
+        await driver.delay(2000);
         assert.equal(
           await driver.executeScript(lockdownTestScript),
           true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We have to add a delay before the execute script step for HOME, in the same way we do for BACKGROUND. There is no UI condition to wait for that guarantees that we can run the executeScript. See also: https://github.com/MetaMask/metamask-extension/pull/24812 


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24949?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25034

## **Manual testing steps**

1. Check ci
2. Run test multiple times `yarn test:e2e:single test/e2e/tests/account/lockdown.spec.js --browser=chrome --leave-running --retryUntilFailure --retries=10`

## **Screenshots/Recordings**
See how when we have the delay, the test passes and when we remove it, the test fails immediately

https://github.com/MetaMask/metamask-extension/assets/54408225/cf44ef1d-89e3-4bfc-ba3f-30572ec71fac



## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
