### PR TITLE
fix: 25457 firefox extension not work for trezor connect

### DIFF
--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -2,14 +2,14 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import {
+  Text,
   Box,
+  IconName,
+  ButtonIconSize,
+  ButtonIcon,
   Button,
   BUTTON_SIZES,
   BUTTON_VARIANT,
-  ButtonIcon,
-  ButtonIconSize,
-  IconName,
-  Text,
 } from '../../../components/component-library';
 import LogoLedger from '../../../components/ui/logo/logo-ledger';
 import LogoQRBased from '../../../components/ui/logo/logo-qr-based';
@@ -17,10 +17,10 @@ import LogoTrezor from '../../../components/ui/logo/logo-trezor';
 import LogoLattice from '../../../components/ui/logo/logo-lattice';
 
 import {
-  HardwareAffiliateLinks,
-  HardwareAffiliateTutorialLinks,
   HardwareDeviceNames,
   LedgerTransportTypes,
+  HardwareAffiliateLinks,
+  HardwareAffiliateTutorialLinks,
 } from '../../../../shared/constants/hardware-wallets';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';

--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -2,14 +2,14 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import {
-  Text,
   Box,
-  IconName,
-  ButtonIconSize,
-  ButtonIcon,
   Button,
   BUTTON_SIZES,
   BUTTON_VARIANT,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  Text,
 } from '../../../components/component-library';
 import LogoLedger from '../../../components/ui/logo/logo-ledger';
 import LogoQRBased from '../../../components/ui/logo/logo-qr-based';
@@ -17,10 +17,10 @@ import LogoTrezor from '../../../components/ui/logo/logo-trezor';
 import LogoLattice from '../../../components/ui/logo/logo-lattice';
 
 import {
-  HardwareDeviceNames,
-  LedgerTransportTypes,
   HardwareAffiliateLinks,
   HardwareAffiliateTutorialLinks,
+  HardwareDeviceNames,
+  LedgerTransportTypes,
 } from '../../../../shared/constants/hardware-wallets';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';
@@ -56,7 +56,7 @@ export default class SelectHardware extends Component {
 
   connect = async () => {
     if (this.state.selectedDevice) {
-      if (this.state.selectedDevice === 'trezor') {
+      if (this.state.selectedDevice === 'trezor' && window.navigator.usb) {
         this.setState({ trezorRequestDevicePending: true });
         try {
           await window.navigator.usb.requestDevice({

--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -56,6 +56,15 @@ export default class SelectHardware extends Component {
 
   connect = async () => {
     if (this.state.selectedDevice) {
+      // Not all browsers have usb support. In particular, Firefox does
+      // not support usb. More information on that can be found here:
+      // https://mozilla.github.io/standards-positions/#webusb
+      //
+      // The below `&& window.navigator.usb` condition ensures that we
+      // only attempt to connect Trezor via usb if we are in a browser
+      // that supports usb. If not, the connection of the hardware wallet
+      // to the browser will be handled by the Trezor connect screen. In
+      // the case of Firefox, this will depend on the Trezor bridge software
       if (this.state.selectedDevice === 'trezor' && window.navigator.usb) {
         this.setState({ trezorRequestDevicePending: true });
         try {


### PR DESCRIPTION
#25457 Because firefox doesn't support usb api, which cause the `window.navigator.usb` is undefined in firefox, which break the trezor connection.

This PR will check whether window.navigator.usb is undefined or not. if yes, then select-hardware will fall back to use trezor bridge to connect.

## **Description**

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25487?quickstart=1)

## **Related issues**

Fixes: #25457 

## **Manual testing steps**

1. Open `metamask` in firefox
2. select `account drop down` in home page and then select `Add Account and hardware wallet`
3. select `trezor` in hardware select screen.
4. approve at trezor screen
5. you should be able to select `accounts` from trezor.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/MetaMask/metamask-extension/assets/7315988/980c6c78-2765-4f97-8781-8250eeec1f9b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
