### PR TITLE
fix: Localize AvatarToken alt attribute

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -636,6 +636,10 @@
   "autoLockTimeLimitDescription": {
     "message": "Set the idle time in minutes before MetaMask will become locked."
   },
+  "avatarTokenAlt": {
+    "message": "$1 logo",
+    "description": "$1 represents the token name"
+  },
   "average": {
     "message": "Average"
   },

--- a/ui/components/component-library/avatar-token/__snapshots__/avatar-token.test.tsx.snap
+++ b/ui/components/component-library/avatar-token/__snapshots__/avatar-token.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AvatarToken should render correctly 1`] = `
     data-testid="avatar-token"
   >
     <img
-      alt="ast logo"
+      alt="[avatarTokenAlt]"
       class="mm-avatar-token__token-image"
       src="./AST.png"
     />

--- a/ui/components/component-library/avatar-token/avatar-token.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.tsx
@@ -8,6 +8,7 @@ import {
   TextColor,
   BackgroundColor,
 } from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 import type { PolymorphicRef } from '../box';
 import type { AvatarTokenComponent } from './avatar-token.types';
 import { AvatarTokenProps, AvatarTokenSize } from './avatar-token.types';
@@ -27,6 +28,7 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
     }: AvatarTokenProps<C>,
     ref: PolymorphicRef<C>,
   ) => {
+    const t = useI18nContext();
     const [showFallback, setShowFallback] = useState(false);
 
     useEffect(() => {
@@ -79,7 +81,7 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
               }
               onError={handleOnError}
               src={src}
-              alt={`${name} logo` || 'token logo'}
+              alt={t('avatarTokenAlt', [name || t('token')])}
             />
           </>
         )}

--- a/ui/components/component-library/avatar-token/avatar-token.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.tsx
@@ -71,6 +71,7 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
                   showHalo ? 'mm-avatar-token__token-image--blurred' : ''
                 }
                 aria-hidden="true"
+                alt=""
               />
             )}
             <img

--- a/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`AssetPicker matches snapshot 1`] = `
               src="./images/eth_logo.svg"
             />
             <img
-              alt="NATIVE TICKER logo"
+              alt="[avatarTokenAlt]"
               class="mm-avatar-token__token-image--size-reduced"
               src="./images/eth_logo.svg"
             />


### PR DESCRIPTION

## **Description**

Localizes the AvatarToken component's image alt txt

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25282?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Right-click a token image in the token list
2. See the localized ALT text

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
