### PR TITLE
fix: updating icon sizes inside of avatar icon component

### DIFF
--- a/ui/components/component-library/avatar-icon/README.mdx
+++ b/ui/components/component-library/avatar-icon/README.mdx
@@ -28,11 +28,11 @@ Use the `size` prop and the `AvatarIconSize` enum to change the size of `AvatarI
 
 Possible sizes include:
 
-- `AvatarIconSize.Xs` 16px
-- `AvatarIconSize.Sm` 24px
-- `AvatarIconSize.Md` 32px
-- `AvatarIconSize.Lg` 40px
-- `AvatarIconSize.Xl` 48px
+- `AvatarIconSize.Xs` 16px (icon size: 10px)
+- `AvatarIconSize.Sm` 24px (icon size: 15px)
+- `AvatarIconSize.Md` 32px (icon size: 20px)
+- `AvatarIconSize.Lg` 40px (icon size: 25px)
+- `AvatarIconSize.Xl` 48px (icon size: 30px)
 
 Defaults to `AvatarIconSize.Md`
 

--- a/ui/components/component-library/avatar-icon/__snapshots__/avatar-icon.test.tsx.snap
+++ b/ui/components/component-library/avatar-icon/__snapshots__/avatar-icon.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AvatarIcon should render correctly 1`] = `
     data-testid="avatar-icon"
   >
     <span
-      class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+      class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-md mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
       style="mask-image: url('./images/icons/swap-horizontal.svg');"
     />
   </div>

--- a/ui/components/component-library/avatar-icon/avatar-icon.scss
+++ b/ui/components/component-library/avatar-icon/avatar-icon.scss
@@ -1,0 +1,27 @@
+.mm-avatar-icon {
+  --icon-size: var(--size, 10px);
+
+  font-size: var(--icon-size);
+
+  &__icon {
+    &--size-xs {
+      --size: 10px;
+    }
+
+    &--size-sm {
+      --size: 15px;
+    }
+
+    &--size-md {
+      --size: 20px;
+    }
+
+    &--size-lg {
+      --size: 25px;
+    }
+
+    &--size-xl {
+      --size: 30px;
+    }
+  }
+}

--- a/ui/components/component-library/avatar-icon/avatar-icon.test.tsx
+++ b/ui/components/component-library/avatar-icon/avatar-icon.test.tsx
@@ -28,26 +28,46 @@ describe('AvatarIcon', () => {
           iconName={IconName.SwapHorizontal}
           size={AvatarIconSize.Xs}
           data-testid={AvatarIconSize.Xs}
+          iconProps={{
+            'data-testid': 'xs-icon',
+            name: IconName.SwapHorizontal,
+          }}
         />
         <AvatarIcon
           iconName={IconName.SwapHorizontal}
           size={AvatarIconSize.Sm}
           data-testid={AvatarIconSize.Sm}
+          iconProps={{
+            'data-testid': 'sm-icon',
+            name: IconName.SwapHorizontal,
+          }}
         />
         <AvatarIcon
           iconName={IconName.SwapHorizontal}
           size={AvatarIconSize.Md}
           data-testid={AvatarIconSize.Md}
+          iconProps={{
+            'data-testid': 'md-icon',
+            name: IconName.SwapHorizontal,
+          }}
         />
         <AvatarIcon
           iconName={IconName.SwapHorizontal}
           size={AvatarIconSize.Lg}
           data-testid={AvatarIconSize.Lg}
+          iconProps={{
+            'data-testid': 'lg-icon',
+            name: IconName.SwapHorizontal,
+          }}
         />
         <AvatarIcon
           iconName={IconName.SwapHorizontal}
           size={AvatarIconSize.Xl}
           data-testid={AvatarIconSize.Xl}
+          iconProps={{
+            'data-testid': 'xl-icon',
+            name: IconName.SwapHorizontal,
+          }}
         />
       </>,
     );
@@ -65,6 +85,22 @@ describe('AvatarIcon', () => {
     );
     expect(getByTestId(AvatarIconSize.Xl)).toHaveClass(
       `mm-avatar-base--size-${AvatarIconSize.Xl}`,
+    );
+    // Check icon sizes
+    expect(getByTestId('xs-icon')).toHaveClass(
+      `mm-avatar-icon__icon--size-${AvatarIconSize.Xs}`,
+    );
+    expect(getByTestId('sm-icon')).toHaveClass(
+      `mm-avatar-icon__icon--size-${AvatarIconSize.Sm}`,
+    );
+    expect(getByTestId('md-icon')).toHaveClass(
+      `mm-avatar-icon__icon--size-${AvatarIconSize.Md}`,
+    );
+    expect(getByTestId('lg-icon')).toHaveClass(
+      `mm-avatar-icon__icon--size-${AvatarIconSize.Lg}`,
+    );
+    expect(getByTestId('xl-icon')).toHaveClass(
+      `mm-avatar-icon__icon--size-${AvatarIconSize.Xl}`,
     );
   });
 

--- a/ui/components/component-library/avatar-icon/avatar-icon.tsx
+++ b/ui/components/component-library/avatar-icon/avatar-icon.tsx
@@ -32,33 +32,29 @@ export const AvatarIcon: AvatarIconComponent = React.forwardRef(
       ...props
     }: AvatarIconProps<C>,
     ref?: PolymorphicRef<C>,
-  ) => {
-    const iconSize = avatarIconSizeToIconSize[size];
-    return (
-      <AvatarBase
-        ref={ref}
-        size={size}
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.center}
-        color={color as TextColor}
-        backgroundColor={backgroundColor}
-        borderColor={BorderColor.transparent}
-        className={classnames('mm-avatar-icon', className)}
-        {...(props as AvatarBaseProps<C>)}
-      >
-        <Icon
-          color={IconColor.inherit}
-          name={iconName}
-          size={iconSize}
-          {...iconProps}
-          className={classnames(
-            'mm-avatar-icon__icon',
-            `mm-avatar-icon__icon--size-${size}`,
-            iconProps?.className || '',
-          )}
-        />
-      </AvatarBase>
-    );
-  },
+  ) => (
+    <AvatarBase
+      ref={ref}
+      size={size}
+      display={Display.Flex}
+      alignItems={AlignItems.center}
+      justifyContent={JustifyContent.center}
+      color={color as TextColor}
+      backgroundColor={backgroundColor}
+      borderColor={BorderColor.transparent}
+      className={classnames('mm-avatar-icon', className)}
+      {...(props as AvatarBaseProps<C>)}
+    >
+      <Icon
+        color={IconColor.inherit}
+        name={iconName}
+        {...iconProps}
+        className={classnames(
+          'mm-avatar-icon__icon',
+          `mm-avatar-icon__icon--size-${size}`,
+          iconProps?.className || '',
+        )}
+      />
+    </AvatarBase>
+  ),
 );

--- a/ui/components/component-library/avatar-icon/avatar-icon.tsx
+++ b/ui/components/component-library/avatar-icon/avatar-icon.tsx
@@ -52,6 +52,11 @@ export const AvatarIcon: AvatarIconComponent = React.forwardRef(
           name={iconName}
           size={iconSize}
           {...iconProps}
+          className={classnames(
+            'mm-avatar-icon__icon',
+            `mm-avatar-icon__icon--size-${size}`,
+            iconProps?.className || '',
+          )}
         />
       </AvatarBase>
     );

--- a/ui/components/component-library/avatar-icon/avatar-icon.types.ts
+++ b/ui/components/component-library/avatar-icon/avatar-icon.types.ts
@@ -1,5 +1,5 @@
 import { IconColor, TextColor } from '../../../helpers/constants/design-system';
-import { IconName, IconProps, IconSize } from '../icon';
+import { IconName, IconProps } from '../icon';
 import type { PolymorphicComponentPropWithRef } from '../box';
 import type { AvatarBaseStyleUtilityProps } from '../avatar-base/avatar-base.types';
 
@@ -10,14 +10,6 @@ export enum AvatarIconSize {
   Lg = 'lg',
   Xl = 'xl',
 }
-
-export const avatarIconSizeToIconSize: Record<AvatarIconSize, IconSize> = {
-  [AvatarIconSize.Xs]: IconSize.Xs,
-  [AvatarIconSize.Sm]: IconSize.Sm,
-  [AvatarIconSize.Md]: IconSize.Md,
-  [AvatarIconSize.Lg]: IconSize.Lg,
-  [AvatarIconSize.Xl]: IconSize.Xl,
-};
 
 // TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/ui/components/component-library/component-library-components.scss
+++ b/ui/components/component-library/component-library-components.scss
@@ -20,6 +20,7 @@
 @import 'avatar-base/avatar-base';
 @import 'avatar-account/avatar-account';
 @import 'avatar-favicon/avatar-favicon';
+@import 'avatar-icon/avatar-icon';
 @import 'avatar-network/avatar-network';
 @import 'avatar-token/avatar-token';
 @import 'badge-wrapper/badge-wrapper';

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
@@ -34,7 +34,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-alternative mm-box--border-width-2 box--border-style-solid"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"
+                    class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-sm mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-info-inverse"
                     style="mask-image: url('./images/icons/snaps.svg');"
                   />
                 </div>
@@ -63,7 +63,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon snaps-authorship-header__button mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-md mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/info.svg');"
               />
             </div>
@@ -83,7 +83,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-icon mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-xl mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/user-circle-add.svg');"
                 />
               </div>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/error.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/error.test.js.snap
@@ -24,7 +24,7 @@ exports[`error template matches the snapshot 1`] = `
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-icon mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-error-default mm-box--background-color-error-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-xl mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/warning.svg');"
             />
           </div>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -34,7 +34,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-alternative mm-box--border-width-2 box--border-style-solid"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"
