### PR TITLE
V12 cherrypick: bump @metamask/queued-request controller to ^2.0.0 to fix confirmation popup focus in request queue

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -452,6 +452,7 @@ export default class MetamaskController extends EventEmitter {
       shouldRequestSwitchNetwork: ({ method }) =>
         methodsRequiringNetworkSwitch.includes(method),
       clearPendingConfirmations,
+      showApprovalRequest: opts.showUserConfirmation,
     });
 
     this.approvalController = new ApprovalController({

--- a/package.json
+++ b/package.json
@@ -329,7 +329,7 @@
     "@metamask/post-message-stream": "^8.0.0",
     "@metamask/ppom-validator": "^0.30.0",
     "@metamask/providers": "^14.0.2",
-    "@metamask/queued-request-controller": "^1.0.0",
+    "@metamask/queued-request-controller": "^2.0.0",
     "@metamask/rate-limit-controller": "^5.0.1",
     "@metamask/safe-event-emitter": "^3.1.1",
     "@metamask/scure-bip39": "^2.0.3",

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.js
@@ -67,7 +67,7 @@ describe('Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Accounts Tx', functio
         assert.deepStrictEqual(accountsBeforeConnect, '');
 
         // Reject the pending confirmation from the first dapp
-        await switchToNotificationWindow(driver);
+        await switchToNotificationWindow(driver, 4);
         await driver.clickElement({ text: 'Reject', tag: 'button' });
 
         // Wait for switch confirmation to close then request accounts confirmation to show for the second dapp

--- a/yarn.lock
+++ b/yarn.lock
@@ -6086,9 +6086,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/queued-request-controller@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/queued-request-controller@npm:1.0.0"
+"@metamask/queued-request-controller@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/queued-request-controller@npm:2.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^6.0.0"
     "@metamask/controller-utils": "npm:^11.0.0"
@@ -6099,7 +6099,7 @@ __metadata:
   peerDependencies:
     "@metamask/network-controller": ^19.0.0
     "@metamask/selected-network-controller": ^15.0.0
-  checksum: 10/84b5442035ef4843ad5c3effdb961c9725c07fa3caf37928c4315ffb4929160a1032b8e0f814061fa8487f499d147766f3cfdd4172c8a3941c2996b11628a46b
+  checksum: 10/b618fa05465a52e5b689d932d99b47552b5987a9141d58260966611f1057190132f14b1a2123c48399f218fc57c577e1c86375e8ee2b43871cdc597fbaeedb7a
   languageName: node
   linkType: hard
 
@@ -25092,7 +25092,7 @@ __metadata:
     "@metamask/post-message-stream": "npm:^8.0.0"
     "@metamask/ppom-validator": "npm:^0.30.0"
     "@metamask/providers": "npm:^14.0.2"
-    "@metamask/queued-request-controller": "npm:^1.0.0"
+    "@metamask/queued-request-controller": "npm:^2.0.0"
     "@metamask/rate-limit-controller": "npm:^5.0.1"
     "@metamask/safe-event-emitter": "npm:^3.1.1"
     "@metamask/scure-bip39": "npm:^2.0.3"


### PR DESCRIPTION
Cherrypicks https://github.com/MetaMask/metamask-extension/pull/25497

Fixes confirmation notification not receiving focus when a request is enqueued

No merge conflicts