### PR TITLE
fix: fix usd amount in swap notifications

### DIFF
--- a/ui/helpers/utils/notification.util.ts
+++ b/ui/helpers/utils/notification.util.ts
@@ -260,8 +260,11 @@ export const getUsdAmount = (amount: string, decimals: string, usd: string) => {
     return '';
   }
 
-  const amountInEther = getAmount(amount, decimals);
-  const numericAmount = parseFloat(amountInEther) * parseFloat(usd);
+  const amountInEther = calcTokenAmount(
+    amount,
+    parseFloat(decimals),
+  ).toNumber();
+  const numericAmount = parseFloat(`${amountInEther}`) * parseFloat(usd);
 
   return formatAmount(numericAmount);
 };

--- a/ui/helpers/utils/notification.utils.test.ts
+++ b/ui/helpers/utils/notification.utils.test.ts
@@ -3,6 +3,7 @@ import {
   formatMenuItemDate,
   getLeadingZeroCount,
   getRandomKey,
+  getUsdAmount,
 } from './notification.util';
 
 describe('formatMenuItemDate', () => {
@@ -180,5 +181,40 @@ describe('getRandomKey', () => {
     const index = 1;
     const result = getRandomKey(text, index);
     expect(result).toContain('testtext');
+  });
+});
+
+describe('getUsdAmount', () => {
+  it('should return formatted USD amount based on token amount, decimals, and USD rate', () => {
+    const amount = '1000000000000000000'; // 1 Ether (1e18 wei)
+    const decimals = '18';
+    const usdRate = '2000'; // 1 Ether = $2000
+
+    const result = getUsdAmount(amount, decimals, usdRate);
+    expect(result).toBe('2K'); // Since 1 Ether * $2000 = $2000, formatted as '2K'
+  });
+
+  it('should return an empty string if any of the parameters are missing', () => {
+    expect(getUsdAmount('', '18', '2000')).toBe('');
+    expect(getUsdAmount('1000000000000000000', '', '2000')).toBe('');
+    expect(getUsdAmount('1000000000000000000', '18', '')).toBe('');
+  });
+
+  it('should handle small amounts correctly', () => {
+    const amount = '1000000000000000'; // 0.001 Ether (1e15 wei)
+    const decimals = '18';
+    const usdRate = '1500'; // 1 Ether = $1500
+
+    const result = getUsdAmount(amount, decimals, usdRate);
+    expect(result).toBe('1.5'); // Since 0.001 Ether * $1500 = $1.5
+  });
+
+  it('should handle large amounts correctly', () => {
+    const amount = '5000000000000000000000'; // 5000 Ether
+    const decimals = '18';
+    const usdRate = '1000'; // 1 Ether = $1000
+
+    const result = getUsdAmount(amount, decimals, usdRate);
+    expect(result).toBe('5M'); // Since 5000 Ether * $1000 = $5,000,000, formatted as '5M'
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the fiat (USD) conversion for the values displayed in the Swap notifications.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25444?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/1284304/8a7c817a-6f5f-4ee9-9e33-b02c44cd01f8)

<!-- [screenshots/recordings] -->

### **After**

![Screenshot 2024-06-20 at 18 00 31](https://github.com/MetaMask/metamask-extension/assets/1284304/17a5c7bf-a797-4e1f-a618-9408723f6fed)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
