### PR TITLE
fix(ci): Restrict test-e2e-firefox-flask & test-e2e-firefox-confirmation-redesign jobs to develop, master, and release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,14 @@ rc_branch_only: &rc_branch_only
       only:
         - /^Version-v(\d+)[.](\d+)[.](\d+)/
 
+develop_master_rc_only: &develop_master_rc_only
+  filters:
+    branches:
+      only:
+        - develop
+        - master
+        - /^Version-v(\d+)[.](\d+)[.](\d+)/
+
 aliases:
   # Shallow Git Clone
   - &shallow-git-clone
@@ -184,6 +192,7 @@ workflows:
           requires:
             - prep-build-test-mv2
       - test-e2e-firefox-confirmation-redesign:
+          <<: *develop_master_rc_only
           requires:
             - prep-build-confirmation-redesign-test-mv2
       - test-e2e-chrome-rpc:
@@ -196,6 +205,7 @@ workflows:
           requires:
             - prep-build-test-flask
       - test-e2e-firefox-flask:
+          <<: *develop_master_rc_only
           requires:
             - prep-build-test-flask-mv2
       - test-e2e-chrome-mmi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,12 +151,14 @@ workflows:
           requires:
             - prep-deps
       - prep-build-confirmation-redesign-test-mv2:
+          <<: *develop_master_rc_only
           requires:
             - prep-deps
       - prep-build-test-flask:
           requires:
             - prep-deps
       - prep-build-test-flask-mv2:
+          <<: *develop_master_rc_only
           requires:
             - prep-deps
       - prep-build-test-mmi:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR aims to update our CI pipeline to ensure that `test-e2e-firefox-flask` and `test-e2e-firefox-confirmation-redesign` jobs only run on develop, Release branches, and master.

We don't want these jobs to run on every PR anymore.

Also: Giving the `prep-build-test-flask-mv2` and `prep-build-confirmation-redesign-test-mv2` (prerequisite steps) the same restriction. Thanks @DDDDDanica 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25469?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25233

## **Manual testing steps**

1. Neither `test-e2e-firefox-flask` nor `test-e2e-firefox-confirmation-redesign` jobs should run on this pipeline
2. They should run when merging to develop, RC branch, and prod

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
