### PR TITLE
fix: iframe injection in MV3

### DIFF
--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -169,6 +169,7 @@ const registerInPageContentScript = async () => {
         js: ['scripts/inpage.js'],
         runAt: 'document_start',
         world: 'MAIN',
+        allFrames: true,
       },
     ]);
   } catch (err) {


### PR DESCRIPTION
## **Description**

Fixes injection into iframes in the MV3 build by enabling `allFrames`. This is also currently enabled in MV2: https://github.com/MetaMask/metamask-extension/blob/13bd82914d1ac2c584fb799e6eee9b90fe889fe2/app/manifest/v2/_base.json#L42

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25051?quickstart=1)

## **Manual testing steps**

1. Go to https://jup.ag/
2. Try connecting with MetaMask, this will use Solflare snap
3. You should be able to fully connect to the site

