### PR TITLE
fix: Update file path for fetching locales, to match mv3 folder structure

### DIFF
--- a/shared/modules/i18n.test.ts
+++ b/shared/modules/i18n.test.ts
@@ -281,7 +281,7 @@ describe('I18N Module', () => {
     it('returns json from locale file', async () => {
       const result = await fetchLocale(localeCodeMock);
       expect(result).toStrictEqual({
-        url: `./_locales/${localeCodeMock}/messages.json`,
+        url: `../_locales/${localeCodeMock}/messages.json`,
       });
     });
 

--- a/shared/modules/i18n.ts
+++ b/shared/modules/i18n.ts
@@ -91,7 +91,7 @@ export async function fetchLocale(
 ): Promise<I18NMessageDict> {
   try {
     const response = await fetchWithTimeout(
-      `./_locales/${localeCode}/messages.json`,
+      `../_locales/${localeCode}/messages.json`,
     );
     return await response.json();
   } catch (error) {


### PR DESCRIPTION
## **Description**

This fixes an error found in this comment https://github.com/MetaMask/metamask-extension/pull/24942#issuecomment-2143346898 "I get Fail to fetch when I switch languages."

This error is a result of the changes in https://github.com/MetaMask/metamask-extension/pull/23672

That PR has the following in the description:

> ...The manifest file sometimes references files using a path relative to both the repo and the bundled extension (background.html and popup.html) and sometimes it doesn't (inpage.js lives in the scripts folder).
This PR makes the paths relative to the repo (and the bundled extension).

We need to adjust the filepath for fetching these locales as well, which this PR does

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24983?quickstart=1)

## **Manual testing steps**

1. Go to the settings page and try to switch a language
2. The language should update successfully AND there should be no error in the console
3. Reload the extension. The same language should be selected

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
