### PR TITLE
WIP: Propose local dev feature flag

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -1087,6 +1087,16 @@ async function getCleanAppState(driver) {
   );
 }
 
+// Should execute at the beginning of a test
+async function setLocalDeveloperFlag(driver, flagName, value) {
+  return await driver.executeScript(() => {
+    window.metamaskFeatureFlags = {
+      ...(window.metamaskFeatureFlags || {}),
+      [flagName]: value,
+    };
+  });
+}
+
 async function initBundler(bundlerServer, ganacheServer, usePaymaster) {
   try {
     const ganacheSeeder = new GanacheSeeder(ganacheServer.getProvider());
@@ -1179,4 +1189,5 @@ module.exports = {
   getCleanAppState,
   editGasFeeForm,
   clickNestedButton,
+  setLocalDeveloperFlag,
 };

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2587,3 +2587,7 @@ export function getKeyringSnapRemovalResult(state) {
 }
 
 ///: END:ONLY_INCLUDE_IF
+
+export function getLocalDeveloperFlag(flagName) {
+  return process.env[flagName] || window.metamaskFeatureFlags?.[flagName];
+}

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -5597,3 +5597,10 @@ export async function getNextAvailableAccountName(): Promise<string> {
     [],
   );
 }
+
+export function setLocalDeveloperFlag(
+  flagName: string,
+  value: string | boolean,
+) {
+  process.env[flagName] = value;
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR represents a proposed way to have local feature flags without needing a separate CI job or even a toggle in the Developer settings tab.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25130?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

The idea here is that the `getLocalDeveloperFlag` / `setLocalDeveloperFlag` functions look for the environment variable and return accordingly, or set accordingly.  By using `setLocalDeveloperFlag` at the top of a E2E, that feature toggle will be turned on for just that test, and should never effect prod/release.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
