### PR TITLE
chore: Update defunct, potentially risky QR dependency

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -3976,8 +3976,6 @@
         "devicePixelRatio": true
       },
       "packages": {
-        "prop-types": true,
-        "qrcode.react>qr.js": true,
         "react": true
       }
     },

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -4288,8 +4288,6 @@
         "devicePixelRatio": true
       },
       "packages": {
-        "prop-types": true,
-        "qrcode.react>qr.js": true,
         "react": true
       }
     },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -4340,8 +4340,6 @@
         "devicePixelRatio": true
       },
       "packages": {
-        "prop-types": true,
-        "qrcode.react>qr.js": true,
         "react": true
       }
     },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -4189,8 +4189,6 @@
         "devicePixelRatio": true
       },
       "packages": {
-        "prop-types": true,
-        "qrcode.react>qr.js": true,
         "react": true
       }
     },

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -4474,8 +4474,6 @@
         "devicePixelRatio": true
       },
       "packages": {
-        "prop-types": true,
-        "qrcode.react>qr.js": true,
         "react": true
       }
     },

--- a/package.json
+++ b/package.json
@@ -391,7 +391,7 @@
     "prop-types": "^15.6.1",
     "punycode": "^2.1.1",
     "qrcode-generator": "1.4.1",
-    "qrcode.react": "3.1.0",
+    "qrcode.react": "^3.1.0",
     "react": "^16.12.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -391,7 +391,7 @@
     "prop-types": "^15.6.1",
     "punycode": "^2.1.1",
     "qrcode-generator": "1.4.1",
-    "qrcode.react": "^1.0.1",
+    "qrcode.react": "3.1.0",
     "react": "^16.12.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^16.12.0",

--- a/ui/components/institutional/qr-code-modal/qr-code-modal.tsx
+++ b/ui/components/institutional/qr-code-modal/qr-code-modal.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-// @ts-expect-error: No available type definitions for module 'qrcode.react'
 import QRCode from 'qrcode.react';
 import { v4 as uuid } from 'uuid';
 import { captureException } from '@sentry/browser';

--- a/yarn.lock
+++ b/yarn.lock
@@ -24965,7 +24965,7 @@ __metadata:
     pumpify: "npm:^2.0.1"
     punycode: "npm:^2.1.1"
     qrcode-generator: "npm:1.4.1"
-    qrcode.react: "npm:^1.0.1"
+    qrcode.react: "npm:3.1.0"
     randomcolor: "npm:^0.5.4"
     react: "npm:^16.12.0"
     react-beautiful-dnd: "npm:^13.1.1"
@@ -28705,13 +28705,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qr.js@npm:0.0.0":
-  version: 0.0.0
-  resolution: "qr.js@npm:0.0.0"
-  checksum: 10/a05943d13cbc478e48935de8669b72312fe02de05057c35ebfab59a574c084530a9afb9ee651d53c8c870a54f9ec93ea7b63231de202740ce16a71c797e37ce9
-  languageName: node
-  linkType: hard
-
 "qrcode-generator@npm:1.4.1":
   version: 1.4.1
   resolution: "qrcode-generator@npm:1.4.1"
@@ -28719,16 +28712,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qrcode.react@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "qrcode.react@npm:1.0.1"
-  dependencies:
-    loose-envify: "npm:^1.4.0"
-    prop-types: "npm:^15.6.0"
-    qr.js: "npm:0.0.0"
+"qrcode.react@npm:3.1.0":
+  version: 3.1.0
+  resolution: "qrcode.react@npm:3.1.0"
   peerDependencies:
-    react: ^15.5.3 || ^16.0.0 || ^17.0.0
-  checksum: 10/8e8290e25da10918735d5763fe830c8a497bb8964797d156b9b03822087f25484fc3add0dcb14fcbeedf61dfde480bdd3aef3ba289ec492d8e8b6c87fb9958b3
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 71953241f151ca5ad4013c034cb13033e1ebad56a1db77297a7ddd7fd4d5f137f37f3be51133aeef0b54dc52d6c76630429d2269bd72e6858c3209fe42310498
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28717,7 +28717,7 @@ __metadata:
   resolution: "qrcode.react@npm:3.1.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 71953241f151ca5ad4013c034cb13033e1ebad56a1db77297a7ddd7fd4d5f137f37f3be51133aeef0b54dc52d6c76630429d2269bd72e6858c3209fe42310498
