### PR TITLE
fix: fix percentage changes when balance is zero

### DIFF
--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.test.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.test.tsx
@@ -89,4 +89,13 @@ describe('PercentageChange Component', () => {
     expect(percentageElement).toBeInTheDocument();
     expect(numberElement).toBeInTheDocument();
   });
+
+  it('displays zero percentage with number in default color if balance is zero', () => {
+    mockGetSelectedAccountCachedBalance.mockReturnValue('0x0');
+    render(<PercentageAndAmountChange value={-1.234} />);
+    const percentageElement = screen.getByText('(+0.00%)');
+    const numberElement = screen.getByText('+$0.00');
+    expect(percentageElement).toBeInTheDocument();
+    expect(numberElement).toBeInTheDocument();
+  });
 });

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
@@ -105,17 +105,17 @@ export const PercentageAndAmountChange = ({
 
   let color = TextColor.textDefault;
 
-  if (isValidAmount(value)) {
-    if ((value as number) === 0) {
+  if (isValidAmount(balanceChange)) {
+    if ((balanceChange as number) === 0) {
       color = TextColor.textDefault;
-    } else if ((value as number) > 0) {
+    } else if ((balanceChange as number) > 0) {
       color = TextColor.successDefault;
     } else {
       color = TextColor.errorDefault;
     }
   }
 
-  const formattedValue = formatValue(value, true);
+  const formattedValue = formatValue(balanceChange === 0 ? 0 : value, true);
 
   const formattedValuePrice = isValidAmount(balanceChange)
     ? `${(balanceChange as number) >= 0 ? '+' : ''}${Intl.NumberFormat(locale, {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses a UI inconsistency observed in the account balance display, particularly when the account balance is at 0.00. Users have reported confusion over the display of a non-zero percentage change next to a +0.00 change in account value. This scenario occurs when there is no balance (neither in ETH nor in the selected fiat currency, USD in this case) in the user's account. The expectation is that if the account has not increased or decreased in value (due to having no balance), the displayed percentage change should also reflect a 0% change, aligning with the +$0.00 change displayed.

**Problem:** When the account balance is zero, the UI currently shows a +$0.00 change (as expected) but accompanies this with a non-zero percentage change (e.g., -1.74%), which is misleading and confusing to users. This discrepancy occurs despite the account's value not actually changing, given the lack of funds.

**Solution:** The proposed solution involves adjusting the logic that calculates and displays the percentage change in account value. Specifically, when the account balance is $0.00, the percentage change should also display as +0.00%, reflecting the true state of the account's value change (or lack thereof). This change ensures consistency in the UI and improves user understanding of their account's status.

**Implementation Details:**

Modify the calculation function to check for a $0.00 account balance condition. Upon detecting this condition, the function will automatically set the percentage change value to +0.00%.
Update the UI component responsible for displaying the percentage change to correctly render the +0.00% value when the account balance is zero.
Add unit tests to cover this scenario, ensuring that the percentage change correctly reflects a 0% change when the account balance is $0.00.
**Expected Outcome:** With this fix, users with a 0.00 account balance will see both a +0.00 change and a +0.00% change, eliminating confusion and providing a clearer understanding of their account's status. This update aims to enhance the user experience by ensuring consistency and clarity in the display of account value changes.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25550?quickstart=1)

## **Related issues**

Fixes: #25539 

## **Manual testing steps**

1. Go to the wallet page
2. Select account with 0 native token balance

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="803" alt="Screenshot 2024-06-27 at 11 41 18" src="https://github.com/MetaMask/metamask-extension/assets/26223211/8ea3c9ec-fba7-4d04-b209-b50383a01e08">

### **After**

<!-- [screenshots/recordings] -->
<img width="1079" alt="Screenshot 2024-06-27 at 11 41 39" src="https://github.com/MetaMask/metamask-extension/assets/26223211/5d2d71cb-7086-4338-bc32-4eaeb67e69e8">


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
