### PR TITLE
fix: Include missing files in Sentry release artifact upload

### DIFF
--- a/development/sentry-upload-artifacts.sh
+++ b/development/sentry-upload-artifacts.sh
@@ -31,7 +31,7 @@ function upload_sourcemaps {
   local release="${1}"; shift
   local dist_directory="${1}"; shift
 
-  sentry-cli releases files "${release}" upload-sourcemaps "${dist_directory}"/chrome/*.js "${dist_directory}"/sourcemaps/ --rewrite --url-prefix '/metamask'
+  sentry-cli releases files "${release}" upload-sourcemaps "${dist_directory}"/chrome/ "${dist_directory}"/sourcemaps/ --rewrite --url-prefix '/metamask'
 }
 
 function main {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Sentry release artifact upload step was assuming that all JavaScript files were at the root of the build directory. This is not the case; in #23672 some of them were moved to a `scripts/` subdirectory. These files have been missing from release artifacts for some time now.

The script has been updated to include all JavaScript files included in the build. It references the entire build directory now rather than specifically targetting JavaScript files at the top-level. No additional filter is needed to exclude non-JavaScript files because this command defaults to only including JavaScript and sourcemap files (and some React native files that don't exist in our build).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25113?quickstart=1)

## **Related issues**

Fixes #25110

## **Manual testing steps**

1. Create a personal Sentry account (if you don't have one already)
2. Create a project in Sentry called `metamask` (if you don't have one already)
2. Run this script:
```
SENTRY_ORG=[your account name/organization] SENTRY_PROJECT=metamask yarn exec ./development/sentry-upload-artifacts.sh --release v11.16.7
```
3. Verify that all JavaScript files and source maps are shown on the CLI as being uploaded, and visible in the artifact bundle on the Sentry dashboard
  * The artifact bundle should be listed here: `https://[your username/organization].sentry.io/settings/projects/metamask/source-maps/artifact-bundles/`

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
