### PR TITLE
fix: UX: Remove legacy onboarding text

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -3212,23 +3212,11 @@
   "onboardingMetametricsAgree": {
     "message": "Ich stimme zu"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Erlaubt Ihnen immer die Abmeldung über Einstellungen"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Diese Daten werden gesammelt und sind daher im Rahmen der Datenschutz-Grundverordnung (EU) 2016/679 anonym."
-  },
   "onboardingMetametricsDescription": {
     "message": "Wir würden gerne grundlegende Nutzungs- und Diagnosedaten sammeln, um MetaMask zu verbessern. Sie sollten wissen, dass wir die Daten, die Sie uns hier zur Verfügung stellen, niemals verkaufen."
   },
   "onboardingMetametricsDescription2": {
     "message": "Wenn wir Metriken sammeln, wird es immer wie folgt sein ..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask wird ..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask möchte Nutzungsdaten sammeln, um ein besseres Verständnis zu erhalten, wie unsere Nutzer mit MetaMask interagieren. Diese Daten werden verwendet, um Dienste anzubieten, was auf Ihrer Nutzung basierte Dienstverbesserungen einschließt."
   },
   "onboardingMetametricsDisagree": {
     "message": "Nein, danke!"
@@ -3237,18 +3225,8 @@
     "message": "Wir werden Sie informieren, wenn wir beschließen, diese Daten für andere Zwecke zu verwenden. Für weitere Informationen können Sie unsere $1 einsehen. Vergessen Sie nicht, dass Sie jederzeit zu Einstellungen gehen und sich abmelden können.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "*Wenn Sie Infura als Standard-RPC-Anbieter in MetaMask vewenden, speichert Infura Ihre IP-Adresse und Ihre Etherum-Wallet-Adresse, wenn Sie eine Transaktion senden. Wir speichern diese Daten in keinster Weise in unserem System, um sie miteinander in Verbindung zu bringen. Für weitere Informationen darüber, wie MetaMask und Infura in Hinischt auf Datenspeicherung zusammenarbeiten, sehen Sie sich bitte unser Update $1 an. Für mehr Informationen bezüglich unseren allgemeinen Datenschutzpraktiken, sehen Sie sich bitte unsere $2 an.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Datenschutzrichtlinie"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Datenschutzerklärung hier"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "hier"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Benutzerdefiniertes Netzwerk hinzufügen"
@@ -3267,30 +3245,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Allgemein:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 speichert Ihre vollständige IP-Adresse*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 speichert Daten, die wir nicht benötigen, um die Dienstleistung zur Verfügung zu stellen (wie zum Beispiel Schlüssel, Adresse, Transaktions-Hashs oder Guthaben)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Nie"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 Sie können jederzeit über die Einstellungen entscheiden, ob Sie Ihre Nutzungsdaten freigeben oder löschen möchten.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Optional:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 Daten verkaufen. Niemals!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Anonymisierte Ereignisse für Klicks und Seitenaufrufe senden"
   },
   "onboardingMetametricsTitle": {
     "message": "Helfen Sie uns, MetaMask zu verbessern."

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -3212,23 +3212,11 @@
   "onboardingMetametricsAgree": {
     "message": "Συμφωνώ"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Σας επιτρέπεται πάντα να εξαιρεθείτε μέσω των Ρυθμίσεων"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Τα δεδομένα αυτά είναι συγκεντρωτικά και συνεπώς ανώνυμα για τους σκοπούς του Γενικού Κανονισμού για την Προστασία Δεδομένων (ΕΕ) 2016/679."
-  },
   "onboardingMetametricsDescription": {
     "message": "Θέλουμε να συλλέξουμε βασικά δεδομένα χρήσης και διάγνωσης για να βελτιώσουμε το MetaMask. Λάβετε υπόψη ότι δεν πουλάμε ποτέ τα δεδομένα που μας παρέχετε εδώ."
   },
   "onboardingMetametricsDescription2": {
     "message": "Όταν συγκεντρώνουμε μετρήσεις, θα είναι πάντα..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "Το MetaMask θα..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "Το MetaMask θα ήθελε να συλλέγει δεδομένα χρήσης για να κατανοήσει καλύτερα τον τρόπο με τον οποίο οι χρήστες μας αλληλεπιδρούν με το MetaMask. Τα δεδομένα αυτά θα χρησιμοποιηθούν για την παροχή της υπηρεσίας, η οποία περιλαμβάνει τη βελτίωση της υπηρεσίας με βάση τη χρήση σας."
   },
   "onboardingMetametricsDisagree": {
     "message": "Όχι, ευχαριστώ"
@@ -3237,18 +3225,8 @@
     "message": "Θα σας ενημερώσουμε εάν αποφασίσουμε να χρησιμοποιήσουμε αυτά τα δεδομένα για άλλους σκοπούς. Για περισσότερες πληροφορίες, μπορείτε να ανατρέξετε στην $1. Να θυμάστε ότι μπορείτε να μεταβείτε στις ρυθμίσεις και να εξαιρεθείτε ανά πάσα στιγμή.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* Όταν χρησιμοποιείτε την Infura ως τον προεπιλεγμένο πάροχο RPC στο MetaMask, η Infura θα συλλέγει τη διεύθυνση IP σας και τη διεύθυνση του πορτοφολιού σας στο Ethereum όταν αποστέλλετε μια συναλλαγή. Δεν αποθηκεύουμε αυτές τις πληροφορίες με τρόπο που να επιτρέπει στα συστήματά μας να συσχετίζουν αυτά τα δύο δεδομένα. Για περισσότερες πληροφορίες σχετικά με τον τρόπο με τον οποίο αλληλεπιδρούν το MetaMask και η Infura από την πλευρά της συλλογής δεδομένων, δείτε την ενημέρωσή μας $1. Για περισσότερες πληροφορίες σχετικά με τις πρακτικές απορρήτου μας γενικά, δείτε την ενημέρωσή μας $2.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Πολιτική Απορρήτου"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Πολιτική Απορρήτου εδώ"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "εδώ"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Προσθήκη προσαρμοσμένου δικτύου"
@@ -3267,30 +3245,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Γενικές:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "To $1 συλλέγει την πλήρη διεύθυνση IP σας*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "To $1 συλλέγει πληροφορίες που δεν χρειαζόμαστε για την παροχή της υπηρεσίας (όπως κλειδιά, διευθύνσεις, αναλύσεις συναλλαγών ή υπόλοιπα)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Ποτέ"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 εσείς αποφασίζετε αν θέλετε να κοινοποιήσετε ή να διαγράψετε τα δεδομένα χρήσης σας μέσω των ρυθμίσεων ανά πάσα στιγμή.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Προαιρετικές:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "To $1 πουλάει δεδομένα.  Ποτέ!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Αποστολή ανώνυμων συμβάντων κλικ και προβολής ιστοσελίδων"
   },
   "onboardingMetametricsTitle": {
     "message": "Βοηθήστε μας να βελτιώσουμε το MetaMask"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3339,23 +3339,11 @@
   "onboardingMetametricsAgree": {
     "message": "I agree"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Always allow you to opt-out via Settings"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "This data is aggregated and is therefore anonymous for the purposes of General Data Protection Regulation (EU) 2016/679."
-  },
   "onboardingMetametricsDescription": {
     "message": "We’d like to gather basic usage and diagnostics data to improve MetaMask. Know that we never sell the data you provide here."
   },
   "onboardingMetametricsDescription2": {
     "message": "When we gather metrics, it will always be..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask will..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask would like to gather usage data to better understand how our users interact with MetaMask. This data will be used to provide the service, which includes improving the service based on your use."
   },
   "onboardingMetametricsDisagree": {
     "message": "No thanks"
@@ -3364,18 +3352,8 @@
     "message": "We’ll let you know if we decide to use this data for other purposes. You can review our $1 for more information. Remember, you can go to settings and opt out at any time.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* When you use Infura as your default RPC provider in MetaMask, Infura will collect your IP address and your Ethereum wallet address when you send a transaction. We don’t store this information in a way that allows our systems to associate those two pieces of data. For more information on how MetaMask and Infura interact from a data collection perspective, see our update $1. For more information on our privacy practices in general, see our $2.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Privacy Policy"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Privacy Policy here"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "here"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Add custom network"
@@ -3394,30 +3372,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "General:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 collect your full IP address*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 collect information we don’t need to provide the service (such as keys, addresses, transaction hashes, or balances)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Never"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 you decide if you want to share or delete your usage data via settings any time.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Optional:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 sell data.  Ever!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Send anonymized click and pageview events"
   },
   "onboardingMetametricsTitle": {
     "message": "Help us improve MetaMask"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -3209,23 +3209,11 @@
   "onboardingMetametricsAgree": {
     "message": "Acepto"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Siempre le permitirá excluirse a través de la Configuración"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Estos datos se agrupan y, por lo tanto, son anónimos a los efectos del Reglamento general de protección de datos (UE) 2016/679."
-  },
   "onboardingMetametricsDescription": {
     "message": "Nos gustaría recopilar datos básicos de uso y diagnóstico para mejorar MetaMask. Tenga presente que nunca venderemos los datos que nos proporcione aquí."
   },
   "onboardingMetametricsDescription2": {
     "message": "Al recopilar métricas, siempre será..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask quisiera recopilar datos de uso para comprender mejor cómo nuestros usuarios interactúan con MetaMask. Estos datos se utilizarán para proporcionar el servicio, lo que incluye mejorarlo en función de su uso."
   },
   "onboardingMetametricsDisagree": {
     "message": "No, gracias"
@@ -3234,18 +3222,8 @@
     "message": "Le informaremos si decidimos usar estos datos para otros fines. Puede consultar $1 para obtener más información. Recuerde que puede acceder a la configuración y excluirse en cualquier momento.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "*Al utilizar Infura como su proveedor de RPC predeterminado en MetaMask, Infura recopilará su dirección IP y la dirección de su monedero de Ethereum cuando envíe una transacción. No almacenamos esta información de una manera que permita qie nuestros sistemas asocien esos dos datos. Para obtener más información sobre cómo interactúan MetaMask e Infura desde la perspectiva de la recopilación de datos, consulte nuestra actualización $1. Para obtener más información sobre nuestras prácticas de privacidad en general, consulte nuestra $2.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Política de privacidad"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Política de privacidad aquí"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "aquí"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Agregar red personalizada"
@@ -3264,30 +3242,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Generales:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 recopilará su dirección IP completa*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 recopilará información que no necesitamos para brindar el servicio (como claves, direcciones, hashes de transacciones o saldos)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Nunca"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 usted decide si desea compartir o eliminar sus datos de uso a través de la configuración en cualquier momento.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Opcionales:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 venderá datos. ¡Jamás!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Enviará eventos de vistas de página y clics anónimos"
   },
   "onboardingMetametricsTitle": {
     "message": "Ayúdenos a mejorar MetaMask"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -3212,23 +3212,11 @@
   "onboardingMetametricsAgree": {
     "message": "J’accepte"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Vous pourrez toujours vous désinscrire depuis les Paramètres"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Conformément au règlement général sur la protection des données (UE) 2016/679, ces données sont agrégées pour préserver l’anonymat des utilisateurs."
-  },
   "onboardingMetametricsDescription": {
     "message": "Nous aimerions recueillir des données d’utilisation et de diagnostic de base afin d’améliorer MetaMask. Sachez que nous ne vendons jamais les données que vous nous fournissez ici."
   },
   "onboardingMetametricsDescription2": {
     "message": "Lorsque nous recueillons des données, elles sont toujours…"
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask souhaite recueillir des données d’utilisation afin de mieux comprendre comment les utilisateurs interagissent avec MetaMask. Ces données seront utilisées pour améliorer les services que nous proposons ainsi que l’expérience utilisateur."
   },
   "onboardingMetametricsDisagree": {
     "message": "Non merci"
@@ -3237,18 +3225,8 @@
     "message": "Nous vous informerons si nous décidons d’utiliser ces données à d’autres fins. Pour plus d’informations, vous pouvez consulter notre $1. N’oubliez pas que vous pouvez aller dans les paramètres et vous désinscrire à tout moment.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* Sachez que lorsque vous définissez Infura comme fournisseur de RPC par défaut dans MetaMask, votre adresse IP et l’adresse de votre portefeuille Ethereum seront communiquées à Infura pour valider les transactions. Ces données sont stockées séparément sur nos systèmes pour préserver l’anonymat des utilisateurs. Pour plus d’informations sur la façon dont MetaMask et Infura collectent les données, consultez nos dernières mises à jour $1. Pour plus d’informations, consultez notre $2.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Politique de confidentialité"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Politique de confidentialité ici"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "ici"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Ajouter un réseau personnalisé"
@@ -3267,30 +3245,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Général :"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "Nous ne collectons $1 l’intégralité de votre adresse IP*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "Nous ne collectons $1 d’informations dont nous n’avons pas besoin pour fournir nos services (comme les clés, les adresses, les hachages de transactions ou les soldes)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Jamais"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 vous pouvez décider à tout moment de partager ou de supprimer vos données d’utilisation dans les paramètres.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Facultatif :"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "Nous ne vendons $1 vos données !",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Envoyer des données anonymisées sur les clics effectués et les pages vues"
   },
   "onboardingMetametricsTitle": {
     "message": "Aidez-nous à améliorer MetaMask"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -3209,23 +3209,11 @@
   "onboardingMetametricsAgree": {
     "message": "मैं सहमत हूं"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "सेटिंग के माध्यम से आपको हमेशा ऑप्ट-आउट करने की अनुमति देता है"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "यह डेटा एग्रीगेट किया गया है और इसलिए सामान्य डेटा संरक्षण विनियम (EU) 2016/679 के उद्देश्यों के लिए अज्ञात है।"
-  },
   "onboardingMetametricsDescription": {
     "message": "हम MetaMask को बेहतर बनाने के लिए बुनियादी यूसेज और डाएगोनोस्टिक्स डेटा कलेक्ट करना चाहेंगे। जान लें कि हम आपके द्वारा यहां उपलब्ध कराया गया डेटा कभी नहीं बेचते हैं।"
   },
   "onboardingMetametricsDescription2": {
     "message": "जब हम मेट्रिक्स इकट्ठा करते हैं, तो यह हमेशा... रहेगा"
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask करेगा..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask यह समझने के लिए इस्तेमाल डेटा एकत्र करना चाहता है कि हमारे यूज़र MetaMask से कैसे इंटरैक्ट करते हैं। इस डेटा का इस्तेमाल सर्विस प्रदान करने के लिए किया जाएगा, जिसमें आपके इस्तेमाल के आधार पर सर्विस में सुधार करना शामिल है।"
   },
   "onboardingMetametricsDisagree": {
     "message": "जी नहीं, धन्यवाद"
@@ -3234,18 +3222,8 @@
     "message": "यदि हम इस डेटा का उपयोग अन्य उद्देश्यों के लिए करने का निर्णय लेते हैं तो हम आपको बताएंगे। अधिक जानकारी के लिए आप हमारे $1 की समीक्षा कर सकते हैं। याद रखें, आप किसी भी समय सेटिंग्स में जाकर ऑप्ट आउट कर सकते हैं।",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* जब आप MetaMask में अपने डिफॉल्ट RPC प्रोवाइडर के रूप में Infura का इस्तेमाल करते हैं, तो जब आप ट्रांसेक्शन भेजते हैं तो Infura आपका IP एड्रेस और आपके Ethereum वॉलेट का एड्रेस एकत्र कर लेगा। हम इस जानकारी को इस तरह से स्टोर नहीं करते हैं जिससे हमारे सिस्टम डेटा के उन दो टुकड़ों को जोड़ सकें। डेटा कलेक्शन के नज़रिए से MetaMask और Infura कैसे इंटरैक्ट करते हैं, इस बारे में अधिक जानकारी के लिए, हमारा अपडेट $1 देखें। सामान्य तौर पर हमारी गोपनीयता की कार्यप्रणाली के बारे में अधिक जानकारी के लिए, हमारा $2 देखें।",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "गोपनीयता नीति"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "यहां गोपनीयता नीति"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "यहां"
   },
   "onboardingMetametricsModalTitle": {
     "message": "कस्टम नेटवर्क जोड़ें"
@@ -3264,30 +3242,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "सामान्य:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 आपका पूरा IP एड्रेस एकत्र करते हैं*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 ऐसी जानकारी एकत्र करते हैं जिसे हमें सर्विस प्रदान करने की आवश्यकता नहीं है (जैसे keys, एड्रेस, ट्रांसेक्शन हैशेज़ या बैलेंस)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "कभी नहीं"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 आप तय करते हैं कि आप किसी भी समय सेटिंग्स के माध्यम से अपना यूसेज डेटा शेयर करना चाहते हैं या हटाना चाहते हैं।",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "वैकल्पिक:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 डेटा बेचते हैं। कभी!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "अज्ञात क्लिक और पेजव्यू इवेंट भेजें"
   },
   "onboardingMetametricsTitle": {
     "message": "MetaMask को बेहतर बनाने में हमारी मदद करें"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -3212,23 +3212,11 @@
   "onboardingMetametricsAgree": {
     "message": "Saya setuju"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Selalu izinkan Anda untuk keluar melalui Pengaturan"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Data ini dikumpulkan sehingga bersifat anonim untuk tujuan Peraturan Perlindungan Data Umum (UE) 2016/679."
-  },
   "onboardingMetametricsDescription": {
     "message": "Kami ingin mengumpulkan data penggunaan dasar dan diagnostik untuk meningkatkan MetaMask. Pahami bahwa kami tidak pernah menjual data yang Anda berikan di sini."
   },
   "onboardingMetametricsDescription2": {
     "message": "Saat kami mengumpulkan metrik, maka akan selalu..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask akan..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask ingin mengumpulkan data penggunaan untuk lebih memahami cara pengguna kami berinteraksi dengan MetaMask. Data ini akan digunakan untuk menyediakan layanan, termasuk meningkatkan layanan berdasarkan penggunaan Anda."
   },
   "onboardingMetametricsDisagree": {
     "message": "Tidak, terima kasih"
@@ -3237,18 +3225,8 @@
     "message": "Kami akan memberitahukan keputusan untuk menggunakan data ini dengan tujuan lain. Anda dapat meninjau $1 kami untuk informasi selengkapnya. Ingat, Anda dapat membuka pengaturan dan memilih keluar setiap saat.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* Saat Anda menggunakan Infura sebagai penyedia RPC awal di MetaMask, Infura akan mengumpulkan alamat IP dan alamat dompet Ethereum Anda saat mengirim transaksi. Kami tidak menyimpan informasi ini dengan cara yang memungkinkan sistem kami menghubungkan kedua bagian data tersebut. Untuk informasi lebih lanjut seputar cara MetaMask dan Infura berinteraksi dari perspektif pengumpulan data, lihat pembaruan $1. Untuk informasi lebih lanjut seputar praktik privasi kami secara umum, lihat $2 kami.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Kebijakan Privasi"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Kebijakan Privasi di sini"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "di sini"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Tambahkan jaringan khusus"
@@ -3267,30 +3245,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Umum:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 mengumpulkan alamat IP lengkap Anda*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 mengumpulkan informasi yang tidak kami perlukan untuk menyediakan layanan (seperti kunci, alamat, hash transaksi, atau saldo)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Jangan"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 memutuskan jika Anda ingin membagikan atau menghapus data penggunaan melalui pengaturan setiap saat.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Opsional:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 menjual data. Jangan pernah!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Kirim klik anonim dan acara tampilan laman"
   },
   "onboardingMetametricsTitle": {
     "message": "Bantu kami meningkatkan MetaMask"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -3209,23 +3209,11 @@
   "onboardingMetametricsAgree": {
     "message": "同意します"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "いつでも設定からオプトアウトできるようにします"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "一般データ保護規則 (EU) 2016/679 の目的に従い、このデータは集約され匿名化されます。"
-  },
   "onboardingMetametricsDescription": {
     "message": "MetaMaskの改善を目的に、基本的な使用状況および診断データを収集したいと思います。ここで提供されるデータが販売されることはありません。"
   },
   "onboardingMetametricsDescription2": {
     "message": "指標を収集する際、常に次の条件が適用されます..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMaskは..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMaskは、ユーザーによるMetaMaskの使用状況をより詳細に把握するため、使用データを収集したいと考えています。このデータは、使用状況に基づくサービスの改善を含め、サービスの提供を目的に使用されます。"
   },
   "onboardingMetametricsDisagree": {
     "message": "結構です"
@@ -3234,18 +3222,8 @@
     "message": "このデータを他の目的に使用する際は、お知らせします。詳細は当社の$1をご覧ください。設定でいつでもオプトアウトできます。",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* MetaMaskでInfuraをデフォルトのRPCプロバイダーとして使用する場合、Infuraはトランザクションの送信時にユーザーのIPアドレスおよびイーサリアムウォレットアドレスを収集します。当社がこれらの情報を、システムによりこれら2つのデータが関連付けられる形で保管することはありません。データ収集の観点から見たMetaMaskとInfuraとのやり取りに関する詳細は、当社の最新の$1をご覧ください。当社のプライバシー慣行全般に関する詳細は、$2をご覧ください。",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "プライバシー ポリシー"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "こちらのプライバシーポリシー"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "こちら"
   },
   "onboardingMetametricsModalTitle": {
     "message": "カスタムネットワークを追加"
@@ -3264,30 +3242,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "一般:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "ユーザーの完全なIPアドレスを収集することは、$1*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "サービスの提供に不要な情報 (キー、アドレス、トランザクションハッシュ、残高) を収集することは、$1",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "一切ありません"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 使用状況データを共有するか削除するかは、設定でいつでも指定できます。",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "任意:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "データを販売することは$1。絶対です！",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "匿名のクリックおよびページ閲覧イベントを送信"
   },
   "onboardingMetametricsTitle": {
     "message": "MetaMaskの改善にご協力ください"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -3209,23 +3209,11 @@
   "onboardingMetametricsAgree": {
     "message": "동의함"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "언제든 설정을 통해 옵트아웃할 수 있습니다."
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "이 데이터는 집계 처리된 정보이며 일반 데이터 보호 규정 (EU) 2016/679의 목적에 따라 익명으로 관리됩니다."
-  },
   "onboardingMetametricsDescription": {
     "message": "MetaMask를 개선하기 위해 기본적인 사용 및 진단 데이터를 수집하고자 합니다. MetaMask는 제공받은 데이터를 절대 판매하지 않습니다."
   },
   "onboardingMetametricsDescription2": {
     "message": "메트릭을 수집할 때는 항상..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask에서는..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask는 사용자가 MetaMask를 어떻게 사용하는지 이해하기 위해 기본적인 사용 데이터를 수집하고자 합니다. 이 데이터는 사용자 경험을 통한 서비스 개선에 사용됩니다."
   },
   "onboardingMetametricsDisagree": {
     "message": "괜찮습니다"
@@ -3234,18 +3222,8 @@
     "message": "이 데이터를 다른 목적으로 사용하기로 결정하면 알려드리겠습니다. 자세한 내용은 $1을(를) 참고하세요. 언제든지 설정으로 이동하여 해제할 수 있습니다.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* MetaMask에서 Infura를 기본 RPC 공급업체로 이용하는 경우, 트랜잭션 전송 시 Infura가 IP 주소와 이더리움 지갑 주소 정보를 수집합니다. MetaMask는 해당 두 정보를 연계할 수 있는 방식으로 정보를 저장하지 않습니다. 데이터 수집 관점에서 MetaMask와 Infura가 인터렉션하는 방법에 대한 자세한 내용은 $1 업데이트를 참조하세요. 일반적인 개인정보 처리방침에 대한 자세한 내용은 $2에서 확인하세요.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "개인정보 처리방침"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "개인정보 처리방침"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "여기"
   },
   "onboardingMetametricsModalTitle": {
     "message": "맞춤 네트워크 추가"
@@ -3264,30 +3242,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "일반:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1에서는 사용자의 IP 주소 전체를 수집합니다.",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1에서는 서비스 제공에 필요하지 않은 정보(예: 키, 주소, 트랜잭션 해시 또는 잔액)를 수집합니다.",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "절대로"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 언제든지 설정을 통해 사용 데이터를 공유할지 삭제할지 결정할 수 있습니다.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "선택 사항:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1에서는 데이터를 판매합니다. 항상요!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "익명 클릭 및 페이지뷰 이벤트 보내기"
   },
   "onboardingMetametricsTitle": {
     "message": "MetaMask 개선에 도움을 주세요"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -3212,23 +3212,11 @@
   "onboardingMetametricsAgree": {
     "message": "Concordo"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Permite que você cancele a inscrição a qualquer momento nas Configurações"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Esses dados são agregados e, portanto, anônimos para os fins do Regulamento Geral sobre a Proteção de Dados (UE) de 2016/679."
-  },
   "onboardingMetametricsDescription": {
     "message": "Gostaríamos de coletar dados básicos de uso para melhorar a MetaMask. Saiba que nunca vendemos os dados que você fornece aqui."
   },
   "onboardingMetametricsDescription2": {
     "message": "Quando coletamos as métricas, elas sempre são..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "A MetaMask..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "A MetaMask gostaria de reunir dados de uso para entender melhor como nossos usuários interagem com a MetaMask. Esses dados serão usados para prestar o serviço, o que inclui melhorá-lo com base em seu uso."
   },
   "onboardingMetametricsDisagree": {
     "message": "Não, obrigado"
@@ -3237,18 +3225,8 @@
     "message": "Informaremos a você se decidirmos usar esses dados para outras finalidades. Você pode analisar nossa $1 para obter mais informações. Lembre-se: você pode acessar as configurações e revogar a permissão a qualquer momento.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* Quando você usa a Infura como seu provedor RPC padrão na MetaMask, a Infura coleta seu endereço IP e da carteira de Ethereum quando você envia uma transação. Não armazenamos essas informações de forma que permita aos nossos sistemas cruzarem os dois fragmentos de dados. Para obter mais informações sobre como a MetaMask e a Infura interagem da perspectiva da coleta de dados, veja nossa atualização $1. Para obter mais informações sobre nossas práticas de privacidade em geral, veja nossa $2.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Política de Privacidade"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Política de Privacidade aqui"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "aqui"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Adicionar rede personalizada"
@@ -3267,30 +3245,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Gerais:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 coletará seu endereço IP completo*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 coletará informações de que não precisamos para prestar o serviço (tais como chaves, endereços, hashes de transações ou saldos)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Nunca"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 você decide se quer compartilhar ou excluir seus dados de uso nas configurações, a qualquer momento.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Opcionais:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 venderá dados. Jamais!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Enviará eventos de cliques e visualizações de páginas anonimizados"
   },
   "onboardingMetametricsTitle": {
     "message": "Ajude-nos a melhorar a MetaMask"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -3212,23 +3212,11 @@
   "onboardingMetametricsAgree": {
     "message": "Я согласен(-на)"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Всегда разрешать вам отказываться в Настройках"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Эти данные агрегированы и, следовательно, являются анонимными для целей Общего регламента по защите данных (ЕС) 2016/679."
-  },
   "onboardingMetametricsDescription": {
     "message": "Мы хотели бы собрать базовые данные об использовании и диагностике для улучшения MetaMask. Помните, что мы никогда не продаем данные, которые вы здесь предоставляете."
   },
   "onboardingMetametricsDescription2": {
     "message": "Когда мы собираем показатели, они всегда будут..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask хотел бы собрать данные об использовании, чтобы лучше понять, как наши пользователи взаимодействуют с MetaMask. Эти данные будут использоваться для предоставления обслуживания, в том числе его улучшения услуги на основе вашего использования."
   },
   "onboardingMetametricsDisagree": {
     "message": "Нет, спасибо"
@@ -3237,18 +3225,8 @@
     "message": "Мы сообщим вам, если решим использовать эти данные для других целей. Вы можете ознакомиться с нашей $1 для получения дополнительной информации. Помните, что вы можете перейти в настройки и отказаться в любой момент.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* Когда вы используете Infura в качестве поставщика RPC по умолчанию в MetaMask, Infura будет собирать ваш IP-адрес и адрес вашего кошелька Ethereum при отправке транзакции. Мы не храним эту информацию таким образом, чтобы наши системы могли связать эти две части данных. Для получения дополнительной информации о том, как MetaMask и Infura взаимодействуют с точки зрения сбора данных, см. нашу обновленную $1. Для получения дополнительной информации о нашей политике конфиденциальности в целом см. нашу $2.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Политикой конфиденциальности"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Политику конфиденциальности здесь"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "здесь"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Добавить пользовательскую сеть"
@@ -3267,30 +3245,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Общедоступными:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 не сохраняет ваш полный IP-адрес*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 не будет собирать информацию, которая нам не нужна для предоставления услуги (например, ключи, адреса, хэши транзакций или остатки)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Никогда"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 вы в любое время решаете, хотите ли вы поделиться своими данными об использовании или удалить их в настройках.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Необязательными:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 не продает данные.  Никогда!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Отправлять анонимизированные события кликов и просмотров страниц"
   },
   "onboardingMetametricsTitle": {
     "message": "Помогите нам улучшить MetaMask"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -3209,23 +3209,11 @@
   "onboardingMetametricsAgree": {
     "message": "Sumasang-ayon ako"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Palagi kang pinapayagan na mag-opt out sa pamamagitan ng Mga Setting"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Ang datos na ito ay pinagsama-sama at samakatuwid ay hindi nagpapakilala para sa mga layunin ng General Data Protection Regulation (EU) 2016/679."
-  },
   "onboardingMetametricsDescription": {
     "message": "Nais naming mangalap ng data para sa batayang paggamit upang mapahusay ang MetaMask. Dapat mong malaman na hindi namin ibebenta ang data na iyong ibibigay rito."
   },
   "onboardingMetametricsDescription2": {
     "message": "Kapag kami ay nangangalap ng metrics, ito ay palaging..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "Ang MetaMask ay..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "Nais ng MetaMask na mangalap ng datos ng paggamit upang mas maunawaan kung paano nakikipag-ugnayan ang aming mga user sa MetaMask. Gagamitin ang datos na ito upang ibigay ang serbisyo, na kinabibilangan ng pagpapabuti ng serbisyo batay sa iyong paggamit."
   },
   "onboardingMetametricsDisagree": {
     "message": "Salamat nalang"
@@ -3234,18 +3222,8 @@
     "message": "Ipapaalam namin sa iyo kung magdesisyon kaming gamitin ang data na ito para sa ibang layunin. Maaari mong suriin ang aming $1 para sa karagdagang impormasyon. Tandaan, maaari kang magpunta sa mga setting at mag-opt out anumang oras.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* Kapag ginamit mo ang Infura bilang iyong default na provider ng RPC sa MetaMask, kukunin ng Infura ang iyong IP address at ang iyong Ethereum wallet address kapag nagpadala ka ng transaksyon. Hindi namin iniimbak ang impormasyong ito sa paraan na nagpapahintulot sa aming mga system na iugnay ang dalawang piraso ng data na iyon. Para sa higit pang impormasyon kung paano nakikipag-ugnayan ang MetaMask at Infura mula sa pananaw ng pagkolekta ng data, tingnan ang aming update na $1. Para sa higit pang impormasyon sa aming mga kasanayan sa pagkapribado sa pangkalahatan, tingnan ang aming $2.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Patakaran sa Pagkapribado"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Patakaran sa Pagkapribado dito"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "dito"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Magdagdag ng custom na network"
@@ -3264,30 +3242,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Pangkalahatan:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "Kinokolekta ng $1 ang iyong buong IP address*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "Kinokolekta ng $1 ang impormasyon na hindi namin kailangan para ibigay ang serbisyo (tulad ng mga key, address, hash ng transaksyon, o balanse)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Hindi kailanman"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 ikaw ang magdedesisyon kung nais mong ibahagi o burahin ang iyong data sa paggamit sa pamamagitan ng mga setting anumang oras.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Opsyonal:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "Ang $1 ay nagbebenta ng datos.  Kailanman!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Magpapadala ng mga anonymous na kaganapang pag-click at pagtingin sa page"
   },
   "onboardingMetametricsTitle": {
     "message": "Tulungan kaming mapahusay ang MetaMask"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -3212,23 +3212,11 @@
   "onboardingMetametricsAgree": {
     "message": "Kabul ediyorum"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Her zaman Ayarlar kısmından vazgeçebilmenize izin verir"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Bu veriler toplanmıştır ve bu nedenle 2016/679 sayılı Genel Veri Koruma Tüzüğü (AB) maksadıyla isimsizdir."
-  },
   "onboardingMetametricsDescription": {
     "message": "MetaMask'i iyileştirmek için temel kullanım ve tanılama verilerini toplamak istiyoruz. Burada sunduğunuz verileri asla satmadığımızı bilmenizi isteriz."
   },
   "onboardingMetametricsDescription2": {
     "message": "Ölçümleri toplarken bu her zaman aşağıdaki gibi olacaktır..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask kullanıcılarımızn MetaMask ile nasıl etkileşimde bulunduklarını daha iyi anlamak amacıyla kullanım verilerini toplamak ister. Bu veriler, hizmeti kullanımınıza göre geliştirmek de dahil olmak üzere hizmeti sunmak için kullanılacaktır."
   },
   "onboardingMetametricsDisagree": {
     "message": "Hayır, istemiyorum"
@@ -3237,18 +3225,8 @@
     "message": "Bu verileri başka amaçlar için kullanmaya karar vermemiz durumunda sizi bilgilendireceğiz. Daha fazla bilgi için $1 bölümümüzü inceleyebilirsiniz. Unutmayın, dilediğiniz zaman ayarlar kısmına giderek vazgeçebilirsiniz.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* MetaMask'te varsayılan RPC sağlayıcınız olarak Infura'yı kullandığınızda, siz bir işlem gönderdiğinizde Infura tarafından IP adresiniz ve Ethereum cüzdan adresiniz toplanır. Bu bilgileri sistemlerimizin bu iki veri parçasını ilişkilendirebilmesini sağlayan şekilde saklamayız. MetaMask ve Infura'nın veri toplama açısından nasıl etkileşimde bulundukları hakkında daha fazla bilgi için lütfen güncel $1 bölümümüze bakın. Genel olarak gizlilik uygulamalarımız hakkında daha fazla bilgi için $2 bölümümüze bakın.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Gizlilik Politikası"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "buradan Gizlilik Politikası"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "burada"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Özel ağ ekle"
@@ -3267,30 +3245,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Genel:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 tam IP adresinizi toplar*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 ihtiyacımız olmayan bilgileri (anahtarlar, adresler, işlem hash değerleri veya bakiyeler gibi) hizmeti sunmak için toplar",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Hiçbir Zaman"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 kullanım verilerinizi paylaşmak veya silmek isteyip istemediğinize ayarlar kısmından dilediğiniz zaman siz karar verirsiniz.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "İsteğe bağlı:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 verileri satmaz. Asla!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "İsimsiz tıklama ve sayfa görüntüleme etkinlikleri gönder"
   },
   "onboardingMetametricsTitle": {
     "message": "MetaMask'i iyileştirmemize yardımcı olun"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -3209,23 +3209,11 @@
   "onboardingMetametricsAgree": {
     "message": "Tôi đồng ý"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "Luôn cho phép bạn chọn không tham gia thông qua phần Cài đặt"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "Do đó, dữ liệu này được tổng hợp và ẩn danh theo các mục đích của Quy định bảo vệ dữ liệu chung (EU) 2016/679."
-  },
   "onboardingMetametricsDescription": {
     "message": "Chúng tôi muốn thu thập dữ liệu sử dụng và chẩn đoán cơ bản để cải tiến MetaMask. Xin lưu ý, chúng tôi không bao giờ bán dữ liệu mà bạn cung cấp ở đây."
   },
   "onboardingMetametricsDescription2": {
     "message": "Khi thu thập số liệu, chúng tôi sẽ luôn cam kết điều này..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask sẽ..."
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask muốn thu thập dữ liệu sử dụng để hiểu rõ hơn cách người dùng tương tác với MetaMask. Dữ liệu này sẽ được sử dụng để cung cấp dịch vụ, bao gồm cả cải thiện dịch vụ dựa trên quá trình sử dụng của bạn."
   },
   "onboardingMetametricsDisagree": {
     "message": "Không, cảm ơn"
@@ -3234,18 +3222,8 @@
     "message": "Chúng tôi sẽ thông báo cho bạn nếu chúng tôi quyết định sử dụng dữ liệu này cho các mục đích khác. Bạn có thể xem lại $1 của chúng tôi để biết thêm thông tin. Lưu ý, bạn có thể truy cập cài đặt và chọn không tham gia bất kỳ lúc nào.",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* Khi bạn sử dụng Infura làm nhà cung cấp RPC mặc định trong MetaMask, Infura sẽ thu thập địa chỉ IP và địa chỉ ví Ethereum của bạn khi bạn gửi giao dịch. Chúng tôi không lưu trữ thông tin này để cho phép hệ thống của chúng tôi liên kết hai loại dữ liệu đó. Để biết thêm thông tin về cách MetaMask và Infura tương tác trong việc thu thập dữ liệu, hãy xem bản cập nhật $1 của chúng tôi. Để biết thêm thông tin về các phương pháp bảo vệ quyền riêng tư của chúng tôi nói chung, hãy xem $2.",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "Chính sách quyền riêng tư"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "Chính sách quyền riêng tư tại đây"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "tại đây"
   },
   "onboardingMetametricsModalTitle": {
     "message": "Thêm mạng tùy chỉnh"
@@ -3264,30 +3242,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "Chung:"
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1 thu thập địa chỉ IP đầy đủ của bạn*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 thu thập các thông tin mà chúng tôi không cần để cung cấp dịch vụ (chẳng hạn như khóa, địa chỉ, mã băm giao dịch hoặc số dư)",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "Không bao giờ"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 bạn có thể chọn chia sẻ hoặc xóa dữ liệu sử dụng của mình trong phần cài đặt bất kỳ lúc nào.",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "Không bắt buộc:"
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 không bao giờ bán dữ liệu!",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "Gửi các sự kiện nhấp chuột & lượt xem trang ẩn danh"
   },
   "onboardingMetametricsTitle": {
     "message": "Giúp chúng tôi cải thiện MetaMask"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -3209,23 +3209,11 @@
   "onboardingMetametricsAgree": {
     "message": "我同意"
   },
-  "onboardingMetametricsAllowOptOutLegacy": {
-    "message": "始终允许您通过设置选择退出"
-  },
-  "onboardingMetametricsDataTermsLegacy": {
-    "message": "此数据是汇总数据，因而可以保持匿名，以遵守《通用数据保护条例》（欧盟）2016/679。"
-  },
   "onboardingMetametricsDescription": {
     "message": "我们希望收集基本的使用和诊断数据，以改进 MetaMask。请注意，我们绝不会出卖您在此处提供的数据。"
   },
   "onboardingMetametricsDescription2": {
     "message": "当我们收集指标时，总是..."
-  },
-  "onboardingMetametricsDescription2Legacy": {
-    "message": "MetaMask 将会......"
-  },
-  "onboardingMetametricsDescriptionLegacy": {
-    "message": "MetaMask 希望收集使用数据，以更好地了解我们的用户如何与 MetaMask 交互。这些数据将用于提供服务，包括根据您的使用情况改进服务。"
   },
   "onboardingMetametricsDisagree": {
     "message": "不，谢谢"
@@ -3234,18 +3222,8 @@
     "message": "如果我们决定将这些数据用于其他目的，我们会通知您。您可以查看我们的 $1 以了解更多信息。请记住，您可以随时转到设置并选择退出。",
     "description": "$1 represents `onboardingMetametricsInfuraTermsPolicy`"
   },
-  "onboardingMetametricsInfuraTermsLegacy": {
-    "message": "* 如您在 MetaMask中 使用 Infura 作为默认的 RPC 提供商，Infura 将在您发送交易时收集您的 IP 地址和以太坊钱包地址。我们不会以允许系统将这两项数据关联起来的方式存储这些信息。如需从数据收集角度进一步了解 MetaMask 和 Infura 如何进行交互，请参阅我们的更新版 $1。如需进一步了解我们的一般隐私准则，请参阅我们的 $2。",
-    "description": "$1 represents `onboardingMetametricsInfuraTermsPolicyLink`, $2 represents `onboardingMetametricsInfuraTermsPolicy`"
-  },
   "onboardingMetametricsInfuraTermsPolicy": {
     "message": "隐私政策"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLegacy": {
-    "message": "隐私政策在此处"
-  },
-  "onboardingMetametricsInfuraTermsPolicyLinkLegacy": {
-    "message": "此处"
   },
   "onboardingMetametricsModalTitle": {
     "message": "添加自定义网络"
@@ -3264,30 +3242,12 @@
   "onboardingMetametricsNeverCollectIPEmphasis": {
     "message": "通用："
   },
-  "onboardingMetametricsNeverCollectIPLegacy": {
-    "message": "$1收集您的完整 IP 地址*",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverCollectLegacy": {
-    "message": "$1 收集我们不需要提供服务的信息（如私钥、地址、交易散列或余额）",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsNeverEmphasisLegacy": {
-    "message": "永远不会发生"
-  },
   "onboardingMetametricsNeverSellData": {
     "message": "$1 您可以随时决定是否通过设置共享或删除您的使用数据。",
     "description": "$1 represents `onboardingMetametricsNeverSellDataEmphasis`"
   },
   "onboardingMetametricsNeverSellDataEmphasis": {
     "message": "可选："
-  },
-  "onboardingMetametricsNeverSellDataLegacy": {
-    "message": "$1 出售数据。永远不会！",
-    "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
-  },
-  "onboardingMetametricsSendAnonymizeLegacy": {
-    "message": "发送匿名的点击和页面浏览事件"
   },
   "onboardingMetametricsTitle": {
     "message": "请帮助我们改进 MetaMask"

--- a/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.js.snap
+++ b/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.js.snap
@@ -146,7 +146,7 @@ exports[`Onboarding Metametrics Component should match snapshot after new policy
 <div>
   <div
     class="onboarding-metametrics"
-    data-testid="onboarding-legacy-metametrics"
+    data-testid="onboarding-metametrics"
   >
     <h2
       class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h2 typography--weight-bold typography--style-normal typography--align-center typography--color-text-default"
@@ -154,37 +154,23 @@ exports[`Onboarding Metametrics Component should match snapshot after new policy
       Help us improve MetaMask
     </h2>
     <p
-      class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography onboarding-metametrics__desc typography--p typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
+      class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography onboarding-metametrics__desc typography--p typography--weight-normal typography--style-normal typography--align-left typography--color-text-default"
     >
-      MetaMask would like to gather usage data to better understand how our users interact with MetaMask. This data will be used to provide the service, which includes improving the service based on your use.
+      We’d like to gather basic usage and diagnostics data to improve MetaMask. Know that we never sell the data you provide here.
     </p>
     <p
-      class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography onboarding-metametrics__desc typography--p typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
+      class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography onboarding-metametrics__desc typography--p typography--weight-normal typography--style-normal typography--align-left typography--color-text-default"
     >
-      MetaMask will...
+      When we gather metrics, it will always be...
     </p>
     <ul>
-      <li>
-        <span
-          class="mm-box mm-icon mm-icon--size-md mm-box--margin-inline-end-3 mm-box--display-inline-block mm-box--color-success-default"
-          style="mask-image: url('./images/icons/check.svg');"
-        />
-        Always allow you to opt-out via Settings
-      </li>
-      <li>
-        <span
-          class="mm-box mm-icon mm-icon--size-md mm-box--margin-inline-end-3 mm-box--display-inline-block mm-box--color-success-default"
-          style="mask-image: url('./images/icons/check.svg');"
-        />
-        Send anonymized click and pageview events
-      </li>
       <li>
         <div
           class="box box--flex-direction-row"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-2 mm-box--display-inline-block mm-box--color-error-default"
-            style="mask-image: url('./images/icons/close.svg');"
+            class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-2 mm-box--display-inline-block mm-box--color-success-default"
+            style="mask-image: url('./images/icons/check.svg');"
           />
           <span>
              
@@ -192,9 +178,9 @@ exports[`Onboarding Metametrics Component should match snapshot after new policy
             <span
               class="box box--margin-bottom-1 box--flex-direction-row typography typography--span typography--weight-bold typography--style-normal typography--color-text-default"
             >
-              Never
+              Private:
             </span>
-             collect information we don’t need to provide the service (such as keys, addresses, transaction hashes, or balances)
+             clicks and views on the app are stored, but other details (like your public address) are not.
              
           </span>
         </div>
@@ -204,8 +190,8 @@ exports[`Onboarding Metametrics Component should match snapshot after new policy
           class="box box--flex-direction-row"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-2 mm-box--display-inline-block mm-box--color-error-default"
-            style="mask-image: url('./images/icons/close.svg');"
+            class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-2 mm-box--display-inline-block mm-box--color-success-default"
+            style="mask-image: url('./images/icons/check.svg');"
           />
           <span>
              
@@ -213,9 +199,9 @@ exports[`Onboarding Metametrics Component should match snapshot after new policy
             <span
               class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--span typography--weight-bold typography--style-normal typography--color-text-default"
             >
-              Never
+              General:
             </span>
-             collect your full IP address*
+             we temporarily use your IP address to detect a general location (like your country or region), but it's never stored.
              
           </span>
         </div>
@@ -225,8 +211,8 @@ exports[`Onboarding Metametrics Component should match snapshot after new policy
           class="box box--flex-direction-row"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-2 mm-box--display-inline-block mm-box--color-error-default"
-            style="mask-image: url('./images/icons/close.svg');"
+            class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-2 mm-box--display-inline-block mm-box--color-success-default"
+            style="mask-image: url('./images/icons/check.svg');"
           />
           <span>
              
@@ -234,42 +220,47 @@ exports[`Onboarding Metametrics Component should match snapshot after new policy
             <span
               class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--span typography--weight-bold typography--style-normal typography--color-text-default"
             >
-              Never
+              Optional:
             </span>
-             sell data.  Ever!
+             you decide if you want to share or delete your usage data via settings any time.
              
           </span>
         </div>
          
       </li>
     </ul>
-    <h6
-      class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography onboarding-metametrics__terms typography--h6 typography--weight-normal typography--style-normal typography--align-center typography--color-text-alternative"
+    <label
+      class="mm-box mm-text mm-checkbox mm-text--body-md mm-box--padding-bottom-3 mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
+      for="metametrics-opt-in"
     >
-      This data is aggregated and is therefore anonymous for the purposes of General Data Protection Regulation (EU) 2016/679.
-    </h6>
+      <span
+        class="mm-checkbox__input-wrapper"
+      >
+        <input
+          class="mm-box mm-checkbox__input mm-box--margin-0 mm-box--margin-right-2 mm-box--display-flex mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-color-border-default mm-box--border-width-2 box--border-style-solid"
+          id="metametrics-opt-in"
+          title="We’ll use this data to learn how you interact with our marketing communications. We may share relevant news (like product features)."
+          type="checkbox"
+        />
+      </span>
+      <span>
+        We’ll use this data to learn how you interact with our marketing communications. We may share relevant news (like product features).
+      </span>
+    </label>
     <h6
-      class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography onboarding-metametrics__terms typography--h6 typography--weight-normal typography--style-normal typography--align-center typography--color-text-alternative"
+      class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography onboarding-metametrics__terms typography--h6 typography--weight-normal typography--style-normal typography--align-left typography--color-text-alternative"
     >
       <span>
          
-        * When you use Infura as your default RPC provider in MetaMask, Infura will collect your IP address and your Ethereum wallet address when you send a transaction. We don’t store this information in a way that allows our systems to associate those two pieces of data. For more information on how MetaMask and Infura interact from a data collection perspective, see our update 
-        <a
-          href="https://consensys.io/blog/consensys-data-retention-update"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          here
-        </a>
-        . For more information on our privacy practices in general, see our 
+        We’ll let you know if we decide to use this data for other purposes. You can review our 
         <a
           href="https://metamask.io/privacy.html"
           rel="noopener noreferrer"
           target="_blank"
         >
-          Privacy Policy here
+          Privacy Policy
         </a>
-        .
+         for more information. Remember, you can go to settings and opt out at any time.
          
       </span>
     </h6>

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -35,7 +35,6 @@ import {
   IconName,
   IconSize,
 } from '../../../components/component-library';
-import { PRIVACY_POLICY_DATE } from '../../../helpers/constants/privacy-policy';
 
 import Box from '../../../components/ui/box/box';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
@@ -44,9 +43,6 @@ export default function OnboardingMetametrics() {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const history = useHistory();
-
-  const newPrivacyPolicyDate = new Date(PRIVACY_POLICY_DATE);
-  const currentDate = new Date(Date.now());
 
   const nextRoute = useSelector(getFirstTimeFlowTypeRouteAfterMetaMetricsOptIn);
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
@@ -108,298 +104,135 @@ export default function OnboardingMetametrics() {
     history.push(nextRoute);
   };
 
-  const renderLegacyOnboarding = () => {
-    return (
-      <div
-        className="onboarding-metametrics"
-        data-testid="onboarding-legacy-metametrics"
+  return (
+    <div
+      className="onboarding-metametrics"
+      data-testid="onboarding-metametrics"
+    >
+      <Typography
+        variant={TypographyVariant.H2}
+        align={TEXT_ALIGN.CENTER}
+        fontWeight={FONT_WEIGHT.BOLD}
       >
-        <Typography
-          variant={TypographyVariant.H2}
-          align={TEXT_ALIGN.CENTER}
-          fontWeight={FONT_WEIGHT.BOLD}
-        >
-          {t('onboardingMetametricsTitle')}
-        </Typography>
-        <Typography
-          className="onboarding-metametrics__desc"
-          align={TEXT_ALIGN.CENTER}
-        >
-          {t('onboardingMetametricsDescriptionLegacy')}
-        </Typography>
-        <Typography
-          className="onboarding-metametrics__desc"
-          align={TEXT_ALIGN.CENTER}
-        >
-          {t('onboardingMetametricsDescription2Legacy')}
-        </Typography>
-        <ul>
-          <li>
-            <Icon
-              name={IconName.Check}
-              color={IconColor.successDefault}
-              marginInlineEnd={3}
-            />
-            {t('onboardingMetametricsAllowOptOutLegacy')}
-          </li>
-          <li>
-            <Icon
-              name={IconName.Check}
-              color={IconColor.successDefault}
-              marginInlineEnd={3}
-            />
-            {t('onboardingMetametricsSendAnonymizeLegacy')}
-          </li>
-          <li>
-            <Box>
-              <Icon
-                marginInlineEnd={2}
-                name={IconName.Close}
-                size={IconSize.Sm}
-                color={IconColor.errorDefault}
-              />
-              {t('onboardingMetametricsNeverCollectLegacy', [
-                <Typography
-                  variant={TypographyVariant.span}
-                  key="never"
-                  fontWeight={FONT_WEIGHT.BOLD}
-                  marginTop={0}
-                >
-                  {t('onboardingMetametricsNeverEmphasisLegacy')}
-                </Typography>,
-              ])}
-            </Box>
-          </li>
-          <li>
-            <Box>
-              <Icon
-                marginInlineEnd={2}
-                name={IconName.Close}
-                size={IconSize.Sm}
-                color={IconColor.errorDefault}
-              />
-              {t('onboardingMetametricsNeverCollectIPLegacy', [
-                <Typography
-                  variant={TypographyVariant.span}
-                  key="never-collect"
-                  fontWeight={FONT_WEIGHT.BOLD}
-                >
-                  {t('onboardingMetametricsNeverEmphasisLegacy')}
-                </Typography>,
-              ])}
-            </Box>
-          </li>
-          <li>
-            <Box>
-              <Icon
-                marginInlineEnd={2}
-                name={IconName.Close}
-                size={IconSize.Sm}
-                color={IconColor.errorDefault}
-              />
-              {t('onboardingMetametricsNeverSellDataLegacy', [
-                <Typography
-                  variant={TypographyVariant.span}
-                  key="never-sell"
-                  fontWeight={FONT_WEIGHT.BOLD}
-                >
-                  {t('onboardingMetametricsNeverEmphasisLegacy')}
-                </Typography>,
-              ])}
-            </Box>{' '}
-          </li>
-        </ul>
-        <Typography
-          color={TextColor.textAlternative}
-          align={TEXT_ALIGN.CENTER}
-          variant={TypographyVariant.H6}
-          className="onboarding-metametrics__terms"
-        >
-          {t('onboardingMetametricsDataTermsLegacy')}
-        </Typography>
-        <Typography
-          color={TextColor.textAlternative}
-          align={TEXT_ALIGN.CENTER}
-          variant={TypographyVariant.H6}
-          className="onboarding-metametrics__terms"
-        >
-          {t('onboardingMetametricsInfuraTermsLegacy', [
-            <a
-              href="https://consensys.io/blog/consensys-data-retention-update"
-              target="_blank"
-              rel="noopener noreferrer"
-              key="retention-link"
-            >
-              {t('onboardingMetametricsInfuraTermsPolicyLinkLegacy')}
-            </a>,
-            <a
-              href="https://metamask.io/privacy.html"
-              target="_blank"
-              rel="noopener noreferrer"
-              key="privacy-link"
-            >
-              {t('onboardingMetametricsInfuraTermsPolicyLegacy')}
-            </a>,
-          ])}
-        </Typography>
-
-        <div className="onboarding-metametrics__buttons">
-          <Button
-            data-testid="metametrics-i-agree"
-            type="primary"
-            large
-            onClick={onConfirm}
-          >
-            {t('onboardingMetametricsAgree')}
-          </Button>
-          <Button
-            data-testid="metametrics-no-thanks"
-            type="secondary"
-            large
-            onClick={onCancel}
-          >
-            {t('onboardingMetametricsDisagree')}
-          </Button>
-        </div>
-      </div>
-    );
-  };
-
-  const renderOnboarding = () => {
-    return (
-      <div
-        className="onboarding-metametrics"
-        data-testid="onboarding-metametrics"
+        {t('onboardingMetametricsTitle')}
+      </Typography>
+      <Typography
+        className="onboarding-metametrics__desc"
+        align={TEXT_ALIGN.LEFT}
       >
-        <Typography
-          variant={TypographyVariant.H2}
-          align={TEXT_ALIGN.CENTER}
-          fontWeight={FONT_WEIGHT.BOLD}
-        >
-          {t('onboardingMetametricsTitle')}
-        </Typography>
-        <Typography
-          className="onboarding-metametrics__desc"
-          align={TEXT_ALIGN.LEFT}
-        >
-          {t('onboardingMetametricsDescription')}
-        </Typography>
-        <Typography
-          className="onboarding-metametrics__desc"
-          align={TEXT_ALIGN.LEFT}
-        >
-          {t('onboardingMetametricsDescription2')}
-        </Typography>
-        <ul>
-          <li>
-            <Box>
-              <Icon
-                marginInlineEnd={2}
-                name={IconName.Check}
-                size={IconSize.Sm}
-                color={IconColor.successDefault}
-              />
-              {t('onboardingMetametricsNeverCollect', [
-                <Typography
-                  variant={TypographyVariant.span}
-                  key="never"
-                  fontWeight={FONT_WEIGHT.BOLD}
-                  marginTop={0}
-                >
-                  {t('onboardingMetametricsNeverCollectEmphasis')}
-                </Typography>,
-              ])}
-            </Box>
-          </li>
-          <li>
-            <Box>
-              <Icon
-                marginInlineEnd={2}
-                name={IconName.Check}
-                size={IconSize.Sm}
-                color={IconColor.successDefault}
-              />
-              {t('onboardingMetametricsNeverCollectIP', [
-                <Typography
-                  variant={TypographyVariant.span}
-                  key="never-collect"
-                  fontWeight={FONT_WEIGHT.BOLD}
-                >
-                  {t('onboardingMetametricsNeverCollectIPEmphasis')}
-                </Typography>,
-              ])}
-            </Box>
-          </li>
-          <li>
-            <Box>
-              <Icon
-                marginInlineEnd={2}
-                name={IconName.Check}
-                size={IconSize.Sm}
-                color={IconColor.successDefault}
-              />
-              {t('onboardingMetametricsNeverSellData', [
-                <Typography
-                  variant={TypographyVariant.span}
-                  key="never-sell"
-                  fontWeight={FONT_WEIGHT.BOLD}
-                >
-                  {t('onboardingMetametricsNeverSellDataEmphasis')}
-                </Typography>,
-              ])}
-            </Box>{' '}
-          </li>
-        </ul>
-        <Checkbox
-          id="metametrics-opt-in"
-          isChecked={dataCollectionForMarketing}
-          onClick={() =>
-            dispatch(setDataCollectionForMarketing(!dataCollectionForMarketing))
-          }
-          label={t('onboardingMetametricsUseDataCheckbox')}
-          paddingBottom={3}
-        />
-        <Typography
-          color={TextColor.textAlternative}
-          align={TEXT_ALIGN.LEFT}
-          variant={TypographyVariant.H6}
-          className="onboarding-metametrics__terms"
-        >
-          {t('onboardingMetametricsInfuraTerms', [
-            <a
-              href="https://metamask.io/privacy.html"
-              target="_blank"
-              rel="noopener noreferrer"
-              key="privacy-link"
-            >
-              {t('onboardingMetametricsInfuraTermsPolicy')}
-            </a>,
-          ])}
-        </Typography>
+        {t('onboardingMetametricsDescription')}
+      </Typography>
+      <Typography
+        className="onboarding-metametrics__desc"
+        align={TEXT_ALIGN.LEFT}
+      >
+        {t('onboardingMetametricsDescription2')}
+      </Typography>
+      <ul>
+        <li>
+          <Box>
+            <Icon
+              marginInlineEnd={2}
+              name={IconName.Check}
+              size={IconSize.Sm}
+              color={IconColor.successDefault}
+            />
+            {t('onboardingMetametricsNeverCollect', [
+              <Typography
+                variant={TypographyVariant.span}
+                key="never"
+                fontWeight={FONT_WEIGHT.BOLD}
+                marginTop={0}
+              >
+                {t('onboardingMetametricsNeverCollectEmphasis')}
+              </Typography>,
+            ])}
+          </Box>
+        </li>
+        <li>
+          <Box>
+            <Icon
+              marginInlineEnd={2}
+              name={IconName.Check}
+              size={IconSize.Sm}
+              color={IconColor.successDefault}
+            />
+            {t('onboardingMetametricsNeverCollectIP', [
+              <Typography
+                variant={TypographyVariant.span}
+                key="never-collect"
+                fontWeight={FONT_WEIGHT.BOLD}
+              >
+                {t('onboardingMetametricsNeverCollectIPEmphasis')}
+              </Typography>,
+            ])}
+          </Box>
+        </li>
+        <li>
+          <Box>
+            <Icon
+              marginInlineEnd={2}
+              name={IconName.Check}
+              size={IconSize.Sm}
+              color={IconColor.successDefault}
+            />
+            {t('onboardingMetametricsNeverSellData', [
+              <Typography
+                variant={TypographyVariant.span}
+                key="never-sell"
+                fontWeight={FONT_WEIGHT.BOLD}
+              >
+                {t('onboardingMetametricsNeverSellDataEmphasis')}
+              </Typography>,
+            ])}
+          </Box>{' '}
+        </li>
+      </ul>
+      <Checkbox
+        id="metametrics-opt-in"
+        isChecked={dataCollectionForMarketing}
+        onClick={() =>
+          dispatch(setDataCollectionForMarketing(!dataCollectionForMarketing))
+        }
+        label={t('onboardingMetametricsUseDataCheckbox')}
+        paddingBottom={3}
+      />
+      <Typography
+        color={TextColor.textAlternative}
+        align={TEXT_ALIGN.LEFT}
+        variant={TypographyVariant.H6}
+        className="onboarding-metametrics__terms"
+      >
+        {t('onboardingMetametricsInfuraTerms', [
+          <a
+            href="https://metamask.io/privacy.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            key="privacy-link"
+          >
+            {t('onboardingMetametricsInfuraTermsPolicy')}
+          </a>,
+        ])}
+      </Typography>
 
-        <div className="onboarding-metametrics__buttons">
-          <Button
-            data-testid="metametrics-i-agree"
-            type="primary"
-            large
-            onClick={onConfirm}
-          >
-            {t('onboardingMetametricsAgree')}
-          </Button>
-          <Button
-            data-testid="metametrics-no-thanks"
-            type="secondary"
-            large
-            onClick={onCancel}
-          >
-            {t('onboardingMetametricsDisagree')}
-          </Button>
-        </div>
+      <div className="onboarding-metametrics__buttons">
+        <Button
+          data-testid="metametrics-i-agree"
+          type="primary"
+          large
+          onClick={onConfirm}
+        >
+          {t('onboardingMetametricsAgree')}
+        </Button>
+        <Button
+          data-testid="metametrics-no-thanks"
+          type="secondary"
+          large
+          onClick={onCancel}
+        >
+          {t('onboardingMetametricsDisagree')}
+        </Button>
       </div>
-    );
-  };
-
-  return currentDate >= newPrivacyPolicyDate
-    ? renderOnboarding()
-    : renderLegacyOnboarding();
+    </div>
+  );
 }

--- a/ui/pages/onboarding-flow/metametrics/metametrics.test.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.test.js
@@ -140,13 +140,4 @@ describe('Onboarding Metametrics Component', () => {
     );
     expect(queryByTestId('onboarding-metametrics')).toBeInTheDocument();
   });
-
-  it('should render the Legacy Onboarding component when the current date is before the new privacy policy date', () => {
-    jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-    const { queryByTestId } = renderWithProvider(
-      <OnboardingMetametrics />,
-      mockStore,
-    );
-    expect(queryByTestId('onboarding-legacy-metametrics')).toBeInTheDocument();
-  });
 });


### PR DESCRIPTION


## **Description**

Removes the legacy onboarding text that was in place before the recent privacy notice update.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25404?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go through onboarding
2. See new metametrics text
3. Look at code, don't see old onboarding text

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
