### PR TITLE
feat: contributor docs

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -38,7 +38,7 @@ Fixes:
 
 ## **Pre-merge author checklist**
 
-- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/pull-requests.md) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
+- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
 - [ ] I've completed the PR template to the best of my ability
 - [ ] I’ve included tests if applicable
 - [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -38,8 +38,7 @@ Fixes:
 
 ## **Pre-merge author checklist**
 
-- [ ] I've read [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/pull-requests.md)
-- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
+- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/pull-requests.md) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
 - [ ] I've completed the PR template to the best of my ability
 - [ ] I’ve included tests if applicable
 - [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -38,6 +38,7 @@ Fixes:
 
 ## **Pre-merge author checklist**
 
+- [ ] I've read [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/pull-requests.md)
 - [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
 - [ ] I've completed the PR template to the best of my ability
 - [ ] I’ve included tests if applicable

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ For up to the minute news, follow our [Twitter](https://twitter.com/metamask) or
 
 To learn how to develop MetaMask-compatible applications, visit our [Developer Docs](https://metamask.github.io/metamask-docs/).
 
-To learn how to contribute to the MetaMask project itself, visit our [Internal Docs](https://github.com/MetaMask/metamask-extension/tree/develop/docs).
+To learn how to contribute to the MetaMask codebase, visit our [Contributor Docs](https://github.com/MetaMask/contributor-docs).
+
+To learn how to contribute to the MetaMask Extension project itself, visit our [Extension Docs](https://github.com/MetaMask/metamask-extension/tree/develop/docs).
 
 ## GitHub Codespaces quickstart
 


### PR DESCRIPTION
## **Description**

This PR aims to add a link to contributor docs in the PR template and in the README, to foster adoption of contributor docs guidelines.

[Same PR for Mobile repo.](https://github.com/MetaMask/metamask-mobile/pull/9884)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1843

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
