### PR TITLE
fix: UX: Limit Send Page width in full screen

### DIFF
--- a/ui/components/multichain/pages/send/index.scss
+++ b/ui/components/multichain/pages/send/index.scss
@@ -2,6 +2,7 @@
 
 .multichain-send-page {
   width: 100%;
+  max-width: 408px;
 
   &__account-picker {
     height: 62px;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Limits the width of the new Send page.  Broken by https://github.com/MetaMask/metamask-extension/commit/a3cbcef95ce1cad638ea2af6cbdba43f6a6d7b1a

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25347?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open MetaMask in full screen
2. Go to the send flow
3. See width of send form limited

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1060" alt="SCR-20240614-qqnx" src="https://github.com/MetaMask/metamask-extension/assets/46655/6380e883-4ebc-471b-b621-23be06585df2">




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
