### PR TITLE
chore(ci): disable retries of failing e2e jobs

### DIFF
--- a/.circleci/scripts/test-run-e2e.sh
+++ b/.circleci/scripts/test-run-e2e.sh
@@ -23,7 +23,7 @@ TIMEOUT_MINUTES=$(yarn tsx .circleci/scripts/test-run-e2e-timeout-minutes.ts)
 echo "TIMEOUT_MINUTES: $TIMEOUT_MINUTES"
 
 # Run the actual test command from the parameters
-timeout "${TIMEOUT_MINUTES}"m "$@" --retries 1
+timeout "${TIMEOUT_MINUTES}"m "$@" --retries 0
 
 # Error code 124 means the command timed out
 if [ $? -eq 124 ]


### PR DESCRIPTION
## **Description**

This reduces:
- E2E CI attempts from 2 to 1 (don't retry failing e2e tests)
- The average cost and time to run individual CI jobs
- Feedback loops for e2e errors
- Success rate (and therefore hopefully introduction rate) of flaky tests
- Success rate (and therefore hopefully introduction rate) of inconsistent application behavior which relies on specific CI conditions to pass E2E tests

Non-E2E CI jobs have their existing retry count unchanged.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24972?quickstart=1)

## **Related issues**

Follow-up to:
- #24531

## **Manual testing steps**

## **Screenshots/Recordings**


### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
