### PR TITLE
feat: update network list item to include start accessory and end

### DIFF
--- a/ui/components/multichain/network-list-item/network-list-item.js
+++ b/ui/components/multichain/network-list-item/network-list-item.js
@@ -38,6 +38,8 @@ export const NetworkListItem = ({
   onClick,
   onDeleteClick,
   onEditClick,
+  startAccessory,
+  showEndAccessory = true,
 }) => {
   const t = useI18nContext();
   const networkRef = useRef();
@@ -110,6 +112,11 @@ export const NetworkListItem = ({
       width={BlockSize.Full}
       onClick={onClick}
     >
+      {startAccessory ? (
+        <Box marginInlineEnd={2} marginTop={1}>
+          {startAccessory}
+        </Box>
+      ) : null}
       {selected && (
         <Box
           className="multichain-network-list-item__selected-indicator"
@@ -150,13 +157,15 @@ export const NetworkListItem = ({
         </Text>
       </Box>
       {renderButton()}
-      <NetworkListItemMenu
-        anchorElement={networkListItemMenuElement}
-        isOpen={networkOptionsMenuOpen}
-        onDeleteClick={onDeleteClick}
-        onEditClick={onEditClick}
-        onClose={() => setNetworkOptionsMenuOpen(false)}
-      />
+      {showEndAccessory ? (
+        <NetworkListItemMenu
+          anchorElement={networkListItemMenuElement}
+          isOpen={networkOptionsMenuOpen}
+          onDeleteClick={onDeleteClick}
+          onEditClick={onEditClick}
+          onClose={() => setNetworkOptionsMenuOpen(false)}
+        />
+      ) : null}
     </Box>
   );
 };
@@ -190,4 +199,12 @@ NetworkListItem.propTypes = {
    * Represents if the network item should be keyboard selected
    */
   focus: PropTypes.bool,
+  /**
+   * Represents start accessory
+   */
+  startAccessory: PropTypes.node,
+    /**
+   * Represents start accessory
+   */
+  showEndAccessory: PropTypes.bool,
 };

--- a/ui/components/multichain/network-list-item/network-list-item.js
+++ b/ui/components/multichain/network-list-item/network-list-item.js
@@ -203,8 +203,8 @@ NetworkListItem.propTypes = {
    * Represents start accessory
    */
   startAccessory: PropTypes.node,
-    /**
-   * Represents start accessory
+  /**
+   * Represents if we need to show menu option
    */
   showEndAccessory: PropTypes.bool,
 };

--- a/ui/components/multichain/network-list-item/network-list-item.stories.js
+++ b/ui/components/multichain/network-list-item/network-list-item.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import { Checkbox } from '../../component-library';
 import { NetworkListItem } from '.';
-import { Checkbox } from '../../component-library/index';
 
 export default {
   title: 'Components/Multichain/NetworkListItem',

--- a/ui/components/multichain/network-list-item/network-list-item.stories.js
+++ b/ui/components/multichain/network-list-item/network-list-item.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NetworkListItem } from '.';
+import { Checkbox } from '../../component-library/index';
 
 export default {
   title: 'Components/Multichain/NetworkListItem',
@@ -53,6 +54,15 @@ export const SelectedStory = (args) => (
   </div>
 );
 SelectedStory.args = { selected: true };
+
+export const WithAccessoryStory = (args) => (
+  <div
+    style={{ width: '328px', border: '1px solid var(--color-border-muted)' }}
+  >
+    <NetworkListItem {...args} />
+  </div>
+);
+WithAccessoryStory.args = { startAccessory: <Checkbox /> };
 
 export const ChaosStory = (args) => (
   <div


### PR DESCRIPTION
This PR is to update network list item to include start accessory and end accessory 
## **Related issues**

Fixes: [2728](https://github.com/MetaMask/MetaMask-planning/issues/2728)

## **Manual testing steps**

1. No UI changes, networks list shouldn't change

## **Screenshots/Recordings**

NA


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
