### PR TITLE
chore: Revert master sync PR #25040

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,34 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.16.7]
-### Fixed
-- Fix bug that breaks dapps that expect users to switch chains manually([#25046]https://github.com/MetaMask/metamask-extension/pull/25046)
-
-## [11.16.6]
-### Added
-- Add a Basic Functionality Toggle to settings, enabling users to opt-out of some features that send network requests to external services  ([#23456](https://github.com/MetaMask/metamask-extension/pull/23456))
-
-### Changed
-- Update MetaMask Chrome builds to Manifest V3 ([#24746](https://github.com/MetaMask/metamask-extension/pull/24746))
-
-### Fixed
-- Ensure network requests are not made during onboarding
-	- ([#24890](https://github.com/MetaMask/metamask-extension/pull/24890))
-	- ([#24891](https://github.com/MetaMask/metamask-extension/pull/24891))
-	- ([#24887](https://github.com/MetaMask/metamask-extension/pull/24887))
-
-## [11.16.5]
-### Changed
-- Re-enable the opt-in modal (2df1eb566b)
-
-## [11.16.4]
-### Changed
-- Temporarily disable the opt-in modal ([#25007](https://github.com/MetaMask/metamask-extension/pull/25007))
-
 ## [11.16.3]
 ### Changed
-- Update Trezor logo ([#24343](https://github.com/MetaMask/metamask-extension/pull/24343))
+- Update Trezor logo ([#24343]https://github.com/MetaMask/metamask-extension/pull/24343)
 
 ## [11.16.2]
 ### Fixed
@@ -4785,11 +4760,7 @@ Update styles and spacing on the critical error page  ([#20350](https://github.c
 - Added the ability to restore accounts from seed words.
 
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.16.7...HEAD
-[11.16.7]: https://github.com/MetaMask/metamask-extension/compare/v11.16.6...v11.16.7
-[11.16.6]: https://github.com/MetaMask/metamask-extension/compare/v11.16.5...v11.16.6
-[11.16.5]: https://github.com/MetaMask/metamask-extension/compare/v11.16.4...v11.16.5
-[11.16.4]: https://github.com/MetaMask/metamask-extension/compare/v11.16.3...v11.16.4
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.16.3...HEAD
 [11.16.3]: https://github.com/MetaMask/metamask-extension/compare/v11.16.2...v11.16.3
 [11.16.2]: https://github.com/MetaMask/metamask-extension/compare/v11.16.1...v11.16.2
 [11.16.1]: https://github.com/MetaMask/metamask-extension/compare/v11.16.0...v11.16.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "11.16.7",
+  "version": "11.16.3",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
master sync PR #25040 was squashed and merged when it should have just been merged. This PR reverts it so that we can re-do the master sync PR with just a merge commit