### PR TITLE
fix(25335): fix flaky test "Unlock wallet should send first three Page metric events upon fullscreen page load"

### DIFF
--- a/test/e2e/tests/metrics/unlock-wallet.spec.js
+++ b/test/e2e/tests/metrics/unlock-wallet.spec.js
@@ -40,14 +40,25 @@ describe('Unlock wallet', function () {
         await unlockWallet(driver);
         await waitForAccountRendered(driver);
         const events = await getEventPayloads(driver, mockedEndpoint);
-        assert.equal(events.length, 3);
-        assertBatchValue(events[0], 'Home', '/');
-        assertBatchValue(events[1], 'Unlock Page', '/unlock');
-        assertBatchValue(events[2], 'Home', '/');
+        const sortedEvents = sortEventsByTime(events);
+        await assert.equal(sortedEvents.length, 3);
+        assertBatchValue(sortedEvents[0], 'Home', '/');
+        assertBatchValue(sortedEvents[1], 'Unlock Page', '/unlock');
+        assertBatchValue(sortedEvents[2], 'Home', '/');
       },
     );
   });
 });
+
+function sortEventsByTime(events) {
+  events.sort((event1, event2) => {
+    const timestamp1 = new Date(event1.timestamp);
+    const timestamp2 = new Date(event2.timestamp);
+    // Compare timestamps, return -1 for earlier, 1 for later, 0 for equal
+    return timestamp1 - timestamp2;
+  });
+  return events;
+}
 
 function assertBatchValue(event, assertedTitle, assertedPath) {
   const { title, path } = event.context.page;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The flakyness comes from unordered events from time to time. 
Based on the log of events when unlock wallet: 

<img width="903" alt="截屏2024-06-14 22 33 12" src="https://github.com/MetaMask/metamask-extension/assets/12678455/69396558-d514-4db9-ab44-ae2f921e0546">


The `events` array is not sorted, and there is nothing wrong with metrics itself and the order of sending, which can be validated by `timestamp`. 

Therefore the fix is to order events by `timestamp` and assert the value.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25351?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25335

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