+  checksum: 10/71953241f151ca5ad4013c034cb13033e1ebad56a1db77297a7ddd7fd4d5f137f37f3be51133aeef0b54dc52d6c76630429d2269bd72e6858c3209fe42310498
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24965,7 +24965,7 @@ __metadata:
     pumpify: "npm:^2.0.1"
     punycode: "npm:^2.1.1"
     qrcode-generator: "npm:1.4.1"
-    qrcode.react: "npm:3.1.0"
+    qrcode.react: "npm:^3.1.0"
     randomcolor: "npm:^0.5.4"
     react: "npm:^16.12.0"
     react-beautiful-dnd: "npm:^13.1.1"
@@ -28712,7 +28712,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qrcode.react@npm:3.1.0":
+"qrcode.react@npm:^3.1.0":
   version: 3.1.0
   resolution: "qrcode.react@npm:3.1.0"
   peerDependencies:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## Determining the cause behind the differences between the MetaMask extension and MetaMask mobile app QR codes

We noticed differences in density, i.e. QR version number, between the animated QR codes generated by the MetaMask extension and the MetaMask mobile app.

The MetaMask E2E Test Dapp page was used to compare the differences. We will be using the `NFTs: Deploy` test as the main test case for comparison.

(Reported by @tkrioua)

## Visual comparison
First, a visual comparison of the animated QRs generated for the `NFTs: Deploy` test case by the MM extension and MM app is presented:

