### PR TITLE
chore: adding storybook stories to review colors

### DIFF
--- a/ui/components/app/app-loading-spinner/app-loading-spinner.stories.js
+++ b/ui/components/app/app-loading-spinner/app-loading-spinner.stories.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import testData from '../../../../test/data/mock-state.json';
+
+import configureStore from '../../../store/store';
+import AppLoadingSpinner from './app-loading-spinner';
+
+const customData = {
+  ...testData,
+  appState: {
+    ...testData.appState,
+    isLoading: true,
+  },
+};
+const customStore = configureStore(customData);
+
+export default {
+  title: 'Components/App/AppLoadingSpinner',
+  component: AppLoadingSpinner,
+  decorators: [
+    (Story) => (
+      <Provider store={customStore}>
+        <Story />
+      </Provider>
+    ),
+  ],
+};
+
+const Template = (args) => <AppLoadingSpinner {...args} />;
+export const Default = Template.bind({});

--- a/ui/components/app/wallet-overview/eth-overview.stories.js
+++ b/ui/components/app/wallet-overview/eth-overview.stories.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import EthOverview from './eth-overview';
+
+export default {
+  title: 'Components/App/WalletOverview/EthOverview',
+  component: EthOverview,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A component that displays an overview of Ethereum wallet information.',
+      },
+    },
+  },
+};
+
+const Template = (args) => <EthOverview {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  // Add any necessary props here
+};

--- a/ui/components/app/wallet-overview/eth-overview.stories.js
+++ b/ui/components/app/wallet-overview/eth-overview.stories.js
@@ -17,6 +17,3 @@ export default {
 const Template = (args) => <EthOverview {...args} />;
 
 export const Default = Template.bind({});
-Default.args = {
-  // Add any necessary props here
-};

--- a/ui/components/ui/loading-screen/loading-screen.stories.js
+++ b/ui/components/ui/loading-screen/loading-screen.stories.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import LoadingScreen from './loading-screen.component';
+
+export default {
+  title: 'Components/UI/LoadingScreen',
+  component: LoadingScreen,
+};
+
+const Template = (args) => <LoadingScreen {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  // header: <h1>Loading Screen</h1>,
+  loadingMessage: 'Loading...',
+  showLoadingSpinner: true,
+};

--- a/ui/components/ui/loading-screen/loading-screen.stories.js
+++ b/ui/components/ui/loading-screen/loading-screen.stories.js
@@ -10,7 +10,6 @@ const Template = (args) => <LoadingScreen {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
-  // header: <h1>Loading Screen</h1>,
   loadingMessage: 'Loading...',
   showLoadingSpinner: true,
 };


### PR DESCRIPTION
## **Description**

This pull request adds Storybook stories for the following components: `AppLoadingSpinner`, `EthOverview`, and `LoadingScreen`. The goal is to provide better visual documentation and enable easier testing of these components within Storybook. It also breaks up a PR to remove all deprecated secondary colors. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25083?quickstart=1)
## **Related issues**

Part of: https://github.com/MetaMask/metamask-extension/issues/24964

## **Manual testing steps**


1. Go to storybook build of this PR or start the Storybook server using `yarn storybook`.
2. In the Storybook interface, navigate to the stories for `AppLoadingSpinner`, `EthOverview`, and `LoadingScreen`.
3. Verify that the components render correctly and interact as expected

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-extension/assets/8112138/f030a908-b6f9-4877-9e1a-16f10a16a765

### **After**

https://github.com/MetaMask/metamask-extension/assets/8112138/37c4fd40-7e92-4480-ba8b-5d6b0ac8cd13

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and/or screenshots.
