### PR TITLE
chore: removing deprecated button color css variables

### DIFF
--- a/.storybook/4.SHADOW.stories.mdx
+++ b/.storybook/4.SHADOW.stories.mdx
@@ -115,7 +115,7 @@ As well as the neutral colors for shadow 2 other colors exist that are used for 
     style={{
       height: 100,
       backgroundColor: 'var(--color-primary-default)',
-      boxShadow: 'var(--shadow-size-lg) var(--color-primary-shadow',
+      boxShadow: 'var(--shadow-size-lg) var(--color-shadow-primary',
       borderRadius: '4px',
       display: 'grid',
       alignContent: 'center',
@@ -129,7 +129,7 @@ As well as the neutral colors for shadow 2 other colors exist that are used for 
     style={{
       height: 100,
       backgroundColor: 'var(--color-error-default)',
-      boxShadow: 'var(--shadow-size-lg) var(--color-error-shadow',
+      boxShadow: 'var(--shadow-size-lg) var(--color-shadow-error',
       borderRadius: '4px',
       display: 'grid',
       alignContent: 'center',
@@ -144,8 +144,8 @@ As well as the neutral colors for shadow 2 other colors exist that are used for 
 | Color       | CSS                           |
 | ----------- | ----------------------------- |
 | **neutral** | `var(--color-shadow-default)` |
-| **primary** | `var(--color-primary-shadow)` |
-| **danger**  | `var(--color-error-shadow)`   |
+| **primary** | `var(--color-shadow-primary)` |
+| **danger**  | `var(--color-shadow-error)`   |
 
 ## Example usage
 
@@ -232,7 +232,7 @@ Using both size and color tokens, different shadows can be applied to components
         justifyContent: 'center',
         height: 100,
         textAlign: 'center',
-        boxShadow: 'var(--component-button-primary-shadow)',
+        boxShadow: 'var(--shadow-size-sm) var(--color-primary-shadow)',
         backgroundColor: 'var(--color-primary-default)',
         color: 'var(--color-primary-inverse)',
       }}
@@ -247,7 +247,7 @@ Using both size and color tokens, different shadows can be applied to components
         justifyContent: 'center',
         height: 100,
         textAlign: 'center',
-        boxShadow: 'var(--component-button-danger-shadow)',
+        boxShadow: 'var(--shadow-size-sm) var(--color-error-shadow)',
         backgroundColor: 'var(--color-error-default)',
         color: 'var(--color-error-inverse)',
       }}
@@ -263,8 +263,8 @@ Using both size and color tokens, different shadows can be applied to components
 | **Dropdown**             | `box-shadow: var(--shadow-size-sm) var(--color-shadow-default);` |
 | **Toast**                | `box-shadow: var(--shadow-size-md) var(--color-shadow-default);` |
 | **Modal**                | `box-shadow: var(--shadow-size-lg) var(--color-shadow-default);` |
-| **Button Primary Hover** | `box-shadow: var(--shadow-size-sm) var(--color-primary-shadow);` |
-| **Button Danger Hover**  | `box-shadow: var(--shadow-size-sm) var(--color-error-shadow);`   |
+| **Button Primary Hover** | `box-shadow: var(--shadow-size-sm) var(--color-shadow-primary);` |
+| **Button Danger Hover**  | `box-shadow: var(--shadow-size-sm) var(--color-shadow-error);`   |
 
 ## Takeaways
 