### MetaMask extension
![image](https://github.com/MetaMask/metamask-extension/assets/26218337/1101dbf6-9c3f-46e6-933b-0a0f0ff60532)


### MetaMask mobile app

![image](https://github.com/MetaMask/metamask-extension/assets/26218337/d8059ac5-9199-4bbf-8023-4e9ae92c4844)

## Verification of settings
### MetaMask extension
The settings can be found in `metamask-extension/../qr-hardware-popover/qr-hardware-sign-request/player.js`

Fragment length
```
  const urEncoder = useMemo(
    // For NGRAVE ZERO support please keep to a maximum fragment size of 200
    () => new UREncoder(new UR(Buffer.from(cbor, 'hex'), type), 200),
    [cbor, type],
  );
```
Interval
```
    const id = setInterval(() => {
      setCurrentQRCode(urEncoder.nextPart());
    }, 100);
```
Size
```
  <QRCode value={currentQRCode.toUpperCase()} size={250} />  
    
```

### MetaMask mobile app
The settings can be found in `metamask-mobile/app/components/UI/QRHardware/AnimatedQRCode.tsx`

Fragment length and QR code size
```
const MAX_FRAGMENT_LENGTH = 200;
const QR_CODE_SIZE = 250;

...
  const urEncoder = useMemo(
    () =>
      new UREncoder(
        new UR(Buffer.from(cbor, 'hex'), type),
        MAX_FRAGMENT_LENGTH,
      ),
    [cbor, type],
  );
  
...

    <View style={styles.wrapper}>
      <QRCode value={currentQRCode.toUpperCase()} size={QR_CODE_SIZE} />
    </View>  
```

Interval
```
      const id = setInterval(() => {
        setCurrentQRCode(urEncoder.nextPart());
      }, 250);
```

The differences reside in the interval value, which is `250ms` in the mobile app compared to `100ms` in the extension. As well as the ECL, which is 'M' for the mobile app.

# Differences
Given the exact same fragment, the MetaMask extension generates QR codes with version number 15 and ECL L.
While the mobile app generates QR codes with version number 13 and ECL M.

The difference resides in the QR encoding library used.

The MetaMask extension uses qrcode.react: https://github.com/zpao/qrcode.react

While the mobile app uses react-native-qrcode-svg: https://github.com/awesomejerry/react-native-qrcode-svg . The default ECL of this library is 'M'.

Upon further verification, the MetaMask extension uses qrcode.react at version 1.0.0, as evident in `metamask-extension/package.json`:
```
qrcode.react: "^1.0.0"
```

This specific version, uses a second dependency to generate the QR images: `qr.js` (https://github.com/defunctzombie/qr.js)

# Inspection of qr.js
After inspection, the `qr.js` library has quite the surprising resume.

## 1. Indication of incomplete implementation of the QR standard
Source-code comments can be found in qrcode.react 1.0.0 indicating `qr.js` does not implement error-correction level 'M'

https://github.com/zpao/qrcode.react/blob/v1.0.1/src/index.js
https://github.com/zpao/qrcode.react/blob/v1.0.0/src/index.js

```
// qr.js doesn't handle error level of zero (M) so we need to do it right,
// thus the deep require.
const QRCodeImpl = require('qr.js/lib/QRCode');
const ErrorCorrectLevel = require('qr.js/lib/ErrorCorrectLevel');
```

## 2. Hijacked original repo
A quick search resulted in alarming evidence that the repo, or the NPM account of `qr.js`, could have been hijacked:
https://github.com/zpao/qrcode.react/issues/168

## 3. Unmaintained restored repo
The repo of `qr.js` is unmaintained. It has been pushed 11 years ago at the time of writing, and updated 9 years ago.
https://github.com/defunctzombie/qr.js


## 4. Hard-coded binary encoding mode
The root cause for the increased QR version number can be found in the sources.
`qr.js` encodes all data in binary mode, which takes up more space resulting in less efficient data transmission.
This encoding mode is hard-coded:

https://github.com/defunctzombie/qr.js/blob/master/lib/mode.js

```
module.exports = {
	MODE_NUMBER :		1 << 0,
	MODE_ALPHA_NUM : 	1 << 1,
	MODE_8BIT_BYTE : 	1 << 2,
	MODE_KANJI :		1 << 3
};
```

The 8-bit byte, i.e. binary mode, corresponds to value 4 (i.e 1 << 2). 

In functions `proto.make` and `QRCode.createData` , mode 4 is hard-coded:
https://github.com/defunctzombie/qr.js/blob/master/lib/QRCode.js  lines 51 and 327 respectively

```
proto.make
51: buffer.put(data.mode, 4);

QRCode.createData
327: buffer.put(data.mode, 4);
```

This results in bigger than necessary QR codes than expected by the data type. 

The QR spec (https://www.iso.org/standard/62021.html) specifies the alphanumeric mode of encoding, in section `7.3.4 Alphanumeric mode`, which encodes data from a set of 45 characters: 

- 10 numeric digits (0 - 9)
- 26 alphabetic characters (A - Z)
- 9 symbols (SP, $, %, *, +, -, ., /, :)

The Uniform Resources specification specifies that it was designed for that particular encoding mode (https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-005-ur.md):

- *QR Codes support an "alphanumeric" mode optimized for efficiently conveying a subset of ASCII consisting of 45 characters*
  - *Use the alphanumeric QR code mode for efficiency.*
  - *Avoid the use of QR code binary mode to support transparency and wide compatibility with QR code reader libraries.*

This is the rationale for the usage of UR types in `EIP-4527` (https://eips.ethereum.org/EIPS/eip-4527), *QR Code transmission protocol for wallets*, as described in the rationale section:

- *UR provides a solid foundation for QR Code data transmission*
  - *Uses the alphanumeric QR code mode for efficiency*


### Reference comparisons

For an identical UR of length 200, python's `qrcode` library and `qrcodegen` generate a QR code with the expected encoding type and version number.

### qrcode
![image](https://github.com/MetaMask/metamask-extension/assets/26218337/8ed7b77b-4f05-4d30-a6bf-9e5e1c25f256)

```
version = 11 
ecl=1
length=404
mode = 2
charcount = 465
```

### qrcodegen

https://github.com/nayuki/QR-Code-generator/tree/master/typescript-javascript

![image](https://github.com/MetaMask/metamask-extension/assets/26218337/0d08f20e-64ff-4a50-8999-6c5c020b8c2a)

```
Statistics:	QR Code version = 11, mask pattern = 0, character count = 465,
encoding mode = alphanumeric, error correction = level L, data bits = 2573.
```

### qr.js

The `qr.js` library on the other hand, as evident in the sources, encodes the UR using the binary encoding mode.

![image](https://github.com/MetaMask/metamask-extension/assets/26218337/830a0e26-bf96-449b-88e6-9c0012ba1eae)

```
version=15
grade=4 
ecl=1 
length=655
mode = 4
charcount = 465
```


# Proposed modification
To address the potential security risk and the irregular QR codes generated by the defunct dependency, it suffices to increase the version number of `qrcode.react` to the latest version.
`metamask-extension/package.json`:

```
qrcode.react: "^3.1.0"
```

`qrcode.react` version 3.1.0 uses the reputable `qrcodegen` to generate the QR code images, since version `v3.0.0`.


# Verification 
After the proposed modification is applied, the QR codes generated by the extension have the expected version number and encoding mode for alphanumerical data with a maximum length 200 and ECL 'L'.

![image](https://github.com/MetaMask/metamask-extension/assets/26218337/b0eae008-7974-430f-98ee-dad7e01ef9e5)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24952?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
