### PR TITLE
fix: Capture Segment errors during initialization

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -188,7 +188,11 @@ export default class MetaMetricsController {
     // Code below submits any pending segmentApiCalls to Segment if/when the controller is re-instantiated
     if (isManifestV3) {
       Object.values(segmentApiCalls).forEach(({ eventType, payload }) => {
-        this._submitSegmentAPICall(eventType, payload);
+        try {
+          this._submitSegmentAPICall(eventType, payload);
+        } catch (error) {
+          this._captureException(error)
+        }
       });
     }
 

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -191,7 +191,7 @@ export default class MetaMetricsController {
         try {
           this._submitSegmentAPICall(eventType, payload);
         } catch (error) {
-          this._captureException(error)
+          this._captureException(error);
         }
       });
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We were submitting Segment events in the MetaMetrics constructor without catching errors. This was the sole place where we failed to catch errors resulting from Segment calls.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25253?quickstart=1)

## **Related issues**

Mitigates #25244

## **Manual testing steps**

See this comment for details: https://github.com/MetaMask/metamask-extension/pull/25254#issuecomment-2162922421

## **Screenshots/Recordings**

N./A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
