### PR TITLE
test: Fix `AppMetadataController` tests

### DIFF
--- a/app/scripts/controllers/app-metadata.test.ts
+++ b/app/scripts/controllers/app-metadata.test.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import AppMetadataController from './app-metadata';
 
 const EXPECTED_DEFAULT_STATE = {
@@ -6,6 +5,7 @@ const EXPECTED_DEFAULT_STATE = {
   previousAppVersion: '',
   previousMigrationVersion: 0,
   currentMigrationVersion: 0,
+  showTokenAutodetectModalOnUpgrade: false,
 };
 
 describe('AppMetadataController', () => {
@@ -16,21 +16,21 @@ describe('AppMetadataController', () => {
         previousAppVersion: '1',
         previousMigrationVersion: 1,
         currentMigrationVersion: 1,
+        showTokenAutodetectModalOnUpgrade: false,
       };
       const appMetadataController = new AppMetadataController({
         state: initState,
         currentMigrationVersion: 1,
         currentAppVersion: '1',
       });
-      assert.deepStrictEqual(appMetadataController.store.getState(), initState);
+      expect(appMetadataController.store.getState()).toStrictEqual(initState);
     });
 
     it('sets default state and does not modify it', async () => {
       const appMetadataController = new AppMetadataController({
         state: {},
       });
-      assert.deepStrictEqual(
-        appMetadataController.store.getState(),
+      expect(appMetadataController.store.getState()).toStrictEqual(
         EXPECTED_DEFAULT_STATE,
       );
     });
@@ -41,8 +41,7 @@ describe('AppMetadataController', () => {
         currentMigrationVersion: 0,
         currentAppVersion: '',
       });
-      assert.deepStrictEqual(
-        appMetadataController.store.getState(),
+      expect(appMetadataController.store.getState()).toStrictEqual(
         EXPECTED_DEFAULT_STATE,
       );
     });
@@ -53,9 +52,10 @@ describe('AppMetadataController', () => {
         currentMigrationVersion: 0,
         currentAppVersion: '1',
       });
-      assert.deepStrictEqual(appMetadataController.store.getState(), {
+      expect(appMetadataController.store.getState()).toStrictEqual({
         ...EXPECTED_DEFAULT_STATE,
         currentAppVersion: '1',
+        showTokenAutodetectModalOnUpgrade: null,
       });
     });
 
@@ -68,10 +68,11 @@ describe('AppMetadataController', () => {
         currentAppVersion: '3',
         currentMigrationVersion: 0,
       });
-      assert.deepStrictEqual(appMetadataController.store.getState(), {
+      expect(appMetadataController.store.getState()).toStrictEqual({
         ...EXPECTED_DEFAULT_STATE,
         currentAppVersion: '3',
         previousAppVersion: '2',
+        showTokenAutodetectModalOnUpgrade: null,
       });
     });
 
@@ -80,7 +81,7 @@ describe('AppMetadataController', () => {
         state: {},
         currentMigrationVersion: 1,
       });
-      assert.deepStrictEqual(appMetadataController.store.getState(), {
+      expect(appMetadataController.store.getState()).toStrictEqual({
         ...EXPECTED_DEFAULT_STATE,
         currentMigrationVersion: 1,
       });
@@ -94,7 +95,7 @@ describe('AppMetadataController', () => {
         },
         currentMigrationVersion: 3,
       });
-      assert.deepStrictEqual(appMetadataController.store.getState(), {
+      expect(appMetadataController.store.getState()).toStrictEqual({
         ...EXPECTED_DEFAULT_STATE,
         currentMigrationVersion: 3,
         previousMigrationVersion: 2,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   collectCoverageFrom: [
     '<rootDir>/app/scripts/constants/error-utils.js',
+    '<rootDir>/app/scripts/controllers/app-metadata.ts',
     '<rootDir>/app/scripts/controllers/permissions/**/*.js',
     '<rootDir>/app/scripts/controllers/sign.ts',
     '<rootDir>/app/scripts/controllers/decrypt-message.ts',
@@ -40,6 +41,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/test/jest/setup.js'],
   testMatch: [
     '<rootDir>/app/scripts/constants/error-utils.test.js',
+    '<rootDir>/app/scripts/controllers/app-metadata.test.ts',
     '<rootDir>/app/scripts/controllers/app-state.test.js',
     '<rootDir>/app/scripts/controllers/transactions/etherscan.test.ts',
     '<rootDir>/app/scripts/controllers/transactions/EtherscanRemoteTransactionSource.test.ts',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `AppMetadataController` tests were broken, but this was not discovered because they were never run. These tests were Mocha tests that were written in TypeScript, but we don't run Mocha on any TypeScript files.

The tests have been fixed and migrated to Jest, so that they correctly run as part of our unit test suite.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25012?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

Run `yarn test:unit:jest` and find the `app-metadata` test results in the resulting test report and coverage report.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
