### PR TITLE
chore: wire up bridge input actions 

### DIFF
--- a/app/scripts/controllers/bridge.test.ts
+++ b/app/scripts/controllers/bridge.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { BRIDGE_API_BASE_URL } from '../../../shared/constants/bridge';
-import BridgeController from './bridge';
+import BridgeController, { BridgeUserAction } from './bridge';
 
 const EMPTY_INIT_STATE = {
   bridgeState: {
@@ -10,6 +10,7 @@ const EMPTY_INIT_STATE = {
       srcNetworkAllowlist: [],
       destNetworkAllowlist: [],
     },
+    destTokens: {},
   },
 };
 
@@ -29,6 +30,20 @@ describe('BridgeController', function () {
         'src-network-allowlist': [10, 534352],
         'dest-network-allowlist': [137, 42161],
       });
+    nock(BRIDGE_API_BASE_URL)
+      .get('/getTokens?chainId=10')
+      .reply(200, [
+        {
+          address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+          symbol: 'ABC',
+          decimals: 16,
+        },
+        {
+          address: '0x1291478912',
+          symbol: 'DEF',
+          decimals: 16,
+        },
+      ]);
   });
 
   it('constructor should setup correctly', function () {
@@ -47,5 +62,25 @@ describe('BridgeController', function () {
     expect(
       bridgeController.store.getState().bridgeState.bridgeFeatureFlags,
     ).toStrictEqual(featureFlagsResponse);
+  });
+
+  it('selectDestNetwork should set the bridge dest tokens', async function () {
+    await bridgeController[BridgeUserAction.SELECT_DEST_NETWORK]('0xa');
+    expect(
+      bridgeController.store.getState().bridgeState.destTokens,
+    ).toStrictEqual({
+      '0x0000000000000000000000000000000000000000': {
+        address: '0x0000000000000000000000000000000000000000',
+        decimals: 18,
+        iconUrl: './images/eth_logo.svg',
+        name: 'Ether',
+        symbol: 'ETH',
+      },
+      '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984': {
+        address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        symbol: 'ABC',
+        decimals: 16,
+      },
+    });
   });
 });

--- a/app/scripts/controllers/bridge.test.ts
+++ b/app/scripts/controllers/bridge.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { BRIDGE_API_BASE_URL } from '../../../shared/constants/bridge';
+import { SWAPS_API_V2_BASE_URL } from '../../../shared/constants/swaps';
 import BridgeController, { BridgeUserAction } from './bridge';
 
 const EMPTY_INIT_STATE = {
@@ -11,6 +12,7 @@ const EMPTY_INIT_STATE = {
       destNetworkAllowlist: [],
     },
     destTokens: {},
+    destTopAssets: [],
   },
 };
 
@@ -44,6 +46,14 @@ describe('BridgeController', function () {
           decimals: 16,
         },
       ]);
+    nock(SWAPS_API_V2_BASE_URL)
+      .get('/networks/10/topAssets')
+      .reply(200, [
+        {
+          address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+          symbol: 'ABC',
+        },
+      ]);
   });
 
   it('constructor should setup correctly', function () {
@@ -64,7 +74,7 @@ describe('BridgeController', function () {
     ).toStrictEqual(featureFlagsResponse);
   });
 
-  it('selectDestNetwork should set the bridge dest tokens', async function () {
+  it('selectDestNetwork should set the bridge dest tokens and top assets', async function () {
     await bridgeController[BridgeUserAction.SELECT_DEST_NETWORK]('0xa');
     expect(
       bridgeController.store.getState().bridgeState.destTokens,
@@ -82,5 +92,10 @@ describe('BridgeController', function () {
         decimals: 16,
       },
     });
+    expect(
+      bridgeController.store.getState().bridgeState.destTopAssets,
+    ).toStrictEqual([
+      { address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', symbol: 'ABC' },
+    ]);
   });
 });

--- a/app/scripts/controllers/bridge.test.ts
+++ b/app/scripts/controllers/bridge.test.ts
@@ -11,6 +11,8 @@ const EMPTY_INIT_STATE = {
       srcNetworkAllowlist: [],
       destNetworkAllowlist: [],
     },
+    srcTokens: {},
+    srcTopAssets: [],
     destTokens: {},
     destTopAssets: [],
   },
@@ -96,6 +98,34 @@ describe('BridgeController', function () {
       bridgeController.store.getState().bridgeState.destTopAssets,
     ).toStrictEqual([
       { address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', symbol: 'ABC' },
+    ]);
+  });
+
+  it('selectSrcNetwork should set the bridge src tokens and top assets', async function () {
+    await bridgeController[BridgeUserAction.SELECT_SRC_NETWORK]('0xa');
+    expect(
+      bridgeController.store.getState().bridgeState.srcTokens,
+    ).toStrictEqual({
+      '0x0000000000000000000000000000000000000000': {
+        address: '0x0000000000000000000000000000000000000000',
+        decimals: 18,
+        iconUrl: './images/eth_logo.svg',
+        name: 'Ether',
+        symbol: 'ETH',
+      },
+      '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984': {
+        address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        symbol: 'ABC',
+        decimals: 16,
+      },
+    });
+    expect(
+      bridgeController.store.getState().bridgeState.srcTopAssets,
+    ).toStrictEqual([
+      {
+        address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        symbol: 'ABC',
+      },
     ]);
   });
 });

--- a/app/scripts/controllers/bridge.test.ts
+++ b/app/scripts/controllers/bridge.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import { CHAIN_IDS } from '../../../shared/constants/network';
 import { BRIDGE_API_BASE_URL } from '../../../shared/constants/bridge';
 import BridgeController from './bridge';
 
@@ -6,6 +7,8 @@ const EMPTY_INIT_STATE = {
   bridgeState: {
     bridgeFeatureFlags: {
       extensionSupport: false,
+      srcNetworkAllowlist: [],
+      destNetworkAllowlist: [],
     },
   },
 };
@@ -17,21 +20,32 @@ describe('BridgeController', function () {
     bridgeController = new BridgeController();
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nock(BRIDGE_API_BASE_URL)
+      .get('/getAllFeatureFlags')
+      .reply(200, {
+        'extension-support': true,
+        'src-network-allowlist': [10, 534352],
+        'dest-network-allowlist': [137, 42161],
+      });
+  });
+
   it('constructor should setup correctly', function () {
     expect(bridgeController.store.getState()).toStrictEqual(EMPTY_INIT_STATE);
   });
 
   it('setBridgeFeatureFlags should fetch and set the bridge feature flags', async function () {
-    nock(BRIDGE_API_BASE_URL).get('/getAllFeatureFlags').reply(200, {
-      'extension-support': true,
-    });
-    expect(
-      bridgeController.store.getState().bridgeState.bridgeFeatureFlags,
-    ).toStrictEqual({ extensionSupport: false });
+    const featureFlagsResponse = {
+      extensionSupport: true,
+      destNetworkAllowlist: [CHAIN_IDS.POLYGON, CHAIN_IDS.ARBITRUM],
+      srcNetworkAllowlist: [CHAIN_IDS.OPTIMISM, CHAIN_IDS.SCROLL],
+    };
+    expect(bridgeController.store.getState()).toStrictEqual(EMPTY_INIT_STATE);
 
     await bridgeController.setBridgeFeatureFlags();
     expect(
       bridgeController.store.getState().bridgeState.bridgeFeatureFlags,
-    ).toStrictEqual({ extensionSupport: true });
+    ).toStrictEqual(featureFlagsResponse);
   });
 });

--- a/app/scripts/controllers/bridge.ts
+++ b/app/scripts/controllers/bridge.ts
@@ -1,4 +1,5 @@
 import { ObservableStore } from '@metamask/obs-store';
+import { Hex } from '@metamask/utils';
 import { fetchBridgeFeatureFlags } from '../../../ui/pages/bridge/bridge.util';
 
 // Maps to BridgeController function names
