### PR TITLE
fix: adding max with to send page in expanded view

### DIFF
--- a/ui/components/multichain/pages/send/index.scss
+++ b/ui/components/multichain/pages/send/index.scss
@@ -2,6 +2,7 @@
 
 .multichain-send-page {
   width: 100%;
+  max-width: 480px;
 
   &__account-picker {
     height: 62px;


### PR DESCRIPTION
## **Description**

This pull request introduces a maximum width of `480px` to the send screen in expanded view. This change is intended to enhance the user interface by preventing it from taking up 100% of the screen width on larger screens, thereby improving the visual presentation and user experience.

[Related slack thread](https://consensys.slack.com/archives/C4V2HTG0Y/p1719265847171869)

https://warpcast.com/antimofm.eth/0x487c8c0e

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25511?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open the extension in expanded view
2. Select "Send" button from home page
3. See send screen is no longer 100% width of large screens

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/MetaMask/metamask-extension/assets/8112138/e7d04e51-d952-443f-b8ee-c02b8043df51



### **After**


https://github.com/MetaMask/metamask-extension/assets/8112138/8da41a3c-7d63-4e83-9059-4ba5c8020c33



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
