### PR TITLE
fix: Disable Smart Transactions for the new Send&Swap feature

### DIFF
--- a/app/scripts/lib/transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/transaction/smart-transactions.test.ts
@@ -134,6 +134,13 @@ describe('submitSmartTransactionHook', () => {
     expect(result).toEqual({ transactionHash: undefined });
   });
 
+  it('falls back to regular transaction submit if the transaction type is "swapAndSend"', async () => {
+    const request: SubmitSmartTransactionRequestMocked = createRequest();
+    request.transactionMeta.type = TransactionType.swapAndSend;
+    const result = await submitSmartTransactionHook(request);
+    expect(result).toEqual({ transactionHash: undefined });
+  });
+
   it('falls back to regular transaction submit if /getFees throws an error', async () => {
     const request: SubmitSmartTransactionRequestMocked = createRequest();
     jest

--- a/app/scripts/lib/transaction/smart-transactions.ts
+++ b/app/scripts/lib/transaction/smart-transactions.ts
@@ -10,6 +10,7 @@ import {
   TransactionController,
   TransactionMeta,
   TransactionParams,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import log from 'loglevel';
 import {
@@ -120,9 +121,16 @@ class SmartTransactionHook {
   }
 
   async submit() {
+    const isUnsupportedTransactionTypeForSmartTransaction =
+      this.#transactionMeta.type &&
+      [TransactionType.swapAndSend].includes(this.#transactionMeta.type);
+
     // Will cause TransactionController to publish to the RPC provider as normal.
     const useRegularTransactionSubmit = { transactionHash: undefined };
-    if (!this.#isSmartTransaction) {
+    if (
+      !this.#isSmartTransaction ||
+      isUnsupportedTransactionTypeForSmartTransaction
+    ) {
       return useRegularTransactionSubmit;
     }
     const { id: approvalFlowId } = await this.#controllerMessenger.call(

--- a/app/scripts/lib/transaction/smart-transactions.ts
+++ b/app/scripts/lib/transaction/smart-transactions.ts
@@ -122,8 +122,7 @@ class SmartTransactionHook {
 
   async submit() {
     const isUnsupportedTransactionTypeForSmartTransaction =
-      this.#transactionMeta.type &&
-      [TransactionType.swapAndSend].includes(this.#transactionMeta.type);
+      this.#transactionMeta?.type === TransactionType.swapAndSend;
 
     // Will cause TransactionController to publish to the RPC provider as normal.
     const useRegularTransactionSubmit = { transactionHash: undefined };


### PR DESCRIPTION
## **Description**

Disables Smart Transactions for the new Send&Swap feature, since we don't support it there yet. Support will be added in one of the upcoming releases.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to the Send feature
2. Choose a different destination token, which will make the transaction type "swapAndSend"
3. Submit it. In the background Network tab you can see it's not submitted via Smart Transactions, but as a regular transaction instead

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
