### PR TITLE
fix: Add resolution for rpc-websockets to handle deps audit failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "@expo/config/glob": "^10.3.10",
     "@expo/config-plugins/glob": "^10.3.10",
     "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A18.1.2#~/.yarn/patches/@metamask-network-controller-npm-18.1.2-1bcb8d8610.patch",
-    "rpc-websockets": "^8.0.1"
+    "@solana/web3.js/rpc-websockets": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.24.0#~/.yarn/patches/@babel-runtime-npm-7.24.0-7eb1dd11a2.patch",

--- a/package.json
+++ b/package.json
@@ -252,7 +252,8 @@
     "sucrase@npm:3.34.0": "^3.35.0",
     "@expo/config/glob": "^10.3.10",
     "@expo/config-plugins/glob": "^10.3.10",
-    "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A18.1.2#~/.yarn/patches/@metamask-network-controller-npm-18.1.2-1bcb8d8610.patch"
+    "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A18.1.2#~/.yarn/patches/@metamask-network-controller-npm-18.1.2-1bcb8d8610.patch",
+    "rpc-websockets": "^8.0.1"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.24.0#~/.yarn/patches/@babel-runtime-npm-7.24.0-7eb1dd11a2.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30814,9 +30814,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rpc-websockets@npm:^7.11.0":
-  version: 7.11.1
-  resolution: "rpc-websockets@npm:7.11.1"
+"rpc-websockets@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "rpc-websockets@npm:8.0.1"
   dependencies:
     bufferutil: "npm:^4.0.1"
     eventemitter3: "npm:^4.0.7"
@@ -30828,7 +30828,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/6b23cc7a54eb2158f4098545c0adbf118e9240d6006e262048b3dd5125e352892f989df7337b4ca70a1505699a480c92d6f3c58ebb8f4d3a483dda9606890a28
+  checksum: 10/ec50bebb6d85f977d3ab16c31d107ff7f546ea472be8f827d6236d2bbbb6d807481a7028a16f3fa7a9163b2338d9957a97e78f03761a9adc0e04b68586973c1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

fixes this `test-deps-audit` failure:

```
└─ rpc-websockets
   ├─ ID: rpc-websockets (deprecation)
   ├─ Issue: deprecate 7.11.1
   ├─ Severity: moderate
   ├─ Vulnerable Versions: 7.11.1
   │ 
   ├─ Tree Versions
   │  └─ 7.11.1
   │ 
   └─ Dependents
      └─ @solana/web3.js@npm:1.91.8

Exited with code exit status 1
```

The next version after 7.11.1 is a major version bump, 8.0.1. The [release notes](https://github.com/elpheria/rpc-websockets/releases/tag/v8.0.1) for that version say "Switched to ESNext (ESM). Make sure to use import instead of require to import this package." The one package in our dependency tree that uses this package already uses import (https://github.com/solana-labs/solana-web3.js/blob/abbdc5b1d373cb555b1aab6d450854939407a8ab/packages/library-legacy/src/rpc-websocket.ts#L1). So bumping the version should be safe.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25112?quickstart=1)

## **Manual testing steps**

This change doesn't affect our functionality. The `Trezor` functionality that depends on this package is not used in our usage of trezor.



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
