### PR TITLE
chore: bump GasFeeController to v17.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
     "@metamask/ethjs": "^0.6.0",
     "@metamask/ethjs-contract": "^0.4.1",
     "@metamask/ethjs-query": "^0.7.1",
-    "@metamask/gas-fee-controller": "^15.1.2",
+    "@metamask/gas-fee-controller": "^17.0.0",
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/keyring-api": "^8.0.0",
     "@metamask/keyring-controller": "patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5408,7 +5408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@npm:^15.1.1, @metamask/gas-fee-controller@npm:^15.1.2":
+"@metamask/gas-fee-controller@npm:^15.1.1":
   version: 15.1.2
   resolution: "@metamask/gas-fee-controller@npm:15.1.2"
   dependencies:
@@ -24962,7 +24962,7 @@ __metadata:
     "@metamask/ethjs-contract": "npm:^0.4.1"
     "@metamask/ethjs-query": "npm:^0.7.1"
     "@metamask/forwarder": "npm:^1.1.0"
-    "@metamask/gas-fee-controller": "npm:^15.1.2"
+    "@metamask/gas-fee-controller": "npm:^17.0.0"
     "@metamask/jazzicon": "npm:^2.0.0"
     "@metamask/keyring-api": "npm:^8.0.0"
     "@metamask/keyring-controller": "patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch"


### PR DESCRIPTION
## **Description**

We introduced a bug in the 11.14.0 release where gas fee polling could, under some conditions, fail to stop, leading to multiple concurrent gas fee polling and a nasty downstream bug. In v17.0.0 of the `GasFeeController` - the version we're bumping to in this PR - we have [a fix to the `PollingController`](https://github.com/MetaMask/core/pull/4230) to prevent the case where polling erroneously fails to stop.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25111?quickstart=1)

## **Related issues**

[Slack Thread](https://consensys.slack.com/archives/C029JG63136/p1713297594350439?thread_ts=1711033108.695299&cid=C029JG63136) where issue was surfaced
- There were several potential sources of the bug. The fix in this PR addresses one of them

## **Manual testing steps**

Its very difficult to reproduce this bug

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
