### PR TITLE
chore: Fix boolean setting for `ENABLE_CONFIRMATION_REDESIGN` on `config.yml`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -859,7 +859,7 @@ jobs:
           at: .
       - run:
           name: Build extension for testing
-          command: ENABLE_CONFIRMATION_REDESIGN=true yarn build:test
+          command: ENABLE_CONFIRMATION_REDESIGN="true" yarn build:test
       - run:
           name: Move test build to 'dist-test' to avoid conflict with production build
           command: mv ./dist ./dist-test-confirmations
@@ -881,7 +881,7 @@ jobs:
           at: .
       - run:
           name: Build extension for testing
-          command: ENABLE_CONFIRMATION_REDESIGN=true yarn build:test:mv2
+          command: ENABLE_CONFIRMATION_REDESIGN="true" yarn build:test:mv2
       - run:
           name: Move test build to 'dist-test-confirmations-mv2' to avoid conflict with production build
           command: mv ./dist ./dist-test-confirmations-mv2
@@ -1086,7 +1086,7 @@ jobs:
             fi
           no_output_timeout: 5m
           environment:
-            ENABLE_CONFIRMATION_REDESIGN: true
+            ENABLE_CONFIRMATION_REDESIGN: "true"
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -1377,7 +1377,7 @@ jobs:
             fi
           no_output_timeout: 5m
           environment:
-            ENABLE_CONFIRMATION_REDESIGN: true
+            ENABLE_CONFIRMATION_REDESIGN: "true"
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On [this PR](https://github.com/MetaMask/metamask-extension/pull/25258/files) we moved away from representing a boolean with `1` or `0`.

However, simply using `true` throws linting errors (see image and thread linked below).

This PR explicitly sets the variable as a string to eliminate said errors.

![image](https://github.com/MetaMask/metamask-extension/assets/13814744/d2e83e05-a55e-4e91-8271-b82fd455ace9)
([source thread](https://consensys.slack.com/archives/CTQAGKY5V/p1718307835430529))


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25485?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
