### PR TITLE
cherry-pick chore: revert recent gas api endpoint changes (#25230) into v12.0.0

### DIFF
--- a/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch
+++ b/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch
@@ -1,0 +1,2630 @@
+diff --git a/dist/GasFeeController.js b/dist/GasFeeController.js
+index 089bba219bac937eeccb423f3e69ad5407ef9be0..b6bdda12ceeb0c38b344b20f80c3afc5120ce3f9 100644
+--- a/dist/GasFeeController.js
++++ b/dist/GasFeeController.js
+@@ -3,12 +3,12 @@
+
+
+
+-var _chunkH5WHAYLIjs = require('./chunk-H5WHAYLI.js');
+-require('./chunk-Q2YPK5SL.js');
++var _chunkX74LQX2Yjs = require('./chunk-X74LQX2Y.js');
++require('./chunk-2MFVV2BX.js');
+
+
+
+
+
+-exports.GAS_API_BASE_URL = _chunkH5WHAYLIjs.GAS_API_BASE_URL; exports.GAS_ESTIMATE_TYPES = _chunkH5WHAYLIjs.GAS_ESTIMATE_TYPES; exports.GasFeeController = _chunkH5WHAYLIjs.GasFeeController; exports.default = _chunkH5WHAYLIjs.GasFeeController_default;
++exports.GAS_ESTIMATE_TYPES = _chunkX74LQX2Yjs.GAS_ESTIMATE_TYPES; exports.GasFeeController = _chunkX74LQX2Yjs.GasFeeController; exports.LEGACY_GAS_PRICES_API_URL = _chunkX74LQX2Yjs.LEGACY_GAS_PRICES_API_URL; exports.default = _chunkX74LQX2Yjs.GasFeeController_default;
+ //# sourceMappingURL=GasFeeController.js.map
+\ No newline at end of file
+diff --git a/dist/GasFeeController.mjs b/dist/GasFeeController.mjs
+index 14ab557e85665a30cbd8b4cec41448d5b88fed91..9b9b90786ac35a4cf320d00a933ef151cdf03821 100644
+--- a/dist/GasFeeController.mjs
++++ b/dist/GasFeeController.mjs
+@@ -1,14 +1,14 @@
+ import {
+-  GAS_API_BASE_URL,
+   GAS_ESTIMATE_TYPES,
+   GasFeeController,
+-  GasFeeController_default
+-} from "./chunk-BEVZS3YV.mjs";
+-import "./chunk-KORLXV32.mjs";
++  GasFeeController_default,
++  LEGACY_GAS_PRICES_API_URL
++} from "./chunk-A7NHJBXX.mjs";
++import "./chunk-R3IOI7AK.mjs";
+ export {
+-  GAS_API_BASE_URL,
+   GAS_ESTIMATE_TYPES,
+   GasFeeController,
++  LEGACY_GAS_PRICES_API_URL,
+   GasFeeController_default as default
+ };
+ //# sourceMappingURL=GasFeeController.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-2MFVV2BX.js b/dist/chunk-2MFVV2BX.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..4f83a713baa28f3d687c50ed7ad3c79715a2b588
+--- /dev/null
++++ b/dist/chunk-2MFVV2BX.js
+@@ -0,0 +1,156 @@
++"use strict";Object.defineProperty(exports, "__esModule", {value: true}); function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }var __accessCheck = (obj, member, msg) => {
++  if (!member.has(obj))
++    throw TypeError("Cannot " + msg);
++};
++var __privateGet = (obj, member, getter) => {
++  __accessCheck(obj, member, "read from private field");
++  return getter ? getter.call(obj) : member.get(obj);
++};
++var __privateAdd = (obj, member, value) => {
++  if (member.has(obj))
++    throw TypeError("Cannot add the same private member more than once");
++  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
++};
++var __privateSet = (obj, member, value, setter) => {
++  __accessCheck(obj, member, "write to private field");
++  setter ? setter.call(obj, value) : member.set(obj, value);
++  return value;
++};
++var __privateMethod = (obj, member, method) => {
++  __accessCheck(obj, member, "access private method");
++  return method;
++};
++
++// src/gas-util.ts
++
++
++
++
++
++var _controllerutils = require('@metamask/controller-utils');
++var _bnjs = require('bn.js'); var _bnjs2 = _interopRequireDefault(_bnjs);
++var makeClientIdHeader = (clientId) => ({ "X-Client-Id": clientId });
++function normalizeGWEIDecimalNumbers(n) {
++  const numberAsWEIHex = _controllerutils.gweiDecToWEIBN.call(void 0, n).toString(16);
++  const numberAsGWEI = _controllerutils.weiHexToGweiDec.call(void 0, numberAsWEIHex);
++  return numberAsGWEI;
++}
++async function fetchGasEstimates(url, clientId) {
++  const estimates = await _controllerutils.handleFetch.call(void 0,
++    url,
++    clientId ? { headers: makeClientIdHeader(clientId) } : void 0
++  );
++  return {
++    low: {
++      ...estimates.low,
++      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.low.suggestedMaxPriorityFeePerGas
++      ),
++      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.low.suggestedMaxFeePerGas
++      )
++    },
++    medium: {
++      ...estimates.medium,
++      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.medium.suggestedMaxPriorityFeePerGas
++      ),
++      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.medium.suggestedMaxFeePerGas
++      )
++    },
++    high: {
++      ...estimates.high,
++      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.high.suggestedMaxPriorityFeePerGas
++      ),
++      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.high.suggestedMaxFeePerGas
++      )
++    },
++    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
++    historicalBaseFeeRange: estimates.historicalBaseFeeRange,
++    baseFeeTrend: estimates.baseFeeTrend,
++    latestPriorityFeeRange: estimates.latestPriorityFeeRange,
++    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,
++    priorityFeeTrend: estimates.priorityFeeTrend,
++    networkCongestion: estimates.networkCongestion
++  };
++}
++async function fetchLegacyGasPriceEstimates(url, clientId) {
++  const result = await _controllerutils.handleFetch.call(void 0, url, {
++    referrer: url,
++    referrerPolicy: "no-referrer-when-downgrade",
++    method: "GET",
++    mode: "cors",
++    headers: {
++      "Content-Type": "application/json",
++      ...clientId && makeClientIdHeader(clientId)
++    }
++  });
++  return {
++    low: result.SafeGasPrice,
++    medium: result.ProposeGasPrice,
++    high: result.FastGasPrice
++  };
++}
++async function fetchEthGasPriceEstimate(ethQuery) {
++  const gasPrice = await _controllerutils.query.call(void 0, ethQuery, "gasPrice");
++  return {
++    gasPrice: _controllerutils.weiHexToGweiDec.call(void 0, gasPrice).toString()
++  };
++}
++function calculateTimeEstimate(maxPriorityFeePerGas, maxFeePerGas, gasFeeEstimates) {
++  const { low, medium, high, estimatedBaseFee } = gasFeeEstimates;
++  const maxPriorityFeePerGasInWEI = _controllerutils.gweiDecToWEIBN.call(void 0, maxPriorityFeePerGas);
++  const maxFeePerGasInWEI = _controllerutils.gweiDecToWEIBN.call(void 0, maxFeePerGas);
++  const estimatedBaseFeeInWEI = _controllerutils.gweiDecToWEIBN.call(void 0, estimatedBaseFee);
++  const effectiveMaxPriorityFee = _bnjs2.default.min(
++    maxPriorityFeePerGasInWEI,
++    maxFeePerGasInWEI.sub(estimatedBaseFeeInWEI)
++  );
++  const lowMaxPriorityFeeInWEI = _controllerutils.gweiDecToWEIBN.call(void 0,
++    low.suggestedMaxPriorityFeePerGas
++  );
++  const mediumMaxPriorityFeeInWEI = _controllerutils.gweiDecToWEIBN.call(void 0,
++    medium.suggestedMaxPriorityFeePerGas
++  );
++  const highMaxPriorityFeeInWEI = _controllerutils.gweiDecToWEIBN.call(void 0,
++    high.suggestedMaxPriorityFeePerGas
++  );
++  let lowerTimeBound;
++  let upperTimeBound;
++  if (effectiveMaxPriorityFee.lt(lowMaxPriorityFeeInWEI)) {
++    lowerTimeBound = null;
++    upperTimeBound = "unknown";
++  } else if (effectiveMaxPriorityFee.gte(lowMaxPriorityFeeInWEI) && effectiveMaxPriorityFee.lt(mediumMaxPriorityFeeInWEI)) {
++    lowerTimeBound = low.minWaitTimeEstimate;
++    upperTimeBound = low.maxWaitTimeEstimate;
++  } else if (effectiveMaxPriorityFee.gte(mediumMaxPriorityFeeInWEI) && effectiveMaxPriorityFee.lt(highMaxPriorityFeeInWEI)) {
++    lowerTimeBound = medium.minWaitTimeEstimate;
++    upperTimeBound = medium.maxWaitTimeEstimate;
++  } else if (effectiveMaxPriorityFee.eq(highMaxPriorityFeeInWEI)) {
++    lowerTimeBound = high.minWaitTimeEstimate;
++    upperTimeBound = high.maxWaitTimeEstimate;
++  } else {
++    lowerTimeBound = 0;
++    upperTimeBound = high.maxWaitTimeEstimate;
++  }
++  return {
++    lowerTimeBound,
++    upperTimeBound
++  };
++}
++
++
++
++
++
++
++
++
++
++
++
++exports.__privateGet = __privateGet; exports.__privateAdd = __privateAdd; exports.__privateSet = __privateSet; exports.__privateMethod = __privateMethod; exports.normalizeGWEIDecimalNumbers = normalizeGWEIDecimalNumbers; exports.fetchGasEstimates = fetchGasEstimates; exports.fetchLegacyGasPriceEstimates = fetchLegacyGasPriceEstimates; exports.fetchEthGasPriceEstimate = fetchEthGasPriceEstimate; exports.calculateTimeEstimate = calculateTimeEstimate;
++//# sourceMappingURL=chunk-2MFVV2BX.js.map
+\ No newline at end of file
+diff --git a/dist/chunk-2MFVV2BX.js.map b/dist/chunk-2MFVV2BX.js.map
+new file mode 100644
+index 0000000000000000000000000000000000000000..c6d83c1c168ee0b053be10a74334ac712bb6a6a1
+--- /dev/null
++++ b/dist/chunk-2MFVV2BX.js.map
+@@ -0,0 +1 @@
++{"version":3,"sources":["../src/gas-util.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;AAAA;AAAA,EACE;AAAA,EACA;AAAA,EACA;AAAA,EACA;AAAA,OACK;AAEP,OAAO,QAAQ;AAUf,IAAM,qBAAqB,CAAC,cAAsB,EAAE,eAAe,SAAS;AAQrE,SAAS,4BAA4B,GAAoB;AAC9D,QAAM,iBAAiB,eAAe,CAAC,EAAE,SAAS,EAAE;AACpD,QAAM,eAAe,gBAAgB,cAAc;AACnD,SAAO;AACT;AASA,eAAsB,kBACpB,KACA,UAC0B;AAC1B,QAAM,YAAY,MAAM;AAAA,IACtB;AAAA,IACA,WAAW,EAAE,SAAS,mBAAmB,QAAQ,EAAE,IAAI;AAAA,EACzD;AACA,SAAO;AAAA,IACL,KAAK;AAAA,MACH,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,IAAI;AAAA,MAChB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,IAAI;AAAA,MAChB;AAAA,IACF;AAAA,IACA,QAAQ;AAAA,MACN,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,OAAO;AAAA,MACnB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,OAAO;AAAA,MACnB;AAAA,IACF;AAAA,IACA,MAAM;AAAA,MACJ,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,KAAK;AAAA,MACjB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,KAAK;AAAA,MACjB;AAAA,IACF;AAAA,IACA,kBAAkB,4BAA4B,UAAU,gBAAgB;AAAA,IACxE,wBAAwB,UAAU;AAAA,IAClC,cAAc,UAAU;AAAA,IACxB,wBAAwB,UAAU;AAAA,IAClC,4BAA4B,UAAU;AAAA,IACtC,kBAAkB,UAAU;AAAA,IAC5B,mBAAmB,UAAU;AAAA,EAC/B;AACF;AAUA,eAAsB,6BACpB,KACA,UACiC;AACjC,QAAM,SAAS,MAAM,YAAY,KAAK;AAAA,IACpC,UAAU;AAAA,IACV,gBAAgB;AAAA,IAChB,QAAQ;AAAA,IACR,MAAM;AAAA,IACN,SAAS;AAAA,MACP,gBAAgB;AAAA,MAChB,GAAI,YAAY,mBAAmB,QAAQ;AAAA,IAC7C;AAAA,EACF,CAAC;AACD,SAAO;AAAA,IACL,KAAK,OAAO;AAAA,IACZ,QAAQ,OAAO;AAAA,IACf,MAAM,OAAO;AAAA,EACf;AACF;AAQA,eAAsB,yBACpB,UAC8B;AAC9B,QAAM,WAAW,MAAM,MAAM,UAAU,UAAU;AACjD,SAAO;AAAA,IACL,UAAU,gBAAgB,QAAQ,EAAE,SAAS;AAAA,EAC/C;AACF;AAUO,SAAS,sBACd,sBACA,cACA,iBAC2B;AAC3B,QAAM,EAAE,KAAK,QAAQ,MAAM,iBAAiB,IAAI;AAEhD,QAAM,4BAA4B,eAAe,oBAAoB;AACrE,QAAM,oBAAoB,eAAe,YAAY;AACrD,QAAM,wBAAwB,eAAe,gBAAgB;AAE7D,QAAM,0BAA0B,GAAG;AAAA,IACjC;AAAA,IACA,kBAAkB,IAAI,qBAAqB;AAAA,EAC7C;AAEA,QAAM,yBAAyB;AAAA,IAC7B,IAAI;AAAA,EACN;AACA,QAAM,4BAA4B;AAAA,IAChC,OAAO;AAAA,EACT;AACA,QAAM,0BAA0B;AAAA,IAC9B,KAAK;AAAA,EACP;AAEA,MAAI;AACJ,MAAI;AAEJ,MAAI,wBAAwB,GAAG,sBAAsB,GAAG;AACtD,qBAAiB;AACjB,qBAAiB;AAAA,EACnB,WACE,wBAAwB,IAAI,sBAAsB,KAClD,wBAAwB,GAAG,yBAAyB,GACpD;AACA,qBAAiB,IAAI;AACrB,qBAAiB,IAAI;AAAA,EACvB,WACE,wBAAwB,IAAI,yBAAyB,KACrD,wBAAwB,GAAG,uBAAuB,GAClD;AACA,qBAAiB,OAAO;AACxB,qBAAiB,OAAO;AAAA,EAC1B,WAAW,wBAAwB,GAAG,uBAAuB,GAAG;AAC9D,qBAAiB,KAAK;AACtB,qBAAiB,KAAK;AAAA,EACxB,OAAO;AACL,qBAAiB;AACjB,qBAAiB,KAAK;AAAA,EACxB;AAEA,SAAO;AAAA,IACL;AAAA,IACA;AAAA,EACF;AACF","sourcesContent":["import {\n  query,\n  handleFetch,\n  gweiDecToWEIBN,\n  weiHexToGweiDec,\n} from '@metamask/controller-utils';\nimport type EthQuery from '@metamask/eth-query';\nimport BN from 'bn.js';\n\nimport type {\n  GasFeeEstimates,\n  EthGasPriceEstimate,\n  EstimatedGasFeeTimeBounds,\n  unknownString,\n  LegacyGasPriceEstimate,\n} from './GasFeeController';\n\nconst makeClientIdHeader = (clientId: string) => ({ 'X-Client-Id': clientId });\n\n/**\n * Convert a decimal GWEI value to a decimal string rounded to the nearest WEI.\n *\n * @param n - The input GWEI amount, as a decimal string or a number.\n * @returns The decimal string GWEI amount.\n */\nexport function normalizeGWEIDecimalNumbers(n: string | number) {\n  const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);\n  const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex);\n  return numberAsGWEI;\n}\n\n/**\n * Fetch gas estimates from the given URL.\n *\n * @param url - The gas estimate URL.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The gas estimates.\n */\nexport async function fetchGasEstimates(\n  url: string,\n  clientId?: string,\n): Promise<GasFeeEstimates> {\n  const estimates = await handleFetch(\n    url,\n    clientId ? { headers: makeClientIdHeader(clientId) } : undefined,\n  );\n  return {\n    low: {\n      ...estimates.low,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.low.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.low.suggestedMaxFeePerGas,\n      ),\n    },\n    medium: {\n      ...estimates.medium,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.medium.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.medium.suggestedMaxFeePerGas,\n      ),\n    },\n    high: {\n      ...estimates.high,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.high.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.high.suggestedMaxFeePerGas,\n      ),\n    },\n    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),\n    historicalBaseFeeRange: estimates.historicalBaseFeeRange,\n    baseFeeTrend: estimates.baseFeeTrend,\n    latestPriorityFeeRange: estimates.latestPriorityFeeRange,\n    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,\n    priorityFeeTrend: estimates.priorityFeeTrend,\n    networkCongestion: estimates.networkCongestion,\n  };\n}\n\n/**\n * Hit the legacy MetaSwaps gasPrices estimate api and return the low, medium\n * high values from that API.\n *\n * @param url - The URL to fetch gas price estimates from.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The gas price estimates.\n */\nexport async function fetchLegacyGasPriceEstimates(\n  url: string,\n  clientId?: string,\n): Promise<LegacyGasPriceEstimate> {\n  const result = await handleFetch(url, {\n    referrer: url,\n    referrerPolicy: 'no-referrer-when-downgrade',\n    method: 'GET',\n    mode: 'cors',\n    headers: {\n      'Content-Type': 'application/json',\n      ...(clientId && makeClientIdHeader(clientId)),\n    },\n  });\n  return {\n    low: result.SafeGasPrice,\n    medium: result.ProposeGasPrice,\n    high: result.FastGasPrice,\n  };\n}\n\n/**\n * Get a gas price estimate from the network using the `eth_gasPrice` method.\n *\n * @param ethQuery - The EthQuery instance to call the network with.\n * @returns A gas price estimate.\n */\nexport async function fetchEthGasPriceEstimate(\n  ethQuery: EthQuery,\n): Promise<EthGasPriceEstimate> {\n  const gasPrice = await query(ethQuery, 'gasPrice');\n  return {\n    gasPrice: weiHexToGweiDec(gasPrice).toString(),\n  };\n}\n\n/**\n * Estimate the time it will take for a transaction to be confirmed.\n *\n * @param maxPriorityFeePerGas - The max priority fee per gas.\n * @param maxFeePerGas - The max fee per gas.\n * @param gasFeeEstimates - The gas fee estimates.\n * @returns The estimated lower and upper bounds for when this transaction will be confirmed.\n */\nexport function calculateTimeEstimate(\n  maxPriorityFeePerGas: string,\n  maxFeePerGas: string,\n  gasFeeEstimates: GasFeeEstimates,\n): EstimatedGasFeeTimeBounds {\n  const { low, medium, high, estimatedBaseFee } = gasFeeEstimates;\n\n  const maxPriorityFeePerGasInWEI = gweiDecToWEIBN(maxPriorityFeePerGas);\n  const maxFeePerGasInWEI = gweiDecToWEIBN(maxFeePerGas);\n  const estimatedBaseFeeInWEI = gweiDecToWEIBN(estimatedBaseFee);\n\n  const effectiveMaxPriorityFee = BN.min(\n    maxPriorityFeePerGasInWEI,\n    maxFeePerGasInWEI.sub(estimatedBaseFeeInWEI),\n  );\n\n  const lowMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    low.suggestedMaxPriorityFeePerGas,\n  );\n  const mediumMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    medium.suggestedMaxPriorityFeePerGas,\n  );\n  const highMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    high.suggestedMaxPriorityFeePerGas,\n  );\n\n  let lowerTimeBound;\n  let upperTimeBound;\n\n  if (effectiveMaxPriorityFee.lt(lowMaxPriorityFeeInWEI)) {\n    lowerTimeBound = null;\n    upperTimeBound = 'unknown' as unknownString;\n  } else if (\n    effectiveMaxPriorityFee.gte(lowMaxPriorityFeeInWEI) &&\n    effectiveMaxPriorityFee.lt(mediumMaxPriorityFeeInWEI)\n  ) {\n    lowerTimeBound = low.minWaitTimeEstimate;\n    upperTimeBound = low.maxWaitTimeEstimate;\n  } else if (\n    effectiveMaxPriorityFee.gte(mediumMaxPriorityFeeInWEI) &&\n    effectiveMaxPriorityFee.lt(highMaxPriorityFeeInWEI)\n  ) {\n    lowerTimeBound = medium.minWaitTimeEstimate;\n    upperTimeBound = medium.maxWaitTimeEstimate;\n  } else if (effectiveMaxPriorityFee.eq(highMaxPriorityFeeInWEI)) {\n    lowerTimeBound = high.minWaitTimeEstimate;\n    upperTimeBound = high.maxWaitTimeEstimate;\n  } else {\n    lowerTimeBound = 0;\n    upperTimeBound = high.maxWaitTimeEstimate;\n  }\n\n  return {\n    lowerTimeBound,\n    upperTimeBound,\n  };\n}\n"]}
+\ No newline at end of file
+diff --git a/dist/chunk-A7NHJBXX.mjs b/dist/chunk-A7NHJBXX.mjs
+new file mode 100644
+index 0000000000000000000000000000000000000000..1dd920c4a314888548db98885976b336d2fec79d
+--- /dev/null
++++ b/dist/chunk-A7NHJBXX.mjs
+@@ -0,0 +1,390 @@
++import {
++  __privateAdd,
++  __privateGet,
++  __privateMethod,
++  __privateSet,
++  calculateTimeEstimate,
++  fetchEthGasPriceEstimate,
++  fetchGasEstimates,
++  fetchLegacyGasPriceEstimates
++} from "./chunk-R3IOI7AK.mjs";
++
++// src/GasFeeController.ts
++import {
++  convertHexToDecimal,
++  safelyExecute,
++  toHex
++} from "@metamask/controller-utils";
++import EthQuery from "@metamask/eth-query";
++import { StaticIntervalPollingController } from "@metamask/polling-controller";
++import { v1 as random } from "uuid";
++var LEGACY_GAS_PRICES_API_URL = `https://api.metaswap.codefi.network/gasPrices`;
++var GAS_ESTIMATE_TYPES = {
++  FEE_MARKET: "fee-market",
++  LEGACY: "legacy",
++  ETH_GASPRICE: "eth_gasPrice",
++  NONE: "none"
++};
++var metadata = {
++  gasFeeEstimatesByChainId: {
++    persist: true,
++    anonymous: false
++  },
++  gasFeeEstimates: { persist: true, anonymous: false },
++  estimatedGasFeeTimeBounds: { persist: true, anonymous: false },
++  gasEstimateType: { persist: true, anonymous: false },
++  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false }
++};
++var name = "GasFeeController";
++var defaultState = {
++  gasFeeEstimatesByChainId: {},
++  gasFeeEstimates: {},
++  estimatedGasFeeTimeBounds: {},
++  gasEstimateType: GAS_ESTIMATE_TYPES.NONE,
++  nonRPCGasFeeApisDisabled: false
++};
++var _getProvider, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn;
++var GasFeeController = class extends StaticIntervalPollingController {
++  /**
++   * Creates a GasFeeController instance.
++   *
++   * @param options - The controller options.
++   * @param options.interval - The time in milliseconds to wait between polls.
++   * @param options.messenger - The controller messenger.
++   * @param options.state - The initial state.
++   * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current
++   * network is EIP-1559 compatible.
++   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the
++   * current network is compatible with the legacy gas price API.
++   * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current
++   * account is EIP-1559 compatible.
++   * @param options.getChainId - Returns the current chain ID.
++   * @param options.getProvider - Returns a network provider for the current network.
++   * @param options.onNetworkDidChange - A function for registering an event handler for the
++   * network state change event.
++   * @param options.legacyAPIEndpoint - The legacy gas price API URL. This option is primarily for
++   * testing purposes.
++   * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL.
++   * @param options.clientId - The client ID used to identify to the gas estimation API who is
++   * asking for estimates.
++   */
++  constructor({
++    interval = 15e3,
++    messenger,
++    state,
++    getCurrentNetworkEIP1559Compatibility,
++    getCurrentAccountEIP1559Compatibility,
++    getChainId,
++    getCurrentNetworkLegacyGasAPICompatibility,
++    getProvider,
++    onNetworkDidChange,
++    legacyAPIEndpoint = LEGACY_GAS_PRICES_API_URL,
++    EIP1559APIEndpoint,
++    clientId
++  }) {
++    super({
++      name,
++      metadata,
++      messenger,
++      state: { ...defaultState, ...state }
++    });
++    __privateAdd(this, _onNetworkControllerDidChange);
++    __privateAdd(this, _getProvider, void 0);
++    this.intervalDelay = interval;
++    this.setIntervalLength(interval);
++    this.pollTokens = /* @__PURE__ */ new Set();
++    this.getCurrentNetworkEIP1559Compatibility = getCurrentNetworkEIP1559Compatibility;
++    this.getCurrentNetworkLegacyGasAPICompatibility = getCurrentNetworkLegacyGasAPICompatibility;
++    this.getCurrentAccountEIP1559Compatibility = getCurrentAccountEIP1559Compatibility;
++    __privateSet(this, _getProvider, getProvider);
++    this.EIP1559APIEndpoint = EIP1559APIEndpoint;
++    this.legacyAPIEndpoint = legacyAPIEndpoint;
++    this.clientId = clientId;
++    this.ethQuery = new EthQuery(__privateGet(this, _getProvider).call(this));
++    if (onNetworkDidChange && getChainId) {
++      this.currentChainId = getChainId();
++      onNetworkDidChange(async (networkControllerState) => {
++        await __privateMethod(this, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn).call(this, networkControllerState);
++      });
++    } else {
++      this.currentChainId = this.messagingSystem.call(
++        "NetworkController:getState"
++      ).providerConfig.chainId;
++      this.messagingSystem.subscribe(
++        "NetworkController:networkDidChange",
++        async (networkControllerState) => {
++          await __privateMethod(this, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn).call(this, networkControllerState);
++        }
++      );
++    }
++  }
++  async resetPolling() {
++    if (this.pollTokens.size !== 0) {
++      const tokens = Array.from(this.pollTokens);
++      this.stopPolling();
++      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);
++      tokens.slice(1).forEach((token) => {
++        this.pollTokens.add(token);
++      });
++    }
++  }
++  async fetchGasFeeEstimates(options) {
++    return await this._fetchGasFeeEstimateData(options);
++  }
++  async getGasFeeEstimatesAndStartPolling(pollToken) {
++    const _pollToken = pollToken || random();
++    this.pollTokens.add(_pollToken);
++    if (this.pollTokens.size === 1) {
++      await this._fetchGasFeeEstimateData();
++      this._poll();
++    }
++    return _pollToken;
++  }
++  /**
++   * Gets and sets gasFeeEstimates in state.
++   *
++   * @param options - The gas fee estimate options.
++   * @param options.shouldUpdateState - Determines whether the state should be updated with the
++   * updated gas estimates.
++   * @returns The gas fee estimates.
++   */
++  async _fetchGasFeeEstimateData(options = {}) {
++    const { shouldUpdateState = true, networkClientId } = options;
++    let ethQuery, isEIP1559Compatible, isLegacyGasAPICompatible, decimalChainId;
++    if (networkClientId !== void 0) {
++      const networkClient = this.messagingSystem.call(
++        "NetworkController:getNetworkClientById",
++        networkClientId
++      );
++      isLegacyGasAPICompatible = networkClient.configuration.chainId === "0x38";
++      decimalChainId = convertHexToDecimal(networkClient.configuration.chainId);
++      try {
++        const result = await this.messagingSystem.call(
++          "NetworkController:getEIP1559Compatibility",
++          networkClientId
++        );
++        isEIP1559Compatible = result || false;
++      } catch {
++        isEIP1559Compatible = false;
++      }
++      ethQuery = new EthQuery(networkClient.provider);
++    }
++    ethQuery ?? (ethQuery = this.ethQuery);
++    isLegacyGasAPICompatible ?? (isLegacyGasAPICompatible = this.getCurrentNetworkLegacyGasAPICompatibility());
++    decimalChainId ?? (decimalChainId = convertHexToDecimal(this.currentChainId));
++    try {
++      isEIP1559Compatible ?? (isEIP1559Compatible = await this.getEIP1559Compatibility());
++    } catch (e) {
++      console.error(e);
++      isEIP1559Compatible ?? (isEIP1559Compatible = false);
++    }
++    const gasFeeCalculations = await determineGasFeeCalculations({
++      isEIP1559Compatible,
++      isLegacyGasAPICompatible,
++      fetchGasEstimates,
++      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(
++        "<chain_id>",
++        `${decimalChainId}`
++      ),
++      fetchLegacyGasPriceEstimates,
++      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(
++        "<chain_id>",
++        `${decimalChainId}`
++      ),
++      fetchEthGasPriceEstimate,
++      calculateTimeEstimate,
++      clientId: this.clientId,
++      ethQuery,
++      nonRPCGasFeeApisDisabled: this.state.nonRPCGasFeeApisDisabled
++    });
++    if (shouldUpdateState) {
++      const chainId = toHex(decimalChainId);
++      this.update((state) => {
++        if (this.currentChainId === chainId) {
++          state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;
++          state.estimatedGasFeeTimeBounds = gasFeeCalculations.estimatedGasFeeTimeBounds;
++          state.gasEstimateType = gasFeeCalculations.gasEstimateType;
++        }
++        state.gasFeeEstimatesByChainId ?? (state.gasFeeEstimatesByChainId = {});
++        state.gasFeeEstimatesByChainId[chainId] = {
++          gasFeeEstimates: gasFeeCalculations.gasFeeEstimates,
++          estimatedGasFeeTimeBounds: gasFeeCalculations.estimatedGasFeeTimeBounds,
++          gasEstimateType: gasFeeCalculations.gasEstimateType
++        };
++      });
++    }
++    return gasFeeCalculations;
++  }
++  /**
++   * Remove the poll token, and stop polling if the set of poll tokens is empty.
++   *
++   * @param pollToken - The poll token to disconnect.
++   */
++  disconnectPoller(pollToken) {
++    this.pollTokens.delete(pollToken);
++    if (this.pollTokens.size === 0) {
++      this.stopPolling();
++    }
++  }
++  stopPolling() {
++    if (this.intervalId) {
++      clearInterval(this.intervalId);
++    }
++    this.pollTokens.clear();
++    this.resetState();
++  }
++  /**
++   * Prepare to discard this controller.
++   *
++   * This stops any active polling.
++   */
++  destroy() {
++    super.destroy();
++    this.stopPolling();
++  }
++  _poll() {
++    if (this.intervalId) {
++      clearInterval(this.intervalId);
++    }
++    this.intervalId = setInterval(async () => {
++      await safelyExecute(() => this._fetchGasFeeEstimateData());
++    }, this.intervalDelay);
++  }
++  /**
++   * Fetching token list from the Token Service API.
++   *
++   * @private
++   * @param networkClientId - The ID of the network client triggering the fetch.
++   * @returns A promise that resolves when this operation completes.
++   */
++  async _executePoll(networkClientId) {
++    await this._fetchGasFeeEstimateData({ networkClientId });
++  }
++  resetState() {
++    this.update(() => {
++      return defaultState;
++    });
++  }
++  async getEIP1559Compatibility() {
++    const currentNetworkIsEIP1559Compatible = await this.getCurrentNetworkEIP1559Compatibility();
++    const currentAccountIsEIP1559Compatible = this.getCurrentAccountEIP1559Compatibility?.() ?? true;
++    return currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible;
++  }
++  getTimeEstimate(maxPriorityFeePerGas, maxFeePerGas) {
++    if (!this.state.gasFeeEstimates || this.state.gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET) {
++      return {};
++    }
++    return calculateTimeEstimate(
++      maxPriorityFeePerGas,
++      maxFeePerGas,
++      this.state.gasFeeEstimates
++    );
++  }
++  enableNonRPCGasFeeApis() {
++    this.update((state) => {
++      state.nonRPCGasFeeApisDisabled = false;
++    });
++  }
++  disableNonRPCGasFeeApis() {
++    this.update((state) => {
++      state.nonRPCGasFeeApisDisabled = true;
++    });
++  }
++};
++_getProvider = new WeakMap();
++_onNetworkControllerDidChange = new WeakSet();
++onNetworkControllerDidChange_fn = async function(networkControllerState) {
++  const newChainId = networkControllerState.providerConfig.chainId;
++  if (newChainId !== this.currentChainId) {
++    this.ethQuery = new EthQuery(__privateGet(this, _getProvider).call(this));
++    await this.resetPolling();
++    this.currentChainId = newChainId;
++  }
++};
++var GasFeeController_default = GasFeeController;
++
++// src/determineGasFeeCalculations.ts
++async function determineGasFeeCalculations(args) {
++  try {
++    return await getEstimatesUsingFallbacks(args);
++  } catch (error) {
++    if (error instanceof Error) {
++      throw new Error(
++        `Gas fee/price estimation failed. Message: ${error.message}`
++      );
++    }
++    throw error;
++  }
++}
++async function getEstimatesUsingFallbacks(request) {
++  const {
++    isEIP1559Compatible,
++    isLegacyGasAPICompatible,
++    nonRPCGasFeeApisDisabled
++  } = request;
++  try {
++    if (isEIP1559Compatible && !nonRPCGasFeeApisDisabled) {
++      return await getEstimatesUsingFeeMarketEndpoint(request);
++    }
++    if (isLegacyGasAPICompatible && !nonRPCGasFeeApisDisabled) {
++      return await getEstimatesUsingLegacyEndpoint(request);
++    }
++    throw new Error("Main gas fee/price estimation failed. Use fallback");
++  } catch {
++    return await getEstimatesUsingProvider(request);
++  }
++}
++async function getEstimatesUsingFeeMarketEndpoint(request) {
++  const {
++    fetchGasEstimates: fetchGasEstimates2,
++    fetchGasEstimatesUrl,
++    clientId,
++    calculateTimeEstimate: calculateTimeEstimate2
++  } = request;
++  const estimates = await fetchGasEstimates2(fetchGasEstimatesUrl, clientId);
++  const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } = estimates.medium;
++  const estimatedGasFeeTimeBounds = calculateTimeEstimate2(
++    suggestedMaxPriorityFeePerGas,
++    suggestedMaxFeePerGas,
++    estimates
++  );
++  return {
++    gasFeeEstimates: estimates,
++    estimatedGasFeeTimeBounds,
++    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET
++  };
++}
++async function getEstimatesUsingLegacyEndpoint(request) {
++  const {
++    fetchLegacyGasPriceEstimates: fetchLegacyGasPriceEstimates2,
++    fetchLegacyGasPriceEstimatesUrl,
++    clientId
++  } = request;
++  const estimates = await fetchLegacyGasPriceEstimates2(
++    fetchLegacyGasPriceEstimatesUrl,
++    clientId
++  );
++  return {
++    gasFeeEstimates: estimates,
++    estimatedGasFeeTimeBounds: {},
++    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY
++  };
++}
++async function getEstimatesUsingProvider(request) {
++  const { ethQuery, fetchEthGasPriceEstimate: fetchEthGasPriceEstimate2 } = request;
++  const estimates = await fetchEthGasPriceEstimate2(ethQuery);
++  return {
++    gasFeeEstimates: estimates,
++    estimatedGasFeeTimeBounds: {},
++    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE
++  };
++}
++
++export {
++  determineGasFeeCalculations,
++  LEGACY_GAS_PRICES_API_URL,
++  GAS_ESTIMATE_TYPES,
++  GasFeeController,
++  GasFeeController_default
++};
++//# sourceMappingURL=chunk-A7NHJBXX.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-A7NHJBXX.mjs.map b/dist/chunk-A7NHJBXX.mjs.map
+new file mode 100644
+index 0000000000000000000000000000000000000000..d40e21b8870bb3ef2d3a092e9abdbb83527764f3
+--- /dev/null
++++ b/dist/chunk-A7NHJBXX.mjs.map
+@@ -0,0 +1 @@
++{"version":3,"sources":["../src/GasFeeController.ts","../src/determineGasFeeCalculations.ts"],"sourcesContent":["import type {\n  ControllerGetStateAction,\n  ControllerStateChangeEvent,\n  RestrictedControllerMessenger,\n} from '@metamask/base-controller';\nimport {\n  convertHexToDecimal,\n  safelyExecute,\n  toHex,\n} from '@metamask/controller-utils';\nimport EthQuery from '@metamask/eth-query';\nimport type {\n  NetworkClientId,\n  NetworkControllerGetEIP1559CompatibilityAction,\n  NetworkControllerGetNetworkClientByIdAction,\n  NetworkControllerGetStateAction,\n  NetworkControllerNetworkDidChangeEvent,\n  NetworkState,\n  ProviderProxy,\n} from '@metamask/network-controller';\nimport { StaticIntervalPollingController } from '@metamask/polling-controller';\nimport type { Hex } from '@metamask/utils';\nimport { v1 as random } from 'uuid';\n\nimport determineGasFeeCalculations from './determineGasFeeCalculations';\nimport {\n  fetchGasEstimates,\n  fetchLegacyGasPriceEstimates,\n  fetchEthGasPriceEstimate,\n  calculateTimeEstimate,\n} from './gas-util';\n\nexport const LEGACY_GAS_PRICES_API_URL = `https://api.metaswap.codefi.network/gasPrices`;\n\nexport type unknownString = 'unknown';\n\n// Fee Market describes the way gas is set after the london hardfork, and was\n// defined by EIP-1559.\nexport type FeeMarketEstimateType = 'fee-market';\n// Legacy describes gasPrice estimates from before london hardfork, when the\n// user is connected to mainnet and are presented with fast/average/slow\n// estimate levels to choose from.\nexport type LegacyEstimateType = 'legacy';\n// EthGasPrice describes a gasPrice estimate received from eth_gasPrice. Post\n// london this value should only be used for legacy type transactions when on\n// networks that support EIP-1559. This type of estimate is the most accurate\n// to display on custom networks that don't support EIP-1559.\nexport type EthGasPriceEstimateType = 'eth_gasPrice';\n// NoEstimate describes the state of the controller before receiving its first\n// estimate.\nexport type NoEstimateType = 'none';\n\n/**\n * Indicates which type of gasEstimate the controller is currently returning.\n * This is useful as a way of asserting that the shape of gasEstimates matches\n * expectations. NONE is a special case indicating that no previous gasEstimate\n * has been fetched.\n */\nexport const GAS_ESTIMATE_TYPES = {\n  FEE_MARKET: 'fee-market' as FeeMarketEstimateType,\n  LEGACY: 'legacy' as LegacyEstimateType,\n  ETH_GASPRICE: 'eth_gasPrice' as EthGasPriceEstimateType,\n  NONE: 'none' as NoEstimateType,\n};\n\nexport type GasEstimateType =\n  | FeeMarketEstimateType\n  | EthGasPriceEstimateType\n  | LegacyEstimateType\n  | NoEstimateType;\n\nexport type EstimatedGasFeeTimeBounds = {\n  lowerTimeBound: number | null;\n  upperTimeBound: number | unknownString;\n};\n\n/**\n * @type EthGasPriceEstimate\n *\n * A single gas price estimate for networks and accounts that don't support EIP-1559\n * This estimate comes from eth_gasPrice but is converted to dec gwei to match other\n * return values\n * @property gasPrice - A GWEI dec string\n */\n\nexport type EthGasPriceEstimate = {\n  gasPrice: string;\n};\n\n/**\n * @type LegacyGasPriceEstimate\n *\n * A set of gas price estimates for networks and accounts that don't support EIP-1559\n * These estimates include low, medium and high all as strings representing gwei in\n * decimal format.\n * @property high - gasPrice, in decimal gwei string format, suggested for fast inclusion\n * @property medium - gasPrice, in decimal gwei string format, suggested for avg inclusion\n * @property low - gasPrice, in decimal gwei string format, suggested for slow inclusion\n */\nexport type LegacyGasPriceEstimate = {\n  high: string;\n  medium: string;\n  low: string;\n};\n\n/**\n * @type Eip1559GasFee\n *\n * Data necessary to provide an estimate of a gas fee with a specific tip\n * @property minWaitTimeEstimate - The fastest the transaction will take, in milliseconds\n * @property maxWaitTimeEstimate - The slowest the transaction will take, in milliseconds\n * @property suggestedMaxPriorityFeePerGas - A suggested \"tip\", a GWEI hex number\n * @property suggestedMaxFeePerGas - A suggested max fee, the most a user will pay. a GWEI hex number\n */\nexport type Eip1559GasFee = {\n  minWaitTimeEstimate: number; // a time duration in milliseconds\n  maxWaitTimeEstimate: number; // a time duration in milliseconds\n  suggestedMaxPriorityFeePerGas: string; // a GWEI decimal number\n  suggestedMaxFeePerGas: string; // a GWEI decimal number\n};\n\n/**\n * @type GasFeeEstimates\n *\n * Data necessary to provide multiple GasFee estimates, and supporting information, to the user\n * @property low - A GasFee for a minimum necessary combination of tip and maxFee\n * @property medium - A GasFee for a recommended combination of tip and maxFee\n * @property high - A GasFee for a high combination of tip and maxFee\n * @property estimatedBaseFee - An estimate of what the base fee will be for the pending/next block. A GWEI dec number\n * @property networkCongestion - A normalized number that can be used to gauge the congestion\n * level of the network, with 0 meaning not congested and 1 meaning extremely congested\n */\nexport type GasFeeEstimates = SourcedGasFeeEstimates | FallbackGasFeeEstimates;\n\ntype SourcedGasFeeEstimates = {\n  low: Eip1559GasFee;\n  medium: Eip1559GasFee;\n  high: Eip1559GasFee;\n  estimatedBaseFee: string;\n  historicalBaseFeeRange: [string, string];\n  baseFeeTrend: 'up' | 'down' | 'level';\n  latestPriorityFeeRange: [string, string];\n  historicalPriorityFeeRange: [string, string];\n  priorityFeeTrend: 'up' | 'down' | 'level';\n  networkCongestion: number;\n};\n\ntype FallbackGasFeeEstimates = {\n  low: Eip1559GasFee;\n  medium: Eip1559GasFee;\n  high: Eip1559GasFee;\n  estimatedBaseFee: string;\n  historicalBaseFeeRange: null;\n  baseFeeTrend: null;\n  latestPriorityFeeRange: null;\n  historicalPriorityFeeRange: null;\n  priorityFeeTrend: null;\n  networkCongestion: null;\n};\n\nconst metadata = {\n  gasFeeEstimatesByChainId: {\n    persist: true,\n    anonymous: false,\n  },\n  gasFeeEstimates: { persist: true, anonymous: false },\n  estimatedGasFeeTimeBounds: { persist: true, anonymous: false },\n  gasEstimateType: { persist: true, anonymous: false },\n  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false },\n};\n\nexport type GasFeeStateEthGasPrice = {\n  gasFeeEstimates: EthGasPriceEstimate;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: EthGasPriceEstimateType;\n};\n\nexport type GasFeeStateFeeMarket = {\n  gasFeeEstimates: GasFeeEstimates;\n  estimatedGasFeeTimeBounds: EstimatedGasFeeTimeBounds | Record<string, never>;\n  gasEstimateType: FeeMarketEstimateType;\n};\n\nexport type GasFeeStateLegacy = {\n  gasFeeEstimates: LegacyGasPriceEstimate;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: LegacyEstimateType;\n};\n\nexport type GasFeeStateNoEstimates = {\n  gasFeeEstimates: Record<string, never>;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: NoEstimateType;\n};\n\nexport type FetchGasFeeEstimateOptions = {\n  shouldUpdateState?: boolean;\n  networkClientId?: NetworkClientId;\n};\n\n/**\n * @type GasFeeState\n *\n * Gas Fee controller state\n * @property gasFeeEstimates - Gas fee estimate data based on new EIP-1559 properties\n * @property estimatedGasFeeTimeBounds - Estimates representing the minimum and maximum\n */\nexport type SingleChainGasFeeState =\n  | GasFeeStateEthGasPrice\n  | GasFeeStateFeeMarket\n  | GasFeeStateLegacy\n  | GasFeeStateNoEstimates;\n\nexport type GasFeeEstimatesByChainId = {\n  gasFeeEstimatesByChainId?: Record<string, SingleChainGasFeeState>;\n};\n\nexport type GasFeeState = GasFeeEstimatesByChainId &\n  SingleChainGasFeeState & {\n    nonRPCGasFeeApisDisabled?: boolean;\n  };\n\nconst name = 'GasFeeController';\n\nexport type GasFeeStateChange = ControllerStateChangeEvent<\n  typeof name,\n  GasFeeState\n>;\n\nexport type GetGasFeeState = ControllerGetStateAction<typeof name, GasFeeState>;\n\nexport type GasFeeControllerActions = GetGasFeeState;\n\nexport type GasFeeControllerEvents = GasFeeStateChange;\n\ntype AllowedActions =\n  | NetworkControllerGetStateAction\n  | NetworkControllerGetNetworkClientByIdAction\n  | NetworkControllerGetEIP1559CompatibilityAction;\n\ntype GasFeeMessenger = RestrictedControllerMessenger<\n  typeof name,\n  GasFeeControllerActions | AllowedActions,\n  GasFeeControllerEvents | NetworkControllerNetworkDidChangeEvent,\n  AllowedActions['type'],\n  NetworkControllerNetworkDidChangeEvent['type']\n>;\n\nconst defaultState: GasFeeState = {\n  gasFeeEstimatesByChainId: {},\n  gasFeeEstimates: {},\n  estimatedGasFeeTimeBounds: {},\n  gasEstimateType: GAS_ESTIMATE_TYPES.NONE,\n  nonRPCGasFeeApisDisabled: false,\n};\n\n/**\n * Controller that retrieves gas fee estimate data and polls for updated data on a set interval\n */\nexport class GasFeeController extends StaticIntervalPollingController<\n  typeof name,\n  GasFeeState,\n  GasFeeMessenger\n> {\n  private intervalId?: ReturnType<typeof setTimeout>;\n\n  private readonly intervalDelay;\n\n  private readonly pollTokens: Set<string>;\n\n  private readonly legacyAPIEndpoint: string;\n\n  private readonly EIP1559APIEndpoint: string;\n\n  private readonly getCurrentNetworkEIP1559Compatibility;\n\n  private readonly getCurrentNetworkLegacyGasAPICompatibility;\n\n  private readonly getCurrentAccountEIP1559Compatibility;\n\n  private currentChainId;\n\n  private ethQuery?: EthQuery;\n\n  private readonly clientId?: string;\n\n  #getProvider: () => ProviderProxy;\n\n  /**\n   * Creates a GasFeeController instance.\n   *\n   * @param options - The controller options.\n   * @param options.interval - The time in milliseconds to wait between polls.\n   * @param options.messenger - The controller messenger.\n   * @param options.state - The initial state.\n   * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current\n   * network is EIP-1559 compatible.\n   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the\n   * current network is compatible with the legacy gas price API.\n   * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current\n   * account is EIP-1559 compatible.\n   * @param options.getChainId - Returns the current chain ID.\n   * @param options.getProvider - Returns a network provider for the current network.\n   * @param options.onNetworkDidChange - A function for registering an event handler for the\n   * network state change event.\n   * @param options.legacyAPIEndpoint - The legacy gas price API URL. This option is primarily for\n   * testing purposes.\n   * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL.\n   * @param options.clientId - The client ID used to identify to the gas estimation API who is\n   * asking for estimates.\n   */\n  constructor({\n    interval = 15000,\n    messenger,\n    state,\n    getCurrentNetworkEIP1559Compatibility,\n    getCurrentAccountEIP1559Compatibility,\n    getChainId,\n    getCurrentNetworkLegacyGasAPICompatibility,\n    getProvider,\n    onNetworkDidChange,\n    legacyAPIEndpoint = LEGACY_GAS_PRICES_API_URL,\n    EIP1559APIEndpoint,\n    clientId,\n  }: {\n    interval?: number;\n    messenger: GasFeeMessenger;\n    state?: GasFeeState;\n    getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;\n    getCurrentNetworkLegacyGasAPICompatibility: () => boolean;\n    getCurrentAccountEIP1559Compatibility?: () => boolean;\n    getChainId?: () => Hex;\n    getProvider: () => ProviderProxy;\n    onNetworkDidChange?: (listener: (state: NetworkState) => void) => void;\n    legacyAPIEndpoint?: string;\n    // eslint-disable-next-line @typescript-eslint/naming-convention\n    EIP1559APIEndpoint: string;\n    clientId?: string;\n  }) {\n    super({\n      name,\n      metadata,\n      messenger,\n      state: { ...defaultState, ...state },\n    });\n    this.intervalDelay = interval;\n    this.setIntervalLength(interval);\n    this.pollTokens = new Set();\n    this.getCurrentNetworkEIP1559Compatibility =\n      getCurrentNetworkEIP1559Compatibility;\n    this.getCurrentNetworkLegacyGasAPICompatibility =\n      getCurrentNetworkLegacyGasAPICompatibility;\n    this.getCurrentAccountEIP1559Compatibility =\n      getCurrentAccountEIP1559Compatibility;\n    this.#getProvider = getProvider;\n    this.EIP1559APIEndpoint = EIP1559APIEndpoint;\n    this.legacyAPIEndpoint = legacyAPIEndpoint;\n    this.clientId = clientId;\n\n    this.ethQuery = new EthQuery(this.#getProvider());\n\n    if (onNetworkDidChange && getChainId) {\n      this.currentChainId = getChainId();\n      onNetworkDidChange(async (networkControllerState) => {\n        await this.#onNetworkControllerDidChange(networkControllerState);\n      });\n    } else {\n      this.currentChainId = this.messagingSystem.call(\n        'NetworkController:getState',\n      ).providerConfig.chainId;\n      this.messagingSystem.subscribe(\n        'NetworkController:networkDidChange',\n        async (networkControllerState) => {\n          await this.#onNetworkControllerDidChange(networkControllerState);\n        },\n      );\n    }\n  }\n\n  async resetPolling() {\n    if (this.pollTokens.size !== 0) {\n      const tokens = Array.from(this.pollTokens);\n      this.stopPolling();\n      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);\n      tokens.slice(1).forEach((token) => {\n        this.pollTokens.add(token);\n      });\n    }\n  }\n\n  async fetchGasFeeEstimates(options?: FetchGasFeeEstimateOptions) {\n    return await this._fetchGasFeeEstimateData(options);\n  }\n\n  async getGasFeeEstimatesAndStartPolling(\n    pollToken: string | undefined,\n  ): Promise<string> {\n    const _pollToken = pollToken || random();\n\n    this.pollTokens.add(_pollToken);\n\n    if (this.pollTokens.size === 1) {\n      await this._fetchGasFeeEstimateData();\n      this._poll();\n    }\n\n    return _pollToken;\n  }\n\n  /**\n   * Gets and sets gasFeeEstimates in state.\n   *\n   * @param options - The gas fee estimate options.\n   * @param options.shouldUpdateState - Determines whether the state should be updated with the\n   * updated gas estimates.\n   * @returns The gas fee estimates.\n   */\n  async _fetchGasFeeEstimateData(\n    options: FetchGasFeeEstimateOptions = {},\n  ): Promise<GasFeeState> {\n    const { shouldUpdateState = true, networkClientId } = options;\n\n    let ethQuery,\n      isEIP1559Compatible,\n      isLegacyGasAPICompatible,\n      decimalChainId: number;\n\n    if (networkClientId !== undefined) {\n      const networkClient = this.messagingSystem.call(\n        'NetworkController:getNetworkClientById',\n        networkClientId,\n      );\n      isLegacyGasAPICompatible = networkClient.configuration.chainId === '0x38';\n\n      decimalChainId = convertHexToDecimal(networkClient.configuration.chainId);\n\n      try {\n        const result = await this.messagingSystem.call(\n          'NetworkController:getEIP1559Compatibility',\n          networkClientId,\n        );\n        isEIP1559Compatible = result || false;\n      } catch {\n        isEIP1559Compatible = false;\n      }\n      ethQuery = new EthQuery(networkClient.provider);\n    }\n\n    ethQuery ??= this.ethQuery;\n\n    isLegacyGasAPICompatible ??=\n      this.getCurrentNetworkLegacyGasAPICompatibility();\n\n    decimalChainId ??= convertHexToDecimal(this.currentChainId);\n\n    try {\n      isEIP1559Compatible ??= await this.getEIP1559Compatibility();\n    } catch (e) {\n      console.error(e);\n      isEIP1559Compatible ??= false;\n    }\n\n    const gasFeeCalculations = await determineGasFeeCalculations({\n      isEIP1559Compatible,\n      isLegacyGasAPICompatible,\n      fetchGasEstimates,\n      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(\n        '<chain_id>',\n        `${decimalChainId}`,\n      ),\n      fetchLegacyGasPriceEstimates,\n      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(\n        '<chain_id>',\n        `${decimalChainId}`,\n      ),\n      fetchEthGasPriceEstimate,\n      calculateTimeEstimate,\n      clientId: this.clientId,\n      ethQuery,\n      nonRPCGasFeeApisDisabled: this.state.nonRPCGasFeeApisDisabled,\n    });\n\n    if (shouldUpdateState) {\n      const chainId = toHex(decimalChainId);\n      this.update((state) => {\n        if (this.currentChainId === chainId) {\n          state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;\n          state.estimatedGasFeeTimeBounds =\n            gasFeeCalculations.estimatedGasFeeTimeBounds;\n          state.gasEstimateType = gasFeeCalculations.gasEstimateType;\n        }\n        state.gasFeeEstimatesByChainId ??= {};\n        state.gasFeeEstimatesByChainId[chainId] = {\n          gasFeeEstimates: gasFeeCalculations.gasFeeEstimates,\n          estimatedGasFeeTimeBounds:\n            gasFeeCalculations.estimatedGasFeeTimeBounds,\n          gasEstimateType: gasFeeCalculations.gasEstimateType,\n        } as SingleChainGasFeeState;\n      });\n    }\n\n    return gasFeeCalculations;\n  }\n\n  /**\n   * Remove the poll token, and stop polling if the set of poll tokens is empty.\n   *\n   * @param pollToken - The poll token to disconnect.\n   */\n  disconnectPoller(pollToken: string) {\n    this.pollTokens.delete(pollToken);\n    if (this.pollTokens.size === 0) {\n      this.stopPolling();\n    }\n  }\n\n  stopPolling() {\n    if (this.intervalId) {\n      clearInterval(this.intervalId);\n    }\n    this.pollTokens.clear();\n    this.resetState();\n  }\n\n  /**\n   * Prepare to discard this controller.\n   *\n   * This stops any active polling.\n   */\n  override destroy() {\n    super.destroy();\n    this.stopPolling();\n  }\n\n  private _poll() {\n    if (this.intervalId) {\n      clearInterval(this.intervalId);\n    }\n\n    this.intervalId = setInterval(async () => {\n      await safelyExecute(() => this._fetchGasFeeEstimateData());\n    }, this.intervalDelay);\n  }\n\n  /**\n   * Fetching token list from the Token Service API.\n   *\n   * @private\n   * @param networkClientId - The ID of the network client triggering the fetch.\n   * @returns A promise that resolves when this operation completes.\n   */\n  async _executePoll(networkClientId: string): Promise<void> {\n    await this._fetchGasFeeEstimateData({ networkClientId });\n  }\n\n  private resetState() {\n    this.update(() => {\n      return defaultState;\n    });\n  }\n\n  private async getEIP1559Compatibility() {\n    const currentNetworkIsEIP1559Compatible =\n      await this.getCurrentNetworkEIP1559Compatibility();\n    const currentAccountIsEIP1559Compatible =\n      this.getCurrentAccountEIP1559Compatibility?.() ?? true;\n\n    return (\n      currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible\n    );\n  }\n\n  getTimeEstimate(\n    maxPriorityFeePerGas: string,\n    maxFeePerGas: string,\n  ): EstimatedGasFeeTimeBounds | Record<string, never> {\n    if (\n      !this.state.gasFeeEstimates ||\n      this.state.gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET\n    ) {\n      return {};\n    }\n    return calculateTimeEstimate(\n      maxPriorityFeePerGas,\n      maxFeePerGas,\n      this.state.gasFeeEstimates,\n    );\n  }\n\n  async #onNetworkControllerDidChange(networkControllerState: NetworkState) {\n    const newChainId = networkControllerState.providerConfig.chainId;\n\n    if (newChainId !== this.currentChainId) {\n      this.ethQuery = new EthQuery(this.#getProvider());\n      await this.resetPolling();\n\n      this.currentChainId = newChainId;\n    }\n  }\n\n  enableNonRPCGasFeeApis() {\n    this.update((state) => {\n      state.nonRPCGasFeeApisDisabled = false;\n    });\n  }\n\n  disableNonRPCGasFeeApis() {\n    this.update((state) => {\n      state.nonRPCGasFeeApisDisabled = true;\n    });\n  }\n}\n\nexport default GasFeeController;\n","import type {\n  EstimatedGasFeeTimeBounds,\n  EthGasPriceEstimate,\n  GasFeeEstimates,\n  GasFeeState as GasFeeCalculations,\n  LegacyGasPriceEstimate,\n} from './GasFeeController';\nimport { GAS_ESTIMATE_TYPES } from './GasFeeController';\n\ntype DetermineGasFeeCalculationsRequest = {\n  isEIP1559Compatible: boolean;\n  isLegacyGasAPICompatible: boolean;\n  fetchGasEstimates: (\n    url: string,\n    clientId?: string,\n  ) => Promise<GasFeeEstimates>;\n  fetchGasEstimatesUrl: string;\n  fetchLegacyGasPriceEstimates: (\n    url: string,\n    clientId?: string,\n  ) => Promise<LegacyGasPriceEstimate>;\n  fetchLegacyGasPriceEstimatesUrl: string;\n  // TODO: Replace `any` with type\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\n  fetchEthGasPriceEstimate: (ethQuery: any) => Promise<EthGasPriceEstimate>;\n  calculateTimeEstimate: (\n    maxPriorityFeePerGas: string,\n    maxFeePerGas: string,\n    gasFeeEstimates: GasFeeEstimates,\n  ) => EstimatedGasFeeTimeBounds;\n  clientId: string | undefined;\n  // TODO: Replace `any` with type\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\n  ethQuery: any;\n  nonRPCGasFeeApisDisabled?: boolean;\n};\n\n/**\n * Obtains a set of max base and priority fee estimates along with time estimates so that we\n * can present them to users when they are sending transactions or making swaps.\n *\n * @param args - The arguments.\n * @param args.isEIP1559Compatible - Governs whether or not we can use an EIP-1559-only method to\n * produce estimates.\n * @param args.isLegacyGasAPICompatible - Governs whether or not we can use a non-EIP-1559 method to\n * produce estimates (for instance, testnets do not support estimates altogether).\n * @param args.fetchGasEstimates - A function that fetches gas estimates using an EIP-1559-specific\n * API.\n * @param args.fetchGasEstimatesUrl - The URL for the API we can use to obtain EIP-1559-specific\n * estimates.\n * @param args.fetchLegacyGasPriceEstimates - A function that fetches gas estimates using an\n * non-EIP-1559-specific API.\n * @param args.fetchLegacyGasPriceEstimatesUrl - The URL for the API we can use to obtain\n * non-EIP-1559-specific estimates.\n * @param args.fetchEthGasPriceEstimate - A function that fetches gas estimates using\n * `eth_gasPrice`.\n * @param args.calculateTimeEstimate - A function that determine time estimate bounds.\n * @param args.clientId - An identifier that an API can use to know who is asking for estimates.\n * @param args.ethQuery - An EthQuery instance we can use to talk to Ethereum directly.\n * @param args.nonRPCGasFeeApisDisabled - Whether to disable requests to the legacyAPIEndpoint and the EIP1559APIEndpoint\n * @returns The gas fee calculations.\n */\nexport default async function determineGasFeeCalculations(\n  args: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  try {\n    return await getEstimatesUsingFallbacks(args);\n  } catch (error) {\n    if (error instanceof Error) {\n      throw new Error(\n        `Gas fee/price estimation failed. Message: ${error.message}`,\n      );\n    }\n\n    throw error;\n  }\n}\n\n/**\n * Retrieve the gas fee estimates using a series of fallback mechanisms.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingFallbacks(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    isEIP1559Compatible,\n    isLegacyGasAPICompatible,\n    nonRPCGasFeeApisDisabled,\n  } = request;\n\n  try {\n    if (isEIP1559Compatible && !nonRPCGasFeeApisDisabled) {\n      return await getEstimatesUsingFeeMarketEndpoint(request);\n    }\n\n    if (isLegacyGasAPICompatible && !nonRPCGasFeeApisDisabled) {\n      return await getEstimatesUsingLegacyEndpoint(request);\n    }\n\n    throw new Error('Main gas fee/price estimation failed. Use fallback');\n  } catch {\n    return await getEstimatesUsingProvider(request);\n  }\n}\n\n/**\n * Retrieve gas fee estimates using the EIP-1559 endpoint of the gas API.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingFeeMarketEndpoint(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    fetchGasEstimates,\n    fetchGasEstimatesUrl,\n    clientId,\n    calculateTimeEstimate,\n  } = request;\n\n  const estimates = await fetchGasEstimates(fetchGasEstimatesUrl, clientId);\n\n  const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } =\n    estimates.medium;\n\n  const estimatedGasFeeTimeBounds = calculateTimeEstimate(\n    suggestedMaxPriorityFeePerGas,\n    suggestedMaxFeePerGas,\n    estimates,\n  );\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds,\n    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,\n  };\n}\n\n/**\n * Retrieve gas fee estimates using the legacy endpoint of the gas API.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingLegacyEndpoint(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    fetchLegacyGasPriceEstimates,\n    fetchLegacyGasPriceEstimatesUrl,\n    clientId,\n  } = request;\n\n  const estimates = await fetchLegacyGasPriceEstimates(\n    fetchLegacyGasPriceEstimatesUrl,\n    clientId,\n  );\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds: {},\n    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,\n  };\n}\n\n/**\n * Retrieve gas fee estimates using an `eth_gasPrice` call to the RPC provider.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingProvider(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const { ethQuery, fetchEthGasPriceEstimate } = request;\n\n  const estimates = await fetchEthGasPriceEstimate(ethQuery);\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds: {},\n    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,\n  };\n}\n"],"mappings":";;;;;;;;;;;;AAKA;AAAA,EACE;AAAA,EACA;AAAA,EACA;AAAA,OACK;AACP,OAAO,cAAc;AAUrB,SAAS,uCAAuC;AAEhD,SAAS,MAAM,cAAc;AAUtB,IAAM,4BAA4B;AA0BlC,IAAM,qBAAqB;AAAA,EAChC,YAAY;AAAA,EACZ,QAAQ;AAAA,EACR,cAAc;AAAA,EACd,MAAM;AACR;AAiGA,IAAM,WAAW;AAAA,EACf,0BAA0B;AAAA,IACxB,SAAS;AAAA,IACT,WAAW;AAAA,EACb;AAAA,EACA,iBAAiB,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EACnD,2BAA2B,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EAC7D,iBAAiB,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EACnD,0BAA0B,EAAE,SAAS,MAAM,WAAW,MAAM;AAC9D;AAqDA,IAAM,OAAO;AA0Bb,IAAM,eAA4B;AAAA,EAChC,0BAA0B,CAAC;AAAA,EAC3B,iBAAiB,CAAC;AAAA,EAClB,2BAA2B,CAAC;AAAA,EAC5B,iBAAiB,mBAAmB;AAAA,EACpC,0BAA0B;AAC5B;AA9PA;AAmQO,IAAM,mBAAN,cAA+B,gCAIpC;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAgDA,YAAY;AAAA,IACV,WAAW;AAAA,IACX;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA,oBAAoB;AAAA,IACpB;AAAA,IACA;AAAA,EACF,GAcG;AACD,UAAM;AAAA,MACJ;AAAA,MACA;AAAA,MACA;AAAA,MACA,OAAO,EAAE,GAAG,cAAc,GAAG,MAAM;AAAA,IACrC,CAAC;AAqPH,uBAAM;AA/SN;AA2DE,SAAK,gBAAgB;AACrB,SAAK,kBAAkB,QAAQ;AAC/B,SAAK,aAAa,oBAAI,IAAI;AAC1B,SAAK,wCACH;AACF,SAAK,6CACH;AACF,SAAK,wCACH;AACF,uBAAK,cAAe;AACpB,SAAK,qBAAqB;AAC1B,SAAK,oBAAoB;AACzB,SAAK,WAAW;AAEhB,SAAK,WAAW,IAAI,SAAS,mBAAK,cAAL,UAAmB;AAEhD,QAAI,sBAAsB,YAAY;AACpC,WAAK,iBAAiB,WAAW;AACjC,yBAAmB,OAAO,2BAA2B;AACnD,cAAM,sBAAK,gEAAL,WAAmC;AAAA,MAC3C,CAAC;AAAA,IACH,OAAO;AACL,WAAK,iBAAiB,KAAK,gBAAgB;AAAA,QACzC;AAAA,MACF,EAAE,eAAe;AACjB,WAAK,gBAAgB;AAAA,QACnB;AAAA,QACA,OAAO,2BAA2B;AAChC,gBAAM,sBAAK,gEAAL,WAAmC;AAAA,QAC3C;AAAA,MACF;AAAA,IACF;AAAA,EACF;AAAA,EAEA,MAAM,eAAe;AACnB,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,YAAM,SAAS,MAAM,KAAK,KAAK,UAAU;AACzC,WAAK,YAAY;AACjB,YAAM,KAAK,kCAAkC,OAAO,CAAC,CAAC;AACtD,aAAO,MAAM,CAAC,EAAE,QAAQ,CAAC,UAAU;AACjC,aAAK,WAAW,IAAI,KAAK;AAAA,MAC3B,CAAC;AAAA,IACH;AAAA,EACF;AAAA,EAEA,MAAM,qBAAqB,SAAsC;AAC/D,WAAO,MAAM,KAAK,yBAAyB,OAAO;AAAA,EACpD;AAAA,EAEA,MAAM,kCACJ,WACiB;AACjB,UAAM,aAAa,aAAa,OAAO;AAEvC,SAAK,WAAW,IAAI,UAAU;AAE9B,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,YAAM,KAAK,yBAAyB;AACpC,WAAK,MAAM;AAAA,IACb;AAEA,WAAO;AAAA,EACT;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAUA,MAAM,yBACJ,UAAsC,CAAC,GACjB;AACtB,UAAM,EAAE,oBAAoB,MAAM,gBAAgB,IAAI;AAEtD,QAAI,UACF,qBACA,0BACA;AAEF,QAAI,oBAAoB,QAAW;AACjC,YAAM,gBAAgB,KAAK,gBAAgB;AAAA,QACzC;AAAA,QACA;AAAA,MACF;AACA,iCAA2B,cAAc,cAAc,YAAY;AAEnE,uBAAiB,oBAAoB,cAAc,cAAc,OAAO;AAExE,UAAI;AACF,cAAM,SAAS,MAAM,KAAK,gBAAgB;AAAA,UACxC;AAAA,UACA;AAAA,QACF;AACA,8BAAsB,UAAU;AAAA,MAClC,QAAQ;AACN,8BAAsB;AAAA,MACxB;AACA,iBAAW,IAAI,SAAS,cAAc,QAAQ;AAAA,IAChD;AAEA,4BAAa,KAAK;AAElB,4DACE,KAAK,2CAA2C;AAElD,wCAAmB,oBAAoB,KAAK,cAAc;AAE1D,QAAI;AACF,oDAAwB,MAAM,KAAK,wBAAwB;AAAA,IAC7D,SAAS,GAAG;AACV,cAAQ,MAAM,CAAC;AACf,oDAAwB;AAAA,IAC1B;AAEA,UAAM,qBAAqB,MAAM,4BAA4B;AAAA,MAC3D;AAAA,MACA;AAAA,MACA;AAAA,MACA,sBAAsB,KAAK,mBAAmB;AAAA,QAC5C;AAAA,QACA,GAAG,cAAc;AAAA,MACnB;AAAA,MACA;AAAA,MACA,iCAAiC,KAAK,kBAAkB;AAAA,QACtD;AAAA,QACA,GAAG,cAAc;AAAA,MACnB;AAAA,MACA;AAAA,MACA;AAAA,MACA,UAAU,KAAK;AAAA,MACf;AAAA,MACA,0BAA0B,KAAK,MAAM;AAAA,IACvC,CAAC;AAED,QAAI,mBAAmB;AACrB,YAAM,UAAU,MAAM,cAAc;AACpC,WAAK,OAAO,CAAC,UAAU;AACrB,YAAI,KAAK,mBAAmB,SAAS;AACnC,gBAAM,kBAAkB,mBAAmB;AAC3C,gBAAM,4BACJ,mBAAmB;AACrB,gBAAM,kBAAkB,mBAAmB;AAAA,QAC7C;AACA,cAAM,6BAAN,MAAM,2BAA6B,CAAC;AACpC,cAAM,yBAAyB,OAAO,IAAI;AAAA,UACxC,iBAAiB,mBAAmB;AAAA,UACpC,2BACE,mBAAmB;AAAA,UACrB,iBAAiB,mBAAmB;AAAA,QACtC;AAAA,MACF,CAAC;AAAA,IACH;AAEA,WAAO;AAAA,EACT;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAOA,iBAAiB,WAAmB;AAClC,SAAK,WAAW,OAAO,SAAS;AAChC,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,WAAK,YAAY;AAAA,IACnB;AAAA,EACF;AAAA,EAEA,cAAc;AACZ,QAAI,KAAK,YAAY;AACnB,oBAAc,KAAK,UAAU;AAAA,IAC/B;AACA,SAAK,WAAW,MAAM;AACtB,SAAK,WAAW;AAAA,EAClB;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAOS,UAAU;AACjB,UAAM,QAAQ;AACd,SAAK,YAAY;AAAA,EACnB;AAAA,EAEQ,QAAQ;AACd,QAAI,KAAK,YAAY;AACnB,oBAAc,KAAK,UAAU;AAAA,IAC/B;AAEA,SAAK,aAAa,YAAY,YAAY;AACxC,YAAM,cAAc,MAAM,KAAK,yBAAyB,CAAC;AAAA,IAC3D,GAAG,KAAK,aAAa;AAAA,EACvB;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EASA,MAAM,aAAa,iBAAwC;AACzD,UAAM,KAAK,yBAAyB,EAAE,gBAAgB,CAAC;AAAA,EACzD;AAAA,EAEQ,aAAa;AACnB,SAAK,OAAO,MAAM;AAChB,aAAO;AAAA,IACT,CAAC;AAAA,EACH;AAAA,EAEA,MAAc,0BAA0B;AACtC,UAAM,oCACJ,MAAM,KAAK,sCAAsC;AACnD,UAAM,oCACJ,KAAK,wCAAwC,KAAK;AAEpD,WACE,qCAAqC;AAAA,EAEzC;AAAA,EAEA,gBACE,sBACA,cACmD;AACnD,QACE,CAAC,KAAK,MAAM,mBACZ,KAAK,MAAM,oBAAoB,mBAAmB,YAClD;AACA,aAAO,CAAC;AAAA,IACV;AACA,WAAO;AAAA,MACL;AAAA,MACA;AAAA,MACA,KAAK,MAAM;AAAA,IACb;AAAA,EACF;AAAA,EAaA,yBAAyB;AACvB,SAAK,OAAO,CAAC,UAAU;AACrB,YAAM,2BAA2B;AAAA,IACnC,CAAC;AAAA,EACH;AAAA,EAEA,0BAA0B;AACxB,SAAK,OAAO,CAAC,UAAU;AACrB,YAAM,2BAA2B;AAAA,IACnC,CAAC;AAAA,EACH;AACF;AArUE;AA+SM;AAAA,kCAA6B,eAAC,wBAAsC;AACxE,QAAM,aAAa,uBAAuB,eAAe;AAEzD,MAAI,eAAe,KAAK,gBAAgB;AACtC,SAAK,WAAW,IAAI,SAAS,mBAAK,cAAL,UAAmB;AAChD,UAAM,KAAK,aAAa;AAExB,SAAK,iBAAiB;AAAA,EACxB;AACF;AAeF,IAAO,2BAAQ;;;ACviBf,eAAO,4BACL,MAC6B;AAC7B,MAAI;AACF,WAAO,MAAM,2BAA2B,IAAI;AAAA,EAC9C,SAAS,OAAO;AACd,QAAI,iBAAiB,OAAO;AAC1B,YAAM,IAAI;AAAA,QACR,6CAA6C,MAAM,OAAO;AAAA,MAC5D;AAAA,IACF;AAEA,UAAM;AAAA,EACR;AACF;AAOA,eAAe,2BACb,SAC6B;AAC7B,QAAM;AAAA,IACJ;AAAA,IACA;AAAA,IACA;AAAA,EACF,IAAI;AAEJ,MAAI;AACF,QAAI,uBAAuB,CAAC,0BAA0B;AACpD,aAAO,MAAM,mCAAmC,OAAO;AAAA,IACzD;AAEA,QAAI,4BAA4B,CAAC,0BAA0B;AACzD,aAAO,MAAM,gCAAgC,OAAO;AAAA,IACtD;AAEA,UAAM,IAAI,MAAM,oDAAoD;AAAA,EACtE,QAAQ;AACN,WAAO,MAAM,0BAA0B,OAAO;AAAA,EAChD;AACF;AAOA,eAAe,mCACb,SAC6B;AAC7B,QAAM;AAAA,IACJ,mBAAAA;AAAA,IACA;AAAA,IACA;AAAA,IACA,uBAAAC;AAAA,EACF,IAAI;AAEJ,QAAM,YAAY,MAAMD,mBAAkB,sBAAsB,QAAQ;AAExE,QAAM,EAAE,+BAA+B,sBAAsB,IAC3D,UAAU;AAEZ,QAAM,4BAA4BC;AAAA,IAChC;AAAA,IACA;AAAA,IACA;AAAA,EACF;AAEA,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB;AAAA,IACA,iBAAiB,mBAAmB;AAAA,EACtC;AACF;AAOA,eAAe,gCACb,SAC6B;AAC7B,QAAM;AAAA,IACJ,8BAAAC;AAAA,IACA;AAAA,IACA;AAAA,EACF,IAAI;AAEJ,QAAM,YAAY,MAAMA;AAAA,IACtB;AAAA,IACA;AAAA,EACF;AAEA,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB,2BAA2B,CAAC;AAAA,IAC5B,iBAAiB,mBAAmB;AAAA,EACtC;AACF;AAOA,eAAe,0BACb,SAC6B;AAC7B,QAAM,EAAE,UAAU,0BAAAC,0BAAyB,IAAI;AAE/C,QAAM,YAAY,MAAMA,0BAAyB,QAAQ;AAEzD,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB,2BAA2B,CAAC;AAAA,IAC5B,iBAAiB,mBAAmB;AAAA,EACtC;AACF;","names":["fetchGasEstimates","calculateTimeEstimate","fetchLegacyGasPriceEstimates","fetchEthGasPriceEstimate"]}
+\ No newline at end of file
+diff --git a/dist/chunk-BEVZS3YV.mjs b/dist/chunk-BEVZS3YV.mjs
+deleted file mode 100644
+index 3be5db0695ee6a2c71e64ed76c43a1f30cc9e5ac..0000000000000000000000000000000000000000
+--- a/dist/chunk-BEVZS3YV.mjs
++++ /dev/null
+@@ -1,396 +0,0 @@
+-import {
+-  __privateAdd,
+-  __privateGet,
+-  __privateMethod,
+-  __privateSet,
+-  calculateTimeEstimate,
+-  fetchEthGasPriceEstimate,
+-  fetchGasEstimates,
+-  fetchLegacyGasPriceEstimates
+-} from "./chunk-KORLXV32.mjs";
+-
+-// src/GasFeeController.ts
+-import {
+-  convertHexToDecimal,
+-  safelyExecute,
+-  toHex
+-} from "@metamask/controller-utils";
+-import EthQuery from "@metamask/eth-query";
+-import { StaticIntervalPollingController } from "@metamask/polling-controller";
+-import { v1 as random } from "uuid";
+-var GAS_API_BASE_URL = "https://gas.api.infura.io";
+-var GAS_ESTIMATE_TYPES = {
+-  FEE_MARKET: "fee-market",
+-  LEGACY: "legacy",
+-  ETH_GASPRICE: "eth_gasPrice",
+-  NONE: "none"
+-};
+-var metadata = {
+-  gasFeeEstimatesByChainId: {
+-    persist: true,
+-    anonymous: false
+-  },
+-  gasFeeEstimates: { persist: true, anonymous: false },
+-  estimatedGasFeeTimeBounds: { persist: true, anonymous: false },
+-  gasEstimateType: { persist: true, anonymous: false },
+-  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false }
+-};
+-var name = "GasFeeController";
+-var defaultState = {
+-  gasFeeEstimatesByChainId: {},
+-  gasFeeEstimates: {},
+-  estimatedGasFeeTimeBounds: {},
+-  gasEstimateType: GAS_ESTIMATE_TYPES.NONE,
+-  nonRPCGasFeeApisDisabled: false
+-};
+-var _getProvider, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn;
+-var GasFeeController = class extends StaticIntervalPollingController {
+-  /**
+-   * Creates a GasFeeController instance.
+-   *
+-   * @param options - The controller options.
+-   * @param options.interval - The time in milliseconds to wait between polls.
+-   * @param options.messenger - The controller messenger.
+-   * @param options.state - The initial state.
+-   * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current
+-   * network is EIP-1559 compatible.
+-   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the
+-   * current network is compatible with the legacy gas price API.
+-   * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current
+-   * account is EIP-1559 compatible.
+-   * @param options.getChainId - Returns the current chain ID.
+-   * @param options.getProvider - Returns a network provider for the current network.
+-   * @param options.onNetworkDidChange - A function for registering an event handler for the
+-   * network state change event.
+-   * @param options.clientId - The client ID used to identify to the gas estimation API who is
+-   * asking for estimates.
+-   * @param options.infuraAPIKey - The Infura API key used for infura API requests.
+-   */
+-  constructor({
+-    interval = 15e3,
+-    messenger,
+-    state,
+-    getCurrentNetworkEIP1559Compatibility,
+-    getCurrentAccountEIP1559Compatibility,
+-    getChainId,
+-    getCurrentNetworkLegacyGasAPICompatibility,
+-    getProvider,
+-    onNetworkDidChange,
+-    clientId,
+-    infuraAPIKey
+-  }) {
+-    super({
+-      name,
+-      metadata,
+-      messenger,
+-      state: { ...defaultState, ...state }
+-    });
+-    __privateAdd(this, _onNetworkControllerDidChange);
+-    __privateAdd(this, _getProvider, void 0);
+-    this.intervalDelay = interval;
+-    this.setIntervalLength(interval);
+-    this.pollTokens = /* @__PURE__ */ new Set();
+-    this.getCurrentNetworkEIP1559Compatibility = getCurrentNetworkEIP1559Compatibility;
+-    this.getCurrentNetworkLegacyGasAPICompatibility = getCurrentNetworkLegacyGasAPICompatibility;
+-    this.getCurrentAccountEIP1559Compatibility = getCurrentAccountEIP1559Compatibility;
+-    __privateSet(this, _getProvider, getProvider);
+-    this.EIP1559APIEndpoint = `${GAS_API_BASE_URL}/networks/<chain_id>/suggestedGasFees`;
+-    this.legacyAPIEndpoint = `${GAS_API_BASE_URL}/networks/<chain_id>/gasPrices`;
+-    this.clientId = clientId;
+-    this.infuraAPIKey = infuraAPIKey;
+-    this.ethQuery = new EthQuery(__privateGet(this, _getProvider).call(this));
+-    if (onNetworkDidChange && getChainId) {
+-      this.currentChainId = getChainId();
+-      onNetworkDidChange(async (networkControllerState) => {
+-        await __privateMethod(this, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn).call(this, networkControllerState);
+-      });
+-    } else {
+-      this.currentChainId = this.messagingSystem.call(
+-        "NetworkController:getState"
+-      ).providerConfig.chainId;
+-      this.messagingSystem.subscribe(
+-        "NetworkController:networkDidChange",
+-        async (networkControllerState) => {
+-          await __privateMethod(this, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn).call(this, networkControllerState);
+-        }
+-      );
+-    }
+-  }
+-  async resetPolling() {
+-    if (this.pollTokens.size !== 0) {
+-      const tokens = Array.from(this.pollTokens);
+-      this.stopPolling();
+-      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);
+-      tokens.slice(1).forEach((token) => {
+-        this.pollTokens.add(token);
+-      });
+-    }
+-  }
+-  async fetchGasFeeEstimates(options) {
+-    return await this._fetchGasFeeEstimateData(options);
+-  }
+-  async getGasFeeEstimatesAndStartPolling(pollToken) {
+-    const _pollToken = pollToken || random();
+-    this.pollTokens.add(_pollToken);
+-    if (this.pollTokens.size === 1) {
+-      await this._fetchGasFeeEstimateData();
+-      this._poll();
+-    }
+-    return _pollToken;
+-  }
+-  /**
+-   * Gets and sets gasFeeEstimates in state.
+-   *
+-   * @param options - The gas fee estimate options.
+-   * @param options.shouldUpdateState - Determines whether the state should be updated with the
+-   * updated gas estimates.
+-   * @returns The gas fee estimates.
+-   */
+-  async _fetchGasFeeEstimateData(options = {}) {
+-    const { shouldUpdateState = true, networkClientId } = options;
+-    let ethQuery, isEIP1559Compatible, isLegacyGasAPICompatible, decimalChainId;
+-    if (networkClientId !== void 0) {
+-      const networkClient = this.messagingSystem.call(
+-        "NetworkController:getNetworkClientById",
+-        networkClientId
+-      );
+-      isLegacyGasAPICompatible = networkClient.configuration.chainId === "0x38";
+-      decimalChainId = convertHexToDecimal(networkClient.configuration.chainId);
+-      try {
+-        const result = await this.messagingSystem.call(
+-          "NetworkController:getEIP1559Compatibility",
+-          networkClientId
+-        );
+-        isEIP1559Compatible = result || false;
+-      } catch {
+-        isEIP1559Compatible = false;
+-      }
+-      ethQuery = new EthQuery(networkClient.provider);
+-    }
+-    ethQuery ?? (ethQuery = this.ethQuery);
+-    isLegacyGasAPICompatible ?? (isLegacyGasAPICompatible = this.getCurrentNetworkLegacyGasAPICompatibility());
+-    decimalChainId ?? (decimalChainId = convertHexToDecimal(this.currentChainId));
+-    try {
+-      isEIP1559Compatible ?? (isEIP1559Compatible = await this.getEIP1559Compatibility());
+-    } catch (e) {
+-      console.error(e);
+-      isEIP1559Compatible ?? (isEIP1559Compatible = false);
+-    }
+-    const gasFeeCalculations = await determineGasFeeCalculations({
+-      isEIP1559Compatible,
+-      isLegacyGasAPICompatible,
+-      fetchGasEstimates,
+-      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(
+-        "<chain_id>",
+-        `${decimalChainId}`
+-      ),
+-      fetchLegacyGasPriceEstimates,
+-      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(
+-        "<chain_id>",
+-        `${decimalChainId}`
+-      ),
+-      fetchEthGasPriceEstimate,
+-      calculateTimeEstimate,
+-      clientId: this.clientId,
+-      ethQuery,
+-      infuraAPIKey: this.infuraAPIKey,
+-      nonRPCGasFeeApisDisabled: this.state.nonRPCGasFeeApisDisabled
+-    });
+-    if (shouldUpdateState) {
+-      const chainId = toHex(decimalChainId);
+-      this.update((state) => {
+-        if (this.currentChainId === chainId) {
+-          state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;
+-          state.estimatedGasFeeTimeBounds = gasFeeCalculations.estimatedGasFeeTimeBounds;
+-          state.gasEstimateType = gasFeeCalculations.gasEstimateType;
+-        }
+-        state.gasFeeEstimatesByChainId ?? (state.gasFeeEstimatesByChainId = {});
+-        state.gasFeeEstimatesByChainId[chainId] = {
+-          gasFeeEstimates: gasFeeCalculations.gasFeeEstimates,
+-          estimatedGasFeeTimeBounds: gasFeeCalculations.estimatedGasFeeTimeBounds,
+-          gasEstimateType: gasFeeCalculations.gasEstimateType
+-        };
+-      });
+-    }
+-    return gasFeeCalculations;
+-  }
+-  /**
+-   * Remove the poll token, and stop polling if the set of poll tokens is empty.
+-   *
+-   * @param pollToken - The poll token to disconnect.
+-   */
+-  disconnectPoller(pollToken) {
+-    this.pollTokens.delete(pollToken);
+-    if (this.pollTokens.size === 0) {
+-      this.stopPolling();
+-    }
+-  }
+-  stopPolling() {
+-    if (this.intervalId) {
+-      clearInterval(this.intervalId);
+-    }
+-    this.pollTokens.clear();
+-    this.resetState();
+-  }
+-  /**
+-   * Prepare to discard this controller.
+-   *
+-   * This stops any active polling.
+-   */
+-  destroy() {
+-    super.destroy();
+-    this.stopPolling();
+-  }
+-  _poll() {
+-    if (this.intervalId) {
+-      clearInterval(this.intervalId);
+-    }
+-    this.intervalId = setInterval(async () => {
+-      await safelyExecute(() => this._fetchGasFeeEstimateData());
+-    }, this.intervalDelay);
+-  }
+-  /**
+-   * Fetching token list from the Token Service API.
+-   *
+-   * @private
+-   * @param networkClientId - The ID of the network client triggering the fetch.
+-   * @returns A promise that resolves when this operation completes.
+-   */
+-  async _executePoll(networkClientId) {
+-    await this._fetchGasFeeEstimateData({ networkClientId });
+-  }
+-  resetState() {
+-    this.update(() => {
+-      return defaultState;
+-    });
+-  }
+-  async getEIP1559Compatibility() {
+-    const currentNetworkIsEIP1559Compatible = await this.getCurrentNetworkEIP1559Compatibility();
+-    const currentAccountIsEIP1559Compatible = this.getCurrentAccountEIP1559Compatibility?.() ?? true;
+-    return currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible;
+-  }
+-  getTimeEstimate(maxPriorityFeePerGas, maxFeePerGas) {
+-    if (!this.state.gasFeeEstimates || this.state.gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET) {
+-      return {};
+-    }
+-    return calculateTimeEstimate(
+-      maxPriorityFeePerGas,
+-      maxFeePerGas,
+-      this.state.gasFeeEstimates
+-    );
+-  }
+-  enableNonRPCGasFeeApis() {
+-    this.update((state) => {
+-      state.nonRPCGasFeeApisDisabled = false;
+-    });
+-  }
+-  disableNonRPCGasFeeApis() {
+-    this.update((state) => {
+-      state.nonRPCGasFeeApisDisabled = true;
+-    });
+-  }
+-};
+-_getProvider = new WeakMap();
+-_onNetworkControllerDidChange = new WeakSet();
+-onNetworkControllerDidChange_fn = async function(networkControllerState) {
+-  const newChainId = networkControllerState.providerConfig.chainId;
+-  if (newChainId !== this.currentChainId) {
+-    this.ethQuery = new EthQuery(__privateGet(this, _getProvider).call(this));
+-    await this.resetPolling();
+-    this.currentChainId = newChainId;
+-  }
+-};
+-var GasFeeController_default = GasFeeController;
+-
+-// src/determineGasFeeCalculations.ts
+-async function determineGasFeeCalculations(args) {
+-  try {
+-    return await getEstimatesUsingFallbacks(args);
+-  } catch (error) {
+-    if (error instanceof Error) {
+-      throw new Error(
+-        `Gas fee/price estimation failed. Message: ${error.message}`
+-      );
+-    }
+-    throw error;
+-  }
+-}
+-async function getEstimatesUsingFallbacks(request) {
+-  const {
+-    isEIP1559Compatible,
+-    isLegacyGasAPICompatible,
+-    nonRPCGasFeeApisDisabled
+-  } = request;
+-  try {
+-    if (isEIP1559Compatible && !nonRPCGasFeeApisDisabled) {
+-      return await getEstimatesUsingFeeMarketEndpoint(request);
+-    }
+-    if (isLegacyGasAPICompatible && !nonRPCGasFeeApisDisabled) {
+-      return await getEstimatesUsingLegacyEndpoint(request);
+-    }
+-    throw new Error("Main gas fee/price estimation failed. Use fallback");
+-  } catch {
+-    return await getEstimatesUsingProvider(request);
+-  }
+-}
+-async function getEstimatesUsingFeeMarketEndpoint(request) {
+-  const {
+-    fetchGasEstimates: fetchGasEstimates2,
+-    fetchGasEstimatesUrl,
+-    infuraAPIKey,
+-    clientId,
+-    calculateTimeEstimate: calculateTimeEstimate2
+-  } = request;
+-  const estimates = await fetchGasEstimates2(
+-    fetchGasEstimatesUrl,
+-    infuraAPIKey,
+-    clientId
+-  );
+-  const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } = estimates.medium;
+-  const estimatedGasFeeTimeBounds = calculateTimeEstimate2(
+-    suggestedMaxPriorityFeePerGas,
+-    suggestedMaxFeePerGas,
+-    estimates
+-  );
+-  return {
+-    gasFeeEstimates: estimates,
+-    estimatedGasFeeTimeBounds,
+-    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET
+-  };
+-}
+-async function getEstimatesUsingLegacyEndpoint(request) {
+-  const {
+-    fetchLegacyGasPriceEstimates: fetchLegacyGasPriceEstimates2,
+-    fetchLegacyGasPriceEstimatesUrl,
+-    infuraAPIKey,
+-    clientId
+-  } = request;
+-  const estimates = await fetchLegacyGasPriceEstimates2(
+-    fetchLegacyGasPriceEstimatesUrl,
+-    infuraAPIKey,
+-    clientId
+-  );
+-  return {
+-    gasFeeEstimates: estimates,
+-    estimatedGasFeeTimeBounds: {},
+-    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY
+-  };
+-}
+-async function getEstimatesUsingProvider(request) {
+-  const { ethQuery, fetchEthGasPriceEstimate: fetchEthGasPriceEstimate2 } = request;
+-  const estimates = await fetchEthGasPriceEstimate2(ethQuery);
+-  return {
+-    gasFeeEstimates: estimates,
+-    estimatedGasFeeTimeBounds: {},
+-    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE
+-  };
+-}
+-
+-export {
+-  determineGasFeeCalculations,
+-  GAS_API_BASE_URL,
+-  GAS_ESTIMATE_TYPES,
+-  GasFeeController,
+-  GasFeeController_default
+-};
+-//# sourceMappingURL=chunk-BEVZS3YV.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-BEVZS3YV.mjs.map b/dist/chunk-BEVZS3YV.mjs.map
+deleted file mode 100644
+index fc90025f10e73e5cdafc8964cd84365e51ad0c42..0000000000000000000000000000000000000000
+--- a/dist/chunk-BEVZS3YV.mjs.map
++++ /dev/null
+@@ -1 +0,0 @@
+-{"version":3,"sources":["../src/GasFeeController.ts","../src/determineGasFeeCalculations.ts"],"sourcesContent":["import type {\n  ControllerGetStateAction,\n  ControllerStateChangeEvent,\n  RestrictedControllerMessenger,\n} from '@metamask/base-controller';\nimport {\n  convertHexToDecimal,\n  safelyExecute,\n  toHex,\n} from '@metamask/controller-utils';\nimport EthQuery from '@metamask/eth-query';\nimport type {\n  NetworkClientId,\n  NetworkControllerGetEIP1559CompatibilityAction,\n  NetworkControllerGetNetworkClientByIdAction,\n  NetworkControllerGetStateAction,\n  NetworkControllerNetworkDidChangeEvent,\n  NetworkState,\n  ProviderProxy,\n} from '@metamask/network-controller';\nimport { StaticIntervalPollingController } from '@metamask/polling-controller';\nimport type { Hex } from '@metamask/utils';\nimport { v1 as random } from 'uuid';\n\nimport determineGasFeeCalculations from './determineGasFeeCalculations';\nimport {\n  calculateTimeEstimate,\n  fetchGasEstimates,\n  fetchLegacyGasPriceEstimates,\n  fetchEthGasPriceEstimate,\n} from './gas-util';\n\nexport const GAS_API_BASE_URL = 'https://gas.api.infura.io';\n\nexport type unknownString = 'unknown';\n\n// Fee Market describes the way gas is set after the london hardfork, and was\n// defined by EIP-1559.\nexport type FeeMarketEstimateType = 'fee-market';\n// Legacy describes gasPrice estimates from before london hardfork, when the\n// user is connected to mainnet and are presented with fast/average/slow\n// estimate levels to choose from.\nexport type LegacyEstimateType = 'legacy';\n// EthGasPrice describes a gasPrice estimate received from eth_gasPrice. Post\n// london this value should only be used for legacy type transactions when on\n// networks that support EIP-1559. This type of estimate is the most accurate\n// to display on custom networks that don't support EIP-1559.\nexport type EthGasPriceEstimateType = 'eth_gasPrice';\n// NoEstimate describes the state of the controller before receiving its first\n// estimate.\nexport type NoEstimateType = 'none';\n\n/**\n * Indicates which type of gasEstimate the controller is currently returning.\n * This is useful as a way of asserting that the shape of gasEstimates matches\n * expectations. NONE is a special case indicating that no previous gasEstimate\n * has been fetched.\n */\nexport const GAS_ESTIMATE_TYPES = {\n  FEE_MARKET: 'fee-market' as FeeMarketEstimateType,\n  LEGACY: 'legacy' as LegacyEstimateType,\n  ETH_GASPRICE: 'eth_gasPrice' as EthGasPriceEstimateType,\n  NONE: 'none' as NoEstimateType,\n};\n\nexport type GasEstimateType =\n  | FeeMarketEstimateType\n  | EthGasPriceEstimateType\n  | LegacyEstimateType\n  | NoEstimateType;\n\nexport type EstimatedGasFeeTimeBounds = {\n  lowerTimeBound: number | null;\n  upperTimeBound: number | unknownString;\n};\n\n/**\n * @type EthGasPriceEstimate\n *\n * A single gas price estimate for networks and accounts that don't support EIP-1559\n * This estimate comes from eth_gasPrice but is converted to dec gwei to match other\n * return values\n * @property gasPrice - A GWEI dec string\n */\n\nexport type EthGasPriceEstimate = {\n  gasPrice: string;\n};\n\n/**\n * @type LegacyGasPriceEstimate\n *\n * A set of gas price estimates for networks and accounts that don't support EIP-1559\n * These estimates include low, medium and high all as strings representing gwei in\n * decimal format.\n * @property high - gasPrice, in decimal gwei string format, suggested for fast inclusion\n * @property medium - gasPrice, in decimal gwei string format, suggested for avg inclusion\n * @property low - gasPrice, in decimal gwei string format, suggested for slow inclusion\n */\nexport type LegacyGasPriceEstimate = {\n  high: string;\n  medium: string;\n  low: string;\n};\n\n/**\n * @type Eip1559GasFee\n *\n * Data necessary to provide an estimate of a gas fee with a specific tip\n * @property minWaitTimeEstimate - The fastest the transaction will take, in milliseconds\n * @property maxWaitTimeEstimate - The slowest the transaction will take, in milliseconds\n * @property suggestedMaxPriorityFeePerGas - A suggested \"tip\", a GWEI hex number\n * @property suggestedMaxFeePerGas - A suggested max fee, the most a user will pay. a GWEI hex number\n */\nexport type Eip1559GasFee = {\n  minWaitTimeEstimate: number; // a time duration in milliseconds\n  maxWaitTimeEstimate: number; // a time duration in milliseconds\n  suggestedMaxPriorityFeePerGas: string; // a GWEI decimal number\n  suggestedMaxFeePerGas: string; // a GWEI decimal number\n};\n\n/**\n * @type GasFeeEstimates\n *\n * Data necessary to provide multiple GasFee estimates, and supporting information, to the user\n * @property low - A GasFee for a minimum necessary combination of tip and maxFee\n * @property medium - A GasFee for a recommended combination of tip and maxFee\n * @property high - A GasFee for a high combination of tip and maxFee\n * @property estimatedBaseFee - An estimate of what the base fee will be for the pending/next block. A GWEI dec number\n * @property networkCongestion - A normalized number that can be used to gauge the congestion\n * level of the network, with 0 meaning not congested and 1 meaning extremely congested\n */\nexport type GasFeeEstimates = SourcedGasFeeEstimates | FallbackGasFeeEstimates;\n\ntype SourcedGasFeeEstimates = {\n  low: Eip1559GasFee;\n  medium: Eip1559GasFee;\n  high: Eip1559GasFee;\n  estimatedBaseFee: string;\n  historicalBaseFeeRange: [string, string];\n  baseFeeTrend: 'up' | 'down' | 'level';\n  latestPriorityFeeRange: [string, string];\n  historicalPriorityFeeRange: [string, string];\n  priorityFeeTrend: 'up' | 'down' | 'level';\n  networkCongestion: number;\n};\n\ntype FallbackGasFeeEstimates = {\n  low: Eip1559GasFee;\n  medium: Eip1559GasFee;\n  high: Eip1559GasFee;\n  estimatedBaseFee: string;\n  historicalBaseFeeRange: null;\n  baseFeeTrend: null;\n  latestPriorityFeeRange: null;\n  historicalPriorityFeeRange: null;\n  priorityFeeTrend: null;\n  networkCongestion: null;\n};\n\nconst metadata = {\n  gasFeeEstimatesByChainId: {\n    persist: true,\n    anonymous: false,\n  },\n  gasFeeEstimates: { persist: true, anonymous: false },\n  estimatedGasFeeTimeBounds: { persist: true, anonymous: false },\n  gasEstimateType: { persist: true, anonymous: false },\n  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false },\n};\n\nexport type GasFeeStateEthGasPrice = {\n  gasFeeEstimates: EthGasPriceEstimate;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: EthGasPriceEstimateType;\n};\n\nexport type GasFeeStateFeeMarket = {\n  gasFeeEstimates: GasFeeEstimates;\n  estimatedGasFeeTimeBounds: EstimatedGasFeeTimeBounds | Record<string, never>;\n  gasEstimateType: FeeMarketEstimateType;\n};\n\nexport type GasFeeStateLegacy = {\n  gasFeeEstimates: LegacyGasPriceEstimate;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: LegacyEstimateType;\n};\n\nexport type GasFeeStateNoEstimates = {\n  gasFeeEstimates: Record<string, never>;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: NoEstimateType;\n};\n\nexport type FetchGasFeeEstimateOptions = {\n  shouldUpdateState?: boolean;\n  networkClientId?: NetworkClientId;\n};\n\n/**\n * @type GasFeeState\n *\n * Gas Fee controller state\n * @property gasFeeEstimates - Gas fee estimate data based on new EIP-1559 properties\n * @property estimatedGasFeeTimeBounds - Estimates representing the minimum and maximum\n */\nexport type SingleChainGasFeeState =\n  | GasFeeStateEthGasPrice\n  | GasFeeStateFeeMarket\n  | GasFeeStateLegacy\n  | GasFeeStateNoEstimates;\n\nexport type GasFeeEstimatesByChainId = {\n  gasFeeEstimatesByChainId?: Record<string, SingleChainGasFeeState>;\n};\n\nexport type GasFeeState = GasFeeEstimatesByChainId &\n  SingleChainGasFeeState & {\n    nonRPCGasFeeApisDisabled?: boolean;\n  };\n\nconst name = 'GasFeeController';\n\nexport type GasFeeStateChange = ControllerStateChangeEvent<\n  typeof name,\n  GasFeeState\n>;\n\nexport type GetGasFeeState = ControllerGetStateAction<typeof name, GasFeeState>;\n\nexport type GasFeeControllerActions = GetGasFeeState;\n\nexport type GasFeeControllerEvents = GasFeeStateChange;\n\ntype AllowedActions =\n  | NetworkControllerGetStateAction\n  | NetworkControllerGetNetworkClientByIdAction\n  | NetworkControllerGetEIP1559CompatibilityAction;\n\ntype GasFeeMessenger = RestrictedControllerMessenger<\n  typeof name,\n  GasFeeControllerActions | AllowedActions,\n  GasFeeControllerEvents | NetworkControllerNetworkDidChangeEvent,\n  AllowedActions['type'],\n  NetworkControllerNetworkDidChangeEvent['type']\n>;\n\nconst defaultState: GasFeeState = {\n  gasFeeEstimatesByChainId: {},\n  gasFeeEstimates: {},\n  estimatedGasFeeTimeBounds: {},\n  gasEstimateType: GAS_ESTIMATE_TYPES.NONE,\n  nonRPCGasFeeApisDisabled: false,\n};\n\n/**\n * Controller that retrieves gas fee estimate data and polls for updated data on a set interval\n */\nexport class GasFeeController extends StaticIntervalPollingController<\n  typeof name,\n  GasFeeState,\n  GasFeeMessenger\n> {\n  private intervalId?: ReturnType<typeof setTimeout>;\n\n  private readonly intervalDelay;\n\n  private readonly pollTokens: Set<string>;\n\n  private readonly legacyAPIEndpoint: string;\n\n  private readonly EIP1559APIEndpoint: string;\n\n  private readonly getCurrentNetworkEIP1559Compatibility;\n\n  private readonly getCurrentNetworkLegacyGasAPICompatibility;\n\n  private readonly getCurrentAccountEIP1559Compatibility;\n\n  private readonly infuraAPIKey: string;\n\n  private currentChainId;\n\n  private ethQuery?: EthQuery;\n\n  private readonly clientId?: string;\n\n  #getProvider: () => ProviderProxy;\n\n  /**\n   * Creates a GasFeeController instance.\n   *\n   * @param options - The controller options.\n   * @param options.interval - The time in milliseconds to wait between polls.\n   * @param options.messenger - The controller messenger.\n   * @param options.state - The initial state.\n   * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current\n   * network is EIP-1559 compatible.\n   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the\n   * current network is compatible with the legacy gas price API.\n   * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current\n   * account is EIP-1559 compatible.\n   * @param options.getChainId - Returns the current chain ID.\n   * @param options.getProvider - Returns a network provider for the current network.\n   * @param options.onNetworkDidChange - A function for registering an event handler for the\n   * network state change event.\n   * @param options.clientId - The client ID used to identify to the gas estimation API who is\n   * asking for estimates.\n   * @param options.infuraAPIKey - The Infura API key used for infura API requests.\n   */\n  constructor({\n    interval = 15000,\n    messenger,\n    state,\n    getCurrentNetworkEIP1559Compatibility,\n    getCurrentAccountEIP1559Compatibility,\n    getChainId,\n    getCurrentNetworkLegacyGasAPICompatibility,\n    getProvider,\n    onNetworkDidChange,\n    clientId,\n    infuraAPIKey,\n  }: {\n    interval?: number;\n    messenger: GasFeeMessenger;\n    state?: GasFeeState;\n    getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;\n    getCurrentNetworkLegacyGasAPICompatibility: () => boolean;\n    getCurrentAccountEIP1559Compatibility?: () => boolean;\n    getChainId?: () => Hex;\n    getProvider: () => ProviderProxy;\n    onNetworkDidChange?: (listener: (state: NetworkState) => void) => void;\n    clientId?: string;\n    infuraAPIKey: string;\n  }) {\n    super({\n      name,\n      metadata,\n      messenger,\n      state: { ...defaultState, ...state },\n    });\n    this.intervalDelay = interval;\n    this.setIntervalLength(interval);\n    this.pollTokens = new Set();\n    this.getCurrentNetworkEIP1559Compatibility =\n      getCurrentNetworkEIP1559Compatibility;\n    this.getCurrentNetworkLegacyGasAPICompatibility =\n      getCurrentNetworkLegacyGasAPICompatibility;\n    this.getCurrentAccountEIP1559Compatibility =\n      getCurrentAccountEIP1559Compatibility;\n    this.#getProvider = getProvider;\n    this.EIP1559APIEndpoint = `${GAS_API_BASE_URL}/networks/<chain_id>/suggestedGasFees`;\n    this.legacyAPIEndpoint = `${GAS_API_BASE_URL}/networks/<chain_id>/gasPrices`;\n    this.clientId = clientId;\n    this.infuraAPIKey = infuraAPIKey;\n\n    this.ethQuery = new EthQuery(this.#getProvider());\n\n    if (onNetworkDidChange && getChainId) {\n      this.currentChainId = getChainId();\n      onNetworkDidChange(async (networkControllerState) => {\n        await this.#onNetworkControllerDidChange(networkControllerState);\n      });\n    } else {\n      this.currentChainId = this.messagingSystem.call(\n        'NetworkController:getState',\n      ).providerConfig.chainId;\n      this.messagingSystem.subscribe(\n        'NetworkController:networkDidChange',\n        async (networkControllerState) => {\n          await this.#onNetworkControllerDidChange(networkControllerState);\n        },\n      );\n    }\n  }\n\n  async resetPolling() {\n    if (this.pollTokens.size !== 0) {\n      const tokens = Array.from(this.pollTokens);\n      this.stopPolling();\n      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);\n      tokens.slice(1).forEach((token) => {\n        this.pollTokens.add(token);\n      });\n    }\n  }\n\n  async fetchGasFeeEstimates(options?: FetchGasFeeEstimateOptions) {\n    return await this._fetchGasFeeEstimateData(options);\n  }\n\n  async getGasFeeEstimatesAndStartPolling(\n    pollToken: string | undefined,\n  ): Promise<string> {\n    const _pollToken = pollToken || random();\n\n    this.pollTokens.add(_pollToken);\n\n    if (this.pollTokens.size === 1) {\n      await this._fetchGasFeeEstimateData();\n      this._poll();\n    }\n\n    return _pollToken;\n  }\n\n  /**\n   * Gets and sets gasFeeEstimates in state.\n   *\n   * @param options - The gas fee estimate options.\n   * @param options.shouldUpdateState - Determines whether the state should be updated with the\n   * updated gas estimates.\n   * @returns The gas fee estimates.\n   */\n  async _fetchGasFeeEstimateData(\n    options: FetchGasFeeEstimateOptions = {},\n  ): Promise<GasFeeState> {\n    const { shouldUpdateState = true, networkClientId } = options;\n\n    let ethQuery,\n      isEIP1559Compatible,\n      isLegacyGasAPICompatible,\n      decimalChainId: number;\n\n    if (networkClientId !== undefined) {\n      const networkClient = this.messagingSystem.call(\n        'NetworkController:getNetworkClientById',\n        networkClientId,\n      );\n      isLegacyGasAPICompatible = networkClient.configuration.chainId === '0x38';\n\n      decimalChainId = convertHexToDecimal(networkClient.configuration.chainId);\n\n      try {\n        const result = await this.messagingSystem.call(\n          'NetworkController:getEIP1559Compatibility',\n          networkClientId,\n        );\n        isEIP1559Compatible = result || false;\n      } catch {\n        isEIP1559Compatible = false;\n      }\n      ethQuery = new EthQuery(networkClient.provider);\n    }\n\n    ethQuery ??= this.ethQuery;\n\n    isLegacyGasAPICompatible ??=\n      this.getCurrentNetworkLegacyGasAPICompatibility();\n\n    decimalChainId ??= convertHexToDecimal(this.currentChainId);\n\n    try {\n      isEIP1559Compatible ??= await this.getEIP1559Compatibility();\n    } catch (e) {\n      console.error(e);\n      isEIP1559Compatible ??= false;\n    }\n\n    const gasFeeCalculations = await determineGasFeeCalculations({\n      isEIP1559Compatible,\n      isLegacyGasAPICompatible,\n      fetchGasEstimates,\n      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(\n        '<chain_id>',\n        `${decimalChainId}`,\n      ),\n      fetchLegacyGasPriceEstimates,\n      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(\n        '<chain_id>',\n        `${decimalChainId}`,\n      ),\n      fetchEthGasPriceEstimate,\n      calculateTimeEstimate,\n      clientId: this.clientId,\n      ethQuery,\n      infuraAPIKey: this.infuraAPIKey,\n      nonRPCGasFeeApisDisabled: this.state.nonRPCGasFeeApisDisabled,\n    });\n\n    if (shouldUpdateState) {\n      const chainId = toHex(decimalChainId);\n      this.update((state) => {\n        if (this.currentChainId === chainId) {\n          state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;\n          state.estimatedGasFeeTimeBounds =\n            gasFeeCalculations.estimatedGasFeeTimeBounds;\n          state.gasEstimateType = gasFeeCalculations.gasEstimateType;\n        }\n        state.gasFeeEstimatesByChainId ??= {};\n        state.gasFeeEstimatesByChainId[chainId] = {\n          gasFeeEstimates: gasFeeCalculations.gasFeeEstimates,\n          estimatedGasFeeTimeBounds:\n            gasFeeCalculations.estimatedGasFeeTimeBounds,\n          gasEstimateType: gasFeeCalculations.gasEstimateType,\n        } as SingleChainGasFeeState;\n      });\n    }\n\n    return gasFeeCalculations;\n  }\n\n  /**\n   * Remove the poll token, and stop polling if the set of poll tokens is empty.\n   *\n   * @param pollToken - The poll token to disconnect.\n   */\n  disconnectPoller(pollToken: string) {\n    this.pollTokens.delete(pollToken);\n    if (this.pollTokens.size === 0) {\n      this.stopPolling();\n    }\n  }\n\n  stopPolling() {\n    if (this.intervalId) {\n      clearInterval(this.intervalId);\n    }\n    this.pollTokens.clear();\n    this.resetState();\n  }\n\n  /**\n   * Prepare to discard this controller.\n   *\n   * This stops any active polling.\n   */\n  override destroy() {\n    super.destroy();\n    this.stopPolling();\n  }\n\n  private _poll() {\n    if (this.intervalId) {\n      clearInterval(this.intervalId);\n    }\n\n    this.intervalId = setInterval(async () => {\n      await safelyExecute(() => this._fetchGasFeeEstimateData());\n    }, this.intervalDelay);\n  }\n\n  /**\n   * Fetching token list from the Token Service API.\n   *\n   * @private\n   * @param networkClientId - The ID of the network client triggering the fetch.\n   * @returns A promise that resolves when this operation completes.\n   */\n  async _executePoll(networkClientId: string): Promise<void> {\n    await this._fetchGasFeeEstimateData({ networkClientId });\n  }\n\n  private resetState() {\n    this.update(() => {\n      return defaultState;\n    });\n  }\n\n  private async getEIP1559Compatibility() {\n    const currentNetworkIsEIP1559Compatible =\n      await this.getCurrentNetworkEIP1559Compatibility();\n    const currentAccountIsEIP1559Compatible =\n      this.getCurrentAccountEIP1559Compatibility?.() ?? true;\n\n    return (\n      currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible\n    );\n  }\n\n  getTimeEstimate(\n    maxPriorityFeePerGas: string,\n    maxFeePerGas: string,\n  ): EstimatedGasFeeTimeBounds | Record<string, never> {\n    if (\n      !this.state.gasFeeEstimates ||\n      this.state.gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET\n    ) {\n      return {};\n    }\n    return calculateTimeEstimate(\n      maxPriorityFeePerGas,\n      maxFeePerGas,\n      this.state.gasFeeEstimates,\n    );\n  }\n\n  async #onNetworkControllerDidChange(networkControllerState: NetworkState) {\n    const newChainId = networkControllerState.providerConfig.chainId;\n\n    if (newChainId !== this.currentChainId) {\n      this.ethQuery = new EthQuery(this.#getProvider());\n      await this.resetPolling();\n\n      this.currentChainId = newChainId;\n    }\n  }\n\n  enableNonRPCGasFeeApis() {\n    this.update((state) => {\n      state.nonRPCGasFeeApisDisabled = false;\n    });\n  }\n\n  disableNonRPCGasFeeApis() {\n    this.update((state) => {\n      state.nonRPCGasFeeApisDisabled = true;\n    });\n  }\n}\n\nexport default GasFeeController;\n","import type {\n  EstimatedGasFeeTimeBounds,\n  EthGasPriceEstimate,\n  GasFeeEstimates,\n  GasFeeState as GasFeeCalculations,\n  LegacyGasPriceEstimate,\n} from './GasFeeController';\nimport { GAS_ESTIMATE_TYPES } from './GasFeeController';\n\ntype DetermineGasFeeCalculationsRequest = {\n  isEIP1559Compatible: boolean;\n  isLegacyGasAPICompatible: boolean;\n  fetchGasEstimates: (\n    url: string,\n    infuraAPIKey: string,\n    clientId?: string,\n  ) => Promise<GasFeeEstimates>;\n  fetchGasEstimatesUrl: string;\n  fetchLegacyGasPriceEstimates: (\n    url: string,\n    infuraAPIKey: string,\n    clientId?: string,\n  ) => Promise<LegacyGasPriceEstimate>;\n  fetchLegacyGasPriceEstimatesUrl: string;\n  // TODO: Replace `any` with type\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\n  fetchEthGasPriceEstimate: (ethQuery: any) => Promise<EthGasPriceEstimate>;\n  calculateTimeEstimate: (\n    maxPriorityFeePerGas: string,\n    maxFeePerGas: string,\n    gasFeeEstimates: GasFeeEstimates,\n  ) => EstimatedGasFeeTimeBounds;\n  clientId: string | undefined;\n  // TODO: Replace `any` with type\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\n  ethQuery: any;\n  infuraAPIKey: string;\n  nonRPCGasFeeApisDisabled?: boolean;\n};\n\n/**\n * Obtains a set of max base and priority fee estimates along with time estimates so that we\n * can present them to users when they are sending transactions or making swaps.\n *\n * @param args - The arguments.\n * @param args.isEIP1559Compatible - Governs whether or not we can use an EIP-1559-only method to\n * produce estimates.\n * @param args.isLegacyGasAPICompatible - Governs whether or not we can use a non-EIP-1559 method to\n * produce estimates (for instance, testnets do not support estimates altogether).\n * @param args.fetchGasEstimates - A function that fetches gas estimates using an EIP-1559-specific\n * API.\n * @param args.fetchGasEstimatesUrl - The URL for the API we can use to obtain EIP-1559-specific\n * estimates.\n * @param args.fetchLegacyGasPriceEstimates - A function that fetches gas estimates using an\n * non-EIP-1559-specific API.\n * @param args.fetchLegacyGasPriceEstimatesUrl - The URL for the API we can use to obtain\n * non-EIP-1559-specific estimates.\n * @param args.fetchEthGasPriceEstimate - A function that fetches gas estimates using\n * `eth_gasPrice`.\n * @param args.calculateTimeEstimate - A function that determine time estimate bounds.\n * @param args.clientId - An identifier that an API can use to know who is asking for estimates.\n * @param args.ethQuery - An EthQuery instance we can use to talk to Ethereum directly.\n * @param args.infuraAPIKey - Infura API key to use for requests to Infura.\n * @param args.nonRPCGasFeeApisDisabled - Whether to disable requests to the legacyAPIEndpoint and the EIP1559APIEndpoint\n * @returns The gas fee calculations.\n */\nexport default async function determineGasFeeCalculations(\n  args: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  try {\n    return await getEstimatesUsingFallbacks(args);\n  } catch (error) {\n    if (error instanceof Error) {\n      throw new Error(\n        `Gas fee/price estimation failed. Message: ${error.message}`,\n      );\n    }\n\n    throw error;\n  }\n}\n\n/**\n * Retrieve the gas fee estimates using a series of fallback mechanisms.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingFallbacks(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    isEIP1559Compatible,\n    isLegacyGasAPICompatible,\n    nonRPCGasFeeApisDisabled,\n  } = request;\n\n  try {\n    if (isEIP1559Compatible && !nonRPCGasFeeApisDisabled) {\n      return await getEstimatesUsingFeeMarketEndpoint(request);\n    }\n\n    if (isLegacyGasAPICompatible && !nonRPCGasFeeApisDisabled) {\n      return await getEstimatesUsingLegacyEndpoint(request);\n    }\n\n    throw new Error('Main gas fee/price estimation failed. Use fallback');\n  } catch {\n    return await getEstimatesUsingProvider(request);\n  }\n}\n\n/**\n * Retrieve gas fee estimates using the EIP-1559 endpoint of the gas API.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingFeeMarketEndpoint(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    fetchGasEstimates,\n    fetchGasEstimatesUrl,\n    infuraAPIKey,\n    clientId,\n    calculateTimeEstimate,\n  } = request;\n\n  const estimates = await fetchGasEstimates(\n    fetchGasEstimatesUrl,\n    infuraAPIKey,\n    clientId,\n  );\n\n  const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } =\n    estimates.medium;\n\n  const estimatedGasFeeTimeBounds = calculateTimeEstimate(\n    suggestedMaxPriorityFeePerGas,\n    suggestedMaxFeePerGas,\n    estimates,\n  );\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds,\n    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,\n  };\n}\n\n/**\n * Retrieve gas fee estimates using the legacy endpoint of the gas API.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingLegacyEndpoint(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    fetchLegacyGasPriceEstimates,\n    fetchLegacyGasPriceEstimatesUrl,\n    infuraAPIKey,\n    clientId,\n  } = request;\n\n  const estimates = await fetchLegacyGasPriceEstimates(\n    fetchLegacyGasPriceEstimatesUrl,\n    infuraAPIKey,\n    clientId,\n  );\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds: {},\n    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,\n  };\n}\n\n/**\n * Retrieve gas fee estimates using an `eth_gasPrice` call to the RPC provider.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingProvider(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const { ethQuery, fetchEthGasPriceEstimate } = request;\n\n  const estimates = await fetchEthGasPriceEstimate(ethQuery);\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds: {},\n    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,\n  };\n}\n"],"mappings":";;;;;;;;;;;;AAKA;AAAA,EACE;AAAA,EACA;AAAA,EACA;AAAA,OACK;AACP,OAAO,cAAc;AAUrB,SAAS,uCAAuC;AAEhD,SAAS,MAAM,cAAc;AAUtB,IAAM,mBAAmB;AA0BzB,IAAM,qBAAqB;AAAA,EAChC,YAAY;AAAA,EACZ,QAAQ;AAAA,EACR,cAAc;AAAA,EACd,MAAM;AACR;AAiGA,IAAM,WAAW;AAAA,EACf,0BAA0B;AAAA,IACxB,SAAS;AAAA,IACT,WAAW;AAAA,EACb;AAAA,EACA,iBAAiB,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EACnD,2BAA2B,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EAC7D,iBAAiB,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EACnD,0BAA0B,EAAE,SAAS,MAAM,WAAW,MAAM;AAC9D;AAqDA,IAAM,OAAO;AA0Bb,IAAM,eAA4B;AAAA,EAChC,0BAA0B,CAAC;AAAA,EAC3B,iBAAiB,CAAC;AAAA,EAClB,2BAA2B,CAAC;AAAA,EAC5B,iBAAiB,mBAAmB;AAAA,EACpC,0BAA0B;AAC5B;AA9PA;AAmQO,IAAM,mBAAN,cAA+B,gCAIpC;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAgDA,YAAY;AAAA,IACV,WAAW;AAAA,IACX;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,EACF,GAYG;AACD,UAAM;AAAA,MACJ;AAAA,MACA;AAAA,MACA;AAAA,MACA,OAAO,EAAE,GAAG,cAAc,GAAG,MAAM;AAAA,IACrC,CAAC;AAuPH,uBAAM;AA5SN;AAsDE,SAAK,gBAAgB;AACrB,SAAK,kBAAkB,QAAQ;AAC/B,SAAK,aAAa,oBAAI,IAAI;AAC1B,SAAK,wCACH;AACF,SAAK,6CACH;AACF,SAAK,wCACH;AACF,uBAAK,cAAe;AACpB,SAAK,qBAAqB,GAAG,gBAAgB;AAC7C,SAAK,oBAAoB,GAAG,gBAAgB;AAC5C,SAAK,WAAW;AAChB,SAAK,eAAe;AAEpB,SAAK,WAAW,IAAI,SAAS,mBAAK,cAAL,UAAmB;AAEhD,QAAI,sBAAsB,YAAY;AACpC,WAAK,iBAAiB,WAAW;AACjC,yBAAmB,OAAO,2BAA2B;AACnD,cAAM,sBAAK,gEAAL,WAAmC;AAAA,MAC3C,CAAC;AAAA,IACH,OAAO;AACL,WAAK,iBAAiB,KAAK,gBAAgB;AAAA,QACzC;AAAA,MACF,EAAE,eAAe;AACjB,WAAK,gBAAgB;AAAA,QACnB;AAAA,QACA,OAAO,2BAA2B;AAChC,gBAAM,sBAAK,gEAAL,WAAmC;AAAA,QAC3C;AAAA,MACF;AAAA,IACF;AAAA,EACF;AAAA,EAEA,MAAM,eAAe;AACnB,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,YAAM,SAAS,MAAM,KAAK,KAAK,UAAU;AACzC,WAAK,YAAY;AACjB,YAAM,KAAK,kCAAkC,OAAO,CAAC,CAAC;AACtD,aAAO,MAAM,CAAC,EAAE,QAAQ,CAAC,UAAU;AACjC,aAAK,WAAW,IAAI,KAAK;AAAA,MAC3B,CAAC;AAAA,IACH;AAAA,EACF;AAAA,EAEA,MAAM,qBAAqB,SAAsC;AAC/D,WAAO,MAAM,KAAK,yBAAyB,OAAO;AAAA,EACpD;AAAA,EAEA,MAAM,kCACJ,WACiB;AACjB,UAAM,aAAa,aAAa,OAAO;AAEvC,SAAK,WAAW,IAAI,UAAU;AAE9B,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,YAAM,KAAK,yBAAyB;AACpC,WAAK,MAAM;AAAA,IACb;AAEA,WAAO;AAAA,EACT;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAUA,MAAM,yBACJ,UAAsC,CAAC,GACjB;AACtB,UAAM,EAAE,oBAAoB,MAAM,gBAAgB,IAAI;AAEtD,QAAI,UACF,qBACA,0BACA;AAEF,QAAI,oBAAoB,QAAW;AACjC,YAAM,gBAAgB,KAAK,gBAAgB;AAAA,QACzC;AAAA,QACA;AAAA,MACF;AACA,iCAA2B,cAAc,cAAc,YAAY;AAEnE,uBAAiB,oBAAoB,cAAc,cAAc,OAAO;AAExE,UAAI;AACF,cAAM,SAAS,MAAM,KAAK,gBAAgB;AAAA,UACxC;AAAA,UACA;AAAA,QACF;AACA,8BAAsB,UAAU;AAAA,MAClC,QAAQ;AACN,8BAAsB;AAAA,MACxB;AACA,iBAAW,IAAI,SAAS,cAAc,QAAQ;AAAA,IAChD;AAEA,4BAAa,KAAK;AAElB,4DACE,KAAK,2CAA2C;AAElD,wCAAmB,oBAAoB,KAAK,cAAc;AAE1D,QAAI;AACF,oDAAwB,MAAM,KAAK,wBAAwB;AAAA,IAC7D,SAAS,GAAG;AACV,cAAQ,MAAM,CAAC;AACf,oDAAwB;AAAA,IAC1B;AAEA,UAAM,qBAAqB,MAAM,4BAA4B;AAAA,MAC3D;AAAA,MACA;AAAA,MACA;AAAA,MACA,sBAAsB,KAAK,mBAAmB;AAAA,QAC5C;AAAA,QACA,GAAG,cAAc;AAAA,MACnB;AAAA,MACA;AAAA,MACA,iCAAiC,KAAK,kBAAkB;AAAA,QACtD;AAAA,QACA,GAAG,cAAc;AAAA,MACnB;AAAA,MACA;AAAA,MACA;AAAA,MACA,UAAU,KAAK;AAAA,MACf;AAAA,MACA,cAAc,KAAK;AAAA,MACnB,0BAA0B,KAAK,MAAM;AAAA,IACvC,CAAC;AAED,QAAI,mBAAmB;AACrB,YAAM,UAAU,MAAM,cAAc;AACpC,WAAK,OAAO,CAAC,UAAU;AACrB,YAAI,KAAK,mBAAmB,SAAS;AACnC,gBAAM,kBAAkB,mBAAmB;AAC3C,gBAAM,4BACJ,mBAAmB;AACrB,gBAAM,kBAAkB,mBAAmB;AAAA,QAC7C;AACA,cAAM,6BAAN,MAAM,2BAA6B,CAAC;AACpC,cAAM,yBAAyB,OAAO,IAAI;AAAA,UACxC,iBAAiB,mBAAmB;AAAA,UACpC,2BACE,mBAAmB;AAAA,UACrB,iBAAiB,mBAAmB;AAAA,QACtC;AAAA,MACF,CAAC;AAAA,IACH;AAEA,WAAO;AAAA,EACT;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAOA,iBAAiB,WAAmB;AAClC,SAAK,WAAW,OAAO,SAAS;AAChC,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,WAAK,YAAY;AAAA,IACnB;AAAA,EACF;AAAA,EAEA,cAAc;AACZ,QAAI,KAAK,YAAY;AACnB,oBAAc,KAAK,UAAU;AAAA,IAC/B;AACA,SAAK,WAAW,MAAM;AACtB,SAAK,WAAW;AAAA,EAClB;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAOS,UAAU;AACjB,UAAM,QAAQ;AACd,SAAK,YAAY;AAAA,EACnB;AAAA,EAEQ,QAAQ;AACd,QAAI,KAAK,YAAY;AACnB,oBAAc,KAAK,UAAU;AAAA,IAC/B;AAEA,SAAK,aAAa,YAAY,YAAY;AACxC,YAAM,cAAc,MAAM,KAAK,yBAAyB,CAAC;AAAA,IAC3D,GAAG,KAAK,aAAa;AAAA,EACvB;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EASA,MAAM,aAAa,iBAAwC;AACzD,UAAM,KAAK,yBAAyB,EAAE,gBAAgB,CAAC;AAAA,EACzD;AAAA,EAEQ,aAAa;AACnB,SAAK,OAAO,MAAM;AAChB,aAAO;AAAA,IACT,CAAC;AAAA,EACH;AAAA,EAEA,MAAc,0BAA0B;AACtC,UAAM,oCACJ,MAAM,KAAK,sCAAsC;AACnD,UAAM,oCACJ,KAAK,wCAAwC,KAAK;AAEpD,WACE,qCAAqC;AAAA,EAEzC;AAAA,EAEA,gBACE,sBACA,cACmD;AACnD,QACE,CAAC,KAAK,MAAM,mBACZ,KAAK,MAAM,oBAAoB,mBAAmB,YAClD;AACA,aAAO,CAAC;AAAA,IACV;AACA,WAAO;AAAA,MACL;AAAA,MACA;AAAA,MACA,KAAK,MAAM;AAAA,IACb;AAAA,EACF;AAAA,EAaA,yBAAyB;AACvB,SAAK,OAAO,CAAC,UAAU;AACrB,YAAM,2BAA2B;AAAA,IACnC,CAAC;AAAA,EACH;AAAA,EAEA,0BAA0B;AACxB,SAAK,OAAO,CAAC,UAAU;AACrB,YAAM,2BAA2B;AAAA,IACnC,CAAC;AAAA,EACH;AACF;AAlUE;AA4SM;AAAA,kCAA6B,eAAC,wBAAsC;AACxE,QAAM,aAAa,uBAAuB,eAAe;AAEzD,MAAI,eAAe,KAAK,gBAAgB;AACtC,SAAK,WAAW,IAAI,SAAS,mBAAK,cAAL,UAAmB;AAChD,UAAM,KAAK,aAAa;AAExB,SAAK,iBAAiB;AAAA,EACxB;AACF;AAeF,IAAO,2BAAQ;;;ACliBf,eAAO,4BACL,MAC6B;AAC7B,MAAI;AACF,WAAO,MAAM,2BAA2B,IAAI;AAAA,EAC9C,SAAS,OAAO;AACd,QAAI,iBAAiB,OAAO;AAC1B,YAAM,IAAI;AAAA,QACR,6CAA6C,MAAM,OAAO;AAAA,MAC5D;AAAA,IACF;AAEA,UAAM;AAAA,EACR;AACF;AAOA,eAAe,2BACb,SAC6B;AAC7B,QAAM;AAAA,IACJ;AAAA,IACA;AAAA,IACA;AAAA,EACF,IAAI;AAEJ,MAAI;AACF,QAAI,uBAAuB,CAAC,0BAA0B;AACpD,aAAO,MAAM,mCAAmC,OAAO;AAAA,IACzD;AAEA,QAAI,4BAA4B,CAAC,0BAA0B;AACzD,aAAO,MAAM,gCAAgC,OAAO;AAAA,IACtD;AAEA,UAAM,IAAI,MAAM,oDAAoD;AAAA,EACtE,QAAQ;AACN,WAAO,MAAM,0BAA0B,OAAO;AAAA,EAChD;AACF;AAOA,eAAe,mCACb,SAC6B;AAC7B,QAAM;AAAA,IACJ,mBAAAA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA,uBAAAC;AAAA,EACF,IAAI;AAEJ,QAAM,YAAY,MAAMD;AAAA,IACtB;AAAA,IACA;AAAA,IACA;AAAA,EACF;AAEA,QAAM,EAAE,+BAA+B,sBAAsB,IAC3D,UAAU;AAEZ,QAAM,4BAA4BC;AAAA,IAChC;AAAA,IACA;AAAA,IACA;AAAA,EACF;AAEA,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB;AAAA,IACA,iBAAiB,mBAAmB;AAAA,EACtC;AACF;AAOA,eAAe,gCACb,SAC6B;AAC7B,QAAM;AAAA,IACJ,8BAAAC;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,EACF,IAAI;AAEJ,QAAM,YAAY,MAAMA;AAAA,IACtB;AAAA,IACA;AAAA,IACA;AAAA,EACF;AAEA,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB,2BAA2B,CAAC;AAAA,IAC5B,iBAAiB,mBAAmB;AAAA,EACtC;AACF;AAOA,eAAe,0BACb,SAC6B;AAC7B,QAAM,EAAE,UAAU,0BAAAC,0BAAyB,IAAI;AAE/C,QAAM,YAAY,MAAMA,0BAAyB,QAAQ;AAEzD,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB,2BAA2B,CAAC;AAAA,IAC5B,iBAAiB,mBAAmB;AAAA,EACtC;AACF;","names":["fetchGasEstimates","calculateTimeEstimate","fetchLegacyGasPriceEstimates","fetchEthGasPriceEstimate"]}
+\ No newline at end of file
+diff --git a/dist/chunk-H5WHAYLI.js b/dist/chunk-H5WHAYLI.js
+deleted file mode 100644
+index 3d6f8458707153d0b3cdd19da2bce7cb32da8eef..0000000000000000000000000000000000000000
+--- a/dist/chunk-H5WHAYLI.js
++++ /dev/null
+@@ -1,396 +0,0 @@
+-"use strict";Object.defineProperty(exports, "__esModule", {value: true}); function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+-
+-
+-
+-
+-
+-
+-
+-
+-var _chunkQ2YPK5SLjs = require('./chunk-Q2YPK5SL.js');
+-
+-// src/GasFeeController.ts
+-
+-
+-
+-
+-var _controllerutils = require('@metamask/controller-utils');
+-var _ethquery = require('@metamask/eth-query'); var _ethquery2 = _interopRequireDefault(_ethquery);
+-var _pollingcontroller = require('@metamask/polling-controller');
+-var _uuid = require('uuid');
+-var GAS_API_BASE_URL = "https://gas.api.infura.io";
+-var GAS_ESTIMATE_TYPES = {
+-  FEE_MARKET: "fee-market",
+-  LEGACY: "legacy",
+-  ETH_GASPRICE: "eth_gasPrice",
+-  NONE: "none"
+-};
+-var metadata = {
+-  gasFeeEstimatesByChainId: {
+-    persist: true,
+-    anonymous: false
+-  },
+-  gasFeeEstimates: { persist: true, anonymous: false },
+-  estimatedGasFeeTimeBounds: { persist: true, anonymous: false },
+-  gasEstimateType: { persist: true, anonymous: false },
+-  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false }
+-};
+-var name = "GasFeeController";
+-var defaultState = {
+-  gasFeeEstimatesByChainId: {},
+-  gasFeeEstimates: {},
+-  estimatedGasFeeTimeBounds: {},
+-  gasEstimateType: GAS_ESTIMATE_TYPES.NONE,
+-  nonRPCGasFeeApisDisabled: false
+-};
+-var _getProvider, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn;
+-var GasFeeController = class extends _pollingcontroller.StaticIntervalPollingController {
+-  /**
+-   * Creates a GasFeeController instance.
+-   *
+-   * @param options - The controller options.
+-   * @param options.interval - The time in milliseconds to wait between polls.
+-   * @param options.messenger - The controller messenger.
+-   * @param options.state - The initial state.
+-   * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current
+-   * network is EIP-1559 compatible.
+-   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the
+-   * current network is compatible with the legacy gas price API.
+-   * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current
+-   * account is EIP-1559 compatible.
+-   * @param options.getChainId - Returns the current chain ID.
+-   * @param options.getProvider - Returns a network provider for the current network.
+-   * @param options.onNetworkDidChange - A function for registering an event handler for the
+-   * network state change event.
+-   * @param options.clientId - The client ID used to identify to the gas estimation API who is
+-   * asking for estimates.
+-   * @param options.infuraAPIKey - The Infura API key used for infura API requests.
+-   */
+-  constructor({
+-    interval = 15e3,
+-    messenger,
+-    state,
+-    getCurrentNetworkEIP1559Compatibility,
+-    getCurrentAccountEIP1559Compatibility,
+-    getChainId,
+-    getCurrentNetworkLegacyGasAPICompatibility,
+-    getProvider,
+-    onNetworkDidChange,
+-    clientId,
+-    infuraAPIKey
+-  }) {
+-    super({
+-      name,
+-      metadata,
+-      messenger,
+-      state: { ...defaultState, ...state }
+-    });
+-    _chunkQ2YPK5SLjs.__privateAdd.call(void 0, this, _onNetworkControllerDidChange);
+-    _chunkQ2YPK5SLjs.__privateAdd.call(void 0, this, _getProvider, void 0);
+-    this.intervalDelay = interval;
+-    this.setIntervalLength(interval);
+-    this.pollTokens = /* @__PURE__ */ new Set();
+-    this.getCurrentNetworkEIP1559Compatibility = getCurrentNetworkEIP1559Compatibility;
+-    this.getCurrentNetworkLegacyGasAPICompatibility = getCurrentNetworkLegacyGasAPICompatibility;
+-    this.getCurrentAccountEIP1559Compatibility = getCurrentAccountEIP1559Compatibility;
+-    _chunkQ2YPK5SLjs.__privateSet.call(void 0, this, _getProvider, getProvider);
+-    this.EIP1559APIEndpoint = `${GAS_API_BASE_URL}/networks/<chain_id>/suggestedGasFees`;
+-    this.legacyAPIEndpoint = `${GAS_API_BASE_URL}/networks/<chain_id>/gasPrices`;
+-    this.clientId = clientId;
+-    this.infuraAPIKey = infuraAPIKey;
+-    this.ethQuery = new (0, _ethquery2.default)(_chunkQ2YPK5SLjs.__privateGet.call(void 0, this, _getProvider).call(this));
+-    if (onNetworkDidChange && getChainId) {
+-      this.currentChainId = getChainId();
+-      onNetworkDidChange(async (networkControllerState) => {
+-        await _chunkQ2YPK5SLjs.__privateMethod.call(void 0, this, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn).call(this, networkControllerState);
+-      });
+-    } else {
+-      this.currentChainId = this.messagingSystem.call(
+-        "NetworkController:getState"
+-      ).providerConfig.chainId;
+-      this.messagingSystem.subscribe(
+-        "NetworkController:networkDidChange",
+-        async (networkControllerState) => {
+-          await _chunkQ2YPK5SLjs.__privateMethod.call(void 0, this, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn).call(this, networkControllerState);
+-        }
+-      );
+-    }
+-  }
+-  async resetPolling() {
+-    if (this.pollTokens.size !== 0) {
+-      const tokens = Array.from(this.pollTokens);
+-      this.stopPolling();
+-      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);
+-      tokens.slice(1).forEach((token) => {
+-        this.pollTokens.add(token);
+-      });
+-    }
+-  }
+-  async fetchGasFeeEstimates(options) {
+-    return await this._fetchGasFeeEstimateData(options);
+-  }
+-  async getGasFeeEstimatesAndStartPolling(pollToken) {
+-    const _pollToken = pollToken || _uuid.v1.call(void 0, );
+-    this.pollTokens.add(_pollToken);
+-    if (this.pollTokens.size === 1) {
+-      await this._fetchGasFeeEstimateData();
+-      this._poll();
+-    }
+-    return _pollToken;
+-  }
+-  /**
+-   * Gets and sets gasFeeEstimates in state.
+-   *
+-   * @param options - The gas fee estimate options.
+-   * @param options.shouldUpdateState - Determines whether the state should be updated with the
+-   * updated gas estimates.
+-   * @returns The gas fee estimates.
+-   */
+-  async _fetchGasFeeEstimateData(options = {}) {
+-    const { shouldUpdateState = true, networkClientId } = options;
+-    let ethQuery, isEIP1559Compatible, isLegacyGasAPICompatible, decimalChainId;
+-    if (networkClientId !== void 0) {
+-      const networkClient = this.messagingSystem.call(
+-        "NetworkController:getNetworkClientById",
+-        networkClientId
+-      );
+-      isLegacyGasAPICompatible = networkClient.configuration.chainId === "0x38";
+-      decimalChainId = _controllerutils.convertHexToDecimal.call(void 0, networkClient.configuration.chainId);
+-      try {
+-        const result = await this.messagingSystem.call(
+-          "NetworkController:getEIP1559Compatibility",
+-          networkClientId
+-        );
+-        isEIP1559Compatible = result || false;
+-      } catch {
+-        isEIP1559Compatible = false;
+-      }
+-      ethQuery = new (0, _ethquery2.default)(networkClient.provider);
+-    }
+-    ethQuery ?? (ethQuery = this.ethQuery);
+-    isLegacyGasAPICompatible ?? (isLegacyGasAPICompatible = this.getCurrentNetworkLegacyGasAPICompatibility());
+-    decimalChainId ?? (decimalChainId = _controllerutils.convertHexToDecimal.call(void 0, this.currentChainId));
+-    try {
+-      isEIP1559Compatible ?? (isEIP1559Compatible = await this.getEIP1559Compatibility());
+-    } catch (e) {
+-      console.error(e);
+-      isEIP1559Compatible ?? (isEIP1559Compatible = false);
+-    }
+-    const gasFeeCalculations = await determineGasFeeCalculations({
+-      isEIP1559Compatible,
+-      isLegacyGasAPICompatible,
+-      fetchGasEstimates: _chunkQ2YPK5SLjs.fetchGasEstimates,
+-      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(
+-        "<chain_id>",
+-        `${decimalChainId}`
+-      ),
+-      fetchLegacyGasPriceEstimates: _chunkQ2YPK5SLjs.fetchLegacyGasPriceEstimates,
+-      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(
+-        "<chain_id>",
+-        `${decimalChainId}`
+-      ),
+-      fetchEthGasPriceEstimate: _chunkQ2YPK5SLjs.fetchEthGasPriceEstimate,
+-      calculateTimeEstimate: _chunkQ2YPK5SLjs.calculateTimeEstimate,
+-      clientId: this.clientId,
+-      ethQuery,
+-      infuraAPIKey: this.infuraAPIKey,
+-      nonRPCGasFeeApisDisabled: this.state.nonRPCGasFeeApisDisabled
+-    });
+-    if (shouldUpdateState) {
+-      const chainId = _controllerutils.toHex.call(void 0, decimalChainId);
+-      this.update((state) => {
+-        if (this.currentChainId === chainId) {
+-          state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;
+-          state.estimatedGasFeeTimeBounds = gasFeeCalculations.estimatedGasFeeTimeBounds;
+-          state.gasEstimateType = gasFeeCalculations.gasEstimateType;
+-        }
+-        state.gasFeeEstimatesByChainId ?? (state.gasFeeEstimatesByChainId = {});
+-        state.gasFeeEstimatesByChainId[chainId] = {
+-          gasFeeEstimates: gasFeeCalculations.gasFeeEstimates,
+-          estimatedGasFeeTimeBounds: gasFeeCalculations.estimatedGasFeeTimeBounds,
+-          gasEstimateType: gasFeeCalculations.gasEstimateType
+-        };
+-      });
+-    }
+-    return gasFeeCalculations;
+-  }
+-  /**
+-   * Remove the poll token, and stop polling if the set of poll tokens is empty.
+-   *
+-   * @param pollToken - The poll token to disconnect.
+-   */
+-  disconnectPoller(pollToken) {
+-    this.pollTokens.delete(pollToken);
+-    if (this.pollTokens.size === 0) {
+-      this.stopPolling();
+-    }
+-  }
+-  stopPolling() {
+-    if (this.intervalId) {
+-      clearInterval(this.intervalId);
+-    }
+-    this.pollTokens.clear();
+-    this.resetState();
+-  }
+-  /**
+-   * Prepare to discard this controller.
+-   *
+-   * This stops any active polling.
+-   */
+-  destroy() {
+-    super.destroy();
+-    this.stopPolling();
+-  }
+-  _poll() {
+-    if (this.intervalId) {
+-      clearInterval(this.intervalId);
+-    }
+-    this.intervalId = setInterval(async () => {
+-      await _controllerutils.safelyExecute.call(void 0, () => this._fetchGasFeeEstimateData());
+-    }, this.intervalDelay);
+-  }
+-  /**
+-   * Fetching token list from the Token Service API.
+-   *
+-   * @private
+-   * @param networkClientId - The ID of the network client triggering the fetch.
+-   * @returns A promise that resolves when this operation completes.
+-   */
+-  async _executePoll(networkClientId) {
+-    await this._fetchGasFeeEstimateData({ networkClientId });
+-  }
+-  resetState() {
+-    this.update(() => {
+-      return defaultState;
+-    });
+-  }
+-  async getEIP1559Compatibility() {
+-    const currentNetworkIsEIP1559Compatible = await this.getCurrentNetworkEIP1559Compatibility();
+-    const currentAccountIsEIP1559Compatible = this.getCurrentAccountEIP1559Compatibility?.() ?? true;
+-    return currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible;
+-  }
+-  getTimeEstimate(maxPriorityFeePerGas, maxFeePerGas) {
+-    if (!this.state.gasFeeEstimates || this.state.gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET) {
+-      return {};
+-    }
+-    return _chunkQ2YPK5SLjs.calculateTimeEstimate.call(void 0,
+-      maxPriorityFeePerGas,
+-      maxFeePerGas,
+-      this.state.gasFeeEstimates
+-    );
+-  }
+-  enableNonRPCGasFeeApis() {
+-    this.update((state) => {
+-      state.nonRPCGasFeeApisDisabled = false;
+-    });
+-  }
+-  disableNonRPCGasFeeApis() {
+-    this.update((state) => {
+-      state.nonRPCGasFeeApisDisabled = true;
+-    });
+-  }
+-};
+-_getProvider = new WeakMap();
+-_onNetworkControllerDidChange = new WeakSet();
+-onNetworkControllerDidChange_fn = async function(networkControllerState) {
+-  const newChainId = networkControllerState.providerConfig.chainId;
+-  if (newChainId !== this.currentChainId) {
+-    this.ethQuery = new (0, _ethquery2.default)(_chunkQ2YPK5SLjs.__privateGet.call(void 0, this, _getProvider).call(this));
+-    await this.resetPolling();
+-    this.currentChainId = newChainId;
+-  }
+-};
+-var GasFeeController_default = GasFeeController;
+-
+-// src/determineGasFeeCalculations.ts
+-async function determineGasFeeCalculations(args) {
+-  try {
+-    return await getEstimatesUsingFallbacks(args);
+-  } catch (error) {
+-    if (error instanceof Error) {
+-      throw new Error(
+-        `Gas fee/price estimation failed. Message: ${error.message}`
+-      );
+-    }
+-    throw error;
+-  }
+-}
+-async function getEstimatesUsingFallbacks(request) {
+-  const {
+-    isEIP1559Compatible,
+-    isLegacyGasAPICompatible,
+-    nonRPCGasFeeApisDisabled
+-  } = request;
+-  try {
+-    if (isEIP1559Compatible && !nonRPCGasFeeApisDisabled) {
+-      return await getEstimatesUsingFeeMarketEndpoint(request);
+-    }
+-    if (isLegacyGasAPICompatible && !nonRPCGasFeeApisDisabled) {
+-      return await getEstimatesUsingLegacyEndpoint(request);
+-    }
+-    throw new Error("Main gas fee/price estimation failed. Use fallback");
+-  } catch {
+-    return await getEstimatesUsingProvider(request);
+-  }
+-}
+-async function getEstimatesUsingFeeMarketEndpoint(request) {
+-  const {
+-    fetchGasEstimates: fetchGasEstimates2,
+-    fetchGasEstimatesUrl,
+-    infuraAPIKey,
+-    clientId,
+-    calculateTimeEstimate: calculateTimeEstimate2
+-  } = request;
+-  const estimates = await fetchGasEstimates2(
+-    fetchGasEstimatesUrl,
+-    infuraAPIKey,
+-    clientId
+-  );
+-  const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } = estimates.medium;
+-  const estimatedGasFeeTimeBounds = calculateTimeEstimate2(
+-    suggestedMaxPriorityFeePerGas,
+-    suggestedMaxFeePerGas,
+-    estimates
+-  );
+-  return {
+-    gasFeeEstimates: estimates,
+-    estimatedGasFeeTimeBounds,
+-    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET
+-  };
+-}
+-async function getEstimatesUsingLegacyEndpoint(request) {
+-  const {
+-    fetchLegacyGasPriceEstimates: fetchLegacyGasPriceEstimates2,
+-    fetchLegacyGasPriceEstimatesUrl,
+-    infuraAPIKey,
+-    clientId
+-  } = request;
+-  const estimates = await fetchLegacyGasPriceEstimates2(
+-    fetchLegacyGasPriceEstimatesUrl,
+-    infuraAPIKey,
+-    clientId
+-  );
+-  return {
+-    gasFeeEstimates: estimates,
+-    estimatedGasFeeTimeBounds: {},
+-    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY
+-  };
+-}
+-async function getEstimatesUsingProvider(request) {
+-  const { ethQuery, fetchEthGasPriceEstimate: fetchEthGasPriceEstimate2 } = request;
+-  const estimates = await fetchEthGasPriceEstimate2(ethQuery);
+-  return {
+-    gasFeeEstimates: estimates,
+-    estimatedGasFeeTimeBounds: {},
+-    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE
+-  };
+-}
+-
+-
+-
+-
+-
+-
+-
+-exports.determineGasFeeCalculations = determineGasFeeCalculations; exports.GAS_API_BASE_URL = GAS_API_BASE_URL; exports.GAS_ESTIMATE_TYPES = GAS_ESTIMATE_TYPES; exports.GasFeeController = GasFeeController; exports.GasFeeController_default = GasFeeController_default;
+-//# sourceMappingURL=chunk-H5WHAYLI.js.map
+\ No newline at end of file
+diff --git a/dist/chunk-H5WHAYLI.js.map b/dist/chunk-H5WHAYLI.js.map
+deleted file mode 100644
+index ed761f584584470a8176f029d9d860dc017428fc..0000000000000000000000000000000000000000
+--- a/dist/chunk-H5WHAYLI.js.map
++++ /dev/null
+@@ -1 +0,0 @@
+-{"version":3,"sources":["../src/GasFeeController.ts","../src/determineGasFeeCalculations.ts"],"names":["fetchGasEstimates","calculateTimeEstimate","fetchLegacyGasPriceEstimates","fetchEthGasPriceEstimate"],"mappings":";;;;;;;;;;;;AAKA;AAAA,EACE;AAAA,EACA;AAAA,EACA;AAAA,OACK;AACP,OAAO,cAAc;AAUrB,SAAS,uCAAuC;AAEhD,SAAS,MAAM,cAAc;AAUtB,IAAM,mBAAmB;AA0BzB,IAAM,qBAAqB;AAAA,EAChC,YAAY;AAAA,EACZ,QAAQ;AAAA,EACR,cAAc;AAAA,EACd,MAAM;AACR;AAiGA,IAAM,WAAW;AAAA,EACf,0BAA0B;AAAA,IACxB,SAAS;AAAA,IACT,WAAW;AAAA,EACb;AAAA,EACA,iBAAiB,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EACnD,2BAA2B,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EAC7D,iBAAiB,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EACnD,0BAA0B,EAAE,SAAS,MAAM,WAAW,MAAM;AAC9D;AAqDA,IAAM,OAAO;AA0Bb,IAAM,eAA4B;AAAA,EAChC,0BAA0B,CAAC;AAAA,EAC3B,iBAAiB,CAAC;AAAA,EAClB,2BAA2B,CAAC;AAAA,EAC5B,iBAAiB,mBAAmB;AAAA,EACpC,0BAA0B;AAC5B;AA9PA;AAmQO,IAAM,mBAAN,cAA+B,gCAIpC;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAgDA,YAAY;AAAA,IACV,WAAW;AAAA,IACX;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,EACF,GAYG;AACD,UAAM;AAAA,MACJ;AAAA,MACA;AAAA,MACA;AAAA,MACA,OAAO,EAAE,GAAG,cAAc,GAAG,MAAM;AAAA,IACrC,CAAC;AAuPH,uBAAM;AA5SN;AAsDE,SAAK,gBAAgB;AACrB,SAAK,kBAAkB,QAAQ;AAC/B,SAAK,aAAa,oBAAI,IAAI;AAC1B,SAAK,wCACH;AACF,SAAK,6CACH;AACF,SAAK,wCACH;AACF,uBAAK,cAAe;AACpB,SAAK,qBAAqB,GAAG,gBAAgB;AAC7C,SAAK,oBAAoB,GAAG,gBAAgB;AAC5C,SAAK,WAAW;AAChB,SAAK,eAAe;AAEpB,SAAK,WAAW,IAAI,SAAS,mBAAK,cAAL,UAAmB;AAEhD,QAAI,sBAAsB,YAAY;AACpC,WAAK,iBAAiB,WAAW;AACjC,yBAAmB,OAAO,2BAA2B;AACnD,cAAM,sBAAK,gEAAL,WAAmC;AAAA,MAC3C,CAAC;AAAA,IACH,OAAO;AACL,WAAK,iBAAiB,KAAK,gBAAgB;AAAA,QACzC;AAAA,MACF,EAAE,eAAe;AACjB,WAAK,gBAAgB;AAAA,QACnB;AAAA,QACA,OAAO,2BAA2B;AAChC,gBAAM,sBAAK,gEAAL,WAAmC;AAAA,QAC3C;AAAA,MACF;AAAA,IACF;AAAA,EACF;AAAA,EAEA,MAAM,eAAe;AACnB,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,YAAM,SAAS,MAAM,KAAK,KAAK,UAAU;AACzC,WAAK,YAAY;AACjB,YAAM,KAAK,kCAAkC,OAAO,CAAC,CAAC;AACtD,aAAO,MAAM,CAAC,EAAE,QAAQ,CAAC,UAAU;AACjC,aAAK,WAAW,IAAI,KAAK;AAAA,MAC3B,CAAC;AAAA,IACH;AAAA,EACF;AAAA,EAEA,MAAM,qBAAqB,SAAsC;AAC/D,WAAO,MAAM,KAAK,yBAAyB,OAAO;AAAA,EACpD;AAAA,EAEA,MAAM,kCACJ,WACiB;AACjB,UAAM,aAAa,aAAa,OAAO;AAEvC,SAAK,WAAW,IAAI,UAAU;AAE9B,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,YAAM,KAAK,yBAAyB;AACpC,WAAK,MAAM;AAAA,IACb;AAEA,WAAO;AAAA,EACT;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAUA,MAAM,yBACJ,UAAsC,CAAC,GACjB;AACtB,UAAM,EAAE,oBAAoB,MAAM,gBAAgB,IAAI;AAEtD,QAAI,UACF,qBACA,0BACA;AAEF,QAAI,oBAAoB,QAAW;AACjC,YAAM,gBAAgB,KAAK,gBAAgB;AAAA,QACzC;AAAA,QACA;AAAA,MACF;AACA,iCAA2B,cAAc,cAAc,YAAY;AAEnE,uBAAiB,oBAAoB,cAAc,cAAc,OAAO;AAExE,UAAI;AACF,cAAM,SAAS,MAAM,KAAK,gBAAgB;AAAA,UACxC;AAAA,UACA;AAAA,QACF;AACA,8BAAsB,UAAU;AAAA,MAClC,QAAQ;AACN,8BAAsB;AAAA,MACxB;AACA,iBAAW,IAAI,SAAS,cAAc,QAAQ;AAAA,IAChD;AAEA,4BAAa,KAAK;AAElB,4DACE,KAAK,2CAA2C;AAElD,wCAAmB,oBAAoB,KAAK,cAAc;AAE1D,QAAI;AACF,oDAAwB,MAAM,KAAK,wBAAwB;AAAA,IAC7D,SAAS,GAAG;AACV,cAAQ,MAAM,CAAC;AACf,oDAAwB;AAAA,IAC1B;AAEA,UAAM,qBAAqB,MAAM,4BAA4B;AAAA,MAC3D;AAAA,MACA;AAAA,MACA;AAAA,MACA,sBAAsB,KAAK,mBAAmB;AAAA,QAC5C;AAAA,QACA,GAAG,cAAc;AAAA,MACnB;AAAA,MACA;AAAA,MACA,iCAAiC,KAAK,kBAAkB;AAAA,QACtD;AAAA,QACA,GAAG,cAAc;AAAA,MACnB;AAAA,MACA;AAAA,MACA;AAAA,MACA,UAAU,KAAK;AAAA,MACf;AAAA,MACA,cAAc,KAAK;AAAA,MACnB,0BAA0B,KAAK,MAAM;AAAA,IACvC,CAAC;AAED,QAAI,mBAAmB;AACrB,YAAM,UAAU,MAAM,cAAc;AACpC,WAAK,OAAO,CAAC,UAAU;AACrB,YAAI,KAAK,mBAAmB,SAAS;AACnC,gBAAM,kBAAkB,mBAAmB;AAC3C,gBAAM,4BACJ,mBAAmB;AACrB,gBAAM,kBAAkB,mBAAmB;AAAA,QAC7C;AACA,cAAM,6BAAN,MAAM,2BAA6B,CAAC;AACpC,cAAM,yBAAyB,OAAO,IAAI;AAAA,UACxC,iBAAiB,mBAAmB;AAAA,UACpC,2BACE,mBAAmB;AAAA,UACrB,iBAAiB,mBAAmB;AAAA,QACtC;AAAA,MACF,CAAC;AAAA,IACH;AAEA,WAAO;AAAA,EACT;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAOA,iBAAiB,WAAmB;AAClC,SAAK,WAAW,OAAO,SAAS;AAChC,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,WAAK,YAAY;AAAA,IACnB;AAAA,EACF;AAAA,EAEA,cAAc;AACZ,QAAI,KAAK,YAAY;AACnB,oBAAc,KAAK,UAAU;AAAA,IAC/B;AACA,SAAK,WAAW,MAAM;AACtB,SAAK,WAAW;AAAA,EAClB;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAOS,UAAU;AACjB,UAAM,QAAQ;AACd,SAAK,YAAY;AAAA,EACnB;AAAA,EAEQ,QAAQ;AACd,QAAI,KAAK,YAAY;AACnB,oBAAc,KAAK,UAAU;AAAA,IAC/B;AAEA,SAAK,aAAa,YAAY,YAAY;AACxC,YAAM,cAAc,MAAM,KAAK,yBAAyB,CAAC;AAAA,IAC3D,GAAG,KAAK,aAAa;AAAA,EACvB;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EASA,MAAM,aAAa,iBAAwC;AACzD,UAAM,KAAK,yBAAyB,EAAE,gBAAgB,CAAC;AAAA,EACzD;AAAA,EAEQ,aAAa;AACnB,SAAK,OAAO,MAAM;AAChB,aAAO;AAAA,IACT,CAAC;AAAA,EACH;AAAA,EAEA,MAAc,0BAA0B;AACtC,UAAM,oCACJ,MAAM,KAAK,sCAAsC;AACnD,UAAM,oCACJ,KAAK,wCAAwC,KAAK;AAEpD,WACE,qCAAqC;AAAA,EAEzC;AAAA,EAEA,gBACE,sBACA,cACmD;AACnD,QACE,CAAC,KAAK,MAAM,mBACZ,KAAK,MAAM,oBAAoB,mBAAmB,YAClD;AACA,aAAO,CAAC;AAAA,IACV;AACA,WAAO;AAAA,MACL;AAAA,MACA;AAAA,MACA,KAAK,MAAM;AAAA,IACb;AAAA,EACF;AAAA,EAaA,yBAAyB;AACvB,SAAK,OAAO,CAAC,UAAU;AACrB,YAAM,2BAA2B;AAAA,IACnC,CAAC;AAAA,EACH;AAAA,EAEA,0BAA0B;AACxB,SAAK,OAAO,CAAC,UAAU;AACrB,YAAM,2BAA2B;AAAA,IACnC,CAAC;AAAA,EACH;AACF;AAlUE;AA4SM;AAAA,kCAA6B,eAAC,wBAAsC;AACxE,QAAM,aAAa,uBAAuB,eAAe;AAEzD,MAAI,eAAe,KAAK,gBAAgB;AACtC,SAAK,WAAW,IAAI,SAAS,mBAAK,cAAL,UAAmB;AAChD,UAAM,KAAK,aAAa;AAExB,SAAK,iBAAiB;AAAA,EACxB;AACF;AAeF,IAAO,2BAAQ;;;ACliBf,eAAO,4BACL,MAC6B;AAC7B,MAAI;AACF,WAAO,MAAM,2BAA2B,IAAI;AAAA,EAC9C,SAAS,OAAO;AACd,QAAI,iBAAiB,OAAO;AAC1B,YAAM,IAAI;AAAA,QACR,6CAA6C,MAAM,OAAO;AAAA,MAC5D;AAAA,IACF;AAEA,UAAM;AAAA,EACR;AACF;AAOA,eAAe,2BACb,SAC6B;AAC7B,QAAM;AAAA,IACJ;AAAA,IACA;AAAA,IACA;AAAA,EACF,IAAI;AAEJ,MAAI;AACF,QAAI,uBAAuB,CAAC,0BAA0B;AACpD,aAAO,MAAM,mCAAmC,OAAO;AAAA,IACzD;AAEA,QAAI,4BAA4B,CAAC,0BAA0B;AACzD,aAAO,MAAM,gCAAgC,OAAO;AAAA,IACtD;AAEA,UAAM,IAAI,MAAM,oDAAoD;AAAA,EACtE,QAAQ;AACN,WAAO,MAAM,0BAA0B,OAAO;AAAA,EAChD;AACF;AAOA,eAAe,mCACb,SAC6B;AAC7B,QAAM;AAAA,IACJ,mBAAAA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA,uBAAAC;AAAA,EACF,IAAI;AAEJ,QAAM,YAAY,MAAMD;AAAA,IACtB;AAAA,IACA;AAAA,IACA;AAAA,EACF;AAEA,QAAM,EAAE,+BAA+B,sBAAsB,IAC3D,UAAU;AAEZ,QAAM,4BAA4BC;AAAA,IAChC;AAAA,IACA;AAAA,IACA;AAAA,EACF;AAEA,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB;AAAA,IACA,iBAAiB,mBAAmB;AAAA,EACtC;AACF;AAOA,eAAe,gCACb,SAC6B;AAC7B,QAAM;AAAA,IACJ,8BAAAC;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,EACF,IAAI;AAEJ,QAAM,YAAY,MAAMA;AAAA,IACtB;AAAA,IACA;AAAA,IACA;AAAA,EACF;AAEA,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB,2BAA2B,CAAC;AAAA,IAC5B,iBAAiB,mBAAmB;AAAA,EACtC;AACF;AAOA,eAAe,0BACb,SAC6B;AAC7B,QAAM,EAAE,UAAU,0BAAAC,0BAAyB,IAAI;AAE/C,QAAM,YAAY,MAAMA,0BAAyB,QAAQ;AAEzD,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB,2BAA2B,CAAC;AAAA,IAC5B,iBAAiB,mBAAmB;AAAA,EACtC;AACF","sourcesContent":["import type {\n  ControllerGetStateAction,\n  ControllerStateChangeEvent,\n  RestrictedControllerMessenger,\n} from '@metamask/base-controller';\nimport {\n  convertHexToDecimal,\n  safelyExecute,\n  toHex,\n} from '@metamask/controller-utils';\nimport EthQuery from '@metamask/eth-query';\nimport type {\n  NetworkClientId,\n  NetworkControllerGetEIP1559CompatibilityAction,\n  NetworkControllerGetNetworkClientByIdAction,\n  NetworkControllerGetStateAction,\n  NetworkControllerNetworkDidChangeEvent,\n  NetworkState,\n  ProviderProxy,\n} from '@metamask/network-controller';\nimport { StaticIntervalPollingController } from '@metamask/polling-controller';\nimport type { Hex } from '@metamask/utils';\nimport { v1 as random } from 'uuid';\n\nimport determineGasFeeCalculations from './determineGasFeeCalculations';\nimport {\n  calculateTimeEstimate,\n  fetchGasEstimates,\n  fetchLegacyGasPriceEstimates,\n  fetchEthGasPriceEstimate,\n} from './gas-util';\n\nexport const GAS_API_BASE_URL = 'https://gas.api.infura.io';\n\nexport type unknownString = 'unknown';\n\n// Fee Market describes the way gas is set after the london hardfork, and was\n// defined by EIP-1559.\nexport type FeeMarketEstimateType = 'fee-market';\n// Legacy describes gasPrice estimates from before london hardfork, when the\n// user is connected to mainnet and are presented with fast/average/slow\n// estimate levels to choose from.\nexport type LegacyEstimateType = 'legacy';\n// EthGasPrice describes a gasPrice estimate received from eth_gasPrice. Post\n// london this value should only be used for legacy type transactions when on\n// networks that support EIP-1559. This type of estimate is the most accurate\n// to display on custom networks that don't support EIP-1559.\nexport type EthGasPriceEstimateType = 'eth_gasPrice';\n// NoEstimate describes the state of the controller before receiving its first\n// estimate.\nexport type NoEstimateType = 'none';\n\n/**\n * Indicates which type of gasEstimate the controller is currently returning.\n * This is useful as a way of asserting that the shape of gasEstimates matches\n * expectations. NONE is a special case indicating that no previous gasEstimate\n * has been fetched.\n */\nexport const GAS_ESTIMATE_TYPES = {\n  FEE_MARKET: 'fee-market' as FeeMarketEstimateType,\n  LEGACY: 'legacy' as LegacyEstimateType,\n  ETH_GASPRICE: 'eth_gasPrice' as EthGasPriceEstimateType,\n  NONE: 'none' as NoEstimateType,\n};\n\nexport type GasEstimateType =\n  | FeeMarketEstimateType\n  | EthGasPriceEstimateType\n  | LegacyEstimateType\n  | NoEstimateType;\n\nexport type EstimatedGasFeeTimeBounds = {\n  lowerTimeBound: number | null;\n  upperTimeBound: number | unknownString;\n};\n\n/**\n * @type EthGasPriceEstimate\n *\n * A single gas price estimate for networks and accounts that don't support EIP-1559\n * This estimate comes from eth_gasPrice but is converted to dec gwei to match other\n * return values\n * @property gasPrice - A GWEI dec string\n */\n\nexport type EthGasPriceEstimate = {\n  gasPrice: string;\n};\n\n/**\n * @type LegacyGasPriceEstimate\n *\n * A set of gas price estimates for networks and accounts that don't support EIP-1559\n * These estimates include low, medium and high all as strings representing gwei in\n * decimal format.\n * @property high - gasPrice, in decimal gwei string format, suggested for fast inclusion\n * @property medium - gasPrice, in decimal gwei string format, suggested for avg inclusion\n * @property low - gasPrice, in decimal gwei string format, suggested for slow inclusion\n */\nexport type LegacyGasPriceEstimate = {\n  high: string;\n  medium: string;\n  low: string;\n};\n\n/**\n * @type Eip1559GasFee\n *\n * Data necessary to provide an estimate of a gas fee with a specific tip\n * @property minWaitTimeEstimate - The fastest the transaction will take, in milliseconds\n * @property maxWaitTimeEstimate - The slowest the transaction will take, in milliseconds\n * @property suggestedMaxPriorityFeePerGas - A suggested \"tip\", a GWEI hex number\n * @property suggestedMaxFeePerGas - A suggested max fee, the most a user will pay. a GWEI hex number\n */\nexport type Eip1559GasFee = {\n  minWaitTimeEstimate: number; // a time duration in milliseconds\n  maxWaitTimeEstimate: number; // a time duration in milliseconds\n  suggestedMaxPriorityFeePerGas: string; // a GWEI decimal number\n  suggestedMaxFeePerGas: string; // a GWEI decimal number\n};\n\n/**\n * @type GasFeeEstimates\n *\n * Data necessary to provide multiple GasFee estimates, and supporting information, to the user\n * @property low - A GasFee for a minimum necessary combination of tip and maxFee\n * @property medium - A GasFee for a recommended combination of tip and maxFee\n * @property high - A GasFee for a high combination of tip and maxFee\n * @property estimatedBaseFee - An estimate of what the base fee will be for the pending/next block. A GWEI dec number\n * @property networkCongestion - A normalized number that can be used to gauge the congestion\n * level of the network, with 0 meaning not congested and 1 meaning extremely congested\n */\nexport type GasFeeEstimates = SourcedGasFeeEstimates | FallbackGasFeeEstimates;\n\ntype SourcedGasFeeEstimates = {\n  low: Eip1559GasFee;\n  medium: Eip1559GasFee;\n  high: Eip1559GasFee;\n  estimatedBaseFee: string;\n  historicalBaseFeeRange: [string, string];\n  baseFeeTrend: 'up' | 'down' | 'level';\n  latestPriorityFeeRange: [string, string];\n  historicalPriorityFeeRange: [string, string];\n  priorityFeeTrend: 'up' | 'down' | 'level';\n  networkCongestion: number;\n};\n\ntype FallbackGasFeeEstimates = {\n  low: Eip1559GasFee;\n  medium: Eip1559GasFee;\n  high: Eip1559GasFee;\n  estimatedBaseFee: string;\n  historicalBaseFeeRange: null;\n  baseFeeTrend: null;\n  latestPriorityFeeRange: null;\n  historicalPriorityFeeRange: null;\n  priorityFeeTrend: null;\n  networkCongestion: null;\n};\n\nconst metadata = {\n  gasFeeEstimatesByChainId: {\n    persist: true,\n    anonymous: false,\n  },\n  gasFeeEstimates: { persist: true, anonymous: false },\n  estimatedGasFeeTimeBounds: { persist: true, anonymous: false },\n  gasEstimateType: { persist: true, anonymous: false },\n  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false },\n};\n\nexport type GasFeeStateEthGasPrice = {\n  gasFeeEstimates: EthGasPriceEstimate;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: EthGasPriceEstimateType;\n};\n\nexport type GasFeeStateFeeMarket = {\n  gasFeeEstimates: GasFeeEstimates;\n  estimatedGasFeeTimeBounds: EstimatedGasFeeTimeBounds | Record<string, never>;\n  gasEstimateType: FeeMarketEstimateType;\n};\n\nexport type GasFeeStateLegacy = {\n  gasFeeEstimates: LegacyGasPriceEstimate;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: LegacyEstimateType;\n};\n\nexport type GasFeeStateNoEstimates = {\n  gasFeeEstimates: Record<string, never>;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: NoEstimateType;\n};\n\nexport type FetchGasFeeEstimateOptions = {\n  shouldUpdateState?: boolean;\n  networkClientId?: NetworkClientId;\n};\n\n/**\n * @type GasFeeState\n *\n * Gas Fee controller state\n * @property gasFeeEstimates - Gas fee estimate data based on new EIP-1559 properties\n * @property estimatedGasFeeTimeBounds - Estimates representing the minimum and maximum\n */\nexport type SingleChainGasFeeState =\n  | GasFeeStateEthGasPrice\n  | GasFeeStateFeeMarket\n  | GasFeeStateLegacy\n  | GasFeeStateNoEstimates;\n\nexport type GasFeeEstimatesByChainId = {\n  gasFeeEstimatesByChainId?: Record<string, SingleChainGasFeeState>;\n};\n\nexport type GasFeeState = GasFeeEstimatesByChainId &\n  SingleChainGasFeeState & {\n    nonRPCGasFeeApisDisabled?: boolean;\n  };\n\nconst name = 'GasFeeController';\n\nexport type GasFeeStateChange = ControllerStateChangeEvent<\n  typeof name,\n  GasFeeState\n>;\n\nexport type GetGasFeeState = ControllerGetStateAction<typeof name, GasFeeState>;\n\nexport type GasFeeControllerActions = GetGasFeeState;\n\nexport type GasFeeControllerEvents = GasFeeStateChange;\n\ntype AllowedActions =\n  | NetworkControllerGetStateAction\n  | NetworkControllerGetNetworkClientByIdAction\n  | NetworkControllerGetEIP1559CompatibilityAction;\n\ntype GasFeeMessenger = RestrictedControllerMessenger<\n  typeof name,\n  GasFeeControllerActions | AllowedActions,\n  GasFeeControllerEvents | NetworkControllerNetworkDidChangeEvent,\n  AllowedActions['type'],\n  NetworkControllerNetworkDidChangeEvent['type']\n>;\n\nconst defaultState: GasFeeState = {\n  gasFeeEstimatesByChainId: {},\n  gasFeeEstimates: {},\n  estimatedGasFeeTimeBounds: {},\n  gasEstimateType: GAS_ESTIMATE_TYPES.NONE,\n  nonRPCGasFeeApisDisabled: false,\n};\n\n/**\n * Controller that retrieves gas fee estimate data and polls for updated data on a set interval\n */\nexport class GasFeeController extends StaticIntervalPollingController<\n  typeof name,\n  GasFeeState,\n  GasFeeMessenger\n> {\n  private intervalId?: ReturnType<typeof setTimeout>;\n\n  private readonly intervalDelay;\n\n  private readonly pollTokens: Set<string>;\n\n  private readonly legacyAPIEndpoint: string;\n\n  private readonly EIP1559APIEndpoint: string;\n\n  private readonly getCurrentNetworkEIP1559Compatibility;\n\n  private readonly getCurrentNetworkLegacyGasAPICompatibility;\n\n  private readonly getCurrentAccountEIP1559Compatibility;\n\n  private readonly infuraAPIKey: string;\n\n  private currentChainId;\n\n  private ethQuery?: EthQuery;\n\n  private readonly clientId?: string;\n\n  #getProvider: () => ProviderProxy;\n\n  /**\n   * Creates a GasFeeController instance.\n   *\n   * @param options - The controller options.\n   * @param options.interval - The time in milliseconds to wait between polls.\n   * @param options.messenger - The controller messenger.\n   * @param options.state - The initial state.\n   * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current\n   * network is EIP-1559 compatible.\n   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the\n   * current network is compatible with the legacy gas price API.\n   * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current\n   * account is EIP-1559 compatible.\n   * @param options.getChainId - Returns the current chain ID.\n   * @param options.getProvider - Returns a network provider for the current network.\n   * @param options.onNetworkDidChange - A function for registering an event handler for the\n   * network state change event.\n   * @param options.clientId - The client ID used to identify to the gas estimation API who is\n   * asking for estimates.\n   * @param options.infuraAPIKey - The Infura API key used for infura API requests.\n   */\n  constructor({\n    interval = 15000,\n    messenger,\n    state,\n    getCurrentNetworkEIP1559Compatibility,\n    getCurrentAccountEIP1559Compatibility,\n    getChainId,\n    getCurrentNetworkLegacyGasAPICompatibility,\n    getProvider,\n    onNetworkDidChange,\n    clientId,\n    infuraAPIKey,\n  }: {\n    interval?: number;\n    messenger: GasFeeMessenger;\n    state?: GasFeeState;\n    getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;\n    getCurrentNetworkLegacyGasAPICompatibility: () => boolean;\n    getCurrentAccountEIP1559Compatibility?: () => boolean;\n    getChainId?: () => Hex;\n    getProvider: () => ProviderProxy;\n    onNetworkDidChange?: (listener: (state: NetworkState) => void) => void;\n    clientId?: string;\n    infuraAPIKey: string;\n  }) {\n    super({\n      name,\n      metadata,\n      messenger,\n      state: { ...defaultState, ...state },\n    });\n    this.intervalDelay = interval;\n    this.setIntervalLength(interval);\n    this.pollTokens = new Set();\n    this.getCurrentNetworkEIP1559Compatibility =\n      getCurrentNetworkEIP1559Compatibility;\n    this.getCurrentNetworkLegacyGasAPICompatibility =\n      getCurrentNetworkLegacyGasAPICompatibility;\n    this.getCurrentAccountEIP1559Compatibility =\n      getCurrentAccountEIP1559Compatibility;\n    this.#getProvider = getProvider;\n    this.EIP1559APIEndpoint = `${GAS_API_BASE_URL}/networks/<chain_id>/suggestedGasFees`;\n    this.legacyAPIEndpoint = `${GAS_API_BASE_URL}/networks/<chain_id>/gasPrices`;\n    this.clientId = clientId;\n    this.infuraAPIKey = infuraAPIKey;\n\n    this.ethQuery = new EthQuery(this.#getProvider());\n\n    if (onNetworkDidChange && getChainId) {\n      this.currentChainId = getChainId();\n      onNetworkDidChange(async (networkControllerState) => {\n        await this.#onNetworkControllerDidChange(networkControllerState);\n      });\n    } else {\n      this.currentChainId = this.messagingSystem.call(\n        'NetworkController:getState',\n      ).providerConfig.chainId;\n      this.messagingSystem.subscribe(\n        'NetworkController:networkDidChange',\n        async (networkControllerState) => {\n          await this.#onNetworkControllerDidChange(networkControllerState);\n        },\n      );\n    }\n  }\n\n  async resetPolling() {\n    if (this.pollTokens.size !== 0) {\n      const tokens = Array.from(this.pollTokens);\n      this.stopPolling();\n      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);\n      tokens.slice(1).forEach((token) => {\n        this.pollTokens.add(token);\n      });\n    }\n  }\n\n  async fetchGasFeeEstimates(options?: FetchGasFeeEstimateOptions) {\n    return await this._fetchGasFeeEstimateData(options);\n  }\n\n  async getGasFeeEstimatesAndStartPolling(\n    pollToken: string | undefined,\n  ): Promise<string> {\n    const _pollToken = pollToken || random();\n\n    this.pollTokens.add(_pollToken);\n\n    if (this.pollTokens.size === 1) {\n      await this._fetchGasFeeEstimateData();\n      this._poll();\n    }\n\n    return _pollToken;\n  }\n\n  /**\n   * Gets and sets gasFeeEstimates in state.\n   *\n   * @param options - The gas fee estimate options.\n   * @param options.shouldUpdateState - Determines whether the state should be updated with the\n   * updated gas estimates.\n   * @returns The gas fee estimates.\n   */\n  async _fetchGasFeeEstimateData(\n    options: FetchGasFeeEstimateOptions = {},\n  ): Promise<GasFeeState> {\n    const { shouldUpdateState = true, networkClientId } = options;\n\n    let ethQuery,\n      isEIP1559Compatible,\n      isLegacyGasAPICompatible,\n      decimalChainId: number;\n\n    if (networkClientId !== undefined) {\n      const networkClient = this.messagingSystem.call(\n        'NetworkController:getNetworkClientById',\n        networkClientId,\n      );\n      isLegacyGasAPICompatible = networkClient.configuration.chainId === '0x38';\n\n      decimalChainId = convertHexToDecimal(networkClient.configuration.chainId);\n\n      try {\n        const result = await this.messagingSystem.call(\n          'NetworkController:getEIP1559Compatibility',\n          networkClientId,\n        );\n        isEIP1559Compatible = result || false;\n      } catch {\n        isEIP1559Compatible = false;\n      }\n      ethQuery = new EthQuery(networkClient.provider);\n    }\n\n    ethQuery ??= this.ethQuery;\n\n    isLegacyGasAPICompatible ??=\n      this.getCurrentNetworkLegacyGasAPICompatibility();\n\n    decimalChainId ??= convertHexToDecimal(this.currentChainId);\n\n    try {\n      isEIP1559Compatible ??= await this.getEIP1559Compatibility();\n    } catch (e) {\n      console.error(e);\n      isEIP1559Compatible ??= false;\n    }\n\n    const gasFeeCalculations = await determineGasFeeCalculations({\n      isEIP1559Compatible,\n      isLegacyGasAPICompatible,\n      fetchGasEstimates,\n      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(\n        '<chain_id>',\n        `${decimalChainId}`,\n      ),\n      fetchLegacyGasPriceEstimates,\n      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(\n        '<chain_id>',\n        `${decimalChainId}`,\n      ),\n      fetchEthGasPriceEstimate,\n      calculateTimeEstimate,\n      clientId: this.clientId,\n      ethQuery,\n      infuraAPIKey: this.infuraAPIKey,\n      nonRPCGasFeeApisDisabled: this.state.nonRPCGasFeeApisDisabled,\n    });\n\n    if (shouldUpdateState) {\n      const chainId = toHex(decimalChainId);\n      this.update((state) => {\n        if (this.currentChainId === chainId) {\n          state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;\n          state.estimatedGasFeeTimeBounds =\n            gasFeeCalculations.estimatedGasFeeTimeBounds;\n          state.gasEstimateType = gasFeeCalculations.gasEstimateType;\n        }\n        state.gasFeeEstimatesByChainId ??= {};\n        state.gasFeeEstimatesByChainId[chainId] = {\n          gasFeeEstimates: gasFeeCalculations.gasFeeEstimates,\n          estimatedGasFeeTimeBounds:\n            gasFeeCalculations.estimatedGasFeeTimeBounds,\n          gasEstimateType: gasFeeCalculations.gasEstimateType,\n        } as SingleChainGasFeeState;\n      });\n    }\n\n    return gasFeeCalculations;\n  }\n\n  /**\n   * Remove the poll token, and stop polling if the set of poll tokens is empty.\n   *\n   * @param pollToken - The poll token to disconnect.\n   */\n  disconnectPoller(pollToken: string) {\n    this.pollTokens.delete(pollToken);\n    if (this.pollTokens.size === 0) {\n      this.stopPolling();\n    }\n  }\n\n  stopPolling() {\n    if (this.intervalId) {\n      clearInterval(this.intervalId);\n    }\n    this.pollTokens.clear();\n    this.resetState();\n  }\n\n  /**\n   * Prepare to discard this controller.\n   *\n   * This stops any active polling.\n   */\n  override destroy() {\n    super.destroy();\n    this.stopPolling();\n  }\n\n  private _poll() {\n    if (this.intervalId) {\n      clearInterval(this.intervalId);\n    }\n\n    this.intervalId = setInterval(async () => {\n      await safelyExecute(() => this._fetchGasFeeEstimateData());\n    }, this.intervalDelay);\n  }\n\n  /**\n   * Fetching token list from the Token Service API.\n   *\n   * @private\n   * @param networkClientId - The ID of the network client triggering the fetch.\n   * @returns A promise that resolves when this operation completes.\n   */\n  async _executePoll(networkClientId: string): Promise<void> {\n    await this._fetchGasFeeEstimateData({ networkClientId });\n  }\n\n  private resetState() {\n    this.update(() => {\n      return defaultState;\n    });\n  }\n\n  private async getEIP1559Compatibility() {\n    const currentNetworkIsEIP1559Compatible =\n      await this.getCurrentNetworkEIP1559Compatibility();\n    const currentAccountIsEIP1559Compatible =\n      this.getCurrentAccountEIP1559Compatibility?.() ?? true;\n\n    return (\n      currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible\n    );\n  }\n\n  getTimeEstimate(\n    maxPriorityFeePerGas: string,\n    maxFeePerGas: string,\n  ): EstimatedGasFeeTimeBounds | Record<string, never> {\n    if (\n      !this.state.gasFeeEstimates ||\n      this.state.gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET\n    ) {\n      return {};\n    }\n    return calculateTimeEstimate(\n      maxPriorityFeePerGas,\n      maxFeePerGas,\n      this.state.gasFeeEstimates,\n    );\n  }\n\n  async #onNetworkControllerDidChange(networkControllerState: NetworkState) {\n    const newChainId = networkControllerState.providerConfig.chainId;\n\n    if (newChainId !== this.currentChainId) {\n      this.ethQuery = new EthQuery(this.#getProvider());\n      await this.resetPolling();\n\n      this.currentChainId = newChainId;\n    }\n  }\n\n  enableNonRPCGasFeeApis() {\n    this.update((state) => {\n      state.nonRPCGasFeeApisDisabled = false;\n    });\n  }\n\n  disableNonRPCGasFeeApis() {\n    this.update((state) => {\n      state.nonRPCGasFeeApisDisabled = true;\n    });\n  }\n}\n\nexport default GasFeeController;\n","import type {\n  EstimatedGasFeeTimeBounds,\n  EthGasPriceEstimate,\n  GasFeeEstimates,\n  GasFeeState as GasFeeCalculations,\n  LegacyGasPriceEstimate,\n} from './GasFeeController';\nimport { GAS_ESTIMATE_TYPES } from './GasFeeController';\n\ntype DetermineGasFeeCalculationsRequest = {\n  isEIP1559Compatible: boolean;\n  isLegacyGasAPICompatible: boolean;\n  fetchGasEstimates: (\n    url: string,\n    infuraAPIKey: string,\n    clientId?: string,\n  ) => Promise<GasFeeEstimates>;\n  fetchGasEstimatesUrl: string;\n  fetchLegacyGasPriceEstimates: (\n    url: string,\n    infuraAPIKey: string,\n    clientId?: string,\n  ) => Promise<LegacyGasPriceEstimate>;\n  fetchLegacyGasPriceEstimatesUrl: string;\n  // TODO: Replace `any` with type\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\n  fetchEthGasPriceEstimate: (ethQuery: any) => Promise<EthGasPriceEstimate>;\n  calculateTimeEstimate: (\n    maxPriorityFeePerGas: string,\n    maxFeePerGas: string,\n    gasFeeEstimates: GasFeeEstimates,\n  ) => EstimatedGasFeeTimeBounds;\n  clientId: string | undefined;\n  // TODO: Replace `any` with type\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\n  ethQuery: any;\n  infuraAPIKey: string;\n  nonRPCGasFeeApisDisabled?: boolean;\n};\n\n/**\n * Obtains a set of max base and priority fee estimates along with time estimates so that we\n * can present them to users when they are sending transactions or making swaps.\n *\n * @param args - The arguments.\n * @param args.isEIP1559Compatible - Governs whether or not we can use an EIP-1559-only method to\n * produce estimates.\n * @param args.isLegacyGasAPICompatible - Governs whether or not we can use a non-EIP-1559 method to\n * produce estimates (for instance, testnets do not support estimates altogether).\n * @param args.fetchGasEstimates - A function that fetches gas estimates using an EIP-1559-specific\n * API.\n * @param args.fetchGasEstimatesUrl - The URL for the API we can use to obtain EIP-1559-specific\n * estimates.\n * @param args.fetchLegacyGasPriceEstimates - A function that fetches gas estimates using an\n * non-EIP-1559-specific API.\n * @param args.fetchLegacyGasPriceEstimatesUrl - The URL for the API we can use to obtain\n * non-EIP-1559-specific estimates.\n * @param args.fetchEthGasPriceEstimate - A function that fetches gas estimates using\n * `eth_gasPrice`.\n * @param args.calculateTimeEstimate - A function that determine time estimate bounds.\n * @param args.clientId - An identifier that an API can use to know who is asking for estimates.\n * @param args.ethQuery - An EthQuery instance we can use to talk to Ethereum directly.\n * @param args.infuraAPIKey - Infura API key to use for requests to Infura.\n * @param args.nonRPCGasFeeApisDisabled - Whether to disable requests to the legacyAPIEndpoint and the EIP1559APIEndpoint\n * @returns The gas fee calculations.\n */\nexport default async function determineGasFeeCalculations(\n  args: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  try {\n    return await getEstimatesUsingFallbacks(args);\n  } catch (error) {\n    if (error instanceof Error) {\n      throw new Error(\n        `Gas fee/price estimation failed. Message: ${error.message}`,\n      );\n    }\n\n    throw error;\n  }\n}\n\n/**\n * Retrieve the gas fee estimates using a series of fallback mechanisms.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingFallbacks(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    isEIP1559Compatible,\n    isLegacyGasAPICompatible,\n    nonRPCGasFeeApisDisabled,\n  } = request;\n\n  try {\n    if (isEIP1559Compatible && !nonRPCGasFeeApisDisabled) {\n      return await getEstimatesUsingFeeMarketEndpoint(request);\n    }\n\n    if (isLegacyGasAPICompatible && !nonRPCGasFeeApisDisabled) {\n      return await getEstimatesUsingLegacyEndpoint(request);\n    }\n\n    throw new Error('Main gas fee/price estimation failed. Use fallback');\n  } catch {\n    return await getEstimatesUsingProvider(request);\n  }\n}\n\n/**\n * Retrieve gas fee estimates using the EIP-1559 endpoint of the gas API.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingFeeMarketEndpoint(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    fetchGasEstimates,\n    fetchGasEstimatesUrl,\n    infuraAPIKey,\n    clientId,\n    calculateTimeEstimate,\n  } = request;\n\n  const estimates = await fetchGasEstimates(\n    fetchGasEstimatesUrl,\n    infuraAPIKey,\n    clientId,\n  );\n\n  const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } =\n    estimates.medium;\n\n  const estimatedGasFeeTimeBounds = calculateTimeEstimate(\n    suggestedMaxPriorityFeePerGas,\n    suggestedMaxFeePerGas,\n    estimates,\n  );\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds,\n    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,\n  };\n}\n\n/**\n * Retrieve gas fee estimates using the legacy endpoint of the gas API.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingLegacyEndpoint(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    fetchLegacyGasPriceEstimates,\n    fetchLegacyGasPriceEstimatesUrl,\n    infuraAPIKey,\n    clientId,\n  } = request;\n\n  const estimates = await fetchLegacyGasPriceEstimates(\n    fetchLegacyGasPriceEstimatesUrl,\n    infuraAPIKey,\n    clientId,\n  );\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds: {},\n    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,\n  };\n}\n\n/**\n * Retrieve gas fee estimates using an `eth_gasPrice` call to the RPC provider.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingProvider(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const { ethQuery, fetchEthGasPriceEstimate } = request;\n\n  const estimates = await fetchEthGasPriceEstimate(ethQuery);\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds: {},\n    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,\n  };\n}\n"]}
+\ No newline at end of file
+diff --git a/dist/chunk-KORLXV32.mjs b/dist/chunk-KORLXV32.mjs
+deleted file mode 100644
+index a964582d5c161e6b650fe9447442ca9540f9fdb9..0000000000000000000000000000000000000000
+--- a/dist/chunk-KORLXV32.mjs
++++ /dev/null
+@@ -1,165 +0,0 @@
+-var __accessCheck = (obj, member, msg) => {
+-  if (!member.has(obj))
+-    throw TypeError("Cannot " + msg);
+-};
+-var __privateGet = (obj, member, getter) => {
+-  __accessCheck(obj, member, "read from private field");
+-  return getter ? getter.call(obj) : member.get(obj);
+-};
+-var __privateAdd = (obj, member, value) => {
+-  if (member.has(obj))
+-    throw TypeError("Cannot add the same private member more than once");
+-  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+-};
+-var __privateSet = (obj, member, value, setter) => {
+-  __accessCheck(obj, member, "write to private field");
+-  setter ? setter.call(obj, value) : member.set(obj, value);
+-  return value;
+-};
+-var __privateMethod = (obj, member, method) => {
+-  __accessCheck(obj, member, "access private method");
+-  return method;
+-};
+-
+-// src/gas-util.ts
+-import {
+-  query,
+-  handleFetch,
+-  gweiDecToWEIBN,
+-  weiHexToGweiDec
+-} from "@metamask/controller-utils";
+-import BN from "bn.js";
+-var makeClientIdHeader = (clientId) => ({ "X-Client-Id": clientId });
+-function normalizeGWEIDecimalNumbers(n) {
+-  const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);
+-  const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex);
+-  return numberAsGWEI;
+-}
+-async function fetchGasEstimates(url, infuraAPIKey, clientId) {
+-  const infuraAuthToken = buildInfuraAuthToken(infuraAPIKey);
+-  const estimates = await handleFetch(url, {
+-    headers: getHeaders(infuraAuthToken, clientId)
+-  });
+-  return {
+-    low: {
+-      ...estimates.low,
+-      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.low.suggestedMaxPriorityFeePerGas
+-      ),
+-      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.low.suggestedMaxFeePerGas
+-      )
+-    },
+-    medium: {
+-      ...estimates.medium,
+-      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.medium.suggestedMaxPriorityFeePerGas
+-      ),
+-      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.medium.suggestedMaxFeePerGas
+-      )
+-    },
+-    high: {
+-      ...estimates.high,
+-      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.high.suggestedMaxPriorityFeePerGas
+-      ),
+-      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.high.suggestedMaxFeePerGas
+-      )
+-    },
+-    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
+-    historicalBaseFeeRange: estimates.historicalBaseFeeRange,
+-    baseFeeTrend: estimates.baseFeeTrend,
+-    latestPriorityFeeRange: estimates.latestPriorityFeeRange,
+-    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,
+-    priorityFeeTrend: estimates.priorityFeeTrend,
+-    networkCongestion: estimates.networkCongestion
+-  };
+-}
+-async function fetchLegacyGasPriceEstimates(url, infuraAPIKey, clientId) {
+-  const infuraAuthToken = buildInfuraAuthToken(infuraAPIKey);
+-  const result = await handleFetch(url, {
+-    referrer: url,
+-    referrerPolicy: "no-referrer-when-downgrade",
+-    method: "GET",
+-    mode: "cors",
+-    headers: getHeaders(infuraAuthToken, clientId)
+-  });
+-  return {
+-    low: result.SafeGasPrice,
+-    medium: result.ProposeGasPrice,
+-    high: result.FastGasPrice
+-  };
+-}
+-async function fetchEthGasPriceEstimate(ethQuery) {
+-  const gasPrice = await query(ethQuery, "gasPrice");
+-  return {
+-    gasPrice: weiHexToGweiDec(gasPrice).toString()
+-  };
+-}
+-function calculateTimeEstimate(maxPriorityFeePerGas, maxFeePerGas, gasFeeEstimates) {
+-  const { low, medium, high, estimatedBaseFee } = gasFeeEstimates;
+-  const maxPriorityFeePerGasInWEI = gweiDecToWEIBN(maxPriorityFeePerGas);
+-  const maxFeePerGasInWEI = gweiDecToWEIBN(maxFeePerGas);
+-  const estimatedBaseFeeInWEI = gweiDecToWEIBN(estimatedBaseFee);
+-  const effectiveMaxPriorityFee = BN.min(
+-    maxPriorityFeePerGasInWEI,
+-    maxFeePerGasInWEI.sub(estimatedBaseFeeInWEI)
+-  );
+-  const lowMaxPriorityFeeInWEI = gweiDecToWEIBN(
+-    low.suggestedMaxPriorityFeePerGas
+-  );
+-  const mediumMaxPriorityFeeInWEI = gweiDecToWEIBN(
+-    medium.suggestedMaxPriorityFeePerGas
+-  );
+-  const highMaxPriorityFeeInWEI = gweiDecToWEIBN(
+-    high.suggestedMaxPriorityFeePerGas
+-  );
+-  let lowerTimeBound;
+-  let upperTimeBound;
+-  if (effectiveMaxPriorityFee.lt(lowMaxPriorityFeeInWEI)) {
+-    lowerTimeBound = null;
+-    upperTimeBound = "unknown";
+-  } else if (effectiveMaxPriorityFee.gte(lowMaxPriorityFeeInWEI) && effectiveMaxPriorityFee.lt(mediumMaxPriorityFeeInWEI)) {
+-    lowerTimeBound = low.minWaitTimeEstimate;
+-    upperTimeBound = low.maxWaitTimeEstimate;
+-  } else if (effectiveMaxPriorityFee.gte(mediumMaxPriorityFeeInWEI) && effectiveMaxPriorityFee.lt(highMaxPriorityFeeInWEI)) {
+-    lowerTimeBound = medium.minWaitTimeEstimate;
+-    upperTimeBound = medium.maxWaitTimeEstimate;
+-  } else if (effectiveMaxPriorityFee.eq(highMaxPriorityFeeInWEI)) {
+-    lowerTimeBound = high.minWaitTimeEstimate;
+-    upperTimeBound = high.maxWaitTimeEstimate;
+-  } else {
+-    lowerTimeBound = 0;
+-    upperTimeBound = high.maxWaitTimeEstimate;
+-  }
+-  return {
+-    lowerTimeBound,
+-    upperTimeBound
+-  };
+-}
+-function buildInfuraAuthToken(infuraAPIKey) {
+-  return Buffer.from(`${infuraAPIKey}:`).toString("base64");
+-}
+-function getHeaders(infuraAuthToken, clientId) {
+-  return {
+-    "Content-Type": "application/json",
+-    Authorization: `Basic ${infuraAuthToken}`,
+-    // Only add the clientId header if clientId is a non-empty string
+-    ...clientId?.trim() ? makeClientIdHeader(clientId) : {}
+-  };
+-}
+-
+-export {
+-  __privateGet,
+-  __privateAdd,
+-  __privateSet,
+-  __privateMethod,
+-  normalizeGWEIDecimalNumbers,
+-  fetchGasEstimates,
+-  fetchLegacyGasPriceEstimates,
+-  fetchEthGasPriceEstimate,
+-  calculateTimeEstimate
+-};
+-//# sourceMappingURL=chunk-KORLXV32.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-KORLXV32.mjs.map b/dist/chunk-KORLXV32.mjs.map
+deleted file mode 100644
+index b95130543a5b39392214c5fe873ad367e6fa8af7..0000000000000000000000000000000000000000
+--- a/dist/chunk-KORLXV32.mjs.map
++++ /dev/null
+@@ -1 +0,0 @@
+-{"version":3,"sources":["../src/gas-util.ts"],"sourcesContent":["import {\n  query,\n  handleFetch,\n  gweiDecToWEIBN,\n  weiHexToGweiDec,\n} from '@metamask/controller-utils';\nimport type EthQuery from '@metamask/eth-query';\nimport BN from 'bn.js';\n\nimport type {\n  GasFeeEstimates,\n  EthGasPriceEstimate,\n  EstimatedGasFeeTimeBounds,\n  unknownString,\n  LegacyGasPriceEstimate,\n} from './GasFeeController';\n\nconst makeClientIdHeader = (clientId: string) => ({ 'X-Client-Id': clientId });\n\n/**\n * Convert a decimal GWEI value to a decimal string rounded to the nearest WEI.\n *\n * @param n - The input GWEI amount, as a decimal string or a number.\n * @returns The decimal string GWEI amount.\n */\nexport function normalizeGWEIDecimalNumbers(n: string | number) {\n  const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);\n  const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex);\n  return numberAsGWEI;\n}\n\n/**\n * Fetch gas estimates from the given URL.\n *\n * @param url - The gas estimate URL.\n * @param infuraAPIKey - The Infura API key used for infura API requests.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The gas estimates.\n */\nexport async function fetchGasEstimates(\n  url: string,\n  infuraAPIKey: string,\n  clientId?: string,\n): Promise<GasFeeEstimates> {\n  const infuraAuthToken = buildInfuraAuthToken(infuraAPIKey);\n  const estimates = await handleFetch(url, {\n    headers: getHeaders(infuraAuthToken, clientId),\n  });\n  return {\n    low: {\n      ...estimates.low,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.low.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.low.suggestedMaxFeePerGas,\n      ),\n    },\n    medium: {\n      ...estimates.medium,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.medium.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.medium.suggestedMaxFeePerGas,\n      ),\n    },\n    high: {\n      ...estimates.high,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.high.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.high.suggestedMaxFeePerGas,\n      ),\n    },\n    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),\n    historicalBaseFeeRange: estimates.historicalBaseFeeRange,\n    baseFeeTrend: estimates.baseFeeTrend,\n    latestPriorityFeeRange: estimates.latestPriorityFeeRange,\n    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,\n    priorityFeeTrend: estimates.priorityFeeTrend,\n    networkCongestion: estimates.networkCongestion,\n  };\n}\n\n/**\n * Hit the legacy MetaSwaps gasPrices estimate api and return the low, medium\n * high values from that API.\n *\n * @param url - The URL to fetch gas price estimates from.\n * @param infuraAPIKey - The Infura API key used for infura API requests.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The gas price estimates.\n */\nexport async function fetchLegacyGasPriceEstimates(\n  url: string,\n  infuraAPIKey: string,\n  clientId?: string,\n): Promise<LegacyGasPriceEstimate> {\n  const infuraAuthToken = buildInfuraAuthToken(infuraAPIKey);\n  const result = await handleFetch(url, {\n    referrer: url,\n    referrerPolicy: 'no-referrer-when-downgrade',\n    method: 'GET',\n    mode: 'cors',\n    headers: getHeaders(infuraAuthToken, clientId),\n  });\n  return {\n    low: result.SafeGasPrice,\n    medium: result.ProposeGasPrice,\n    high: result.FastGasPrice,\n  };\n}\n\n/**\n * Get a gas price estimate from the network using the `eth_gasPrice` method.\n *\n * @param ethQuery - The EthQuery instance to call the network with.\n * @returns A gas price estimate.\n */\nexport async function fetchEthGasPriceEstimate(\n  ethQuery: EthQuery,\n): Promise<EthGasPriceEstimate> {\n  const gasPrice = await query(ethQuery, 'gasPrice');\n  return {\n    gasPrice: weiHexToGweiDec(gasPrice).toString(),\n  };\n}\n\n/**\n * Estimate the time it will take for a transaction to be confirmed.\n *\n * @param maxPriorityFeePerGas - The max priority fee per gas.\n * @param maxFeePerGas - The max fee per gas.\n * @param gasFeeEstimates - The gas fee estimates.\n * @returns The estimated lower and upper bounds for when this transaction will be confirmed.\n */\nexport function calculateTimeEstimate(\n  maxPriorityFeePerGas: string,\n  maxFeePerGas: string,\n  gasFeeEstimates: GasFeeEstimates,\n): EstimatedGasFeeTimeBounds {\n  const { low, medium, high, estimatedBaseFee } = gasFeeEstimates;\n\n  const maxPriorityFeePerGasInWEI = gweiDecToWEIBN(maxPriorityFeePerGas);\n  const maxFeePerGasInWEI = gweiDecToWEIBN(maxFeePerGas);\n  const estimatedBaseFeeInWEI = gweiDecToWEIBN(estimatedBaseFee);\n\n  const effectiveMaxPriorityFee = BN.min(\n    maxPriorityFeePerGasInWEI,\n    maxFeePerGasInWEI.sub(estimatedBaseFeeInWEI),\n  );\n\n  const lowMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    low.suggestedMaxPriorityFeePerGas,\n  );\n  const mediumMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    medium.suggestedMaxPriorityFeePerGas,\n  );\n  const highMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    high.suggestedMaxPriorityFeePerGas,\n  );\n\n  let lowerTimeBound;\n  let upperTimeBound;\n\n  if (effectiveMaxPriorityFee.lt(lowMaxPriorityFeeInWEI)) {\n    lowerTimeBound = null;\n    upperTimeBound = 'unknown' as unknownString;\n  } else if (\n    effectiveMaxPriorityFee.gte(lowMaxPriorityFeeInWEI) &&\n    effectiveMaxPriorityFee.lt(mediumMaxPriorityFeeInWEI)\n  ) {\n    lowerTimeBound = low.minWaitTimeEstimate;\n    upperTimeBound = low.maxWaitTimeEstimate;\n  } else if (\n    effectiveMaxPriorityFee.gte(mediumMaxPriorityFeeInWEI) &&\n    effectiveMaxPriorityFee.lt(highMaxPriorityFeeInWEI)\n  ) {\n    lowerTimeBound = medium.minWaitTimeEstimate;\n    upperTimeBound = medium.maxWaitTimeEstimate;\n  } else if (effectiveMaxPriorityFee.eq(highMaxPriorityFeeInWEI)) {\n    lowerTimeBound = high.minWaitTimeEstimate;\n    upperTimeBound = high.maxWaitTimeEstimate;\n  } else {\n    lowerTimeBound = 0;\n    upperTimeBound = high.maxWaitTimeEstimate;\n  }\n\n  return {\n    lowerTimeBound,\n    upperTimeBound,\n  };\n}\n\n/**\n * Build an infura auth token from the given API key and secret.\n *\n * @param infuraAPIKey - The Infura API key.\n * @returns The base64 encoded auth token.\n */\nfunction buildInfuraAuthToken(infuraAPIKey: string) {\n  // We intentionally leave the password empty, as Infura does not require one\n  return Buffer.from(`${infuraAPIKey}:`).toString('base64');\n}\n\n/**\n * Get the headers for a request to the gas fee API.\n *\n * @param infuraAuthToken - The Infura auth token to use for the request.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The headers for the request.\n */\nfunction getHeaders(infuraAuthToken: string, clientId?: string) {\n  return {\n    'Content-Type': 'application/json',\n    Authorization: `Basic ${infuraAuthToken}`,\n    // Only add the clientId header if clientId is a non-empty string\n    ...(clientId?.trim() ? makeClientIdHeader(clientId) : {}),\n  };\n}\n"],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;AAAA;AAAA,EACE;AAAA,EACA;AAAA,EACA;AAAA,EACA;AAAA,OACK;AAEP,OAAO,QAAQ;AAUf,IAAM,qBAAqB,CAAC,cAAsB,EAAE,eAAe,SAAS;AAQrE,SAAS,4BAA4B,GAAoB;AAC9D,QAAM,iBAAiB,eAAe,CAAC,EAAE,SAAS,EAAE;AACpD,QAAM,eAAe,gBAAgB,cAAc;AACnD,SAAO;AACT;AAUA,eAAsB,kBACpB,KACA,cACA,UAC0B;AAC1B,QAAM,kBAAkB,qBAAqB,YAAY;AACzD,QAAM,YAAY,MAAM,YAAY,KAAK;AAAA,IACvC,SAAS,WAAW,iBAAiB,QAAQ;AAAA,EAC/C,CAAC;AACD,SAAO;AAAA,IACL,KAAK;AAAA,MACH,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,IAAI;AAAA,MAChB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,IAAI;AAAA,MAChB;AAAA,IACF;AAAA,IACA,QAAQ;AAAA,MACN,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,OAAO;AAAA,MACnB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,OAAO;AAAA,MACnB;AAAA,IACF;AAAA,IACA,MAAM;AAAA,MACJ,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,KAAK;AAAA,MACjB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,KAAK;AAAA,MACjB;AAAA,IACF;AAAA,IACA,kBAAkB,4BAA4B,UAAU,gBAAgB;AAAA,IACxE,wBAAwB,UAAU;AAAA,IAClC,cAAc,UAAU;AAAA,IACxB,wBAAwB,UAAU;AAAA,IAClC,4BAA4B,UAAU;AAAA,IACtC,kBAAkB,UAAU;AAAA,IAC5B,mBAAmB,UAAU;AAAA,EAC/B;AACF;AAWA,eAAsB,6BACpB,KACA,cACA,UACiC;AACjC,QAAM,kBAAkB,qBAAqB,YAAY;AACzD,QAAM,SAAS,MAAM,YAAY,KAAK;AAAA,IACpC,UAAU;AAAA,IACV,gBAAgB;AAAA,IAChB,QAAQ;AAAA,IACR,MAAM;AAAA,IACN,SAAS,WAAW,iBAAiB,QAAQ;AAAA,EAC/C,CAAC;AACD,SAAO;AAAA,IACL,KAAK,OAAO;AAAA,IACZ,QAAQ,OAAO;AAAA,IACf,MAAM,OAAO;AAAA,EACf;AACF;AAQA,eAAsB,yBACpB,UAC8B;AAC9B,QAAM,WAAW,MAAM,MAAM,UAAU,UAAU;AACjD,SAAO;AAAA,IACL,UAAU,gBAAgB,QAAQ,EAAE,SAAS;AAAA,EAC/C;AACF;AAUO,SAAS,sBACd,sBACA,cACA,iBAC2B;AAC3B,QAAM,EAAE,KAAK,QAAQ,MAAM,iBAAiB,IAAI;AAEhD,QAAM,4BAA4B,eAAe,oBAAoB;AACrE,QAAM,oBAAoB,eAAe,YAAY;AACrD,QAAM,wBAAwB,eAAe,gBAAgB;AAE7D,QAAM,0BAA0B,GAAG;AAAA,IACjC;AAAA,IACA,kBAAkB,IAAI,qBAAqB;AAAA,EAC7C;AAEA,QAAM,yBAAyB;AAAA,IAC7B,IAAI;AAAA,EACN;AACA,QAAM,4BAA4B;AAAA,IAChC,OAAO;AAAA,EACT;AACA,QAAM,0BAA0B;AAAA,IAC9B,KAAK;AAAA,EACP;AAEA,MAAI;AACJ,MAAI;AAEJ,MAAI,wBAAwB,GAAG,sBAAsB,GAAG;AACtD,qBAAiB;AACjB,qBAAiB;AAAA,EACnB,WACE,wBAAwB,IAAI,sBAAsB,KAClD,wBAAwB,GAAG,yBAAyB,GACpD;AACA,qBAAiB,IAAI;AACrB,qBAAiB,IAAI;AAAA,EACvB,WACE,wBAAwB,IAAI,yBAAyB,KACrD,wBAAwB,GAAG,uBAAuB,GAClD;AACA,qBAAiB,OAAO;AACxB,qBAAiB,OAAO;AAAA,EAC1B,WAAW,wBAAwB,GAAG,uBAAuB,GAAG;AAC9D,qBAAiB,KAAK;AACtB,qBAAiB,KAAK;AAAA,EACxB,OAAO;AACL,qBAAiB;AACjB,qBAAiB,KAAK;AAAA,EACxB;AAEA,SAAO;AAAA,IACL;AAAA,IACA;AAAA,EACF;AACF;AAQA,SAAS,qBAAqB,cAAsB;AAElD,SAAO,OAAO,KAAK,GAAG,YAAY,GAAG,EAAE,SAAS,QAAQ;AAC1D;AASA,SAAS,WAAW,iBAAyB,UAAmB;AAC9D,SAAO;AAAA,IACL,gBAAgB;AAAA,IAChB,eAAe,SAAS,eAAe;AAAA;AAAA,IAEvC,GAAI,UAAU,KAAK,IAAI,mBAAmB,QAAQ,IAAI,CAAC;AAAA,EACzD;AACF;","names":[]}
+\ No newline at end of file
+diff --git a/dist/chunk-Q2YPK5SL.js b/dist/chunk-Q2YPK5SL.js
+deleted file mode 100644
+index 154d3eafb98cdb84cda1a2ea60f6be8a75f4e7a6..0000000000000000000000000000000000000000
+--- a/dist/chunk-Q2YPK5SL.js
++++ /dev/null
+@@ -1,165 +0,0 @@
+-"use strict";Object.defineProperty(exports, "__esModule", {value: true}); function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }var __accessCheck = (obj, member, msg) => {
+-  if (!member.has(obj))
+-    throw TypeError("Cannot " + msg);
+-};
+-var __privateGet = (obj, member, getter) => {
+-  __accessCheck(obj, member, "read from private field");
+-  return getter ? getter.call(obj) : member.get(obj);
+-};
+-var __privateAdd = (obj, member, value) => {
+-  if (member.has(obj))
+-    throw TypeError("Cannot add the same private member more than once");
+-  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+-};
+-var __privateSet = (obj, member, value, setter) => {
+-  __accessCheck(obj, member, "write to private field");
+-  setter ? setter.call(obj, value) : member.set(obj, value);
+-  return value;
+-};
+-var __privateMethod = (obj, member, method) => {
+-  __accessCheck(obj, member, "access private method");
+-  return method;
+-};
+-
+-// src/gas-util.ts
+-
+-
+-
+-
+-
+-var _controllerutils = require('@metamask/controller-utils');
+-var _bnjs = require('bn.js'); var _bnjs2 = _interopRequireDefault(_bnjs);
+-var makeClientIdHeader = (clientId) => ({ "X-Client-Id": clientId });
+-function normalizeGWEIDecimalNumbers(n) {
+-  const numberAsWEIHex = _controllerutils.gweiDecToWEIBN.call(void 0, n).toString(16);
+-  const numberAsGWEI = _controllerutils.weiHexToGweiDec.call(void 0, numberAsWEIHex);
+-  return numberAsGWEI;
+-}
+-async function fetchGasEstimates(url, infuraAPIKey, clientId) {
+-  const infuraAuthToken = buildInfuraAuthToken(infuraAPIKey);
+-  const estimates = await _controllerutils.handleFetch.call(void 0, url, {
+-    headers: getHeaders(infuraAuthToken, clientId)
+-  });
+-  return {
+-    low: {
+-      ...estimates.low,
+-      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.low.suggestedMaxPriorityFeePerGas
+-      ),
+-      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.low.suggestedMaxFeePerGas
+-      )
+-    },
+-    medium: {
+-      ...estimates.medium,
+-      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.medium.suggestedMaxPriorityFeePerGas
+-      ),
+-      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.medium.suggestedMaxFeePerGas
+-      )
+-    },
+-    high: {
+-      ...estimates.high,
+-      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.high.suggestedMaxPriorityFeePerGas
+-      ),
+-      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+-        estimates.high.suggestedMaxFeePerGas
+-      )
+-    },
+-    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
+-    historicalBaseFeeRange: estimates.historicalBaseFeeRange,
+-    baseFeeTrend: estimates.baseFeeTrend,
+-    latestPriorityFeeRange: estimates.latestPriorityFeeRange,
+-    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,
+-    priorityFeeTrend: estimates.priorityFeeTrend,
+-    networkCongestion: estimates.networkCongestion
+-  };
+-}
+-async function fetchLegacyGasPriceEstimates(url, infuraAPIKey, clientId) {
+-  const infuraAuthToken = buildInfuraAuthToken(infuraAPIKey);
+-  const result = await _controllerutils.handleFetch.call(void 0, url, {
+-    referrer: url,
+-    referrerPolicy: "no-referrer-when-downgrade",
+-    method: "GET",
+-    mode: "cors",
+-    headers: getHeaders(infuraAuthToken, clientId)
+-  });
+-  return {
+-    low: result.SafeGasPrice,
+-    medium: result.ProposeGasPrice,
+-    high: result.FastGasPrice
+-  };
+-}
+-async function fetchEthGasPriceEstimate(ethQuery) {
+-  const gasPrice = await _controllerutils.query.call(void 0, ethQuery, "gasPrice");
+-  return {
+-    gasPrice: _controllerutils.weiHexToGweiDec.call(void 0, gasPrice).toString()
+-  };
+-}
+-function calculateTimeEstimate(maxPriorityFeePerGas, maxFeePerGas, gasFeeEstimates) {
+-  const { low, medium, high, estimatedBaseFee } = gasFeeEstimates;
+-  const maxPriorityFeePerGasInWEI = _controllerutils.gweiDecToWEIBN.call(void 0, maxPriorityFeePerGas);
+-  const maxFeePerGasInWEI = _controllerutils.gweiDecToWEIBN.call(void 0, maxFeePerGas);
+-  const estimatedBaseFeeInWEI = _controllerutils.gweiDecToWEIBN.call(void 0, estimatedBaseFee);
+-  const effectiveMaxPriorityFee = _bnjs2.default.min(
+-    maxPriorityFeePerGasInWEI,
+-    maxFeePerGasInWEI.sub(estimatedBaseFeeInWEI)
+-  );
+-  const lowMaxPriorityFeeInWEI = _controllerutils.gweiDecToWEIBN.call(void 0,
+-    low.suggestedMaxPriorityFeePerGas
+-  );
+-  const mediumMaxPriorityFeeInWEI = _controllerutils.gweiDecToWEIBN.call(void 0,
+-    medium.suggestedMaxPriorityFeePerGas
+-  );
+-  const highMaxPriorityFeeInWEI = _controllerutils.gweiDecToWEIBN.call(void 0,
+-    high.suggestedMaxPriorityFeePerGas
+-  );
+-  let lowerTimeBound;
+-  let upperTimeBound;
+-  if (effectiveMaxPriorityFee.lt(lowMaxPriorityFeeInWEI)) {
+-    lowerTimeBound = null;
+-    upperTimeBound = "unknown";
+-  } else if (effectiveMaxPriorityFee.gte(lowMaxPriorityFeeInWEI) && effectiveMaxPriorityFee.lt(mediumMaxPriorityFeeInWEI)) {
+-    lowerTimeBound = low.minWaitTimeEstimate;
+-    upperTimeBound = low.maxWaitTimeEstimate;
+-  } else if (effectiveMaxPriorityFee.gte(mediumMaxPriorityFeeInWEI) && effectiveMaxPriorityFee.lt(highMaxPriorityFeeInWEI)) {
+-    lowerTimeBound = medium.minWaitTimeEstimate;
+-    upperTimeBound = medium.maxWaitTimeEstimate;
+-  } else if (effectiveMaxPriorityFee.eq(highMaxPriorityFeeInWEI)) {
+-    lowerTimeBound = high.minWaitTimeEstimate;
+-    upperTimeBound = high.maxWaitTimeEstimate;
+-  } else {
+-    lowerTimeBound = 0;
+-    upperTimeBound = high.maxWaitTimeEstimate;
+-  }
+-  return {
+-    lowerTimeBound,
+-    upperTimeBound
+-  };
+-}
+-function buildInfuraAuthToken(infuraAPIKey) {
+-  return Buffer.from(`${infuraAPIKey}:`).toString("base64");
+-}
+-function getHeaders(infuraAuthToken, clientId) {
+-  return {
+-    "Content-Type": "application/json",
+-    Authorization: `Basic ${infuraAuthToken}`,
+-    // Only add the clientId header if clientId is a non-empty string
+-    ...clientId?.trim() ? makeClientIdHeader(clientId) : {}
+-  };
+-}
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-exports.__privateGet = __privateGet; exports.__privateAdd = __privateAdd; exports.__privateSet = __privateSet; exports.__privateMethod = __privateMethod; exports.normalizeGWEIDecimalNumbers = normalizeGWEIDecimalNumbers; exports.fetchGasEstimates = fetchGasEstimates; exports.fetchLegacyGasPriceEstimates = fetchLegacyGasPriceEstimates; exports.fetchEthGasPriceEstimate = fetchEthGasPriceEstimate; exports.calculateTimeEstimate = calculateTimeEstimate;
+-//# sourceMappingURL=chunk-Q2YPK5SL.js.map
+\ No newline at end of file
+diff --git a/dist/chunk-Q2YPK5SL.js.map b/dist/chunk-Q2YPK5SL.js.map
+deleted file mode 100644
+index dc1a17f2cd5fdd749b46fbb546375ea3a1925081..0000000000000000000000000000000000000000
+--- a/dist/chunk-Q2YPK5SL.js.map
++++ /dev/null
+@@ -1 +0,0 @@
+-{"version":3,"sources":["../src/gas-util.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;AAAA;AAAA,EACE;AAAA,EACA;AAAA,EACA;AAAA,EACA;AAAA,OACK;AAEP,OAAO,QAAQ;AAUf,IAAM,qBAAqB,CAAC,cAAsB,EAAE,eAAe,SAAS;AAQrE,SAAS,4BAA4B,GAAoB;AAC9D,QAAM,iBAAiB,eAAe,CAAC,EAAE,SAAS,EAAE;AACpD,QAAM,eAAe,gBAAgB,cAAc;AACnD,SAAO;AACT;AAUA,eAAsB,kBACpB,KACA,cACA,UAC0B;AAC1B,QAAM,kBAAkB,qBAAqB,YAAY;AACzD,QAAM,YAAY,MAAM,YAAY,KAAK;AAAA,IACvC,SAAS,WAAW,iBAAiB,QAAQ;AAAA,EAC/C,CAAC;AACD,SAAO;AAAA,IACL,KAAK;AAAA,MACH,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,IAAI;AAAA,MAChB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,IAAI;AAAA,MAChB;AAAA,IACF;AAAA,IACA,QAAQ;AAAA,MACN,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,OAAO;AAAA,MACnB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,OAAO;AAAA,MACnB;AAAA,IACF;AAAA,IACA,MAAM;AAAA,MACJ,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,KAAK;AAAA,MACjB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,KAAK;AAAA,MACjB;AAAA,IACF;AAAA,IACA,kBAAkB,4BAA4B,UAAU,gBAAgB;AAAA,IACxE,wBAAwB,UAAU;AAAA,IAClC,cAAc,UAAU;AAAA,IACxB,wBAAwB,UAAU;AAAA,IAClC,4BAA4B,UAAU;AAAA,IACtC,kBAAkB,UAAU;AAAA,IAC5B,mBAAmB,UAAU;AAAA,EAC/B;AACF;AAWA,eAAsB,6BACpB,KACA,cACA,UACiC;AACjC,QAAM,kBAAkB,qBAAqB,YAAY;AACzD,QAAM,SAAS,MAAM,YAAY,KAAK;AAAA,IACpC,UAAU;AAAA,IACV,gBAAgB;AAAA,IAChB,QAAQ;AAAA,IACR,MAAM;AAAA,IACN,SAAS,WAAW,iBAAiB,QAAQ;AAAA,EAC/C,CAAC;AACD,SAAO;AAAA,IACL,KAAK,OAAO;AAAA,IACZ,QAAQ,OAAO;AAAA,IACf,MAAM,OAAO;AAAA,EACf;AACF;AAQA,eAAsB,yBACpB,UAC8B;AAC9B,QAAM,WAAW,MAAM,MAAM,UAAU,UAAU;AACjD,SAAO;AAAA,IACL,UAAU,gBAAgB,QAAQ,EAAE,SAAS;AAAA,EAC/C;AACF;AAUO,SAAS,sBACd,sBACA,cACA,iBAC2B;AAC3B,QAAM,EAAE,KAAK,QAAQ,MAAM,iBAAiB,IAAI;AAEhD,QAAM,4BAA4B,eAAe,oBAAoB;AACrE,QAAM,oBAAoB,eAAe,YAAY;AACrD,QAAM,wBAAwB,eAAe,gBAAgB;AAE7D,QAAM,0BAA0B,GAAG;AAAA,IACjC;AAAA,IACA,kBAAkB,IAAI,qBAAqB;AAAA,EAC7C;AAEA,QAAM,yBAAyB;AAAA,IAC7B,IAAI;AAAA,EACN;AACA,QAAM,4BAA4B;AAAA,IAChC,OAAO;AAAA,EACT;AACA,QAAM,0BAA0B;AAAA,IAC9B,KAAK;AAAA,EACP;AAEA,MAAI;AACJ,MAAI;AAEJ,MAAI,wBAAwB,GAAG,sBAAsB,GAAG;AACtD,qBAAiB;AACjB,qBAAiB;AAAA,EACnB,WACE,wBAAwB,IAAI,sBAAsB,KAClD,wBAAwB,GAAG,yBAAyB,GACpD;AACA,qBAAiB,IAAI;AACrB,qBAAiB,IAAI;AAAA,EACvB,WACE,wBAAwB,IAAI,yBAAyB,KACrD,wBAAwB,GAAG,uBAAuB,GAClD;AACA,qBAAiB,OAAO;AACxB,qBAAiB,OAAO;AAAA,EAC1B,WAAW,wBAAwB,GAAG,uBAAuB,GAAG;AAC9D,qBAAiB,KAAK;AACtB,qBAAiB,KAAK;AAAA,EACxB,OAAO;AACL,qBAAiB;AACjB,qBAAiB,KAAK;AAAA,EACxB;AAEA,SAAO;AAAA,IACL;AAAA,IACA;AAAA,EACF;AACF;AAQA,SAAS,qBAAqB,cAAsB;AAElD,SAAO,OAAO,KAAK,GAAG,YAAY,GAAG,EAAE,SAAS,QAAQ;AAC1D;AASA,SAAS,WAAW,iBAAyB,UAAmB;AAC9D,SAAO;AAAA,IACL,gBAAgB;AAAA,IAChB,eAAe,SAAS,eAAe;AAAA;AAAA,IAEvC,GAAI,UAAU,KAAK,IAAI,mBAAmB,QAAQ,IAAI,CAAC;AAAA,EACzD;AACF","sourcesContent":["import {\n  query,\n  handleFetch,\n  gweiDecToWEIBN,\n  weiHexToGweiDec,\n} from '@metamask/controller-utils';\nimport type EthQuery from '@metamask/eth-query';\nimport BN from 'bn.js';\n\nimport type {\n  GasFeeEstimates,\n  EthGasPriceEstimate,\n  EstimatedGasFeeTimeBounds,\n  unknownString,\n  LegacyGasPriceEstimate,\n} from './GasFeeController';\n\nconst makeClientIdHeader = (clientId: string) => ({ 'X-Client-Id': clientId });\n\n/**\n * Convert a decimal GWEI value to a decimal string rounded to the nearest WEI.\n *\n * @param n - The input GWEI amount, as a decimal string or a number.\n * @returns The decimal string GWEI amount.\n */\nexport function normalizeGWEIDecimalNumbers(n: string | number) {\n  const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);\n  const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex);\n  return numberAsGWEI;\n}\n\n/**\n * Fetch gas estimates from the given URL.\n *\n * @param url - The gas estimate URL.\n * @param infuraAPIKey - The Infura API key used for infura API requests.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The gas estimates.\n */\nexport async function fetchGasEstimates(\n  url: string,\n  infuraAPIKey: string,\n  clientId?: string,\n): Promise<GasFeeEstimates> {\n  const infuraAuthToken = buildInfuraAuthToken(infuraAPIKey);\n  const estimates = await handleFetch(url, {\n    headers: getHeaders(infuraAuthToken, clientId),\n  });\n  return {\n    low: {\n      ...estimates.low,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.low.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.low.suggestedMaxFeePerGas,\n      ),\n    },\n    medium: {\n      ...estimates.medium,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.medium.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.medium.suggestedMaxFeePerGas,\n      ),\n    },\n    high: {\n      ...estimates.high,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.high.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.high.suggestedMaxFeePerGas,\n      ),\n    },\n    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),\n    historicalBaseFeeRange: estimates.historicalBaseFeeRange,\n    baseFeeTrend: estimates.baseFeeTrend,\n    latestPriorityFeeRange: estimates.latestPriorityFeeRange,\n    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,\n    priorityFeeTrend: estimates.priorityFeeTrend,\n    networkCongestion: estimates.networkCongestion,\n  };\n}\n\n/**\n * Hit the legacy MetaSwaps gasPrices estimate api and return the low, medium\n * high values from that API.\n *\n * @param url - The URL to fetch gas price estimates from.\n * @param infuraAPIKey - The Infura API key used for infura API requests.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The gas price estimates.\n */\nexport async function fetchLegacyGasPriceEstimates(\n  url: string,\n  infuraAPIKey: string,\n  clientId?: string,\n): Promise<LegacyGasPriceEstimate> {\n  const infuraAuthToken = buildInfuraAuthToken(infuraAPIKey);\n  const result = await handleFetch(url, {\n    referrer: url,\n    referrerPolicy: 'no-referrer-when-downgrade',\n    method: 'GET',\n    mode: 'cors',\n    headers: getHeaders(infuraAuthToken, clientId),\n  });\n  return {\n    low: result.SafeGasPrice,\n    medium: result.ProposeGasPrice,\n    high: result.FastGasPrice,\n  };\n}\n\n/**\n * Get a gas price estimate from the network using the `eth_gasPrice` method.\n *\n * @param ethQuery - The EthQuery instance to call the network with.\n * @returns A gas price estimate.\n */\nexport async function fetchEthGasPriceEstimate(\n  ethQuery: EthQuery,\n): Promise<EthGasPriceEstimate> {\n  const gasPrice = await query(ethQuery, 'gasPrice');\n  return {\n    gasPrice: weiHexToGweiDec(gasPrice).toString(),\n  };\n}\n\n/**\n * Estimate the time it will take for a transaction to be confirmed.\n *\n * @param maxPriorityFeePerGas - The max priority fee per gas.\n * @param maxFeePerGas - The max fee per gas.\n * @param gasFeeEstimates - The gas fee estimates.\n * @returns The estimated lower and upper bounds for when this transaction will be confirmed.\n */\nexport function calculateTimeEstimate(\n  maxPriorityFeePerGas: string,\n  maxFeePerGas: string,\n  gasFeeEstimates: GasFeeEstimates,\n): EstimatedGasFeeTimeBounds {\n  const { low, medium, high, estimatedBaseFee } = gasFeeEstimates;\n\n  const maxPriorityFeePerGasInWEI = gweiDecToWEIBN(maxPriorityFeePerGas);\n  const maxFeePerGasInWEI = gweiDecToWEIBN(maxFeePerGas);\n  const estimatedBaseFeeInWEI = gweiDecToWEIBN(estimatedBaseFee);\n\n  const effectiveMaxPriorityFee = BN.min(\n    maxPriorityFeePerGasInWEI,\n    maxFeePerGasInWEI.sub(estimatedBaseFeeInWEI),\n  );\n\n  const lowMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    low.suggestedMaxPriorityFeePerGas,\n  );\n  const mediumMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    medium.suggestedMaxPriorityFeePerGas,\n  );\n  const highMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    high.suggestedMaxPriorityFeePerGas,\n  );\n\n  let lowerTimeBound;\n  let upperTimeBound;\n\n  if (effectiveMaxPriorityFee.lt(lowMaxPriorityFeeInWEI)) {\n    lowerTimeBound = null;\n    upperTimeBound = 'unknown' as unknownString;\n  } else if (\n    effectiveMaxPriorityFee.gte(lowMaxPriorityFeeInWEI) &&\n    effectiveMaxPriorityFee.lt(mediumMaxPriorityFeeInWEI)\n  ) {\n    lowerTimeBound = low.minWaitTimeEstimate;\n    upperTimeBound = low.maxWaitTimeEstimate;\n  } else if (\n    effectiveMaxPriorityFee.gte(mediumMaxPriorityFeeInWEI) &&\n    effectiveMaxPriorityFee.lt(highMaxPriorityFeeInWEI)\n  ) {\n    lowerTimeBound = medium.minWaitTimeEstimate;\n    upperTimeBound = medium.maxWaitTimeEstimate;\n  } else if (effectiveMaxPriorityFee.eq(highMaxPriorityFeeInWEI)) {\n    lowerTimeBound = high.minWaitTimeEstimate;\n    upperTimeBound = high.maxWaitTimeEstimate;\n  } else {\n    lowerTimeBound = 0;\n    upperTimeBound = high.maxWaitTimeEstimate;\n  }\n\n  return {\n    lowerTimeBound,\n    upperTimeBound,\n  };\n}\n\n/**\n * Build an infura auth token from the given API key and secret.\n *\n * @param infuraAPIKey - The Infura API key.\n * @returns The base64 encoded auth token.\n */\nfunction buildInfuraAuthToken(infuraAPIKey: string) {\n  // We intentionally leave the password empty, as Infura does not require one\n  return Buffer.from(`${infuraAPIKey}:`).toString('base64');\n}\n\n/**\n * Get the headers for a request to the gas fee API.\n *\n * @param infuraAuthToken - The Infura auth token to use for the request.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The headers for the request.\n */\nfunction getHeaders(infuraAuthToken: string, clientId?: string) {\n  return {\n    'Content-Type': 'application/json',\n    Authorization: `Basic ${infuraAuthToken}`,\n    // Only add the clientId header if clientId is a non-empty string\n    ...(clientId?.trim() ? makeClientIdHeader(clientId) : {}),\n  };\n}\n"]}
+\ No newline at end of file
+diff --git a/dist/chunk-R3IOI7AK.mjs b/dist/chunk-R3IOI7AK.mjs
+new file mode 100644
+index 0000000000000000000000000000000000000000..005f6ca08cfdc55aabcf1849e2a3b651ee7d9303
+--- /dev/null
++++ b/dist/chunk-R3IOI7AK.mjs
+@@ -0,0 +1,156 @@
++var __accessCheck = (obj, member, msg) => {
++  if (!member.has(obj))
++    throw TypeError("Cannot " + msg);
++};
++var __privateGet = (obj, member, getter) => {
++  __accessCheck(obj, member, "read from private field");
++  return getter ? getter.call(obj) : member.get(obj);
++};
++var __privateAdd = (obj, member, value) => {
++  if (member.has(obj))
++    throw TypeError("Cannot add the same private member more than once");
++  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
++};
++var __privateSet = (obj, member, value, setter) => {
++  __accessCheck(obj, member, "write to private field");
++  setter ? setter.call(obj, value) : member.set(obj, value);
++  return value;
++};
++var __privateMethod = (obj, member, method) => {
++  __accessCheck(obj, member, "access private method");
++  return method;
++};
++
++// src/gas-util.ts
++import {
++  query,
++  handleFetch,
++  gweiDecToWEIBN,
++  weiHexToGweiDec
++} from "@metamask/controller-utils";
++import BN from "bn.js";
++var makeClientIdHeader = (clientId) => ({ "X-Client-Id": clientId });
++function normalizeGWEIDecimalNumbers(n) {
++  const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);
++  const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex);
++  return numberAsGWEI;
++}
++async function fetchGasEstimates(url, clientId) {
++  const estimates = await handleFetch(
++    url,
++    clientId ? { headers: makeClientIdHeader(clientId) } : void 0
++  );
++  return {
++    low: {
++      ...estimates.low,
++      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.low.suggestedMaxPriorityFeePerGas
++      ),
++      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.low.suggestedMaxFeePerGas
++      )
++    },
++    medium: {
++      ...estimates.medium,
++      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.medium.suggestedMaxPriorityFeePerGas
++      ),
++      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.medium.suggestedMaxFeePerGas
++      )
++    },
++    high: {
++      ...estimates.high,
++      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.high.suggestedMaxPriorityFeePerGas
++      ),
++      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
++        estimates.high.suggestedMaxFeePerGas
++      )
++    },
++    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
++    historicalBaseFeeRange: estimates.historicalBaseFeeRange,
++    baseFeeTrend: estimates.baseFeeTrend,
++    latestPriorityFeeRange: estimates.latestPriorityFeeRange,
++    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,
++    priorityFeeTrend: estimates.priorityFeeTrend,
++    networkCongestion: estimates.networkCongestion
++  };
++}
++async function fetchLegacyGasPriceEstimates(url, clientId) {
++  const result = await handleFetch(url, {
++    referrer: url,
++    referrerPolicy: "no-referrer-when-downgrade",
++    method: "GET",
++    mode: "cors",
++    headers: {
++      "Content-Type": "application/json",
++      ...clientId && makeClientIdHeader(clientId)
++    }
++  });
++  return {
++    low: result.SafeGasPrice,
++    medium: result.ProposeGasPrice,
++    high: result.FastGasPrice
++  };
++}
++async function fetchEthGasPriceEstimate(ethQuery) {
++  const gasPrice = await query(ethQuery, "gasPrice");
++  return {
++    gasPrice: weiHexToGweiDec(gasPrice).toString()
++  };
++}
++function calculateTimeEstimate(maxPriorityFeePerGas, maxFeePerGas, gasFeeEstimates) {
++  const { low, medium, high, estimatedBaseFee } = gasFeeEstimates;
++  const maxPriorityFeePerGasInWEI = gweiDecToWEIBN(maxPriorityFeePerGas);
++  const maxFeePerGasInWEI = gweiDecToWEIBN(maxFeePerGas);
++  const estimatedBaseFeeInWEI = gweiDecToWEIBN(estimatedBaseFee);
++  const effectiveMaxPriorityFee = BN.min(
++    maxPriorityFeePerGasInWEI,
++    maxFeePerGasInWEI.sub(estimatedBaseFeeInWEI)
++  );
++  const lowMaxPriorityFeeInWEI = gweiDecToWEIBN(
++    low.suggestedMaxPriorityFeePerGas
++  );
++  const mediumMaxPriorityFeeInWEI = gweiDecToWEIBN(
++    medium.suggestedMaxPriorityFeePerGas
++  );
++  const highMaxPriorityFeeInWEI = gweiDecToWEIBN(
++    high.suggestedMaxPriorityFeePerGas
++  );
++  let lowerTimeBound;
++  let upperTimeBound;
++  if (effectiveMaxPriorityFee.lt(lowMaxPriorityFeeInWEI)) {
++    lowerTimeBound = null;
++    upperTimeBound = "unknown";
++  } else if (effectiveMaxPriorityFee.gte(lowMaxPriorityFeeInWEI) && effectiveMaxPriorityFee.lt(mediumMaxPriorityFeeInWEI)) {
++    lowerTimeBound = low.minWaitTimeEstimate;
++    upperTimeBound = low.maxWaitTimeEstimate;
++  } else if (effectiveMaxPriorityFee.gte(mediumMaxPriorityFeeInWEI) && effectiveMaxPriorityFee.lt(highMaxPriorityFeeInWEI)) {
++    lowerTimeBound = medium.minWaitTimeEstimate;
++    upperTimeBound = medium.maxWaitTimeEstimate;
++  } else if (effectiveMaxPriorityFee.eq(highMaxPriorityFeeInWEI)) {
++    lowerTimeBound = high.minWaitTimeEstimate;
++    upperTimeBound = high.maxWaitTimeEstimate;
++  } else {
++    lowerTimeBound = 0;
++    upperTimeBound = high.maxWaitTimeEstimate;
++  }
++  return {
++    lowerTimeBound,
++    upperTimeBound
++  };
++}
++
++export {
++  __privateGet,
++  __privateAdd,
++  __privateSet,
++  __privateMethod,
++  normalizeGWEIDecimalNumbers,
++  fetchGasEstimates,
++  fetchLegacyGasPriceEstimates,
++  fetchEthGasPriceEstimate,
++  calculateTimeEstimate
++};
++//# sourceMappingURL=chunk-R3IOI7AK.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-R3IOI7AK.mjs.map b/dist/chunk-R3IOI7AK.mjs.map
+new file mode 100644
+index 0000000000000000000000000000000000000000..151a4aa1146e106a273c2e7cbfe8e97c7e6ae6b6
+--- /dev/null
++++ b/dist/chunk-R3IOI7AK.mjs.map
+@@ -0,0 +1 @@
++{"version":3,"sources":["../src/gas-util.ts"],"sourcesContent":["import {\n  query,\n  handleFetch,\n  gweiDecToWEIBN,\n  weiHexToGweiDec,\n} from '@metamask/controller-utils';\nimport type EthQuery from '@metamask/eth-query';\nimport BN from 'bn.js';\n\nimport type {\n  GasFeeEstimates,\n  EthGasPriceEstimate,\n  EstimatedGasFeeTimeBounds,\n  unknownString,\n  LegacyGasPriceEstimate,\n} from './GasFeeController';\n\nconst makeClientIdHeader = (clientId: string) => ({ 'X-Client-Id': clientId });\n\n/**\n * Convert a decimal GWEI value to a decimal string rounded to the nearest WEI.\n *\n * @param n - The input GWEI amount, as a decimal string or a number.\n * @returns The decimal string GWEI amount.\n */\nexport function normalizeGWEIDecimalNumbers(n: string | number) {\n  const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);\n  const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex);\n  return numberAsGWEI;\n}\n\n/**\n * Fetch gas estimates from the given URL.\n *\n * @param url - The gas estimate URL.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The gas estimates.\n */\nexport async function fetchGasEstimates(\n  url: string,\n  clientId?: string,\n): Promise<GasFeeEstimates> {\n  const estimates = await handleFetch(\n    url,\n    clientId ? { headers: makeClientIdHeader(clientId) } : undefined,\n  );\n  return {\n    low: {\n      ...estimates.low,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.low.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.low.suggestedMaxFeePerGas,\n      ),\n    },\n    medium: {\n      ...estimates.medium,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.medium.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.medium.suggestedMaxFeePerGas,\n      ),\n    },\n    high: {\n      ...estimates.high,\n      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.high.suggestedMaxPriorityFeePerGas,\n      ),\n      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(\n        estimates.high.suggestedMaxFeePerGas,\n      ),\n    },\n    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),\n    historicalBaseFeeRange: estimates.historicalBaseFeeRange,\n    baseFeeTrend: estimates.baseFeeTrend,\n    latestPriorityFeeRange: estimates.latestPriorityFeeRange,\n    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,\n    priorityFeeTrend: estimates.priorityFeeTrend,\n    networkCongestion: estimates.networkCongestion,\n  };\n}\n\n/**\n * Hit the legacy MetaSwaps gasPrices estimate api and return the low, medium\n * high values from that API.\n *\n * @param url - The URL to fetch gas price estimates from.\n * @param clientId - The client ID used to identify to the API who is asking for estimates.\n * @returns The gas price estimates.\n */\nexport async function fetchLegacyGasPriceEstimates(\n  url: string,\n  clientId?: string,\n): Promise<LegacyGasPriceEstimate> {\n  const result = await handleFetch(url, {\n    referrer: url,\n    referrerPolicy: 'no-referrer-when-downgrade',\n    method: 'GET',\n    mode: 'cors',\n    headers: {\n      'Content-Type': 'application/json',\n      ...(clientId && makeClientIdHeader(clientId)),\n    },\n  });\n  return {\n    low: result.SafeGasPrice,\n    medium: result.ProposeGasPrice,\n    high: result.FastGasPrice,\n  };\n}\n\n/**\n * Get a gas price estimate from the network using the `eth_gasPrice` method.\n *\n * @param ethQuery - The EthQuery instance to call the network with.\n * @returns A gas price estimate.\n */\nexport async function fetchEthGasPriceEstimate(\n  ethQuery: EthQuery,\n): Promise<EthGasPriceEstimate> {\n  const gasPrice = await query(ethQuery, 'gasPrice');\n  return {\n    gasPrice: weiHexToGweiDec(gasPrice).toString(),\n  };\n}\n\n/**\n * Estimate the time it will take for a transaction to be confirmed.\n *\n * @param maxPriorityFeePerGas - The max priority fee per gas.\n * @param maxFeePerGas - The max fee per gas.\n * @param gasFeeEstimates - The gas fee estimates.\n * @returns The estimated lower and upper bounds for when this transaction will be confirmed.\n */\nexport function calculateTimeEstimate(\n  maxPriorityFeePerGas: string,\n  maxFeePerGas: string,\n  gasFeeEstimates: GasFeeEstimates,\n): EstimatedGasFeeTimeBounds {\n  const { low, medium, high, estimatedBaseFee } = gasFeeEstimates;\n\n  const maxPriorityFeePerGasInWEI = gweiDecToWEIBN(maxPriorityFeePerGas);\n  const maxFeePerGasInWEI = gweiDecToWEIBN(maxFeePerGas);\n  const estimatedBaseFeeInWEI = gweiDecToWEIBN(estimatedBaseFee);\n\n  const effectiveMaxPriorityFee = BN.min(\n    maxPriorityFeePerGasInWEI,\n    maxFeePerGasInWEI.sub(estimatedBaseFeeInWEI),\n  );\n\n  const lowMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    low.suggestedMaxPriorityFeePerGas,\n  );\n  const mediumMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    medium.suggestedMaxPriorityFeePerGas,\n  );\n  const highMaxPriorityFeeInWEI = gweiDecToWEIBN(\n    high.suggestedMaxPriorityFeePerGas,\n  );\n\n  let lowerTimeBound;\n  let upperTimeBound;\n\n  if (effectiveMaxPriorityFee.lt(lowMaxPriorityFeeInWEI)) {\n    lowerTimeBound = null;\n    upperTimeBound = 'unknown' as unknownString;\n  } else if (\n    effectiveMaxPriorityFee.gte(lowMaxPriorityFeeInWEI) &&\n    effectiveMaxPriorityFee.lt(mediumMaxPriorityFeeInWEI)\n  ) {\n    lowerTimeBound = low.minWaitTimeEstimate;\n    upperTimeBound = low.maxWaitTimeEstimate;\n  } else if (\n    effectiveMaxPriorityFee.gte(mediumMaxPriorityFeeInWEI) &&\n    effectiveMaxPriorityFee.lt(highMaxPriorityFeeInWEI)\n  ) {\n    lowerTimeBound = medium.minWaitTimeEstimate;\n    upperTimeBound = medium.maxWaitTimeEstimate;\n  } else if (effectiveMaxPriorityFee.eq(highMaxPriorityFeeInWEI)) {\n    lowerTimeBound = high.minWaitTimeEstimate;\n    upperTimeBound = high.maxWaitTimeEstimate;\n  } else {\n    lowerTimeBound = 0;\n    upperTimeBound = high.maxWaitTimeEstimate;\n  }\n\n  return {\n    lowerTimeBound,\n    upperTimeBound,\n  };\n}\n"],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;AAAA;AAAA,EACE;AAAA,EACA;AAAA,EACA;AAAA,EACA;AAAA,OACK;AAEP,OAAO,QAAQ;AAUf,IAAM,qBAAqB,CAAC,cAAsB,EAAE,eAAe,SAAS;AAQrE,SAAS,4BAA4B,GAAoB;AAC9D,QAAM,iBAAiB,eAAe,CAAC,EAAE,SAAS,EAAE;AACpD,QAAM,eAAe,gBAAgB,cAAc;AACnD,SAAO;AACT;AASA,eAAsB,kBACpB,KACA,UAC0B;AAC1B,QAAM,YAAY,MAAM;AAAA,IACtB;AAAA,IACA,WAAW,EAAE,SAAS,mBAAmB,QAAQ,EAAE,IAAI;AAAA,EACzD;AACA,SAAO;AAAA,IACL,KAAK;AAAA,MACH,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,IAAI;AAAA,MAChB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,IAAI;AAAA,MAChB;AAAA,IACF;AAAA,IACA,QAAQ;AAAA,MACN,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,OAAO;AAAA,MACnB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,OAAO;AAAA,MACnB;AAAA,IACF;AAAA,IACA,MAAM;AAAA,MACJ,GAAG,UAAU;AAAA,MACb,+BAA+B;AAAA,QAC7B,UAAU,KAAK;AAAA,MACjB;AAAA,MACA,uBAAuB;AAAA,QACrB,UAAU,KAAK;AAAA,MACjB;AAAA,IACF;AAAA,IACA,kBAAkB,4BAA4B,UAAU,gBAAgB;AAAA,IACxE,wBAAwB,UAAU;AAAA,IAClC,cAAc,UAAU;AAAA,IACxB,wBAAwB,UAAU;AAAA,IAClC,4BAA4B,UAAU;AAAA,IACtC,kBAAkB,UAAU;AAAA,IAC5B,mBAAmB,UAAU;AAAA,EAC/B;AACF;AAUA,eAAsB,6BACpB,KACA,UACiC;AACjC,QAAM,SAAS,MAAM,YAAY,KAAK;AAAA,IACpC,UAAU;AAAA,IACV,gBAAgB;AAAA,IAChB,QAAQ;AAAA,IACR,MAAM;AAAA,IACN,SAAS;AAAA,MACP,gBAAgB;AAAA,MAChB,GAAI,YAAY,mBAAmB,QAAQ;AAAA,IAC7C;AAAA,EACF,CAAC;AACD,SAAO;AAAA,IACL,KAAK,OAAO;AAAA,IACZ,QAAQ,OAAO;AAAA,IACf,MAAM,OAAO;AAAA,EACf;AACF;AAQA,eAAsB,yBACpB,UAC8B;AAC9B,QAAM,WAAW,MAAM,MAAM,UAAU,UAAU;AACjD,SAAO;AAAA,IACL,UAAU,gBAAgB,QAAQ,EAAE,SAAS;AAAA,EAC/C;AACF;AAUO,SAAS,sBACd,sBACA,cACA,iBAC2B;AAC3B,QAAM,EAAE,KAAK,QAAQ,MAAM,iBAAiB,IAAI;AAEhD,QAAM,4BAA4B,eAAe,oBAAoB;AACrE,QAAM,oBAAoB,eAAe,YAAY;AACrD,QAAM,wBAAwB,eAAe,gBAAgB;AAE7D,QAAM,0BAA0B,GAAG;AAAA,IACjC;AAAA,IACA,kBAAkB,IAAI,qBAAqB;AAAA,EAC7C;AAEA,QAAM,yBAAyB;AAAA,IAC7B,IAAI;AAAA,EACN;AACA,QAAM,4BAA4B;AAAA,IAChC,OAAO;AAAA,EACT;AACA,QAAM,0BAA0B;AAAA,IAC9B,KAAK;AAAA,EACP;AAEA,MAAI;AACJ,MAAI;AAEJ,MAAI,wBAAwB,GAAG,sBAAsB,GAAG;AACtD,qBAAiB;AACjB,qBAAiB;AAAA,EACnB,WACE,wBAAwB,IAAI,sBAAsB,KAClD,wBAAwB,GAAG,yBAAyB,GACpD;AACA,qBAAiB,IAAI;AACrB,qBAAiB,IAAI;AAAA,EACvB,WACE,wBAAwB,IAAI,yBAAyB,KACrD,wBAAwB,GAAG,uBAAuB,GAClD;AACA,qBAAiB,OAAO;AACxB,qBAAiB,OAAO;AAAA,EAC1B,WAAW,wBAAwB,GAAG,uBAAuB,GAAG;AAC9D,qBAAiB,KAAK;AACtB,qBAAiB,KAAK;AAAA,EACxB,OAAO;AACL,qBAAiB;AACjB,qBAAiB,KAAK;AAAA,EACxB;AAEA,SAAO;AAAA,IACL;AAAA,IACA;AAAA,EACF;AACF;","names":[]}
+\ No newline at end of file
+diff --git a/dist/chunk-X74LQX2Y.js b/dist/chunk-X74LQX2Y.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..11d4e4b36c51872b5b529eb4e7d4f7eea91e87c7
+--- /dev/null
++++ b/dist/chunk-X74LQX2Y.js
+@@ -0,0 +1,390 @@
++"use strict";Object.defineProperty(exports, "__esModule", {value: true}); function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
++
++
++
++
++
++
++
++
++var _chunk2MFVV2BXjs = require('./chunk-2MFVV2BX.js');
++
++// src/GasFeeController.ts
++
++
++
++
++var _controllerutils = require('@metamask/controller-utils');
++var _ethquery = require('@metamask/eth-query'); var _ethquery2 = _interopRequireDefault(_ethquery);
++var _pollingcontroller = require('@metamask/polling-controller');
++var _uuid = require('uuid');
++var LEGACY_GAS_PRICES_API_URL = `https://api.metaswap.codefi.network/gasPrices`;
++var GAS_ESTIMATE_TYPES = {
++  FEE_MARKET: "fee-market",
++  LEGACY: "legacy",
++  ETH_GASPRICE: "eth_gasPrice",
++  NONE: "none"
++};
++var metadata = {
++  gasFeeEstimatesByChainId: {
++    persist: true,
++    anonymous: false
++  },
++  gasFeeEstimates: { persist: true, anonymous: false },
++  estimatedGasFeeTimeBounds: { persist: true, anonymous: false },
++  gasEstimateType: { persist: true, anonymous: false },
++  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false }
++};
++var name = "GasFeeController";
++var defaultState = {
++  gasFeeEstimatesByChainId: {},
++  gasFeeEstimates: {},
++  estimatedGasFeeTimeBounds: {},
++  gasEstimateType: GAS_ESTIMATE_TYPES.NONE,
++  nonRPCGasFeeApisDisabled: false
++};
++var _getProvider, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn;
++var GasFeeController = class extends _pollingcontroller.StaticIntervalPollingController {
++  /**
++   * Creates a GasFeeController instance.
++   *
++   * @param options - The controller options.
++   * @param options.interval - The time in milliseconds to wait between polls.
++   * @param options.messenger - The controller messenger.
++   * @param options.state - The initial state.
++   * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current
++   * network is EIP-1559 compatible.
++   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the
++   * current network is compatible with the legacy gas price API.
++   * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current
++   * account is EIP-1559 compatible.
++   * @param options.getChainId - Returns the current chain ID.
++   * @param options.getProvider - Returns a network provider for the current network.
++   * @param options.onNetworkDidChange - A function for registering an event handler for the
++   * network state change event.
++   * @param options.legacyAPIEndpoint - The legacy gas price API URL. This option is primarily for
++   * testing purposes.
++   * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL.
++   * @param options.clientId - The client ID used to identify to the gas estimation API who is
++   * asking for estimates.
++   */
++  constructor({
++    interval = 15e3,
++    messenger,
++    state,
++    getCurrentNetworkEIP1559Compatibility,
++    getCurrentAccountEIP1559Compatibility,
++    getChainId,
++    getCurrentNetworkLegacyGasAPICompatibility,
++    getProvider,
++    onNetworkDidChange,
++    legacyAPIEndpoint = LEGACY_GAS_PRICES_API_URL,
++    EIP1559APIEndpoint,
++    clientId
++  }) {
++    super({
++      name,
++      metadata,
++      messenger,
++      state: { ...defaultState, ...state }
++    });
++    _chunk2MFVV2BXjs.__privateAdd.call(void 0, this, _onNetworkControllerDidChange);
++    _chunk2MFVV2BXjs.__privateAdd.call(void 0, this, _getProvider, void 0);
++    this.intervalDelay = interval;
++    this.setIntervalLength(interval);
++    this.pollTokens = /* @__PURE__ */ new Set();
++    this.getCurrentNetworkEIP1559Compatibility = getCurrentNetworkEIP1559Compatibility;
++    this.getCurrentNetworkLegacyGasAPICompatibility = getCurrentNetworkLegacyGasAPICompatibility;
++    this.getCurrentAccountEIP1559Compatibility = getCurrentAccountEIP1559Compatibility;
++    _chunk2MFVV2BXjs.__privateSet.call(void 0, this, _getProvider, getProvider);
++    this.EIP1559APIEndpoint = EIP1559APIEndpoint;
++    this.legacyAPIEndpoint = legacyAPIEndpoint;
++    this.clientId = clientId;
++    this.ethQuery = new (0, _ethquery2.default)(_chunk2MFVV2BXjs.__privateGet.call(void 0, this, _getProvider).call(this));
++    if (onNetworkDidChange && getChainId) {
++      this.currentChainId = getChainId();
++      onNetworkDidChange(async (networkControllerState) => {
++        await _chunk2MFVV2BXjs.__privateMethod.call(void 0, this, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn).call(this, networkControllerState);
++      });
++    } else {
++      this.currentChainId = this.messagingSystem.call(
++        "NetworkController:getState"
++      ).providerConfig.chainId;
++      this.messagingSystem.subscribe(
++        "NetworkController:networkDidChange",
++        async (networkControllerState) => {
++          await _chunk2MFVV2BXjs.__privateMethod.call(void 0, this, _onNetworkControllerDidChange, onNetworkControllerDidChange_fn).call(this, networkControllerState);
++        }
++      );
++    }
++  }
++  async resetPolling() {
++    if (this.pollTokens.size !== 0) {
++      const tokens = Array.from(this.pollTokens);
++      this.stopPolling();
++      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);
++      tokens.slice(1).forEach((token) => {
++        this.pollTokens.add(token);
++      });
++    }
++  }
++  async fetchGasFeeEstimates(options) {
++    return await this._fetchGasFeeEstimateData(options);
++  }
++  async getGasFeeEstimatesAndStartPolling(pollToken) {
++    const _pollToken = pollToken || _uuid.v1.call(void 0, );
++    this.pollTokens.add(_pollToken);
++    if (this.pollTokens.size === 1) {
++      await this._fetchGasFeeEstimateData();
++      this._poll();
++    }
++    return _pollToken;
++  }
++  /**
++   * Gets and sets gasFeeEstimates in state.
++   *
++   * @param options - The gas fee estimate options.
++   * @param options.shouldUpdateState - Determines whether the state should be updated with the
++   * updated gas estimates.
++   * @returns The gas fee estimates.
++   */
++  async _fetchGasFeeEstimateData(options = {}) {
++    const { shouldUpdateState = true, networkClientId } = options;
++    let ethQuery, isEIP1559Compatible, isLegacyGasAPICompatible, decimalChainId;
++    if (networkClientId !== void 0) {
++      const networkClient = this.messagingSystem.call(
++        "NetworkController:getNetworkClientById",
++        networkClientId
++      );
++      isLegacyGasAPICompatible = networkClient.configuration.chainId === "0x38";
++      decimalChainId = _controllerutils.convertHexToDecimal.call(void 0, networkClient.configuration.chainId);
++      try {
++        const result = await this.messagingSystem.call(
++          "NetworkController:getEIP1559Compatibility",
++          networkClientId
++        );
++        isEIP1559Compatible = result || false;
++      } catch {
++        isEIP1559Compatible = false;
++      }
++      ethQuery = new (0, _ethquery2.default)(networkClient.provider);
++    }
++    ethQuery ?? (ethQuery = this.ethQuery);
++    isLegacyGasAPICompatible ?? (isLegacyGasAPICompatible = this.getCurrentNetworkLegacyGasAPICompatibility());
++    decimalChainId ?? (decimalChainId = _controllerutils.convertHexToDecimal.call(void 0, this.currentChainId));
++    try {
++      isEIP1559Compatible ?? (isEIP1559Compatible = await this.getEIP1559Compatibility());
++    } catch (e) {
++      console.error(e);
++      isEIP1559Compatible ?? (isEIP1559Compatible = false);
++    }
++    const gasFeeCalculations = await determineGasFeeCalculations({
++      isEIP1559Compatible,
++      isLegacyGasAPICompatible,
++      fetchGasEstimates: _chunk2MFVV2BXjs.fetchGasEstimates,
++      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(
++        "<chain_id>",
++        `${decimalChainId}`
++      ),
++      fetchLegacyGasPriceEstimates: _chunk2MFVV2BXjs.fetchLegacyGasPriceEstimates,
++      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(
++        "<chain_id>",
++        `${decimalChainId}`
++      ),
++      fetchEthGasPriceEstimate: _chunk2MFVV2BXjs.fetchEthGasPriceEstimate,
++      calculateTimeEstimate: _chunk2MFVV2BXjs.calculateTimeEstimate,
++      clientId: this.clientId,
++      ethQuery,
++      nonRPCGasFeeApisDisabled: this.state.nonRPCGasFeeApisDisabled
++    });
++    if (shouldUpdateState) {
++      const chainId = _controllerutils.toHex.call(void 0, decimalChainId);
++      this.update((state) => {
++        if (this.currentChainId === chainId) {
++          state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;
++          state.estimatedGasFeeTimeBounds = gasFeeCalculations.estimatedGasFeeTimeBounds;
++          state.gasEstimateType = gasFeeCalculations.gasEstimateType;
++        }
++        state.gasFeeEstimatesByChainId ?? (state.gasFeeEstimatesByChainId = {});
++        state.gasFeeEstimatesByChainId[chainId] = {
++          gasFeeEstimates: gasFeeCalculations.gasFeeEstimates,
++          estimatedGasFeeTimeBounds: gasFeeCalculations.estimatedGasFeeTimeBounds,
++          gasEstimateType: gasFeeCalculations.gasEstimateType
++        };
++      });
++    }
++    return gasFeeCalculations;
++  }
++  /**
++   * Remove the poll token, and stop polling if the set of poll tokens is empty.
++   *
++   * @param pollToken - The poll token to disconnect.
++   */
++  disconnectPoller(pollToken) {
++    this.pollTokens.delete(pollToken);
++    if (this.pollTokens.size === 0) {
++      this.stopPolling();
++    }
++  }
++  stopPolling() {
++    if (this.intervalId) {
++      clearInterval(this.intervalId);
++    }
++    this.pollTokens.clear();
++    this.resetState();
++  }
++  /**
++   * Prepare to discard this controller.
++   *
++   * This stops any active polling.
++   */
++  destroy() {
++    super.destroy();
++    this.stopPolling();
++  }
++  _poll() {
++    if (this.intervalId) {
++      clearInterval(this.intervalId);
++    }
++    this.intervalId = setInterval(async () => {
++      await _controllerutils.safelyExecute.call(void 0, () => this._fetchGasFeeEstimateData());
++    }, this.intervalDelay);
++  }
++  /**
++   * Fetching token list from the Token Service API.
++   *
++   * @private
++   * @param networkClientId - The ID of the network client triggering the fetch.
++   * @returns A promise that resolves when this operation completes.
++   */
++  async _executePoll(networkClientId) {
++    await this._fetchGasFeeEstimateData({ networkClientId });
++  }
++  resetState() {
++    this.update(() => {
++      return defaultState;
++    });
++  }
++  async getEIP1559Compatibility() {
++    const currentNetworkIsEIP1559Compatible = await this.getCurrentNetworkEIP1559Compatibility();
++    const currentAccountIsEIP1559Compatible = this.getCurrentAccountEIP1559Compatibility?.() ?? true;
++    return currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible;
++  }
++  getTimeEstimate(maxPriorityFeePerGas, maxFeePerGas) {
++    if (!this.state.gasFeeEstimates || this.state.gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET) {
++      return {};
++    }
++    return _chunk2MFVV2BXjs.calculateTimeEstimate.call(void 0,
++      maxPriorityFeePerGas,
++      maxFeePerGas,
++      this.state.gasFeeEstimates
++    );
++  }
++  enableNonRPCGasFeeApis() {
++    this.update((state) => {
++      state.nonRPCGasFeeApisDisabled = false;
++    });
++  }
++  disableNonRPCGasFeeApis() {
++    this.update((state) => {
++      state.nonRPCGasFeeApisDisabled = true;
++    });
++  }
++};
++_getProvider = new WeakMap();
++_onNetworkControllerDidChange = new WeakSet();
++onNetworkControllerDidChange_fn = async function(networkControllerState) {
++  const newChainId = networkControllerState.providerConfig.chainId;
++  if (newChainId !== this.currentChainId) {
++    this.ethQuery = new (0, _ethquery2.default)(_chunk2MFVV2BXjs.__privateGet.call(void 0, this, _getProvider).call(this));
++    await this.resetPolling();
++    this.currentChainId = newChainId;
++  }
++};
++var GasFeeController_default = GasFeeController;
++
++// src/determineGasFeeCalculations.ts
++async function determineGasFeeCalculations(args) {
++  try {
++    return await getEstimatesUsingFallbacks(args);
++  } catch (error) {
++    if (error instanceof Error) {
++      throw new Error(
++        `Gas fee/price estimation failed. Message: ${error.message}`
++      );
++    }
++    throw error;
++  }
++}
++async function getEstimatesUsingFallbacks(request) {
++  const {
++    isEIP1559Compatible,
++    isLegacyGasAPICompatible,
++    nonRPCGasFeeApisDisabled
++  } = request;
++  try {
++    if (isEIP1559Compatible && !nonRPCGasFeeApisDisabled) {
++      return await getEstimatesUsingFeeMarketEndpoint(request);
++    }
++    if (isLegacyGasAPICompatible && !nonRPCGasFeeApisDisabled) {
++      return await getEstimatesUsingLegacyEndpoint(request);
++    }
++    throw new Error("Main gas fee/price estimation failed. Use fallback");
++  } catch {
++    return await getEstimatesUsingProvider(request);
++  }
++}
++async function getEstimatesUsingFeeMarketEndpoint(request) {
++  const {
++    fetchGasEstimates: fetchGasEstimates2,
++    fetchGasEstimatesUrl,
++    clientId,
++    calculateTimeEstimate: calculateTimeEstimate2
++  } = request;
++  const estimates = await fetchGasEstimates2(fetchGasEstimatesUrl, clientId);
++  const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } = estimates.medium;
++  const estimatedGasFeeTimeBounds = calculateTimeEstimate2(
++    suggestedMaxPriorityFeePerGas,
++    suggestedMaxFeePerGas,
++    estimates
++  );
++  return {
++    gasFeeEstimates: estimates,
++    estimatedGasFeeTimeBounds,
++    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET
++  };
++}
++async function getEstimatesUsingLegacyEndpoint(request) {
++  const {
++    fetchLegacyGasPriceEstimates: fetchLegacyGasPriceEstimates2,
++    fetchLegacyGasPriceEstimatesUrl,
++    clientId
++  } = request;
++  const estimates = await fetchLegacyGasPriceEstimates2(
++    fetchLegacyGasPriceEstimatesUrl,
++    clientId
++  );
++  return {
++    gasFeeEstimates: estimates,
++    estimatedGasFeeTimeBounds: {},
++    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY
++  };
++}
++async function getEstimatesUsingProvider(request) {
++  const { ethQuery, fetchEthGasPriceEstimate: fetchEthGasPriceEstimate2 } = request;
++  const estimates = await fetchEthGasPriceEstimate2(ethQuery);
++  return {
++    gasFeeEstimates: estimates,
++    estimatedGasFeeTimeBounds: {},
++    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE
++  };
++}
++
++
++
++
++
++
++
++exports.determineGasFeeCalculations = determineGasFeeCalculations; exports.LEGACY_GAS_PRICES_API_URL = LEGACY_GAS_PRICES_API_URL; exports.GAS_ESTIMATE_TYPES = GAS_ESTIMATE_TYPES; exports.GasFeeController = GasFeeController; exports.GasFeeController_default = GasFeeController_default;
++//# sourceMappingURL=chunk-X74LQX2Y.js.map
+\ No newline at end of file
+diff --git a/dist/chunk-X74LQX2Y.js.map b/dist/chunk-X74LQX2Y.js.map
+new file mode 100644
+index 0000000000000000000000000000000000000000..c330267c1f74907a70d669611fb5d8eff71305aa
+--- /dev/null
++++ b/dist/chunk-X74LQX2Y.js.map
+@@ -0,0 +1 @@
++{"version":3,"sources":["../src/GasFeeController.ts","../src/determineGasFeeCalculations.ts"],"names":["fetchGasEstimates","calculateTimeEstimate","fetchLegacyGasPriceEstimates","fetchEthGasPriceEstimate"],"mappings":";;;;;;;;;;;;AAKA;AAAA,EACE;AAAA,EACA;AAAA,EACA;AAAA,OACK;AACP,OAAO,cAAc;AAUrB,SAAS,uCAAuC;AAEhD,SAAS,MAAM,cAAc;AAUtB,IAAM,4BAA4B;AA0BlC,IAAM,qBAAqB;AAAA,EAChC,YAAY;AAAA,EACZ,QAAQ;AAAA,EACR,cAAc;AAAA,EACd,MAAM;AACR;AAiGA,IAAM,WAAW;AAAA,EACf,0BAA0B;AAAA,IACxB,SAAS;AAAA,IACT,WAAW;AAAA,EACb;AAAA,EACA,iBAAiB,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EACnD,2BAA2B,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EAC7D,iBAAiB,EAAE,SAAS,MAAM,WAAW,MAAM;AAAA,EACnD,0BAA0B,EAAE,SAAS,MAAM,WAAW,MAAM;AAC9D;AAqDA,IAAM,OAAO;AA0Bb,IAAM,eAA4B;AAAA,EAChC,0BAA0B,CAAC;AAAA,EAC3B,iBAAiB,CAAC;AAAA,EAClB,2BAA2B,CAAC;AAAA,EAC5B,iBAAiB,mBAAmB;AAAA,EACpC,0BAA0B;AAC5B;AA9PA;AAmQO,IAAM,mBAAN,cAA+B,gCAIpC;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAgDA,YAAY;AAAA,IACV,WAAW;AAAA,IACX;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA;AAAA,IACA,oBAAoB;AAAA,IACpB;AAAA,IACA;AAAA,EACF,GAcG;AACD,UAAM;AAAA,MACJ;AAAA,MACA;AAAA,MACA;AAAA,MACA,OAAO,EAAE,GAAG,cAAc,GAAG,MAAM;AAAA,IACrC,CAAC;AAqPH,uBAAM;AA/SN;AA2DE,SAAK,gBAAgB;AACrB,SAAK,kBAAkB,QAAQ;AAC/B,SAAK,aAAa,oBAAI,IAAI;AAC1B,SAAK,wCACH;AACF,SAAK,6CACH;AACF,SAAK,wCACH;AACF,uBAAK,cAAe;AACpB,SAAK,qBAAqB;AAC1B,SAAK,oBAAoB;AACzB,SAAK,WAAW;AAEhB,SAAK,WAAW,IAAI,SAAS,mBAAK,cAAL,UAAmB;AAEhD,QAAI,sBAAsB,YAAY;AACpC,WAAK,iBAAiB,WAAW;AACjC,yBAAmB,OAAO,2BAA2B;AACnD,cAAM,sBAAK,gEAAL,WAAmC;AAAA,MAC3C,CAAC;AAAA,IACH,OAAO;AACL,WAAK,iBAAiB,KAAK,gBAAgB;AAAA,QACzC;AAAA,MACF,EAAE,eAAe;AACjB,WAAK,gBAAgB;AAAA,QACnB;AAAA,QACA,OAAO,2BAA2B;AAChC,gBAAM,sBAAK,gEAAL,WAAmC;AAAA,QAC3C;AAAA,MACF;AAAA,IACF;AAAA,EACF;AAAA,EAEA,MAAM,eAAe;AACnB,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,YAAM,SAAS,MAAM,KAAK,KAAK,UAAU;AACzC,WAAK,YAAY;AACjB,YAAM,KAAK,kCAAkC,OAAO,CAAC,CAAC;AACtD,aAAO,MAAM,CAAC,EAAE,QAAQ,CAAC,UAAU;AACjC,aAAK,WAAW,IAAI,KAAK;AAAA,MAC3B,CAAC;AAAA,IACH;AAAA,EACF;AAAA,EAEA,MAAM,qBAAqB,SAAsC;AAC/D,WAAO,MAAM,KAAK,yBAAyB,OAAO;AAAA,EACpD;AAAA,EAEA,MAAM,kCACJ,WACiB;AACjB,UAAM,aAAa,aAAa,OAAO;AAEvC,SAAK,WAAW,IAAI,UAAU;AAE9B,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,YAAM,KAAK,yBAAyB;AACpC,WAAK,MAAM;AAAA,IACb;AAEA,WAAO;AAAA,EACT;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAUA,MAAM,yBACJ,UAAsC,CAAC,GACjB;AACtB,UAAM,EAAE,oBAAoB,MAAM,gBAAgB,IAAI;AAEtD,QAAI,UACF,qBACA,0BACA;AAEF,QAAI,oBAAoB,QAAW;AACjC,YAAM,gBAAgB,KAAK,gBAAgB;AAAA,QACzC;AAAA,QACA;AAAA,MACF;AACA,iCAA2B,cAAc,cAAc,YAAY;AAEnE,uBAAiB,oBAAoB,cAAc,cAAc,OAAO;AAExE,UAAI;AACF,cAAM,SAAS,MAAM,KAAK,gBAAgB;AAAA,UACxC;AAAA,UACA;AAAA,QACF;AACA,8BAAsB,UAAU;AAAA,MAClC,QAAQ;AACN,8BAAsB;AAAA,MACxB;AACA,iBAAW,IAAI,SAAS,cAAc,QAAQ;AAAA,IAChD;AAEA,4BAAa,KAAK;AAElB,4DACE,KAAK,2CAA2C;AAElD,wCAAmB,oBAAoB,KAAK,cAAc;AAE1D,QAAI;AACF,oDAAwB,MAAM,KAAK,wBAAwB;AAAA,IAC7D,SAAS,GAAG;AACV,cAAQ,MAAM,CAAC;AACf,oDAAwB;AAAA,IAC1B;AAEA,UAAM,qBAAqB,MAAM,4BAA4B;AAAA,MAC3D;AAAA,MACA;AAAA,MACA;AAAA,MACA,sBAAsB,KAAK,mBAAmB;AAAA,QAC5C;AAAA,QACA,GAAG,cAAc;AAAA,MACnB;AAAA,MACA;AAAA,MACA,iCAAiC,KAAK,kBAAkB;AAAA,QACtD;AAAA,QACA,GAAG,cAAc;AAAA,MACnB;AAAA,MACA;AAAA,MACA;AAAA,MACA,UAAU,KAAK;AAAA,MACf;AAAA,MACA,0BAA0B,KAAK,MAAM;AAAA,IACvC,CAAC;AAED,QAAI,mBAAmB;AACrB,YAAM,UAAU,MAAM,cAAc;AACpC,WAAK,OAAO,CAAC,UAAU;AACrB,YAAI,KAAK,mBAAmB,SAAS;AACnC,gBAAM,kBAAkB,mBAAmB;AAC3C,gBAAM,4BACJ,mBAAmB;AACrB,gBAAM,kBAAkB,mBAAmB;AAAA,QAC7C;AACA,cAAM,6BAAN,MAAM,2BAA6B,CAAC;AACpC,cAAM,yBAAyB,OAAO,IAAI;AAAA,UACxC,iBAAiB,mBAAmB;AAAA,UACpC,2BACE,mBAAmB;AAAA,UACrB,iBAAiB,mBAAmB;AAAA,QACtC;AAAA,MACF,CAAC;AAAA,IACH;AAEA,WAAO;AAAA,EACT;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAOA,iBAAiB,WAAmB;AAClC,SAAK,WAAW,OAAO,SAAS;AAChC,QAAI,KAAK,WAAW,SAAS,GAAG;AAC9B,WAAK,YAAY;AAAA,IACnB;AAAA,EACF;AAAA,EAEA,cAAc;AACZ,QAAI,KAAK,YAAY;AACnB,oBAAc,KAAK,UAAU;AAAA,IAC/B;AACA,SAAK,WAAW,MAAM;AACtB,SAAK,WAAW;AAAA,EAClB;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAOS,UAAU;AACjB,UAAM,QAAQ;AACd,SAAK,YAAY;AAAA,EACnB;AAAA,EAEQ,QAAQ;AACd,QAAI,KAAK,YAAY;AACnB,oBAAc,KAAK,UAAU;AAAA,IAC/B;AAEA,SAAK,aAAa,YAAY,YAAY;AACxC,YAAM,cAAc,MAAM,KAAK,yBAAyB,CAAC;AAAA,IAC3D,GAAG,KAAK,aAAa;AAAA,EACvB;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EASA,MAAM,aAAa,iBAAwC;AACzD,UAAM,KAAK,yBAAyB,EAAE,gBAAgB,CAAC;AAAA,EACzD;AAAA,EAEQ,aAAa;AACnB,SAAK,OAAO,MAAM;AAChB,aAAO;AAAA,IACT,CAAC;AAAA,EACH;AAAA,EAEA,MAAc,0BAA0B;AACtC,UAAM,oCACJ,MAAM,KAAK,sCAAsC;AACnD,UAAM,oCACJ,KAAK,wCAAwC,KAAK;AAEpD,WACE,qCAAqC;AAAA,EAEzC;AAAA,EAEA,gBACE,sBACA,cACmD;AACnD,QACE,CAAC,KAAK,MAAM,mBACZ,KAAK,MAAM,oBAAoB,mBAAmB,YAClD;AACA,aAAO,CAAC;AAAA,IACV;AACA,WAAO;AAAA,MACL;AAAA,MACA;AAAA,MACA,KAAK,MAAM;AAAA,IACb;AAAA,EACF;AAAA,EAaA,yBAAyB;AACvB,SAAK,OAAO,CAAC,UAAU;AACrB,YAAM,2BAA2B;AAAA,IACnC,CAAC;AAAA,EACH;AAAA,EAEA,0BAA0B;AACxB,SAAK,OAAO,CAAC,UAAU;AACrB,YAAM,2BAA2B;AAAA,IACnC,CAAC;AAAA,EACH;AACF;AArUE;AA+SM;AAAA,kCAA6B,eAAC,wBAAsC;AACxE,QAAM,aAAa,uBAAuB,eAAe;AAEzD,MAAI,eAAe,KAAK,gBAAgB;AACtC,SAAK,WAAW,IAAI,SAAS,mBAAK,cAAL,UAAmB;AAChD,UAAM,KAAK,aAAa;AAExB,SAAK,iBAAiB;AAAA,EACxB;AACF;AAeF,IAAO,2BAAQ;;;ACviBf,eAAO,4BACL,MAC6B;AAC7B,MAAI;AACF,WAAO,MAAM,2BAA2B,IAAI;AAAA,EAC9C,SAAS,OAAO;AACd,QAAI,iBAAiB,OAAO;AAC1B,YAAM,IAAI;AAAA,QACR,6CAA6C,MAAM,OAAO;AAAA,MAC5D;AAAA,IACF;AAEA,UAAM;AAAA,EACR;AACF;AAOA,eAAe,2BACb,SAC6B;AAC7B,QAAM;AAAA,IACJ;AAAA,IACA;AAAA,IACA;AAAA,EACF,IAAI;AAEJ,MAAI;AACF,QAAI,uBAAuB,CAAC,0BAA0B;AACpD,aAAO,MAAM,mCAAmC,OAAO;AAAA,IACzD;AAEA,QAAI,4BAA4B,CAAC,0BAA0B;AACzD,aAAO,MAAM,gCAAgC,OAAO;AAAA,IACtD;AAEA,UAAM,IAAI,MAAM,oDAAoD;AAAA,EACtE,QAAQ;AACN,WAAO,MAAM,0BAA0B,OAAO;AAAA,EAChD;AACF;AAOA,eAAe,mCACb,SAC6B;AAC7B,QAAM;AAAA,IACJ,mBAAAA;AAAA,IACA;AAAA,IACA;AAAA,IACA,uBAAAC;AAAA,EACF,IAAI;AAEJ,QAAM,YAAY,MAAMD,mBAAkB,sBAAsB,QAAQ;AAExE,QAAM,EAAE,+BAA+B,sBAAsB,IAC3D,UAAU;AAEZ,QAAM,4BAA4BC;AAAA,IAChC;AAAA,IACA;AAAA,IACA;AAAA,EACF;AAEA,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB;AAAA,IACA,iBAAiB,mBAAmB;AAAA,EACtC;AACF;AAOA,eAAe,gCACb,SAC6B;AAC7B,QAAM;AAAA,IACJ,8BAAAC;AAAA,IACA;AAAA,IACA;AAAA,EACF,IAAI;AAEJ,QAAM,YAAY,MAAMA;AAAA,IACtB;AAAA,IACA;AAAA,EACF;AAEA,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB,2BAA2B,CAAC;AAAA,IAC5B,iBAAiB,mBAAmB;AAAA,EACtC;AACF;AAOA,eAAe,0BACb,SAC6B;AAC7B,QAAM,EAAE,UAAU,0BAAAC,0BAAyB,IAAI;AAE/C,QAAM,YAAY,MAAMA,0BAAyB,QAAQ;AAEzD,SAAO;AAAA,IACL,iBAAiB;AAAA,IACjB,2BAA2B,CAAC;AAAA,IAC5B,iBAAiB,mBAAmB;AAAA,EACtC;AACF","sourcesContent":["import type {\n  ControllerGetStateAction,\n  ControllerStateChangeEvent,\n  RestrictedControllerMessenger,\n} from '@metamask/base-controller';\nimport {\n  convertHexToDecimal,\n  safelyExecute,\n  toHex,\n} from '@metamask/controller-utils';\nimport EthQuery from '@metamask/eth-query';\nimport type {\n  NetworkClientId,\n  NetworkControllerGetEIP1559CompatibilityAction,\n  NetworkControllerGetNetworkClientByIdAction,\n  NetworkControllerGetStateAction,\n  NetworkControllerNetworkDidChangeEvent,\n  NetworkState,\n  ProviderProxy,\n} from '@metamask/network-controller';\nimport { StaticIntervalPollingController } from '@metamask/polling-controller';\nimport type { Hex } from '@metamask/utils';\nimport { v1 as random } from 'uuid';\n\nimport determineGasFeeCalculations from './determineGasFeeCalculations';\nimport {\n  fetchGasEstimates,\n  fetchLegacyGasPriceEstimates,\n  fetchEthGasPriceEstimate,\n  calculateTimeEstimate,\n} from './gas-util';\n\nexport const LEGACY_GAS_PRICES_API_URL = `https://api.metaswap.codefi.network/gasPrices`;\n\nexport type unknownString = 'unknown';\n\n// Fee Market describes the way gas is set after the london hardfork, and was\n// defined by EIP-1559.\nexport type FeeMarketEstimateType = 'fee-market';\n// Legacy describes gasPrice estimates from before london hardfork, when the\n// user is connected to mainnet and are presented with fast/average/slow\n// estimate levels to choose from.\nexport type LegacyEstimateType = 'legacy';\n// EthGasPrice describes a gasPrice estimate received from eth_gasPrice. Post\n// london this value should only be used for legacy type transactions when on\n// networks that support EIP-1559. This type of estimate is the most accurate\n// to display on custom networks that don't support EIP-1559.\nexport type EthGasPriceEstimateType = 'eth_gasPrice';\n// NoEstimate describes the state of the controller before receiving its first\n// estimate.\nexport type NoEstimateType = 'none';\n\n/**\n * Indicates which type of gasEstimate the controller is currently returning.\n * This is useful as a way of asserting that the shape of gasEstimates matches\n * expectations. NONE is a special case indicating that no previous gasEstimate\n * has been fetched.\n */\nexport const GAS_ESTIMATE_TYPES = {\n  FEE_MARKET: 'fee-market' as FeeMarketEstimateType,\n  LEGACY: 'legacy' as LegacyEstimateType,\n  ETH_GASPRICE: 'eth_gasPrice' as EthGasPriceEstimateType,\n  NONE: 'none' as NoEstimateType,\n};\n\nexport type GasEstimateType =\n  | FeeMarketEstimateType\n  | EthGasPriceEstimateType\n  | LegacyEstimateType\n  | NoEstimateType;\n\nexport type EstimatedGasFeeTimeBounds = {\n  lowerTimeBound: number | null;\n  upperTimeBound: number | unknownString;\n};\n\n/**\n * @type EthGasPriceEstimate\n *\n * A single gas price estimate for networks and accounts that don't support EIP-1559\n * This estimate comes from eth_gasPrice but is converted to dec gwei to match other\n * return values\n * @property gasPrice - A GWEI dec string\n */\n\nexport type EthGasPriceEstimate = {\n  gasPrice: string;\n};\n\n/**\n * @type LegacyGasPriceEstimate\n *\n * A set of gas price estimates for networks and accounts that don't support EIP-1559\n * These estimates include low, medium and high all as strings representing gwei in\n * decimal format.\n * @property high - gasPrice, in decimal gwei string format, suggested for fast inclusion\n * @property medium - gasPrice, in decimal gwei string format, suggested for avg inclusion\n * @property low - gasPrice, in decimal gwei string format, suggested for slow inclusion\n */\nexport type LegacyGasPriceEstimate = {\n  high: string;\n  medium: string;\n  low: string;\n};\n\n/**\n * @type Eip1559GasFee\n *\n * Data necessary to provide an estimate of a gas fee with a specific tip\n * @property minWaitTimeEstimate - The fastest the transaction will take, in milliseconds\n * @property maxWaitTimeEstimate - The slowest the transaction will take, in milliseconds\n * @property suggestedMaxPriorityFeePerGas - A suggested \"tip\", a GWEI hex number\n * @property suggestedMaxFeePerGas - A suggested max fee, the most a user will pay. a GWEI hex number\n */\nexport type Eip1559GasFee = {\n  minWaitTimeEstimate: number; // a time duration in milliseconds\n  maxWaitTimeEstimate: number; // a time duration in milliseconds\n  suggestedMaxPriorityFeePerGas: string; // a GWEI decimal number\n  suggestedMaxFeePerGas: string; // a GWEI decimal number\n};\n\n/**\n * @type GasFeeEstimates\n *\n * Data necessary to provide multiple GasFee estimates, and supporting information, to the user\n * @property low - A GasFee for a minimum necessary combination of tip and maxFee\n * @property medium - A GasFee for a recommended combination of tip and maxFee\n * @property high - A GasFee for a high combination of tip and maxFee\n * @property estimatedBaseFee - An estimate of what the base fee will be for the pending/next block. A GWEI dec number\n * @property networkCongestion - A normalized number that can be used to gauge the congestion\n * level of the network, with 0 meaning not congested and 1 meaning extremely congested\n */\nexport type GasFeeEstimates = SourcedGasFeeEstimates | FallbackGasFeeEstimates;\n\ntype SourcedGasFeeEstimates = {\n  low: Eip1559GasFee;\n  medium: Eip1559GasFee;\n  high: Eip1559GasFee;\n  estimatedBaseFee: string;\n  historicalBaseFeeRange: [string, string];\n  baseFeeTrend: 'up' | 'down' | 'level';\n  latestPriorityFeeRange: [string, string];\n  historicalPriorityFeeRange: [string, string];\n  priorityFeeTrend: 'up' | 'down' | 'level';\n  networkCongestion: number;\n};\n\ntype FallbackGasFeeEstimates = {\n  low: Eip1559GasFee;\n  medium: Eip1559GasFee;\n  high: Eip1559GasFee;\n  estimatedBaseFee: string;\n  historicalBaseFeeRange: null;\n  baseFeeTrend: null;\n  latestPriorityFeeRange: null;\n  historicalPriorityFeeRange: null;\n  priorityFeeTrend: null;\n  networkCongestion: null;\n};\n\nconst metadata = {\n  gasFeeEstimatesByChainId: {\n    persist: true,\n    anonymous: false,\n  },\n  gasFeeEstimates: { persist: true, anonymous: false },\n  estimatedGasFeeTimeBounds: { persist: true, anonymous: false },\n  gasEstimateType: { persist: true, anonymous: false },\n  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false },\n};\n\nexport type GasFeeStateEthGasPrice = {\n  gasFeeEstimates: EthGasPriceEstimate;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: EthGasPriceEstimateType;\n};\n\nexport type GasFeeStateFeeMarket = {\n  gasFeeEstimates: GasFeeEstimates;\n  estimatedGasFeeTimeBounds: EstimatedGasFeeTimeBounds | Record<string, never>;\n  gasEstimateType: FeeMarketEstimateType;\n};\n\nexport type GasFeeStateLegacy = {\n  gasFeeEstimates: LegacyGasPriceEstimate;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: LegacyEstimateType;\n};\n\nexport type GasFeeStateNoEstimates = {\n  gasFeeEstimates: Record<string, never>;\n  estimatedGasFeeTimeBounds: Record<string, never>;\n  gasEstimateType: NoEstimateType;\n};\n\nexport type FetchGasFeeEstimateOptions = {\n  shouldUpdateState?: boolean;\n  networkClientId?: NetworkClientId;\n};\n\n/**\n * @type GasFeeState\n *\n * Gas Fee controller state\n * @property gasFeeEstimates - Gas fee estimate data based on new EIP-1559 properties\n * @property estimatedGasFeeTimeBounds - Estimates representing the minimum and maximum\n */\nexport type SingleChainGasFeeState =\n  | GasFeeStateEthGasPrice\n  | GasFeeStateFeeMarket\n  | GasFeeStateLegacy\n  | GasFeeStateNoEstimates;\n\nexport type GasFeeEstimatesByChainId = {\n  gasFeeEstimatesByChainId?: Record<string, SingleChainGasFeeState>;\n};\n\nexport type GasFeeState = GasFeeEstimatesByChainId &\n  SingleChainGasFeeState & {\n    nonRPCGasFeeApisDisabled?: boolean;\n  };\n\nconst name = 'GasFeeController';\n\nexport type GasFeeStateChange = ControllerStateChangeEvent<\n  typeof name,\n  GasFeeState\n>;\n\nexport type GetGasFeeState = ControllerGetStateAction<typeof name, GasFeeState>;\n\nexport type GasFeeControllerActions = GetGasFeeState;\n\nexport type GasFeeControllerEvents = GasFeeStateChange;\n\ntype AllowedActions =\n  | NetworkControllerGetStateAction\n  | NetworkControllerGetNetworkClientByIdAction\n  | NetworkControllerGetEIP1559CompatibilityAction;\n\ntype GasFeeMessenger = RestrictedControllerMessenger<\n  typeof name,\n  GasFeeControllerActions | AllowedActions,\n  GasFeeControllerEvents | NetworkControllerNetworkDidChangeEvent,\n  AllowedActions['type'],\n  NetworkControllerNetworkDidChangeEvent['type']\n>;\n\nconst defaultState: GasFeeState = {\n  gasFeeEstimatesByChainId: {},\n  gasFeeEstimates: {},\n  estimatedGasFeeTimeBounds: {},\n  gasEstimateType: GAS_ESTIMATE_TYPES.NONE,\n  nonRPCGasFeeApisDisabled: false,\n};\n\n/**\n * Controller that retrieves gas fee estimate data and polls for updated data on a set interval\n */\nexport class GasFeeController extends StaticIntervalPollingController<\n  typeof name,\n  GasFeeState,\n  GasFeeMessenger\n> {\n  private intervalId?: ReturnType<typeof setTimeout>;\n\n  private readonly intervalDelay;\n\n  private readonly pollTokens: Set<string>;\n\n  private readonly legacyAPIEndpoint: string;\n\n  private readonly EIP1559APIEndpoint: string;\n\n  private readonly getCurrentNetworkEIP1559Compatibility;\n\n  private readonly getCurrentNetworkLegacyGasAPICompatibility;\n\n  private readonly getCurrentAccountEIP1559Compatibility;\n\n  private currentChainId;\n\n  private ethQuery?: EthQuery;\n\n  private readonly clientId?: string;\n\n  #getProvider: () => ProviderProxy;\n\n  /**\n   * Creates a GasFeeController instance.\n   *\n   * @param options - The controller options.\n   * @param options.interval - The time in milliseconds to wait between polls.\n   * @param options.messenger - The controller messenger.\n   * @param options.state - The initial state.\n   * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current\n   * network is EIP-1559 compatible.\n   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the\n   * current network is compatible with the legacy gas price API.\n   * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current\n   * account is EIP-1559 compatible.\n   * @param options.getChainId - Returns the current chain ID.\n   * @param options.getProvider - Returns a network provider for the current network.\n   * @param options.onNetworkDidChange - A function for registering an event handler for the\n   * network state change event.\n   * @param options.legacyAPIEndpoint - The legacy gas price API URL. This option is primarily for\n   * testing purposes.\n   * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL.\n   * @param options.clientId - The client ID used to identify to the gas estimation API who is\n   * asking for estimates.\n   */\n  constructor({\n    interval = 15000,\n    messenger,\n    state,\n    getCurrentNetworkEIP1559Compatibility,\n    getCurrentAccountEIP1559Compatibility,\n    getChainId,\n    getCurrentNetworkLegacyGasAPICompatibility,\n    getProvider,\n    onNetworkDidChange,\n    legacyAPIEndpoint = LEGACY_GAS_PRICES_API_URL,\n    EIP1559APIEndpoint,\n    clientId,\n  }: {\n    interval?: number;\n    messenger: GasFeeMessenger;\n    state?: GasFeeState;\n    getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;\n    getCurrentNetworkLegacyGasAPICompatibility: () => boolean;\n    getCurrentAccountEIP1559Compatibility?: () => boolean;\n    getChainId?: () => Hex;\n    getProvider: () => ProviderProxy;\n    onNetworkDidChange?: (listener: (state: NetworkState) => void) => void;\n    legacyAPIEndpoint?: string;\n    // eslint-disable-next-line @typescript-eslint/naming-convention\n    EIP1559APIEndpoint: string;\n    clientId?: string;\n  }) {\n    super({\n      name,\n      metadata,\n      messenger,\n      state: { ...defaultState, ...state },\n    });\n    this.intervalDelay = interval;\n    this.setIntervalLength(interval);\n    this.pollTokens = new Set();\n    this.getCurrentNetworkEIP1559Compatibility =\n      getCurrentNetworkEIP1559Compatibility;\n    this.getCurrentNetworkLegacyGasAPICompatibility =\n      getCurrentNetworkLegacyGasAPICompatibility;\n    this.getCurrentAccountEIP1559Compatibility =\n      getCurrentAccountEIP1559Compatibility;\n    this.#getProvider = getProvider;\n    this.EIP1559APIEndpoint = EIP1559APIEndpoint;\n    this.legacyAPIEndpoint = legacyAPIEndpoint;\n    this.clientId = clientId;\n\n    this.ethQuery = new EthQuery(this.#getProvider());\n\n    if (onNetworkDidChange && getChainId) {\n      this.currentChainId = getChainId();\n      onNetworkDidChange(async (networkControllerState) => {\n        await this.#onNetworkControllerDidChange(networkControllerState);\n      });\n    } else {\n      this.currentChainId = this.messagingSystem.call(\n        'NetworkController:getState',\n      ).providerConfig.chainId;\n      this.messagingSystem.subscribe(\n        'NetworkController:networkDidChange',\n        async (networkControllerState) => {\n          await this.#onNetworkControllerDidChange(networkControllerState);\n        },\n      );\n    }\n  }\n\n  async resetPolling() {\n    if (this.pollTokens.size !== 0) {\n      const tokens = Array.from(this.pollTokens);\n      this.stopPolling();\n      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);\n      tokens.slice(1).forEach((token) => {\n        this.pollTokens.add(token);\n      });\n    }\n  }\n\n  async fetchGasFeeEstimates(options?: FetchGasFeeEstimateOptions) {\n    return await this._fetchGasFeeEstimateData(options);\n  }\n\n  async getGasFeeEstimatesAndStartPolling(\n    pollToken: string | undefined,\n  ): Promise<string> {\n    const _pollToken = pollToken || random();\n\n    this.pollTokens.add(_pollToken);\n\n    if (this.pollTokens.size === 1) {\n      await this._fetchGasFeeEstimateData();\n      this._poll();\n    }\n\n    return _pollToken;\n  }\n\n  /**\n   * Gets and sets gasFeeEstimates in state.\n   *\n   * @param options - The gas fee estimate options.\n   * @param options.shouldUpdateState - Determines whether the state should be updated with the\n   * updated gas estimates.\n   * @returns The gas fee estimates.\n   */\n  async _fetchGasFeeEstimateData(\n    options: FetchGasFeeEstimateOptions = {},\n  ): Promise<GasFeeState> {\n    const { shouldUpdateState = true, networkClientId } = options;\n\n    let ethQuery,\n      isEIP1559Compatible,\n      isLegacyGasAPICompatible,\n      decimalChainId: number;\n\n    if (networkClientId !== undefined) {\n      const networkClient = this.messagingSystem.call(\n        'NetworkController:getNetworkClientById',\n        networkClientId,\n      );\n      isLegacyGasAPICompatible = networkClient.configuration.chainId === '0x38';\n\n      decimalChainId = convertHexToDecimal(networkClient.configuration.chainId);\n\n      try {\n        const result = await this.messagingSystem.call(\n          'NetworkController:getEIP1559Compatibility',\n          networkClientId,\n        );\n        isEIP1559Compatible = result || false;\n      } catch {\n        isEIP1559Compatible = false;\n      }\n      ethQuery = new EthQuery(networkClient.provider);\n    }\n\n    ethQuery ??= this.ethQuery;\n\n    isLegacyGasAPICompatible ??=\n      this.getCurrentNetworkLegacyGasAPICompatibility();\n\n    decimalChainId ??= convertHexToDecimal(this.currentChainId);\n\n    try {\n      isEIP1559Compatible ??= await this.getEIP1559Compatibility();\n    } catch (e) {\n      console.error(e);\n      isEIP1559Compatible ??= false;\n    }\n\n    const gasFeeCalculations = await determineGasFeeCalculations({\n      isEIP1559Compatible,\n      isLegacyGasAPICompatible,\n      fetchGasEstimates,\n      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(\n        '<chain_id>',\n        `${decimalChainId}`,\n      ),\n      fetchLegacyGasPriceEstimates,\n      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(\n        '<chain_id>',\n        `${decimalChainId}`,\n      ),\n      fetchEthGasPriceEstimate,\n      calculateTimeEstimate,\n      clientId: this.clientId,\n      ethQuery,\n      nonRPCGasFeeApisDisabled: this.state.nonRPCGasFeeApisDisabled,\n    });\n\n    if (shouldUpdateState) {\n      const chainId = toHex(decimalChainId);\n      this.update((state) => {\n        if (this.currentChainId === chainId) {\n          state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;\n          state.estimatedGasFeeTimeBounds =\n            gasFeeCalculations.estimatedGasFeeTimeBounds;\n          state.gasEstimateType = gasFeeCalculations.gasEstimateType;\n        }\n        state.gasFeeEstimatesByChainId ??= {};\n        state.gasFeeEstimatesByChainId[chainId] = {\n          gasFeeEstimates: gasFeeCalculations.gasFeeEstimates,\n          estimatedGasFeeTimeBounds:\n            gasFeeCalculations.estimatedGasFeeTimeBounds,\n          gasEstimateType: gasFeeCalculations.gasEstimateType,\n        } as SingleChainGasFeeState;\n      });\n    }\n\n    return gasFeeCalculations;\n  }\n\n  /**\n   * Remove the poll token, and stop polling if the set of poll tokens is empty.\n   *\n   * @param pollToken - The poll token to disconnect.\n   */\n  disconnectPoller(pollToken: string) {\n    this.pollTokens.delete(pollToken);\n    if (this.pollTokens.size === 0) {\n      this.stopPolling();\n    }\n  }\n\n  stopPolling() {\n    if (this.intervalId) {\n      clearInterval(this.intervalId);\n    }\n    this.pollTokens.clear();\n    this.resetState();\n  }\n\n  /**\n   * Prepare to discard this controller.\n   *\n   * This stops any active polling.\n   */\n  override destroy() {\n    super.destroy();\n    this.stopPolling();\n  }\n\n  private _poll() {\n    if (this.intervalId) {\n      clearInterval(this.intervalId);\n    }\n\n    this.intervalId = setInterval(async () => {\n      await safelyExecute(() => this._fetchGasFeeEstimateData());\n    }, this.intervalDelay);\n  }\n\n  /**\n   * Fetching token list from the Token Service API.\n   *\n   * @private\n   * @param networkClientId - The ID of the network client triggering the fetch.\n   * @returns A promise that resolves when this operation completes.\n   */\n  async _executePoll(networkClientId: string): Promise<void> {\n    await this._fetchGasFeeEstimateData({ networkClientId });\n  }\n\n  private resetState() {\n    this.update(() => {\n      return defaultState;\n    });\n  }\n\n  private async getEIP1559Compatibility() {\n    const currentNetworkIsEIP1559Compatible =\n      await this.getCurrentNetworkEIP1559Compatibility();\n    const currentAccountIsEIP1559Compatible =\n      this.getCurrentAccountEIP1559Compatibility?.() ?? true;\n\n    return (\n      currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible\n    );\n  }\n\n  getTimeEstimate(\n    maxPriorityFeePerGas: string,\n    maxFeePerGas: string,\n  ): EstimatedGasFeeTimeBounds | Record<string, never> {\n    if (\n      !this.state.gasFeeEstimates ||\n      this.state.gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET\n    ) {\n      return {};\n    }\n    return calculateTimeEstimate(\n      maxPriorityFeePerGas,\n      maxFeePerGas,\n      this.state.gasFeeEstimates,\n    );\n  }\n\n  async #onNetworkControllerDidChange(networkControllerState: NetworkState) {\n    const newChainId = networkControllerState.providerConfig.chainId;\n\n    if (newChainId !== this.currentChainId) {\n      this.ethQuery = new EthQuery(this.#getProvider());\n      await this.resetPolling();\n\n      this.currentChainId = newChainId;\n    }\n  }\n\n  enableNonRPCGasFeeApis() {\n    this.update((state) => {\n      state.nonRPCGasFeeApisDisabled = false;\n    });\n  }\n\n  disableNonRPCGasFeeApis() {\n    this.update((state) => {\n      state.nonRPCGasFeeApisDisabled = true;\n    });\n  }\n}\n\nexport default GasFeeController;\n","import type {\n  EstimatedGasFeeTimeBounds,\n  EthGasPriceEstimate,\n  GasFeeEstimates,\n  GasFeeState as GasFeeCalculations,\n  LegacyGasPriceEstimate,\n} from './GasFeeController';\nimport { GAS_ESTIMATE_TYPES } from './GasFeeController';\n\ntype DetermineGasFeeCalculationsRequest = {\n  isEIP1559Compatible: boolean;\n  isLegacyGasAPICompatible: boolean;\n  fetchGasEstimates: (\n    url: string,\n    clientId?: string,\n  ) => Promise<GasFeeEstimates>;\n  fetchGasEstimatesUrl: string;\n  fetchLegacyGasPriceEstimates: (\n    url: string,\n    clientId?: string,\n  ) => Promise<LegacyGasPriceEstimate>;\n  fetchLegacyGasPriceEstimatesUrl: string;\n  // TODO: Replace `any` with type\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\n  fetchEthGasPriceEstimate: (ethQuery: any) => Promise<EthGasPriceEstimate>;\n  calculateTimeEstimate: (\n    maxPriorityFeePerGas: string,\n    maxFeePerGas: string,\n    gasFeeEstimates: GasFeeEstimates,\n  ) => EstimatedGasFeeTimeBounds;\n  clientId: string | undefined;\n  // TODO: Replace `any` with type\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\n  ethQuery: any;\n  nonRPCGasFeeApisDisabled?: boolean;\n};\n\n/**\n * Obtains a set of max base and priority fee estimates along with time estimates so that we\n * can present them to users when they are sending transactions or making swaps.\n *\n * @param args - The arguments.\n * @param args.isEIP1559Compatible - Governs whether or not we can use an EIP-1559-only method to\n * produce estimates.\n * @param args.isLegacyGasAPICompatible - Governs whether or not we can use a non-EIP-1559 method to\n * produce estimates (for instance, testnets do not support estimates altogether).\n * @param args.fetchGasEstimates - A function that fetches gas estimates using an EIP-1559-specific\n * API.\n * @param args.fetchGasEstimatesUrl - The URL for the API we can use to obtain EIP-1559-specific\n * estimates.\n * @param args.fetchLegacyGasPriceEstimates - A function that fetches gas estimates using an\n * non-EIP-1559-specific API.\n * @param args.fetchLegacyGasPriceEstimatesUrl - The URL for the API we can use to obtain\n * non-EIP-1559-specific estimates.\n * @param args.fetchEthGasPriceEstimate - A function that fetches gas estimates using\n * `eth_gasPrice`.\n * @param args.calculateTimeEstimate - A function that determine time estimate bounds.\n * @param args.clientId - An identifier that an API can use to know who is asking for estimates.\n * @param args.ethQuery - An EthQuery instance we can use to talk to Ethereum directly.\n * @param args.nonRPCGasFeeApisDisabled - Whether to disable requests to the legacyAPIEndpoint and the EIP1559APIEndpoint\n * @returns The gas fee calculations.\n */\nexport default async function determineGasFeeCalculations(\n  args: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  try {\n    return await getEstimatesUsingFallbacks(args);\n  } catch (error) {\n    if (error instanceof Error) {\n      throw new Error(\n        `Gas fee/price estimation failed. Message: ${error.message}`,\n      );\n    }\n\n    throw error;\n  }\n}\n\n/**\n * Retrieve the gas fee estimates using a series of fallback mechanisms.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingFallbacks(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    isEIP1559Compatible,\n    isLegacyGasAPICompatible,\n    nonRPCGasFeeApisDisabled,\n  } = request;\n\n  try {\n    if (isEIP1559Compatible && !nonRPCGasFeeApisDisabled) {\n      return await getEstimatesUsingFeeMarketEndpoint(request);\n    }\n\n    if (isLegacyGasAPICompatible && !nonRPCGasFeeApisDisabled) {\n      return await getEstimatesUsingLegacyEndpoint(request);\n    }\n\n    throw new Error('Main gas fee/price estimation failed. Use fallback');\n  } catch {\n    return await getEstimatesUsingProvider(request);\n  }\n}\n\n/**\n * Retrieve gas fee estimates using the EIP-1559 endpoint of the gas API.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingFeeMarketEndpoint(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    fetchGasEstimates,\n    fetchGasEstimatesUrl,\n    clientId,\n    calculateTimeEstimate,\n  } = request;\n\n  const estimates = await fetchGasEstimates(fetchGasEstimatesUrl, clientId);\n\n  const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } =\n    estimates.medium;\n\n  const estimatedGasFeeTimeBounds = calculateTimeEstimate(\n    suggestedMaxPriorityFeePerGas,\n    suggestedMaxFeePerGas,\n    estimates,\n  );\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds,\n    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,\n  };\n}\n\n/**\n * Retrieve gas fee estimates using the legacy endpoint of the gas API.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingLegacyEndpoint(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const {\n    fetchLegacyGasPriceEstimates,\n    fetchLegacyGasPriceEstimatesUrl,\n    clientId,\n  } = request;\n\n  const estimates = await fetchLegacyGasPriceEstimates(\n    fetchLegacyGasPriceEstimatesUrl,\n    clientId,\n  );\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds: {},\n    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,\n  };\n}\n\n/**\n * Retrieve gas fee estimates using an `eth_gasPrice` call to the RPC provider.\n * @param request - The request object.\n * @returns The gas fee estimates.\n */\nasync function getEstimatesUsingProvider(\n  request: DetermineGasFeeCalculationsRequest,\n): Promise<GasFeeCalculations> {\n  const { ethQuery, fetchEthGasPriceEstimate } = request;\n\n  const estimates = await fetchEthGasPriceEstimate(ethQuery);\n\n  return {\n    gasFeeEstimates: estimates,\n    estimatedGasFeeTimeBounds: {},\n    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,\n  };\n}\n"]}
+\ No newline at end of file
+diff --git a/dist/determineGasFeeCalculations.js b/dist/determineGasFeeCalculations.js
+index 87f583d091e574fc81b84ce35ee4b9979dbabdf6..ccfd460054f0affdec3857d8ec0015fe5c0814cb 100644
+--- a/dist/determineGasFeeCalculations.js
++++ b/dist/determineGasFeeCalculations.js
+@@ -1,8 +1,8 @@
+ "use strict";Object.defineProperty(exports, "__esModule", {value: true});
+
+-var _chunkH5WHAYLIjs = require('./chunk-H5WHAYLI.js');
+-require('./chunk-Q2YPK5SL.js');
++var _chunkX74LQX2Yjs = require('./chunk-X74LQX2Y.js');
++require('./chunk-2MFVV2BX.js');
+
+
+-exports.default = _chunkH5WHAYLIjs.determineGasFeeCalculations;
++exports.default = _chunkX74LQX2Yjs.determineGasFeeCalculations;
+ //# sourceMappingURL=determineGasFeeCalculations.js.map
+\ No newline at end of file
+diff --git a/dist/determineGasFeeCalculations.mjs b/dist/determineGasFeeCalculations.mjs
+index b372041262f1d8372632922919f52aa2c6c5ee89..e5b349a8f349076b85481dceec5795b07aeb19ca 100644
+--- a/dist/determineGasFeeCalculations.mjs
++++ b/dist/determineGasFeeCalculations.mjs
+@@ -1,7 +1,7 @@
+ import {
+   determineGasFeeCalculations
+-} from "./chunk-BEVZS3YV.mjs";
+-import "./chunk-KORLXV32.mjs";
++} from "./chunk-A7NHJBXX.mjs";
++import "./chunk-R3IOI7AK.mjs";
+ export {
+   determineGasFeeCalculations as default
+ };
+diff --git a/dist/gas-util.js b/dist/gas-util.js
+index 74c93749878df29b40eea3d998d26d734112d75c..aad155e1a969ac01a09f8e18becac39a79860199 100644
+--- a/dist/gas-util.js
++++ b/dist/gas-util.js
+@@ -4,12 +4,12 @@
+
+
+
+-var _chunkQ2YPK5SLjs = require('./chunk-Q2YPK5SL.js');
++var _chunk2MFVV2BXjs = require('./chunk-2MFVV2BX.js');
+
+
+
+
+
+
+-exports.calculateTimeEstimate = _chunkQ2YPK5SLjs.calculateTimeEstimate; exports.fetchEthGasPriceEstimate = _chunkQ2YPK5SLjs.fetchEthGasPriceEstimate; exports.fetchGasEstimates = _chunkQ2YPK5SLjs.fetchGasEstimates; exports.fetchLegacyGasPriceEstimates = _chunkQ2YPK5SLjs.fetchLegacyGasPriceEstimates; exports.normalizeGWEIDecimalNumbers = _chunkQ2YPK5SLjs.normalizeGWEIDecimalNumbers;
++exports.calculateTimeEstimate = _chunk2MFVV2BXjs.calculateTimeEstimate; exports.fetchEthGasPriceEstimate = _chunk2MFVV2BXjs.fetchEthGasPriceEstimate; exports.fetchGasEstimates = _chunk2MFVV2BXjs.fetchGasEstimates; exports.fetchLegacyGasPriceEstimates = _chunk2MFVV2BXjs.fetchLegacyGasPriceEstimates; exports.normalizeGWEIDecimalNumbers = _chunk2MFVV2BXjs.normalizeGWEIDecimalNumbers;
+ //# sourceMappingURL=gas-util.js.map
+\ No newline at end of file
+diff --git a/dist/gas-util.mjs b/dist/gas-util.mjs
+index c0846d32a7fe2598691c5c0bcc19ce2b8af67bc3..60f38a1b3899f0223fa7651988e57fa659e713e8 100644
+--- a/dist/gas-util.mjs
++++ b/dist/gas-util.mjs
+@@ -4,7 +4,7 @@ import {
+   fetchGasEstimates,
+   fetchLegacyGasPriceEstimates,
+   normalizeGWEIDecimalNumbers
+-} from "./chunk-KORLXV32.mjs";
++} from "./chunk-R3IOI7AK.mjs";
+ export {
+   calculateTimeEstimate,
+   fetchEthGasPriceEstimate,
+diff --git a/dist/index.js b/dist/index.js
+index 499a7d57b68212db4402be72ab8d3384a841dba0..f172d463bef0093dd477dfad74ff50d30e42a7f0 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -2,11 +2,11 @@
+
+
+
+-var _chunkH5WHAYLIjs = require('./chunk-H5WHAYLI.js');
+-require('./chunk-Q2YPK5SL.js');
++var _chunkX74LQX2Yjs = require('./chunk-X74LQX2Y.js');
++require('./chunk-2MFVV2BX.js');
+
+
+
+
+-exports.GAS_API_BASE_URL = _chunkH5WHAYLIjs.GAS_API_BASE_URL; exports.GAS_ESTIMATE_TYPES = _chunkH5WHAYLIjs.GAS_ESTIMATE_TYPES; exports.GasFeeController = _chunkH5WHAYLIjs.GasFeeController;
++exports.GAS_ESTIMATE_TYPES = _chunkX74LQX2Yjs.GAS_ESTIMATE_TYPES; exports.GasFeeController = _chunkX74LQX2Yjs.GasFeeController; exports.LEGACY_GAS_PRICES_API_URL = _chunkX74LQX2Yjs.LEGACY_GAS_PRICES_API_URL;
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 47fbe488932996ec192dd04a6b92d72c038681cc..71847186d44947ec3b2d75d142afbeede0aa64fc 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1,12 +1,12 @@
+ import {
+-  GAS_API_BASE_URL,
+   GAS_ESTIMATE_TYPES,
+-  GasFeeController
+-} from "./chunk-BEVZS3YV.mjs";
+-import "./chunk-KORLXV32.mjs";
++  GasFeeController,
++  LEGACY_GAS_PRICES_API_URL
++} from "./chunk-A7NHJBXX.mjs";
++import "./chunk-R3IOI7AK.mjs";
+ export {
+-  GAS_API_BASE_URL,
+   GAS_ESTIMATE_TYPES,
+-  GasFeeController
++  GasFeeController,
++  LEGACY_GAS_PRICES_API_URL
+ };
+ //# sourceMappingURL=index.mjs.map
+\ No newline at end of file
+diff --git a/dist/tsconfig.build.tsbuildinfo b/dist/tsconfig.build.tsbuildinfo
+index c226cf271a32a00bf6054fba381ed5f846ed9752..008d925dcefc659662cbfa15bd507ce773b8fc56 100644
+--- a/dist/tsconfig.build.tsbuildinfo
++++ b/dist/tsconfig.build.tsbuildinfo
+@@ -1 +1 @@
+-{"program":{"fileNames":["../../../node_modules/typescript/lib/lib.es5.d.ts","../../../node_modules/typescript/lib/lib.es2015.d.ts","../../../node_modules/typescript/lib/lib.es2016.d.ts","../../../node_modules/typescript/lib/lib.es2017.d.ts","../../../node_modules/typescript/lib/lib.es2018.d.ts","../../../node_modules/typescript/lib/lib.es2019.d.ts","../../../node_modules/typescript/lib/lib.es2020.d.ts","../../../node_modules/typescript/lib/lib.dom.d.ts","../../../node_modules/typescript/lib/lib.es2015.core.d.ts","../../../node_modules/typescript/lib/lib.es2015.collection.d.ts","../../../node_modules/typescript/lib/lib.es2015.generator.d.ts","../../../node_modules/typescript/lib/lib.es2015.iterable.d.ts","../../../node_modules/typescript/lib/lib.es2015.promise.d.ts","../../../node_modules/typescript/lib/lib.es2015.proxy.d.ts","../../../node_modules/typescript/lib/lib.es2015.reflect.d.ts","../../../node_modules/typescript/lib/lib.es2015.symbol.d.ts","../../../node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts","../../../node_modules/typescript/lib/lib.es2016.array.include.d.ts","../../../node_modules/typescript/lib/lib.es2017.object.d.ts","../../../node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts","../../../node_modules/typescript/lib/lib.es2017.string.d.ts","../../../node_modules/typescript/lib/lib.es2017.intl.d.ts","../../../node_modules/typescript/lib/lib.es2017.typedarrays.d.ts","../../../node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts","../../../node_modules/typescript/lib/lib.es2018.asynciterable.d.ts","../../../node_modules/typescript/lib/lib.es2018.intl.d.ts","../../../node_modules/typescript/lib/lib.es2018.promise.d.ts","../../../node_modules/typescript/lib/lib.es2018.regexp.d.ts","../../../node_modules/typescript/lib/lib.es2019.array.d.ts","../../../node_modules/typescript/lib/lib.es2019.object.d.ts","../../../node_modules/typescript/lib/lib.es2019.string.d.ts","../../../node_modules/typescript/lib/lib.es2019.symbol.d.ts","../../../node_modules/typescript/lib/lib.es2019.intl.d.ts","../../../node_modules/typescript/lib/lib.es2020.bigint.d.ts","../../../node_modules/typescript/lib/lib.es2020.date.d.ts","../../../node_modules/typescript/lib/lib.es2020.promise.d.ts","../../../node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts","../../../node_modules/typescript/lib/lib.es2020.string.d.ts","../../../node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts","../../../node_modules/typescript/lib/lib.es2020.intl.d.ts","../../../node_modules/typescript/lib/lib.es2020.number.d.ts","../../../node_modules/typescript/lib/lib.esnext.intl.d.ts","../../../types/eth-ens-namehash.d.ts","../../../types/ethereum-ens-network-map.d.ts","../../../types/global.d.ts","../../../types/single-call-balance-checker-abi.d.ts","../../../types/@metamask/contract-metadata.d.ts","../../../types/@metamask/eth-hd-keyring.d.ts","../../../types/@metamask/eth-simple-keyring.d.ts","../../../types/@metamask/ethjs-provider-http.d.ts","../../../types/@metamask/ethjs-unit.d.ts","../../../types/@metamask/metamask-eth-abis.d.ts","../../../types/eth-json-rpc-infura/src/createProvider.d.ts","../../../types/eth-phishing-detect/src/config.json.d.ts","../../../types/eth-phishing-detect/src/detector.d.ts","../../base-controller/dist/types/BaseControllerV1.d.ts","../../../node_modules/superstruct/dist/error.d.ts","../../../node_modules/superstruct/dist/utils.d.ts","../../../node_modules/superstruct/dist/struct.d.ts","../../../node_modules/superstruct/dist/structs/coercions.d.ts","../../../node_modules/superstruct/dist/structs/refinements.d.ts","../../../node_modules/superstruct/dist/structs/types.d.ts","../../../node_modules/superstruct/dist/structs/utilities.d.ts","../../../node_modules/superstruct/dist/index.d.ts","../../../node_modules/@metamask/utils/dist/types/assert.d.ts","../../../node_modules/@metamask/utils/dist/types/base64.d.ts","../../../node_modules/@metamask/utils/dist/types/hex.d.ts","../../../node_modules/@metamask/utils/dist/types/bytes.d.ts","../../../node_modules/@metamask/utils/dist/types/caip-types.d.ts","../../../node_modules/@metamask/utils/dist/types/checksum.d.ts","../../../node_modules/@metamask/utils/dist/types/coercers.d.ts","../../../node_modules/@metamask/utils/dist/types/collections.d.ts","../../../node_modules/@metamask/utils/dist/types/encryption-types.d.ts","../../../node_modules/@metamask/utils/dist/types/errors.d.ts","../../../node_modules/@metamask/utils/dist/types/json.d.ts","../../../node_modules/@types/node/assert.d.ts","../../../node_modules/@types/node/assert/strict.d.ts","../../../node_modules/@types/node/globals.d.ts","../../../node_modules/@types/node/async_hooks.d.ts","../../../node_modules/@types/node/buffer.d.ts","../../../node_modules/@types/node/child_process.d.ts","../../../node_modules/@types/node/cluster.d.ts","../../../node_modules/@types/node/console.d.ts","../../../node_modules/@types/node/constants.d.ts","../../../node_modules/@types/node/crypto.d.ts","../../../node_modules/@types/node/dgram.d.ts","../../../node_modules/@types/node/diagnostics_channel.d.ts","../../../node_modules/@types/node/dns.d.ts","../../../node_modules/@types/node/dns/promises.d.ts","../../../node_modules/@types/node/dom-events.d.ts","../../../node_modules/@types/node/domain.d.ts","../../../node_modules/@types/node/events.d.ts","../../../node_modules/@types/node/fs.d.ts","../../../node_modules/@types/node/fs/promises.d.ts","../../../node_modules/@types/node/http.d.ts","../../../node_modules/@types/node/http2.d.ts","../../../node_modules/@types/node/https.d.ts","../../../node_modules/@types/node/inspector.d.ts","../../../node_modules/@types/node/module.d.ts","../../../node_modules/@types/node/net.d.ts","../../../node_modules/@types/node/os.d.ts","../../../node_modules/@types/node/path.d.ts","../../../node_modules/@types/node/perf_hooks.d.ts","../../../node_modules/@types/node/process.d.ts","../../../node_modules/@types/node/punycode.d.ts","../../../node_modules/@types/node/querystring.d.ts","../../../node_modules/@types/node/readline.d.ts","../../../node_modules/@types/node/repl.d.ts","../../../node_modules/@types/node/stream.d.ts","../../../node_modules/@types/node/stream/promises.d.ts","../../../node_modules/@types/node/stream/consumers.d.ts","../../../node_modules/@types/node/stream/web.d.ts","../../../node_modules/@types/node/string_decoder.d.ts","../../../node_modules/@types/node/test.d.ts","../../../node_modules/@types/node/timers.d.ts","../../../node_modules/@types/node/timers/promises.d.ts","../../../node_modules/@types/node/tls.d.ts","../../../node_modules/@types/node/trace_events.d.ts","../../../node_modules/@types/node/tty.d.ts","../../../node_modules/@types/node/url.d.ts","../../../node_modules/@types/node/util.d.ts","../../../node_modules/@types/node/v8.d.ts","../../../node_modules/@types/node/vm.d.ts","../../../node_modules/@types/node/wasi.d.ts","../../../node_modules/@types/node/worker_threads.d.ts","../../../node_modules/@types/node/zlib.d.ts","../../../node_modules/@types/node/globals.global.d.ts","../../../node_modules/@types/node/index.d.ts","../../../node_modules/@ethereumjs/common/dist/enums.d.ts","../../../node_modules/@ethereumjs/common/dist/types.d.ts","../../../node_modules/buffer/index.d.ts","../../../node_modules/@ethereumjs/util/dist/constants.d.ts","../../../node_modules/@ethereumjs/util/dist/units.d.ts","../../../node_modules/@ethereumjs/util/dist/address.d.ts","../../../node_modules/@ethereumjs/util/dist/bytes.d.ts","../../../node_modules/@ethereumjs/util/dist/types.d.ts","../../../node_modules/@ethereumjs/util/dist/account.d.ts","../../../node_modules/@ethereumjs/util/dist/withdrawal.d.ts","../../../node_modules/@ethereumjs/util/dist/signature.d.ts","../../../node_modules/@ethereumjs/util/dist/encoding.d.ts","../../../node_modules/@ethereumjs/util/dist/asyncEventEmitter.d.ts","../../../node_modules/@ethereumjs/util/dist/internal.d.ts","../../../node_modules/@ethereumjs/util/dist/lock.d.ts","../../../node_modules/@ethereumjs/util/dist/provider.d.ts","../../../node_modules/@ethereumjs/util/dist/index.d.ts","../../../node_modules/@ethereumjs/common/dist/common.d.ts","../../../node_modules/@ethereumjs/common/dist/utils.d.ts","../../../node_modules/@ethereumjs/common/dist/index.d.ts","../../../node_modules/@ethereumjs/tx/dist/eip2930Transaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/legacyTransaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/types.d.ts","../../../node_modules/@ethereumjs/tx/dist/baseTransaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/eip1559Transaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/transactionFactory.d.ts","../../../node_modules/@ethereumjs/tx/dist/index.d.ts","../../../node_modules/@metamask/utils/dist/types/keyring.d.ts","../../../node_modules/@types/ms/index.d.ts","../../../node_modules/@types/debug/index.d.ts","../../../node_modules/@metamask/utils/dist/types/logging.d.ts","../../../node_modules/@metamask/utils/dist/types/misc.d.ts","../../../node_modules/@metamask/utils/dist/types/number.d.ts","../../../node_modules/@metamask/utils/dist/types/opaque.d.ts","../../../node_modules/@metamask/utils/dist/types/promise.d.ts","../../../node_modules/@metamask/utils/dist/types/time.d.ts","../../../node_modules/@metamask/utils/dist/types/transaction-types.d.ts","../../../node_modules/@metamask/utils/dist/types/versions.d.ts","../../../node_modules/@metamask/utils/dist/types/index.d.ts","../../../node_modules/immer/dist/utils/env.d.ts","../../../node_modules/immer/dist/utils/errors.d.ts","../../../node_modules/immer/dist/types/types-external.d.ts","../../../node_modules/immer/dist/types/types-internal.d.ts","../../../node_modules/immer/dist/utils/common.d.ts","../../../node_modules/immer/dist/utils/plugins.d.ts","../../../node_modules/immer/dist/core/scope.d.ts","../../../node_modules/immer/dist/core/finalize.d.ts","../../../node_modules/immer/dist/core/proxy.d.ts","../../../node_modules/immer/dist/core/immerClass.d.ts","../../../node_modules/immer/dist/core/current.d.ts","../../../node_modules/immer/dist/internal.d.ts","../../../node_modules/immer/dist/plugins/es5.d.ts","../../../node_modules/immer/dist/plugins/patches.d.ts","../../../node_modules/immer/dist/plugins/mapset.d.ts","../../../node_modules/immer/dist/plugins/all.d.ts","../../../node_modules/immer/dist/immer.d.ts","../../base-controller/dist/types/RestrictedControllerMessenger.d.ts","../../base-controller/dist/types/ControllerMessenger.d.ts","../../base-controller/dist/types/BaseControllerV2.d.ts","../../base-controller/dist/types/index.d.ts","../../controller-utils/dist/types/types.d.ts","../../controller-utils/dist/types/constants.d.ts","../../../node_modules/@metamask/eth-query/index.d.ts","../../../node_modules/@types/bn.js/index.d.ts","../../controller-utils/dist/types/util.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/abnf.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/utils.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/parsers.d.ts","../../controller-utils/dist/types/siwe.d.ts","../../controller-utils/dist/types/index.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/types.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/createEventEmitterProxy.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/createSwappableProxy.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/index.d.ts","../../network-controller/dist/types/constants.d.ts","../../../node_modules/@metamask/safe-event-emitter/dist/cjs/index.d.ts","../../json-rpc-engine/dist/types/JsonRpcEngine.d.ts","../../json-rpc-engine/dist/types/createAsyncMiddleware.d.ts","../../json-rpc-engine/dist/types/createScaffoldMiddleware.d.ts","../../json-rpc-engine/dist/types/getUniqueId.d.ts","../../json-rpc-engine/dist/types/idRemapMiddleware.d.ts","../../json-rpc-engine/dist/types/mergeMiddleware.d.ts","../../json-rpc-engine/dist/types/index.d.ts","../../eth-json-rpc-provider/dist/types/safe-event-emitter-provider.d.ts","../../eth-json-rpc-provider/dist/types/provider-from-engine.d.ts","../../eth-json-rpc-provider/dist/types/provider-from-middleware.d.ts","../../eth-json-rpc-provider/dist/types/index.d.ts","../../../node_modules/eth-block-tracker/dist/BlockTracker.d.ts","../../../node_modules/eth-block-tracker/dist/PollingBlockTracker.d.ts","../../../node_modules/eth-block-tracker/dist/SubscribeBlockTracker.d.ts","../../../node_modules/eth-block-tracker/dist/index.d.ts","../../network-controller/dist/types/types.d.ts","../../network-controller/dist/types/create-auto-managed-network-client.d.ts","../../network-controller/dist/types/NetworkController.d.ts","../../network-controller/dist/types/create-network-client.d.ts","../../network-controller/dist/types/index.d.ts","../../polling-controller/dist/types/types.d.ts","../../polling-controller/dist/types/BlockTrackerPollingController.d.ts","../../polling-controller/dist/types/StaticIntervalPollingController.d.ts","../../polling-controller/dist/types/index.d.ts","../../../node_modules/@types/uuid/index.d.ts","../src/determineGasFeeCalculations.ts","../src/gas-util.ts","../src/GasFeeController.ts","../src/index.ts","../../../node_modules/@babel/types/lib/index.d.ts","../../../node_modules/@types/babel__generator/index.d.ts","../../../node_modules/@babel/parser/typings/babel-parser.d.ts","../../../node_modules/@types/babel__template/index.d.ts","../../../node_modules/@types/babel__traverse/index.d.ts","../../../node_modules/@types/babel__core/index.d.ts","../../../node_modules/@types/deep-freeze-strict/index.d.ts","../../../node_modules/@types/eslint/helpers.d.ts","../../../node_modules/@types/estree/index.d.ts","../../../node_modules/@types/json-schema/index.d.ts","../../../node_modules/@types/eslint/index.d.ts","../../../node_modules/@types/graceful-fs/index.d.ts","../../../node_modules/@types/istanbul-lib-coverage/index.d.ts","../../../node_modules/@types/istanbul-lib-report/index.d.ts","../../../node_modules/@types/istanbul-reports/index.d.ts","../../../node_modules/chalk/index.d.ts","../../../node_modules/jest-diff/build/cleanupSemantic.d.ts","../../../node_modules/pretty-format/build/types.d.ts","../../../node_modules/pretty-format/build/index.d.ts","../../../node_modules/jest-diff/build/types.d.ts","../../../node_modules/jest-diff/build/diffLines.d.ts","../../../node_modules/jest-diff/build/printDiffs.d.ts","../../../node_modules/jest-diff/build/index.d.ts","../../../node_modules/jest-matcher-utils/build/index.d.ts","../../../node_modules/@types/jest/index.d.ts","../../../node_modules/@types/jest-when/index.d.ts","../../../node_modules/@types/json5/index.d.ts","../../../node_modules/@types/lodash/common/common.d.ts","../../../node_modules/@types/lodash/common/array.d.ts","../../../node_modules/@types/lodash/common/collection.d.ts","../../../node_modules/@types/lodash/common/date.d.ts","../../../node_modules/@types/lodash/common/function.d.ts","../../../node_modules/@types/lodash/common/lang.d.ts","../../../node_modules/@types/lodash/common/math.d.ts","../../../node_modules/@types/lodash/common/number.d.ts","../../../node_modules/@types/lodash/common/object.d.ts","../../../node_modules/@types/lodash/common/seq.d.ts","../../../node_modules/@types/lodash/common/string.d.ts","../../../node_modules/@types/lodash/common/util.d.ts","../../../node_modules/@types/lodash/index.d.ts","../../../node_modules/@types/minimatch/index.d.ts","../../../node_modules/@types/parse-json/index.d.ts","../../../node_modules/@types/pbkdf2/index.d.ts","../../../node_modules/@types/prettier/index.d.ts","../../../node_modules/@types/punycode/index.d.ts","../../../node_modules/@types/readable-stream/node_modules/safe-buffer/index.d.ts","../../../node_modules/@types/readable-stream/index.d.ts","../../../node_modules/@types/secp256k1/index.d.ts","../../../node_modules/@types/semver/classes/semver.d.ts","../../../node_modules/@types/semver/functions/parse.d.ts","../../../node_modules/@types/semver/functions/valid.d.ts","../../../node_modules/@types/semver/functions/clean.d.ts","../../../node_modules/@types/semver/functions/inc.d.ts","../../../node_modules/@types/semver/functions/diff.d.ts","../../../node_modules/@types/semver/functions/major.d.ts","../../../node_modules/@types/semver/functions/minor.d.ts","../../../node_modules/@types/semver/functions/patch.d.ts","../../../node_modules/@types/semver/functions/prerelease.d.ts","../../../node_modules/@types/semver/functions/compare.d.ts","../../../node_modules/@types/semver/functions/rcompare.d.ts","../../../node_modules/@types/semver/functions/compare-loose.d.ts","../../../node_modules/@types/semver/functions/compare-build.d.ts","../../../node_modules/@types/semver/functions/sort.d.ts","../../../node_modules/@types/semver/functions/rsort.d.ts","../../../node_modules/@types/semver/functions/gt.d.ts","../../../node_modules/@types/semver/functions/lt.d.ts","../../../node_modules/@types/semver/functions/eq.d.ts","../../../node_modules/@types/semver/functions/neq.d.ts","../../../node_modules/@types/semver/functions/gte.d.ts","../../../node_modules/@types/semver/functions/lte.d.ts","../../../node_modules/@types/semver/functions/cmp.d.ts","../../../node_modules/@types/semver/functions/coerce.d.ts","../../../node_modules/@types/semver/classes/comparator.d.ts","../../../node_modules/@types/semver/classes/range.d.ts","../../../node_modules/@types/semver/functions/satisfies.d.ts","../../../node_modules/@types/semver/ranges/max-satisfying.d.ts","../../../node_modules/@types/semver/ranges/min-satisfying.d.ts","../../../node_modules/@types/semver/ranges/to-comparators.d.ts","../../../node_modules/@types/semver/ranges/min-version.d.ts","../../../node_modules/@types/semver/ranges/valid.d.ts","../../../node_modules/@types/semver/ranges/outside.d.ts","../../../node_modules/@types/semver/ranges/gtr.d.ts","../../../node_modules/@types/semver/ranges/ltr.d.ts","../../../node_modules/@types/semver/ranges/intersects.d.ts","../../../node_modules/@types/semver/ranges/simplify.d.ts","../../../node_modules/@types/semver/ranges/subset.d.ts","../../../node_modules/@types/semver/internals/identifiers.d.ts","../../../node_modules/@types/semver/index.d.ts","../../../node_modules/@types/sinonjs__fake-timers/index.d.ts","../../../node_modules/@types/sinon/index.d.ts","../../../node_modules/@types/stack-utils/index.d.ts","../../../node_modules/@types/yargs-parser/index.d.ts","../../../node_modules/@types/yargs/index.d.ts"],"fileInfos":[{"version":"8730f4bf322026ff5229336391a18bcaa1f94d4f82416c8b2f3954e2ccaae2ba","affectsGlobalScope":true},"dc47c4fa66b9b9890cf076304de2a9c5201e94b740cffdf09f87296d877d71f6","7a387c58583dfca701b6c85e0adaf43fb17d590fb16d5b2dc0a2fbd89f35c467","8a12173c586e95f4433e0c6dc446bc88346be73ffe9ca6eec7aa63c8f3dca7f9","5f4e733ced4e129482ae2186aae29fde948ab7182844c3a5a51dd346182c7b06","4b421cbfb3a38a27c279dec1e9112c3d1da296f77a1a85ddadf7e7a425d45d18","1fc5ab7a764205c68fa10d381b08417795fc73111d6dd16b5b1ed36badb743d9",{"version":"3aafcb693fe5b5c3bd277bd4c3a617b53db474fe498fc5df067c5603b1eebde7","affectsGlobalScope":true},{"version":"adb996790133eb33b33aadb9c09f15c2c575e71fb57a62de8bf74dbf59ec7dfb","affectsGlobalScope":true},{"version":"8cc8c5a3bac513368b0157f3d8b31cfdcfe78b56d3724f30f80ed9715e404af8","affectsGlobalScope":true},{"version":"cdccba9a388c2ee3fd6ad4018c640a471a6c060e96f1232062223063b0a5ac6a","affectsGlobalScope":true},{"version":"c5c05907c02476e4bde6b7e76a79ffcd948aedd14b6a8f56e4674221b0417398","affectsGlobalScope":true},{"version":"5f406584aef28a331c36523df688ca3650288d14f39c5d2e555c95f0d2ff8f6f","affectsGlobalScope":true},{"version":"22f230e544b35349cfb3bd9110b6ef37b41c6d6c43c3314a31bd0d9652fcec72","affectsGlobalScope":true},{"version":"7ea0b55f6b315cf9ac2ad622b0a7813315bb6e97bf4bb3fbf8f8affbca7dc695","affectsGlobalScope":true},{"version":"3013574108c36fd3aaca79764002b3717da09725a36a6fc02eac386593110f93","affectsGlobalScope":true},{"version":"eb26de841c52236d8222f87e9e6a235332e0788af8c87a71e9e210314300410a","affectsGlobalScope":true},{"version":"3be5a1453daa63e031d266bf342f3943603873d890ab8b9ada95e22389389006","affectsGlobalScope":true},{"version":"17bb1fc99591b00515502d264fa55dc8370c45c5298f4a5c2083557dccba5a2a","affectsGlobalScope":true},{"version":"7ce9f0bde3307ca1f944119f6365f2d776d281a393b576a18a2f2893a2d75c98","affectsGlobalScope":true},{"version":"6a6b173e739a6a99629a8594bfb294cc7329bfb7b227f12e1f7c11bc163b8577","affectsGlobalScope":true},{"version":"81cac4cbc92c0c839c70f8ffb94eb61e2d32dc1c3cf6d95844ca099463cf37ea","affectsGlobalScope":true},{"version":"b0124885ef82641903d232172577f2ceb5d3e60aed4da1153bab4221e1f6dd4e","affectsGlobalScope":true},{"version":"0eb85d6c590b0d577919a79e0084fa1744c1beba6fd0d4e951432fa1ede5510a","affectsGlobalScope":true},{"version":"da233fc1c8a377ba9e0bed690a73c290d843c2c3d23a7bd7ec5cd3d7d73ba1e0","affectsGlobalScope":true},{"version":"d154ea5bb7f7f9001ed9153e876b2d5b8f5c2bb9ec02b3ae0d239ec769f1f2ae","affectsGlobalScope":true},{"version":"bb2d3fb05a1d2ffbca947cc7cbc95d23e1d053d6595391bd325deb265a18d36c","affectsGlobalScope":true},{"version":"c80df75850fea5caa2afe43b9949338ce4e2de086f91713e9af1a06f973872b8","affectsGlobalScope":true},{"version":"9d57b2b5d15838ed094aa9ff1299eecef40b190722eb619bac4616657a05f951","affectsGlobalScope":true},{"version":"6c51b5dd26a2c31dbf37f00cfc32b2aa6a92e19c995aefb5b97a3a64f1ac99de","affectsGlobalScope":true},{"version":"6e7997ef61de3132e4d4b2250e75343f487903ddf5370e7ce33cf1b9db9a63ed","affectsGlobalScope":true},{"version":"2ad234885a4240522efccd77de6c7d99eecf9b4de0914adb9a35c0c22433f993","affectsGlobalScope":true},{"version":"5e5e095c4470c8bab227dbbc61374878ecead104c74ab9960d3adcccfee23205","affectsGlobalScope":true},{"version":"09aa50414b80c023553090e2f53827f007a301bc34b0495bfb2c3c08ab9ad1eb","affectsGlobalScope":true},{"version":"d7f680a43f8cd12a6b6122c07c54ba40952b0c8aa140dcfcf32eb9e6cb028596","affectsGlobalScope":true},{"version":"3787b83e297de7c315d55d4a7c546ae28e5f6c0a361b7a1dcec1f1f50a54ef11","affectsGlobalScope":true},{"version":"e7e8e1d368290e9295ef18ca23f405cf40d5456fa9f20db6373a61ca45f75f40","affectsGlobalScope":true},{"version":"faf0221ae0465363c842ce6aa8a0cbda5d9296940a8e26c86e04cc4081eea21e","affectsGlobalScope":true},{"version":"06393d13ea207a1bfe08ec8d7be562549c5e2da8983f2ee074e00002629d1871","affectsGlobalScope":true},{"version":"2768ef564cfc0689a1b76106c421a2909bdff0acbe87da010785adab80efdd5c","affectsGlobalScope":true},{"version":"b248e32ca52e8f5571390a4142558ae4f203ae2f94d5bac38a3084d529ef4e58","affectsGlobalScope":true},{"version":"52d1bb7ab7a3306fd0375c8bff560feed26ed676a5b0457fa8027b563aecb9a4","affectsGlobalScope":true},"70bbfaec021ac4a0c805374225b55d70887f987df8b8dd7711d79464bb7b4385","869089d60b67219f63e6aca810284c89bae1b384b5cbc7ce64e53d82ad223ed5",{"version":"18338b6a4b920ec7d49b4ffafcbf0fa8a86b4bfd432966efd722dab611157cf4","affectsGlobalScope":true},"62a0875a0397b35a2364f1d401c0ce17975dfa4d47bf6844de858ae04da349f9","ee7491d0318d1fafcba97d5b72b450eb52671570f7a4ecd9e8898d40eaae9472","e3e7d217d89b380c1f34395eadc9289542851b0f0a64007dfe1fb7cf7423d24e","fd79909e93b4d50fd0ed9f3d39ddf8ba0653290bac25c295aac49f6befbd081b","345a9cc2945406f53051cd0e9b51f82e1e53929848eab046fdda91ee8aa7da31","9debe2de883da37a914e5e784a7be54c201b8f1d783822ad6f443ff409a5ea21","dee5d5c5440cda1f3668f11809a5503c30db0476ad117dd450f7ba5a45300e8f","f5e396c1424c391078c866d6f84afe0b4d2f7f85a160b9c756cd63b5b1775d93","5caa6f4fff16066d377d4e254f6c34c16540da3809cd66cd626a303bc33c419f","730d055528bdf12c8524870bb33d237991be9084c57634e56e5d8075f6605e02","75b22c74010ba649de1a1676a4c4b8b5bb4294fecd05089e2094429b16d7840c","5615ccf831db2ffc82145243081ebdb60ea8e1005ee8f975d1c0c1401a9c894e","38682ed3630bb6ecdace80d5a9adc811fc20a419f1940446e306c3a020d083b9","cc182e6e4f691cd6f7bf7cb491247a4c7818f9f1cb2db1d45c65ff906e3f741b","a50599c08934a62f11657bdbe0dc929ab66da1b1f09974408fd9a33ec1bb8060","5a20e7d6c630b91be15e9b837853173829d00273197481dc8d3e94df61105a71","8d478048d71cc16f806d4b71b252ecb67c7444ccf4f4b09b29a312712184f859","e0eda929c6b9b628cdeb0e54cd3582cb97e64f28aab34612fc1431c545899584","9df4662ca3dbc2522bc115833ee04faa1afbb4e249a85ef4a0a09c621346bd08","b25d9065cf1c1f537a140bbc508e953ed2262f77134574c432d206ff36f4bdbf","1b103313097041aa9cd705a682c652f08613cb5cf8663321061c0902f845e81c","68ccec8662818911d8a12b8ed028bc5729fb4f1d34793c4701265ba60bc73cf4","5f85b8b79dc4d36af672c035b2beb71545de63a5d60bccbeee64c260941672ab","b3d48529ae61dc27d0bfbfa2cb3e0dff8189644bd155bdf5df1e8e14669f7043","40fe4b689225816b31fe5794c0fbf3534568819709e40295ead998a2bc1ab237","f65b5e33b9ad545a1eebbd6afe857314725ad42aaf069913e33f928ab3e4990a","fb6f2a87beb7fb1f4c2b762d0c76a9459fc91f557231569b0ee21399e22aa13d","31c858dc85996fac4b7fa944e1016d5c72f514930a72357ab5001097bf6511c7","3de30a871b3340be8b679c52aa12f90dd1c8c60874517be58968fdbcc4d79445","6fd985bd31eaf77542625306fb0404d32bff978990f0a06428e5f0b9a3b58109","5b3cd03ae354ea96eff1f74d7c410fe4852e6382227e8b0ecf87ab5e3a5bbcd4","7394959e5a741b185456e1ef5d64599c36c60a323207450991e7a42e08911419",{"version":"056097110efd16869ec118cedb44ecbac9a019576eee808d61304ca6d5cb2cbe","affectsGlobalScope":true},"f51b4042a3ac86f1f707500a9768f88d0b0c1fc3f3e45a73333283dea720cdc6",{"version":"6fb8358e10ed92a7f515b7d79da3904c955a3ffd4e14aa9df6f0ea113041f1cf","affectsGlobalScope":true},"45c831238c6dac21c72da5f335747736a56a3847192bf03c84b958a7e9ec93e2","661a11d16ad2e3543a77c53bcd4017ee9a450f47ab7def3ab493a86eae4d550c",{"version":"8cdc646cec7819581ef343b83855b1bfe4fe674f2c84f4fb8dc90d82fb56bd3a","affectsGlobalScope":true},"a40826e8476694e90da94aa008283a7de50d1dafd37beada623863f1901cb7fb","9dd56225cc2d8cb8fe5ceb0043ff386987637e12fecc6078896058a99deae284","2375ed4b439215aa3b6d0c6fd175c78a4384b30cb43cbadaecbf0a18954c98cb","7693b90b3075deaccafd5efb467bf9f2b747a3075be888652ef73e64396d8628","41231da15bb5e3e806a8395bd15c7befd2ec90f9f4e3c9d0ae1356bccb76dbb0","fccfef201d057cb407fa515311bd608549bab6c7b8adcf8f2df31f5d3b796478",{"version":"ee1ee365d88c4c6c0c0a5a5701d66ebc27ccd0bcfcfaa482c6e2e7fe7b98edf7","affectsGlobalScope":true},"5f20d20b7607174caf1a6da9141aeb9f2142159ae2410ca30c7a0fccd1d19c99",{"version":"464762c6213566d072f1ced5e8e9a954785ec5e53883b7397198abb5ef5b8f71","affectsGlobalScope":true},"6387920dc3e18927335b086deec75bf8e50f879a5e273d32ee7bb7a55ba50572","9bba37424094688c4663c177a1379b229f919b8912889a472f32fdc5f08ddb4d","29a4be13b3a30d3e66667b75c58ec61fb2df8fa0422534fdee3cfb30c5dbf450","83366d901beda79d6eb37aaaf6ca248dcd88946302b2a7d975590783be51e88e","bf268a0aea37ad4ae3b7a9b58559190b6fc01ea16a31e35cd05817a0a60f895a","43ec77c369473e92e2ecebf0554a0fdaa9c256644a6070f28228dfcceec77351",{"version":"d7dad6db394a3d9f7b49755e4b610fbf8ed6eb0c9810ae5f1a119f6b5d76de45","affectsGlobalScope":true},"95ed02bacb4502c985b69742ec82a4576d4ff4a6620ecc91593f611d502ae546","bf755525c4e6f85a970b98c4755d98e8aa1b6dbd83a5d8fcc57d3d497351b936","dd67d2b5e4e8a182a38de8e69fb736945eaa4588e0909c14e01a14bd3cc1fd1e",{"version":"28084e15b63e6211769db2fe646d8bc5c4c6776321e0deffe2d12eefd52cb6b9","affectsGlobalScope":true},{"version":"aed37dabf86c99d6c8508700576ecede86688397bc12523541858705a0c737c2","affectsGlobalScope":true},"cc6ef5733d4ea6d2e06310a32dffd2c16418b467c5033d49cecc4f3a25de7497","94768454c3348b6ebe48e45fbad8c92e2bb7af4a35243edbe2b90823d0bd7f9a","0be79b3ff0f16b6c2f9bc8c4cc7097ea417d8d67f8267f7e1eec8e32b548c2ff","1c61ffa3a71b77363b30d19832c269ef62fba787f5610cac7254728d3b69ab2e","84da3c28344e621fd1d591f2c09e9595292d2b70018da28a553268ac122597d4","269929a24b2816343a178008ac9ae9248304d92a8ba8e233055e0ed6dbe6ef71","6e191fea1db6e9e4fa828259cf489e820ec9170effff57fb081a2f3295db4722","aed943465fbce1efe49ee16b5ea409050f15cd8eaf116f6fadb64ef0772e7d95","70d08483a67bf7050dbedace398ef3fee9f436fcd60517c97c4c1e22e3c6f3e8","c40fdf7b2e18df49ce0568e37f0292c12807a0748be79e272745e7216bed2606",{"version":"e933de8143e1d12dd51d89b398760fd5a9081896be366dad88a922d0b29f3c69","affectsGlobalScope":true},"4e228e78c1e9b0a75c70588d59288f63a6258e8b1fe4a67b0c53fe03461421d9","b38d55d08708c2410a3039687db70b4a5bfa69fc4845617c313b5a10d9c5c637","205d50c24359ead003dc537b9b65d2a64208dfdffe368f403cf9e0357831db9e","1265fddcd0c68be9d2a3b29805d0280484c961264dd95e0b675f7bd91f777e78",{"version":"a05e2d784c9be7051c4ac87a407c66d2106e23490c18c038bbd0712bde7602fd","affectsGlobalScope":true},{"version":"df90b9d0e9980762da8daf8adf6ffa0c853e76bfd269c377be0d07a9ad87acd2","affectsGlobalScope":true},"cf434b5c04792f62d6f4bdd5e2c8673f36e638e910333c172614d5def9b17f98","1d65d4798df9c2df008884035c41d3e67731f29db5ecb64cd7378797c7c53a2f","0faee6b555890a1cb106e2adc5d3ffd89545b1da894d474e9d436596d654998f","c6c01ea1c42508edf11a36d13b70f6e35774f74355ba5d358354d4a77cc67ea1","867f95abf1df444aab146b19847391fc2f922a55f6a970a27ed8226766cee29f",{"version":"ab9b9a36e5284fd8d3bf2f7d5fcbc60052f25f27e4d20954782099282c60d23e","affectsGlobalScope":true},"b0297b09e607bec9698cac7cf55463d6731406efb1161ee4d448293b47397c84","175323e2a79a6076e0bada8a390d535a3ea817158bf1b1f46e31efca9028a0a2","7a10053aadc19335532a4d02756db4865974fd69bea5439ddcc5bfdf062d9476","4967529644e391115ca5592184d4b63980569adf60ee685f968fd59ab1557188","aed9e712a9b168345362e8f3a949f16c99ca1e05d21328f05735dfdbb24414ef","b04fe6922ed3db93afdbd49cdda8576aa75f744592fceea96fb0d5f32158c4f5","ed8d6c8de90fc2a4faaebc28e91f2469928738efd5208fb75ade0fa607e892b7","d7c52b198d680fe65b1a8d1b001f0173ffa2536ca2e7082431d726ce1f6714cd","c07f251e1c4e415a838e5498380b55cfea94f3513229de292d2aa85ae52fc3e9","0ed401424892d6bf294a5374efe512d6951b54a71e5dd0290c55b6d0d915f6f7","b945be6da6a3616ef3a250bfe223362b1c7c6872e775b0c4d82a1bf7a28ff902","beea49237dd7c7110fabf3c7509919c9cb9da841d847c53cac162dc3479e2f87","0f45f8a529c450d8f394106cc622bff79e44a1716e1ac9c3cc68b43f7ecf65ee","c624ce90b04c27ce4f318ba6330d39bde3d4e306f0f497ce78d4bda5ab8e22ca","9b8253aa5cb2c82d505f72afdbf96e83b15cc6b9a6f4fadbbbab46210d5f1977","86a8f52e4b1ac49155e889376bcfa8528a634c90c27fec65aa0e949f77b740c5","aab5dd41c1e2316cc0b42a7dd15684f8582d5a1d16c0516276a2a8a7d0fecd9c","59948226626ee210045296ba1fc6cb0fe748d1ff613204e08e7157ab6862dee7","ec3e54d8b713c170fdc8110a7e4a6a97513a7ab6b05ac9e1100cb064d2bb7349","43beb30ecb39a603fde4376554887310b0699f25f7f39c5c91e3147b51bb3a26","666b77d7f06f49da114b090a399abbfa66d5b6c01a3fd9dc4f063a52ace28507","31997714a93fbc570f52d47d6a8ebfb021a34a68ea9ba58bbb69cdec9565657e","6032e4262822160128e644de3fc4410bcd7517c2f137525fd2623d2bb23cb0d3","8bd5c9b1016629c144fd228983395b9dbf0676a576716bc3d316cab612c33cd5","2ed90bd3925b23aed8f859ffd0e885250be0424ca2b57e9866dabef152e1d6b7","93f6bd17d92dab9db7897e1430a5aeaa03bcf51623156213d8397710367a76ce","3f62b770a42e8c47c7008726f95aa383e69d97e85e680d237b99fcb0ee601dd8","5b84cfe78028c35c3bb89c042f18bf08d09da11e82d275c378ae4d07d8477e6c","980d21b0081cbf81774083b1e3a46f4bbdcd2b68858df0f66d7fad9c82bc34bc","68cc8d6fcc2f270d7108f02f3ebc59480a54615be3e09a47e14527f349e9d53e","3eb11dbf3489064a47a2e1cf9d261b1f100ef0b3b50ffca6c44dd99d6dd81ac1","b17f3bb7d8333479c7e45e5f3d876761b9bca58f97594eca3f6a944fd825e632","3c1f1236cce6d6e0c4e2c1b4371e6f72d7c14842ecd76a98ed0748ee5730c8f3","6d7f58d5ea72d7834946fd7104a734dc7d40661be8b2e1eaced1ddce3268ebaf","4c26222991e6c97d5a8f541d4f2c67585eda9e8b33cf9f52931b098045236e88","277983d414aa99d78655186c3ee1e1c38c302e336aff1d77b47fcdc39d8273fe","47383b45796d525a4039cd22d2840ac55a1ff03a43d027f7f867ba7314a9cf53","6548773b3abbc18de29176c2141f766d4e437e40596ee480447abf83575445ad","6ddd27af0436ce59dd4c1896e2bfdb2bdb2529847d078b83ce67a144dff05491","816264799aef3fd5a09a3b6c25217d5ec26a9dfc7465eac7d6073bcdc7d88f3f","4df0891b133884cd9ed752d31c7d0ec0a09234e9ed5394abffd3c660761598db","b603b62d3dcd31ef757dc7339b4fa8acdbca318b0fb9ac485f9a1351955615f9","e642bd47b75ad6b53cbf0dfd7ddfa0f120bd10193f0c58ec37d87b59bf604aca","be90b24d2ee6f875ce3aaa482e7c41a54278856b03d04212681c4032df62baf9","78f5ff400b3cb37e7b90eef1ff311253ed31c8cb66505e9828fad099bffde021","372c47090e1131305d163469a895ff2938f33fa73aad988df31cd31743f9efb6","71c67dc6987bdbd5599353f90009ff825dd7db0450ef9a0aee5bb0c574d18512","6f12403b5eca6ae7ca8e3efe3eeb9c683b06ce3e3844ccfd04098d83cd7e4957","282c535df88175d64d9df4550d2fd1176fd940c1c6822f1e7584003237f179d3","c3a4752cf103e4c6034d5bd449c8f9d5e7b352d22a5f8f9a41a8efb11646f9c2","11a9e38611ac3c77c74240c58b6bd64a0032128b29354e999650f1de1e034b1c","4ed103ca6fff9cb244f7c4b86d1eb28ce8069c32db720784329946731badb5bb","d738f282842970e058672663311c6875482ee36607c88b98ffb6604fba99cb2a","ec859cd8226aa623e41bbb47c249a55ee16dc1b8647359585244d57d3a5ed0c7","8891c6e959d253a66434ff5dc9ae46058fb3493e84b4ca39f710ef2d350656b1","c4463cf02535444dcbc3e67ecd29f1972490f74e49957d6fd4282a1013796ba6","0cb0a957ff02de0b25fd0f3f37130ca7f22d1e0dea256569c714c1f73c6791f8","2f5075dc512d51786b1ba3b1696565641dfaae3ac854f5f13d61fa12ef81a47e","ca3353cc82b1981f0d25d71d7432d583a6ef882ccdea82d65fbe49af37be51cb","50679a8e27aacf72f8c40bcab15d7ef5e83494089b4726b83eec4554344d5cdc","45351e0d51780b6f4088277a4457b9879506ee2720a887de232df0f1efcb33d8","5d697a4b315cc5bb3042ae869abffd10c3b0d7b182cda0e4c45d8819937e5796","563fa27fdaec8f195b84f71a7af0ef48d30d5cc830575db86da86a63a470c8e6","6ee58aa536dabb19b09bc036f1abe83feb51e13d63b23d30b2d0631a2de99b8f","8aceb205dcc6f814ad99635baf1e40b6e01d06d3fe27b72fd766c6d0b8c0c600","299567f84bfedd1468dca2755a829cb19e607a6811673788807dc8921e211bc9","795d9fb85aad92221504db74dd179b506bd189bba0c104426f7e7bb8a66ffee5","1311bc194e0a69fe61031e852c1c0b439e2a2a3d1d5e2d8ff795499b9f283459","4b7ce19369d7e7fae76720c2c6c7f671bf3fa0f7093edb864f1ac358ca7c456c","c972ef44deca1fa8fab465915ffa00f82e126aacf3dfc8979c03b1b066ce5bb6","30285a1011c6d6b52f3ba3abb0a984be8148c05cdefb8eb6eb562335a3991f35","8e7adb22c0adecf7464861fc58ae3fc617b41ffbd70c97aa8493dc0966a82273","755f3cd1d9c1b564cff090e3b0e29200ae55690a91b87cb9e7a64c2dbeb314d3","d6bb7e0a6877b7856c183bff13d09dd9ae599ea43c6f6b33d3d5f72a830ed460","f1b51ae93c762d7c43f559933cd4842dd870367e8d92e90704ffa685dd5b29a3","3f450762fd7c34ed545e738abccb0af6a703572a10521643cf8fc88e3724c99c","fcc8beef29f39f09b1d9c9f99c42f9fed605ab1c28d2a630185f732b9ba53763","d6e6620a30d582182acc3f0a992a0c311adc589f111096aea11ab83fc09a5ccc","6213b8f686f56beab22b59a0f468590fd3a4c5fa931236a017efeca91d7c9584","c451cec9a588b1f105a5ea2c6063d4fca112b9d70105cacdadda0e1ef67e9379","cb047832dc68f5a2c41c62c5e95ddcacbae3a8b034d40cd15319a8cb7f25104a","980336ccdfc3c08f3c3b201aa6662e6016e20f15847f8465b68f3e8e67b4665c","5a3493939995f46ff3d9073cd534fb8961c3bf4e08c71db27066ff03d906dea8","bb5a2ac327605ebebf831c469b05bd34a33a6a46ee8c1edd9f3310aad32cf6a1","bf5d041f2440b4a9391e2b5eb3b8d94cbf1e3b8ff4703b6539d4e65e758c8f37","8516469eb90e723b0eb03df1be098f7e6a4709f6f48fd4532868d20a0a934f6e","d60e9ab369a72d234aac49adbe2900d8ef1408a6ea4db552cf2a48c9d8d6a1bc","0ebb4698803f01e2e7df6acce572fff068f4a20c47221721dafd70a27e372831","03460a54d0e0481d1e11097f66ad43f054bc95efdafe5f81bbc7a82be181af75","4070c2f1c3434fcf84886e04d30d82cd650ee443e53b82b404b144175cf8741e","2cea9689efa8591732096235abe7f084fc29c92badd5b0897a5e876b77e71887","4ed4e504126014fee13aaef5e3fc140f2ff7031ff3a8b5386717905820ea2d09","8129a34006218a6f3cdc81bbd438d5429eb18b08b4338a26977ac3b4df129d75","30d2170e1a718b5035611af55e3618b4ba8f42f0749bb52ee593da6082c4e2ce","98ef38666d88ec9699a722053e07ede65d3042f693fe7ff8c786e53dbb6fd43b","a3b8b6be7620897d1e481e8650c980a210a138fceb6e710eaf95fd9dd0dfe94a","12c89d0e32758c120a569045f21cf5b77244f86792611ced8de7f86b37e77781","14bd47270e654c8eb3b1489fa8c095912ee62a0a29bb92743393203722347c53","3d9297165e67fd59d9821cc93a9808213e33c56a8ac1c4273171f6afaaa2d4d5","e7af7d288b89287ad031b19583c597fcd9f5edc0b0d579b7b492f06cf57e058c","92cb686a9ca5eb5dd7d5d8d43a3707194c1e91ea07a027b3bcb60b6011b24632","fab58e600970e66547644a44bc9918e3223aa2cbd9e8763cec004b2cfb48827e",{"version":"f3e418819a6765dc6715ab2a51771c798543815d8499e29a857229bbf74ff419","signature":"b146c2211fb74ff8f672aa026d3992562e1c9c0d282cc712708b740c8f4cfb1a"},{"version":"d320adcc9e016b24e5873a7efb081d684a7990fbe23fe49c1c5354ba89bd129b","signature":"56c727d4c937865b6e7b114f58aa30f7678d5a9d924c0adb42368c403efb337d"},{"version":"fd1051fabcbc5740a5b3db8582c0bfee17883217121619fd765fbdd171f5d068","signature":"e4a433dbb39db571df95fa9677c8dede9cc6e21eb91a5a23e89ce2725cbd97da"},"d021f18758b28bda32bdaf0a987e0804cec074a9a4cfab8232ed81d96e75dfae","4489c6a9fde8934733aa7df6f7911461ee6e9e4ad092736bd416f6b2cc20b2c6","2c8e55457aaf4902941dfdba4061935922e8ee6e120539c9801cd7b400fae050","8041cfce439ff29d339742389de04c136e3029d6b1817f07b2d7fcbfb7534990","670a76db379b27c8ff42f1ba927828a22862e2ab0b0908e38b671f0e912cc5ed","9d38964b57191567a14b396422c87488cecd48f405c642daa734159875ee81d9","069bebfee29864e3955378107e243508b163e77ab10de6a5ee03ae06939f0bb9","8c95f96ccd4be0674944077aec1e4f2cccd515ca06d4327562dd017250e7d3fc",{"version":"64d4b35c5456adf258d2cf56c341e203a073253f229ef3208fc0d5020253b241","affectsGlobalScope":true},"ee7d8894904b465b072be0d2e4b45cf6b887cdba16a467645c4e200982ece7ea","f3d8c757e148ad968f0d98697987db363070abada5f503da3c06aefd9d4248c1","bc3cba7b0af2d52e7425299aee518db479d44004eff6fbbd206d1ee7e5ec3fb5","afe73051ff6a03a9565cbd8ebb0e956ee3df5e913ad5c1ded64218aabfa3dcb5","035a5df183489c2e22f3cf59fc1ed2b043d27f357eecc0eb8d8e840059d44245","a4809f4d92317535e6b22b01019437030077a76fec1d93b9881c9ed4738fcc54","5f53fa0bd22096d2a78533f94e02c899143b8f0f9891a46965294ee8b91a9434","0d14fa22c41fdc7277e6f71473b20ebc07f40f00e38875142335d5b63cdfc9d2","d8aab31ba8e618cc3eea10b0945de81cb93b7e8150a013a482332263b9305322","462bccdf75fcafc1ae8c30400c9425e1a4681db5d605d1a0edb4f990a54d8094","5923d8facbac6ecf7c84739a5c701a57af94a6f6648d6229a6c768cf28f0f8cb","7adecb2c3238794c378d336a8182d4c3dd2c4fa6fa1785e2797a3db550edea62","dc12dc0e5aa06f4e1a7692149b78f89116af823b9e1f1e4eae140cd3e0e674e6","1bfc6565b90c8771615cd8cfcf9b36efc0275e5e83ac7d9181307e96eb495161","8a8a96898906f065f296665e411f51010b51372fa260d5373bf9f64356703190","7f82ef88bdb67d9a850dd1c7cd2d690f33e0f0acd208e3c9eba086f3670d4f73",{"version":"ccfd8774cd9b929f63ff7dcf657977eb0652e3547f1fcac1b3a1dc5db22d4d58","affectsGlobalScope":true},"d92dc90fecd2552db74d8dc3c6fb4db9145b2aa0efe2c127236ba035969068d4","96d14f21b7652903852eef49379d04dbda28c16ed36468f8c9fa08f7c14c9538","b8442e9db28157344d1bc5d8a5a256f1692de213f0c0ddeb84359834015a008c","458111fc89d11d2151277c822dfdc1a28fa5b6b2493cf942e37d4cd0a6ee5f22","da2b6356b84a40111aaecb18304ea4e4fcb43d70efb1c13ca7d7a906445ee0d3","187119ff4f9553676a884e296089e131e8cc01691c546273b1d0089c3533ce42","febf0b2de54781102b00f61653b21377390a048fbf5262718c91860d11ff34a6","6f294731b495c65ecf46a5694f0082954b961cf05463bea823f8014098eaffa0","0aaef8cded245bf5036a7a40b65622dd6c4da71f7a35343112edbe112b348a1e","00baffbe8a2f2e4875367479489b5d43b5fc1429ecb4a4cc98cfc3009095f52a","68a0d0c508e1b6d8d23a519a8a0a3303dc5baa4849ca049f21e5bad41945e3fc","3c92b6dfd43cc1c2485d9eba5ff0b74a19bb8725b692773ef1d66dac48cda4bd","b03afe4bec768ae333582915146f48b161e567a81b5ebc31c4d78af089770ac9","df996e25faa505f85aeb294d15ebe61b399cf1d1e49959cdfaf2cc0815c203f9","4f6a12044ee6f458db11964153830abbc499e73d065c51c329ec97407f4b13dd","8841e2aa774b89bd23302dede20663306dc1b9902431ac64b24be8b8d0e3f649","916be7d770b0ae0406be9486ac12eb9825f21514961dd050594c4b250617d5a8","254d9fb8c872d73d34594be8a200fd7311dbfa10a4116bfc465fba408052f2b3","d88a5e779faf033be3d52142a04fbe1cb96009868e3bbdd296b2bc6c59e06c0e","2ccea88888048bbfcacbc9531a5596ea48a3e7dcd0a25f531a81bb717903ba4f","5e379df3d61561c2ed7789b5995b9ba2143bbba21a905e2381e16efe7d1fa424","f07a137bbe2de7a122c37bfea00e761975fb264c49f18003d398d71b3fb35a5f","d8f7109e14f20eb735225a62fd3f8366da1a8349e90331cdad57f4b04caf6c5a","cf3d384d082b933d987c4e2fe7bfb8710adfd9dc8155190056ed6695a25a559e","9871b7ee672bc16c78833bdab3052615834b08375cb144e4d2cba74473f4a589","c863198dae89420f3c552b5a03da6ed6d0acfa3807a64772b895db624b0de707","8b03a5e327d7db67112ebbc93b4f744133eda2c1743dbb0a990c61a8007823ef","86c73f2ee1752bac8eeeece234fd05dfcf0637a4fbd8032e4f5f43102faa8eec","42fad1f540271e35ca37cecda12c4ce2eef27f0f5cf0f8dd761d723c744d3159","ff3743a5de32bee10906aff63d1de726f6a7fd6ee2da4b8229054dfa69de2c34","83acd370f7f84f203e71ebba33ba61b7f1291ca027d7f9a662c6307d74e4ac22","1445cec898f90bdd18b2949b9590b3c012f5b7e1804e6e329fb0fe053946d5ec","0e5318ec2275d8da858b541920d9306650ae6ac8012f0e872fe66eb50321a669","cf530297c3fb3a92ec9591dd4fa229d58b5981e45fe6702a0bd2bea53a5e59be","c1f6f7d08d42148ddfe164d36d7aba91f467dbcb3caa715966ff95f55048b3a4","f4e9bf9103191ef3b3612d3ec0044ca4044ca5be27711fe648ada06fad4bcc85","0c1ee27b8f6a00097c2d6d91a21ee4d096ab52c1e28350f6362542b55380059a","7677d5b0db9e020d3017720f853ba18f415219fb3a9597343b1b1012cfd699f7","bc1c6bc119c1784b1a2be6d9c47addec0d83ef0d52c8fbe1f14a51b4dfffc675","52cf2ce99c2a23de70225e252e9822a22b4e0adb82643ab0b710858810e00bf1","770625067bb27a20b9826255a8d47b6b5b0a2d3dfcbd21f89904c731f671ba77","d1ed6765f4d7906a05968fb5cd6d1db8afa14dbe512a4884e8ea5c0f5e142c80","799c0f1b07c092626cf1efd71d459997635911bb5f7fc1196efe449bba87e965","2a184e4462b9914a30b1b5c41cf80c6d3428f17b20d3afb711fff3f0644001fd","9eabde32a3aa5d80de34af2c2206cdc3ee094c6504a8d0c2d6d20c7c179503cc","397c8051b6cfcb48aa22656f0faca2553c5f56187262135162ee79d2b2f6c966","a8ead142e0c87dcd5dc130eba1f8eeed506b08952d905c47621dc2f583b1bff9","a02f10ea5f73130efca046429254a4e3c06b5475baecc8f7b99a0014731be8b3","c2576a4083232b0e2d9bd06875dd43d371dee2e090325a9eac0133fd5650c1cb","4c9a0564bb317349de6a24eb4efea8bb79898fa72ad63a1809165f5bd42970dd","f40ac11d8859092d20f953aae14ba967282c3bb056431a37fced1866ec7a2681","cc11e9e79d4746cc59e0e17473a59d6f104692fd0eeea1bdb2e206eabed83b03","b444a410d34fb5e98aa5ee2b381362044f4884652e8bc8a11c8fe14bbd85518e","c35808c1f5e16d2c571aa65067e3cb95afeff843b259ecfa2fc107a9519b5392","14d5dc055143e941c8743c6a21fa459f961cbc3deedf1bfe47b11587ca4b3ef5","a3ad4e1fc542751005267d50a6298e6765928c0c3a8dce1572f2ba6ca518661c","f237e7c97a3a89f4591afd49ecb3bd8d14f51a1c4adc8fcae3430febedff5eb6","3ffdfbec93b7aed71082af62b8c3e0cc71261cc68d796665faa1e91604fbae8f","662201f943ed45b1ad600d03a90dffe20841e725203ced8b708c91fcd7f9379a","c9ef74c64ed051ea5b958621e7fb853fe3b56e8787c1587aefc6ea988b3c7e79","2462ccfac5f3375794b861abaa81da380f1bbd9401de59ffa43119a0b644253d","34baf65cfee92f110d6653322e2120c2d368ee64b3c7981dff08ed105c4f19b0","7d8ddf0f021c53099e34ee831a06c394d50371816caa98684812f089b4c6b3d4","7d2a0ba1297be385a89b5515b88cd31b4a1eeef5236f710166dc1b36b1741e1b","9d92b037978bb9525bc4b673ebddd443277542e010c0aef019c03a170ccdaa73","ab82804a14454734010dcdcd43f564ff7b0389bee4c5692eec76ff5b30d4cf66","bae8d023ef6b23df7da26f51cea44321f95817c190342a36882e93b80d07a960","ae271d475b632ce7b03fea6d9cf6da72439e57a109672671cbc79f54e1386938"],"options":{"composite":true,"declaration":true,"declarationMap":true,"emitDeclarationOnly":true,"esModuleInterop":true,"inlineSources":true,"module":1,"outDir":"./types","rootDir":"../src","sourceMap":true,"strict":true,"target":7},"fileIdsList":[[234],[92,128,129,130,145],[129,130,146,147],[128,129],[128,145,148,151],[128,148,151,152],[149,150,151,153,154],[128,151],[128,145,148,149,150,153],[128,136],[128],[92,128],[80,128],[132,133,134,135,136,137,138,139,140,141,142,143,144],[128,134,135],[128,134,136],[199],[199,200,201],[64],[67],[64,67],[65,66,67,68,69,70,71,72,73,74,75,156,159,160,161,162,163,164,165,166],[58,64,65],[67,73,75,155],[158],[67,68],[64,162],[194,195],[234,235,236,237,238],[234,236],[157],[241,242,243],[93,128],[246],[247],[258],[252,257],[261,263,264,265,266,267,268,269,270,271,272,273],[261,262,264,265,266,267,268,269,270,271,272,273],[262,263,264,265,266,267,268,269,270,271,272,273],[261,262,263,265,266,267,268,269,270,271,272,273],[261,262,263,264,266,267,268,269,270,271,272,273],[261,262,263,264,265,267,268,269,270,271,272,273],[261,262,263,264,265,266,268,269,270,271,272,273],[261,262,263,264,265,266,267,269,270,271,272,273],[261,262,263,264,265,266,267,268,270,271,272,273],[261,262,263,264,265,266,267,268,269,271,272,273],[261,262,263,264,265,266,267,268,269,270,272,273],[261,262,263,264,265,266,267,268,269,270,271,273],[261,262,263,264,265,266,267,268,269,270,271,272],[76],[79],[80,85,112],[81,92,93,100,109,120],[81,82,92,100],[83,121],[84,85,93,101],[85,109,117],[86,88,92,100],[87],[88,89],[92],[91,92],[79,92],[92,93,94,109,120],[92,93,94,109],[92,95,100,109,120],[92,93,95,96,100,109,117,120],[95,97,109,117,120],[76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127],[92,98],[99,120,125],[88,92,100,109],[101],[102],[79,103],[104,119,125],[105],[106],[92,107],[107,108,121,123],[80,92,109,110,111],[80,109,111],[109,110],[112],[113],[92,115,116],[115,116],[85,100,109,117],[118],[100,119],[80,95,106,120],[85,121],[109,122],[123],[124],[80,85,92,94,103,109,120,123,125],[109,126],[128,279],[282,321],[282,306,321],[321],[282],[282,307,321],[282,283,284,285,286,287,288,289,290,291,292,293,294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,320],[307,321],[322],[325],[204],[204,215,216],[216,217,218],[179],[179,180,181,182,183],[168,169,170,171,172,173,174,175,176,177,178],[250,253],[250,253,254,255],[252],[249,256],[251],[57,59,60,61,62,63],[57,58],[59],[58,59],[57,59],[167,184,185,186],[185],[186],[56,185,186,187],[189],[189,190,193,197],[196],[167,191,192],[212,213,214],[211,212],[167,211,212],[167,204,211],[167,188,191,198,224,228,229,230,231],[232],[191,192,198,232],[167,204],[167,205],[205,206,207,208,209,210],[167,188,191,198,202,203,220,221],[220],[203,220,222,223],[167,198,215,219],[167,188,224,225],[128,167,188,224,225],[225,226,227],[167,224],[167,188,224,228],[191,232]],"referencedMap":[[236,1],[146,2],[148,3],[130,4],[152,5],[153,6],[149,6],[155,7],[150,6],[154,8],[151,9],[137,10],[134,11],[141,12],[135,10],[132,13],[145,14],[139,11],[136,15],[138,16],[204,12],[200,17],[201,17],[202,18],[65,19],[66,19],[68,20],[69,19],[70,19],[71,21],[67,19],[167,22],[75,23],[156,24],[159,25],[165,26],[166,27],[196,28],[239,29],[235,1],[237,30],[238,1],[192,11],[158,31],[244,32],[245,33],[247,34],[248,35],[259,36],[258,37],[262,38],[263,39],[261,40],[264,41],[265,42],[266,43],[267,44],[268,45],[269,46],[270,47],[271,48],[272,49],[273,50],[76,51],[77,51],[79,52],[80,53],[81,54],[82,55],[83,56],[84,57],[85,58],[86,59],[87,60],[88,61],[89,61],[90,62],[91,63],[92,64],[93,65],[94,66],[95,67],[96,68],[97,69],[128,70],[98,71],[99,72],[100,73],[101,74],[102,75],[103,76],[104,77],[105,78],[106,79],[107,80],[108,81],[109,82],[111,83],[110,84],[112,85],[113,86],[115,87],[116,88],[117,89],[118,90],[119,91],[120,92],[121,93],[122,94],[123,95],[124,96],[125,97],[126,98],[276,11],[280,99],[281,11],[306,100],[307,101],[282,102],[285,102],[304,100],[305,100],[295,100],[294,103],[292,100],[287,100],[300,100],[298,100],[302,100],[286,100],[299,100],[303,100],[288,100],[289,100],[301,100],[283,100],[290,100],[291,100],[293,100],[297,100],[308,104],[296,100],[284,100],[321,105],[315,104],[317,106],[316,104],[309,104],[310,104],[312,104],[314,104],[318,106],[319,106],[311,106],[313,106],[323,107],[326,108],[216,109],[217,110],[218,110],[219,111],[175,112],[177,112],[176,112],[174,112],[184,113],[179,114],[170,112],[171,112],[172,112],[173,112],[254,115],[256,116],[255,115],[253,117],[257,118],[252,119],[64,120],[59,121],[60,122],[61,122],[62,123],[63,123],[58,124],[187,125],[186,126],[185,127],[188,128],[190,129],[198,130],[197,131],[193,132],[215,133],[213,134],[214,135],[212,136],[232,137],[230,138],[231,139],[233,138],[205,140],[206,141],[207,141],[209,141],[211,142],[210,141],[222,143],[221,144],[223,144],[224,145],[220,146],[226,147],[227,148],[228,149],[225,150]],"exportedModulesMap":[[236,1],[146,2],[148,3],[130,4],[152,5],[153,6],[149,6],[155,7],[150,6],[154,8],[151,9],[137,10],[134,11],[141,12],[135,10],[132,13],[145,14],[139,11],[136,15],[138,16],[204,12],[200,17],[201,17],[202,18],[65,19],[66,19],[68,20],[69,19],[70,19],[71,21],[67,19],[167,22],[75,23],[156,24],[159,25],[165,26],[166,27],[196,28],[239,29],[235,1],[237,30],[238,1],[192,11],[158,31],[244,32],[245,33],[247,34],[248,35],[259,36],[258,37],[262,38],[263,39],[261,40],[264,41],[265,42],[266,43],[267,44],[268,45],[269,46],[270,47],[271,48],[272,49],[273,50],[76,51],[77,51],[79,52],[80,53],[81,54],[82,55],[83,56],[84,57],[85,58],[86,59],[87,60],[88,61],[89,61],[90,62],[91,63],[92,64],[93,65],[94,66],[95,67],[96,68],[97,69],[128,70],[98,71],[99,72],[100,73],[101,74],[102,75],[103,76],[104,77],[105,78],[106,79],[107,80],[108,81],[109,82],[111,83],[110,84],[112,85],[113,86],[115,87],[116,88],[117,89],[118,90],[119,91],[120,92],[121,93],[122,94],[123,95],[124,96],[125,97],[126,98],[276,11],[280,99],[281,11],[306,100],[307,101],[282,102],[285,102],[304,100],[305,100],[295,100],[294,103],[292,100],[287,100],[300,100],[298,100],[302,100],[286,100],[299,100],[303,100],[288,100],[289,100],[301,100],[283,100],[290,100],[291,100],[293,100],[297,100],[308,104],[296,100],[284,100],[321,105],[315,104],[317,106],[316,104],[309,104],[310,104],[312,104],[314,104],[318,106],[319,106],[311,106],[313,106],[323,107],[326,108],[216,109],[217,110],[218,110],[219,111],[175,112],[177,112],[176,112],[174,112],[184,113],[179,114],[170,112],[171,112],[172,112],[173,112],[254,115],[256,116],[255,115],[253,117],[257,118],[252,119],[64,120],[59,121],[60,122],[61,122],[62,123],[63,123],[58,124],[187,125],[186,126],[185,127],[188,128],[190,129],[198,130],[197,131],[193,132],[215,133],[213,134],[214,135],[212,136],[232,151],[230,138],[231,152],[233,138],[205,140],[206,141],[207,141],[209,141],[211,142],[210,141],[222,143],[221,144],[223,144],[224,145],[220,146],[226,147],[227,148],[228,149],[225,150]],"semanticDiagnosticsPerFile":[236,234,146,129,148,130,147,152,153,149,155,150,154,151,137,134,141,135,132,140,145,142,143,144,139,136,133,138,191,204,200,201,202,199,65,66,68,69,70,71,72,73,74,67,167,75,156,159,160,161,162,163,164,165,166,194,196,195,239,235,237,238,192,158,240,241,244,242,245,246,247,248,259,258,243,260,262,263,261,264,265,266,267,268,269,270,271,272,273,274,157,76,77,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,78,127,95,96,97,128,98,99,100,101,102,103,104,105,106,107,108,109,111,110,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,275,276,277,278,280,279,281,306,307,282,285,304,305,295,294,292,287,300,298,302,286,299,303,288,289,301,283,290,291,293,297,308,296,284,321,320,315,317,316,309,310,312,314,318,319,311,313,323,322,324,229,325,326,131,249,216,217,218,219,178,175,177,176,174,184,179,183,180,182,181,170,171,172,168,169,173,250,254,256,255,253,257,252,251,57,64,59,60,61,62,63,58,8,10,9,2,11,12,13,14,15,16,17,18,3,4,22,19,20,21,23,24,25,5,26,27,28,29,6,33,30,31,32,34,7,35,40,41,36,37,38,39,1,42,56,187,186,185,188,190,198,197,189,193,215,213,214,212,232,230,231,233,205,206,207,208,209,211,210,222,203,221,223,224,220,226,227,228,225,47,48,49,50,51,52,43,53,54,55,44,45,46],"latestChangedDtsFile":"./types/index.d.ts"},"version":"4.9.5"}
+\ No newline at end of file
++{"program":{"fileNames":["../../../node_modules/typescript/lib/lib.es5.d.ts","../../../node_modules/typescript/lib/lib.es2015.d.ts","../../../node_modules/typescript/lib/lib.es2016.d.ts","../../../node_modules/typescript/lib/lib.es2017.d.ts","../../../node_modules/typescript/lib/lib.es2018.d.ts","../../../node_modules/typescript/lib/lib.es2019.d.ts","../../../node_modules/typescript/lib/lib.es2020.d.ts","../../../node_modules/typescript/lib/lib.dom.d.ts","../../../node_modules/typescript/lib/lib.es2015.core.d.ts","../../../node_modules/typescript/lib/lib.es2015.collection.d.ts","../../../node_modules/typescript/lib/lib.es2015.generator.d.ts","../../../node_modules/typescript/lib/lib.es2015.iterable.d.ts","../../../node_modules/typescript/lib/lib.es2015.promise.d.ts","../../../node_modules/typescript/lib/lib.es2015.proxy.d.ts","../../../node_modules/typescript/lib/lib.es2015.reflect.d.ts","../../../node_modules/typescript/lib/lib.es2015.symbol.d.ts","../../../node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts","../../../node_modules/typescript/lib/lib.es2016.array.include.d.ts","../../../node_modules/typescript/lib/lib.es2017.object.d.ts","../../../node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts","../../../node_modules/typescript/lib/lib.es2017.string.d.ts","../../../node_modules/typescript/lib/lib.es2017.intl.d.ts","../../../node_modules/typescript/lib/lib.es2017.typedarrays.d.ts","../../../node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts","../../../node_modules/typescript/lib/lib.es2018.asynciterable.d.ts","../../../node_modules/typescript/lib/lib.es2018.intl.d.ts","../../../node_modules/typescript/lib/lib.es2018.promise.d.ts","../../../node_modules/typescript/lib/lib.es2018.regexp.d.ts","../../../node_modules/typescript/lib/lib.es2019.array.d.ts","../../../node_modules/typescript/lib/lib.es2019.object.d.ts","../../../node_modules/typescript/lib/lib.es2019.string.d.ts","../../../node_modules/typescript/lib/lib.es2019.symbol.d.ts","../../../node_modules/typescript/lib/lib.es2019.intl.d.ts","../../../node_modules/typescript/lib/lib.es2020.bigint.d.ts","../../../node_modules/typescript/lib/lib.es2020.date.d.ts","../../../node_modules/typescript/lib/lib.es2020.promise.d.ts","../../../node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts","../../../node_modules/typescript/lib/lib.es2020.string.d.ts","../../../node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts","../../../node_modules/typescript/lib/lib.es2020.intl.d.ts","../../../node_modules/typescript/lib/lib.es2020.number.d.ts","../../../node_modules/typescript/lib/lib.esnext.intl.d.ts","../../../types/eth-ens-namehash.d.ts","../../../types/ethereum-ens-network-map.d.ts","../../../types/global.d.ts","../../../types/single-call-balance-checker-abi.d.ts","../../../types/@metamask/contract-metadata.d.ts","../../../types/@metamask/eth-hd-keyring.d.ts","../../../types/@metamask/eth-simple-keyring.d.ts","../../../types/@metamask/ethjs-provider-http.d.ts","../../../types/@metamask/ethjs-unit.d.ts","../../../types/@metamask/metamask-eth-abis.d.ts","../../../types/eth-json-rpc-infura/src/createprovider.d.ts","../../../types/eth-phishing-detect/src/config.json.d.ts","../../../types/eth-phishing-detect/src/detector.d.ts","../../base-controller/dist/types/basecontrollerv1.d.ts","../../../node_modules/superstruct/dist/error.d.ts","../../../node_modules/superstruct/dist/utils.d.ts","../../../node_modules/superstruct/dist/struct.d.ts","../../../node_modules/superstruct/dist/structs/coercions.d.ts","../../../node_modules/superstruct/dist/structs/refinements.d.ts","../../../node_modules/superstruct/dist/structs/types.d.ts","../../../node_modules/superstruct/dist/structs/utilities.d.ts","../../../node_modules/superstruct/dist/index.d.ts","../../../node_modules/@metamask/utils/dist/types/assert.d.ts","../../../node_modules/@metamask/utils/dist/types/base64.d.ts","../../../node_modules/@metamask/utils/dist/types/hex.d.ts","../../../node_modules/@metamask/utils/dist/types/bytes.d.ts","../../../node_modules/@metamask/utils/dist/types/caip-types.d.ts","../../../node_modules/@metamask/utils/dist/types/checksum.d.ts","../../../node_modules/@metamask/utils/dist/types/coercers.d.ts","../../../node_modules/@metamask/utils/dist/types/collections.d.ts","../../../node_modules/@metamask/utils/dist/types/encryption-types.d.ts","../../../node_modules/@metamask/utils/dist/types/errors.d.ts","../../../node_modules/@metamask/utils/dist/types/json.d.ts","../../../node_modules/@types/node/assert.d.ts","../../../node_modules/@types/node/assert/strict.d.ts","../../../node_modules/@types/node/globals.d.ts","../../../node_modules/@types/node/async_hooks.d.ts","../../../node_modules/@types/node/buffer.d.ts","../../../node_modules/@types/node/child_process.d.ts","../../../node_modules/@types/node/cluster.d.ts","../../../node_modules/@types/node/console.d.ts","../../../node_modules/@types/node/constants.d.ts","../../../node_modules/@types/node/crypto.d.ts","../../../node_modules/@types/node/dgram.d.ts","../../../node_modules/@types/node/diagnostics_channel.d.ts","../../../node_modules/@types/node/dns.d.ts","../../../node_modules/@types/node/dns/promises.d.ts","../../../node_modules/@types/node/dom-events.d.ts","../../../node_modules/@types/node/domain.d.ts","../../../node_modules/@types/node/events.d.ts","../../../node_modules/@types/node/fs.d.ts","../../../node_modules/@types/node/fs/promises.d.ts","../../../node_modules/@types/node/http.d.ts","../../../node_modules/@types/node/http2.d.ts","../../../node_modules/@types/node/https.d.ts","../../../node_modules/@types/node/inspector.d.ts","../../../node_modules/@types/node/module.d.ts","../../../node_modules/@types/node/net.d.ts","../../../node_modules/@types/node/os.d.ts","../../../node_modules/@types/node/path.d.ts","../../../node_modules/@types/node/perf_hooks.d.ts","../../../node_modules/@types/node/process.d.ts","../../../node_modules/@types/node/punycode.d.ts","../../../node_modules/@types/node/querystring.d.ts","../../../node_modules/@types/node/readline.d.ts","../../../node_modules/@types/node/repl.d.ts","../../../node_modules/@types/node/stream.d.ts","../../../node_modules/@types/node/stream/promises.d.ts","../../../node_modules/@types/node/stream/consumers.d.ts","../../../node_modules/@types/node/stream/web.d.ts","../../../node_modules/@types/node/string_decoder.d.ts","../../../node_modules/@types/node/test.d.ts","../../../node_modules/@types/node/timers.d.ts","../../../node_modules/@types/node/timers/promises.d.ts","../../../node_modules/@types/node/tls.d.ts","../../../node_modules/@types/node/trace_events.d.ts","../../../node_modules/@types/node/tty.d.ts","../../../node_modules/@types/node/url.d.ts","../../../node_modules/@types/node/util.d.ts","../../../node_modules/@types/node/v8.d.ts","../../../node_modules/@types/node/vm.d.ts","../../../node_modules/@types/node/wasi.d.ts","../../../node_modules/@types/node/worker_threads.d.ts","../../../node_modules/@types/node/zlib.d.ts","../../../node_modules/@types/node/globals.global.d.ts","../../../node_modules/@types/node/index.d.ts","../../../node_modules/@ethereumjs/common/dist/enums.d.ts","../../../node_modules/@ethereumjs/common/dist/types.d.ts","../../../node_modules/buffer/index.d.ts","../../../node_modules/@ethereumjs/util/dist/constants.d.ts","../../../node_modules/@ethereumjs/util/dist/units.d.ts","../../../node_modules/@ethereumjs/util/dist/address.d.ts","../../../node_modules/@ethereumjs/util/dist/bytes.d.ts","../../../node_modules/@ethereumjs/util/dist/types.d.ts","../../../node_modules/@ethereumjs/util/dist/account.d.ts","../../../node_modules/@ethereumjs/util/dist/withdrawal.d.ts","../../../node_modules/@ethereumjs/util/dist/signature.d.ts","../../../node_modules/@ethereumjs/util/dist/encoding.d.ts","../../../node_modules/@ethereumjs/util/dist/asynceventemitter.d.ts","../../../node_modules/@ethereumjs/util/dist/internal.d.ts","../../../node_modules/@ethereumjs/util/dist/lock.d.ts","../../../node_modules/@ethereumjs/util/dist/provider.d.ts","../../../node_modules/@ethereumjs/util/dist/index.d.ts","../../../node_modules/@ethereumjs/common/dist/common.d.ts","../../../node_modules/@ethereumjs/common/dist/utils.d.ts","../../../node_modules/@ethereumjs/common/dist/index.d.ts","../../../node_modules/@ethereumjs/tx/dist/eip2930transaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/legacytransaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/types.d.ts","../../../node_modules/@ethereumjs/tx/dist/basetransaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/eip1559transaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/transactionfactory.d.ts","../../../node_modules/@ethereumjs/tx/dist/index.d.ts","../../../node_modules/@metamask/utils/dist/types/keyring.d.ts","../../../node_modules/@types/ms/index.d.ts","../../../node_modules/@types/debug/index.d.ts","../../../node_modules/@metamask/utils/dist/types/logging.d.ts","../../../node_modules/@metamask/utils/dist/types/misc.d.ts","../../../node_modules/@metamask/utils/dist/types/number.d.ts","../../../node_modules/@metamask/utils/dist/types/opaque.d.ts","../../../node_modules/@metamask/utils/dist/types/promise.d.ts","../../../node_modules/@metamask/utils/dist/types/time.d.ts","../../../node_modules/@metamask/utils/dist/types/transaction-types.d.ts","../../../node_modules/@metamask/utils/dist/types/versions.d.ts","../../../node_modules/@metamask/utils/dist/types/index.d.ts","../../../node_modules/immer/dist/utils/env.d.ts","../../../node_modules/immer/dist/utils/errors.d.ts","../../../node_modules/immer/dist/types/types-external.d.ts","../../../node_modules/immer/dist/types/types-internal.d.ts","../../../node_modules/immer/dist/utils/common.d.ts","../../../node_modules/immer/dist/utils/plugins.d.ts","../../../node_modules/immer/dist/core/scope.d.ts","../../../node_modules/immer/dist/core/finalize.d.ts","../../../node_modules/immer/dist/core/proxy.d.ts","../../../node_modules/immer/dist/core/immerclass.d.ts","../../../node_modules/immer/dist/core/current.d.ts","../../../node_modules/immer/dist/internal.d.ts","../../../node_modules/immer/dist/plugins/es5.d.ts","../../../node_modules/immer/dist/plugins/patches.d.ts","../../../node_modules/immer/dist/plugins/mapset.d.ts","../../../node_modules/immer/dist/plugins/all.d.ts","../../../node_modules/immer/dist/immer.d.ts","../../base-controller/dist/types/restrictedcontrollermessenger.d.ts","../../base-controller/dist/types/controllermessenger.d.ts","../../base-controller/dist/types/basecontrollerv2.d.ts","../../base-controller/dist/types/index.d.ts","../../controller-utils/dist/types/types.d.ts","../../controller-utils/dist/types/constants.d.ts","../../../node_modules/@metamask/eth-query/index.d.ts","../../../node_modules/@types/bn.js/index.d.ts","../../controller-utils/dist/types/util.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/abnf.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/utils.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/parsers.d.ts","../../controller-utils/dist/types/siwe.d.ts","../../controller-utils/dist/types/index.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/types.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/createeventemitterproxy.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/createswappableproxy.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/index.d.ts","../../network-controller/dist/types/constants.d.ts","../../../node_modules/@metamask/safe-event-emitter/dist/cjs/index.d.ts","../../json-rpc-engine/dist/types/jsonrpcengine.d.ts","../../json-rpc-engine/dist/types/createasyncmiddleware.d.ts","../../json-rpc-engine/dist/types/createscaffoldmiddleware.d.ts","../../json-rpc-engine/dist/types/getuniqueid.d.ts","../../json-rpc-engine/dist/types/idremapmiddleware.d.ts","../../json-rpc-engine/dist/types/mergemiddleware.d.ts","../../json-rpc-engine/dist/types/index.d.ts","../../eth-json-rpc-provider/dist/types/safe-event-emitter-provider.d.ts","../../eth-json-rpc-provider/dist/types/provider-from-engine.d.ts","../../eth-json-rpc-provider/dist/types/provider-from-middleware.d.ts","../../eth-json-rpc-provider/dist/types/index.d.ts","../../../node_modules/eth-block-tracker/dist/blocktracker.d.ts","../../../node_modules/eth-block-tracker/dist/pollingblocktracker.d.ts","../../../node_modules/eth-block-tracker/dist/subscribeblocktracker.d.ts","../../../node_modules/eth-block-tracker/dist/index.d.ts","../../network-controller/dist/types/types.d.ts","../../network-controller/dist/types/create-auto-managed-network-client.d.ts","../../network-controller/dist/types/networkcontroller.d.ts","../../network-controller/dist/types/create-network-client.d.ts","../../network-controller/dist/types/index.d.ts","../../polling-controller/dist/types/types.d.ts","../../polling-controller/dist/types/blocktrackerpollingcontroller.d.ts","../../polling-controller/dist/types/staticintervalpollingcontroller.d.ts","../../polling-controller/dist/types/index.d.ts","../../../node_modules/@types/uuid/index.d.ts","../src/determinegasfeecalculations.ts","../src/gas-util.ts","../src/gasfeecontroller.ts","../src/index.ts","../../../node_modules/@babel/types/lib/index.d.ts","../../../node_modules/@types/babel__generator/index.d.ts","../../../node_modules/@babel/parser/typings/babel-parser.d.ts","../../../node_modules/@types/babel__template/index.d.ts","../../../node_modules/@types/babel__traverse/index.d.ts","../../../node_modules/@types/babel__core/index.d.ts","../../../node_modules/@types/deep-freeze-strict/index.d.ts","../../../node_modules/@types/eslint/helpers.d.ts","../../../node_modules/@types/estree/index.d.ts","../../../node_modules/@types/json-schema/index.d.ts","../../../node_modules/@types/eslint/index.d.ts","../../../node_modules/@types/graceful-fs/index.d.ts","../../../node_modules/@types/istanbul-lib-coverage/index.d.ts","../../../node_modules/@types/istanbul-lib-report/index.d.ts","../../../node_modules/@types/istanbul-reports/index.d.ts","../../../node_modules/chalk/index.d.ts","../../../node_modules/jest-diff/build/cleanupsemantic.d.ts","../../../node_modules/pretty-format/build/types.d.ts","../../../node_modules/pretty-format/build/index.d.ts","../../../node_modules/jest-diff/build/types.d.ts","../../../node_modules/jest-diff/build/difflines.d.ts","../../../node_modules/jest-diff/build/printdiffs.d.ts","../../../node_modules/jest-diff/build/index.d.ts","../../../node_modules/jest-matcher-utils/build/index.d.ts","../../../node_modules/@types/jest/index.d.ts","../../../node_modules/@types/jest-when/index.d.ts","../../../node_modules/@types/json5/index.d.ts","../../../node_modules/@types/lodash/common/common.d.ts","../../../node_modules/@types/lodash/common/array.d.ts","../../../node_modules/@types/lodash/common/collection.d.ts","../../../node_modules/@types/lodash/common/date.d.ts","../../../node_modules/@types/lodash/common/function.d.ts","../../../node_modules/@types/lodash/common/lang.d.ts","../../../node_modules/@types/lodash/common/math.d.ts","../../../node_modules/@types/lodash/common/number.d.ts","../../../node_modules/@types/lodash/common/object.d.ts","../../../node_modules/@types/lodash/common/seq.d.ts","../../../node_modules/@types/lodash/common/string.d.ts","../../../node_modules/@types/lodash/common/util.d.ts","../../../node_modules/@types/lodash/index.d.ts","../../../node_modules/@types/minimatch/index.d.ts","../../../node_modules/@types/parse-json/index.d.ts","../../../node_modules/@types/pbkdf2/index.d.ts","../../../node_modules/@types/prettier/index.d.ts","../../../node_modules/@types/punycode/index.d.ts","../../../node_modules/@types/readable-stream/node_modules/safe-buffer/index.d.ts","../../../node_modules/@types/readable-stream/index.d.ts","../../../node_modules/@types/secp256k1/index.d.ts","../../../node_modules/@types/semver/classes/semver.d.ts","../../../node_modules/@types/semver/functions/parse.d.ts","../../../node_modules/@types/semver/functions/valid.d.ts","../../../node_modules/@types/semver/functions/clean.d.ts","../../../node_modules/@types/semver/functions/inc.d.ts","../../../node_modules/@types/semver/functions/diff.d.ts","../../../node_modules/@types/semver/functions/major.d.ts","../../../node_modules/@types/semver/functions/minor.d.ts","../../../node_modules/@types/semver/functions/patch.d.ts","../../../node_modules/@types/semver/functions/prerelease.d.ts","../../../node_modules/@types/semver/functions/compare.d.ts","../../../node_modules/@types/semver/functions/rcompare.d.ts","../../../node_modules/@types/semver/functions/compare-loose.d.ts","../../../node_modules/@types/semver/functions/compare-build.d.ts","../../../node_modules/@types/semver/functions/sort.d.ts","../../../node_modules/@types/semver/functions/rsort.d.ts","../../../node_modules/@types/semver/functions/gt.d.ts","../../../node_modules/@types/semver/functions/lt.d.ts","../../../node_modules/@types/semver/functions/eq.d.ts","../../../node_modules/@types/semver/functions/neq.d.ts","../../../node_modules/@types/semver/functions/gte.d.ts","../../../node_modules/@types/semver/functions/lte.d.ts","../../../node_modules/@types/semver/functions/cmp.d.ts","../../../node_modules/@types/semver/functions/coerce.d.ts","../../../node_modules/@types/semver/classes/comparator.d.ts","../../../node_modules/@types/semver/classes/range.d.ts","../../../node_modules/@types/semver/functions/satisfies.d.ts","../../../node_modules/@types/semver/ranges/max-satisfying.d.ts","../../../node_modules/@types/semver/ranges/min-satisfying.d.ts","../../../node_modules/@types/semver/ranges/to-comparators.d.ts","../../../node_modules/@types/semver/ranges/min-version.d.ts","../../../node_modules/@types/semver/ranges/valid.d.ts","../../../node_modules/@types/semver/ranges/outside.d.ts","../../../node_modules/@types/semver/ranges/gtr.d.ts","../../../node_modules/@types/semver/ranges/ltr.d.ts","../../../node_modules/@types/semver/ranges/intersects.d.ts","../../../node_modules/@types/semver/ranges/simplify.d.ts","../../../node_modules/@types/semver/ranges/subset.d.ts","../../../node_modules/@types/semver/internals/identifiers.d.ts","../../../node_modules/@types/semver/index.d.ts","../../../node_modules/@types/sinonjs__fake-timers/index.d.ts","../../../node_modules/@types/sinon/index.d.ts","../../../node_modules/@types/stack-utils/index.d.ts","../../../node_modules/@types/yargs-parser/index.d.ts","../../../node_modules/@types/yargs/index.d.ts"],"fileInfos":[{"version":"8730f4bf322026ff5229336391a18bcaa1f94d4f82416c8b2f3954e2ccaae2ba","affectsGlobalScope":true},"dc47c4fa66b9b9890cf076304de2a9c5201e94b740cffdf09f87296d877d71f6","7a387c58583dfca701b6c85e0adaf43fb17d590fb16d5b2dc0a2fbd89f35c467","8a12173c586e95f4433e0c6dc446bc88346be73ffe9ca6eec7aa63c8f3dca7f9","5f4e733ced4e129482ae2186aae29fde948ab7182844c3a5a51dd346182c7b06","4b421cbfb3a38a27c279dec1e9112c3d1da296f77a1a85ddadf7e7a425d45d18","1fc5ab7a764205c68fa10d381b08417795fc73111d6dd16b5b1ed36badb743d9",{"version":"3aafcb693fe5b5c3bd277bd4c3a617b53db474fe498fc5df067c5603b1eebde7","affectsGlobalScope":true},{"version":"adb996790133eb33b33aadb9c09f15c2c575e71fb57a62de8bf74dbf59ec7dfb","affectsGlobalScope":true},{"version":"8cc8c5a3bac513368b0157f3d8b31cfdcfe78b56d3724f30f80ed9715e404af8","affectsGlobalScope":true},{"version":"cdccba9a388c2ee3fd6ad4018c640a471a6c060e96f1232062223063b0a5ac6a","affectsGlobalScope":true},{"version":"c5c05907c02476e4bde6b7e76a79ffcd948aedd14b6a8f56e4674221b0417398","affectsGlobalScope":true},{"version":"5f406584aef28a331c36523df688ca3650288d14f39c5d2e555c95f0d2ff8f6f","affectsGlobalScope":true},{"version":"22f230e544b35349cfb3bd9110b6ef37b41c6d6c43c3314a31bd0d9652fcec72","affectsGlobalScope":true},{"version":"7ea0b55f6b315cf9ac2ad622b0a7813315bb6e97bf4bb3fbf8f8affbca7dc695","affectsGlobalScope":true},{"version":"3013574108c36fd3aaca79764002b3717da09725a36a6fc02eac386593110f93","affectsGlobalScope":true},{"version":"eb26de841c52236d8222f87e9e6a235332e0788af8c87a71e9e210314300410a","affectsGlobalScope":true},{"version":"3be5a1453daa63e031d266bf342f3943603873d890ab8b9ada95e22389389006","affectsGlobalScope":true},{"version":"17bb1fc99591b00515502d264fa55dc8370c45c5298f4a5c2083557dccba5a2a","affectsGlobalScope":true},{"version":"7ce9f0bde3307ca1f944119f6365f2d776d281a393b576a18a2f2893a2d75c98","affectsGlobalScope":true},{"version":"6a6b173e739a6a99629a8594bfb294cc7329bfb7b227f12e1f7c11bc163b8577","affectsGlobalScope":true},{"version":"81cac4cbc92c0c839c70f8ffb94eb61e2d32dc1c3cf6d95844ca099463cf37ea","affectsGlobalScope":true},{"version":"b0124885ef82641903d232172577f2ceb5d3e60aed4da1153bab4221e1f6dd4e","affectsGlobalScope":true},{"version":"0eb85d6c590b0d577919a79e0084fa1744c1beba6fd0d4e951432fa1ede5510a","affectsGlobalScope":true},{"version":"da233fc1c8a377ba9e0bed690a73c290d843c2c3d23a7bd7ec5cd3d7d73ba1e0","affectsGlobalScope":true},{"version":"d154ea5bb7f7f9001ed9153e876b2d5b8f5c2bb9ec02b3ae0d239ec769f1f2ae","affectsGlobalScope":true},{"version":"bb2d3fb05a1d2ffbca947cc7cbc95d23e1d053d6595391bd325deb265a18d36c","affectsGlobalScope":true},{"version":"c80df75850fea5caa2afe43b9949338ce4e2de086f91713e9af1a06f973872b8","affectsGlobalScope":true},{"version":"9d57b2b5d15838ed094aa9ff1299eecef40b190722eb619bac4616657a05f951","affectsGlobalScope":true},{"version":"6c51b5dd26a2c31dbf37f00cfc32b2aa6a92e19c995aefb5b97a3a64f1ac99de","affectsGlobalScope":true},{"version":"6e7997ef61de3132e4d4b2250e75343f487903ddf5370e7ce33cf1b9db9a63ed","affectsGlobalScope":true},{"version":"2ad234885a4240522efccd77de6c7d99eecf9b4de0914adb9a35c0c22433f993","affectsGlobalScope":true},{"version":"5e5e095c4470c8bab227dbbc61374878ecead104c74ab9960d3adcccfee23205","affectsGlobalScope":true},{"version":"09aa50414b80c023553090e2f53827f007a301bc34b0495bfb2c3c08ab9ad1eb","affectsGlobalScope":true},{"version":"d7f680a43f8cd12a6b6122c07c54ba40952b0c8aa140dcfcf32eb9e6cb028596","affectsGlobalScope":true},{"version":"3787b83e297de7c315d55d4a7c546ae28e5f6c0a361b7a1dcec1f1f50a54ef11","affectsGlobalScope":true},{"version":"e7e8e1d368290e9295ef18ca23f405cf40d5456fa9f20db6373a61ca45f75f40","affectsGlobalScope":true},{"version":"faf0221ae0465363c842ce6aa8a0cbda5d9296940a8e26c86e04cc4081eea21e","affectsGlobalScope":true},{"version":"06393d13ea207a1bfe08ec8d7be562549c5e2da8983f2ee074e00002629d1871","affectsGlobalScope":true},{"version":"2768ef564cfc0689a1b76106c421a2909bdff0acbe87da010785adab80efdd5c","affectsGlobalScope":true},{"version":"b248e32ca52e8f5571390a4142558ae4f203ae2f94d5bac38a3084d529ef4e58","affectsGlobalScope":true},{"version":"52d1bb7ab7a3306fd0375c8bff560feed26ed676a5b0457fa8027b563aecb9a4","affectsGlobalScope":true},"70bbfaec021ac4a0c805374225b55d70887f987df8b8dd7711d79464bb7b4385","869089d60b67219f63e6aca810284c89bae1b384b5cbc7ce64e53d82ad223ed5",{"version":"18338b6a4b920ec7d49b4ffafcbf0fa8a86b4bfd432966efd722dab611157cf4","affectsGlobalScope":true},"62a0875a0397b35a2364f1d401c0ce17975dfa4d47bf6844de858ae04da349f9","ee7491d0318d1fafcba97d5b72b450eb52671570f7a4ecd9e8898d40eaae9472","e3e7d217d89b380c1f34395eadc9289542851b0f0a64007dfe1fb7cf7423d24e","fd79909e93b4d50fd0ed9f3d39ddf8ba0653290bac25c295aac49f6befbd081b","345a9cc2945406f53051cd0e9b51f82e1e53929848eab046fdda91ee8aa7da31","9debe2de883da37a914e5e784a7be54c201b8f1d783822ad6f443ff409a5ea21","dee5d5c5440cda1f3668f11809a5503c30db0476ad117dd450f7ba5a45300e8f","f5e396c1424c391078c866d6f84afe0b4d2f7f85a160b9c756cd63b5b1775d93","5caa6f4fff16066d377d4e254f6c34c16540da3809cd66cd626a303bc33c419f","730d055528bdf12c8524870bb33d237991be9084c57634e56e5d8075f6605e02","75b22c74010ba649de1a1676a4c4b8b5bb4294fecd05089e2094429b16d7840c","5615ccf831db2ffc82145243081ebdb60ea8e1005ee8f975d1c0c1401a9c894e","38682ed3630bb6ecdace80d5a9adc811fc20a419f1940446e306c3a020d083b9","cc182e6e4f691cd6f7bf7cb491247a4c7818f9f1cb2db1d45c65ff906e3f741b","a50599c08934a62f11657bdbe0dc929ab66da1b1f09974408fd9a33ec1bb8060","5a20e7d6c630b91be15e9b837853173829d00273197481dc8d3e94df61105a71","8d478048d71cc16f806d4b71b252ecb67c7444ccf4f4b09b29a312712184f859","e0eda929c6b9b628cdeb0e54cd3582cb97e64f28aab34612fc1431c545899584","9df4662ca3dbc2522bc115833ee04faa1afbb4e249a85ef4a0a09c621346bd08","b25d9065cf1c1f537a140bbc508e953ed2262f77134574c432d206ff36f4bdbf","1b103313097041aa9cd705a682c652f08613cb5cf8663321061c0902f845e81c","68ccec8662818911d8a12b8ed028bc5729fb4f1d34793c4701265ba60bc73cf4","5f85b8b79dc4d36af672c035b2beb71545de63a5d60bccbeee64c260941672ab","b3d48529ae61dc27d0bfbfa2cb3e0dff8189644bd155bdf5df1e8e14669f7043","40fe4b689225816b31fe5794c0fbf3534568819709e40295ead998a2bc1ab237","f65b5e33b9ad545a1eebbd6afe857314725ad42aaf069913e33f928ab3e4990a","fb6f2a87beb7fb1f4c2b762d0c76a9459fc91f557231569b0ee21399e22aa13d","31c858dc85996fac4b7fa944e1016d5c72f514930a72357ab5001097bf6511c7","3de30a871b3340be8b679c52aa12f90dd1c8c60874517be58968fdbcc4d79445","6fd985bd31eaf77542625306fb0404d32bff978990f0a06428e5f0b9a3b58109","5b3cd03ae354ea96eff1f74d7c410fe4852e6382227e8b0ecf87ab5e3a5bbcd4","7394959e5a741b185456e1ef5d64599c36c60a323207450991e7a42e08911419",{"version":"056097110efd16869ec118cedb44ecbac9a019576eee808d61304ca6d5cb2cbe","affectsGlobalScope":true},"f51b4042a3ac86f1f707500a9768f88d0b0c1fc3f3e45a73333283dea720cdc6",{"version":"6fb8358e10ed92a7f515b7d79da3904c955a3ffd4e14aa9df6f0ea113041f1cf","affectsGlobalScope":true},"45c831238c6dac21c72da5f335747736a56a3847192bf03c84b958a7e9ec93e2","661a11d16ad2e3543a77c53bcd4017ee9a450f47ab7def3ab493a86eae4d550c",{"version":"8cdc646cec7819581ef343b83855b1bfe4fe674f2c84f4fb8dc90d82fb56bd3a","affectsGlobalScope":true},"a40826e8476694e90da94aa008283a7de50d1dafd37beada623863f1901cb7fb","9dd56225cc2d8cb8fe5ceb0043ff386987637e12fecc6078896058a99deae284","2375ed4b439215aa3b6d0c6fd175c78a4384b30cb43cbadaecbf0a18954c98cb","7693b90b3075deaccafd5efb467bf9f2b747a3075be888652ef73e64396d8628","41231da15bb5e3e806a8395bd15c7befd2ec90f9f4e3c9d0ae1356bccb76dbb0","fccfef201d057cb407fa515311bd608549bab6c7b8adcf8f2df31f5d3b796478",{"version":"ee1ee365d88c4c6c0c0a5a5701d66ebc27ccd0bcfcfaa482c6e2e7fe7b98edf7","affectsGlobalScope":true},"5f20d20b7607174caf1a6da9141aeb9f2142159ae2410ca30c7a0fccd1d19c99",{"version":"464762c6213566d072f1ced5e8e9a954785ec5e53883b7397198abb5ef5b8f71","affectsGlobalScope":true},"6387920dc3e18927335b086deec75bf8e50f879a5e273d32ee7bb7a55ba50572","9bba37424094688c4663c177a1379b229f919b8912889a472f32fdc5f08ddb4d","29a4be13b3a30d3e66667b75c58ec61fb2df8fa0422534fdee3cfb30c5dbf450","83366d901beda79d6eb37aaaf6ca248dcd88946302b2a7d975590783be51e88e","bf268a0aea37ad4ae3b7a9b58559190b6fc01ea16a31e35cd05817a0a60f895a","43ec77c369473e92e2ecebf0554a0fdaa9c256644a6070f28228dfcceec77351",{"version":"d7dad6db394a3d9f7b49755e4b610fbf8ed6eb0c9810ae5f1a119f6b5d76de45","affectsGlobalScope":true},"95ed02bacb4502c985b69742ec82a4576d4ff4a6620ecc91593f611d502ae546","bf755525c4e6f85a970b98c4755d98e8aa1b6dbd83a5d8fcc57d3d497351b936","dd67d2b5e4e8a182a38de8e69fb736945eaa4588e0909c14e01a14bd3cc1fd1e",{"version":"28084e15b63e6211769db2fe646d8bc5c4c6776321e0deffe2d12eefd52cb6b9","affectsGlobalScope":true},{"version":"aed37dabf86c99d6c8508700576ecede86688397bc12523541858705a0c737c2","affectsGlobalScope":true},"cc6ef5733d4ea6d2e06310a32dffd2c16418b467c5033d49cecc4f3a25de7497","94768454c3348b6ebe48e45fbad8c92e2bb7af4a35243edbe2b90823d0bd7f9a","0be79b3ff0f16b6c2f9bc8c4cc7097ea417d8d67f8267f7e1eec8e32b548c2ff","1c61ffa3a71b77363b30d19832c269ef62fba787f5610cac7254728d3b69ab2e","84da3c28344e621fd1d591f2c09e9595292d2b70018da28a553268ac122597d4","269929a24b2816343a178008ac9ae9248304d92a8ba8e233055e0ed6dbe6ef71","6e191fea1db6e9e4fa828259cf489e820ec9170effff57fb081a2f3295db4722","aed943465fbce1efe49ee16b5ea409050f15cd8eaf116f6fadb64ef0772e7d95","70d08483a67bf7050dbedace398ef3fee9f436fcd60517c97c4c1e22e3c6f3e8","c40fdf7b2e18df49ce0568e37f0292c12807a0748be79e272745e7216bed2606",{"version":"e933de8143e1d12dd51d89b398760fd5a9081896be366dad88a922d0b29f3c69","affectsGlobalScope":true},"4e228e78c1e9b0a75c70588d59288f63a6258e8b1fe4a67b0c53fe03461421d9","b38d55d08708c2410a3039687db70b4a5bfa69fc4845617c313b5a10d9c5c637","205d50c24359ead003dc537b9b65d2a64208dfdffe368f403cf9e0357831db9e","1265fddcd0c68be9d2a3b29805d0280484c961264dd95e0b675f7bd91f777e78",{"version":"a05e2d784c9be7051c4ac87a407c66d2106e23490c18c038bbd0712bde7602fd","affectsGlobalScope":true},{"version":"df90b9d0e9980762da8daf8adf6ffa0c853e76bfd269c377be0d07a9ad87acd2","affectsGlobalScope":true},"cf434b5c04792f62d6f4bdd5e2c8673f36e638e910333c172614d5def9b17f98","1d65d4798df9c2df008884035c41d3e67731f29db5ecb64cd7378797c7c53a2f","0faee6b555890a1cb106e2adc5d3ffd89545b1da894d474e9d436596d654998f","c6c01ea1c42508edf11a36d13b70f6e35774f74355ba5d358354d4a77cc67ea1","867f95abf1df444aab146b19847391fc2f922a55f6a970a27ed8226766cee29f",{"version":"ab9b9a36e5284fd8d3bf2f7d5fcbc60052f25f27e4d20954782099282c60d23e","affectsGlobalScope":true},"b0297b09e607bec9698cac7cf55463d6731406efb1161ee4d448293b47397c84","175323e2a79a6076e0bada8a390d535a3ea817158bf1b1f46e31efca9028a0a2","7a10053aadc19335532a4d02756db4865974fd69bea5439ddcc5bfdf062d9476","4967529644e391115ca5592184d4b63980569adf60ee685f968fd59ab1557188","aed9e712a9b168345362e8f3a949f16c99ca1e05d21328f05735dfdbb24414ef","b04fe6922ed3db93afdbd49cdda8576aa75f744592fceea96fb0d5f32158c4f5","ed8d6c8de90fc2a4faaebc28e91f2469928738efd5208fb75ade0fa607e892b7","d7c52b198d680fe65b1a8d1b001f0173ffa2536ca2e7082431d726ce1f6714cd","c07f251e1c4e415a838e5498380b55cfea94f3513229de292d2aa85ae52fc3e9","0ed401424892d6bf294a5374efe512d6951b54a71e5dd0290c55b6d0d915f6f7","b945be6da6a3616ef3a250bfe223362b1c7c6872e775b0c4d82a1bf7a28ff902","beea49237dd7c7110fabf3c7509919c9cb9da841d847c53cac162dc3479e2f87","0f45f8a529c450d8f394106cc622bff79e44a1716e1ac9c3cc68b43f7ecf65ee","c624ce90b04c27ce4f318ba6330d39bde3d4e306f0f497ce78d4bda5ab8e22ca","9b8253aa5cb2c82d505f72afdbf96e83b15cc6b9a6f4fadbbbab46210d5f1977","86a8f52e4b1ac49155e889376bcfa8528a634c90c27fec65aa0e949f77b740c5","aab5dd41c1e2316cc0b42a7dd15684f8582d5a1d16c0516276a2a8a7d0fecd9c","59948226626ee210045296ba1fc6cb0fe748d1ff613204e08e7157ab6862dee7","ec3e54d8b713c170fdc8110a7e4a6a97513a7ab6b05ac9e1100cb064d2bb7349","43beb30ecb39a603fde4376554887310b0699f25f7f39c5c91e3147b51bb3a26","666b77d7f06f49da114b090a399abbfa66d5b6c01a3fd9dc4f063a52ace28507","31997714a93fbc570f52d47d6a8ebfb021a34a68ea9ba58bbb69cdec9565657e","6032e4262822160128e644de3fc4410bcd7517c2f137525fd2623d2bb23cb0d3","8bd5c9b1016629c144fd228983395b9dbf0676a576716bc3d316cab612c33cd5","2ed90bd3925b23aed8f859ffd0e885250be0424ca2b57e9866dabef152e1d6b7","93f6bd17d92dab9db7897e1430a5aeaa03bcf51623156213d8397710367a76ce","3f62b770a42e8c47c7008726f95aa383e69d97e85e680d237b99fcb0ee601dd8","5b84cfe78028c35c3bb89c042f18bf08d09da11e82d275c378ae4d07d8477e6c","980d21b0081cbf81774083b1e3a46f4bbdcd2b68858df0f66d7fad9c82bc34bc","68cc8d6fcc2f270d7108f02f3ebc59480a54615be3e09a47e14527f349e9d53e","3eb11dbf3489064a47a2e1cf9d261b1f100ef0b3b50ffca6c44dd99d6dd81ac1","b17f3bb7d8333479c7e45e5f3d876761b9bca58f97594eca3f6a944fd825e632","3c1f1236cce6d6e0c4e2c1b4371e6f72d7c14842ecd76a98ed0748ee5730c8f3","6d7f58d5ea72d7834946fd7104a734dc7d40661be8b2e1eaced1ddce3268ebaf","4c26222991e6c97d5a8f541d4f2c67585eda9e8b33cf9f52931b098045236e88","277983d414aa99d78655186c3ee1e1c38c302e336aff1d77b47fcdc39d8273fe","47383b45796d525a4039cd22d2840ac55a1ff03a43d027f7f867ba7314a9cf53","6548773b3abbc18de29176c2141f766d4e437e40596ee480447abf83575445ad","6ddd27af0436ce59dd4c1896e2bfdb2bdb2529847d078b83ce67a144dff05491","816264799aef3fd5a09a3b6c25217d5ec26a9dfc7465eac7d6073bcdc7d88f3f","4df0891b133884cd9ed752d31c7d0ec0a09234e9ed5394abffd3c660761598db","b603b62d3dcd31ef757dc7339b4fa8acdbca318b0fb9ac485f9a1351955615f9","e642bd47b75ad6b53cbf0dfd7ddfa0f120bd10193f0c58ec37d87b59bf604aca","be90b24d2ee6f875ce3aaa482e7c41a54278856b03d04212681c4032df62baf9","78f5ff400b3cb37e7b90eef1ff311253ed31c8cb66505e9828fad099bffde021","372c47090e1131305d163469a895ff2938f33fa73aad988df31cd31743f9efb6","71c67dc6987bdbd5599353f90009ff825dd7db0450ef9a0aee5bb0c574d18512","6f12403b5eca6ae7ca8e3efe3eeb9c683b06ce3e3844ccfd04098d83cd7e4957","282c535df88175d64d9df4550d2fd1176fd940c1c6822f1e7584003237f179d3","c3a4752cf103e4c6034d5bd449c8f9d5e7b352d22a5f8f9a41a8efb11646f9c2","11a9e38611ac3c77c74240c58b6bd64a0032128b29354e999650f1de1e034b1c","4ed103ca6fff9cb244f7c4b86d1eb28ce8069c32db720784329946731badb5bb","d738f282842970e058672663311c6875482ee36607c88b98ffb6604fba99cb2a","ec859cd8226aa623e41bbb47c249a55ee16dc1b8647359585244d57d3a5ed0c7","8891c6e959d253a66434ff5dc9ae46058fb3493e84b4ca39f710ef2d350656b1","c4463cf02535444dcbc3e67ecd29f1972490f74e49957d6fd4282a1013796ba6","0cb0a957ff02de0b25fd0f3f37130ca7f22d1e0dea256569c714c1f73c6791f8","2f5075dc512d51786b1ba3b1696565641dfaae3ac854f5f13d61fa12ef81a47e","ca3353cc82b1981f0d25d71d7432d583a6ef882ccdea82d65fbe49af37be51cb","50679a8e27aacf72f8c40bcab15d7ef5e83494089b4726b83eec4554344d5cdc","45351e0d51780b6f4088277a4457b9879506ee2720a887de232df0f1efcb33d8","5d697a4b315cc5bb3042ae869abffd10c3b0d7b182cda0e4c45d8819937e5796","563fa27fdaec8f195b84f71a7af0ef48d30d5cc830575db86da86a63a470c8e6","6ee58aa536dabb19b09bc036f1abe83feb51e13d63b23d30b2d0631a2de99b8f","8aceb205dcc6f814ad99635baf1e40b6e01d06d3fe27b72fd766c6d0b8c0c600","299567f84bfedd1468dca2755a829cb19e607a6811673788807dc8921e211bc9","795d9fb85aad92221504db74dd179b506bd189bba0c104426f7e7bb8a66ffee5","1311bc194e0a69fe61031e852c1c0b439e2a2a3d1d5e2d8ff795499b9f283459","4b7ce19369d7e7fae76720c2c6c7f671bf3fa0f7093edb864f1ac358ca7c456c","c972ef44deca1fa8fab465915ffa00f82e126aacf3dfc8979c03b1b066ce5bb6","30285a1011c6d6b52f3ba3abb0a984be8148c05cdefb8eb6eb562335a3991f35","8e7adb22c0adecf7464861fc58ae3fc617b41ffbd70c97aa8493dc0966a82273","755f3cd1d9c1b564cff090e3b0e29200ae55690a91b87cb9e7a64c2dbeb314d3","d6bb7e0a6877b7856c183bff13d09dd9ae599ea43c6f6b33d3d5f72a830ed460","f1b51ae93c762d7c43f559933cd4842dd870367e8d92e90704ffa685dd5b29a3","3f450762fd7c34ed545e738abccb0af6a703572a10521643cf8fc88e3724c99c","fcc8beef29f39f09b1d9c9f99c42f9fed605ab1c28d2a630185f732b9ba53763","d6e6620a30d582182acc3f0a992a0c311adc589f111096aea11ab83fc09a5ccc","6213b8f686f56beab22b59a0f468590fd3a4c5fa931236a017efeca91d7c9584","c451cec9a588b1f105a5ea2c6063d4fca112b9d70105cacdadda0e1ef67e9379","cb047832dc68f5a2c41c62c5e95ddcacbae3a8b034d40cd15319a8cb7f25104a","980336ccdfc3c08f3c3b201aa6662e6016e20f15847f8465b68f3e8e67b4665c","5a3493939995f46ff3d9073cd534fb8961c3bf4e08c71db27066ff03d906dea8","bb5a2ac327605ebebf831c469b05bd34a33a6a46ee8c1edd9f3310aad32cf6a1","bf5d041f2440b4a9391e2b5eb3b8d94cbf1e3b8ff4703b6539d4e65e758c8f37","8516469eb90e723b0eb03df1be098f7e6a4709f6f48fd4532868d20a0a934f6e","d60e9ab369a72d234aac49adbe2900d8ef1408a6ea4db552cf2a48c9d8d6a1bc","0ebb4698803f01e2e7df6acce572fff068f4a20c47221721dafd70a27e372831","03460a54d0e0481d1e11097f66ad43f054bc95efdafe5f81bbc7a82be181af75","4070c2f1c3434fcf84886e04d30d82cd650ee443e53b82b404b144175cf8741e","2cea9689efa8591732096235abe7f084fc29c92badd5b0897a5e876b77e71887","4ed4e504126014fee13aaef5e3fc140f2ff7031ff3a8b5386717905820ea2d09","8129a34006218a6f3cdc81bbd438d5429eb18b08b4338a26977ac3b4df129d75","30d2170e1a718b5035611af55e3618b4ba8f42f0749bb52ee593da6082c4e2ce","98ef38666d88ec9699a722053e07ede65d3042f693fe7ff8c786e53dbb6fd43b","a3b8b6be7620897d1e481e8650c980a210a138fceb6e710eaf95fd9dd0dfe94a","12c89d0e32758c120a569045f21cf5b77244f86792611ced8de7f86b37e77781","14bd47270e654c8eb3b1489fa8c095912ee62a0a29bb92743393203722347c53","3d9297165e67fd59d9821cc93a9808213e33c56a8ac1c4273171f6afaaa2d4d5","e7af7d288b89287ad031b19583c597fcd9f5edc0b0d579b7b492f06cf57e058c","92cb686a9ca5eb5dd7d5d8d43a3707194c1e91ea07a027b3bcb60b6011b24632","fab58e600970e66547644a44bc9918e3223aa2cbd9e8763cec004b2cfb48827e",{"version":"d1a5f486914e3ead50534f48742c4e5e885d28909bec274017189d3284bcb833","signature":"b943b90c649678cec7987a6d56f4917db1712079294cffdf650699235ff9f37d"},{"version":"15433a2e97dcee760d97f8e56afe908fe932611ef00711aed9b246ba058ce0be","signature":"c5fc52cba80e6ba6fde33b0f9370b8ba6866831070cbc84b20a7c6e9e1163160"},{"version":"674d97345e4d79afd1248bdf3a032c9280f2ef163b1a074d14a1a927d93397a4","signature":"6991b558e53d59bb2160b64ee154678e069bd9bfe5131c628dcb6ac0363ca00d"},"d021f18758b28bda32bdaf0a987e0804cec074a9a4cfab8232ed81d96e75dfae","4489c6a9fde8934733aa7df6f7911461ee6e9e4ad092736bd416f6b2cc20b2c6","2c8e55457aaf4902941dfdba4061935922e8ee6e120539c9801cd7b400fae050","8041cfce439ff29d339742389de04c136e3029d6b1817f07b2d7fcbfb7534990","670a76db379b27c8ff42f1ba927828a22862e2ab0b0908e38b671f0e912cc5ed","9d38964b57191567a14b396422c87488cecd48f405c642daa734159875ee81d9","069bebfee29864e3955378107e243508b163e77ab10de6a5ee03ae06939f0bb9","8c95f96ccd4be0674944077aec1e4f2cccd515ca06d4327562dd017250e7d3fc",{"version":"64d4b35c5456adf258d2cf56c341e203a073253f229ef3208fc0d5020253b241","affectsGlobalScope":true},"ee7d8894904b465b072be0d2e4b45cf6b887cdba16a467645c4e200982ece7ea","f3d8c757e148ad968f0d98697987db363070abada5f503da3c06aefd9d4248c1","bc3cba7b0af2d52e7425299aee518db479d44004eff6fbbd206d1ee7e5ec3fb5","afe73051ff6a03a9565cbd8ebb0e956ee3df5e913ad5c1ded64218aabfa3dcb5","035a5df183489c2e22f3cf59fc1ed2b043d27f357eecc0eb8d8e840059d44245","a4809f4d92317535e6b22b01019437030077a76fec1d93b9881c9ed4738fcc54","5f53fa0bd22096d2a78533f94e02c899143b8f0f9891a46965294ee8b91a9434","0d14fa22c41fdc7277e6f71473b20ebc07f40f00e38875142335d5b63cdfc9d2","d8aab31ba8e618cc3eea10b0945de81cb93b7e8150a013a482332263b9305322","462bccdf75fcafc1ae8c30400c9425e1a4681db5d605d1a0edb4f990a54d8094","5923d8facbac6ecf7c84739a5c701a57af94a6f6648d6229a6c768cf28f0f8cb","7adecb2c3238794c378d336a8182d4c3dd2c4fa6fa1785e2797a3db550edea62","dc12dc0e5aa06f4e1a7692149b78f89116af823b9e1f1e4eae140cd3e0e674e6","1bfc6565b90c8771615cd8cfcf9b36efc0275e5e83ac7d9181307e96eb495161","8a8a96898906f065f296665e411f51010b51372fa260d5373bf9f64356703190","7f82ef88bdb67d9a850dd1c7cd2d690f33e0f0acd208e3c9eba086f3670d4f73",{"version":"ccfd8774cd9b929f63ff7dcf657977eb0652e3547f1fcac1b3a1dc5db22d4d58","affectsGlobalScope":true},"d92dc90fecd2552db74d8dc3c6fb4db9145b2aa0efe2c127236ba035969068d4","96d14f21b7652903852eef49379d04dbda28c16ed36468f8c9fa08f7c14c9538","b8442e9db28157344d1bc5d8a5a256f1692de213f0c0ddeb84359834015a008c","458111fc89d11d2151277c822dfdc1a28fa5b6b2493cf942e37d4cd0a6ee5f22","da2b6356b84a40111aaecb18304ea4e4fcb43d70efb1c13ca7d7a906445ee0d3","187119ff4f9553676a884e296089e131e8cc01691c546273b1d0089c3533ce42","febf0b2de54781102b00f61653b21377390a048fbf5262718c91860d11ff34a6","6f294731b495c65ecf46a5694f0082954b961cf05463bea823f8014098eaffa0","0aaef8cded245bf5036a7a40b65622dd6c4da71f7a35343112edbe112b348a1e","00baffbe8a2f2e4875367479489b5d43b5fc1429ecb4a4cc98cfc3009095f52a","68a0d0c508e1b6d8d23a519a8a0a3303dc5baa4849ca049f21e5bad41945e3fc","3c92b6dfd43cc1c2485d9eba5ff0b74a19bb8725b692773ef1d66dac48cda4bd","b03afe4bec768ae333582915146f48b161e567a81b5ebc31c4d78af089770ac9","df996e25faa505f85aeb294d15ebe61b399cf1d1e49959cdfaf2cc0815c203f9","4f6a12044ee6f458db11964153830abbc499e73d065c51c329ec97407f4b13dd","8841e2aa774b89bd23302dede20663306dc1b9902431ac64b24be8b8d0e3f649","916be7d770b0ae0406be9486ac12eb9825f21514961dd050594c4b250617d5a8","254d9fb8c872d73d34594be8a200fd7311dbfa10a4116bfc465fba408052f2b3","d88a5e779faf033be3d52142a04fbe1cb96009868e3bbdd296b2bc6c59e06c0e","2ccea88888048bbfcacbc9531a5596ea48a3e7dcd0a25f531a81bb717903ba4f","5e379df3d61561c2ed7789b5995b9ba2143bbba21a905e2381e16efe7d1fa424","f07a137bbe2de7a122c37bfea00e761975fb264c49f18003d398d71b3fb35a5f","d8f7109e14f20eb735225a62fd3f8366da1a8349e90331cdad57f4b04caf6c5a","cf3d384d082b933d987c4e2fe7bfb8710adfd9dc8155190056ed6695a25a559e","9871b7ee672bc16c78833bdab3052615834b08375cb144e4d2cba74473f4a589","c863198dae89420f3c552b5a03da6ed6d0acfa3807a64772b895db624b0de707","8b03a5e327d7db67112ebbc93b4f744133eda2c1743dbb0a990c61a8007823ef","86c73f2ee1752bac8eeeece234fd05dfcf0637a4fbd8032e4f5f43102faa8eec","42fad1f540271e35ca37cecda12c4ce2eef27f0f5cf0f8dd761d723c744d3159","ff3743a5de32bee10906aff63d1de726f6a7fd6ee2da4b8229054dfa69de2c34","83acd370f7f84f203e71ebba33ba61b7f1291ca027d7f9a662c6307d74e4ac22","1445cec898f90bdd18b2949b9590b3c012f5b7e1804e6e329fb0fe053946d5ec","0e5318ec2275d8da858b541920d9306650ae6ac8012f0e872fe66eb50321a669","cf530297c3fb3a92ec9591dd4fa229d58b5981e45fe6702a0bd2bea53a5e59be","c1f6f7d08d42148ddfe164d36d7aba91f467dbcb3caa715966ff95f55048b3a4","f4e9bf9103191ef3b3612d3ec0044ca4044ca5be27711fe648ada06fad4bcc85","0c1ee27b8f6a00097c2d6d91a21ee4d096ab52c1e28350f6362542b55380059a","7677d5b0db9e020d3017720f853ba18f415219fb3a9597343b1b1012cfd699f7","bc1c6bc119c1784b1a2be6d9c47addec0d83ef0d52c8fbe1f14a51b4dfffc675","52cf2ce99c2a23de70225e252e9822a22b4e0adb82643ab0b710858810e00bf1","770625067bb27a20b9826255a8d47b6b5b0a2d3dfcbd21f89904c731f671ba77","d1ed6765f4d7906a05968fb5cd6d1db8afa14dbe512a4884e8ea5c0f5e142c80","799c0f1b07c092626cf1efd71d459997635911bb5f7fc1196efe449bba87e965","2a184e4462b9914a30b1b5c41cf80c6d3428f17b20d3afb711fff3f0644001fd","9eabde32a3aa5d80de34af2c2206cdc3ee094c6504a8d0c2d6d20c7c179503cc","397c8051b6cfcb48aa22656f0faca2553c5f56187262135162ee79d2b2f6c966","a8ead142e0c87dcd5dc130eba1f8eeed506b08952d905c47621dc2f583b1bff9","a02f10ea5f73130efca046429254a4e3c06b5475baecc8f7b99a0014731be8b3","c2576a4083232b0e2d9bd06875dd43d371dee2e090325a9eac0133fd5650c1cb","4c9a0564bb317349de6a24eb4efea8bb79898fa72ad63a1809165f5bd42970dd","f40ac11d8859092d20f953aae14ba967282c3bb056431a37fced1866ec7a2681","cc11e9e79d4746cc59e0e17473a59d6f104692fd0eeea1bdb2e206eabed83b03","b444a410d34fb5e98aa5ee2b381362044f4884652e8bc8a11c8fe14bbd85518e","c35808c1f5e16d2c571aa65067e3cb95afeff843b259ecfa2fc107a9519b5392","14d5dc055143e941c8743c6a21fa459f961cbc3deedf1bfe47b11587ca4b3ef5","a3ad4e1fc542751005267d50a6298e6765928c0c3a8dce1572f2ba6ca518661c","f237e7c97a3a89f4591afd49ecb3bd8d14f51a1c4adc8fcae3430febedff5eb6","3ffdfbec93b7aed71082af62b8c3e0cc71261cc68d796665faa1e91604fbae8f","662201f943ed45b1ad600d03a90dffe20841e725203ced8b708c91fcd7f9379a","c9ef74c64ed051ea5b958621e7fb853fe3b56e8787c1587aefc6ea988b3c7e79","2462ccfac5f3375794b861abaa81da380f1bbd9401de59ffa43119a0b644253d","34baf65cfee92f110d6653322e2120c2d368ee64b3c7981dff08ed105c4f19b0","7d8ddf0f021c53099e34ee831a06c394d50371816caa98684812f089b4c6b3d4","7d2a0ba1297be385a89b5515b88cd31b4a1eeef5236f710166dc1b36b1741e1b","9d92b037978bb9525bc4b673ebddd443277542e010c0aef019c03a170ccdaa73","ab82804a14454734010dcdcd43f564ff7b0389bee4c5692eec76ff5b30d4cf66","bae8d023ef6b23df7da26f51cea44321f95817c190342a36882e93b80d07a960","ae271d475b632ce7b03fea6d9cf6da72439e57a109672671cbc79f54e1386938"],"options":{"composite":true,"declaration":true,"declarationMap":true,"emitDeclarationOnly":true,"esModuleInterop":true,"inlineSources":true,"module":1,"outDir":"./types","rootDir":"../src","sourceMap":true,"strict":true,"target":7},"fileIdsList":[[234],[92,128,129,130,145],[129,130,146,147],[128,129],[128,145,148,151],[128,148,151,152],[149,150,151,153,154],[128,151],[128,145,148,149,150,153],[128,136],[128],[92,128],[80,128],[132,133,134,135,136,137,138,139,140,141,142,143,144],[128,134,135],[128,134,136],[199],[199,200,201],[64],[67],[64,67],[65,66,67,68,69,70,71,72,73,74,75,156,159,160,161,162,163,164,165,166],[58,64,65],[67,73,75,155],[158],[67,68],[64,162],[194,195],[234,235,236,237,238],[234,236],[157],[241,242,243],[93,128],[246],[247],[258],[252,257],[261,263,264,265,266,267,268,269,270,271,272,273],[261,262,264,265,266,267,268,269,270,271,272,273],[262,263,264,265,266,267,268,269,270,271,272,273],[261,262,263,265,266,267,268,269,270,271,272,273],[261,262,263,264,266,267,268,269,270,271,272,273],[261,262,263,264,265,267,268,269,270,271,272,273],[261,262,263,264,265,266,268,269,270,271,272,273],[261,262,263,264,265,266,267,269,270,271,272,273],[261,262,263,264,265,266,267,268,270,271,272,273],[261,262,263,264,265,266,267,268,269,271,272,273],[261,262,263,264,265,266,267,268,269,270,272,273],[261,262,263,264,265,266,267,268,269,270,271,273],[261,262,263,264,265,266,267,268,269,270,271,272],[76],[79],[80,85,112],[81,92,93,100,109,120],[81,82,92,100],[83,121],[84,85,93,101],[85,109,117],[86,88,92,100],[87],[88,89],[92],[91,92],[79,92],[92,93,94,109,120],[92,93,94,109],[92,95,100,109,120],[92,93,95,96,100,109,117,120],[95,97,109,117,120],[76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127],[92,98],[99,120,125],[88,92,100,109],[101],[102],[79,103],[104,119,125],[105],[106],[92,107],[107,108,121,123],[80,92,109,110,111],[80,109,111],[109,110],[112],[113],[92,115,116],[115,116],[85,100,109,117],[118],[100,119],[80,95,106,120],[85,121],[109,122],[123],[124],[80,85,92,94,103,109,120,123,125],[109,126],[128,279],[282,321],[282,306,321],[321],[282],[282,307,321],[282,283,284,285,286,287,288,289,290,291,292,293,294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,320],[307,321],[322],[325],[204],[216,217,218],[204,215,216],[179],[179,180,181,182,183],[168,169,170,171,172,173,174,175,176,177,178],[250,253],[250,253,254,255],[252],[249,256],[251],[57,59,60,61,62,63],[57,58],[59],[58,59],[57,59],[167,184,185,186],[185],[56,185,186,187],[186],[189],[189,190,193,197],[196],[167,191,192],[212,213,214],[211,212],[167,211,212],[167,204,211],[232],[191,192,198,232],[167,188,191,198,224,228,229,230,231],[167,205],[205,206,207,208,209,210],[167,204],[220],[203,220,222,223],[167,188,191,198,202,203,220,221],[167,198,215,219],[167,188,224,225],[225,226,227],[128,167,188,224,225],[167,224],[191,232],[167,188,224,228]],"referencedMap":[[236,1],[146,2],[148,3],[130,4],[152,5],[153,6],[149,6],[155,7],[150,6],[154,8],[151,9],[137,10],[134,11],[141,12],[135,10],[132,13],[145,14],[139,11],[136,15],[138,16],[204,12],[200,17],[201,17],[202,18],[65,19],[66,19],[68,20],[69,19],[70,19],[71,21],[67,19],[167,22],[75,23],[156,24],[159,25],[165,26],[166,27],[196,28],[239,29],[235,1],[237,30],[238,1],[192,11],[158,31],[244,32],[245,33],[247,34],[248,35],[259,36],[258,37],[262,38],[263,39],[261,40],[264,41],[265,42],[266,43],[267,44],[268,45],[269,46],[270,47],[271,48],[272,49],[273,50],[76,51],[77,51],[79,52],[80,53],[81,54],[82,55],[83,56],[84,57],[85,58],[86,59],[87,60],[88,61],[89,61],[90,62],[91,63],[92,64],[93,65],[94,66],[95,67],[96,68],[97,69],[128,70],[98,71],[99,72],[100,73],[101,74],[102,75],[103,76],[104,77],[105,78],[106,79],[107,80],[108,81],[109,82],[111,83],[110,84],[112,85],[113,86],[115,87],[116,88],[117,89],[118,90],[119,91],[120,92],[121,93],[122,94],[123,95],[124,96],[125,97],[126,98],[276,11],[280,99],[281,11],[306,100],[307,101],[282,102],[285,102],[304,100],[305,100],[295,100],[294,103],[292,100],[287,100],[300,100],[298,100],[302,100],[286,100],[299,100],[303,100],[288,100],[289,100],[301,100],[283,100],[290,100],[291,100],[293,100],[297,100],[308,104],[296,100],[284,100],[321,105],[315,104],[317,106],[316,104],[309,104],[310,104],[312,104],[314,104],[318,106],[319,106],[311,106],[313,106],[323,107],[326,108],[216,109],[219,110],[217,111],[218,111],[175,112],[177,112],[176,112],[174,112],[184,113],[179,114],[170,112],[171,112],[172,112],[173,112],[254,115],[256,116],[255,115],[253,117],[257,118],[252,119],[64,120],[59,121],[60,122],[61,122],[62,123],[63,123],[58,124],[187,125],[186,126],[188,127],[185,128],[190,129],[198,130],[197,131],[193,132],[215,133],[213,134],[214,135],[212,136],[230,137],[231,138],[232,139],[233,137],[206,140],[207,140],[209,140],[211,141],[205,142],[210,140],[221,143],[223,143],[224,144],[222,145],[220,146],[226,147],[228,148],[227,149],[225,150]],"exportedModulesMap":[[236,1],[146,2],[148,3],[130,4],[152,5],[153,6],[149,6],[155,7],[150,6],[154,8],[151,9],[137,10],[134,11],[141,12],[135,10],[132,13],[145,14],[139,11],[136,15],[138,16],[204,12],[200,17],[201,17],[202,18],[65,19],[66,19],[68,20],[69,19],[70,19],[71,21],[67,19],[167,22],[75,23],[156,24],[159,25],[165,26],[166,27],[196,28],[239,29],[235,1],[237,30],[238,1],[192,11],[158,31],[244,32],[245,33],[247,34],[248,35],[259,36],[258,37],[262,38],[263,39],[261,40],[264,41],[265,42],[266,43],[267,44],[268,45],[269,46],[270,47],[271,48],[272,49],[273,50],[76,51],[77,51],[79,52],[80,53],[81,54],[82,55],[83,56],[84,57],[85,58],[86,59],[87,60],[88,61],[89,61],[90,62],[91,63],[92,64],[93,65],[94,66],[95,67],[96,68],[97,69],[128,70],[98,71],[99,72],[100,73],[101,74],[102,75],[103,76],[104,77],[105,78],[106,79],[107,80],[108,81],[109,82],[111,83],[110,84],[112,85],[113,86],[115,87],[116,88],[117,89],[118,90],[119,91],[120,92],[121,93],[122,94],[123,95],[124,96],[125,97],[126,98],[276,11],[280,99],[281,11],[306,100],[307,101],[282,102],[285,102],[304,100],[305,100],[295,100],[294,103],[292,100],[287,100],[300,100],[298,100],[302,100],[286,100],[299,100],[303,100],[288,100],[289,100],[301,100],[283,100],[290,100],[291,100],[293,100],[297,100],[308,104],[296,100],[284,100],[321,105],[315,104],[317,106],[316,104],[309,104],[310,104],[312,104],[314,104],[318,106],[319,106],[311,106],[313,106],[323,107],[326,108],[216,109],[219,110],[217,111],[218,111],[175,112],[177,112],[176,112],[174,112],[184,113],[179,114],[170,112],[171,112],[172,112],[173,112],[254,115],[256,116],[255,115],[253,117],[257,118],[252,119],[64,120],[59,121],[60,122],[61,122],[62,123],[63,123],[58,124],[187,125],[186,126],[188,127],[185,128],[190,129],[198,130],[197,131],[193,132],[215,133],[213,134],[214,135],[212,136],[230,137],[231,151],[232,152],[233,137],[206,140],[207,140],[209,140],[211,141],[205,142],[210,140],[221,143],[223,143],[224,144],[222,145],[220,146],[226,147],[228,148],[227,149],[225,150]],"semanticDiagnosticsPerFile":[236,234,146,129,148,130,147,152,153,149,155,150,154,151,137,134,141,135,132,140,145,142,143,144,139,136,133,138,191,204,200,201,202,199,65,66,68,69,70,71,72,73,74,67,167,75,156,159,160,161,162,163,164,165,166,194,196,195,239,235,237,238,192,158,240,241,244,242,245,246,247,248,259,258,243,260,262,263,261,264,265,266,267,268,269,270,271,272,273,274,157,76,77,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,78,127,95,96,97,128,98,99,100,101,102,103,104,105,106,107,108,109,111,110,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,275,276,277,278,280,279,281,306,307,282,285,304,305,295,294,292,287,300,298,302,286,299,303,288,289,301,283,290,291,293,297,308,296,284,321,320,315,317,316,309,310,312,314,318,319,311,313,323,322,324,229,325,326,131,249,216,219,217,218,178,175,177,176,174,184,179,183,180,182,181,170,171,172,168,169,173,250,254,256,255,253,257,252,251,57,64,59,60,61,62,63,58,8,10,9,2,11,12,13,14,15,16,17,18,3,4,22,19,20,21,23,24,25,5,26,27,28,29,6,33,30,31,32,34,7,35,40,41,36,37,38,39,1,42,56,187,186,188,185,190,198,197,189,193,215,213,214,212,230,231,232,233,206,207,208,209,211,205,210,203,221,223,224,222,220,226,228,227,225,47,48,49,50,51,52,43,53,54,55,44,45,46],"latestChangedDtsFile":"./types/index.d.ts"},"version":"4.9.5"}
+\ No newline at end of file
+diff --git a/dist/types/GasFeeController.d.ts b/dist/types/GasFeeController.d.ts
+index b6ffa7cd5b356ef6c5df6a79876308d21749bd06..56d9420b539cc8d98b8aeb0a84ba541fc3beae1b 100644
+--- a/dist/types/GasFeeController.d.ts
++++ b/dist/types/GasFeeController.d.ts
+@@ -2,7 +2,7 @@ import type { ControllerGetStateAction, ControllerStateChangeEvent, RestrictedCo
+ import type { NetworkClientId, NetworkControllerGetEIP1559CompatibilityAction, NetworkControllerGetNetworkClientByIdAction, NetworkControllerGetStateAction, NetworkControllerNetworkDidChangeEvent, NetworkState, ProviderProxy } from '@metamask/network-controller';
+ import { StaticIntervalPollingController } from '@metamask/polling-controller';
+ import type { Hex } from '@metamask/utils';
+-export declare const GAS_API_BASE_URL = "https://gas.api.infura.io";
++export declare const LEGACY_GAS_PRICES_API_URL = "https://api.metaswap.codefi.network/gasPrices";
+ export type unknownString = 'unknown';
+ export type FeeMarketEstimateType = 'fee-market';
+ export type LegacyEstimateType = 'legacy';
+@@ -160,7 +160,6 @@ export declare class GasFeeController extends StaticIntervalPollingController<ty
+     private readonly getCurrentNetworkEIP1559Compatibility;
+     private readonly getCurrentNetworkLegacyGasAPICompatibility;
+     private readonly getCurrentAccountEIP1559Compatibility;
+-    private readonly infuraAPIKey;
+     private currentChainId;
+     private ethQuery?;
+     private readonly clientId?;
+@@ -181,11 +180,13 @@ export declare class GasFeeController extends StaticIntervalPollingController<ty
+      * @param options.getProvider - Returns a network provider for the current network.
+      * @param options.onNetworkDidChange - A function for registering an event handler for the
+      * network state change event.
++     * @param options.legacyAPIEndpoint - The legacy gas price API URL. This option is primarily for
++     * testing purposes.
++     * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL.
+      * @param options.clientId - The client ID used to identify to the gas estimation API who is
+      * asking for estimates.
+-     * @param options.infuraAPIKey - The Infura API key used for infura API requests.
+      */
+-    constructor({ interval, messenger, state, getCurrentNetworkEIP1559Compatibility, getCurrentAccountEIP1559Compatibility, getChainId, getCurrentNetworkLegacyGasAPICompatibility, getProvider, onNetworkDidChange, clientId, infuraAPIKey, }: {
++    constructor({ interval, messenger, state, getCurrentNetworkEIP1559Compatibility, getCurrentAccountEIP1559Compatibility, getChainId, getCurrentNetworkLegacyGasAPICompatibility, getProvider, onNetworkDidChange, legacyAPIEndpoint, EIP1559APIEndpoint, clientId, }: {
+         interval?: number;
+         messenger: GasFeeMessenger;
+         state?: GasFeeState;
+@@ -195,8 +196,9 @@ export declare class GasFeeController extends StaticIntervalPollingController<ty
+         getChainId?: () => Hex;
+         getProvider: () => ProviderProxy;
+         onNetworkDidChange?: (listener: (state: NetworkState) => void) => void;
++        legacyAPIEndpoint?: string;
++        EIP1559APIEndpoint: string;
+         clientId?: string;
+-        infuraAPIKey: string;
+     });
+     resetPolling(): Promise<void>;
+     fetchGasFeeEstimates(options?: FetchGasFeeEstimateOptions): Promise<GasFeeState>;
+diff --git a/dist/types/GasFeeController.d.ts.map b/dist/types/GasFeeController.d.ts.map
+index 0dd80816d0083029fcc5ef3a85a47f188a5b4c02..127cdbe0c0fbfb37938403190c49d2a5687cf9c4 100644
+--- a/dist/types/GasFeeController.d.ts.map
++++ b/dist/types/GasFeeController.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"GasFeeController.d.ts","sourceRoot":"","sources":["../../src/GasFeeController.ts"],"names":[],"mappings":"AAAA,OAAO,KAAK,EACV,wBAAwB,EACxB,0BAA0B,EAC1B,6BAA6B,EAC9B,MAAM,2BAA2B,CAAC;AAOnC,OAAO,KAAK,EACV,eAAe,EACf,8CAA8C,EAC9C,2CAA2C,EAC3C,+BAA+B,EAC/B,sCAAsC,EACtC,YAAY,EACZ,aAAa,EACd,MAAM,8BAA8B,CAAC;AACtC,OAAO,EAAE,+BAA+B,EAAE,MAAM,8BAA8B,CAAC;AAC/E,OAAO,KAAK,EAAE,GAAG,EAAE,MAAM,iBAAiB,CAAC;AAW3C,eAAO,MAAM,gBAAgB,8BAA8B,CAAC;AAE5D,MAAM,MAAM,aAAa,GAAG,SAAS,CAAC;AAItC,MAAM,MAAM,qBAAqB,GAAG,YAAY,CAAC;AAIjD,MAAM,MAAM,kBAAkB,GAAG,QAAQ,CAAC;AAK1C,MAAM,MAAM,uBAAuB,GAAG,cAAc,CAAC;AAGrD,MAAM,MAAM,cAAc,GAAG,MAAM,CAAC;AAEpC;;;;;GAKG;AACH,eAAO,MAAM,kBAAkB;;;;;CAK9B,CAAC;AAEF,MAAM,MAAM,eAAe,GACvB,qBAAqB,GACrB,uBAAuB,GACvB,kBAAkB,GAClB,cAAc,CAAC;AAEnB,MAAM,MAAM,yBAAyB,GAAG;IACtC,cAAc,EAAE,MAAM,GAAG,IAAI,CAAC;IAC9B,cAAc,EAAE,MAAM,GAAG,aAAa,CAAC;CACxC,CAAC;AAEF;;;;;;;GAOG;AAEH,MAAM,MAAM,mBAAmB,GAAG;IAChC,QAAQ,EAAE,MAAM,CAAC;CAClB,CAAC;AAEF;;;;;;;;;GASG;AACH,MAAM,MAAM,sBAAsB,GAAG;IACnC,IAAI,EAAE,MAAM,CAAC;IACb,MAAM,EAAE,MAAM,CAAC;IACf,GAAG,EAAE,MAAM,CAAC;CACb,CAAC;AAEF;;;;;;;;GAQG;AACH,MAAM,MAAM,aAAa,GAAG;IAC1B,mBAAmB,EAAE,MAAM,CAAC;IAC5B,mBAAmB,EAAE,MAAM,CAAC;IAC5B,6BAA6B,EAAE,MAAM,CAAC;IACtC,qBAAqB,EAAE,MAAM,CAAC;CAC/B,CAAC;AAEF;;;;;;;;;;GAUG;AACH,MAAM,MAAM,eAAe,GAAG,sBAAsB,GAAG,uBAAuB,CAAC;AAE/E,KAAK,sBAAsB,GAAG;IAC5B,GAAG,EAAE,aAAa,CAAC;IACnB,MAAM,EAAE,aAAa,CAAC;IACtB,IAAI,EAAE,aAAa,CAAC;IACpB,gBAAgB,EAAE,MAAM,CAAC;IACzB,sBAAsB,EAAE,CAAC,MAAM,EAAE,MAAM,CAAC,CAAC;IACzC,YAAY,EAAE,IAAI,GAAG,MAAM,GAAG,OAAO,CAAC;IACtC,sBAAsB,EAAE,CAAC,MAAM,EAAE,MAAM,CAAC,CAAC;IACzC,0BAA0B,EAAE,CAAC,MAAM,EAAE,MAAM,CAAC,CAAC;IAC7C,gBAAgB,EAAE,IAAI,GAAG,MAAM,GAAG,OAAO,CAAC;IAC1C,iBAAiB,EAAE,MAAM,CAAC;CAC3B,CAAC;AAEF,KAAK,uBAAuB,GAAG;IAC7B,GAAG,EAAE,aAAa,CAAC;IACnB,MAAM,EAAE,aAAa,CAAC;IACtB,IAAI,EAAE,aAAa,CAAC;IACpB,gBAAgB,EAAE,MAAM,CAAC;IACzB,sBAAsB,EAAE,IAAI,CAAC;IAC7B,YAAY,EAAE,IAAI,CAAC;IACnB,sBAAsB,EAAE,IAAI,CAAC;IAC7B,0BAA0B,EAAE,IAAI,CAAC;IACjC,gBAAgB,EAAE,IAAI,CAAC;IACvB,iBAAiB,EAAE,IAAI,CAAC;CACzB,CAAC;AAaF,MAAM,MAAM,sBAAsB,GAAG;IACnC,eAAe,EAAE,mBAAmB,CAAC;IACrC,yBAAyB,EAAE,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IACjD,eAAe,EAAE,uBAAuB,CAAC;CAC1C,CAAC;AAEF,MAAM,MAAM,oBAAoB,GAAG;IACjC,eAAe,EAAE,eAAe,CAAC;IACjC,yBAAyB,EAAE,yBAAyB,GAAG,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IAC7E,eAAe,EAAE,qBAAqB,CAAC;CACxC,CAAC;AAEF,MAAM,MAAM,iBAAiB,GAAG;IAC9B,eAAe,EAAE,sBAAsB,CAAC;IACxC,yBAAyB,EAAE,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IACjD,eAAe,EAAE,kBAAkB,CAAC;CACrC,CAAC;AAEF,MAAM,MAAM,sBAAsB,GAAG;IACnC,eAAe,EAAE,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IACvC,yBAAyB,EAAE,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IACjD,eAAe,EAAE,cAAc,CAAC;CACjC,CAAC;AAEF,MAAM,MAAM,0BAA0B,GAAG;IACvC,iBAAiB,CAAC,EAAE,OAAO,CAAC;IAC5B,eAAe,CAAC,EAAE,eAAe,CAAC;CACnC,CAAC;AAEF;;;;;;GAMG;AACH,MAAM,MAAM,sBAAsB,GAC9B,sBAAsB,GACtB,oBAAoB,GACpB,iBAAiB,GACjB,sBAAsB,CAAC;AAE3B,MAAM,MAAM,wBAAwB,GAAG;IACrC,wBAAwB,CAAC,EAAE,MAAM,CAAC,MAAM,EAAE,sBAAsB,CAAC,CAAC;CACnE,CAAC;AAEF,MAAM,MAAM,WAAW,GAAG,wBAAwB,GAChD,sBAAsB,GAAG;IACvB,wBAAwB,CAAC,EAAE,OAAO,CAAC;CACpC,CAAC;AAEJ,QAAA,MAAM,IAAI,qBAAqB,CAAC;AAEhC,MAAM,MAAM,iBAAiB,GAAG,0BAA0B,CACxD,OAAO,IAAI,EACX,WAAW,CACZ,CAAC;AAEF,MAAM,MAAM,cAAc,GAAG,wBAAwB,CAAC,OAAO,IAAI,EAAE,WAAW,CAAC,CAAC;AAEhF,MAAM,MAAM,uBAAuB,GAAG,cAAc,CAAC;AAErD,MAAM,MAAM,sBAAsB,GAAG,iBAAiB,CAAC;AAEvD,KAAK,cAAc,GACf,+BAA+B,GAC/B,2CAA2C,GAC3C,8CAA8C,CAAC;AAEnD,KAAK,eAAe,GAAG,6BAA6B,CAClD,OAAO,IAAI,EACX,uBAAuB,GAAG,cAAc,EACxC,sBAAsB,GAAG,sCAAsC,EAC/D,cAAc,CAAC,MAAM,CAAC,EACtB,sCAAsC,CAAC,MAAM,CAAC,CAC/C,CAAC;AAUF;;GAEG;AACH,qBAAa,gBAAiB,SAAQ,+BAA+B,CACnE,OAAO,IAAI,EACX,WAAW,EACX,eAAe,CAChB;;IACC,OAAO,CAAC,UAAU,CAAC,CAAgC;IAEnD,OAAO,CAAC,QAAQ,CAAC,aAAa,CAAC;IAE/B,OAAO,CAAC,QAAQ,CAAC,UAAU,CAAc;IAEzC,OAAO,CAAC,QAAQ,CAAC,iBAAiB,CAAS;IAE3C,OAAO,CAAC,QAAQ,CAAC,kBAAkB,CAAS;IAE5C,OAAO,CAAC,QAAQ,CAAC,qCAAqC,CAAC;IAEvD,OAAO,CAAC,QAAQ,CAAC,0CAA0C,CAAC;IAE5D,OAAO,CAAC,QAAQ,CAAC,qCAAqC,CAAC;IAEvD,OAAO,CAAC,QAAQ,CAAC,YAAY,CAAS;IAEtC,OAAO,CAAC,cAAc,CAAC;IAEvB,OAAO,CAAC,QAAQ,CAAC,CAAW;IAE5B,OAAO,CAAC,QAAQ,CAAC,QAAQ,CAAC,CAAS;IAInC;;;;;;;;;;;;;;;;;;;;OAoBG;gBACS,EACV,QAAgB,EAChB,SAAS,EACT,KAAK,EACL,qCAAqC,EACrC,qCAAqC,EACrC,UAAU,EACV,0CAA0C,EAC1C,WAAW,EACX,kBAAkB,EAClB,QAAQ,EACR,YAAY,GACb,EAAE;QACD,QAAQ,CAAC,EAAE,MAAM,CAAC;QAClB,SAAS,EAAE,eAAe,CAAC;QAC3B,KAAK,CAAC,EAAE,WAAW,CAAC;QACpB,qCAAqC,EAAE,MAAM,OAAO,CAAC,OAAO,CAAC,CAAC;QAC9D,0CAA0C,EAAE,MAAM,OAAO,CAAC;QAC1D,qCAAqC,CAAC,EAAE,MAAM,OAAO,CAAC;QACtD,UAAU,CAAC,EAAE,MAAM,GAAG,CAAC;QACvB,WAAW,EAAE,MAAM,aAAa,CAAC;QACjC,kBAAkB,CAAC,EAAE,CAAC,QAAQ,EAAE,CAAC,KAAK,EAAE,YAAY,KAAK,IAAI,KAAK,IAAI,CAAC;QACvE,QAAQ,CAAC,EAAE,MAAM,CAAC;QAClB,YAAY,EAAE,MAAM,CAAC;KACtB;IA0CK,YAAY;IAWZ,oBAAoB,CAAC,OAAO,CAAC,EAAE,0BAA0B;IAIzD,iCAAiC,CACrC,SAAS,EAAE,MAAM,GAAG,SAAS,GAC5B,OAAO,CAAC,MAAM,CAAC;IAalB;;;;;;;OAOG;IACG,wBAAwB,CAC5B,OAAO,GAAE,0BAA+B,GACvC,OAAO,CAAC,WAAW,CAAC;IAsFvB;;;;OAIG;IACH,gBAAgB,CAAC,SAAS,EAAE,MAAM;IAOlC,WAAW;IAQX;;;;OAIG;IACM,OAAO;IAKhB,OAAO,CAAC,KAAK;IAUb;;;;;;OAMG;IACG,YAAY,CAAC,eAAe,EAAE,MAAM,GAAG,OAAO,CAAC,IAAI,CAAC;IAI1D,OAAO,CAAC,UAAU;YAMJ,uBAAuB;IAWrC,eAAe,CACb,oBAAoB,EAAE,MAAM,EAC5B,YAAY,EAAE,MAAM,GACnB,yBAAyB,GAAG,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC;IAyBpD,sBAAsB;IAMtB,uBAAuB;CAKxB;AAED,eAAe,gBAAgB,CAAC"}
+\ No newline at end of file
++{"version":3,"file":"GasFeeController.d.ts","sourceRoot":"","sources":["../../src/GasFeeController.ts"],"names":[],"mappings":"AAAA,OAAO,KAAK,EACV,wBAAwB,EACxB,0BAA0B,EAC1B,6BAA6B,EAC9B,MAAM,2BAA2B,CAAC;AAOnC,OAAO,KAAK,EACV,eAAe,EACf,8CAA8C,EAC9C,2CAA2C,EAC3C,+BAA+B,EAC/B,sCAAsC,EACtC,YAAY,EACZ,aAAa,EACd,MAAM,8BAA8B,CAAC;AACtC,OAAO,EAAE,+BAA+B,EAAE,MAAM,8BAA8B,CAAC;AAC/E,OAAO,KAAK,EAAE,GAAG,EAAE,MAAM,iBAAiB,CAAC;AAW3C,eAAO,MAAM,yBAAyB,kDAAkD,CAAC;AAEzF,MAAM,MAAM,aAAa,GAAG,SAAS,CAAC;AAItC,MAAM,MAAM,qBAAqB,GAAG,YAAY,CAAC;AAIjD,MAAM,MAAM,kBAAkB,GAAG,QAAQ,CAAC;AAK1C,MAAM,MAAM,uBAAuB,GAAG,cAAc,CAAC;AAGrD,MAAM,MAAM,cAAc,GAAG,MAAM,CAAC;AAEpC;;;;;GAKG;AACH,eAAO,MAAM,kBAAkB;;;;;CAK9B,CAAC;AAEF,MAAM,MAAM,eAAe,GACvB,qBAAqB,GACrB,uBAAuB,GACvB,kBAAkB,GAClB,cAAc,CAAC;AAEnB,MAAM,MAAM,yBAAyB,GAAG;IACtC,cAAc,EAAE,MAAM,GAAG,IAAI,CAAC;IAC9B,cAAc,EAAE,MAAM,GAAG,aAAa,CAAC;CACxC,CAAC;AAEF;;;;;;;GAOG;AAEH,MAAM,MAAM,mBAAmB,GAAG;IAChC,QAAQ,EAAE,MAAM,CAAC;CAClB,CAAC;AAEF;;;;;;;;;GASG;AACH,MAAM,MAAM,sBAAsB,GAAG;IACnC,IAAI,EAAE,MAAM,CAAC;IACb,MAAM,EAAE,MAAM,CAAC;IACf,GAAG,EAAE,MAAM,CAAC;CACb,CAAC;AAEF;;;;;;;;GAQG;AACH,MAAM,MAAM,aAAa,GAAG;IAC1B,mBAAmB,EAAE,MAAM,CAAC;IAC5B,mBAAmB,EAAE,MAAM,CAAC;IAC5B,6BAA6B,EAAE,MAAM,CAAC;IACtC,qBAAqB,EAAE,MAAM,CAAC;CAC/B,CAAC;AAEF;;;;;;;;;;GAUG;AACH,MAAM,MAAM,eAAe,GAAG,sBAAsB,GAAG,uBAAuB,CAAC;AAE/E,KAAK,sBAAsB,GAAG;IAC5B,GAAG,EAAE,aAAa,CAAC;IACnB,MAAM,EAAE,aAAa,CAAC;IACtB,IAAI,EAAE,aAAa,CAAC;IACpB,gBAAgB,EAAE,MAAM,CAAC;IACzB,sBAAsB,EAAE,CAAC,MAAM,EAAE,MAAM,CAAC,CAAC;IACzC,YAAY,EAAE,IAAI,GAAG,MAAM,GAAG,OAAO,CAAC;IACtC,sBAAsB,EAAE,CAAC,MAAM,EAAE,MAAM,CAAC,CAAC;IACzC,0BAA0B,EAAE,CAAC,MAAM,EAAE,MAAM,CAAC,CAAC;IAC7C,gBAAgB,EAAE,IAAI,GAAG,MAAM,GAAG,OAAO,CAAC;IAC1C,iBAAiB,EAAE,MAAM,CAAC;CAC3B,CAAC;AAEF,KAAK,uBAAuB,GAAG;IAC7B,GAAG,EAAE,aAAa,CAAC;IACnB,MAAM,EAAE,aAAa,CAAC;IACtB,IAAI,EAAE,aAAa,CAAC;IACpB,gBAAgB,EAAE,MAAM,CAAC;IACzB,sBAAsB,EAAE,IAAI,CAAC;IAC7B,YAAY,EAAE,IAAI,CAAC;IACnB,sBAAsB,EAAE,IAAI,CAAC;IAC7B,0BAA0B,EAAE,IAAI,CAAC;IACjC,gBAAgB,EAAE,IAAI,CAAC;IACvB,iBAAiB,EAAE,IAAI,CAAC;CACzB,CAAC;AAaF,MAAM,MAAM,sBAAsB,GAAG;IACnC,eAAe,EAAE,mBAAmB,CAAC;IACrC,yBAAyB,EAAE,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IACjD,eAAe,EAAE,uBAAuB,CAAC;CAC1C,CAAC;AAEF,MAAM,MAAM,oBAAoB,GAAG;IACjC,eAAe,EAAE,eAAe,CAAC;IACjC,yBAAyB,EAAE,yBAAyB,GAAG,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IAC7E,eAAe,EAAE,qBAAqB,CAAC;CACxC,CAAC;AAEF,MAAM,MAAM,iBAAiB,GAAG;IAC9B,eAAe,EAAE,sBAAsB,CAAC;IACxC,yBAAyB,EAAE,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IACjD,eAAe,EAAE,kBAAkB,CAAC;CACrC,CAAC;AAEF,MAAM,MAAM,sBAAsB,GAAG;IACnC,eAAe,EAAE,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IACvC,yBAAyB,EAAE,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC,CAAC;IACjD,eAAe,EAAE,cAAc,CAAC;CACjC,CAAC;AAEF,MAAM,MAAM,0BAA0B,GAAG;IACvC,iBAAiB,CAAC,EAAE,OAAO,CAAC;IAC5B,eAAe,CAAC,EAAE,eAAe,CAAC;CACnC,CAAC;AAEF;;;;;;GAMG;AACH,MAAM,MAAM,sBAAsB,GAC9B,sBAAsB,GACtB,oBAAoB,GACpB,iBAAiB,GACjB,sBAAsB,CAAC;AAE3B,MAAM,MAAM,wBAAwB,GAAG;IACrC,wBAAwB,CAAC,EAAE,MAAM,CAAC,MAAM,EAAE,sBAAsB,CAAC,CAAC;CACnE,CAAC;AAEF,MAAM,MAAM,WAAW,GAAG,wBAAwB,GAChD,sBAAsB,GAAG;IACvB,wBAAwB,CAAC,EAAE,OAAO,CAAC;CACpC,CAAC;AAEJ,QAAA,MAAM,IAAI,qBAAqB,CAAC;AAEhC,MAAM,MAAM,iBAAiB,GAAG,0BAA0B,CACxD,OAAO,IAAI,EACX,WAAW,CACZ,CAAC;AAEF,MAAM,MAAM,cAAc,GAAG,wBAAwB,CAAC,OAAO,IAAI,EAAE,WAAW,CAAC,CAAC;AAEhF,MAAM,MAAM,uBAAuB,GAAG,cAAc,CAAC;AAErD,MAAM,MAAM,sBAAsB,GAAG,iBAAiB,CAAC;AAEvD,KAAK,cAAc,GACf,+BAA+B,GAC/B,2CAA2C,GAC3C,8CAA8C,CAAC;AAEnD,KAAK,eAAe,GAAG,6BAA6B,CAClD,OAAO,IAAI,EACX,uBAAuB,GAAG,cAAc,EACxC,sBAAsB,GAAG,sCAAsC,EAC/D,cAAc,CAAC,MAAM,CAAC,EACtB,sCAAsC,CAAC,MAAM,CAAC,CAC/C,CAAC;AAUF;;GAEG;AACH,qBAAa,gBAAiB,SAAQ,+BAA+B,CACnE,OAAO,IAAI,EACX,WAAW,EACX,eAAe,CAChB;;IACC,OAAO,CAAC,UAAU,CAAC,CAAgC;IAEnD,OAAO,CAAC,QAAQ,CAAC,aAAa,CAAC;IAE/B,OAAO,CAAC,QAAQ,CAAC,UAAU,CAAc;IAEzC,OAAO,CAAC,QAAQ,CAAC,iBAAiB,CAAS;IAE3C,OAAO,CAAC,QAAQ,CAAC,kBAAkB,CAAS;IAE5C,OAAO,CAAC,QAAQ,CAAC,qCAAqC,CAAC;IAEvD,OAAO,CAAC,QAAQ,CAAC,0CAA0C,CAAC;IAE5D,OAAO,CAAC,QAAQ,CAAC,qCAAqC,CAAC;IAEvD,OAAO,CAAC,cAAc,CAAC;IAEvB,OAAO,CAAC,QAAQ,CAAC,CAAW;IAE5B,OAAO,CAAC,QAAQ,CAAC,QAAQ,CAAC,CAAS;IAInC;;;;;;;;;;;;;;;;;;;;;;OAsBG;gBACS,EACV,QAAgB,EAChB,SAAS,EACT,KAAK,EACL,qCAAqC,EACrC,qCAAqC,EACrC,UAAU,EACV,0CAA0C,EAC1C,WAAW,EACX,kBAAkB,EAClB,iBAA6C,EAC7C,kBAAkB,EAClB,QAAQ,GACT,EAAE;QACD,QAAQ,CAAC,EAAE,MAAM,CAAC;QAClB,SAAS,EAAE,eAAe,CAAC;QAC3B,KAAK,CAAC,EAAE,WAAW,CAAC;QACpB,qCAAqC,EAAE,MAAM,OAAO,CAAC,OAAO,CAAC,CAAC;QAC9D,0CAA0C,EAAE,MAAM,OAAO,CAAC;QAC1D,qCAAqC,CAAC,EAAE,MAAM,OAAO,CAAC;QACtD,UAAU,CAAC,EAAE,MAAM,GAAG,CAAC;QACvB,WAAW,EAAE,MAAM,aAAa,CAAC;QACjC,kBAAkB,CAAC,EAAE,CAAC,QAAQ,EAAE,CAAC,KAAK,EAAE,YAAY,KAAK,IAAI,KAAK,IAAI,CAAC;QACvE,iBAAiB,CAAC,EAAE,MAAM,CAAC;QAE3B,kBAAkB,EAAE,MAAM,CAAC;QAC3B,QAAQ,CAAC,EAAE,MAAM,CAAC;KACnB;IAyCK,YAAY;IAWZ,oBAAoB,CAAC,OAAO,CAAC,EAAE,0BAA0B;IAIzD,iCAAiC,CACrC,SAAS,EAAE,MAAM,GAAG,SAAS,GAC5B,OAAO,CAAC,MAAM,CAAC;IAalB;;;;;;;OAOG;IACG,wBAAwB,CAC5B,OAAO,GAAE,0BAA+B,GACvC,OAAO,CAAC,WAAW,CAAC;IAqFvB;;;;OAIG;IACH,gBAAgB,CAAC,SAAS,EAAE,MAAM;IAOlC,WAAW;IAQX;;;;OAIG;IACM,OAAO;IAKhB,OAAO,CAAC,KAAK;IAUb;;;;;;OAMG;IACG,YAAY,CAAC,eAAe,EAAE,MAAM,GAAG,OAAO,CAAC,IAAI,CAAC;IAI1D,OAAO,CAAC,UAAU;YAMJ,uBAAuB;IAWrC,eAAe,CACb,oBAAoB,EAAE,MAAM,EAC5B,YAAY,EAAE,MAAM,GACnB,yBAAyB,GAAG,MAAM,CAAC,MAAM,EAAE,KAAK,CAAC;IAyBpD,sBAAsB;IAMtB,uBAAuB;CAKxB;AAED,eAAe,gBAAgB,CAAC"}
+\ No newline at end of file
+diff --git a/dist/types/determineGasFeeCalculations.d.ts b/dist/types/determineGasFeeCalculations.d.ts
+index 8091a4d4290d6a3ca9ecbecc9ab8c6764a58cac9..6f4b2758a99e4d0d3fd2c8dce4064a2a2fc69c0a 100644
+--- a/dist/types/determineGasFeeCalculations.d.ts
++++ b/dist/types/determineGasFeeCalculations.d.ts
+@@ -2,15 +2,14 @@ import type { EstimatedGasFeeTimeBounds, EthGasPriceEstimate, GasFeeEstimates, G
+ type DetermineGasFeeCalculationsRequest = {
+     isEIP1559Compatible: boolean;
+     isLegacyGasAPICompatible: boolean;
+-    fetchGasEstimates: (url: string, infuraAPIKey: string, clientId?: string) => Promise<GasFeeEstimates>;
++    fetchGasEstimates: (url: string, clientId?: string) => Promise<GasFeeEstimates>;
+     fetchGasEstimatesUrl: string;
+-    fetchLegacyGasPriceEstimates: (url: string, infuraAPIKey: string, clientId?: string) => Promise<LegacyGasPriceEstimate>;
++    fetchLegacyGasPriceEstimates: (url: string, clientId?: string) => Promise<LegacyGasPriceEstimate>;
+     fetchLegacyGasPriceEstimatesUrl: string;
+     fetchEthGasPriceEstimate: (ethQuery: any) => Promise<EthGasPriceEstimate>;
+     calculateTimeEstimate: (maxPriorityFeePerGas: string, maxFeePerGas: string, gasFeeEstimates: GasFeeEstimates) => EstimatedGasFeeTimeBounds;
+     clientId: string | undefined;
+     ethQuery: any;
+-    infuraAPIKey: string;
+     nonRPCGasFeeApisDisabled?: boolean;
+ };
+ /**
+@@ -35,7 +34,6 @@ type DetermineGasFeeCalculationsRequest = {
+  * @param args.calculateTimeEstimate - A function that determine time estimate bounds.
+  * @param args.clientId - An identifier that an API can use to know who is asking for estimates.
+  * @param args.ethQuery - An EthQuery instance we can use to talk to Ethereum directly.
+- * @param args.infuraAPIKey - Infura API key to use for requests to Infura.
+  * @param args.nonRPCGasFeeApisDisabled - Whether to disable requests to the legacyAPIEndpoint and the EIP1559APIEndpoint
+  * @returns The gas fee calculations.
+  */
+diff --git a/dist/types/determineGasFeeCalculations.d.ts.map b/dist/types/determineGasFeeCalculations.d.ts.map
+index 44ce4dc7b691ea0316163952f99d426d417afd1a..17cec260fc0836f59929a053270164e5c10e4b89 100644
+--- a/dist/types/determineGasFeeCalculations.d.ts.map
++++ b/dist/types/determineGasFeeCalculations.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"determineGasFeeCalculations.d.ts","sourceRoot":"","sources":["../../src/determineGasFeeCalculations.ts"],"names":[],"mappings":"AAAA,OAAO,KAAK,EACV,yBAAyB,EACzB,mBAAmB,EACnB,eAAe,EACf,WAAW,IAAI,kBAAkB,EACjC,sBAAsB,EACvB,MAAM,oBAAoB,CAAC;AAG5B,KAAK,kCAAkC,GAAG;IACxC,mBAAmB,EAAE,OAAO,CAAC;IAC7B,wBAAwB,EAAE,OAAO,CAAC;IAClC,iBAAiB,EAAE,CACjB,GAAG,EAAE,MAAM,EACX,YAAY,EAAE,MAAM,EACpB,QAAQ,CAAC,EAAE,MAAM,KACd,OAAO,CAAC,eAAe,CAAC,CAAC;IAC9B,oBAAoB,EAAE,MAAM,CAAC;IAC7B,4BAA4B,EAAE,CAC5B,GAAG,EAAE,MAAM,EACX,YAAY,EAAE,MAAM,EACpB,QAAQ,CAAC,EAAE,MAAM,KACd,OAAO,CAAC,sBAAsB,CAAC,CAAC;IACrC,+BAA+B,EAAE,MAAM,CAAC;IAGxC,wBAAwB,EAAE,CAAC,QAAQ,EAAE,GAAG,KAAK,OAAO,CAAC,mBAAmB,CAAC,CAAC;IAC1E,qBAAqB,EAAE,CACrB,oBAAoB,EAAE,MAAM,EAC5B,YAAY,EAAE,MAAM,EACpB,eAAe,EAAE,eAAe,KAC7B,yBAAyB,CAAC;IAC/B,QAAQ,EAAE,MAAM,GAAG,SAAS,CAAC;IAG7B,QAAQ,EAAE,GAAG,CAAC;IACd,YAAY,EAAE,MAAM,CAAC;IACrB,wBAAwB,CAAC,EAAE,OAAO,CAAC;CACpC,CAAC;AAEF;;;;;;;;;;;;;;;;;;;;;;;;;GAyBG;AACH,wBAA8B,2BAA2B,CACvD,IAAI,EAAE,kCAAkC,GACvC,OAAO,CAAC,kBAAkB,CAAC,CAY7B"}
+\ No newline at end of file
++{"version":3,"file":"determineGasFeeCalculations.d.ts","sourceRoot":"","sources":["../../src/determineGasFeeCalculations.ts"],"names":[],"mappings":"AAAA,OAAO,KAAK,EACV,yBAAyB,EACzB,mBAAmB,EACnB,eAAe,EACf,WAAW,IAAI,kBAAkB,EACjC,sBAAsB,EACvB,MAAM,oBAAoB,CAAC;AAG5B,KAAK,kCAAkC,GAAG;IACxC,mBAAmB,EAAE,OAAO,CAAC;IAC7B,wBAAwB,EAAE,OAAO,CAAC;IAClC,iBAAiB,EAAE,CACjB,GAAG,EAAE,MAAM,EACX,QAAQ,CAAC,EAAE,MAAM,KACd,OAAO,CAAC,eAAe,CAAC,CAAC;IAC9B,oBAAoB,EAAE,MAAM,CAAC;IAC7B,4BAA4B,EAAE,CAC5B,GAAG,EAAE,MAAM,EACX,QAAQ,CAAC,EAAE,MAAM,KACd,OAAO,CAAC,sBAAsB,CAAC,CAAC;IACrC,+BAA+B,EAAE,MAAM,CAAC;IAGxC,wBAAwB,EAAE,CAAC,QAAQ,EAAE,GAAG,KAAK,OAAO,CAAC,mBAAmB,CAAC,CAAC;IAC1E,qBAAqB,EAAE,CACrB,oBAAoB,EAAE,MAAM,EAC5B,YAAY,EAAE,MAAM,EACpB,eAAe,EAAE,eAAe,KAC7B,yBAAyB,CAAC;IAC/B,QAAQ,EAAE,MAAM,GAAG,SAAS,CAAC;IAG7B,QAAQ,EAAE,GAAG,CAAC;IACd,wBAAwB,CAAC,EAAE,OAAO,CAAC;CACpC,CAAC;AAEF;;;;;;;;;;;;;;;;;;;;;;;;GAwBG;AACH,wBAA8B,2BAA2B,CACvD,IAAI,EAAE,kCAAkC,GACvC,OAAO,CAAC,kBAAkB,CAAC,CAY7B"}
+\ No newline at end of file
+diff --git a/dist/types/gas-util.d.ts b/dist/types/gas-util.d.ts
+index 3739e0ffc0f895d20b5ab1e706b893e8606ef62b..661c3a87fbb2160075801e676d216809b01ecf6e 100644
+--- a/dist/types/gas-util.d.ts
++++ b/dist/types/gas-util.d.ts
+@@ -11,21 +11,19 @@ export declare function normalizeGWEIDecimalNumbers(n: string | number): any;
+  * Fetch gas estimates from the given URL.
+  *
+  * @param url - The gas estimate URL.
+- * @param infuraAPIKey - The Infura API key used for infura API requests.
+  * @param clientId - The client ID used to identify to the API who is asking for estimates.
+  * @returns The gas estimates.
+  */
+-export declare function fetchGasEstimates(url: string, infuraAPIKey: string, clientId?: string): Promise<GasFeeEstimates>;
++export declare function fetchGasEstimates(url: string, clientId?: string): Promise<GasFeeEstimates>;
+ /**
+  * Hit the legacy MetaSwaps gasPrices estimate api and return the low, medium
+  * high values from that API.
+  *
+  * @param url - The URL to fetch gas price estimates from.
+- * @param infuraAPIKey - The Infura API key used for infura API requests.
+  * @param clientId - The client ID used to identify to the API who is asking for estimates.
+  * @returns The gas price estimates.
+  */
+-export declare function fetchLegacyGasPriceEstimates(url: string, infuraAPIKey: string, clientId?: string): Promise<LegacyGasPriceEstimate>;
++export declare function fetchLegacyGasPriceEstimates(url: string, clientId?: string): Promise<LegacyGasPriceEstimate>;
+ /**
+  * Get a gas price estimate from the network using the `eth_gasPrice` method.
+  *
+diff --git a/dist/types/gas-util.d.ts.map b/dist/types/gas-util.d.ts.map
+index 8a24af1980fc16f7ecbe97222cab534b3c0f6c2c..ab417991781db0ad097218682c264d7aa738bf12 100644
+--- a/dist/types/gas-util.d.ts.map
++++ b/dist/types/gas-util.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"gas-util.d.ts","sourceRoot":"","sources":["../../src/gas-util.ts"],"names":[],"mappings":"AAMA,OAAO,KAAK,QAAQ,MAAM,qBAAqB,CAAC;AAGhD,OAAO,KAAK,EACV,eAAe,EACf,mBAAmB,EACnB,yBAAyB,EAEzB,sBAAsB,EACvB,MAAM,oBAAoB,CAAC;AAI5B;;;;;GAKG;AACH,wBAAgB,2BAA2B,CAAC,CAAC,EAAE,MAAM,GAAG,MAAM,OAI7D;AAED;;;;;;;GAOG;AACH,wBAAsB,iBAAiB,CACrC,GAAG,EAAE,MAAM,EACX,YAAY,EAAE,MAAM,EACpB,QAAQ,CAAC,EAAE,MAAM,GAChB,OAAO,CAAC,eAAe,CAAC,CAyC1B;AAED;;;;;;;;GAQG;AACH,wBAAsB,4BAA4B,CAChD,GAAG,EAAE,MAAM,EACX,YAAY,EAAE,MAAM,EACpB,QAAQ,CAAC,EAAE,MAAM,GAChB,OAAO,CAAC,sBAAsB,CAAC,CAcjC;AAED;;;;;GAKG;AACH,wBAAsB,wBAAwB,CAC5C,QAAQ,EAAE,QAAQ,GACjB,OAAO,CAAC,mBAAmB,CAAC,CAK9B;AAED;;;;;;;GAOG;AACH,wBAAgB,qBAAqB,CACnC,oBAAoB,EAAE,MAAM,EAC5B,YAAY,EAAE,MAAM,EACpB,eAAe,EAAE,eAAe,GAC/B,yBAAyB,CAoD3B"}
+\ No newline at end of file
++{"version":3,"file":"gas-util.d.ts","sourceRoot":"","sources":["../../src/gas-util.ts"],"names":[],"mappings":"AAMA,OAAO,KAAK,QAAQ,MAAM,qBAAqB,CAAC;AAGhD,OAAO,KAAK,EACV,eAAe,EACf,mBAAmB,EACnB,yBAAyB,EAEzB,sBAAsB,EACvB,MAAM,oBAAoB,CAAC;AAI5B;;;;;GAKG;AACH,wBAAgB,2BAA2B,CAAC,CAAC,EAAE,MAAM,GAAG,MAAM,OAI7D;AAED;;;;;;GAMG;AACH,wBAAsB,iBAAiB,CACrC,GAAG,EAAE,MAAM,EACX,QAAQ,CAAC,EAAE,MAAM,GAChB,OAAO,CAAC,eAAe,CAAC,CAyC1B;AAED;;;;;;;GAOG;AACH,wBAAsB,4BAA4B,CAChD,GAAG,EAAE,MAAM,EACX,QAAQ,CAAC,EAAE,MAAM,GAChB,OAAO,CAAC,sBAAsB,CAAC,CAgBjC;AAED;;;;;GAKG;AACH,wBAAsB,wBAAwB,CAC5C,QAAQ,EAAE,QAAQ,GACjB,OAAO,CAAC,mBAAmB,CAAC,CAK9B;AAED;;;;;;;GAOG;AACH,wBAAgB,qBAAqB,CACnC,oBAAoB,EAAE,MAAM,EAC5B,YAAY,EAAE,MAAM,EACpB,eAAe,EAAE,eAAe,GAC/B,yBAAyB,CAoD3B"}
+\ No newline at end of file

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -164,7 +164,11 @@ import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 ///: END:ONLY_INCLUDE_IF
 
 import { AssetType, TokenStandard } from '../../shared/constants/transaction';
-import { SWAPS_CLIENT_ID } from '../../shared/constants/swaps';
+import {
+  GAS_API_BASE_URL,
+  GAS_DEV_API_BASE_URL,
+  SWAPS_CLIENT_ID,
+} from '../../shared/constants/swaps';
 import {
   CHAIN_IDS,
   NETWORK_TYPES,
@@ -781,6 +785,10 @@ export default class MetamaskController extends EventEmitter {
       allowedEvents: ['NetworkController:stateChange'],
     });
 
+    const gasApiBaseUrl = process.env.SWAPS_USE_DEV_APIS
+      ? GAS_DEV_API_BASE_URL
+      : GAS_API_BASE_URL;
+
     this.gasFeeController = new GasFeeController({
       state: initState.GasFeeController,
       interval: 10000,
@@ -800,12 +808,13 @@ export default class MetamaskController extends EventEmitter {
         ),
       getCurrentAccountEIP1559Compatibility:
         this.getCurrentAccountEIP1559Compatibility.bind(this),
+      legacyAPIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/gasPrices`,
+      EIP1559APIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/suggestedGasFees`,
       getCurrentNetworkLegacyGasAPICompatibility: () => {
         const { chainId } = this.networkController.state.providerConfig;
         return chainId === CHAIN_IDS.BSC;
       },
       getChainId: () => this.networkController.state.providerConfig.chainId,
-      infuraAPIKey: opts.infuraProjectId,
     });
 
     this.appStateController = new AppStateController({

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1469,7 +1469,6 @@
         "@metamask/eth-query": true,
         "@metamask/gas-fee-controller>@metamask/controller-utils": true,
         "bn.js": true,
-        "browserify>buffer": true,
         "uuid": true
       }
     },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1614,7 +1614,6 @@
         "@metamask/eth-query": true,
         "@metamask/gas-fee-controller>@metamask/controller-utils": true,
         "bn.js": true,
-        "browserify>buffer": true,
         "uuid": true
       }
     },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1469,7 +1469,6 @@
         "@metamask/eth-query": true,
         "@metamask/gas-fee-controller>@metamask/controller-utils": true,
         "bn.js": true,
-        "browserify>buffer": true,
         "uuid": true
       }
     },

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -1754,7 +1754,6 @@
         "@metamask/eth-query": true,
         "@metamask/gas-fee-controller>@metamask/controller-utils": true,
         "bn.js": true,
-        "browserify>buffer": true,
         "uuid": true
       }
     },

--- a/package.json
+++ b/package.json
@@ -254,7 +254,8 @@
     "@expo/config-plugins/glob": "^10.3.10",
     "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A18.1.2#~/.yarn/patches/@metamask-network-controller-npm-18.1.2-1bcb8d8610.patch",
     "@solana/web3.js/rpc-websockets": "^8.0.1",
-    "@metamask/nonce-tracker@npm:^5.0.0": "patch:@metamask/nonce-tracker@npm%3A5.0.0#~/.yarn/patches/@metamask-nonce-tracker-npm-5.0.0-d81478218e.patch"
+    "@metamask/nonce-tracker@npm:^5.0.0": "patch:@metamask/nonce-tracker@npm%3A5.0.0#~/.yarn/patches/@metamask-nonce-tracker-npm-5.0.0-d81478218e.patch",
+    "@metamask/gas-fee-controller@npm:^15.1.1": "patch:@metamask/gas-fee-controller@npm%3A15.1.2#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.24.0#~/.yarn/patches/@babel-runtime-npm-7.24.0-7eb1dd11a2.patch",
@@ -306,7 +307,7 @@
     "@metamask/ethjs": "^0.6.0",
     "@metamask/ethjs-contract": "^0.4.1",
     "@metamask/ethjs-query": "^0.7.1",
-    "@metamask/gas-fee-controller": "^15.1.2",
+    "@metamask/gas-fee-controller": "patch:@metamask/gas-fee-controller@npm%3A15.1.2#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch",
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/keyring-api": "^6.3.1",
     "@metamask/keyring-controller": "patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch",

--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -18,7 +18,7 @@
   "etherscan.io",
   "execution.metamask.io",
   "fonts.gstatic.com",
-  "gas.api.infura.io",
+  "gas.api.cx.metamask.io",
   "github.com",
   "goerli.infura.io",
   "localhost:8000",

--- a/shared/constants/swaps.ts
+++ b/shared/constants/swaps.ts
@@ -171,7 +171,7 @@ const SWAPS_TESTNET_CHAIN_ID = '0x539';
 export const SWAPS_API_V2_BASE_URL = 'https://swap.api.cx.metamask.io';
 export const SWAPS_DEV_API_V2_BASE_URL = 'https://swap.dev-api.cx.metamask.io';
 export const TOKEN_API_BASE_URL = 'https://tokens.api.cx.metamask.io';
-export const GAS_API_BASE_URL = 'https://gas.api.infura.io';
+export const GAS_API_BASE_URL = 'https://gas.api.cx.metamask.io';
 export const GAS_DEV_API_BASE_URL = 'https://gas.uat-api.cx.metamask.io';
 
 const BSC_DEFAULT_BLOCK_EXPLORER_URL = 'https://bscscan.com/';

--- a/shared/lib/swaps-utils.js
+++ b/shared/lib/swaps-utils.js
@@ -3,6 +3,7 @@ import log from 'loglevel';
 import { CHAIN_IDS } from '../constants/network';
 import {
   GAS_API_BASE_URL,
+  GAS_DEV_API_BASE_URL,
   SWAPS_API_V2_BASE_URL,
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
   SWAPS_CLIENT_ID,
@@ -130,7 +131,7 @@ const getBaseUrlForNewSwapsApi = (type, chainId) => {
   const v2ApiBaseUrl = useDevApis
     ? SWAPS_DEV_API_V2_BASE_URL
     : SWAPS_API_V2_BASE_URL;
-  const gasApiBaseUrl = GAS_API_BASE_URL;
+  const gasApiBaseUrl = useDevApis ? GAS_DEV_API_BASE_URL : GAS_API_BASE_URL;
   const tokenApiBaseUrl = TOKEN_API_BASE_URL;
   const noNetworkSpecificTypes = ['refreshTime']; // These types don't need network info in the URL.
   if (noNetworkSpecificTypes.includes(type)) {

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -183,60 +183,18 @@ async function setupMocking(
       };
     });
 
-  const gasPricesCallbackMock = () => ({
-    statusCode: 200,
-    json: {
-      SafeGasPrice: '1',
-      ProposeGasPrice: '2',
-      FastGasPrice: '3',
-    },
-  });
-  const suggestedGasFeesCallbackMock = () => ({
-    statusCode: 200,
-    json: {
-      low: {
-        suggestedMaxPriorityFeePerGas: '1',
-        suggestedMaxFeePerGas: '20.44436136',
-        minWaitTimeEstimate: 15000,
-        maxWaitTimeEstimate: 30000,
-      },
-      medium: {
-        suggestedMaxPriorityFeePerGas: '1.5',
-        suggestedMaxFeePerGas: '25.80554517',
-        minWaitTimeEstimate: 15000,
-        maxWaitTimeEstimate: 45000,
-      },
-      high: {
-        suggestedMaxPriorityFeePerGas: '2',
-        suggestedMaxFeePerGas: '27.277766977',
-        minWaitTimeEstimate: 15000,
-        maxWaitTimeEstimate: 60000,
-      },
-      estimatedBaseFee: '19.444436136',
-      networkCongestion: 0.14685,
-      latestPriorityFeeRange: ['0.378818859', '6.555563864'],
-      historicalPriorityFeeRange: ['0.1', '248.262969261'],
-      historicalBaseFeeRange: ['14.146999781', '28.825256275'],
-      priorityFeeTrend: 'down',
-      baseFeeTrend: 'up',
-    },
-  });
-
   await server
     .forGet(`${GAS_API_BASE_URL}/networks/${chainId}/gasPrices`)
-    .thenCallback(gasPricesCallbackMock);
-
-  await server
-    .forGet(`${GAS_API_BASE_URL}/networks/1/gasPrices`)
-    .thenCallback(gasPricesCallbackMock);
-
-  await server
-    .forGet(`${GAS_API_BASE_URL}/networks/1/suggestedGasFees`)
-    .thenCallback(suggestedGasFeesCallbackMock);
-
-  await server
-    .forGet(`${GAS_API_BASE_URL}/networks/${chainId}/suggestedGasFees`)
-    .thenCallback(suggestedGasFeesCallbackMock);
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: {
+          SafeGasPrice: '1',
+          ProposeGasPrice: '2',
+          FastGasPrice: '3',
+        },
+      };
+    });
 
   await server
     .forGet('https://swap.api.cx.metamask.io/networks/1/token')
@@ -251,6 +209,41 @@ async function setupMocking(
           address: '0x72c9fb7ed19d3ce51cea5c56b3e023cd918baadf',
           occurences: 1,
           aggregators: ['dynamic'],
+        },
+      };
+    });
+
+  await server
+    .forGet(`${GAS_API_BASE_URL}/networks/${chainId}/suggestedGasFees`)
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: {
+          low: {
+            suggestedMaxPriorityFeePerGas: '1',
+            suggestedMaxFeePerGas: '20.44436136',
+            minWaitTimeEstimate: 15000,
+            maxWaitTimeEstimate: 30000,
+          },
+          medium: {
+            suggestedMaxPriorityFeePerGas: '1.5',
+            suggestedMaxFeePerGas: '25.80554517',
+            minWaitTimeEstimate: 15000,
+            maxWaitTimeEstimate: 45000,
+          },
+          high: {
+            suggestedMaxPriorityFeePerGas: '2',
+            suggestedMaxFeePerGas: '27.277766977',
+            minWaitTimeEstimate: 15000,
+            maxWaitTimeEstimate: 60000,
+          },
+          estimatedBaseFee: '19.444436136',
+          networkCongestion: 0.14685,
+          latestPriorityFeeRange: ['0.378818859', '6.555563864'],
+          historicalPriorityFeeRange: ['0.1', '248.262969261'],
+          historicalBaseFeeRange: ['14.146999781', '28.825256275'],
+          priorityFeeTrend: 'down',
+          baseFeeTrend: 'up',
         },
       };
     });

--- a/test/jest/constants.js
+++ b/test/jest/constants.js
@@ -1,2 +1,2 @@
 export const METASWAP_BASE_URL = 'https://swap.api.cx.metamask.io';
-export const GAS_API_URL = 'https://gas.api.infura.io';
+export const GAS_API_URL = 'https://gas.api.cx.metamask.io';

--- a/ui/pages/swaps/swaps.util.ts
+++ b/ui/pages/swaps/swaps.util.ts
@@ -49,11 +49,6 @@ const CACHE_REFRESH_FIVE_MINUTES = 300000;
 const USD_CURRENCY_CODE = 'usd';
 
 const clientIdHeader = { 'X-Client-Id': SWAPS_CLIENT_ID };
-const infuraAuthHeader = {
-  Authorization: `Basic ${Buffer.from(
-    `${process.env.INFURA_PROJECT_ID}:`,
-  ).toString('base64')}`,
-};
 
 type Validator = {
   property: string;
@@ -276,13 +271,7 @@ export async function fetchSwapsGasPrices(chainId: any): Promise<
   const gasPricesUrl = getBaseApi('gasPrices', chainId);
   const response = await fetchWithCache({
     url: gasPricesUrl,
-    fetchOptions: {
-      method: 'GET',
-      headers: {
-        ...clientIdHeader,
-        ...infuraAuthHeader,
-      },
-    },
+    fetchOptions: { method: 'GET', headers: clientIdHeader },
     cacheOptions: { cacheRefreshTime: 30000 },
     functionName: 'fetchSwapsGasPrices',
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5408,7 +5408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@npm:^15.1.1, @metamask/gas-fee-controller@npm:^15.1.2":
+"@metamask/gas-fee-controller@npm:15.1.2":
   version: 15.1.2
   resolution: "@metamask/gas-fee-controller@npm:15.1.2"
   dependencies:
@@ -5447,6 +5447,27 @@ __metadata:
   peerDependencies:
     "@metamask/network-controller": ^19.0.0
   checksum: 10/673cbea0d2eb696815a6608303667cc81ba432aeb903c52a78ac71884715dc165db71daea25fc368c68c60ab39ffbefe5191d4faa6ca31d52020cf2ae49d55e4
+  languageName: node
+  linkType: hard
+
+"@metamask/gas-fee-controller@patch:@metamask/gas-fee-controller@npm%3A15.1.2#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch":
+  version: 15.1.2
+  resolution: "@metamask/gas-fee-controller@patch:@metamask/gas-fee-controller@npm%3A15.1.2#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch::version=15.1.2&hash=c5be0a"
+  dependencies:
+    "@metamask/base-controller": "npm:^5.0.2"
+    "@metamask/controller-utils": "npm:^9.1.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/ethjs-unit": "npm:^0.3.0"
+    "@metamask/network-controller": "npm:^18.1.0"
+    "@metamask/polling-controller": "npm:^6.0.2"
+    "@metamask/utils": "npm:^8.3.0"
+    "@types/bn.js": "npm:^5.1.5"
+    "@types/uuid": "npm:^8.3.0"
+    bn.js: "npm:^5.2.1"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/network-controller": ^18.0.0
+  checksum: 10/4785ff26e541911ffc5a280a9e1a9a648fb3d89e672afeedcd4951a8f176d8e6ae91192afe56fa943f6b4eeff3ce0dba7ec05228a62a8fee1664bb82642fcc15
   languageName: node
   linkType: hard
 
@@ -24958,7 +24979,7 @@ __metadata:
     "@metamask/ethjs-contract": "npm:^0.4.1"
     "@metamask/ethjs-query": "npm:^0.7.1"
     "@metamask/forwarder": "npm:^1.1.0"
-    "@metamask/gas-fee-controller": "npm:^15.1.2"
+    "@metamask/gas-fee-controller": "patch:@metamask/gas-fee-controller@npm%3A15.1.2#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch"
     "@metamask/jazzicon": "npm:^2.0.0"
     "@metamask/keyring-api": "npm:^6.3.1"
     "@metamask/keyring-controller": "patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch"


### PR DESCRIPTION
cherry-pick chore: revert recent gas api endpoint changes 04642d21f9feeccd09b16fa318c6c7876fd34ab1 (#25230) into v12.0.0

Merge conflicts – resolved by comparing to 04642d21f9feeccd09b16fa318c6c7876fd34ab1:
* package.json
* mock-e2e.js