### PR TITLE
feat: Add abstraction for Snaps permissions

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4602,6 +4602,10 @@
     "message": "Powered by $1",
     "description": "The security provider that is providing data"
   },
+  "seeAllPermissions": {
+    "message": "See all permissions",
+    "description": "Used for revealing more content (e.g. permission list, etc.)"
+  },
   "seeDetails": {
     "message": "See details"
   },

--- a/shared/constants/permissions.ts
+++ b/shared/constants/permissions.ts
@@ -33,7 +33,7 @@ export const ConnectionPermission = Object.freeze({
 // permissions to show or hide on certain Snap-related flows (Install, Update, etc.)
 export const PermissionWeightThreshold = Object.freeze({
   snapInstall: 3 as const,
-  snapUpdateApprovedPermissions: 2 as const,
+  snapUpdateApprovedPermissions: 3 as const,
 });
 
 // Specify minimum number of permissions to be shown, when abstraction is applied

--- a/shared/constants/permissions.ts
+++ b/shared/constants/permissions.ts
@@ -36,6 +36,9 @@ export const PermissionWeightThreshold = Object.freeze({
   snapUpdateApprovedPermissions: 2 as const,
 });
 
+// Specify minimum number of permissions to be shown, when abstraction is applied
+export const MinPermissionAbstractionDisplayCount = 3;
+
 // Specify number of permissions used as threshold for permission abstraction logic to be applied
 export const PermissionsAbstractionThreshold = 3;
 

--- a/shared/constants/permissions.ts
+++ b/shared/constants/permissions.ts
@@ -29,4 +29,42 @@ export const ConnectionPermission = Object.freeze({
   connection_permission: 'connection_permission',
 });
 
+// This configuration specifies permission weight thresholds used to determine which
+// permissions to show or hide on certain Snap-related flows (Install, Update, etc.)
+export const PermissionWeightThreshold = Object.freeze({
+  snapInstall: 3 as const,
+  snapUpdateApprovedPermissions: 2 as const,
+});
+
+// Specify number of permissions used as threshold for permission abstraction logic to be applied
+export const PermissionsAbstractionThreshold = 3;
+
+export const PermissionWeight = Object.freeze({
+  eth_accounts: 3,
+  permittedChains: 3,
+  snap_dialog: 4,
+  snap_notify: 4,
+  snap_getBip32PublicKey: 3,
+  snap_getBip32Entropy: 1,
+  snap_getBip44Entropy: 1,
+  snap_getEntropy: 3,
+  snap_manageState: 4,
+  snap_getLocale: 4,
+  wallet_snap: 4,
+  endowment_networkAccess: 3,
+  endowment_webassembly: 4,
+  endowment_transactionInsight: 4,
+  endowment_cronjob: 4,
+  endowment_ethereumProvider: 4,
+  endowment_rpc: 4,
+  endowment_lifecycleHooks: 4,
+  endowment_pageHome: 4,
+  snap_manageAccounts: 3,
+  endowment_keyring: 4,
+  endowment_nameLookup: 3,
+  endowment_signatureInsight: 4,
+  connection_permission: 3,
+  unknown_permission: 3,
+});
+
 export * from './snaps/permissions';

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -1937,6 +1937,54 @@
           }
         }
       }
