### PR TITLE
fix: filter only EVM address when calling syncWithAddresses

### DIFF
--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -96,7 +96,7 @@ export default class AccountTracker {
     );
 
     this.controllerMessenger.subscribe(
-      'AccountsController:selectedAccountChange',
+      'AccountsController:selectedEvmAccountChange',
       (newAccount) => {
         const { useMultiAccountBalanceChecker } =
           this.preferencesController.store.getState();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -330,6 +330,7 @@ import { PushPlatformNotificationsController } from './controllers/push-platform
 import { MetamaskNotificationsController } from './controllers/metamask-notifications/metamask-notifications';
 import { updateSecurityAlertResponse } from './lib/ppom/ppom-util';
 import createEvmMethodsToNonEvmAccountReqFilterMiddleware from './lib/createEvmMethodsToNonEvmAccountReqFilterMiddleware';
+import { isEthAddress } from './lib/multichain/address';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -1535,7 +1536,7 @@ export default class MetamaskController extends EventEmitter {
       onboardingController: this.onboardingController,
       controllerMessenger: this.controllerMessenger.getRestricted({
         name: 'AccountTracker',
-        allowedEvents: ['AccountsController:selectedAccountChange'],
+        allowedEvents: ['AccountsController:selectedEvmAccountChange'],
         allowedActions: ['AccountsController:getSelectedAccount'],
       }),
       initState: { accounts: {} },
@@ -4261,6 +4262,7 @@ export default class MetamaskController extends EventEmitter {
     // Merge with existing accounts
     // and make sure addresses are not repeated
     const oldAccounts = await this.keyringController.getAccounts();
+
     const accountsToTrack = [
       ...new Set(
         oldAccounts.concat(accounts.map((a) => a.address.toLowerCase())),
@@ -5612,10 +5614,12 @@ export default class MetamaskController extends EventEmitter {
    */
   async _onKeyringControllerUpdate(state) {
     const { keyrings } = state;
-    const addresses = keyrings.reduce(
-      (acc, { accounts }) => acc.concat(accounts),
-      [],
-    );
+
+    // The accounts tracker only supports EVM addresses and the keyring
+    // controller may pass non-EVM addresses, so we filter them out
+    const addresses = keyrings
+      .reduce((acc, { accounts }) => acc.concat(accounts), [])
+      .filter(isEthAddress);
 
     if (!addresses.length) {
       return;

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1391,6 +1391,33 @@ describe('MetaMaskController', () => {
         ]);
         expect(metamaskController.getState()).toStrictEqual(oldState);
       });
+
+      it('should filter out non-EVM addresses prior to calling syncWithAddresses', async () => {
+        jest
+          .spyOn(metamaskController.accountTracker, 'syncWithAddresses')
+          .mockReturnValue();
+
+        const oldState = metamaskController.getState();
+        await metamaskController._onKeyringControllerUpdate({
+          keyrings: [
+            {
+              accounts: [
+                '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
+                '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
+                '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+              ],
+            },
+          ],
+        });
+
+        expect(
+          metamaskController.accountTracker.syncWithAddresses,
+        ).toHaveBeenCalledWith([
+          '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
+          '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
+        ]);
+        expect(metamaskController.getState()).toStrictEqual(oldState);
+      });
     });
 
     describe('markNotificationsAsRead', () => {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1348,14 +1348,20 @@ describe('MetaMaskController', () => {
         await metamaskController._onKeyringControllerUpdate({
           keyrings: [
             {
-              accounts: ['0x1', '0x2'],
+              accounts: [
+                '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
+                '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
+              ],
             },
           ],
         });
 
         expect(
           metamaskController.accountTracker.syncWithAddresses,
-        ).toHaveBeenCalledWith(['0x1', '0x2']);
+        ).toHaveBeenCalledWith([
+          '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
+          '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
+        ]);
         expect(metamaskController.getState()).toStrictEqual(oldState);
       });
 
@@ -1369,14 +1375,20 @@ describe('MetaMaskController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              accounts: ['0x1', '0x2'],
+              accounts: [
+                '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
+                '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
+              ],
             },
           ],
         });
 
         expect(
           metamaskController.accountTracker.syncWithAddresses,
-        ).toHaveBeenCalledWith(['0x1', '0x2']);
+        ).toHaveBeenCalledWith([
+          '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
+          '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
+        ]);
         expect(metamaskController.getState()).toStrictEqual(oldState);
       });
     });

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1325,6 +1325,11 @@ describe('MetaMaskController', () => {
     });
 
     describe('#_onKeyringControllerUpdate', () => {
+      const accounts = [
+        '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
+        '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
+      ];
+
       it('should do nothing if there are no keyrings in state', async () => {
         jest
           .spyOn(metamaskController.accountTracker, 'syncWithAddresses')
@@ -1348,20 +1353,14 @@ describe('MetaMaskController', () => {
         await metamaskController._onKeyringControllerUpdate({
           keyrings: [
             {
-              accounts: [
-                '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
-                '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
-              ],
+              accounts,
             },
           ],
         });
 
         expect(
           metamaskController.accountTracker.syncWithAddresses,
-        ).toHaveBeenCalledWith([
-          '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
-          '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
-        ]);
+        ).toHaveBeenCalledWith(accounts);
         expect(metamaskController.getState()).toStrictEqual(oldState);
       });
 
@@ -1375,24 +1374,18 @@ describe('MetaMaskController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              accounts: [
-                '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
-                '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
-              ],
+              accounts,
             },
           ],
         });
 
         expect(
           metamaskController.accountTracker.syncWithAddresses,
-        ).toHaveBeenCalledWith([
-          '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
-          '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
-        ]);
+        ).toHaveBeenCalledWith(accounts);
         expect(metamaskController.getState()).toStrictEqual(oldState);
       });
 
-      it('should filter out non-EVM addresses prior to calling syncWithAddresses', async () => {
+      it('filter out non-EVM addresses prior to calling syncWithAddresses', async () => {
         jest
           .spyOn(metamaskController.accountTracker, 'syncWithAddresses')
           .mockReturnValue();
@@ -1402,9 +1395,9 @@ describe('MetaMaskController', () => {
           keyrings: [
             {
               accounts: [
-                '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
-                '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
-                '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+                ...accounts,
+                // Non-EVM address which should not be used by syncWithAddresses
+                'bc1ql49ydapnjafl5t2cp9zqpjwe6pdgmxy98859v2',
               ],
             },
           ],
@@ -1412,10 +1405,7 @@ describe('MetaMaskController', () => {
 
         expect(
           metamaskController.accountTracker.syncWithAddresses,
-        ).toHaveBeenCalledWith([
-          '0x603E83442BA54A2d0E080c34D6908ec228bef59f',
-          '0xDe95cE6E727692286E02A931d074efD1E5E2f03c',
-        ]);
+        ).toHaveBeenCalledWith(accounts);
         expect(metamaskController.getState()).toStrictEqual(oldState);
       });
     });


### PR DESCRIPTION
## **Description**

This PR applies a removes all non EVM addresses prior to calling `syncWithAddresses` during `_onKeyringControllerUpdate`. This is because the `AccountTracker` does not support non EVM addresses. The `AccountTracker` now also subscribes to `onSelectedEvmAccountChange` instead of `onSelectedAccountChange`

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**


### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
