### PR TITLE
chore: Bump Firefox outdated browser version

### DIFF
--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -21,8 +21,10 @@ export const OUTDATED_BROWSER_VERSIONS = {
   // or the earliest version that supports our MV3 functionality, whichever is higher
   chrome: '<109',
   edge: '<109',
-  // Firefox should match the most recent end-of-life extended support release
-  firefox: '<91',
+  // Firefox should match the previous extended support release
+  // Current ESR: 115
+  // Previous ESR: 102
+  firefox: '<102',
   // Opera versions correspond to differently numbered Chromium versions.
   // Opera should be set to the equivalent of the Chromium version set
   // Opera 95 is based on Chromium 109

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -218,14 +218,14 @@ describe('util', () => {
     });
     it('should return false when given a modern firefox browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:78.0) Gecko/20100101 Firefox/91.0',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:78.0) Gecko/20100101 Firefox/102.0',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(false);
     });
     it('should return true when given an outdated firefox browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:75.0) Gecko/20100101 Firefox/90.0',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:75.0) Gecko/20100101 Firefox/91.0',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(true);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The outdated browser version for Firefox has been bumped to 102. Users on older versions of Firefox will now see a warning saying that their browser is outdated. This is inpreparation for updating our minimum supported Firefox version to 102.

102 is the previous ESR version, which matches our browser support policy (we support the current and previous ESR Firefox versions).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25365?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

Run this build with any Firefox version between v91 and 101 (inclusive), and see that the outdated browser version notice appears on the Home screen.

## **Screenshots/Recordings**

None

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