+    },
+    "subjects": {
+      "npm:@metamask/test-snap-bip44": {
+        "origin": "npm:@metamask/test-snap-bip44",
+        "permissions": {
+          "endowment:rpc": {
+            "caveats": [
+              {
+                "type": "rpcOrigin",
+                "value": {
+                  "allowedOrigins": ["npm:@metamask/json-rpc-example-snap"],
+                  "dapps": true
+                }
+              }
+            ],
+            "date": 1718117256761,
+            "id": "MhjpHKQFfGpMzI6YzkPGU",
+            "invoker": "npm:@metamask/test-snap-bip44",
+            "parentCapability": "endowment:rpc"
+          },
+          "snap_dialog": {
+            "caveats": null,
+            "date": 1718117256761,
+            "id": "sBxmdvnow7QiN9aS4uSdn",
+            "invoker": "npm:@metamask/test-snap-bip44",
+            "parentCapability": "snap_dialog"
+          },
+          "snap_getBip44Entropy": {
+            "caveats": [
+              {
+                "type": "permittedCoinTypes",
+                "value": [
+                  {
+                    "coinType": 1
+                  },
+                  {
+                    "coinType": 3
+                  }
+                ]
+              }
+            ],
+            "date": 1718117256762,
+            "id": "R9tggB2pDzyCcbt6dIebN",
+            "invoker": "npm:@metamask/test-snap-bip44",
+            "parentCapability": "snap_getBip44Entropy"
+          }
+        }
+      }
     }
   },
   "ramps": {

--- a/ui/components/app/snaps/snap-permission-adapter/index.js
+++ b/ui/components/app/snaps/snap-permission-adapter/index.js
@@ -1,0 +1,1 @@
+export { default } from './snap-permission-adapter';

--- a/ui/components/app/snaps/snap-permission-adapter/snap-permission-adapter.js
+++ b/ui/components/app/snaps/snap-permission-adapter/snap-permission-adapter.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import SnapPermissionCell from '../snap-permission-cell';
+
+export default function SnapPermissionAdapter({
+  snapId,
+  permissions,
+  showOptions,
+  targetSubjectsMetadata,
+  revoked,
+  approved,
+}) {
+  return permissions.map((permission, index) => (
+    <SnapPermissionCell
+      snapId={snapId}
+      showOptions={showOptions}
+      connectionSubjectMetadata={targetSubjectsMetadata[permission.connection]}
+      permission={permission}
+      index={index}
+      key={`permissionCellDisplay_${snapId}_${index}`}
+      revoked={revoked}
+      approved={approved}
+    />
+  ));
+}
+
+SnapPermissionAdapter.propTypes = {
+  snapId: PropTypes.string.isRequired,
+  snapName: PropTypes.string.isRequired,
+  permissions: PropTypes.array.isRequired,
+  showOptions: PropTypes.bool,
+  targetSubjectsMetadata: PropTypes.object,
+  weightThreshold: PropTypes.number,
+  revoked: PropTypes.bool,
+  approved: PropTypes.bool,
+};

--- a/ui/components/app/snaps/snap-permission-adapter/snap-permission-adapter.test.js
+++ b/ui/components/app/snaps/snap-permission-adapter/snap-permission-adapter.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../test/jest';
+import configureStore from '../../../../store/store';
+import SnapPermissionAdapter from './snap-permission-adapter';
+
+describe('Snap Permission Adapter', () => {
+  const mockSnapId = 'mock-snap-id';
+  const mockSnapName = 'Snap Name';
+  const mockTargetSubjectMetadata = {
+    extensionId: null,
+    iconUrl: null,
+    name: 'TypeScript Example Snap',
+    origin: 'local:http://localhost:8080',
+    subjectType: 'snap',
+    version: '0.2.2',
+  };
+  const mockState = {
+    metamask: {
+      subjectMetadata: {
+        'npm:@metamask/notifications-example-snap': {
+          name: 'Notifications Example Snap',
+          version: '1.2.3',
+          subjectType: 'snap',
+        },
+      },
+      snaps: {
+        'npm:@metamask/notifications-example-snap': {
+          id: 'npm:@metamask/notifications-example-snap',
+          version: '1.2.3',
+          manifest: {
+            proposedName: 'Notifications Example Snap',
+            description: 'A snap',
+          },
+        },
+      },
+    },
+  };
+  const mockWeightedPermissions = [
+    {
+      leftIcon: 'hierarchy',
+      weight: 3,
+      label: 'Allow websites to communicate directly with Dialog Example Snap.',
+      description: {},
+      permissionName: 'endowment:rpc',
+      permissionValue: {
+        caveats: [
+          {
+            type: 'rpcOrigin',
+            value: {
+              dapps: true,
+            },
+          },
+        ],
+      },
+    },
+    {
+      label: 'Display dialog windows in MetaMask.',
+      description: {},
+      leftIcon: 'messages',
+      weight: 4,
+      permissionName: 'snap_dialog',
+      permissionValue: {},
+    },
+  ];
+
+  const store = configureStore(mockState);
+
+  it('renders set of provided permissions', () => {
+    renderWithProvider(
+      <SnapPermissionAdapter
+        snapId={mockSnapId}
+        snapName={mockSnapName}
+        permissions={mockWeightedPermissions}
+        targetSubjectsMetadata={{ ...mockTargetSubjectMetadata }}
+      />,
+      store,
+    );
+    expect(
+      screen.queryByText('Display dialog windows in MetaMask.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Allow websites to communicate directly with Dialog Example Snap.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -87,7 +87,7 @@ export default function SnapPermissionsList({
           paddingTop={2}
           paddingBottom={2}
         >
-          <ButtonLink onClick={() => onShowAllPermissionsHandler()}>
+          <ButtonLink onClick={onShowAllPermissionsHandler}>
             {t('seeAllPermissions')}
           </ButtonLink>
         </Box>

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -13,6 +13,7 @@ import {
   JustifyContent,
 } from '../../../../helpers/constants/design-system';
 import {
+  MinPermissionAbstractionDisplayCount,
   PermissionsAbstractionThreshold,
   PermissionWeightThreshold,
 } from '../../../../../shared/constants/permissions';
@@ -60,7 +61,7 @@ export default function SnapPermissionsList({
   const filteredPermissions = getFilteredSnapPermissions(
     weightedPermissions,
     PermissionWeightThreshold.snapInstall,
-    true,
+    MinPermissionAbstractionDisplayCount,
   );
 
   const onShowAllPermissionsHandler = () => {

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -1,15 +1,27 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { getWeightedPermissions } from '../../../../helpers/utils/permission';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Box } from '../../../component-library';
+import { Box, ButtonLink } from '../../../component-library';
 import {
   getMultipleTargetsSubjectMetadata,
   getSnapsMetadata,
 } from '../../../../selectors';
-import { getSnapName } from '../../../../helpers/utils/util';
-import SnapPermissionCell from '../snap-permission-cell';
+import {
+  Display,
+  FlexDirection,
+  JustifyContent,
+} from '../../../../helpers/constants/design-system';
+import {
+  PermissionsAbstractionThreshold,
+  PermissionWeightThreshold,
+} from '../../../../../shared/constants/permissions';
+import {
+  getFilteredSnapPermissions,
+  getSnapName,
+} from '../../../../helpers/utils/util';
+import { getWeightedPermissions } from '../../../../helpers/utils/permission';
+import SnapPermissionAdapter from '../snap-permission-adapter';
 
 export default function SnapPermissionsList({
   snapId,
@@ -17,36 +29,68 @@ export default function SnapPermissionsList({
   permissions,
   connections,
   showOptions,
+  showAllPermissions,
+  onShowAllPermissions,
 }) {
   const t = useI18nContext();
-  const snapsMetadata = useSelector(getSnapsMetadata);
-  const permissionsToShow = {
-    ...permissions,
-    connection_permission: connections ?? {},
-  };
+
+  const combinedPermissions = useMemo(() => {
+    return { ...permissions, connection_permission: connections ?? {} };
+  }, [permissions, connections]);
+
   const targetSubjectsMetadata = useSelector((state) =>
     getMultipleTargetsSubjectMetadata(state, connections),
   );
 
+  const snapsMetadata = useSelector(getSnapsMetadata);
+
+  const weightedPermissions = getWeightedPermissions({
+    t,
+    permissions: combinedPermissions,
+    subjectName: snapName,
+    getSubjectName: getSnapName(snapsMetadata),
+  });
+
+  const [showAll, setShowAll] = useState(
+    showAllPermissions ||
+      Object.keys(weightedPermissions).length <=
+        PermissionsAbstractionThreshold,
+  );
+
+  const filteredPermissions = getFilteredSnapPermissions(
+    weightedPermissions,
+    PermissionWeightThreshold.snapInstall,
+    true,
+  );
+
+  const onShowAllPermissionsHandler = () => {
+    onShowAllPermissions();
+    setShowAll(true);
+  };
+
   return (
-    <Box className="snap-permissions-list">
-      {getWeightedPermissions({
-        t,
-        permissions: permissionsToShow,
-        subjectName: snapName,
-        getSubjectName: getSnapName(snapsMetadata),
-      }).map((permission, index) => (
-        <SnapPermissionCell
+    <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+      <Box className="snap-permissions-list">
+        <SnapPermissionAdapter
+          permissions={showAll ? weightedPermissions : filteredPermissions}
           snapId={snapId}
+          snapName={snapName}
           showOptions={showOptions}
-          connectionSubjectMetadata={
-            targetSubjectsMetadata[permission.connection]
-          }
-          permission={permission}
-          index={index}
-          key={`permissionCellDisplay_${snapId}_${index}`}
+          targetSubjectsMetadata={targetSubjectsMetadata}
         />
-      ))}
+      </Box>
+      {showAll ? null : (
+        <Box
+          display={Display.Flex}
+          justifyContent={JustifyContent.center}
+          paddingTop={2}
+          paddingBottom={2}
+        >
+          <ButtonLink onClick={() => onShowAllPermissionsHandler()}>
+            {t('seeAllPermissions')}
+          </ButtonLink>
+        </Box>
+      )}
     </Box>
   );
 }
@@ -57,4 +101,6 @@ SnapPermissionsList.propTypes = {
   permissions: PropTypes.object.isRequired,
   connections: PropTypes.object,
   showOptions: PropTypes.bool,
+  showAllPermissions: PropTypes.bool,
+  onShowAllPermissions: PropTypes.func,
 };

--- a/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
+++ b/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
@@ -1,16 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getWeightedPermissions } from '../../../../helpers/utils/permission';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Box } from '../../../component-library';
+import { Box, ButtonLink } from '../../../component-library';
 import {
   getMultipleTargetsSubjectMetadata,
   getSnapMetadata,
   getSnapsMetadata,
 } from '../../../../selectors';
-import { getSnapName } from '../../../../helpers/utils/util';
-import SnapPermissionCell from '../snap-permission-cell';
+import SnapPermissionAdapter from '../snap-permission-adapter';
+import {
+  Display,
+  JustifyContent,
+} from '../../../../helpers/constants/design-system';
+import { PermissionWeightThreshold } from '../../../../../shared/constants/permissions';
+import {
+  getFilteredSnapPermissions,
+  getSnapName,
+} from '../../../../helpers/utils/util';
+import { getWeightedPermissions } from '../../../../helpers/utils/permission';
 
 export default function UpdateSnapPermissionList({
   approvedPermissions,
@@ -20,6 +28,7 @@ export default function UpdateSnapPermissionList({
   revokedConnections,
   newConnections,
   targetSubjectMetadata,
+  showAllPermissions,
 }) {
   const t = useI18nContext();
   const snapId = targetSubjectMetadata.origin;
@@ -37,75 +46,95 @@ export default function UpdateSnapPermissionList({
   );
 
   const snapsMetadata = useSelector(getSnapsMetadata);
-  const snapsNameGetter = getSnapName(snapsMetadata);
 
-  const approvedPermissionsToShow = {
+  const approvedCombinedPermissions = {
     ...approvedPermissions,
     connection_permission: approvedConnections ?? {},
   };
 
-  const revokedPermissionsToShow = {
+  const revokedCombinedPermissions = {
     ...revokedPermissions,
     connection_permission: revokedConnections ?? {},
   };
 
-  const newPermissionsToShow = {
+  const newCombinedPermissions = {
     ...newPermissions,
     connection_permission: newConnections ?? {},
   };
 
+  const newWeightedPermissions = getWeightedPermissions({
+    t,
+    permissions: newCombinedPermissions,
+    subjectName: snapName,
+    getSubjectName: getSnapName(snapsMetadata),
+  });
+
+  const revokedWeightedPermissions = getWeightedPermissions({
+    t,
+    permissions: revokedCombinedPermissions,
+    subjectName: snapName,
+    getSubjectName: getSnapName(snapsMetadata),
+  });
+
+  const approvedWeightedPermissions = getWeightedPermissions({
+    t,
+    permissions: approvedCombinedPermissions,
+    subjectName: snapName,
+    getSubjectName: getSnapName(snapsMetadata),
+  });
+
+  const [showAll, setShowAll] = useState(
+    Object.keys(approvedWeightedPermissions).length < 1,
+  );
+
+  const filteredApprovedWeightedPermissions = getFilteredSnapPermissions(
+    approvedWeightedPermissions,
+    PermissionWeightThreshold.snapUpdateApprovedPermissions,
+  );
+
+  const onShowAllPermissions = () => {
+    showAllPermissions();
+    setShowAll(true);
+  };
+
   return (
     <Box>
-      {getWeightedPermissions({
-        t,
-        permissions: newPermissionsToShow,
-        subjectName: snapName,
-        getSubjectName: snapsNameGetter,
-      }).map((permission, index) => (
-        <SnapPermissionCell
-          snapId={snapId}
-          connectionSubjectMetadata={
-            targetSubjectsMetadata[permission.connection]
-          }
-          permission={permission}
-          index={index}
-          key={`permissionCellDisplay_${snapId}_${index}`}
-        />
-      ))}
-      {getWeightedPermissions({
-        t,
-        permissions: revokedPermissionsToShow,
-        subjectName: snapName,
-        getSubjectName: snapsNameGetter,
-      }).map((permission, index) => (
-        <SnapPermissionCell
-          snapId={snapId}
-          connectionSubjectMetadata={
-            targetSubjectsMetadata[permission.connection]
-          }
-          permission={permission}
-          index={index}
-          key={`permissionCellDisplay_${snapId}_${index}`}
-          revoked
-        />
-      ))}
-      {getWeightedPermissions({
-        t,
-        permissions: approvedPermissionsToShow,
-        subjectName: snapName,
-        getSubjectName: snapsNameGetter,
-      }).map((permission, index) => (
-        <SnapPermissionCell
-          snapId={snapId}
-          connectionSubjectMetadata={
-            targetSubjectsMetadata[permission.connection]
-          }
-          permission={permission}
-          index={index}
-          key={`permissionCellDisplay_${snapId}_${index}`}
-          approved
-        />
-      ))}
+      <SnapPermissionAdapter
+        permissions={newWeightedPermissions}
+        snapId={snapId}
+        snapName={snapName}
+        targetSubjectsMetadata={targetSubjectsMetadata}
+      />
+      <SnapPermissionAdapter
+        permissions={revokedWeightedPermissions}
+        snapId={snapId}
+        snapName={snapName}
+        targetSubjectsMetadata={targetSubjectsMetadata}
+        revoked
+      />
+      <SnapPermissionAdapter
+        permissions={
+          showAll
+            ? approvedWeightedPermissions
+            : filteredApprovedWeightedPermissions
+        }
+        snapId={snapId}
+        snapName={snapName}
+        targetSubjectsMetadata={targetSubjectsMetadata}
+        approved
+      />
+      {showAll ? null : (
+        <Box
+          display={Display.Flex}
+          justifyContent={JustifyContent.center}
+          paddingTop={2}
+          paddingBottom={2}
+        >
+          <ButtonLink onClick={() => onShowAllPermissions()}>
+            {t('seeAllPermissions')}
+          </ButtonLink>
+        </Box>
+      )}
     </Box>
   );
 }
@@ -135,5 +164,9 @@ UpdateSnapPermissionList.propTypes = {
    * New pre-approved connections that are being requested
    */
   newConnections: PropTypes.object.isRequired,
+  /**
+   * Callback function used to handle revealing all permissions action in UI.
+   */
+  showAllPermissions: PropTypes.func.isRequired,
   targetSubjectMetadata: PropTypes.object.isRequired,
 };

--- a/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
+++ b/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
@@ -87,9 +87,31 @@ export default function UpdateSnapPermissionList({
     Object.keys(approvedWeightedPermissions).length < 1,
   );
 
+  // Because approved permissions are sometimes hidden following the abstraction logic,
+  // it is needed sometimes to fill the gap in permission display, in certain edge cases
+  // when there is not enough new and revoked permissions to be shown.
+  let minApprovedPermissionsToShow;
+  const totalNewAndRevokedPermissions =
+    newWeightedPermissions.length + revokedWeightedPermissions.length;
+
+  switch (totalNewAndRevokedPermissions) {
+    case 0:
+      minApprovedPermissionsToShow = 3;
+      break;
+    case 1:
+      minApprovedPermissionsToShow = 2;
+      break;
+    case 2:
+      minApprovedPermissionsToShow = 1;
+      break;
+    default:
+      minApprovedPermissionsToShow = 0;
+  }
+
   const filteredApprovedWeightedPermissions = getFilteredSnapPermissions(
     approvedWeightedPermissions,
     PermissionWeightThreshold.snapUpdateApprovedPermissions,
+    minApprovedPermissionsToShow,
   );
 
   const onShowAllPermissions = () => {

--- a/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
+++ b/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
@@ -13,7 +13,10 @@ import {
   Display,
   JustifyContent,
 } from '../../../../helpers/constants/design-system';
-import { PermissionWeightThreshold } from '../../../../../shared/constants/permissions';
+import {
+  MinPermissionAbstractionDisplayCount,
+  PermissionWeightThreshold,
+} from '../../../../../shared/constants/permissions';
 import {
   getFilteredSnapPermissions,
   getSnapName,
@@ -90,23 +93,12 @@ export default function UpdateSnapPermissionList({
   // Because approved permissions are sometimes hidden following the abstraction logic,
   // it is needed sometimes to fill the gap in permission display, in certain edge cases
   // when there is not enough new and revoked permissions to be shown.
-  let minApprovedPermissionsToShow;
   const totalNewAndRevokedPermissions =
     newWeightedPermissions.length + revokedWeightedPermissions.length;
-
-  switch (totalNewAndRevokedPermissions) {
-    case 0:
-      minApprovedPermissionsToShow = 3;
-      break;
-    case 1:
-      minApprovedPermissionsToShow = 2;
-      break;
-    case 2:
-      minApprovedPermissionsToShow = 1;
-      break;
-    default:
-      minApprovedPermissionsToShow = 0;
-  }
+  const minApprovedPermissionsToShow = Math.max(
+    MinPermissionAbstractionDisplayCount - totalNewAndRevokedPermissions,
+    0,
+  );
 
   const filteredApprovedWeightedPermissions = getFilteredSnapPermissions(
     approvedWeightedPermissions,

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -8,13 +8,12 @@ import {
   getSnapDerivationPathName,
 } from '@metamask/snaps-utils';
 import { isNonEmptyArray } from '@metamask/controller-utils';
-import classnames from 'classnames';
 import {
   RestrictedMethods,
   EndowmentPermissions,
   ConnectionPermission,
+  PermissionWeight,
 } from '../../../shared/constants/permissions';
-import Tooltip from '../../components/ui/tooltip';
 import {
   Icon,
   Text,
@@ -52,12 +51,12 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
   [RestrictedMethods.eth_accounts]: ({ t }) => ({
     label: t('permission_ethereumAccounts'),
     leftIcon: IconName.Eye,
-    weight: 3,
+    weight: PermissionWeight.eth_accounts,
   }),
   [PermissionNames.permittedChains]: ({ t }) => ({
     label: t('permission_walletSwitchEthereumChain'),
     leftIcon: IconName.Wifi,
-    weight: 3,
+    weight: PermissionWeight.permittedChains,
   }),
   [RestrictedMethods.snap_dialog]: ({ t, subjectName }) => ({
     label: t('permission_dialog'),
@@ -65,7 +64,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.Messages,
-    weight: 4,
+    weight: PermissionWeight.snap_dialog,
   }),
   [RestrictedMethods.snap_notify]: ({ t, subjectName }) => ({
     label: t('permission_notifications'),
@@ -73,7 +72,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.Notification,
-    weight: 4,
+    weight: PermissionWeight.snap_notify,
   }),
   [RestrictedMethods.snap_getBip32PublicKey]: ({
     t,
@@ -83,7 +82,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     permissionValue.caveats[0].value.map(({ path, curve }, i) => {
       const baseDescription = {
         leftIcon: IconName.SecuritySearch,
-        weight: 2,
+        weight: PermissionWeight.snap_getBip32PublicKey,
         id: `public-key-access-bip32-${path
           .join('-')
           ?.replace(/'/gu, 'h')}-${curve}-${i}`,
@@ -154,7 +153,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     permissionValue.caveats[0].value.map(({ path, curve }, i) => {
       const baseDescription = {
         leftIcon: IconName.Key,
-        weight: 1,
+        weight: PermissionWeight.snap_getBip32Entropy,
         id: `key-access-bip32-${path
           .join('-')
           ?.replace(/'/gu, 'h')}-${curve}-${i}`,
@@ -221,7 +220,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
         getSnapNameComponent(subjectName),
       ]),
       leftIcon: IconName.Key,
-      weight: 1,
+      weight: PermissionWeight.snap_getBip44Entropy,
       id: `key-access-bip44-${coinType}-${i}`,
       warningMessageSubject:
         getSlip44ProtocolName(coinType) ??
@@ -233,7 +232,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.SecurityKey,
-    weight: 4,
+    weight: PermissionWeight.snap_getEntropy,
   }),
 
   [RestrictedMethods.snap_manageState]: ({ t, subjectName }) => ({
@@ -242,7 +241,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.AddSquare,
-    weight: 4,
+    weight: PermissionWeight.snap_manageState,
   }),
   [RestrictedMethods.snap_getLocale]: ({ t, subjectName }) => ({
     label: t('permission_getLocale'),
@@ -250,13 +249,14 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.Global,
-    weight: 4,
+    weight: PermissionWeight.snap_getLocale,
   }),
   [RestrictedMethods.wallet_snap]: ({ t, permissionValue, getSubjectName }) => {
     const snaps = permissionValue.caveats[0].value;
     const baseDescription = {
       leftIcon: IconName.Flash,
       rightIcon: RIGHT_INFO_ICON,
+      weight: PermissionWeight.wallet_snap,
     };
 
     return Object.keys(snaps).map((snapId) => {
@@ -291,7 +291,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.Wifi,
-    weight: 3,
+    weight: PermissionWeight.endowment_networkAccess,
   }),
   [EndowmentPermissions['endowment:webassembly']]: ({ t, subjectName }) => ({
     label: t('permission_webAssembly'),
@@ -300,7 +300,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     ]),
     leftIcon: IconName.DocumentCode,
     rightIcon: null,
-    weight: 3,
+    weight: PermissionWeight.endowment_webassembly,
   }),
   [EndowmentPermissions['endowment:transaction-insight']]: ({
     t,
@@ -309,7 +309,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
   }) => {
     const baseDescription = {
       leftIcon: IconName.Speedometer,
-      weight: 4,
+      weight: PermissionWeight.endowment_transactionInsight,
     };
 
     const result = [
@@ -345,7 +345,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.Clock,
-    weight: 3,
+    weight: PermissionWeight.endowment_cronjob,
   }),
   [EndowmentPermissions['endowment:ethereum-provider']]: ({
     t,
@@ -356,7 +356,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.Ethereum,
-    weight: 3,
+    weight: PermissionWeight.endowment_ethereumProvider,
     id: 'ethereum-provider-access',
     message: t('ethereumProviderAccess', [getSnapNameComponent(subjectName)]),
   }),
@@ -367,7 +367,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
   }) => {
     const baseDescription = {
       leftIcon: IconName.Hierarchy,
-      weight: 3,
+      weight: PermissionWeight.endowment_rpc,
     };
 
     const { snaps, dapps, allowedOrigins } =
@@ -466,7 +466,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.Hierarchy,
-    weight: 4,
+    weight: PermissionWeight.endowment_lifecycleHooks,
   }),
   [EndowmentPermissions['endowment:page-home']]: ({ t, subjectName }) => ({
     label: t('permission_homePage'),
@@ -474,7 +474,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
       getSnapNameComponent(subjectName),
     ]),
     leftIcon: IconName.Home,
-    weight: 4,
+    weight: PermissionWeight.endowment_pageHome,
   }),
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   [RestrictedMethods.snap_manageAccounts]: ({ t, subjectName }) => ({
@@ -484,7 +484,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     ]),
     leftIcon: IconName.UserCircleAdd,
     rightIcon: null,
-    weight: 3,
+    weight: PermissionWeight.snap_manageAccounts,
   }),
   [EndowmentPermissions['endowment:keyring']]: ({ t, subjectName }) => ({
     label: t('permission_keyring'),
@@ -493,7 +493,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     ]),
     leftIcon: IconName.UserCircleAdd,
     rightIcon: null,
-    weight: 3,
+    weight: PermissionWeight.endowment_keyring,
   }),
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
@@ -501,7 +501,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     label: t('permission_nameLookup'),
     description: t('permission_nameLookupDescription'),
     leftIcon: IconName.Search,
-    weight: 4,
+    weight: PermissionWeight.endowment_nameLookup,
   }),
   ///: END:ONLY_INCLUDE_IF
   [EndowmentPermissions['endowment:signature-insight']]: ({
@@ -511,7 +511,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
   }) => {
     const baseDescription = {
       leftIcon: IconName.Warning,
-      weight: 3,
+      weight: PermissionWeight.endowment_signatureInsight,
     };
 
     const result = [
@@ -582,7 +582,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
         connection,
         connectionName,
         subjectName,
-        weight: 3,
+        weight: PermissionWeight.connection_permission,
       };
     });
   },
@@ -590,7 +590,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     label: t('permission_unknown', [permissionName ?? 'undefined']),
     leftIcon: IconName.Question,
     rightIcon: null,
-    weight: 5,
+    weight: PermissionWeight.unknown_permission,
   }),
 });
 
@@ -686,51 +686,4 @@ export function getWeightedPermissions({
       [],
     )
     .sort((left, right) => left.weight - right.weight);
-}
-
-/**
- * Get the right icon for a permission. If a description is provided, the icon
- * will be wrapped in a tooltip. Otherwise, the icon will be rendered as-is. If
- * there's no right icon, this function will return null.
- *
- * If the weight is 1, the icon will be rendered with a warning color.
- *
- * @param {PermissionLabelObject} permission - The permission object.
- * @param {JSX.Element | string} permission.rightIcon - The right icon.
- * @param {string} permission.description - The description.
- * @param {number} permission.weight - The weight.
- * @returns {JSX.Element | null} The right icon, or null if there's no
- * right icon.
- */
-export function getRightIcon({ rightIcon, description, weight }) {
-  if (rightIcon && description) {
-    return (
-      <Tooltip
-        wrapperClassName={classnames(
-          'permission__tooltip-icon',
-          weight === 1 && 'permission__tooltip-icon__warning',
-        )}
-        html={<div>{description}</div>}
-        position="bottom"
-      >
-        {typeof rightIcon === 'string' ? (
-          <i className={rightIcon} />
-        ) : (
-          rightIcon
-        )}
-      </Tooltip>
-    );
-  }
-
-  if (rightIcon) {
-    if (typeof rightIcon === 'string') {
-      return (
-        <i className={classnames(rightIcon, 'permission__tooltip-icon')} />
-      );
-    }
-
-    return rightIcon;
-  }
-
-  return null;
 }

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -796,7 +796,7 @@ export const getFilteredSnapPermissions = (
   weightThreshold = Infinity,
   minPermissionCount = 3,
 ) => {
-  let filteredPermissions = weightedPermissions.filter(
+  const filteredPermissions = weightedPermissions.filter(
     (permission) => permission.weight <= weightThreshold,
   );
 
@@ -807,7 +807,7 @@ export const getFilteredSnapPermissions = (
       (permission) => permission.weight > weightThreshold,
     );
     // Add permissions until desired count is reached
-    filteredPermissions = filteredPermissions.concat(
+    return filteredPermissions.concat(
       remainingPermissions.slice(
         0,
         minPermissionCount - filteredPermissions.length,

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -793,33 +793,26 @@ export const getAvatarFallbackLetter = (subjectName) => {
  */
 export const getFilteredSnapPermissions = (
   weightedPermissions,
-  weightThreshold,
+  weightThreshold = Infinity,
   minPermissionCount = 3,
 ) => {
-  const filteredPermissions = weightedPermissions.filter(
-    (permission) => permission.weight <= (weightThreshold ?? Infinity),
+  let filteredPermissions = weightedPermissions.filter(
+    (permission) => permission.weight <= weightThreshold,
   );
 
   // If there are not enough permissions that fall into desired set filtered by weight,
   // then fill the gap, no matter what the weight is
   if (minPermissionCount && filteredPermissions.length < minPermissionCount) {
-    const remainingPermissions = [...weightedPermissions];
-
-    // Remove already filtered permissions to avoid duplicates
-    for (const permission of filteredPermissions) {
-      const index = remainingPermissions.indexOf(permission);
-      if (index > -1) {
-        remainingPermissions.splice(index, 1);
-      }
-    }
-
+    const remainingPermissions = weightedPermissions.filter(
+      (permission) => permission.weight > weightThreshold,
+    );
     // Add permissions until desired count is reached
-    while (
-      filteredPermissions.length < minPermissionCount &&
-      remainingPermissions.length > 0
-    ) {
-      filteredPermissions.push(remainingPermissions.shift());
-    }
+    filteredPermissions = filteredPermissions.concat(
+      remainingPermissions.slice(
+        0,
+        minPermissionCount - filteredPermissions.length,
+      ),
+    );
   }
 
   return filteredPermissions;

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -781,3 +781,30 @@ export const hexToText = (hex) => {
 export const getAvatarFallbackLetter = (subjectName) => {
   return subjectName?.match(/[a-z0-9]/iu)?.[0] ?? '?';
 };
+
+/**
+ * Get Snap permissions filtered by weight.
+ *
+ * @param weightedPermissions - Set of Snap permissions that have 'weight' property assigned.
+ * @param weightThreshold - Number that represents weight threshold for filtering.
+ * @param showFirstThreeOnEmpty - Boolean flag to control if first three permissions should be shown
+ * when no permissions meet the weight criteria.
+ * @returns Subset of permissions passing weight threshold.
+ */
+export const getFilteredSnapPermissions = (
+  weightedPermissions,
+  weightThreshold,
+  showFirstThreeOnEmpty = false,
+) => {
+  let filteredPermissions = weightedPermissions.filter(
+    (permission) => permission.weight <= (weightThreshold ?? Infinity),
+  );
+
+  // If there are no permissions that fall into desired set filtered by weight,
+  // then show only the first three, no matter what the weight is
+  if (showFirstThreeOnEmpty && filteredPermissions.length === 0) {
+    filteredPermissions = weightedPermissions.slice(0, 3);
+  }
+
+  return filteredPermissions;
+};

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -1093,4 +1093,90 @@ describe('util', () => {
       ).toStrictEqual('0x12...');
     });
   });
+
+  describe('getFilteredSnapPermissions', () => {
+    it('should return permission filtered by weight', () => {
+      const WEIGHT_THRESHOLD = 3;
+      const mockPermissions = [
+        {
+          label: 'Permission A',
+          weight: 4,
+        },
+        {
+          label: 'Permission B',
+          weight: 4,
+        },
+        {
+          label: 'Permission C',
+          weight: 1,
+        },
+        {
+          label: 'Permission D',
+          weight: 5,
+        },
+        {
+          label: 'Permission E',
+          weight: 2,
+        },
+      ];
+      expect(
+        util.getFilteredSnapPermissions(mockPermissions, WEIGHT_THRESHOLD),
+      ).toStrictEqual([
+        {
+          label: 'Permission C',
+          weight: 1,
+        },
+        {
+          label: 'Permission E',
+          weight: 2,
+        },
+      ]);
+    });
+
+    it('should return the first three permissions because none matches the filter criteria', () => {
+      const WEIGHT_THRESHOLD = 3;
+      const mockPermissions = [
+        {
+          label: 'Permission A',
+          weight: 4,
+        },
+        {
+          label: 'Permission B',
+          weight: 4,
+        },
+        {
+          label: 'Permission C',
+          weight: 5,
+        },
+        {
+          label: 'Permission D',
+          weight: 5,
+        },
+        {
+          label: 'Permission E',
+          weight: 6,
+        },
+      ];
+      expect(
+        util.getFilteredSnapPermissions(
+          mockPermissions,
+          WEIGHT_THRESHOLD,
+          true,
+        ),
+      ).toStrictEqual([
+        {
+          label: 'Permission A',
+          weight: 4,
+        },
+        {
+          label: 'Permission B',
+          weight: 4,
+        },
+        {
+          label: 'Permission C',
+          weight: 5,
+        },
+      ]);
+    });
+  });
 });

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -3,6 +3,7 @@ import { BN, toChecksumAddress } from 'ethereumjs-util';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { addHexPrefixToObjectValues } from '../../../shared/lib/swaps-utils';
 import { toPrecisionWithoutTrailingZeros } from '../../../shared/lib/transactions-controller-utils';
+import { MinPermissionAbstractionDisplayCount } from '../../../shared/constants/permissions';
 import * as util from './util';
 
 describe('util', () => {
@@ -1120,7 +1121,7 @@ describe('util', () => {
         },
       ];
       expect(
-        util.getFilteredSnapPermissions(mockPermissions, WEIGHT_THRESHOLD),
+        util.getFilteredSnapPermissions(mockPermissions, WEIGHT_THRESHOLD, 2),
       ).toStrictEqual([
         {
           label: 'Permission C',
@@ -1161,7 +1162,7 @@ describe('util', () => {
         util.getFilteredSnapPermissions(
           mockPermissions,
           WEIGHT_THRESHOLD,
-          true,
+          MinPermissionAbstractionDisplayCount,
         ),
       ).toStrictEqual([
         {
@@ -1175,6 +1176,52 @@ describe('util', () => {
         {
           label: 'Permission C',
           weight: 5,
+        },
+      ]);
+    });
+
+    it('should return permissions filtered by weight and gap filled with other permissions', () => {
+      const WEIGHT_THRESHOLD = 3;
+      const mockPermissions = [
+        {
+          label: 'Permission A',
+          weight: 4,
+        },
+        {
+          label: 'Permission B',
+          weight: 4,
+        },
+        {
+          label: 'Permission C',
+          weight: 1,
+        },
+        {
+          label: 'Permission D',
+          weight: 5,
+        },
+        {
+          label: 'Permission E',
+          weight: 6,
+        },
+      ];
+      expect(
+        util.getFilteredSnapPermissions(
+          mockPermissions,
+          WEIGHT_THRESHOLD,
+          MinPermissionAbstractionDisplayCount,
+        ),
+      ).toStrictEqual([
+        {
+          label: 'Permission C',
+          weight: 1,
+        },
+        {
+          label: 'Permission A',
+          weight: 4,
+        },
+        {
+          label: 'Permission B',
+          weight: 4,
         },
       ]);
     });

--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -47,8 +47,9 @@ export default function SnapInstall({
   const { origin, iconUrl } = siteMetadata;
   const [isShowingWarning, setIsShowingWarning] = useState(false);
   const snapsMetadata = useSelector(getSnapsMetadata);
+  const [showAllPermissions, setShowAllPermissions] = useState(false);
 
-  const { isScrollable, isScrolledToBottom, scrollToBottom, ref, onScroll } =
+  const { isScrollable, hasScrolledToBottom, scrollToBottom, ref, onScroll } =
     useScrollRequired([requestState]);
 
   const onCancel = useCallback(
@@ -94,6 +95,10 @@ export default function SnapInstall({
       return 'connect';
     }
     return 'confirm';
+  };
+
+  const onShowAllPermissionsHandler = () => {
+    setShowAllPermissions(true);
   };
 
   return (
@@ -190,10 +195,12 @@ export default function SnapInstall({
                 snapName={snapName}
                 permissions={requestState.permissions || {}}
                 connections={requestState.connections || {}}
+                onShowAllPermissions={onShowAllPermissionsHandler}
               />
             </Box>
-            {isScrollable && !isScrolledToBottom ? (
-              <Box className="snap-install__scroll-button-area">
+
+            <Box className="snap-install__scroll-button-area">
+              {isScrollable && !hasScrolledToBottom && !showAllPermissions ? (
                 <AvatarIcon
                   className="snap-install__scroll-button"
                   data-testid="snap-install-scroll"
@@ -203,8 +210,8 @@ export default function SnapInstall({
                   onClick={scrollToBottom}
                   style={{ cursor: 'pointer' }}
                 />
-              </Box>
-            ) : null}
+              ) : null}
+            </Box>
           </>
         )}
       </Box>
@@ -219,7 +226,11 @@ export default function SnapInstall({
           cancelButtonType="default"
           hideCancel={hasError}
           disabled={
-            isLoading || (!hasError && isScrollable && !isScrolledToBottom)
+            isLoading ||
+            (!hasError &&
+              isScrollable &&
+              !hasScrolledToBottom &&
+              !showAllPermissions)
           }
           onCancel={onCancel}
           cancelText={t('cancel')}

--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -226,11 +226,7 @@ export default function SnapInstall({
           cancelButtonType="default"
           hideCancel={hasError}
           disabled={
-            isLoading ||
-            (!hasError &&
-              isScrollable &&
-              !hasScrolledToBottom &&
-              !showAllPermissions)
+            isLoading || (!hasError && isScrollable && !hasScrolledToBottom)
           }
           onCancel={onCancel}
           cancelText={t('cancel')}

--- a/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
+++ b/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
@@ -45,7 +45,9 @@ export default function SnapUpdate({
 
   const [isShowingWarning, setIsShowingWarning] = useState(false);
 
-  const { isScrollable, isScrolledToBottom, scrollToBottom, ref, onScroll } =
+  const [showAllPermissions, setShowAllPermissions] = useState(false);
+
+  const { isScrollable, hasScrolledToBottom, scrollToBottom, ref, onScroll } =
     useScrollRequired([requestState]);
   const snapsMetadata = useSelector(getSnapsMetadata);
 
@@ -91,6 +93,10 @@ export default function SnapUpdate({
     } else {
       onSubmit();
     }
+  };
+
+  const onShowAllPermissions = () => {
+    setShowAllPermissions(true);
   };
 
   return (
@@ -196,10 +202,11 @@ export default function SnapUpdate({
                 revokedConnections={revokedConnections}
                 newConnections={newConnections}
                 targetSubjectMetadata={targetSubjectMetadata}
+                showAllPermissions={onShowAllPermissions}
               />
             </Box>
-            {isScrollable && !isScrolledToBottom ? (
-              <Box className="snap-update__scroll-button-area">
+            <Box className="snap-update__scroll-button-area">
+              {isScrollable && !hasScrolledToBottom && !showAllPermissions ? (
                 <AvatarIcon
                   className="snap-install__scroll-button"
                   data-testid="snap-update-scroll"
@@ -209,8 +216,8 @@ export default function SnapUpdate({
                   onClick={scrollToBottom}
                   style={{ cursor: 'pointer' }}
                 />
-              </Box>
-            ) : null}
+              ) : null}
+            </Box>
           </>
         )}
       </Box>
@@ -225,7 +232,11 @@ export default function SnapUpdate({
           cancelButtonType="default"
           hideCancel={hasError}
           disabled={
-            isLoading || (!hasError && isScrollable && !isScrolledToBottom)
+            isLoading ||
+            (!hasError &&
+              isScrollable &&
+              !hasScrolledToBottom &&
+              !showAllPermissions)
           }
           onCancel={onCancel}
           cancelText={t('cancel')}

--- a/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
+++ b/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
@@ -232,11 +232,7 @@ export default function SnapUpdate({
           cancelButtonType="default"
           hideCancel={hasError}
           disabled={
-            isLoading ||
-            (!hasError &&
-              isScrollable &&
-              !hasScrolledToBottom &&
-              !showAllPermissions)
+            isLoading || (!hasError && isScrollable && !hasScrolledToBottom)
           }
           onCancel={onCancel}
           cancelText={t('cancel')}

--- a/ui/pages/snaps/snap-view/snap-settings.js
+++ b/ui/pages/snaps/snap-view/snap-settings.js
@@ -162,6 +162,7 @@ function SnapSettings({ snapId, initRemove, resetInitRemove }) {
           snapName={snapName}
           permissions={permissions ?? {}}
           showOptions
+          showAllPermissions
         />
       </Box>
       <Box className="snap-view__content__connected-sites" marginTop={12}>

--- a/ui/pages/snaps/snap-view/snap-view.test.js
+++ b/ui/pages/snaps/snap-view/snap-view.test.js
@@ -40,7 +40,7 @@ describe('SnapView', () => {
       renderWithProvider(<SnapView />, mockStore);
 
     // Snap name & Snap authorship component
-    expect(getAllByText('BIP-44 Test Snap')).toHaveLength(1);
+    expect(getAllByText('BIP-44 Test Snap')).toHaveLength(3);
     expect(
       container.getElementsByClassName('snaps-authorship-expanded')?.length,
     ).toBe(1);


### PR DESCRIPTION
## **Description**
Add abstraction for Snaps permissions. Permissions under certain weight threshold are hidden, following the rules described in the related task.

#### Change summary
- Changes are made to Snap Instal and Snap Update components, as well in the hook `useScrollRequired` in order to handle the new scrolling behavior requested by @eriknson. The new requirement is to never show scroll arrow (requirement) again, if the user has scrolled to the bottom once.
- New component `SnapPermissionAdapter` is added to avoid further code complication and duplication. This component will handle displaying final set of permissions.
- Snap settings view is supposed to show all granted permissions at once. So, the new flag is added to the permission list component so the permission abstraction can be disabled in Snap settings.
- Configurations for permission weight thresholds used for abstraction, are added to `shared/constants/permissions.ts`.
- Permission weights are updated according to the notion document.

#### Notes
_(For reviewers)_ Some small fragments of UI might be different from the design sources linked. This is outcome of the several discussions between me and @eriknson. For more information contact me or @eriknson.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25175?quickstart=1)

## **Related issues**
Fixes: https://github.com/MetaMask/snaps/issues/2235

## **Manual testing steps**
1. Try installing or updating Snaps with different numbers of permissions with different weights. The best option is to try many of the test Snaps.
2. Verify that UI is rendered according to logic described in the related task.

## **Screenshots/Recordings**
### **Before**
Before there was no "See all permissions" and similar functionalities related to the scrolling. I think that's the only thing that could compare. There is probably no need to screenshot everything from before, etc. QA to verify.

### **After**
![Screenshot 2024-06-13 at 12 19 45](https://github.com/MetaMask/metamask-extension/assets/13301024/d7d948a6-d7e5-47af-b91d-da16c95edda3)
![Screenshot 2024-06-13 at 12 20 01](https://github.com/MetaMask/metamask-extension/assets/13301024/84845ab2-a4a9-4409-8c15-ff3c41975678)
![Screenshot 2024-06-13 at 12 20 23](https://github.com/MetaMask/metamask-extension/assets/13301024/8c3ee56d-ce30-4b62-a25a-32ae66c8a2ca)
![Screenshot 2024-06-13 at 12 20 33](https://github.com/MetaMask/metamask-extension/assets/13301024/efb123f6-ded6-4ad9-8b8f-e67364c13b0c)
![Screenshot 2024-06-13 at 12 22 07](https://github.com/MetaMask/metamask-extension/assets/13301024/132a8454-b0f8-40b8-b15d-fe638f13d11b)
![Screenshot 2024-06-13 at 12 21 56](https://github.com/MetaMask/metamask-extension/assets/13301024/242c4c43-3ee4-46cd-a571-60d6409febd0)
![Screenshot 2024-06-13 at 12 21 34](https://github.com/MetaMask/metamask-extension/assets/13301024/b53cabe7-7132-4568-ae6b-6d68e726936c)
![Screenshot 2024-06-13 at 12 21 20](https://github.com/MetaMask/metamask-extension/assets/13301024/e4329a15-0da9-455a-967c-0203c0360e0f)


## **Pre-merge author checklist**
- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
