### PR TITLE
feat: Use sandboxed pages for Snaps execution in MV3

### DIFF
--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -75,5 +75,8 @@
     "webRequest",
     "offscreen"
   ],
+  "sandbox": {
+    "pages": ["snaps/index.html"]
+  },
   "short_name": "__MSG_appName__"
 }

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -1,7 +1,7 @@
 {
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none';",
-    "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval';"
+    "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval'; object-src 'none';"
   },
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -1,6 +1,7 @@
 {
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none';"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none';",
+    "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval';"
   },
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -1,7 +1,7 @@
 {
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none';",
-    "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval'; object-src 'none' default-src 'none' connect-src *;"
+    "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval'; object-src 'none'; default-src 'none'; connect-src *;"
   },
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -1,7 +1,7 @@
 {
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none';",
-    "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval'; object-src 'none';"
+    "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval'; object-src 'none' default-src 'none' connect-src *;"
   },
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -202,6 +202,27 @@ function getCopyTargets(
       pattern: `*.html`,
       dest: '',
     },
+    ...(process.env.ENABLE_MV3 === 'true' ||
+    process.env.ENABLE_MV3 === undefined
+      ? [
+          {
+            src: getPathInsideNodeModules(
+              '@metamask/snaps-execution-environments',
+              'dist/browserify/iframe/index.html',
+            ),
+            dest: `snaps/index.html`,
+            pattern: '',
+          },
+          {
+            src: getPathInsideNodeModules(
+              '@metamask/snaps-execution-environments',
+              'dist/browserify/iframe/bundle.js',
+            ),
+            dest: `snaps/bundle.js`,
+            pattern: '',
+          },
+        ]
+      : []),
   ];
 
   if (activeFeatures.includes('blockaid')) {

--- a/offscreen/scripts/offscreen.ts
+++ b/offscreen/scripts/offscreen.ts
@@ -19,4 +19,4 @@ const parentStream = new BrowserRuntimePostMessageStream({
   target: 'parent',
 });
 
-ProxySnapExecutor.initialize(parentStream);
+ProxySnapExecutor.initialize(parentStream, '/snaps/index.html');

--- a/offscreen/scripts/offscreen.ts
+++ b/offscreen/scripts/offscreen.ts
@@ -19,4 +19,4 @@ const parentStream = new BrowserRuntimePostMessageStream({
   target: 'parent',
 });
 
-ProxySnapExecutor.initialize(parentStream, '/snaps/index.html');
+ProxySnapExecutor.initialize(parentStream, './snaps/index.html');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Moves the execution of Snaps to a [sandboxed page](https://developer.chrome.com/docs/extensions/how-to/security/sandboxing-eval) referencing a local HTML file inside the offscreen document when using the MV3 build. This effectively gives us access to `eval` without hitting the network and should reduce the overhead when booting a Snap (+ allow for Snaps to execute when the user is offline).

To support this, this PR introduces some new changes to the manifest as well as the build process. For the build process we simply copy the same iframe bundle currently used in the hosted version to `/dist/chrome/snaps`. For the manifest, we add a reference to the sandboxed page and tweak the CSP of the sandbox to be as restrictive as possible (the default is not very strict). Then we can simply point the existing offscreen executor to use the local iframe instead of the remote one.

Closes https://github.com/MetaMask/metamask-extension/issues/25250

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25171?quickstart=1)
