### PR TITLE
chore(ci/gha): use native permissions in update-lavamoat-policies

### DIFF
--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -11,13 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - name: Determine whether this PR is from a fork
         id: is-fork
         run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
 
   react-to-comment:
@@ -26,6 +30,10 @@ jobs:
     needs: is-fork-pull-request
     # Early exit if this is a fork, since later steps are skipped for forks
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,7 +47,7 @@ jobs:
             -f content='+1'
         env:
           COMMENT_ID: ${{ github.event.comment.id }}
-          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
 
   prepare:
@@ -50,6 +58,10 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     outputs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -61,7 +73,7 @@ jobs:
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -79,6 +91,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -90,7 +106,7 @@ jobs:
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -118,6 +134,10 @@ jobs:
     needs:
       - prepare
       - update-lavamoat-build-policy
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -129,7 +149,7 @@ jobs:
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -164,16 +184,20 @@ jobs:
       - update-lavamoat-webapp-policy
     # Ensure forks don't get access to the LavaMoat update token
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
-          token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          token: ${{ github.token }}
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Get commit SHA
         id: commit-sha
@@ -243,7 +267,7 @@ jobs:
           fi
         env:
           HAS_CHANGES: ${{ steps.policy-changes.outputs.HAS_CHANGES }}
-          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
 
   check-status:
@@ -265,10 +289,14 @@ jobs:
     needs:
       - is-fork-pull-request
       - check-status
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          token: ${{ github.token }}
       - name: Post comment if the update failed
         run: |
           passed="${{ needs.check-status.outputs.PASSED }}"
@@ -276,6 +304,6 @@ jobs:
             gh pr comment "${PR_NUMBER}" --body "Policy update failed. You can [review the logs or retry the policy update here](${ACTION_RUN_URL})"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           ACTION_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## **Description**

The workflow uses a `LAVAMOAT_UPDATE_TOKEN` to authenticate to `github.com`. This is not necessary due to [GitHub Actions permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs), which is already utilized for some other workflows for this repo.

This replaces the token with native permissions. The token is no longer needed and can be revoked after merging this.

This means developers can now run `@metamaskbot update-policies` on their forks without need of configuring any tokens.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24974?quickstart=1)

## **Related issues**
- [demo run on fork](https://github.com/legobeat/metamask-extension/actions/runs/9327038990)

## **Manual testing steps**

1. Fork this repo
2. Merge this fork into the `develop` branch of your fork
3. Create a new PR (contents don't matter much) on your fork
4. Create a comment on the PR with contents `@metamaskbot update-policies`
5. Watch the bot do its thing

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
