### PR TITLE
fix: Don't ignore Yarn patch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,13 +55,14 @@ test-results/
 # This file is used to authenticate with the GitHub Package registry, to
 # enable the use of @metamask preview builds.
 .npmrc
-#yarn
+
+# Yarn
 .yarn/*
 !.yarn/patches
 !.yarn/plugins
 !.yarn/sdks
 !.yarn/versions
-**/.yarn/*
+development/generate-attributions/.yarn/*
 
 # MMI Playwright
 public/playwright


### PR DESCRIPTION
An earlier commit modified `.gitignore` to ignore `.yarn` files in `development/generate-attributions` (which is a special sub-project in this repo used in the attribution generation workflow). However, this change ended up ignoring Yarn patch files in `.yarn/patches` (along with possibly other Yarn-specific files). This commit narrows the pattern in `.gitignore` not to do this.


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25398?quickstart=1)

## **Related issues**

See https://github.com/MetaMask/metamask-extension/pull/24390 for PR that introduced the bug that this fixes.

## **Manual testing steps**

1. Add a file to `.yarn/patches`.
2. Run `git status`.
3. You should not see it ignored.

## **Screenshots/Recordings**

(None)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
