### PR TITLE
fix: display the correct symbol of a native currency

### DIFF
--- a/ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx
@@ -63,8 +63,8 @@ const getTitle = (n: ETHNotification) => {
 };
 
 const getDescription = (n: ETHNotification) => {
-  const { nativeCurrencyName } = getNativeCurrency(n);
-  const items = createTextItems([nativeCurrencyName], TextVariant.bodyMd);
+  const { nativeCurrencySymbol } = getNativeCurrency(n);
+  const items = createTextItems([nativeCurrencySymbol], TextVariant.bodyMd);
   return items;
 };
 


### PR DESCRIPTION
## **Description**

This PR fixes a small bug in the display of certain types of notifications. Specifically, in the case of receiving or sending notifications of native currencies, the symbol of the native currency is now correctly displayed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25364?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="387" alt="Screenshot 2024-06-17 at 11 16 01" src="https://github.com/MetaMask/metamask-extension/assets/1284304/5f66746e-7b32-45a3-899a-672ef65db44e">

### **After**

<img width="443" alt="Screenshot 2024-06-17 at 11 43 31" src="https://github.com/MetaMask/metamask-extension/assets/1284304/686351cd-7940-499b-9e42-f626fe705677">

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