+                    class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-sm mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-info-inverse"
                     style="mask-image: url('./images/icons/snaps.svg');"
                   />
                 </div>
@@ -63,7 +63,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon snaps-authorship-header__button mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-md mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/info.svg');"
               />
             </div>
@@ -86,7 +86,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-icon mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-error-default mm-box--background-color-error-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-xl mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/user-circle-remove.svg');"
                   />
                 </div>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
@@ -34,7 +34,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-alternative mm-box--border-width-2 box--border-style-solid"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"
+                    class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-sm mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-info-inverse"
                     style="mask-image: url('./images/icons/snaps.svg');"
                   />
                 </div>
@@ -59,7 +59,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon snaps-authorship-header__button mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-md mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/info.svg');"
               />
             </div>
@@ -100,7 +100,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-icon snap-delineator__header__icon mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-info-inverse"
+                        class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-xs mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-info-inverse"
                         style="mask-image: url('./images/icons/snaps.svg');"
                       />
                     </div>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/success.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/success.test.js.snap
@@ -24,7 +24,7 @@ exports[`success template matches the snapshot 1`] = `
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-icon mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-success-default mm-box--background-color-success-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-xl mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/confirmation.svg');"
             />
           </div>

--- a/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
+++ b/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-alternative mm-box--border-width-2 box--border-style-solid"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"
+                class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-sm mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-info-inverse"
                 style="mask-image: url('./images/icons/snaps.svg');"
               />
             </div>
@@ -57,7 +57,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon snaps-authorship-header__button mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-md mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/info.svg');"
           />
         </div>
@@ -98,7 +98,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-icon snap-delineator__header__icon mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-info-inverse"
+                    class="mm-box mm-avatar-icon__icon mm-avatar-icon__icon--size-xs mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-info-inverse"
                     style="mask-image: url('./images/icons/snaps.svg');"
                   />
                 </div>


### PR DESCRIPTION
## **Description**

This pull request updates the icon sizes in the `AvatarIcon` component to the following specifications:

xs: 10px
sm: 15px
md: 20px
lg: 25px
xl: 30px

The reason for this change is align the component with [Figma](https://www.figma.com/design/HKpPKij9V3TpsyMV1TpV7C/DS-Components?m=auto&node-id=24776-35374)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25155?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25154

## **Manual testing steps**

1. Open the AvatarIcon storybook.
2. Verify that the icon sizes are updated according to the new specifications (xs: 10px, sm: 15px, md: 20px, lg: 25px, xl: 30px).
3. Ensure that the updated sizes do not break any existing layouts or designs.
4. Check for visual consistency across different components where AvatarIcon is used.

## **Screenshots/Recordings**

### **Before**


https://github.com/MetaMask/metamask-extension/assets/8112138/2d5e45d5-cd7a-4935-ab83-6d53316cfe67



### **After**


https://github.com/MetaMask/metamask-extension/assets/8112138/d7235b94-cc94-4f3e-b3d5-dfc598a8923c



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
