### PR TITLE
fix: use `ProxyExecutionService` for MV3

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -80,6 +80,7 @@ import { LoggingController, LogType } from '@metamask/logging-controller';
 import { PermissionLogController } from '@metamask/permission-log-controller';
 
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
 import { RateLimitController } from '@metamask/rate-limit-controller';
 import { NotificationController } from '@metamask/notification-controller';
 import {
@@ -88,7 +89,7 @@ import {
   SnapController,
   IframeExecutionService,
   SnapInterfaceController,
-  OffscreenExecutionService,
+  ProxyExecutionService,
 } from '@metamask/snaps-controllers';
 import {
   createSnapsMethodMiddleware,
@@ -1245,11 +1246,13 @@ export default class MetamaskController extends EventEmitter {
             ...snapExecutionServiceArgs,
             iframeUrl: new URL(process.env.IFRAME_EXECUTION_ENVIRONMENT_URL),
           })
-        : new OffscreenExecutionService({
-            // eslint-disable-next-line no-undef
-            documentUrl: chrome.runtime.getURL('./offscreen.html'),
-            ...snapExecutionServiceArgs,
-          });
+        : new ProxyExecutionService({
+          ...snapExecutionServiceArgs,
+          stream: new BrowserRuntimePostMessageStream({
+            name: 'parent',
+            target: 'child',
+          })
+        });
 
     const snapControllerMessenger = this.controllerMessenger.getRestricted({
       name: 'SnapController',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1247,12 +1247,12 @@ export default class MetamaskController extends EventEmitter {
             iframeUrl: new URL(process.env.IFRAME_EXECUTION_ENVIRONMENT_URL),
           })
         : new ProxyExecutionService({
-          ...snapExecutionServiceArgs,
-          stream: new BrowserRuntimePostMessageStream({
-            name: 'parent',
-            target: 'child',
-          })
-        });
+            ...snapExecutionServiceArgs,
+            stream: new BrowserRuntimePostMessageStream({
+              name: 'parent',
+              target: 'child',
+            }),
+          });
 
     const snapControllerMessenger = this.controllerMessenger.getRestricted({
       name: 'SnapController',


### PR DESCRIPTION
The only difference between `OffscreenExecutionService` and `ProxyExecutionService` is that the former initialises the offscreen document, which we don't need anymore, since the extension initialises it now. I've simply swapped it out for `ProxyExecutionService`.