### PR TITLE
fix: Disable MV3 for MV2 Flask production build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -691,7 +691,7 @@ jobs:
           steps:
             - run:
                 name: build:prod
-                command: yarn build --build-type flask prod
+                command: ENABLE_MV3=false yarn build --build-type flask prod
       - run:
           name: build:debug
           command: find dist/ -type f -exec md5sum {} \; | sort -k 2

--- a/.circleci/scripts/release-create-gh-release.sh
+++ b/.circleci/scripts/release-create-gh-release.sh
@@ -69,9 +69,9 @@ then
     release_body="$(awk -v version="${tag##v}" -f .circleci/scripts/show-changelog.awk CHANGELOG.md)"
     hub release create \
         --attach builds/metamask-chrome-*.zip \
-        --attach builds/metamask-firefox-*.zip \
+        --attach builds-mv2/metamask-firefox-*.zip \
         --attach builds-flask/metamask-flask-chrome-*.zip \
-        --attach builds-flask/metamask-flask-firefox-*.zip \
+        --attach builds-flask-mv2/metamask-flask-firefox-*.zip \
         --attach builds-mmi/metamask-mmi-chrome-*.zip \
         --attach builds-mmi/metamask-mmi-firefox-*.zip \
         --message "Version ${tag##v}" \


### PR DESCRIPTION
## **Description**

Disables MV3 for the MV2 Flask production build. This was seemingly missed when setting up the CI to build for production and caused problems with the latest build submitted to Firefox.

Also updates the release script to use MV2 builds for Firefox.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25209?quickstart=1)