@@ -8,27 +9,37 @@ export enum BridgeBackgroundAction {
 
 export enum BridgeFeatureFlagsKey {
   EXTENSION_SUPPORT = 'extensionSupport',
+  NETWORK_SRC_ALLOWLIST = 'srcNetworkAllowlist',
+  NETWORK_DEST_ALLOWLIST = 'destNetworkAllowlist',
 }
 
 export type BridgeFeatureFlags = {
   [BridgeFeatureFlagsKey.EXTENSION_SUPPORT]: boolean;
+  [BridgeFeatureFlagsKey.NETWORK_SRC_ALLOWLIST]: Hex[];
+  [BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST]: Hex[];
 };
 
-const initialState = {
-  bridgeState: {
-    bridgeFeatureFlags: {
-      [BridgeFeatureFlagsKey.EXTENSION_SUPPORT]: false,
-    },
+export type BridgeControllerState = {
+  bridgeFeatureFlags: BridgeFeatureFlags;
+};
+
+const initialState: BridgeControllerState = {
+  bridgeFeatureFlags: {
+    [BridgeFeatureFlagsKey.EXTENSION_SUPPORT]: false,
+    [BridgeFeatureFlagsKey.NETWORK_SRC_ALLOWLIST]: [],
+    [BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST]: [],
   },
 };
 
 export default class BridgeController {
-  store = new ObservableStore(initialState);
+  store = new ObservableStore<{ bridgeState: BridgeControllerState }>({
+    bridgeState: initialState,
+  });
 
   resetState = () => {
     this.store.updateState({
       bridgeState: {
-        ...initialState.bridgeState,
+        ...initialState,
       },
     });
   };

--- a/app/scripts/controllers/bridge.ts
+++ b/app/scripts/controllers/bridge.ts
@@ -1,8 +1,16 @@
 import { ObservableStore } from '@metamask/obs-store';
 import { Hex } from '@metamask/utils';
-import { fetchBridgeFeatureFlags } from '../../../ui/pages/bridge/bridge.util';
+import {
+  fetchBridgeFeatureFlags,
+  fetchBridgeTokens,
+} from '../../../ui/pages/bridge/bridge.util';
+import { SwapsTokenObject } from '../../../shared/constants/swaps';
 
 // Maps to BridgeController function names
+export enum BridgeUserAction {
+  SELECT_DEST_NETWORK = 'selectDestNetwork',
+}
+
 export enum BridgeBackgroundAction {
   SET_FEATURE_FLAGS = 'setBridgeFeatureFlags',
 }
@@ -21,6 +29,7 @@ export type BridgeFeatureFlags = {
 
 export type BridgeControllerState = {
   bridgeFeatureFlags: BridgeFeatureFlags;
+  destTokens: Record<string, SwapsTokenObject>;
 };
 
 const initialState: BridgeControllerState = {
@@ -29,6 +38,7 @@ const initialState: BridgeControllerState = {
     [BridgeFeatureFlagsKey.NETWORK_SRC_ALLOWLIST]: [],
     [BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST]: [],
   },
+  destTokens: {},
 };
 
 export default class BridgeController {
@@ -49,6 +59,18 @@ export default class BridgeController {
     const bridgeFeatureFlags = await fetchBridgeFeatureFlags();
     this.store.updateState({
       bridgeState: { ...bridgeState, bridgeFeatureFlags },
+    });
+  };
+
+  selectDestNetwork = async (chainId: Hex) => {
+    await this.#setTokens(chainId, 'destTokens');
+  };
+
+  #setTokens = async (chainId: Hex, stateKey: 'srcTokens' | 'destTokens') => {
+    const { bridgeState } = this.store.getState();
+    const tokens = await fetchBridgeTokens(chainId);
+    this.store.updateState({
+      bridgeState: { ...bridgeState, [stateKey]: tokens },
     });
   };
 }

--- a/app/scripts/controllers/bridge.ts
+++ b/app/scripts/controllers/bridge.ts
@@ -5,6 +5,7 @@ import {
   fetchBridgeTokens,
 } from '../../../ui/pages/bridge/bridge.util';
 import { SwapsTokenObject } from '../../../shared/constants/swaps';
+import { fetchTopAssetsList } from '../../../ui/pages/swaps/swaps.util';
 
 // Maps to BridgeController function names
 export enum BridgeUserAction {
@@ -30,6 +31,7 @@ export type BridgeFeatureFlags = {
 export type BridgeControllerState = {
   bridgeFeatureFlags: BridgeFeatureFlags;
   destTokens: Record<string, SwapsTokenObject>;
+  destTopAssets: { address: string }[];
 };
 
 const initialState: BridgeControllerState = {
@@ -39,6 +41,7 @@ const initialState: BridgeControllerState = {
     [BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST]: [],
   },
   destTokens: {},
+  destTopAssets: [],
 };
 
 export default class BridgeController {
@@ -63,7 +66,19 @@ export default class BridgeController {
   };
 
   selectDestNetwork = async (chainId: Hex) => {
+    await this.#setTopAssets(chainId, 'destTopAssets');
     await this.#setTokens(chainId, 'destTokens');
+  };
+
+  #setTopAssets = async (
+    chainId: Hex,
+    stateKey: 'srcTopAssets' | 'destTopAssets',
+  ) => {
+    const { bridgeState } = this.store.getState();
+    const topAssets = await fetchTopAssetsList(chainId);
+    this.store.updateState({
+      bridgeState: { ...bridgeState, [stateKey]: topAssets },
+    });
   };
 
   #setTokens = async (chainId: Hex, stateKey: 'srcTokens' | 'destTokens') => {

--- a/app/scripts/controllers/bridge.ts
+++ b/app/scripts/controllers/bridge.ts
@@ -9,6 +9,7 @@ import { fetchTopAssetsList } from '../../../ui/pages/swaps/swaps.util';
 
 // Maps to BridgeController function names
 export enum BridgeUserAction {
+  SELECT_SRC_NETWORK = 'selectSrcNetwork',
   SELECT_DEST_NETWORK = 'selectDestNetwork',
 }
 
@@ -30,6 +31,8 @@ export type BridgeFeatureFlags = {
 
 export type BridgeControllerState = {
   bridgeFeatureFlags: BridgeFeatureFlags;
+  srcTokens: Record<string, SwapsTokenObject>;
+  srcTopAssets: { address: string }[];
   destTokens: Record<string, SwapsTokenObject>;
   destTopAssets: { address: string }[];
 };
@@ -40,6 +43,8 @@ const initialState: BridgeControllerState = {
     [BridgeFeatureFlagsKey.NETWORK_SRC_ALLOWLIST]: [],
     [BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST]: [],
   },
+  srcTokens: {},
+  srcTopAssets: [],
   destTokens: {},
   destTopAssets: [],
 };
@@ -63,6 +68,11 @@ export default class BridgeController {
     this.store.updateState({
       bridgeState: { ...bridgeState, bridgeFeatureFlags },
     });
+  };
+
+  selectSrcNetwork = async (chainId: Hex) => {
+    await this.#setTopAssets(chainId, 'srcTopAssets');
+    await this.#setTokens(chainId, 'srcTokens');
   };
 
   selectDestNetwork = async (chainId: Hex) => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -322,7 +322,10 @@ import { updateSecurityAlertResponse } from './lib/ppom/ppom-util';
 import createEvmMethodsToNonEvmAccountReqFilterMiddleware from './lib/createEvmMethodsToNonEvmAccountReqFilterMiddleware';
 import { isEthAddress } from './lib/multichain/address';
 import { decodeTransactionData } from './lib/transaction/decode/util';
-import BridgeController, { BridgeBackgroundAction } from './controllers/bridge';
+import BridgeController, {
+  BridgeBackgroundAction,
+  BridgeUserAction,
+} from './controllers/bridge';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -3559,6 +3562,10 @@ export default class MetamaskController extends EventEmitter {
       // Bridge
       [BridgeBackgroundAction.SET_FEATURE_FLAGS]:
         bridgeController[BridgeBackgroundAction.SET_FEATURE_FLAGS].bind(
+          bridgeController,
+        ),
+      [BridgeUserAction.SELECT_DEST_NETWORK]:
+        bridgeController[BridgeUserAction.SELECT_DEST_NETWORK].bind(
           bridgeController,
         ),
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3564,6 +3564,10 @@ export default class MetamaskController extends EventEmitter {
         bridgeController[BridgeBackgroundAction.SET_FEATURE_FLAGS].bind(
           bridgeController,
         ),
+      [BridgeUserAction.SELECT_SRC_NETWORK]:
+        bridgeController[BridgeUserAction.SELECT_SRC_NETWORK].bind(
+          bridgeController,
+        ),
       [BridgeUserAction.SELECT_DEST_NETWORK]:
         bridgeController[BridgeUserAction.SELECT_DEST_NETWORK].bind(
           bridgeController,

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -671,10 +671,15 @@ export const createSwapsMockStore = () => {
 export const createBridgeMockStore = (
   featureFlagOverrides = {},
   bridgeSliceOverrides = {},
+  swapsSliceOverrides = {},
 ) => {
   const swapsStore = createSwapsMockStore();
   return {
     ...swapsStore,
+    swaps: {
+      ...swapsStore.swaps,
+      ...swapsSliceOverrides,
+    },
     bridge: {
       toChain: null,
       ...bridgeSliceOverrides,

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -668,12 +668,16 @@ export const createSwapsMockStore = () => {
   };
 };
 
-export const createBridgeMockStore = (featureFlagOverrides = {}) => {
+export const createBridgeMockStore = (
+  featureFlagOverrides = {},
+  bridgeSliceOverrides = {},
+) => {
   const swapsStore = createSwapsMockStore();
   return {
     ...swapsStore,
     bridge: {
       toChain: null,
+      ...bridgeSliceOverrides,
     },
     metamask: {
       ...swapsStore.metamask,
@@ -681,6 +685,8 @@ export const createBridgeMockStore = (featureFlagOverrides = {}) => {
         ...(swapsStore.metamask.bridgeState ?? {}),
         bridgeFeatureFlags: {
           extensionSupport: false,
+          srcNetworkAllowlist: [],
+          destNetworkAllowlist: [],
           ...featureFlagOverrides,
         },
       },

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -672,6 +672,7 @@ export const createBridgeMockStore = (
   featureFlagOverrides = {},
   bridgeSliceOverrides = {},
   swapsSliceOverrides = {},
+  bridgeStateOverrides = {},
 ) => {
   const swapsStore = createSwapsMockStore();
   return {
@@ -694,6 +695,7 @@ export const createBridgeMockStore = (
           destNetworkAllowlist: [],
           ...featureFlagOverrides,
         },
+        ...bridgeStateOverrides,
       },
     },
   };

--- a/ui/ducks/bridge/actions.ts
+++ b/ui/ducks/bridge/actions.ts
@@ -5,8 +5,9 @@ import { MetaMaskReduxDispatch } from '../../store/store';
 import { swapsSlice } from '../swaps/swaps';
 import { bridgeSlice } from './bridge';
 
-// eslint-disable-next-line no-empty-pattern
-const {} = swapsSlice.actions;
+// Proxied swaps actions
+export const { setFromToken, setToToken, setFromTokenInputValue } =
+  swapsSlice.actions;
 
 export const { setToChain } = bridgeSlice.actions;
 

--- a/ui/ducks/bridge/actions.ts
+++ b/ui/ducks/bridge/actions.ts
@@ -1,18 +1,24 @@
-import { BridgeBackgroundAction } from '../../../app/scripts/controllers/bridge';
+import { ProviderConfig } from '@metamask/network-controller';
+import { Hex } from '@metamask/utils';
 import { forceUpdateMetamaskState } from '../../store/actions';
 import { submitRequestToBackground } from '../../store/background-connection';
-import { MetaMaskReduxDispatch } from '../../store/store';
 import { swapsSlice } from '../swaps/swaps';
+import { RPCDefinition } from '../../../shared/constants/network';
+import { MetaMaskReduxDispatch } from '../../store/store';
+import {
+  BridgeBackgroundAction,
+  BridgeUserAction,
+} from '../../../app/scripts/controllers/bridge';
 import { bridgeSlice } from './bridge';
 
 // Proxied swaps actions
 export const { setFromToken, setToToken, setFromTokenInputValue } =
   swapsSlice.actions;
 
-export const { setToChain } = bridgeSlice.actions;
+const { setToChain: setToChain_ } = bridgeSlice.actions;
 
 const callBridgeControllerMethod = <T>(
-  bridgeAction: BridgeBackgroundAction,
+  bridgeAction: BridgeUserAction | BridgeBackgroundAction,
   args?: T[],
 ) => {
   return async (dispatch: MetaMaskReduxDispatch) => {
@@ -21,13 +27,29 @@ const callBridgeControllerMethod = <T>(
   };
 };
 
-// User actions
-
 // Background actions
 export const setBridgeFeatureFlags = () => {
   return async (dispatch: MetaMaskReduxDispatch) => {
     return dispatch(
       callBridgeControllerMethod(BridgeBackgroundAction.SET_FEATURE_FLAGS),
     );
+  };
+};
+
+// User actions
+export const setToChain = (network: ProviderConfig | RPCDefinition) => {
+  return async (dispatch: MetaMaskReduxDispatch) => {
+    const { chainId } = network;
+    // TODO if network has not been added (network.id === undefined), add new network OR prompt user to add network
+    try {
+      dispatch(setToChain_(network));
+      dispatch(
+        callBridgeControllerMethod<Hex>(BridgeUserAction.SELECT_DEST_NETWORK, [
+          chainId,
+        ]),
+      );
+    } catch (error) {
+      // TODO reset to previous chain, empty token and top assets lists
+    }
   };
 };

--- a/ui/ducks/bridge/bridge.test.ts
+++ b/ui/ducks/bridge/bridge.test.ts
@@ -3,7 +3,10 @@ import thunk from 'redux-thunk';
 import { createBridgeMockStore } from '../../../test/jest/mock-store';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { setBackgroundConnection } from '../../store/background-connection';
-import { BridgeBackgroundAction } from '../../../app/scripts/controllers/bridge';
+import {
+  BridgeBackgroundAction,
+  BridgeUserAction,
+} from '../../../app/scripts/controllers/bridge';
 import bridgeReducer from './bridge';
 import { setBridgeFeatureFlags, setToChain } from './actions';
 
@@ -14,14 +17,28 @@ describe('Ducks - Bridge', () => {
   const store = configureMockStore<any>(middleware)(createBridgeMockStore());
 
   describe('setToChain', () => {
-    it('calls the "bridge/setToChain" action', () => {
+    it('calls the "bridge/setToChain" action and the selectDestNetwork background action', () => {
       const state = store.getState().bridge;
-      const actionPayload = CHAIN_IDS.BSC;
-      store.dispatch(setToChain(actionPayload));
+      const actionPayload = { chainId: CHAIN_IDS.OPTIMISM, id: '2313-314njk' };
+
+      const mockSelectDestNetwork = jest.fn().mockReturnValue({});
+      setBackgroundConnection({
+        [BridgeUserAction.SELECT_DEST_NETWORK]: mockSelectDestNetwork,
+      } as never);
+
+      store.dispatch(setToChain(actionPayload as never) as never);
+
+      // Check redux state
       const actions = store.getActions();
       expect(actions[0].type).toBe('bridge/setToChain');
       const newState = bridgeReducer(state, actions[0]);
       expect(newState.toChain).toBe(actionPayload);
+      // Check background state
+      expect(mockSelectDestNetwork).toHaveBeenCalledTimes(1);
+      expect(mockSelectDestNetwork).toHaveBeenCalledWith(
+        '0xa',
+        expect.anything(),
+      );
     });
   });
 

--- a/ui/ducks/bridge/bridge.test.ts
+++ b/ui/ducks/bridge/bridge.test.ts
@@ -8,13 +8,17 @@ import {
   BridgeUserAction,
 } from '../../../app/scripts/controllers/bridge';
 import bridgeReducer from './bridge';
-import { setBridgeFeatureFlags, setToChain } from './actions';
+import { setBridgeFeatureFlags, setFromChain, setToChain } from './actions';
 
 const middleware = [thunk];
 
 describe('Ducks - Bridge', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const store = configureMockStore<any>(middleware)(createBridgeMockStore());
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   describe('setToChain', () => {
     it('calls the "bridge/setToChain" action and the selectDestNetwork background action', () => {
@@ -50,6 +54,35 @@ describe('Ducks - Bridge', () => {
       } as never);
       store.dispatch(setBridgeFeatureFlags() as never);
       expect(mockSetBridgeFeatureFlags).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setFromChain', () => {
+    it('calls the setActiveNetwork and selectSrcNetwork background actions', async () => {
+      const mockSetActiveNetwork = jest.fn().mockReturnValue({});
+      const mockSelectSrcNetwork = jest.fn().mockReturnValue({});
+      setBackgroundConnection({
+        setActiveNetwork: mockSetActiveNetwork,
+        [BridgeUserAction.SELECT_SRC_NETWORK]: mockSelectSrcNetwork,
+      } as never);
+
+      const actionPayload = {
+        chainId: CHAIN_IDS.MAINNET,
+        id: '2313-314njk',
+      };
+      await store.dispatch(setFromChain(actionPayload as never) as never);
+
+      expect(mockSetActiveNetwork).toHaveBeenCalledTimes(1);
+      expect(mockSetActiveNetwork).toHaveBeenCalledWith(
+        '2313-314njk',
+        expect.anything(),
+      );
+
+      expect(mockSelectSrcNetwork).toHaveBeenCalledTimes(1);
+      expect(mockSelectSrcNetwork).toHaveBeenCalledWith(
+        '0x1',
+        expect.anything(),
+      );
     });
   });
 });

--- a/ui/ducks/bridge/bridge.ts
+++ b/ui/ducks/bridge/bridge.ts
@@ -1,9 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { ProviderConfig } from '@metamask/network-controller';
+
 import { swapsSlice } from '../swaps/swaps';
 
 // Only states that are not in swaps slice
-type BridgeState = {
-  toChain: string | null;
+export type BridgeState = {
+  toChain: ProviderConfig | null;
 };
 
 const initialState: BridgeState = {

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -14,6 +14,7 @@ import {
   getToChain,
   getToChains,
   getToToken,
+  getToTokens,
 } from './selectors';
 
 describe('Bridge selectors', () => {
@@ -354,6 +355,38 @@ describe('Bridge selectors', () => {
       const result = getToAmount(state as never);
 
       expect(result).toStrictEqual('0');
+    });
+  });
+
+  describe('getToTokens', () => {
+    it('returns dest tokens from controller state when toChain is defined', () => {
+      const state = createBridgeMockStore(
+        {},
+        { toChain: { chainId: '0x1' } },
+        {},
+        {
+          destTokens: { '0x00': { address: '0x00', symbol: 'TEST' } },
+        },
+      );
+      const result = getToTokens(state as never);
+
+      expect(result).toStrictEqual({
+        '0x00': { address: '0x00', symbol: 'TEST' },
+      });
+    });
+
+    it('returns empty dest tokens from controller state when toChain is undefined', () => {
+      const state = createBridgeMockStore(
+        {},
+        {},
+        {},
+        {
+          destTokens: { '0x00': { address: '0x00', symbol: 'TEST' } },
+        },
+      );
+      const result = getToTokens(state as never);
+
+      expect(result).toStrictEqual({});
     });
   });
 });

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -1,0 +1,259 @@
+import { ProviderConfig } from '@metamask/network-controller';
+import { getProviderConfig } from '../metamask/metamask';
+import { createBridgeMockStore } from '../../../test/jest/mock-store';
+import { CHAIN_IDS, FEATURED_RPCS } from '../../../shared/constants/network';
+import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../../shared/constants/bridge';
+import {
+  getAllBridgeableNetworks,
+  getFromChain,
+  getFromChains,
+  getIsBridgeTx,
+  getToChain,
+  getToChains,
+} from './selectors';
+
+describe('Bridge selectors', () => {
+  describe('getFromChain', () => {
+    it('returns the fromChain from the state', () => {
+      const state = {
+        metamask: { providerConfig: { chainId: '0x1' } },
+      };
+
+      const result = getFromChain(state as never);
+      expect(result).toStrictEqual({ chainId: '0x1' });
+
+      const providerConfig = getProviderConfig(state);
+      expect(result).toStrictEqual(providerConfig);
+    });
+  });
+
+  describe('getToChain', () => {
+    it('returns the toChain from the state', () => {
+      const state = {
+        bridge: {
+          toChain: { chainId: '0x1' } as unknown as ProviderConfig,
+        },
+      };
+
+      const result = getToChain(state as never);
+
+      expect(result).toStrictEqual({ chainId: '0x1' });
+    });
+  });
+
+  describe('getAllBridgeableNetworks', () => {
+    it('returns list of ALLOWED_BRIDGE_CHAIN_IDS networks', () => {
+      const state = createBridgeMockStore();
+      const result = getAllBridgeableNetworks(state as never);
+
+      expect(result).toHaveLength(9);
+      expect(result[0]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.MAINNET }),
+      );
+      expect(result[1]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.LINEA_MAINNET }),
+      );
+      expect(result.slice(2)).toStrictEqual(FEATURED_RPCS);
+      result.forEach(({ chainId }) => {
+        expect(ALLOWED_BRIDGE_CHAIN_IDS).toContain(chainId);
+      });
+      ALLOWED_BRIDGE_CHAIN_IDS.forEach((allowedChainId) => {
+        expect(
+          result.findIndex(({ chainId }) => chainId === allowedChainId),
+        ).toBeGreaterThan(-1);
+      });
+    });
+
+    it('uses config from allNetworks if network is in both FEATURED_RPCS and allNetworks', () => {
+      const addedFeaturedNetwork = {
+        ...FEATURED_RPCS[FEATURED_RPCS.length - 1],
+        id: 'testid',
+      };
+      const state = {
+        ...createBridgeMockStore(),
+        metamask: {
+          networkConfigurations: [addedFeaturedNetwork],
+        },
+      };
+      const result = getAllBridgeableNetworks(state as never);
+
+      expect(result).toHaveLength(9);
+      expect(result[0]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.MAINNET }),
+      );
+      expect(result[1]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.LINEA_MAINNET }),
+      );
+      expect(result[2]).toStrictEqual({
+        ...addedFeaturedNetwork,
+        removable: true,
+      });
+      expect(result.slice(3)).toStrictEqual(FEATURED_RPCS.slice(0, -1));
+    });
+
+    it('returns network if included in ALLOWED_BRIDGE_CHAIN_IDS', () => {
+      const addedFeaturedNetwork = {
+        chainId: '0x11212131241523151',
+        nickname: 'scroll',
+        rpcUrl: 'https://a',
+        ticker: 'ETH',
+        rpcPrefs: {
+          blockExplorerUrl: 'https://a',
+          imageUrl: 'https://a',
+        },
+      };
+      const state = {
+        ...createBridgeMockStore(),
+        metamask: {
+          networkConfigurations: [addedFeaturedNetwork],
+        },
+      };
+      const result = getAllBridgeableNetworks(state as never);
+
+      expect(result).toHaveLength(9);
+      expect(result[0]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.MAINNET }),
+      );
+      expect(result[1]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.LINEA_MAINNET }),
+      );
+      expect(result.slice(2)).toStrictEqual(FEATURED_RPCS);
+    });
+  });
+
+  describe('getFromChains', () => {
+    it('excludes selected toChain and disabled chains from options', () => {
+      const state = createBridgeMockStore(
+        {
+          srcNetworkAllowlist: [
+            CHAIN_IDS.MAINNET,
+            CHAIN_IDS.OPTIMISM,
+            CHAIN_IDS.POLYGON,
+          ],
+        },
+        { toChain: { chainId: CHAIN_IDS.MAINNET } },
+      );
+      const result = getFromChains(state as never);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.OPTIMISM }),
+      );
+      expect(result[1]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.POLYGON }),
+      );
+    });
+
+    it('returns empty list when bridgeFeatureFlags are not set', () => {
+      const state = createBridgeMockStore();
+      const result = getFromChains(state as never);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('getToChains', () => {
+    it('excludes selected providerConfig and disabled chains from options', () => {
+      const state = createBridgeMockStore({
+        destNetworkAllowlist: [
+          CHAIN_IDS.MAINNET,
+          CHAIN_IDS.OPTIMISM,
+          CHAIN_IDS.POLYGON,
+        ],
+      });
+      const result = getToChains(state as never);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.OPTIMISM }),
+      );
+      expect(result[1]).toStrictEqual(
+        expect.objectContaining({ chainId: CHAIN_IDS.POLYGON }),
+      );
+    });
+
+    it('returns empty list when bridgeFeatureFlags are not set', () => {
+      const state = createBridgeMockStore();
+      const result = getToChains(state as never);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('getIsBridgeTx', () => {
+    it('returns false if bridge is not enabled', () => {
+      const state = {
+        metamask: {
+          providerConfig: { chainId: '0x1' },
+          useExternalServices: true,
+          bridgeState: { bridgeFeatureFlags: { extensionSupport: false } },
+        },
+        bridge: { toChain: { chainId: '0x38' } as unknown as ProviderConfig },
+      };
+
+      const result = getIsBridgeTx(state as never);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false if toChain is null', () => {
+      const state = {
+        metamask: {
+          providerConfig: { chainId: '0x1' },
+          useExternalServices: true,
+          bridgeState: { bridgeFeatureFlags: { extensionSupport: true } },
+        },
+        bridge: { toChain: null },
+      };
+
+      const result = getIsBridgeTx(state as never);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false if fromChain and toChain have the same chainId', () => {
+      const state = {
+        metamask: {
+          providerConfig: { chainId: '0x1' },
+          useExternalServices: true,
+          bridgeState: { bridgeFeatureFlags: { extensionSupport: true } },
+        },
+        bridge: { toChain: { chainId: '0x1' } },
+      };
+
+      const result = getIsBridgeTx(state as never);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false if useExternalServices is not enabled', () => {
+      const state = {
+        metamask: {
+          providerConfig: { chainId: '0x1' },
+          useExternalServices: false,
+          bridgeState: { bridgeFeatureFlags: { extensionSupport: true } },
+        },
+        bridge: { toChain: { chainId: '0x38' } },
+      };
+
+      const result = getIsBridgeTx(state as never);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true if bridge is enabled and fromChain and toChain have different chainIds', () => {
+      const state = {
+        metamask: {
+          providerConfig: { chainId: '0x1' },
+          useExternalServices: true,
+          bridgeState: { bridgeFeatureFlags: { extensionSupport: true } },
+        },
+        bridge: { toChain: { chainId: '0x38' } },
+      };
+
+      const result = getIsBridgeTx(state as never);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -15,6 +15,7 @@ import {
   getToChains,
   getToToken,
   getToTokens,
+  getToTopAssets,
 } from './selectors';
 
 describe('Bridge selectors', () => {
@@ -385,6 +386,38 @@ describe('Bridge selectors', () => {
         },
       );
       const result = getToTokens(state as never);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('getToTopAssets', () => {
+    it('returns dest top assets from controller state when toChain is defined', () => {
+      const state = createBridgeMockStore(
+        {},
+        { toChain: { chainId: '0x1' } },
+        {},
+        {
+          destTokens: { '0x00': { address: '0x00', symbol: 'TEST' } },
+          destTopAssets: [{ address: '0x00', symbol: 'TEST' }],
+        },
+      );
+      const result = getToTopAssets(state as never);
+
+      expect(result).toStrictEqual([{ address: '0x00', symbol: 'TEST' }]);
+    });
+
+    it('returns empty dest tokens from controller state when toChain is undefined', () => {
+      const state = createBridgeMockStore(
+        {},
+        {},
+        {},
+        {
+          destTokens: { '0x00': { address: '0x00', symbol: 'TEST' } },
+          destTopAssets: [{ address: '0x00', symbol: 'TEST' }],
+        },
+      );
+      const result = getToTopAssets(state as never);
 
       expect(result).toStrictEqual({});
     });

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -5,11 +5,15 @@ import { CHAIN_IDS, FEATURED_RPCS } from '../../../shared/constants/network';
 import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../../shared/constants/bridge';
 import {
   getAllBridgeableNetworks,
+  getFromAmount,
   getFromChain,
   getFromChains,
+  getFromToken,
   getIsBridgeTx,
+  getToAmount,
   getToChain,
   getToChains,
+  getToToken,
 } from './selectors';
 
 describe('Bridge selectors', () => {
@@ -254,6 +258,102 @@ describe('Bridge selectors', () => {
       const result = getIsBridgeTx(state as never);
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe('getFromToken', () => {
+    it('returns swaps fromToken', () => {
+      const state = createBridgeMockStore(
+        {},
+        {},
+        { fromToken: { address: '0x123', symbol: 'TEST' } },
+      );
+      const result = getFromToken(state as never);
+
+      expect(result).toStrictEqual({ address: '0x123', symbol: 'TEST' });
+    });
+
+    it('returns defaultToken if fromToken has no address', () => {
+      const state = createBridgeMockStore(
+        {},
+        {},
+        { fromToken: { symbol: 'NATIVE' } },
+      );
+      const result = getFromToken(state as never);
+
+      expect(result).toStrictEqual({
+        address: '0x0000000000000000000000000000000000000000',
+        balance: '0',
+        decimals: 18,
+        iconUrl: './images/eth_logo.svg',
+        name: 'Ether',
+        string: '0',
+        symbol: 'ETH',
+      });
+    });
+
+    it('returns defautlToken if fromToken is undefined', () => {
+      const state = createBridgeMockStore({}, {}, { fromToken: null });
+      const result = getFromToken(state as never);
+
+      expect(result).toStrictEqual({
+        address: '0x0000000000000000000000000000000000000000',
+        balance: '0',
+        decimals: 18,
+        iconUrl: './images/eth_logo.svg',
+        name: 'Ether',
+        string: '0',
+        symbol: 'ETH',
+      });
+    });
+  });
+
+  describe('getToToken', () => {
+    it('returns swaps toToken', () => {
+      const state = createBridgeMockStore(
+        {},
+        {},
+        { toToken: { address: '0x123', symbol: 'TEST' } },
+      );
+      const result = getToToken(state as never);
+
+      expect(result).toStrictEqual({ address: '0x123', symbol: 'TEST' });
+    });
+
+    it('returns undefined if swaps toToken is undefined', () => {
+      const state = createBridgeMockStore({}, {}, { toToken: null });
+      const result = getToToken(state as never);
+
+      expect(result).toStrictEqual(null);
+    });
+  });
+
+  describe('getFromAmount', () => {
+    it('returns swaps fromTokenInputValue', () => {
+      const state = createBridgeMockStore(
+        {},
+        {},
+        { fromTokenInputValue: '123' },
+      );
+      const result = getFromAmount(state as never);
+
+      expect(result).toStrictEqual('123');
+    });
+
+    it('returns empty string', () => {
+      const state = createBridgeMockStore({}, {}, { fromTokenInputValue: '' });
+      const result = getFromAmount(state as never);
+
+      expect(result).toStrictEqual('');
+    });
+  });
+
+  describe('getToAmount', () => {
+    it('returns hardcoded 0', () => {
+      const state = createBridgeMockStore();
+      const result = getToAmount(state as never);
+
+      expect(result).toStrictEqual('0');
     });
   });
 });

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -9,6 +9,8 @@ import {
   getFromChain,
   getFromChains,
   getFromToken,
+  getFromTokens,
+  getFromTopAssets,
   getIsBridgeTx,
   getToAmount,
   getToChain,
@@ -420,6 +422,41 @@ describe('Bridge selectors', () => {
       const result = getToTopAssets(state as never);
 
       expect(result).toStrictEqual({});
+    });
+  });
+
+  describe('getFromTokens', () => {
+    it('returns src tokens from controller state', () => {
+      const state = createBridgeMockStore(
+        {},
+        { toChain: { chainId: '0x1' } },
+        {},
+        {
+          srcTokens: { '0x00': { address: '0x00', symbol: 'TEST' } },
+        },
+      );
+      const result = getFromTokens(state as never);
+
+      expect(result).toStrictEqual({
+        '0x00': { address: '0x00', symbol: 'TEST' },
+      });
+    });
+  });
+
+  describe('getFromTopAssets', () => {
+    it('returns src top assets from controller state', () => {
+      const state = createBridgeMockStore(
+        {},
+        { toChain: { chainId: '0x1' } },
+        {},
+        {
+          srcTokens: { '0x00': { address: '0x00', symbol: 'TEST' } },
+          srcTopAssets: [{ address: '0x00', symbol: 'TEST' }],
+        },
+      );
+      const result = getFromTopAssets(state as never);
+
+      expect(result).toStrictEqual([{ address: '0x00', symbol: 'TEST' }]);
     });
   });
 });

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -1,0 +1,81 @@
+import { createSelector } from 'reselect';
+import { NetworkState, ProviderConfig } from '@metamask/network-controller';
+import { uniqBy } from 'lodash';
+import { getProviderConfig } from '../metamask/metamask';
+import { getAllNetworks, getIsBridgeEnabled } from '../../selectors';
+import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../../shared/constants/bridge';
+import {
+  BridgeControllerState,
+  BridgeFeatureFlagsKey,
+} from '../../../app/scripts/controllers/bridge';
+import {
+  FEATURED_RPCS,
+  RPCDefinition,
+} from '../../../shared/constants/network';
+import { BridgeState } from './bridge';
+
+// TODO add swaps state
+type BridgeAppState = {
+  metamask: NetworkState & { bridgeState: BridgeControllerState } & {
+    useExternalServices: boolean;
+  };
+  bridge: BridgeState;
+};
+
+export const getFromChain = (state: BridgeAppState): ProviderConfig =>
+  getProviderConfig(state);
+export const getToChain = (state: BridgeAppState): ProviderConfig | null =>
+  state.bridge.toChain;
+
+export const getAllBridgeableNetworks = (
+  state: BridgeAppState,
+): (ProviderConfig | RPCDefinition)[] => {
+  const allNetworks = getAllNetworks(state); // includes networks user has added
+  return uniqBy([...allNetworks, ...FEATURED_RPCS], 'chainId').filter(
+    ({ chainId }) => ALLOWED_BRIDGE_CHAIN_IDS.includes(chainId),
+  );
+};
+export const getFromChains = createSelector(
+  getAllBridgeableNetworks,
+  (state: BridgeAppState) => state.metamask.bridgeState?.bridgeFeatureFlags,
+  getToChain,
+  (
+    allBridgeableNetworks,
+    bridgeFeatureFlags,
+    toChain,
+  ): (ProviderConfig | RPCDefinition)[] =>
+    allBridgeableNetworks.filter(
+      ({ chainId }) =>
+        chainId !== toChain?.chainId &&
+        bridgeFeatureFlags[
+          BridgeFeatureFlagsKey.NETWORK_SRC_ALLOWLIST
+        ].includes(chainId),
+    ),
+);
+export const getToChains = createSelector(
+  getAllBridgeableNetworks,
+  (state: BridgeAppState) => state.metamask.bridgeState?.bridgeFeatureFlags,
+  getFromChain,
+  (
+    allBridgeableNetworks,
+    bridgeFeatureFlags,
+    fromChain,
+  ): (ProviderConfig | RPCDefinition)[] =>
+    allBridgeableNetworks.filter(
+      ({ chainId }) =>
+        chainId !== fromChain.chainId &&
+        bridgeFeatureFlags[
+          BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST
+        ].includes(chainId),
+    ),
+);
+
+export const getIsBridgeTx = createSelector(
+  getFromChain,
+  getToChain,
+  (state: BridgeAppState) => getIsBridgeEnabled(state),
+  (fromChain, toChain, isBridgeEnabled: boolean) =>
+    isBridgeEnabled &&
+    toChain !== null &&
+    fromChain.chainId !== toChain.chainId,
+);

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -89,6 +89,9 @@ export const getToToken = (state: BridgeAppState) => {
 export const getToTokens = (state: BridgeAppState) => {
   return state.bridge.toChain ? state.metamask.bridgeState.destTokens : {};
 };
+export const getToTopAssets = (state: BridgeAppState) => {
+  return state.bridge.toChain ? state.metamask.bridgeState.destTopAssets : [];
+};
 
 export const getFromAmount = (state: BridgeAppState) =>
   swapsSlice.getFromTokenInputValue(state);

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -2,7 +2,13 @@ import { createSelector } from 'reselect';
 import { NetworkState, ProviderConfig } from '@metamask/network-controller';
 import { uniqBy } from 'lodash';
 import { getProviderConfig } from '../metamask/metamask';
-import { getAllNetworks, getIsBridgeEnabled } from '../../selectors';
+import {
+  getAllNetworks,
+  getIsBridgeEnabled,
+  getSwapsDefaultToken,
+} from '../../selectors';
+import * as swapsSlice from '../swaps/swaps';
+
 import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../../shared/constants/bridge';
 import {
   BridgeControllerState,
@@ -69,6 +75,23 @@ export const getToChains = createSelector(
         ].includes(chainId),
     ),
 );
+
+export const getFromToken = (state: BridgeAppState) => {
+  const swapsFromToken = swapsSlice.getFromToken(state);
+  if (!swapsFromToken?.address) {
+    return getSwapsDefaultToken(state);
+  }
+  return swapsFromToken;
+};
+export const getToToken = (state: BridgeAppState) => {
+  return swapsSlice.getToToken(state);
+};
+
+export const getFromAmount = (state: BridgeAppState) =>
+  swapsSlice.getFromTokenInputValue(state);
+export const getToAmount = (_state: BridgeAppState) => {
+  return '0';
+};
 
 export const getIsBridgeTx = createSelector(
   getFromChain,

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -83,6 +83,13 @@ export const getFromToken = (state: BridgeAppState) => {
   }
   return swapsFromToken;
 };
+export const getFromTokens = (state: BridgeAppState) => {
+  return state.metamask.bridgeState.srcTokens;
+};
+export const getFromTopAssets = (state: BridgeAppState) => {
+  return state.metamask.bridgeState.srcTopAssets;
+};
+
 export const getToToken = (state: BridgeAppState) => {
   return swapsSlice.getToToken(state);
 };

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -86,6 +86,9 @@ export const getFromToken = (state: BridgeAppState) => {
 export const getToToken = (state: BridgeAppState) => {
   return swapsSlice.getToToken(state);
 };
+export const getToTokens = (state: BridgeAppState) => {
+  return state.bridge.toChain ? state.metamask.bridgeState.destTokens : {};
+};
 
 export const getFromAmount = (state: BridgeAppState) =>
   swapsSlice.getFromTokenInputValue(state);

--- a/ui/pages/bridge/bridge.util.test.ts
+++ b/ui/pages/bridge/bridge.util.test.ts
@@ -1,59 +1,82 @@
 import fetchWithCache from '../../../shared/lib/fetch-with-cache';
+import { CHAIN_IDS } from '../../../shared/constants/network';
 import { fetchBridgeFeatureFlags } from './bridge.util';
 
 jest.mock('../../../shared/lib/fetch-with-cache');
 
 describe('Bridge utils', () => {
-  it('should fetch bridge feature flags successfully', async () => {
-    const mockResponse = {
-      'extension-support': true,
-    };
+  describe('fetchBridgeFeatureFlags', () => {
+    it('should fetch bridge feature flags successfully', async () => {
+      const mockResponse = {
+        'extension-support': true,
+        'src-network-allowlist': [1, 10, 59144, 120],
+        'dest-network-allowlist': [1, 137, 59144, 11111],
+      };
 
-    (fetchWithCache as jest.Mock).mockResolvedValue(mockResponse);
+      (fetchWithCache as jest.Mock).mockResolvedValue(mockResponse);
 
-    const result = await fetchBridgeFeatureFlags();
+      const result = await fetchBridgeFeatureFlags();
 
-    expect(fetchWithCache).toHaveBeenCalledWith({
-      url: 'https://bridge.api.cx.metamask.io/getAllFeatureFlags',
-      fetchOptions: {
-        method: 'GET',
-        headers: { 'X-Client-Id': 'extension' },
-      },
-      cacheOptions: { cacheRefreshTime: 600000 },
-      functionName: 'fetchBridgeFeatureFlags',
+      expect(fetchWithCache).toHaveBeenCalledWith({
+        url: 'https://bridge.api.cx.metamask.io/getAllFeatureFlags',
+        fetchOptions: {
+          method: 'GET',
+          headers: { 'X-Client-Id': 'extension' },
+        },
+        cacheOptions: { cacheRefreshTime: 600000 },
+        functionName: 'fetchBridgeFeatureFlags',
+      });
+
+      expect(result).toStrictEqual({
+        extensionSupport: true,
+        srcNetworkAllowlist: [
+          CHAIN_IDS.MAINNET,
+          CHAIN_IDS.OPTIMISM,
+          CHAIN_IDS.LINEA_MAINNET,
+          '0x78',
+        ],
+        destNetworkAllowlist: [
+          CHAIN_IDS.MAINNET,
+          CHAIN_IDS.POLYGON,
+          CHAIN_IDS.LINEA_MAINNET,
+          '0x2b67',
+        ],
+      });
     });
 
-    expect(result).toEqual({ extensionSupport: true });
-  });
+    it('should use fallback bridge feature flags if response is unexpected', async () => {
+      const mockResponse = {
+        flag1: true,
+        flag2: false,
+      };
 
-  it('should use fallback bridge feature flags if response is unexpected', async () => {
-    const mockResponse = {
-      flag1: true,
-      flag2: false,
-    };
+      (fetchWithCache as jest.Mock).mockResolvedValue(mockResponse);
 
-    (fetchWithCache as jest.Mock).mockResolvedValue(mockResponse);
+      const result = await fetchBridgeFeatureFlags();
 
-    const result = await fetchBridgeFeatureFlags();
+      expect(fetchWithCache).toHaveBeenCalledWith({
+        url: 'https://bridge.api.cx.metamask.io/getAllFeatureFlags',
+        fetchOptions: {
+          method: 'GET',
+          headers: { 'X-Client-Id': 'extension' },
+        },
+        cacheOptions: { cacheRefreshTime: 600000 },
+        functionName: 'fetchBridgeFeatureFlags',
+      });
 
-    expect(fetchWithCache).toHaveBeenCalledWith({
-      url: 'https://bridge.api.cx.metamask.io/getAllFeatureFlags',
-      fetchOptions: {
-        method: 'GET',
-        headers: { 'X-Client-Id': 'extension' },
-      },
-      cacheOptions: { cacheRefreshTime: 600000 },
-      functionName: 'fetchBridgeFeatureFlags',
+      expect(result).toStrictEqual({
+        extensionSupport: false,
+        srcNetworkAllowlist: [],
+        destNetworkAllowlist: [],
+      });
     });
 
-    expect(result).toEqual({ extensionSupport: false });
-  });
+    it('should handle fetch error', async () => {
+      const mockError = new Error('Failed to fetch');
 
-  it('should handle fetch error', async () => {
-    const mockError = new Error('Failed to fetch');
+      (fetchWithCache as jest.Mock).mockRejectedValue(mockError);
 
-    (fetchWithCache as jest.Mock).mockRejectedValue(mockError);
-
-    await expect(fetchBridgeFeatureFlags()).rejects.toThrowError(mockError);
+      await expect(fetchBridgeFeatureFlags()).rejects.toThrowError(mockError);
+    });
   });
 });

--- a/ui/pages/bridge/bridge.util.test.ts
+++ b/ui/pages/bridge/bridge.util.test.ts
@@ -1,6 +1,6 @@
 import fetchWithCache from '../../../shared/lib/fetch-with-cache';
 import { CHAIN_IDS } from '../../../shared/constants/network';
-import { fetchBridgeFeatureFlags } from './bridge.util';
+import { fetchBridgeFeatureFlags, fetchBridgeTokens } from './bridge.util';
 
 jest.mock('../../../shared/lib/fetch-with-cache');
 
@@ -77,6 +77,68 @@ describe('Bridge utils', () => {
       (fetchWithCache as jest.Mock).mockRejectedValue(mockError);
 
       await expect(fetchBridgeFeatureFlags()).rejects.toThrowError(mockError);
+    });
+  });
+
+  describe('fetchBridgeTokens', () => {
+    it('should fetch bridge tokens successfully', async () => {
+      const mockResponse = [
+        {
+          address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+          symbol: 'ABC',
+          decimals: 16,
+        },
+        {
+          address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f985',
+          decimals: 16,
+        },
+        {
+          address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f986',
+          symbol: 'DEF',
+        },
+        {
+          address: '0x124',
+          symbol: 'JKL',
+          decimals: 16,
+        },
+      ];
+
+      (fetchWithCache as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await fetchBridgeTokens('0xa');
+
+      expect(fetchWithCache).toHaveBeenCalledWith({
+        url: 'https://bridge.api.cx.metamask.io/getTokens?chainId=10',
+        fetchOptions: {
+          method: 'GET',
+          headers: { 'X-Client-Id': 'extension' },
+        },
+        cacheOptions: { cacheRefreshTime: 600000 },
+        functionName: 'fetchBridgeTokens',
+      });
+
+      expect(result).toStrictEqual({
+        '0x0000000000000000000000000000000000000000': {
+          address: '0x0000000000000000000000000000000000000000',
+          decimals: 18,
+          iconUrl: './images/eth_logo.svg',
+          name: 'Ether',
+          symbol: 'ETH',
+        },
+        '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984': {
+          address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+          decimals: 16,
+          symbol: 'ABC',
+        },
+      });
+    });
+
+    it('should handle fetch error', async () => {
+      const mockError = new Error('Failed to fetch');
+
+      (fetchWithCache as jest.Mock).mockRejectedValue(mockError);
+
+      await expect(fetchBridgeTokens('0xa')).rejects.toThrowError(mockError);
     });
   });
 });

--- a/ui/pages/bridge/bridge.util.ts
+++ b/ui/pages/bridge/bridge.util.ts
@@ -1,3 +1,4 @@
+import { add0x } from '@metamask/utils';
 import {
   BridgeFeatureFlagsKey,
   BridgeFeatureFlags,
@@ -9,6 +10,7 @@ import {
 import { MINUTE } from '../../../shared/constants/time';
 import fetchWithCache from '../../../shared/lib/fetch-with-cache';
 import { validateData } from '../../../shared/lib/swaps-utils';
+import { decimalToHex } from '../../../shared/modules/conversion.utils';
 
 const CLIENT_ID_HEADER = { 'X-Client-Id': BRIDGE_CLIENT_ID };
 const CACHE_REFRESH_TEN_MINUTES = 10 * MINUTE;
@@ -16,10 +18,14 @@ const CACHE_REFRESH_TEN_MINUTES = 10 * MINUTE;
 // Types copied from Metabridge API
 enum BridgeFlag {
   EXTENSION_SUPPORT = 'extension-support',
+  NETWORK_SRC_ALLOWLIST = 'src-network-allowlist',
+  NETWORK_DEST_ALLOWLIST = 'dest-network-allowlist',
 }
 
 type FeatureFlagResponse = {
   [BridgeFlag.EXTENSION_SUPPORT]: boolean;
+  [BridgeFlag.NETWORK_SRC_ALLOWLIST]: number[];
+  [BridgeFlag.NETWORK_DEST_ALLOWLIST]: number[];
 };
 // End of copied types
 
@@ -54,6 +60,22 @@ export async function fetchBridgeFeatureFlags(): Promise<BridgeFeatureFlags> {
           type: 'boolean',
           validator: (v) => typeof v === 'boolean',
         },
+        {
+          property: BridgeFlag.NETWORK_SRC_ALLOWLIST,
+          type: 'object',
+          validator: (v): v is number[] =>
+            Object.values(v as { [s: string]: unknown }).every(
+              (i) => typeof i === 'number',
+            ),
+        },
+        {
+          property: BridgeFlag.NETWORK_DEST_ALLOWLIST,
+          type: 'object',
+          validator: (v): v is number[] =>
+            Object.values(v as { [s: string]: unknown }).every(
+              (i) => typeof i === 'number',
+            ),
+        },
       ],
       rawFeatureFlags,
       url,
@@ -62,11 +84,21 @@ export async function fetchBridgeFeatureFlags(): Promise<BridgeFeatureFlags> {
     return {
       [BridgeFeatureFlagsKey.EXTENSION_SUPPORT]:
         rawFeatureFlags[BridgeFlag.EXTENSION_SUPPORT],
+      [BridgeFeatureFlagsKey.NETWORK_SRC_ALLOWLIST]: rawFeatureFlags[
+        BridgeFlag.NETWORK_SRC_ALLOWLIST
+      ].map((chainIdDec) => add0x(decimalToHex(chainIdDec))),
+      [BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST]: rawFeatureFlags[
+        BridgeFlag.NETWORK_DEST_ALLOWLIST
+      ].map((chainIdDec) => add0x(decimalToHex(chainIdDec))),
     };
   }
 
   return {
     // TODO set default to true once bridging is live
     [BridgeFeatureFlagsKey.EXTENSION_SUPPORT]: false,
+    // TODO set default to ALLOWED_BRIDGE_CHAIN_IDS once bridging is live
+    [BridgeFeatureFlagsKey.NETWORK_SRC_ALLOWLIST]: [],
+    // TODO set default to ALLOWED_BRIDGE_CHAIN_IDS once bridging is live
+    [BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST]: [],
   };
 }

--- a/ui/pages/bridge/bridge.util.ts
+++ b/ui/pages/bridge/bridge.util.ts
@@ -1,4 +1,4 @@
-import { add0x } from '@metamask/utils';
+import { Hex, add0x } from '@metamask/utils';
 import {
   BridgeFeatureFlagsKey,
   BridgeFeatureFlags,
@@ -10,7 +10,19 @@ import {
 import { MINUTE } from '../../../shared/constants/time';
 import fetchWithCache from '../../../shared/lib/fetch-with-cache';
 import { validateData } from '../../../shared/lib/swaps-utils';
-import { decimalToHex } from '../../../shared/modules/conversion.utils';
+import {
+  decimalToHex,
+  hexToDecimal,
+} from '../../../shared/modules/conversion.utils';
+import {
+  SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
+  SwapsTokenObject,
+} from '../../../shared/constants/swaps';
+import { TOKEN_VALIDATORS } from '../swaps/swaps.util';
+import {
+  isSwapsDefaultTokenAddress,
+  isSwapsDefaultTokenSymbol,
+} from '../../../shared/modules/swaps.utils';
 
 const CLIENT_ID_HEADER = { 'X-Client-Id': BRIDGE_CLIENT_ID };
 const CACHE_REFRESH_TEN_MINUTES = 10 * MINUTE;
@@ -29,17 +41,17 @@ type FeatureFlagResponse = {
 };
 // End of copied types
 
-type Validator<T> = {
-  property: keyof T;
+type Validator<ExpectedResponse, DataToValidate> = {
+  property: keyof ExpectedResponse | string;
   type: string;
-  validator: (value: unknown) => boolean;
+  validator: (value: DataToValidate) => boolean;
 };
 
-const validateResponse = <T>(
-  validators: Validator<T>[],
+const validateResponse = <ExpectedResponse, DataToValidate>(
+  validators: Validator<ExpectedResponse, DataToValidate>[],
   data: unknown,
   urlUsed: string,
-): data is T => {
+): data is ExpectedResponse => {
   return validateData(validators, data, urlUsed);
 };
 
@@ -53,7 +65,7 @@ export async function fetchBridgeFeatureFlags(): Promise<BridgeFeatureFlags> {
   });
 
   if (
-    validateResponse<FeatureFlagResponse>(
+    validateResponse<FeatureFlagResponse, unknown>(
       [
         {
           property: BridgeFlag.EXTENSION_SUPPORT,
@@ -101,4 +113,50 @@ export async function fetchBridgeFeatureFlags(): Promise<BridgeFeatureFlags> {
     // TODO set default to ALLOWED_BRIDGE_CHAIN_IDS once bridging is live
     [BridgeFeatureFlagsKey.NETWORK_DEST_ALLOWLIST]: [],
   };
+}
+
+// Returns a list of enabled (unblocked) tokens
+export async function fetchBridgeTokens(
+  chainId: Hex,
+): Promise<Record<string, SwapsTokenObject>> {
+  // TODO make token api v2 call
+  const url = `${BRIDGE_API_BASE_URL}/getTokens?chainId=${hexToDecimal(
+    chainId,
+  )}`;
+  const tokens = await fetchWithCache({
+    url,
+    fetchOptions: { method: 'GET', headers: CLIENT_ID_HEADER },
+    cacheOptions: { cacheRefreshTime: CACHE_REFRESH_TEN_MINUTES },
+    functionName: 'fetchBridgeTokens',
+  });
+
+  const isSwapsChainId = (
+    c: string,
+  ): c is keyof typeof SWAPS_CHAINID_DEFAULT_TOKEN_MAP =>
+    Object.keys(SWAPS_CHAINID_DEFAULT_TOKEN_MAP).includes(c);
+  const nativeToken = isSwapsChainId(chainId)
+    ? SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId]
+    : null;
+
+  const transformedTokens: Record<string, SwapsTokenObject> = {};
+  if (nativeToken) {
+    transformedTokens[nativeToken.address] = nativeToken;
+  }
+
+  tokens.forEach((token: SwapsTokenObject) => {
+    if (
+      validateResponse<SwapsTokenObject, string>(
+        TOKEN_VALIDATORS,
+        token,
+        url,
+      ) &&
+      !(
+        isSwapsDefaultTokenSymbol(token.symbol, chainId) ||
+        isSwapsDefaultTokenAddress(token.address, chainId)
+      )
+    ) {
+      transformedTokens[token.address] = token;
+    }
+  });
+  return transformedTokens;
 }

--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -35,6 +35,7 @@ import {
   showRemainingTimeInMinAndSec,
   getFeeForSmartTransaction,
   formatSwapsValueForDisplay,
+  fetchTopAssetsList,
 } from './swaps.util';
 
 jest.mock('../../../shared/lib/storage-helpers', () => ({
@@ -82,6 +83,25 @@ describe('Swaps Util', () => {
     it('should fetch aggregator metadata on prod', async () => {
       const result = await fetchAggregatorMetadata(CHAIN_IDS.MAINNET);
       expect(result).toStrictEqual(AGGREGATOR_METADATA);
+    });
+  });
+
+  describe('fetchTopAssetsList', () => {
+    beforeEach(() => {
+      nock('https://swap.api.cx.metamask.io')
+        .persist()
+        .get('/networks/1/topAssets')
+        .reply(200, TOP_ASSETS);
+    });
+
+    it('should fetch top assets', async () => {
+      const result = await fetchTopAssetsList(CHAIN_IDS.MAINNET);
+      expect(result).toStrictEqual(TOP_ASSETS);
+    });
+
+    it('should fetch top assets on prod', async () => {
+      const result = await fetchTopAssetsList(CHAIN_IDS.MAINNET);
+      expect(result).toStrictEqual(TOP_ASSETS);
     });
   });
 

--- a/ui/pages/swaps/swaps.util.ts
+++ b/ui/pages/swaps/swaps.util.ts
@@ -56,7 +56,7 @@ type Validator = {
   validator: (a: string) => boolean;
 };
 
-const TOKEN_VALIDATORS: Validator[] = [
+export const TOKEN_VALIDATORS: Validator[] = [
   {
     property: 'address',
     type: 'string',

--- a/ui/pages/swaps/swaps.util.ts
+++ b/ui/pages/swaps/swaps.util.ts
@@ -199,9 +199,9 @@ export async function fetchAggregatorMetadata(chainId: any): Promise<object> {
   return filteredAggregators;
 }
 
-// TODO: Replace `any` with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function fetchTopAssets(chainId: any): Promise<object> {
+export async function fetchTopAssetsList(
+  chainId: string,
+): Promise<{ address: string }[]> {
   const topAssetsUrl = getBaseApi('topAssets', chainId);
   const response =
     (await fetchWithCache({
@@ -210,14 +210,21 @@ export async function fetchTopAssets(chainId: any): Promise<object> {
       fetchOptions: { method: 'GET', headers: clientIdHeader },
       cacheOptions: { cacheRefreshTime: CACHE_REFRESH_FIVE_MINUTES },
     })) || [];
+  const topAssetsList = response.filter((asset: { address: string }) =>
+    validateData(TOP_ASSET_VALIDATORS, asset, topAssetsUrl),
+  );
+  return topAssetsList;
+}
+
+// TODO: Replace `any` with type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function fetchTopAssets(chainId: any): Promise<any> {
+  const response = await fetchTopAssetsList(chainId);
   const topAssetsMap = response.reduce(
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (_topAssetsMap: any, asset: { address: string }, index: number) => {
-      if (validateData(TOP_ASSET_VALIDATORS, asset, topAssetsUrl)) {
-        return { ..._topAssetsMap, [asset.address]: { index: String(index) } };
-      }
-      return _topAssetsMap;
+      return { ..._topAssetsMap, [asset.address]: { index: String(index) } };
     },
     {},
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This change adds controller and redux methods for managing bridge page input fields (networks, src/dest chain, token, amounts)


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25541?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/METABRIDGE-866

## **Manual testing steps**
1. Run extension locally with `BRIDGE_USE_DEV_APIS=1`
2. Click on Bridge button
3. Network tab should show requests for src tokens and topAssets

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
