### PR TITLE
fix: Update minimum browser warning version, and gracefully fail if chrome.offscreen does not exist

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2734,9 +2734,6 @@
   "mismatchedRpcUrl": {
     "message": "According to our records the submitted RPC URL value does not match a known provider for this chain ID."
   },
-  "noHardwareWalletsOrSnapsSupport": {
-    "message": "Snaps, and most hardware wallets, will not work with your current browser version."
-  },
   "missingSetting": {
     "message": "Can't find a setting?"
   },
@@ -3072,6 +3069,9 @@
   },
   "noDomainResolution": {
     "message": "No resolution for domain provided."
+  },
+  "noHardwareWalletOrSnapsSupport": {
+    "message": "Snaps, and most hardware wallets, will not work with your current browser version."
   },
   "noNFTs": {
     "message": "No NFTs yet"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2734,7 +2734,7 @@
   "mismatchedRpcUrl": {
     "message": "According to our records the submitted RPC URL value does not match a known provider for this chain ID."
   },
-  "browserDoesntSupportHWandSnaps": {
+  "noHardwareWalletsOrSnapsSupport": {
     "message": "Snaps, and most hardware wallets, will not work with your current browser version."
   },
   "missingSetting": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2734,6 +2734,9 @@
   "mismatchedRpcUrl": {
     "message": "According to our records the submitted RPC URL value does not match a known provider for this chain ID."
   },
+  "browserDoesntSupportHWandSnaps": {
+    "message": "Snaps, and most hardware wallets, will not work with your current browser version."
+  },
   "missingSetting": {
     "message": "Can't find a setting?"
   },

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -194,7 +194,7 @@ registerInPageContentScript();
  * folder for more details.
  */
 async function createOffscreen() {
-  if (await chrome.offscreen.hasDocument()) {
+  if (!chrome.offscreen || (await chrome.offscreen.hasDocument())) {
     return;
   }
 

--- a/shared/modules/mv3.utils.js
+++ b/shared/modules/mv3.utils.js
@@ -2,3 +2,8 @@ import browser from 'webextension-polyfill';
 
 export const isManifestV3 =
   browser.runtime.getManifest().manifest_version === 3;
+
+export const isOffscreenAvailable = Boolean(browser.offscreen);
+
+export const isMv3ButOffscreenDocIsMissing =
+  isManifestV3 && !isOffscreenAvailable;

--- a/shared/modules/mv3.utils.js
+++ b/shared/modules/mv3.utils.js
@@ -1,9 +1,24 @@
 import browser from 'webextension-polyfill';
 
+/**
+ * A boolean indicating whether the manifest of the current extension
+ * is set to manifest version 3.
+ */
 export const isManifestV3 =
   browser.runtime.getManifest().manifest_version === 3;
 
+/**
+ * A boolean indicating whether the browser supports the offscreen document api.
+ * This is only available in when the manifest is version 3, and only in chromium
+ * versions 109 and higher. As of June 7, 2024, it is not available in firefox.
+ */
 export const isOffscreenAvailable = Boolean(browser.offscreen);
 
+/**
+ * A boolean indicating whether the current extension's manifest is version 3
+ * while the current browser does not support the offscreen document. This can
+ * happen to users on MetaMask versions 11.16.7 and higher, who are using a
+ * chromium browser with a version below 109.
+ */
 export const isMv3ButOffscreenDocIsMissing =
   isManifestV3 && !isOffscreenAvailable;

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -15,13 +15,13 @@ export const CONTRACT_ADDRESS_LINK = _contractAddressLink;
 export const PASSWORD_MIN_LENGTH = 8;
 export const OUTDATED_BROWSER_VERSIONS = {
   // Chrome and Edge should match the latest Chrome version released ~2 years ago
-  chrome: '<90',
-  edge: '<90',
+  chrome: '<109',
+  edge: '<109',
   // Firefox should match the most recent end-of-life extended support release
   firefox: '<91',
   // Opera should be set to the equivalent of the Chrome version set
   // See https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser
-  opera: '<76',
+  opera: '<109',
 };
 
 /**

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -14,12 +14,15 @@ export const SUPPORT_REQUEST_LINK = process.env.SUPPORT_REQUEST_LINK;
 export const CONTRACT_ADDRESS_LINK = _contractAddressLink;
 export const PASSWORD_MIN_LENGTH = 8;
 export const OUTDATED_BROWSER_VERSIONS = {
-  // Chrome and Edge should match the latest Chrome version released ~2 years ago
+  // Chrome and Edge should match the latest Chrome version released ~2 years ago,
+  // or the earliest version that supports our MV3 functionality, whichever is higher
   chrome: '<109',
   edge: '<109',
   // Firefox should match the most recent end-of-life extended support release
   firefox: '<91',
-  // Opera should be set to the equivalent of the Chrome version set
+  // Opera versions correspond to differently numbered Chromium versions.
+  // Opera should be set to the equivalent of the Chromium version set
+  // Opera 95 is based on Chromium 109
   // See https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser
   opera: '<95',
 };

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -21,7 +21,7 @@ export const OUTDATED_BROWSER_VERSIONS = {
   firefox: '<91',
   // Opera should be set to the equivalent of the Chrome version set
   // See https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser
-  opera: '<109',
+  opera: '<95',
 };
 
 /**

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -204,7 +204,7 @@ describe('util', () => {
     });
     it('should return false when given a modern chrome browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.2623.112 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.2623.112 Safari/537.36',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(false);
@@ -232,7 +232,7 @@ describe('util', () => {
     });
     it('should return false when given a modern opera browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_16_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.3578.98 Safari/537.36 OPR/76.0.3135.47',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_16_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.3578.98 Safari/537.36 OPR/95.0.3135.47',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(false);
@@ -246,7 +246,7 @@ describe('util', () => {
     });
     it('should return false when given a modern edge browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.3578.98 Safari/537.36 Edg/90.0.416.68',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.3578.98 Safari/537.36 Edg/109.0.416.68',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(false);

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -473,8 +473,11 @@ export default class Home extends PureComponent {
     const outdatedBrowserNotificationDescriptionText =
       isMv3ButOffscreenDocIsMissing ? (
         <div>
-          <p>{t('outdatedBrowserNotification')}</p>
-          <p>{t('noHardwareWalletsOrSnapsSupport')}</p>
+          <Text>{t('outdatedBrowserNotification')}</Text>
+          <br />
+          <Text fontWeight={FontWeight.Bold} color={TextColor.warningDefault}>
+            {t('noHardwareWalletsOrSnapsSupport')}
+          </Text>
         </div>
       ) : (
         t('outdatedBrowserNotification')

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -476,7 +476,7 @@ export default class Home extends PureComponent {
           <Text>{t('outdatedBrowserNotification')}</Text>
           <br />
           <Text fontWeight={FontWeight.Bold} color={TextColor.warningDefault}>
-            {t('noHardwareWalletsOrSnapsSupport')}
+            {t('noHardwareWalletOrSnapsSupport')}
           </Text>
         </div>
       ) : (

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -22,6 +22,7 @@ import Popover from '../../components/ui/popover';
 import Button from '../../components/ui/button';
 import ConnectedSites from '../connected-sites';
 import ConnectedAccounts from '../connected-accounts';
+import { isMv3ButOffscreenDocIsMissing } from '../../../shared/modules/mv3.utils';
 
 import ActionableMessage from '../../components/ui/actionable-message/actionable-message';
 import {
@@ -469,6 +470,16 @@ export default class Home extends PureComponent {
 
     const autoHideDelay = 5 * SECOND;
 
+    const outdatedBrowserNotificationDescriptionText =
+      isMv3ButOffscreenDocIsMissing ? (
+        <div>
+          <p>{t('outdatedBrowserNotification')}</p>
+          <p>{t('browserDoesntSupportHWandSnaps')}</p>
+        </div>
+      ) : (
+        t('outdatedBrowserNotification')
+      );
+
     return (
       <MultipleNotifications>
         {newNftAddedMessage === 'success' ? (
@@ -686,7 +697,7 @@ export default class Home extends PureComponent {
         ) : null}
         {showOutdatedBrowserWarning ? (
           <HomeNotification
-            descriptionText={t('outdatedBrowserNotification')}
+            descriptionText={outdatedBrowserNotificationDescriptionText}
             acceptText={t('gotIt')}
             onAccept={this.onOutdatedBrowserWarningClose}
             key="home-outdatedBrowserNotification"

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -474,7 +474,7 @@ export default class Home extends PureComponent {
       isMv3ButOffscreenDocIsMissing ? (
         <div>
           <p>{t('outdatedBrowserNotification')}</p>
-          <p>{t('browserDoesntSupportHWandSnaps')}</p>
+          <p>{t('noHardwareWalletsOrSnapsSupport')}</p>
         </div>
       ) : (
         t('outdatedBrowserNotification')


### PR DESCRIPTION
## **Description**

With the update to manifest v3, users on versions older than chrome 109 would have errors thrown from app-init about chrome.offscreen being undefined. Snaps and hardware wallets would be broken for these users.

We need to update our minimum supported browser version to 109, but before we do that we need to warn users that there current browser version is out of date.

This PR:
1. Handles the of chrome.offscreen being undefined in app-init.js, by simple not attempting to create the offscreen document of chrome.offscreen is undefined
2. Updates the `OUTDATED_BROWSER_VERSIONS` const so that users on chromium versions older than 109 will see a warning about their browser version
3. Adds an additional note to the outdated browser warning to tell users that snaps and hardware wallets won't work on the current version (but only for users on a MV3 version, where there is no offscreen document api)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25142?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25116

## **Manual testing steps**

1. Install a chromium version earlier than 109 (https://www.chromium.org/getting-involved/download-chromium/#downloading-old-builds-of-chrome-chromium)
2. Build, install and onboard on this branch
3. You should see a warning about the browser being out of date, and that snaps and most hardware wallets won't work with this version

## **Screenshots/Recordings**

### **After**

![Screenshot from 2024-06-07 10-26-34](https://github.com/MetaMask/metamask-extension/assets/7499938/fa1ab356-47eb-4720-916c-72e334d9d0e5)
![Screenshot from 2024-06-07 10-25-59](https://github.com/MetaMask/metamask-extension/assets/7499938/36f78219-3266-4e76-9600-1b5f983ae98a)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
