### PR TITLE
feat: add file input component

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6216,6 +6216,12 @@
   "updatedWithDate": {
     "message": "Updated $1"
   },
+  "uploadDropFile": {
+    "message": "Drop your file here"
+  },
+  "uploadFile": {
+    "message": "Upload file"
+  },
   "urlErrorMsg": {
     "message": "URLs require the appropriate HTTP/HTTPS prefix."
   },

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -23,6 +23,7 @@
 @import 'snaps/snap-ui-renderer/index';
 @import 'snaps/snap-ui-markdown/index';
 @import 'snaps/snap-ui-button/index';
+@import 'snaps/snap-ui-file-input/index';
 @import 'snaps/snap-delineator/index';
 @import 'snaps/snap-list-item/index';
 @import 'snaps/copyable/index';

--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -28,6 +28,7 @@ import { SnapUIMarkdown } from '../snaps/snap-ui-markdown';
 import { SnapUILink } from '../snaps/snap-ui-link';
 import { SmartTransactionStatusPage } from '../../../pages/smart-transactions/smart-transaction-status-page';
 import { SnapUIImage } from '../snaps/snap-ui-image';
+import { SnapUIFileInput } from '../snaps/snap-ui-file-input';
 import { SnapUIInput } from '../snaps/snap-ui-input';
 import { SnapUIForm } from '../snaps/snap-ui-form';
 import { SnapUIButton } from '../snaps/snap-ui-button';
@@ -83,6 +84,7 @@ export const safeComponentList = {
   ConfirmInfoRow,
   ConfirmInfoRowAddress,
   ConfirmInfoRowValueDouble,
+  SnapUIFileInput,
   SnapUIInput,
   SnapUIButton,
   SnapUIForm,

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -36,7 +36,10 @@ export const SnapUIButton: FunctionComponent<
       event.preventDefault();
     }
 
-    handleEvent({ event: UserInputEventType.ButtonClickEvent, name });
+    handleEvent({
+      event: UserInputEventType.ButtonClickEvent,
+      name,
+    });
   };
 
   const overriddenVariant = disabled ? 'disabled' : variant;

--- a/ui/components/app/snaps/snap-ui-file-input/index.scss
+++ b/ui/components/app/snaps/snap-ui-file-input/index.scss
@@ -1,0 +1,21 @@
+.snap-ui-renderer {
+  &__file-input {
+    &__drop-zone {
+      background-color: var(--color-background-alternative);
+
+      .mm-icon,
+      .mm-text {
+        color: var(--color-icon-alternative);
+      }
+
+      &:hover .mm-icon,
+      &:hover .mm-text {
+        color: var(--color-info-default);
+      }
+
+      &:hover {
+        background-color: var(--color-background-alternative-hover);
+      }
+    }
+  }
+}

--- a/ui/components/app/snaps/snap-ui-file-input/index.ts
+++ b/ui/components/app/snaps/snap-ui-file-input/index.ts
@@ -1,0 +1,1 @@
+export * from './snap-ui-file-input';

