### PR TITLE
fix: fix network delete trash displayed on mouse over

### DIFF
--- a/ui/components/multichain/network-list-item/index.scss
+++ b/ui/components/multichain/network-list-item/index.scss
@@ -14,6 +14,14 @@
     color: inherit;
   }
 
+  &:hover,
+  &:focus,
+  &:focus-within {
+    .multichain-network-list-item__delete {
+      visibility: visible;
+    }
+  }
+
   &__network-name {
     width: 100%;
     flex: 1;
@@ -35,5 +43,9 @@
     position: absolute;
     top: 4px;
     left: 4px;
+  }
+
+  &__delete {
+    visibility: hidden;
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
the delete network trash logo should be displayed only when we have mouse over
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25547?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Add any popular network
2. Go to network modal
3. check if the trash icon is displayed without mouse over

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/MetaMask/metamask-extension/assets/26223211/b720aff8-54b7-4430-b267-4d3ed39a67e2


### **After**

<!-- [screenshots/recordings] -->

https://github.com/MetaMask/metamask-extension/assets/26223211/dd8783ee-a6a8-4a37-96c1-665d5a5a7ccb



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
