### PR TITLE
chore: removing deprecated secondary colors from codebase

### DIFF
--- a/.storybook/3.COLORS.stories.mdx
+++ b/.storybook/3.COLORS.stories.mdx
@@ -84,12 +84,6 @@ var(--color-primary-alternative)
 var(--color-primary-muted)
 var(--color-primary-inverse)
 
-var(--color-secondary-default) [DEPRECATED]
-var(--color-secondary-alternative) [DEPRECATED]
-var(--color-secondary-muted) [DEPRECATED]
-var(--color-secondary-inverse) [DEPRECATED]
-var(--color-secondary-disabled) [DEPRECATED]
-
 /** States */
 /** Error */
 var(--color-error-default)

--- a/ui/components/app/app-loading-spinner/app-loading-spinner.js
+++ b/ui/components/app/app-loading-spinner/app-loading-spinner.js
@@ -19,7 +19,7 @@ const AppLoadingSpinner = ({ className }) => {
       aria-busy="true"
     >
       <Spinner
-        color="var(--color-secondary-muted)"
+        color="var(--color-icon-muted)"
         className="app-loading-spinner__inner"
       />
     </div>

--- a/ui/components/app/app-loading-spinner/app-loading-spinner.js
+++ b/ui/components/app/app-loading-spinner/app-loading-spinner.js
@@ -18,10 +18,7 @@ const AppLoadingSpinner = ({ className }) => {
       role="alert"
       aria-busy="true"
     >
-      <Spinner
-        color="var(--color-icon-muted)"
-        className="app-loading-spinner__inner"
-      />
+      <Spinner className="app-loading-spinner__inner" />
     </div>
   );
 };

--- a/ui/components/app/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/components/app/modals/qr-scanner/qr-scanner.component.js
@@ -252,7 +252,7 @@ export default function QRCodeScanner({ hideModal, qrCodeDetected }) {
               }}
             />
             {isReady !== READY_STATE.READY && (
-              <Spinner color="var(--color-warning-default)" />
+              <Spinner color="var(--color-icon-muted)" />
             )}
           </div>
         </div>

--- a/ui/components/app/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/components/app/modals/qr-scanner/qr-scanner.component.js
@@ -251,9 +251,7 @@ export default function QRCodeScanner({ hideModal, qrCodeDetected }) {
                 display: isReady === READY_STATE.READY ? 'block' : 'none',
               }}
             />
-            {isReady !== READY_STATE.READY && (
-              <Spinner color="var(--color-icon-muted)" />
-            )}
+            {isReady !== READY_STATE.READY && <Spinner />}
           </div>
         </div>
         <div className="qr-scanner__status">{getQRScanMessage(isReady)}</div>

--- a/ui/components/app/qr-hardware-popover/enhanced-reader.js
+++ b/ui/components/app/qr-hardware-popover/enhanced-reader.js
@@ -55,7 +55,7 @@ const EnhancedReader = ({ handleScan }) => {
           filter: 'blur(4px)',
         }}
       />
-      {canplay ? null : <Spinner color="var(--color-warning-default)" />}
+      {canplay ? null : <Spinner color="var(--color-icon-muted)" />}
     </div>
   );
 };

--- a/ui/components/app/qr-hardware-popover/enhanced-reader.js
+++ b/ui/components/app/qr-hardware-popover/enhanced-reader.js
@@ -55,7 +55,7 @@ const EnhancedReader = ({ handleScan }) => {
           filter: 'blur(4px)',
         }}
       />
-      {canplay ? null : <Spinner color="var(--color-icon-muted)" />}
+      {canplay ? null : <Spinner />}
     </div>
   );
 };

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -368,7 +368,7 @@ export const CoinOverview = ({
                 />
               ) : (
                 <Spinner
-                  color="var(--color-secondary-default)"
+                  color="var(--color-icon-muted)"
                   className="loading-overlay__spinner"
                 />
               )}

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -367,10 +367,7 @@ export const CoinOverview = ({
                   hideTitle
                 />
               ) : (
-                <Spinner
-                  color="var(--color-icon-muted)"
-                  className="loading-overlay__spinner"
-                />
+                <Spinner className="loading-overlay__spinner" />
               )}
               {balanceIsCached && (
                 <span className={`${classPrefix}-overview__cached-star`}>

--- a/ui/components/ui/loading-screen/loading-screen.component.js
+++ b/ui/components/ui/loading-screen/loading-screen.component.js
@@ -32,7 +32,7 @@ const LoadingScreen = ({
       <Box className="loading-overlay__container" marginBottom={3}>
         {showLoadingSpinner && (
           <Spinner
-            color="var(--color-warning-default)"
+            color="var(--color-icon-muted)"
             className="loading-overlay__spinner"
           />
         )}

--- a/ui/components/ui/loading-screen/loading-screen.component.js
+++ b/ui/components/ui/loading-screen/loading-screen.component.js
@@ -30,12 +30,7 @@ const LoadingScreen = ({
     <Box className="loading-overlay">
       {header}
       <Box className="loading-overlay__container" marginBottom={3}>
-        {showLoadingSpinner && (
-          <Spinner
-            color="var(--color-icon-muted)"
-            className="loading-overlay__spinner"
-          />
-        )}
+        {showLoadingSpinner && <Spinner className="loading-overlay__spinner" />}
       </Box>
       <Box
         display={Display.Flex}

--- a/ui/pages/confirmations/confirm-transaction/__snapshots__/confirm-transaction.test.js.snap
+++ b/ui/pages/confirmations/confirm-transaction/__snapshots__/confirm-transaction.test.js.snap
@@ -24,7 +24,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(0 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -45,7 +45,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(30 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -66,7 +66,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(60 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -87,7 +87,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(90 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -108,7 +108,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(120 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -129,7 +129,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(150 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -150,7 +150,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(180 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -171,7 +171,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(210 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -192,7 +192,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(240 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -213,7 +213,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(270 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -234,7 +234,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(300 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"
@@ -255,7 +255,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
           transform="rotate(330 50 50)"
         >
           <rect
-            fill="var(--color-warning-default)"
+            fill="var(--color-icon-muted)"
             height="30"
             rx="0"
             ry="0"


### PR DESCRIPTION
## **Description**

This pull request removes the deprecated secondary colors in preparation for upgrading to [design token v4](https://github.com/MetaMask/design-tokens/blob/main/MIGRATION.md#from-version-300-to-400) and priming the brand evolution. The updates all `Spinner` component instances to use the default `icon-muted` color.

Dependency on 
- https://github.com/MetaMask/metamask-extension/pull/25011
- https://github.com/MetaMask/metamask-extension/pull/25083

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24971?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24964

## **Manual testing steps**

1. Go to the storybook build of this PR
2. Go to all stories that use the Spinner component: `Spinner`, `AppLoadingSpinner`, `EthOverview`, `QRCodeModal`,  `LoadingScreen` (some stories not included in PR as they didn't add much value)
3. See color updates are working as expected
4. Pull this branch search `Spinner` 
5. Ensure no instances have an override color
6. Search for `color-secondary` to ensure no instances of secondary colors remain

## **Screenshots/Recordings**

All before/after screenshots and screencasts of Spinner instnaces have been moved to comments for easier review.

Below screenshot shows all `Spinner` instances have removed `color` prop ensuring colors have been consolidated to use the default icon-muted color

![Screenshot 2024-06-09 at 8 49 57 PM](https://github.com/MetaMask/metamask-extension/assets/8112138/b35cdc4d-3f46-4b5f-9cb5-3918a87322d2)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
