### PR TITLE
fix: UX: Multichain: Ensure setNetworkClientIdForDomain is called for test networks

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -223,6 +223,14 @@ export const NetworkListMenu = ({ onClose }) => {
             } else {
               dispatch(setActiveNetwork(network.id));
             }
+
+            // If presently on a dapp, communicate a change to
+            // the dapp via silent switchEthereumChain that the
+            // network has changed due to user action
+            if (useRequestQueue && selectedTabOrigin) {
+              setNetworkClientIdForDomain(selectedTabOrigin, network.id);
+            }
+
             trackEvent({
               event: MetaMetricsEventName.NavNetworkSwitched,
               category: MetaMetricsEventCategory.Network,

--- a/ui/components/multichain/network-list-menu/network-list-menu.test.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.js
@@ -6,6 +6,7 @@ import mockState from '../../../../test/data/mock-state.json';
 import {
   CHAIN_IDS,
   MAINNET_DISPLAY_NAME,
+  NETWORK_TYPES,
   SEPOLIA_DISPLAY_NAME,
 } from '../../../../shared/constants/network';
 import { NetworkListMenu } from '.';
@@ -14,11 +15,16 @@ const mockSetShowTestNetworks = jest.fn();
 const mockSetProviderType = jest.fn();
 const mockToggleNetworkMenu = jest.fn();
 const mockNetworkMenuRedesignToggle = jest.fn();
+const mockSetNetworkClientIdForDomain = jest.fn();
+const mockSetActiveNetwork = jest.fn();
 
 jest.mock('../../../store/actions.ts', () => ({
   setShowTestNetworks: () => mockSetShowTestNetworks,
   setProviderType: () => mockSetProviderType,
+  setActiveNetwork: () => mockSetActiveNetwork,
   toggleNetworkMenu: () => mockToggleNetworkMenu,
+  setNetworkClientIdForDomain: (network, id) =>
+    mockSetNetworkClientIdForDomain(network, id),
 }));
 
 jest.mock('../../../helpers/utils/feature-flags', () => ({
@@ -26,12 +32,14 @@ jest.mock('../../../helpers/utils/feature-flags', () => ({
   getLocalNetworkMenuRedesignFeatureFlag: () => mockNetworkMenuRedesignToggle,
 }));
 
+const MOCK_ORIGIN = 'https://portfolio.metamask.io';
+
 const render = ({
   showTestNetworks = false,
   currentChainId = '0x5',
   providerConfigId = 'chain5',
   isUnlocked = true,
-  origin = 'https://portfolio.metamask.io',
+  origin = MOCK_ORIGIN,
 } = {}) => {
   const state = {
     metamask: {
@@ -149,5 +157,23 @@ describe('NetworkListMenu', () => {
     expect(
       document.querySelectorAll('multichain-network-list-item__delete'),
     ).toHaveLength(0);
+  });
+
+  it('fires setNetworkClientIdForDomain when network item is clicked', () => {
+    const { getByText } = render();
+    fireEvent.click(getByText(MAINNET_DISPLAY_NAME));
+    expect(mockSetNetworkClientIdForDomain).toHaveBeenCalledWith(
+      MOCK_ORIGIN,
+      NETWORK_TYPES.MAINNET,
+    );
+  });
+
+  it('fires setNetworkClientIdForDomain when test network item is clicked', () => {
+    const { getByText } = render({ showTestNetworks: true });
+    fireEvent.click(getByText(SEPOLIA_DISPLAY_NAME));
+    expect(mockSetNetworkClientIdForDomain).toHaveBeenCalledWith(
+      MOCK_ORIGIN,
+      NETWORK_TYPES.SEPOLIA,
+    );
   });
 });


### PR DESCRIPTION
## **Description**

There's duplicate `<NetworkListItem>` blocks in the `NetworkListMenu` which will be consolidated with https://github.com/MetaMask/metamask-extension/pull/25195 .  In the mean time, a call to `setNetworkClientIdForDomain` was missing for the test network usage of `NetworkListItem`.  The result would be MetaMask not remembering that a given dapp was on a test network when manually switched inside MetaMask.  This PR fixes that issue.

This should be cherry-picked fro 12.0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25197?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Connect to a dapp (that supports Sepolia) on Mainnet
2. Open MetaMask manually, open the network picker, switch to Sepolia
3. See dapp switch to Sepolia

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/df24885c-ee72-4460-b7f5-481e512f5901



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
