### PR TITLE
chore: Add ability to have front-end, local feature flags

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -21,6 +21,10 @@ import { DocsContainer } from '@storybook/addon-docs';
 import { useDarkMode } from 'storybook-dark-mode';
 import { themes } from '@storybook/theming';
 
+// eslint-disable-next-line
+/* @ts-expect-error: Avoids error from window property not existing */
+window.metamaskFeatureFlags = {};
+
 export const parameters = {
   backgrounds: {
     default: 'default',

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1469,6 +1469,12 @@
   "developerOptions": {
     "message": "Developer Options"
   },
+  "developerOptionsNetworkMenuRedesignDescription": {
+    "message": "Toggles the new design of the Networks menu"
+  },
+  "developerOptionsNetworkMenuRedesignTitle": {
+    "message": "Network Menu Redesign"
+  },
   "developerOptionsResetStatesAnnouncementsDescription": {
     "message": "Resets isShown boolean to false for all announcements. Announcements are the notifications shown in the What's New popup modal."
   },

--- a/builds.yml
+++ b/builds.yml
@@ -300,6 +300,8 @@ env:
   - CHAIN_PERMISSIONS: ''
   # Enables use of test gas fee flow to debug gas fee estimation
   - TEST_GAS_FEE_FLOWS: false
+  # Determines if feature flagged network ui new design
+  - ENABLE_NETWORK_UI_REDESIGN: ''
 
     # Enables the notifications feature within the build:
   - NOTIFICATIONS: ''

--- a/ui/helpers/utils/feature-flags.js
+++ b/ui/helpers/utils/feature-flags.js
@@ -1,0 +1,3 @@
+export function getLocalNetworkMenuRedesignFeatureFlag() {
+  return window.metamaskFeatureFlags.networkMenuRedesign;
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -291,6 +291,12 @@ function setupStateHooks(store) {
   };
 }
 
+// Check for local feature flags and represent them so they're avialable
+// to the front-end of the app
+window.metamaskFeatureFlags = {
+  networkMenuRedesign: Boolean(process.env.ENABLE_NETWORK_UI_REDESIGN),
+};
+
 window.logStateString = async function (cb) {
   const state = await window.stateHooks.getCleanAppState();
   const logs = window.stateHooks.getLogs();

--- a/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
+++ b/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
@@ -167,6 +167,76 @@ exports[`Develop options tab should match snapshot 1`] = `
           </label>
         </div>
       </div>
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <div
+            class="settings-page__content-description"
+          >
+            <span>
+              Network Menu Redesign
+            </span>
+            <div
+              class="settings-page__content-description"
+            >
+              Toggles the new design of the Networks menu
+            </div>
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <label
+            class="toggle-button toggle-button--off"
+            tabindex="0"
+          >
+            <div
+              style="display: flex; width: 52px; align-items: center; justify-content: flex-start; position: relative; cursor: pointer; background-color: transparent; border: 0px; padding: 0px; user-select: none;"
+            >
+              <div
+                style="width: 40px; height: 24px; padding: 0px; border-radius: 26px; display: flex; align-items: center; justify-content: center; background-color: rgb(159, 166, 174);"
+              >
+                <div
+                  style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgb(250, 250, 250); margin-top: auto; margin-bottom: auto; line-height: 0; opacity: 0; width: 26px; height: 20px; left: 4px;"
+                />
+                <div
+                  style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgba(255, 255, 255, 0.6); bottom: 0px; margin-top: auto; margin-bottom: auto; padding-right: 5px; line-height: 0; width: 26px; height: 20px; opacity: 1;"
+                />
+              </div>
+              <div
+                style="position: absolute; height: 100%; top: 0px; left: 0px; display: flex; flex: 1; align-self: stretch; align-items: center; justify-content: flex-start;"
+              >
+                <div
+                  style="width: 18px; height: 18px; display: flex; align-self: center; box-shadow: var(--shadow-size-xs) var(--color-shadow-default); border-radius: 50%; box-sizing: border-box; position: relative; background-color: rgb(255, 255, 255); left: 3px;"
+                />
+              </div>
+              <input
+                data-testid="developer-options-network-redesign"
+                style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
+                type="checkbox"
+                value="false"
+              />
+            </div>
+            <div
+              class="toggle-button__status"
+            >
+              <span
+                class="toggle-button__label-off"
+              >
+                Off
+              </span>
+              <span
+                class="toggle-button__label-on"
+              >
+                On
+              </span>
+            </div>
+          </label>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/ui/pages/settings/developer-options-tab/developer-options-tab.test.tsx
+++ b/ui/pages/settings/developer-options-tab/developer-options-tab.test.tsx
@@ -8,6 +8,10 @@ import DeveloperOptionsTab from '.';
 
 const mockSetServiceWorkerKeepAlivePreference = jest.fn();
 
+// eslint-disable-next-line
+/* @ts-expect-error: Avoids error from window property not existing */
+window.metamaskFeatureFlags = {};
+
 jest.mock('../../../store/actions.ts', () => ({
   setServiceWorkerKeepAlivePreference: () =>
     mockSetServiceWorkerKeepAlivePreference,

--- a/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
@@ -44,6 +44,9 @@ const DeveloperOptionsTab = () => {
   const [hasResetOnboarding, setHasResetOnboarding] = useState(false);
   const [isServiceWorkerKeptAlive, setIsServiceWorkerKeptAlive] =
     useState(true);
+  const [enableNetworkRedesign, setEnableNetworkRedesign] = useState(
+    window.metamaskFeatureFlags.networkMenuRedesign,
+  );
 
   const settingsRefs = Array(
     getNumberOfSettingRoutesInTab(t, t('developerOptions')),
@@ -212,6 +215,44 @@ const DeveloperOptionsTab = () => {
       </Box>
     );
   };
+
+  const renderNetworkMenuRedesign = () => {
+    return (
+      <Box
+        ref={settingsRefs[4] as React.RefObject<HTMLDivElement>}
+        className="settings-page__content-row"
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        justifyContent={JustifyContent.spaceBetween}
+        gap={4}
+      >
+        <div className="settings-page__content-item">
+          <div className="settings-page__content-description">
+            <span>{t('developerOptionsNetworkMenuRedesignTitle')}</span>
+            <div className="settings-page__content-description">
+              {t('developerOptionsNetworkMenuRedesignDescription')}
+            </div>
+          </div>
+        </div>
+
+        <div className="settings-page__content-item-col">
+          <ToggleButton
+            value={enableNetworkRedesign}
+            onToggle={(value) => {
+              setEnableNetworkRedesign(!value);
+              // eslint-disable-next-line
+              /* @ts-expect-error: Avoids error from window property not existing */
+              window.metamaskFeatureFlags.networkMenuRedesign = !value;
+            }}
+            offLabel={t('off')}
+            onLabel={t('on')}
+            dataTestId="developer-options-network-redesign"
+          />
+        </div>
+      </Box>
+    );
+  };
+
   return (
     <div className="settings-page__body">
       <Text className="settings-page__security-tab-sub-header__bold">
@@ -230,6 +271,7 @@ const DeveloperOptionsTab = () => {
         {renderAnnouncementReset()}
         {renderOnboardingReset()}
         {renderServiceWorkerKeepAliveToggle()}
+        {renderNetworkMenuRedesign()}
       </div>
     </div>
   );

--- a/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
@@ -45,6 +45,8 @@ const DeveloperOptionsTab = () => {
   const [isServiceWorkerKeptAlive, setIsServiceWorkerKeptAlive] =
     useState(true);
   const [enableNetworkRedesign, setEnableNetworkRedesign] = useState(
+    // eslint-disable-next-line
+    /* @ts-expect-error: Avoids error from window property not existing */
     window.metamaskFeatureFlags.networkMenuRedesign,
   );
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2553,7 +2553,3 @@ export function getKeyringSnapRemovalResult(state) {
 }
 
 ///: END:ONLY_INCLUDE_IF
-
-export function getLocalNetworkMenuRedesignFeatureFlag() {
-  return window.metamaskFeatureFlags.networkMenuRedesign;
-}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2553,3 +2553,7 @@ export function getKeyringSnapRemovalResult(state) {
 }
 
 ///: END:ONLY_INCLUDE_IF
+
+export function getLocalNetworkMenuRedesignFeatureFlag() {
+  return window.metamaskFeatureFlags.networkMenuRedesign;
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a local, developer-only, front-end only feature flag for the Network menu redesign

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25179?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run `yarn && ENABLE_NETWORK_UI_REDESIGN=1 yarn start`
2. Check `window.metamaskFeatureFlags.networkMenuRedesign` is `true`
3. Go to Settings -> Developer Options
4. See the setting on, click the toggle to turn it off
5. Check `window.metamaskFeatureFlags.networkMenuRedesign` is `false

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
