### PR TITLE
chore: update accounts controller to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "@metamask-institutional/sdk": "^0.1.27",
     "@metamask-institutional/transaction-update": "^0.2.2",
     "@metamask/abi-utils": "^2.0.2",
-    "@metamask/accounts-controller": "^15.0.0",
+    "@metamask/accounts-controller": "^16.0.0",
     "@metamask/address-book-controller": "^4.0.1",
     "@metamask/announcement-controller": "^6.1.0",
     "@metamask/approval-controller": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4623,12 +4623,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/accounts-controller@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@metamask/accounts-controller@npm:15.0.0"
+"@metamask/accounts-controller@npm:^16.0.0":
+  version: 16.0.0
+  resolution: "@metamask/accounts-controller@npm:16.0.0"
   dependencies:
     "@ethereumjs/util": "npm:^8.1.0"
-    "@metamask/base-controller": "npm:^5.0.2"
+    "@metamask/base-controller": "npm:^6.0.0"
     "@metamask/eth-snap-keyring": "npm:^4.1.1"
     "@metamask/keyring-api": "npm:^6.1.1"
     "@metamask/snaps-sdk": "npm:^4.2.0"
@@ -4639,9 +4639,9 @@ __metadata:
     immer: "npm:^9.0.6"
     uuid: "npm:^8.3.2"
   peerDependencies:
-    "@metamask/keyring-controller": ^16.1.0
+    "@metamask/keyring-controller": ^17.0.0
     "@metamask/snaps-controllers": ^8.1.1
-  checksum: 10/58c572ca1228268d39caad9bb24d6c1060e02e3ae063bb820f8c221b695b11b0f3a19b1ed56a0264b67192b3bbc354b6a6ff5c0fa94de4350e8ac84c8795a4c9
+  checksum: 10/dadba61bf13235a9d0c2a857d14767229afda923f868c514418dbd6ca662c9fdffb0fb46ef2454f33bdc1390210678e209202c06c92e6fb9d2d13d05da80db70
   languageName: node
   linkType: hard
 
@@ -24913,7 +24913,7 @@ __metadata:
     "@metamask-institutional/sdk": "npm:^0.1.27"
     "@metamask-institutional/transaction-update": "npm:^0.2.2"
     "@metamask/abi-utils": "npm:^2.0.2"
-    "@metamask/accounts-controller": "npm:^15.0.0"
+    "@metamask/accounts-controller": "npm:^16.0.0"
     "@metamask/address-book-controller": "npm:^4.0.1"
     "@metamask/announcement-controller": "npm:^6.1.0"
     "@metamask/approval-controller": "npm:^6.0.1"


### PR DESCRIPTION
## **Description**

This PR bumps the `@metamask/accounts-controller` to ^16.0.0

## **Related issues**

Fixes:

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
