### PR TITLE
fix: flaky test `vault-decrypt` by removing driver navigate to open a new window

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,11 @@ workflows:
           requires:
             - prep-build-test-mmi
       - test-e2e-chrome-vault-decryption:
+          filters:
+            branches:
+              only:
+                - develop
+                - /^Version-v(\d+)[.](\d+)[.](\d+)/
           requires:
             - prep-build
       - test-unit-mocha:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,11 +202,6 @@ workflows:
           requires:
             - prep-build-test-mmi
       - test-e2e-chrome-vault-decryption:
-          filters:
-            branches:
-              only:
-                - develop
-                - /^Version-v(\d+)[.](\d+)[.](\d+)/
           requires:
             - prep-build
       - test-unit-mocha:

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -95,6 +95,7 @@ async function defineAndRunBuildTasks() {
 
     let scuttleGlobalThisExceptions = [
       // globals used by different mm deps outside of lm compartment
+      'Proxy',
       'toString',
       'getComputedStyle',
       'addEventListener',

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -84,9 +84,8 @@ async function getSRP(driver) {
 describe('Vault Decryptor Page', function () {
   it('is able to decrypt the vault using the vault-decryptor webapp', async function () {
     await withFixtures({}, async ({ driver }) => {
-      await driver.navigate();
-      // the first app launch opens a new tab, we need to switch the focus
-      // to the first one.
+      // we don't need to use navigate since MM will automatically open in prod build
+      await driver.waitUntilXWindowHandles(2);
       await driver.switchToWindowWithTitle('MetaMask');
       // create a new vault through onboarding flow
       await completeCreateNewWalletOnboardingFlowWithOptOut(

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -84,7 +84,8 @@ async function getSRP(driver) {
 describe('Vault Decryptor Page', function () {
   it('is able to decrypt the vault using the vault-decryptor webapp', async function () {
     await withFixtures({}, async ({ driver }) => {
-      // we don't need to use navigate since MM will automatically open in prod build
+      // we don't need to use navigate
+      // since MM will automatically open a new window in prod build
       await driver.waitUntilXWindowHandles(2);
       await driver.switchToWindowWithTitle('MetaMask');
       // create a new vault through onboarding flow


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The vault decryption test opens 2 MetaMask windows whenever we start the test, causing flakiness in which window is currently selected and where the actions are performed.

Having 2 MM windows, together with the fact that the Chrome active window can sometimes not be the same as the Webdriver active window (see @HowardBraham 's [work on that area](https://github.com/MetaMask/metamask-extension/pull/25362)), causes unpredictable effects - see video below.

For fixing it, we now remove the step of `driver.navigate` which will open a MM window, and caused to have 2 windows instead of 1.

However, this lead to a new problem. Lavamoat presents a race condition, which now is more present making the test fail in almost all runs. From @naugtur :

> It is indeed a race condition, because scuttling can only destroy the global references after they've been successfully copied and used for establishing the root compartment of the application.

For fixing this, we add `Proxy` in the exceptions, following Lavamoat's team suggestion as a temporary solution.



https://github.com/MetaMask/metamask-extension/assets/54408225/4385b491-eb23-4c7d-94b6-37e30c4ef70f





[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25443?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

See successful run [here](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/88573/workflows/154e6b73-7174-499d-b5f9-cb5ebf490d01/jobs/3261609) 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
