### PR TITLE
Version v11.16.9

### DIFF
--- a/.yarn/patches/@metamask-snaps-controllers-patch-93f004a36a.patch
+++ b/.yarn/patches/@metamask-snaps-controllers-patch-93f004a36a.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/chunk-HBNET6MY.mjs b/dist/chunk-HBNET6MY.mjs
+index 5843d635c91e9125d130a6ef5688550e5d514eaa..6ef8d23c52c7ddb28a1912967e4b658fe6f8ef1c 100644
+--- a/dist/chunk-HBNET6MY.mjs
++++ b/dist/chunk-HBNET6MY.mjs
+@@ -1749,7 +1749,7 @@ decryptSnapState_fn = async function(snapId, state) {
+       snapId,
+       salt,
+       useCache,
+-      keyMetadata
++      keyMetadata: keyMetadata ?? { algorithm: 'PBKDF2', params: { iterations: 10_000 } }
+     });
+     const decryptedState = await __privateGet(this, _encryptor).decryptWithKey(key, parsed);
+     assert(isValidJson(decryptedState));
+diff --git a/dist/chunk-JMP6XYRL.js b/dist/chunk-JMP6XYRL.js
+index 20c3b12643e4f87d70aa0df96a36c4dda8b1ed47..c442feb729f41d9d73d1008a3215d73d7b288090 100644
+--- a/dist/chunk-JMP6XYRL.js
++++ b/dist/chunk-JMP6XYRL.js
+@@ -1749,7 +1749,7 @@ decryptSnapState_fn = async function(snapId, state) {
+       snapId,
+       salt,
+       useCache,
+-      keyMetadata
++      keyMetadata: keyMetadata ?? { algorithm: 'PBKDF2', params: { iterations: 10_000 } }
+     });
+     const decryptedState = await _chunkEXN2TFDJjs.__privateGet.call(void 0, this, _encryptor).decryptWithKey(key, parsed);
+     _utils.assert.call(void 0, _utils.isValidJson.call(void 0, decryptedState));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.16.9]
+### Fixed
+- Fix an issue where Snaps would be unable to decrypt older state ([#25172](https://github.com/MetaMask/metamask-extension/pull/25172))
+
 ## [11.16.8]
 ### Changed
 - Prepare for increasing the minimum Chromium version supported by MetaMask ([#25142](https://github.com/MetaMask/metamask-extension/pull/25142))
@@ -4800,7 +4804,8 @@ Update styles and spacing on the critical error page  ([#20350](https://github.c
 - Added the ability to restore accounts from seed words.
 
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.16.8...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.16.9...HEAD
+[11.16.9]: https://github.com/MetaMask/metamask-extension/compare/v11.16.8...v11.16.9
 [11.16.8]: https://github.com/MetaMask/metamask-extension/compare/v11.16.7...v11.16.8
 [11.16.7]: https://github.com/MetaMask/metamask-extension/compare/v11.16.6...v11.16.7
 [11.16.6]: https://github.com/MetaMask/metamask-extension/compare/v11.16.5...v11.16.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "11.16.8",
+  "version": "11.16.9",
   "private": true,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -331,7 +331,7 @@
     "@metamask/selected-network-controller": "patch:@metamask/selected-network-controller@npm%3A12.0.1#~/.yarn/patches/@metamask-selected-network-controller-npm-12.0.1-34b2edf62d.patch",
     "@metamask/signature-controller": "^12.0.0",
     "@metamask/smart-transactions-controller": "^10.0.1",
-    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A8.0.0#~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch",
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@patch%3A@metamask/snaps-controllers@npm%253A8.0.0%23~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch%3A%3Aversion=8.0.0&hash=79a89d#~/.yarn/patches/@metamask-snaps-controllers-patch-93f004a36a.patch",
     "@metamask/snaps-execution-environments": "6.0.2",
     "@metamask/snaps-rpc-methods": "8.0.0",
     "@metamask/snaps-sdk": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5784,7 +5784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A8.0.0#~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch":
+"@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A8.0.0#~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch::version=8.0.0&hash=79a89d":
   version: 8.0.0
   resolution: "@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A8.0.0#~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch::version=8.0.0&hash=79a89d"
   dependencies:
@@ -5818,6 +5818,43 @@ __metadata:
     "@metamask/snaps-execution-environments":
       optional: true
   checksum: db702ffb0e558762cada896e6c115a31f1676d89de63ce9a78e105967579cb25c7b4a9f4912fd750285dd53d092c8d1742be636923cdbbb3634c983798d2f089
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-controllers@patch:@metamask/snaps-controllers@patch%3A@metamask/snaps-controllers@npm%253A8.0.0%23~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch%3A%3Aversion=8.0.0&hash=79a89d#~/.yarn/patches/@metamask-snaps-controllers-patch-93f004a36a.patch":
+  version: 8.0.0
+  resolution: "@metamask/snaps-controllers@patch:@metamask/snaps-controllers@patch%3A@metamask/snaps-controllers@npm%253A8.0.0%23~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch%3A%3Aversion=8.0.0&hash=79a89d#~/.yarn/patches/@metamask-snaps-controllers-patch-93f004a36a.patch::version=8.0.0&hash=e80d43"
+  dependencies:
+    "@metamask/approval-controller": "npm:^6.0.1"
+    "@metamask/base-controller": "npm:^5.0.1"
+    "@metamask/json-rpc-engine": "npm:^8.0.1"
+    "@metamask/json-rpc-middleware-stream": "npm:^7.0.1"
+    "@metamask/object-multiplex": "npm:^2.0.0"
+    "@metamask/permission-controller": "npm:^9.0.2"
+    "@metamask/phishing-controller": "npm:^9.0.1"
+    "@metamask/post-message-stream": "npm:^8.0.0"
+    "@metamask/rpc-errors": "npm:^6.2.1"
+    "@metamask/snaps-registry": "npm:^3.1.0"
+    "@metamask/snaps-rpc-methods": "npm:^8.0.0"
+    "@metamask/snaps-sdk": "npm:^4.0.1"
+    "@metamask/snaps-utils": "npm:^7.2.0"
+    "@metamask/utils": "npm:^8.3.0"
+    "@xstate/fsm": "npm:^2.0.0"
+    browserify-zlib: "npm:^0.2.0"
+    concat-stream: "npm:^2.0.0"
+    fast-deep-equal: "npm:^3.1.3"
+    get-npm-tarball-url: "npm:^2.0.3"
+    immer: "npm:^9.0.6"
+    nanoid: "npm:^3.1.31"
+    readable-stream: "npm:^3.6.2"
+    readable-web-to-node-stream: "npm:^3.0.2"
+    tar-stream: "npm:^3.1.7"
+  peerDependencies:
+    "@metamask/snaps-execution-environments": ^6.0.2
+  peerDependenciesMeta:
+    "@metamask/snaps-execution-environments":
+      optional: true
+  checksum: 2f7d2a15c0758a0be1058af7f0eecec6ba3b65c87ed88498cc5e11f5fe9ab01de3cc1a11deb39c94ad0d35e6cdf889788a9dc8161b81f60b18857762e2d3be0a
   languageName: node
   linkType: hard
 
@@ -25176,7 +25213,7 @@ __metadata:
     "@metamask/selected-network-controller": "patch:@metamask/selected-network-controller@npm%3A12.0.1#~/.yarn/patches/@metamask-selected-network-controller-npm-12.0.1-34b2edf62d.patch"
     "@metamask/signature-controller": "npm:^12.0.0"
     "@metamask/smart-transactions-controller": "npm:^10.0.1"
-    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A8.0.0#~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch"
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@patch%3A@metamask/snaps-controllers@npm%253A8.0.0%23~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch%3A%3Aversion=8.0.0&hash=79a89d#~/.yarn/patches/@metamask-snaps-controllers-patch-93f004a36a.patch"
     "@metamask/snaps-execution-environments": "npm:6.0.2"
     "@metamask/snaps-rpc-methods": "npm:8.0.0"
     "@metamask/snaps-sdk": "npm:4.0.1"


### PR DESCRIPTION
Hotfix release for an issue affecting Snaps state decryption.

Patches in this upstream fix: https://github.com/MetaMask/snaps/commit/e71713915ee883a37cc327e6486831f74fb84a55