### PR TITLE
fix isHeadless usage in MMI Dockerfile

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 import dotenv from 'dotenv';
+import { isHeadless } from './test/helpers/env';
 
 dotenv.config({ path: './test/e2e/mmi/.env' });
 const logOutputFolder = './public/playwright/playwright-reports';
@@ -43,7 +44,7 @@ const config: PlaywrightTestConfig = {
     trace: 'on',
     video: 'off',
     /* Run tests headless in local */
-    headless: process.env.HEADLESS === 'true',
+    headless: isHeadless('PLAYWRIGHT'),
   },
 
   /* Configure projects for major browsers */

--- a/test/e2e/mmi/Dockerfile
+++ b/test/e2e/mmi/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR '/usr/src/app'
 
 # Copy test files
 COPY playwright.config.ts .
+COPY env.ts test/helpers/env.ts
 COPY . ./test/e2e/mmi/
 # Copy extension for test
 COPY ./dist/chrome ./dist/chrome

--- a/test/e2e/mmi/helpers/extension-loader.ts
+++ b/test/e2e/mmi/helpers/extension-loader.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { test as base, chromium } from '@playwright/test';
 
+import { isHeadless } from '../../../helpers/env';
+
 const extensionPath = path.join(__dirname, '../../../../dist/chrome');
 
 export const test = base.extend({
@@ -10,7 +12,7 @@ export const test = base.extend({
       headless: false,
       args: [`--disable-extensions-except=${extensionPath}`],
     };
-    if (process.env.HEADLESS === 'true') {
+    if (isHeadless('PLAYWRIGHT')) {
       launchOptions.args.push('--headless=new');
     }
     const context = await chromium.launchPersistentContext('', launchOptions);

--- a/test/e2e/mmi/scripts/run-visual-test.sh
+++ b/test/e2e/mmi/scripts/run-visual-test.sh
@@ -13,7 +13,7 @@ mkdir -p test/e2e/mmi/dist
 cp -r dist/chrome test/e2e/mmi/dist/chrome
 
 # copy playwright config to the docker context
-cp playwright.config.ts test/e2e/mmi/
+cp playwright.config.ts test/helpers/env.ts test/e2e/mmi/
 
 # Build the Docker image
 echo "Building the Docker image..."


### PR DESCRIPTION
## **Description**

- Restore parsing of `HEADLESS` and `PLAYWRIGHT_HEADLESS` env vars
  - See #24499
- Copy `env.ts` into MMI E2E oci image to make parsing work in this context   

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25388?quickstart=1)

## **Related issues**

- Targeting: #25247 


## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
