### PR TITLE
fix: swap+send e2e tests

### DIFF
--- a/test/e2e/tests/swap-send/swap-send-erc20.spec.ts
+++ b/test/e2e/tests/swap-send/swap-send-erc20.spec.ts
@@ -74,8 +74,8 @@ describe('Swap-Send ERC20', function () {
 
           await swapSendPage.verifyQuoteDisplay(
             '1 TST = 0.000002634 ETH',
-            '879687 ETH',
-            '≈ $2,647,857,870.00',
+            '0.0075669 ETH',
+            '≈ $22.78',
           );
 
           await swapSendPage.submitSwap();

--- a/test/e2e/tests/swap-send/swap-send-eth.spec.ts
+++ b/test/e2e/tests/swap-send/swap-send-eth.spec.ts
@@ -67,8 +67,8 @@ describe('Swap-Send ETH', function () {
 
           await swapSendPage.verifyQuoteDisplay(
             '1 ETH = 301075.4807 TST',
-            '1500000 ETH', // TODO this looks weird
-            '≈ $4,515,000,000.00',
+            '0.0129028 ETH',
+            '≈ $38.84',
           );
 
           await swapSendPage.submitSwap();
@@ -114,7 +114,7 @@ describe('Swap-Send ETH', function () {
 
         await swapSendPage.verifyMaxButtonClick(
           ['ETH', 'ETH'],
-          ['24.995559472', '24.995559472'],
+          ['24.9970184730279925', '24.9970184730279925'],
         );
       },
     );

--- a/test/e2e/tests/swap-send/swap-send-test-utils.ts
+++ b/test/e2e/tests/swap-send/swap-send-test-utils.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { Mockttp } from 'mockttp';
 import FixtureBuilder from '../../fixture-builder';
 import { SWAPS_API_V2_BASE_URL } from '../../../../shared/constants/swaps';
-import { defaultGanacheOptions } from '../../helpers';
+import { generateGanacheOptions } from '../../helpers';
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import { SWAP_SEND_QUOTES_RESPONSE_ETH_TST } from './mocks/eth-data';
 
@@ -297,7 +297,7 @@ export const getSwapSendFixtures = (
     smartContract: SMART_CONTRACTS.HST,
     ethConversionInUsd: ETH_CONVERSION_RATE_USD,
     testSpecificMock: mockSwapsApi(swapsQuotes),
-    ganacheOptions: defaultGanacheOptions,
+    ganacheOptions: generateGanacheOptions({ hardfork: 'london' }),
     title,
   };
 };


### PR DESCRIPTION
## **Description**
418ecfc6e5db60cb4a9b1d59db72322f0bd797c3 was moved from https://github.com/MetaMask/metamask-extension/pull/25230 into this separate PR.

@micaelae wrote:
> the main change in the commit is to update the test ganache network. we were configuring the tests without EIP-1559 support before. and as a result, gas fees in the Send page were calculated using the response of https://gas.api.cx.metamask.io/networks/1/gasPrices. afaik the response was getting mocked to a constant value before so the tests succeeded reliably.
after your change, the response of that endpoint became variable. which made me look into why the gas fees were excessively high within the test in the first place
since the Swap+Send experience only runs in networks that support EIP-1559, I updated the test network. as a result the tests now use the suggestedGasFees endpoint mock, which also corrected the gas calculation test bug


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25275?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
