### PR TITLE
v12.0.0 Cherry-Pick  fix: Avoid to send the snap notification id to the notifications serv…

### DIFF
--- a/ui/pages/notifications/notifications-list-read-all-button.tsx
+++ b/ui/pages/notifications/notifications-list-read-all-button.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import {
@@ -16,6 +16,7 @@ import { markNotificationsAsRead } from '../../store/actions';
 import { Box, Button, ButtonVariant } from '../../components/component-library';
 import { BlockSize } from '../../helpers/constants/design-system';
 import type { NotificationType } from './notifications';
+import { SNAP } from './snap/types/types';
 
 export type NotificationsListReadAllButtonProps = {
   notifications: NotificationType[];
@@ -28,20 +29,17 @@ export const NotificationsListReadAllButton = ({
   const t = useI18nContext();
   const { markNotificationAsRead } = useMarkNotificationAsRead();
   const trackEvent = useContext(MetaMetricsContext);
-
   const unreadNotifications = useSelector(getUnreadNotifications);
 
-  const [notificationReadArray, setNotificationReadArray] =
-    useState<MarkAsReadNotificationsParam>([]);
-
-  useEffect(() => {
+  const handleOnClick = () => {
     let notificationsRead: MarkAsReadNotificationsParam = [];
 
     if (notifications && notifications.length > 0) {
       notificationsRead = notifications
         .filter(
           (notification): notification is Notification =>
-            (notification as Notification).id !== undefined,
+            (notification as Notification).id !== undefined &&
+            notification.type !== SNAP,
         )
         .map((notification: Notification) => ({
           id: notification.id,
@@ -49,17 +47,14 @@ export const NotificationsListReadAllButton = ({
           isRead: notification.isRead,
         }));
     }
-    setNotificationReadArray(notificationsRead);
-  }, [notifications]);
 
-  const handleOnClick = () => {
     trackEvent({
       category: MetaMetricsEventCategory.NotificationInteraction,
       event: MetaMetricsEventName.MarkAllNotificationsRead,
     });
 
     // Mark all metamask notifications as read
-    markNotificationAsRead(notificationReadArray);
+    markNotificationAsRead(notificationsRead);
 
     // Mark all snap notifications as read
     const unreadNotificationIds = unreadNotifications.map(({ id }) => id);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes a bug related to the "Mark all notifications as read" button. The button is responsible, when clicked, for performing the actions to mark a notification as read. In the case of on-chain notifications, this state needs to be saved via API on the notification server. The PR prevents the IDs of SNAP notifications from being sent to the server, as their read/unread state is managed differently.

Original PR: https://github.com/MetaMask/metamask-extension/pull/25099
This Cherry-Pick did not have any merge conflicts that needed resolving.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25215?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
