### PR TITLE
fix: add deprecated tag back to callBackgroundMethod

### DIFF
--- a/ui/store/background-connection.ts
+++ b/ui/store/background-connection.ts
@@ -39,8 +39,12 @@ type CallbackMethod<R = unknown> = (error?: unknown, result?: R) => void;
 
 /**
  * [Deprecated] Callback-style call to background method
- * invokes promisifiedBackground method directly.
+ * In MV2: invokes promisifiedBackground method directly.
+ * In MV3: action is added to retry queue, along with resolve handler to be executed on completion,
+ * the queue is then immediately processed if background connection is available.
+ * On completion (successful or error) the action is removed from the retry queue.
  *
+ * @deprecated Use async `submitRequestToBackground` function instead.
  * @param method - name of the background method
  * @param [args] - arguments to that method, if any
  * @param callback - Node style (error, result) callback for finishing the operation

--- a/ui/store/background-connection.ts
+++ b/ui/store/background-connection.ts
@@ -39,10 +39,6 @@ type CallbackMethod<R = unknown> = (error?: unknown, result?: R) => void;
 
 /**
  * [Deprecated] Callback-style call to background method
- * In MV2: invokes promisifiedBackground method directly.
- * In MV3: action is added to retry queue, along with resolve handler to be executed on completion,
- * the queue is then immediately processed if background connection is available.
- * On completion (successful or error) the action is removed from the retry queue.
  *
  * @deprecated Use async `submitRequestToBackground` function instead.
  * @param method - name of the background method

--- a/ui/store/background-connection.ts
+++ b/ui/store/background-connection.ts
@@ -39,6 +39,7 @@ type CallbackMethod<R = unknown> = (error?: unknown, result?: R) => void;
 
 /**
  * [Deprecated] Callback-style call to background method
+ * invokes promisifiedBackground method directly.
  *
  * @deprecated Use async `submitRequestToBackground` function instead.
  * @param method - name of the background method


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Removed wrongly in https://github.com/MetaMask/metamask-extension/pull/21410, this PR aims to add `deprecated` tag back to `callBackgroundMethod` for migration purpose.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25216?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