--- a/ui/components/app/snaps/snap-ui-file-input/snap-ui-file-input.tsx
+++ b/ui/components/app/snaps/snap-ui-file-input/snap-ui-file-input.tsx
@@ -1,0 +1,212 @@
+import React, {
+  ChangeEvent,
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  DragEvent,
+  FunctionComponent,
+  useRef,
+  useState,
+} from 'react';
+import classnames from 'classnames';
+import { useSnapInterfaceContext } from '../../../../contexts/snaps';
+import {
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  HelpText,
+  HelpTextSeverity,
+  Icon,
+  IconName,
+  IconSize,
+  Label,
+  Text,
+} from '../../../component-library';
+import {
+  AlignItems,
+  BackgroundColor,
+  BorderColor,
+  BorderRadius,
+  BorderStyle,
+  Display,
+  FlexDirection,
+  IconColor,
+  JustifyContent,
+  TextAlign,
+} from '../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+
+export type SnapUIFileInputProps = {
+  name: string;
+  label?: string;
+  form?: string;
+  accept?: string[];
+  compact?: boolean;
+  error?: boolean;
+  helpText?: string;
+};
+
+/**
+ * A file input component, which is used to create a file input field for Snaps
+ * user interfaces.
+ *
+ * @param props - The props of the component.
+ * @param props.name - The name of the file input. This is used to identify the
+ * file input field in the form data.
+ * @param props.label - The label of the file input, which is displayed above
+ * the file input field.
+ * @param props.form - The name of the form that the file input belongs to. This
+ * is used to group the file input field with other form fields.
+ * @param props.accept - The types of files that the file input can accept. This
+ * is used to filter the files that the user can select when the input field is
+ * clicked.
+ * @param props.compact - Whether the file input should be displayed in a
+ * compact mode. In compact mode, the file input is displayed as a button with
+ * an icon.
+ * @param props.error - Whether the file input has an error. If the file input
+ * has an error, the help text is displayed in red.
+ * @param props.helpText - The help text of the file input, which is displayed
+ * below the file input field.
+ * @returns A file input element.
+ */
+export const SnapUIFileInput: FunctionComponent<SnapUIFileInputProps> = ({
+  name,
+  label,
+  form,
+  accept,
+  compact,
+  error,
+  helpText,
+}) => {
+  const t = useI18nContext();
+  const { handleFileChange } = useSnapInterfaceContext();
+  const ref = useRef<HTMLInputElement>(null);
+  const [active, setActive] = useState(false);
+
+  const handleClick = () => {
+    ref.current?.click();
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    handleFileChange(name, file, form);
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLSpanElement>) => {
+    event.preventDefault();
+    setActive(true);
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLSpanElement>) => {
+    event.preventDefault();
+    setActive(false);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLSpanElement>) => {
+    event.preventDefault();
+    setActive(false);
+
+    const file = event.dataTransfer?.files?.[0] ?? null;
+    handleFileChange(name, file, form);
+  };
+
+  const header = (
+    <>
+      {label && (
+        <Label
+          htmlFor={name}
+          className={classnames('mm-form-text-field__label')}
+        >
+          {label}
+        </Label>
+      )}
+      <input
+        id={name}
+        ref={ref}
+        type="file"
+        name={name}
+        onChange={handleChange}
+        accept={accept?.join(',')}
+        hidden={true}
+      />
+    </>
+  );
+
+  const footer = (
+    <>
+      {helpText && (
+        <HelpText
+          severity={error ? HelpTextSeverity.Danger : undefined}
+          marginTop={1}
+          className="mm-form-text-field__help-text"
+        >
+          {helpText}
+        </HelpText>
+      )}
+    </>
+  );
+
+  if (compact) {
+    return (
+      <Box className="snap-ui-renderer__file-input">
+        {header}
+        <ButtonIcon
+          type="button"
+          iconName={IconName.Upload}
+          color={IconColor.iconAlternative}
+          size={ButtonIconSize.Md}
+          padding={1}
+          backgroundColor={BackgroundColor.backgroundAlternative}
+          borderColor={BorderColor.borderMuted}
+          borderStyle={BorderStyle.solid}
+          borderWidth={1}
+          borderRadius={BorderRadius.MD}
+          onClick={handleClick}
+          ariaLabel={t('uploadFile')}
+        />
+        {footer}
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="snap-ui-renderer__file-input">
+      {header}
+      <Box
+        className="snap-ui-renderer__file-input__drop-zone"
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        justifyContent={JustifyContent.center}
+        alignItems={AlignItems.center}
+        gap={1}
+        paddingTop={5}
+        paddingBottom={5}
+        textAlign={TextAlign.Center}
+        borderColor={BorderColor.borderMuted}
+        borderStyle={BorderStyle.solid}
+        borderWidth={1}
+        borderRadius={BorderRadius.MD}
+        style={{
+          cursor: 'pointer',
+          backgroundColor: active
+            ? 'var(--color-background-alternative-hover)'
+            : undefined,
+        }}
+        onClick={handleClick}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <Icon
+          name={IconName.Upload}
+          size={IconSize.Md}
+          color={active ? IconColor.infoDefault : IconColor.iconAlternative}
+        />
+        <Text
+          color={active ? IconColor.infoDefault : IconColor.iconAlternative}
+        >
+          {t('uploadDropFile')}
+        </Text>
+      </Box>
+      {footer}
+    </Box>
+  );
+};

--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -19,7 +19,10 @@ export const SnapUIForm: FunctionComponent<SnapUIFormProps> = ({
 
   const handleSubmit = (event: FormEvent<HTMLElement>) => {
     event.preventDefault();
-    handleEvent({ event: UserInputEventType.FormSubmitEvent, name });
+    handleEvent({
+      event: UserInputEventType.FormSubmitEvent,
+      name,
+    });
   };
 
   return (

--- a/ui/components/app/snaps/snap-ui-renderer/components/field.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/field.ts
@@ -18,12 +18,29 @@ export const field: UIComponentFactory<FieldElement> = ({ element, form }) => {
   const child = children[0] as JSXElement;
 
   switch (child.type) {
+    case 'FileInput': {
+      return {
+        element: 'SnapUIFileInput',
+        props: {
+          id: child.props.name,
+          name: child.props.name,
+          accept: child.props.accept,
+          compact: child.props.compact,
+          label: element.props.label,
+          form,
+          error: element.props.error !== undefined,
+          helpText: element.props.error,
+        },
+      };
+    }
+
     case 'Input': {
       const input = child as InputElement;
       const button = children[1] as ButtonElement;
       const buttonMapped =
         button &&
         buttonFn({ element: button } as UIComponentParams<ButtonElement>);
+
       return {
         element: 'SnapUIInput',
         props: {

--- a/ui/components/app/snaps/snap-ui-renderer/components/field.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/field.ts
@@ -22,7 +22,6 @@ export const field: UIComponentFactory<FieldElement> = ({ element, form }) => {
       return {
         element: 'SnapUIFileInput',
         props: {
-          id: child.props.name,
           name: child.props.name,
           accept: child.props.accept,
           compact: child.props.compact,

--- a/ui/components/app/snaps/snap-ui-renderer/components/file-input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/file-input.ts
@@ -10,7 +10,6 @@ export const fileInput: UIComponentFactory<FileInputElement> = ({
   props: {
     element: 'SnapUIFileInput',
     props: {
-      id: element.props.name,
       name: element.props.name,
       accept: element.props.accept,
       compact: element.props.compact,

--- a/ui/components/app/snaps/snap-ui-renderer/components/file-input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/file-input.ts
@@ -1,0 +1,20 @@
+import { FileInputElement } from '@metamask/snaps-sdk/jsx';
+
+import { UIComponentFactory } from './types';
+
+export const fileInput: UIComponentFactory<FileInputElement> = ({
+  element,
+  form,
+}) => ({
+  element: 'SnapUIInput',
+  props: {
+    element: 'SnapUIFileInput',
+    props: {
+      id: element.props.name,
+      name: element.props.name,
+      accept: element.props.accept,
+      compact: element.props.compact,
+      form,
+    },
+  },
+});

--- a/ui/components/app/snaps/snap-ui-renderer/components/index.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/index.ts
@@ -8,6 +8,7 @@ import { row } from './row';
 import { address } from './address';
 import { copyable } from './copyable';
 import { button } from './button';
+import { fileInput } from './file-input';
 import { form } from './form';
 import { input } from './input';
 import { bold } from './bold';
@@ -30,6 +31,7 @@ export const COMPONENT_MAPPING = {
   Row: row,
   Address: address,
   Button: button,
+  FileInput: fileInput,
   Form: form,
   Input: input,
   Bold: bold,

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -166,11 +166,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   };
 
   const handleInputChangeDebounced = debounce(
-    (
-      event: UserInputEventType,
-      name: string | undefined,
-      value: Record<string, unknown>,
-    ) =>
+    (event: UserInputEventType, name: string | undefined, value: unknown) =>
       handleEvent({
         event,
         name,
@@ -193,9 +189,11 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
     internalState.current = state;
     updateStateDebounced(state);
-    handleInputChangeDebounced(UserInputEventType.InputChangeEvent, name, {
+    handleInputChangeDebounced(
+      UserInputEventType.InputChangeEvent,
+      name,
       value,
-    });
+    );
   };
 
   const uploadFile = (name: string, file: File | null) => {

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -243,6 +243,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
           internalState.current = state;
           updateStateDebounced(state);
+          updateStateDebounced.flush();
           uploadFile(name, fileObject);
         });
 

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -166,9 +166,9 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   };
 
   const handleInputChangeDebounced = debounce(
-    (event: UserInputEventType, name: string | undefined, value: unknown) =>
+    (name, value) =>
       handleEvent({
-        event,
+        event: UserInputEventType.InputChangeEvent,
         name,
         value,
         flush: true,
@@ -189,11 +189,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
     internalState.current = state;
     updateStateDebounced(state);
-    handleInputChangeDebounced(
-      UserInputEventType.InputChangeEvent,
-      name,
-      value,
-    );
+    handleInputChangeDebounced(name, value);
   };
 
   const uploadFile = (name: string, file: File | null) => {

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -1,9 +1,10 @@
 import {
+  File as FileObject,
   FormState,
   InterfaceState,
   UserInputEventType,
 } from '@metamask/snaps-sdk';
-import { Json } from '@metamask/utils';
+import { Json, bytesToBase64 } from '@metamask/utils';
 import { debounce, throttle } from 'lodash';
 import React, {
   FunctionComponent,
@@ -35,10 +36,17 @@ export type HandleInputChange = <Type>(
 
 export type GetValue = <Type>(name: string, form?: string) => Type | undefined;
 
+export type HandleFileChange = (
+  name: string,
+  file: File | null,
+  form?: string,
+) => void;
+
 export type SnapInterfaceContextType = {
   handleEvent: HandleEvent;
   getValue: GetValue;
   handleInputChange: HandleInputChange;
+  handleFileChange: HandleFileChange;
 };
 
 export const SnapInterfaceContext =
@@ -75,12 +83,13 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 > = ({ children, interfaceId, snapId, initialState, context }) => {
   const dispatch = useDispatch();
 
-  // We keep an internal copy of the state to speed-up the state update in the UI.
-  // It's kept in a ref to avoid useless re-rendering of the entire tree of components.
+  // We keep an internal copy of the state to speed up the state update in the
+  // UI. It's kept in a ref to avoid useless re-rendering of the entire tree of
+  // components.
   const internalState = useRef<InterfaceState>(initialState ?? {});
 
-  // Since the internal state is kept in a reference, it won't update when the interface is updated.
-  // We have to manually update it
+  // Since the internal state is kept in a reference, it won't update when the
+  // interface is updated. We have to manually update it.
   useEffect(() => {
     internalState.current = initialState;
   }, [initialState]);
@@ -88,8 +97,8 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   const rawSnapRequestFunction = (
     event: UserInputEventType,
     name?: string,
-    value?: string,
-  ) =>
+    value?: unknown,
+  ) => {
     handleSnapRequest({
       snapId,
       origin: '',
@@ -109,13 +118,14 @@ export const SnapInterfaceContextProvider: FunctionComponent<
         },
       },
     }).then(() => forceUpdateMetamaskState(dispatch));
+  };
 
-  // The submittion of user input events is debounced or throttled to avoid crashing the snap if
-  // there's too much events sent at the same time
+  // The submission of user input events is debounced or throttled to avoid
+  // crashing the snap if there's too many events sent at the same time.
   const snapRequestDebounced = debounce(rawSnapRequestFunction, 200);
   const snapRequestThrottled = throttle(rawSnapRequestFunction, 200);
 
-  // The update of the state is debounced to avoid crashes due to too much
+  // The update of the state is debounced to avoid crashes due to too many
   // updates in a short amount of time.
   const updateStateDebounced = debounce(
     (state) => dispatch(updateInterfaceState(interfaceId, state)),
@@ -129,7 +139,8 @@ export const SnapInterfaceContextProvider: FunctionComponent<
    * @param options.event - The event type.
    * @param options.name - The name of the component emitting the event.
    * @param options.value - The value of the component emitting the event.
-   * @param options.flush - Optional flag to indicate whether the debounce should be flushed.
+   * @param options.flush - Optional flag to indicate whether the debounce
+   * should be flushed.
    */
   const handleEvent: HandleEvent = ({
     event,
@@ -139,9 +150,11 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   }) => {
     // We always flush the debounced request for updating the state.
     updateStateDebounced.flush();
+
     const fn = THROTTLED_EVENTS.includes(event)
       ? snapRequestThrottled
       : snapRequestDebounced;
+
     fn(event, name, value);
 
     // Certain events have their own debounce or throttling logic
@@ -152,9 +165,13 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   };
 
   const handleInputChangeDebounced = debounce(
-    (name, value) =>
+    (
+      event: UserInputEventType,
+      name: string | undefined,
+      value: Record<string, unknown>,
+    ) =>
       handleEvent({
-        event: UserInputEventType.InputChangeEvent,
+        event,
         name,
         value,
         flush: true,
@@ -175,7 +192,56 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
     internalState.current = state;
     updateStateDebounced(state);
-    handleInputChangeDebounced(name, value ?? '');
+    handleInputChangeDebounced(UserInputEventType.InputChangeEvent, name, {
+      value,
+    });
+  };
+
+  /**
+   * Handle the file change of an input.
+   *
+   * @param name - The name of the input.
+   * @param file - The file to upload.
+   * @param form - The name of the form containing the input.
+   */
+  const handleFileChange: HandleFileChange = (name, file, form) => {
+    if (file) {
+      file
+        .arrayBuffer()
+        .then((arrayBuffer) => new Uint8Array(arrayBuffer))
+        .then((uint8Array) => {
+          const base64 = bytesToBase64(uint8Array);
+          const fileObject: FileObject = {
+            name: file.name,
+            size: file.size,
+            contentType: file.type,
+            contents: base64,
+          };
+
+          const state = mergeValue(
+            internalState.current,
+            name,
+            fileObject,
+            form,
+          );
+
+          internalState.current = state;
+          updateStateDebounced(state);
+          handleInputChangeDebounced(UserInputEventType.FileUploadEvent, name, {
+            file: fileObject,
+          });
+        });
+
+      return;
+    }
+
+    const state = mergeValue(internalState.current, name, null, form);
+
+    internalState.current = state;
+    updateStateDebounced(state);
+    handleInputChangeDebounced(UserInputEventType.FileUploadEvent, name, {
+      file: null,
+    });
   };
 
   /**
@@ -200,7 +266,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
   return (
     <SnapInterfaceContext.Provider
-      value={{ handleEvent, getValue, handleInputChange }}
+      value={{ handleEvent, getValue, handleInputChange, handleFileChange }}
     >
       {children}
     </SnapInterfaceContext.Provider>

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -254,6 +254,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
     internalState.current = state;
     updateStateDebounced(state);
+    updateStateDebounced.flush();
     uploadFile(name, null);
   };
 


### PR DESCRIPTION
## **Description**

This adds a file input component for Snaps to use in custom UI.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25320?quickstart=1)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.