### PR TITLE
fix: Add tests for setNetworkClientIdForDomain being called on all network items

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.test.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.js
@@ -7,6 +7,7 @@ import {
   CHAIN_IDS,
   MAINNET_DISPLAY_NAME,
   SEPOLIA_DISPLAY_NAME,
+  NETWORK_TYPES,
 } from '../../../../shared/constants/network';
 import { NetworkListMenu } from '.';
 
@@ -14,11 +15,16 @@ const mockSetShowTestNetworks = jest.fn();
 const mockSetProviderType = jest.fn();
 const mockToggleNetworkMenu = jest.fn();
 const mockNetworkMenuRedesignToggle = jest.fn();
+const mockSetNetworkClientIdForDomain = jest.fn();
+const mockSetActiveNetwork = jest.fn();
 
 jest.mock('../../../store/actions.ts', () => ({
   setShowTestNetworks: () => mockSetShowTestNetworks,
   setProviderType: () => mockSetProviderType,
+  setActiveNetwork: () => mockSetActiveNetwork,
   toggleNetworkMenu: () => mockToggleNetworkMenu,
+  setNetworkClientIdForDomain: (network, id) =>
+    mockSetNetworkClientIdForDomain(network, id),
 }));
 
 jest.mock('../../../helpers/utils/feature-flags', () => ({
@@ -26,12 +32,14 @@ jest.mock('../../../helpers/utils/feature-flags', () => ({
   getLocalNetworkMenuRedesignFeatureFlag: () => mockNetworkMenuRedesignToggle,
 }));
 
+const MOCK_ORIGIN = 'https://portfolio.metamask.io';
+
 const render = ({
   showTestNetworks = false,
   currentChainId = '0x5',
   providerConfigId = 'chain5',
   isUnlocked = true,
-  origin = 'https://portfolio.metamask.io',
+  origin = MOCK_ORIGIN,
 } = {}) => {
   const state = {
     metamask: {
@@ -149,5 +157,23 @@ describe('NetworkListMenu', () => {
     expect(
       document.querySelectorAll('multichain-network-list-item__delete'),
     ).toHaveLength(0);
+  });
+
+  it('fires setNetworkClientIdForDomain when network item is clicked', () => {
+    const { getByText } = render();
+    fireEvent.click(getByText(MAINNET_DISPLAY_NAME));
+    expect(mockSetNetworkClientIdForDomain).toHaveBeenCalledWith(
+      MOCK_ORIGIN,
+      NETWORK_TYPES.MAINNET,
+    );
+  });
+
+  it('fires setNetworkClientIdForDomain when test network item is clicked', () => {
+    const { getByText } = render({ showTestNetworks: true });
+    fireEvent.click(getByText(SEPOLIA_DISPLAY_NAME));
+    expect(mockSetNetworkClientIdForDomain).toHaveBeenCalledWith(
+      MOCK_ORIGIN,
+      NETWORK_TYPES.SEPOLIA,
+    );
   });
 });


### PR DESCRIPTION

## **Description**

Adds tests for the functionality added in https://github.com/MetaMask/metamask-extension/pull/25260

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25270?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run jest tests

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
