### PR TITLE
fix: flaky test `ENS domain resolves to a correct address` (#25248)

### DIFF
--- a/test/e2e/tests/transaction/ens.spec.js
+++ b/test/e2e/tests/transaction/ens.spec.js
@@ -8,6 +8,11 @@ const FixtureBuilder = require('../../fixture-builder');
 
 describe('ENS', function () {
   const sampleAddress = '1111111111111111111111111111111111111111';
+
+  // Having 2 versions of the address is a bug(#25286)
+  const shortSampleAddress = '0x1111...1111';
+  const shortSampleAddresV2 = '0x11111...11111';
+
   const sampleEnsDomain = 'test.eth';
   const infuraUrl =
     'https://mainnet.infura.io/v3/00000000000000000000000000000000';
@@ -95,7 +100,15 @@ describe('ENS', function () {
           css: '[data-testid="address-list-item-label"]',
         });
 
-        await driver.clickElement('.address-list-item');
+        await driver.waitForSelector({
+          text: shortSampleAddress,
+          css: '.multichain-send-page__recipient__item__subtitle',
+        });
+
+        await driver.clickElement({
+          text: sampleEnsDomain,
+          css: '[data-testid="multichain-send-page__recipient__item__title"]',
+        });
 
         await driver.findElement({
           css: '.ens-input__selected-input__title',
@@ -103,7 +116,7 @@ describe('ENS', function () {
         });
 
         await driver.findElement({
-          text: '0x11111...11111',
+          text: shortSampleAddresV2,
         });
       },
     );


### PR DESCRIPTION
Cherry-pick PR fixes the flaky test `ENS domain resolves to a correct address` #25248 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25535?quickstart=1)