--- a/.storybook/4.SHADOW.stories.mdx
+++ b/.storybook/4.SHADOW.stories.mdx
@@ -101,7 +101,7 @@ As well as the neutral colors for shadow 2 other colors exist that are used for 
     style={{
       height: 100,
       backgroundColor: 'var(--color-background-default)',
-      boxShadow: 'var(--shadow-size-lg) var(--color-shadow-default',
+      boxShadow: 'var(--shadow-size-lg) var(--color-shadow-default)',
       borderRadius: '4px',
       display: 'grid',
       alignContent: 'center',
@@ -115,7 +115,7 @@ As well as the neutral colors for shadow 2 other colors exist that are used for 
     style={{
       height: 100,
       backgroundColor: 'var(--color-primary-default)',
-      boxShadow: 'var(--shadow-size-lg) var(--color-shadow-primary',
+      boxShadow: 'var(--shadow-size-lg) var(--color-primary-shadow)',
       borderRadius: '4px',
       display: 'grid',
       alignContent: 'center',
@@ -129,7 +129,7 @@ As well as the neutral colors for shadow 2 other colors exist that are used for 
     style={{
       height: 100,
       backgroundColor: 'var(--color-error-default)',
-      boxShadow: 'var(--shadow-size-lg) var(--color-shadow-error',
+      boxShadow: 'var(--shadow-size-lg) var(--color-error-shadow)',
       borderRadius: '4px',
       display: 'grid',
       alignContent: 'center',
@@ -144,8 +144,8 @@ As well as the neutral colors for shadow 2 other colors exist that are used for 
 | Color       | CSS                           |
 | ----------- | ----------------------------- |
 | **neutral** | `var(--color-shadow-default)` |
-| **primary** | `var(--color-shadow-primary)` |
-| **danger**  | `var(--color-shadow-error)`   |
+| **primary** | `var(--color-primary-shadow)` |
+| **danger**  | `var(--color-error-shadow)`   |
 
 ## Example usage
 
@@ -263,8 +263,8 @@ Using both size and color tokens, different shadows can be applied to components
 | **Dropdown**             | `box-shadow: var(--shadow-size-sm) var(--color-shadow-default);` |
 | **Toast**                | `box-shadow: var(--shadow-size-md) var(--color-shadow-default);` |
 | **Modal**                | `box-shadow: var(--shadow-size-lg) var(--color-shadow-default);` |
-| **Button Primary Hover** | `box-shadow: var(--shadow-size-sm) var(--color-shadow-primary);` |
-| **Button Danger Hover**  | `box-shadow: var(--shadow-size-sm) var(--color-shadow-error);`   |
+| **Button Primary Hover** | `box-shadow: var(--shadow-size-sm) var(--color-primary-shadow);` |
+| **Button Danger Hover**  | `box-shadow: var(--shadow-size-sm) var(--color-error-shadow);`   |
 
 ## Takeaways
 

--- a/ui/components/component-library/button-primary/button-primary.scss
+++ b/ui/components/component-library/button-primary/button-primary.scss
@@ -1,7 +1,9 @@
 .mm-button-primary {
   &:hover:not(&--disabled) {
     color: var(--color-primary-inverse);
-    box-shadow: var(--component-button-primary-shadow);
+    box-shadow:
+      var(--shadow-size-sm)
+      var(--color-primary-shadow);
   }
 
   &:active {
@@ -13,7 +15,9 @@
   &--type-danger:not(&--disabled) {
     &:hover {
       color: var(--color-error-inverse);
-      box-shadow: var(--component-button-danger-shadow);
+      box-shadow:
+        var(--shadow-size-sm)
+        var(--color-error-shadow);
     }
 
     &:active {

--- a/ui/components/component-library/button-secondary/button-secondary.scss
+++ b/ui/components/component-library/button-secondary/button-secondary.scss
@@ -2,7 +2,9 @@
   &:hover:not(&--disabled) {
     color: var(--color-primary-inverse);
     background-color: var(--color-primary-default);
-    box-shadow: var(--component-button-primary-shadow);
+    box-shadow:
+      var(--shadow-size-sm)
+      var(--color-primary-shadow);;
   }
 
   &:active {
@@ -20,7 +22,9 @@
     &:hover {
       color: var(--color-error-inverse);
       background-color: var(--color-error-default);
-      box-shadow: var(--component-button-danger-shadow);
+      box-shadow:
+        var(--shadow-size-sm)
+        var(--color-error-shadow);
     }
 
     &:active {


### PR DESCRIPTION
## **Description**

This pull request removes the deprecated button component colors in preparation for upgrading to [design token v4](https://github.com/MetaMask/design-tokens/blob/main/MIGRATION.md#from-version-300-to-400).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25125?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24965

## **Manual testing steps**

1. Go the storybook build of this PR or pull this branch and run `yarn storybook`
2. Check the Shadows documentation to ensure primary and error shadows work as expected
3. Search `ButtonPrimary` and `ButtonSecondary` 
4. Hover over the button components and make sure the shadows are present

## **Screenshots/Recordings**

Before/After scereenshots/recordings in code comments for easier review and context

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
