### PR TITLE
Patch selected network controller for v12.0.0

### DIFF
--- a/.yarn/patches/@metamask-selected-network-controller-npm-13.0.0-b0f6db473a.patch
+++ b/.yarn/patches/@metamask-selected-network-controller-npm-13.0.0-b0f6db473a.patch
@@ -1,0 +1,1469 @@
+diff --git a/dist/SelectedNetworkController.js b/dist/SelectedNetworkController.js
+index ca967cd382ba810dadd7ffa914d5a8aceb6f156a..4b4103f6dd6c13e72956daa9557d623ec2c832b6 100644
+--- a/dist/SelectedNetworkController.js
++++ b/dist/SelectedNetworkController.js
+@@ -4,12 +4,12 @@
+ 
+ 
+ 
+-var _chunkOGUVGN6Rjs = require('./chunk-OGUVGN6R.js');
++var _chunkCECZWJ42js = require('./chunk-CECZWJ42.js');
+ 
+ 
+ 
+ 
+ 
+ 
+-exports.METAMASK_DOMAIN = _chunkOGUVGN6Rjs.METAMASK_DOMAIN; exports.SelectedNetworkController = _chunkOGUVGN6Rjs.SelectedNetworkController; exports.SelectedNetworkControllerActionTypes = _chunkOGUVGN6Rjs.SelectedNetworkControllerActionTypes; exports.SelectedNetworkControllerEventTypes = _chunkOGUVGN6Rjs.SelectedNetworkControllerEventTypes; exports.controllerName = _chunkOGUVGN6Rjs.controllerName;
++exports.METAMASK_DOMAIN = _chunkCECZWJ42js.METAMASK_DOMAIN; exports.SelectedNetworkController = _chunkCECZWJ42js.SelectedNetworkController; exports.SelectedNetworkControllerActionTypes = _chunkCECZWJ42js.SelectedNetworkControllerActionTypes; exports.SelectedNetworkControllerEventTypes = _chunkCECZWJ42js.SelectedNetworkControllerEventTypes; exports.controllerName = _chunkCECZWJ42js.controllerName;
+ //# sourceMappingURL=SelectedNetworkController.js.map
+\ No newline at end of file
+diff --git a/dist/SelectedNetworkController.mjs b/dist/SelectedNetworkController.mjs
+index 5228bbe7acb3da6abb826f00670a1034c51a0514..d4b1f0cf8d8e6123df56be0b766e285968f8587c 100644
+--- a/dist/SelectedNetworkController.mjs
++++ b/dist/SelectedNetworkController.mjs
+@@ -4,7 +4,7 @@ import {
+   SelectedNetworkControllerActionTypes,
+   SelectedNetworkControllerEventTypes,
+   controllerName
+-} from "./chunk-S4D42VCM.mjs";
++} from "./chunk-7DSTEJNI.mjs";
+ export {
+   METAMASK_DOMAIN,
+   SelectedNetworkController,
+diff --git a/dist/SelectedNetworkMiddleware.js b/dist/SelectedNetworkMiddleware.js
+index 919f26ef57e8c6af5c63d1e0c8e85c43ec241e4a..0b9e434874a1ead6b596fa933597145ee40362d2 100644
+--- a/dist/SelectedNetworkMiddleware.js
++++ b/dist/SelectedNetworkMiddleware.js
+@@ -1,8 +1,8 @@
+ "use strict";Object.defineProperty(exports, "__esModule", {value: true});
+ 
+-var _chunk6W2ETVOHjs = require('./chunk-6W2ETVOH.js');
+-require('./chunk-OGUVGN6R.js');
++var _chunkANSSZMDIjs = require('./chunk-ANSSZMDI.js');
++require('./chunk-CECZWJ42.js');
+ 
+ 
+-exports.createSelectedNetworkMiddleware = _chunk6W2ETVOHjs.createSelectedNetworkMiddleware;
++exports.createSelectedNetworkMiddleware = _chunkANSSZMDIjs.createSelectedNetworkMiddleware;
+ //# sourceMappingURL=SelectedNetworkMiddleware.js.map
+\ No newline at end of file
+diff --git a/dist/SelectedNetworkMiddleware.mjs b/dist/SelectedNetworkMiddleware.mjs
+index a9031b4aa2589009c2f23d03f1d23a01044c4178..c3302c19f429473963d663e87340b33d9b2caf98 100644
+--- a/dist/SelectedNetworkMiddleware.mjs
++++ b/dist/SelectedNetworkMiddleware.mjs
+@@ -1,7 +1,7 @@
+ import {
+   createSelectedNetworkMiddleware
+-} from "./chunk-ZY7ETPVE.mjs";
+-import "./chunk-S4D42VCM.mjs";
++} from "./chunk-HFN7TKJS.mjs";
++import "./chunk-7DSTEJNI.mjs";
+ export {
+   createSelectedNetworkMiddleware
+ };
+diff --git a/dist/chunk-6W2ETVOH.js b/dist/chunk-6W2ETVOH.js
+deleted file mode 100644
+index 9714addd232767e296dd378a5cc0d57cafc9b882..0000000000000000000000000000000000000000
+--- a/dist/chunk-6W2ETVOH.js
++++ /dev/null
+@@ -1,23 +0,0 @@
+-"use strict";Object.defineProperty(exports, "__esModule", {value: true});
+-
+-var _chunkOGUVGN6Rjs = require('./chunk-OGUVGN6R.js');
+-
+-// src/SelectedNetworkMiddleware.ts
+-var createSelectedNetworkMiddleware = (messenger) => {
+-  const getNetworkClientIdForDomain = (origin) => messenger.call(
+-    _chunkOGUVGN6Rjs.SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
+-    origin
+-  );
+-  return (req, _, next) => {
+-    if (!req.origin) {
+-      throw new Error("Request object is lacking an 'origin'");
+-    }
+-    req.networkClientId = getNetworkClientIdForDomain(req.origin);
+-    return next();
+-  };
+-};
+-
+-
+-
+-exports.createSelectedNetworkMiddleware = createSelectedNetworkMiddleware;
+-//# sourceMappingURL=chunk-6W2ETVOH.js.map
+\ No newline at end of file
+diff --git a/dist/chunk-6W2ETVOH.js.map b/dist/chunk-6W2ETVOH.js.map
+deleted file mode 100644
+index 9fe4c1fd6e9b12bfd9091833618334f2c931098f..0000000000000000000000000000000000000000
+--- a/dist/chunk-6W2ETVOH.js.map
++++ /dev/null
+@@ -1 +0,0 @@
+-{"version":3,"sources":["../src/SelectedNetworkMiddleware.ts"],"names":[],"mappings":";;;;;AAYO,IAAM,kCAAkC,CAC7C,cAC2C;AAC3C,QAAM,8BAA8B,CAAC,WACnC,UAAU;AAAA,IACR,qCAAqC;AAAA,IACrC;AAAA,EACF;AAEF,SAAO,CAAC,KAA8C,GAAG,SAAS;AAChE,QAAI,CAAC,IAAI,QAAQ;AACf,YAAM,IAAI,MAAM,uCAAuC;AAAA,IACzD;AAEA,QAAI,kBAAkB,4BAA4B,IAAI,MAAM;AAC5D,WAAO,KAAK;AAAA,EACd;AACF","sourcesContent":["import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';\nimport type { NetworkClientId } from '@metamask/network-controller';\nimport type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';\n\nimport type { SelectedNetworkControllerMessenger } from './SelectedNetworkController';\nimport { SelectedNetworkControllerActionTypes } from './SelectedNetworkController';\n\nexport type SelectedNetworkMiddlewareJsonRpcRequest = JsonRpcRequest & {\n  networkClientId?: NetworkClientId;\n  origin?: string;\n};\n\nexport const createSelectedNetworkMiddleware = (\n  messenger: SelectedNetworkControllerMessenger,\n): JsonRpcMiddleware<JsonRpcParams, Json> => {\n  const getNetworkClientIdForDomain = (origin: string) =>\n    messenger.call(\n      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,\n      origin,\n    );\n\n  return (req: SelectedNetworkMiddlewareJsonRpcRequest, _, next) => {\n    if (!req.origin) {\n      throw new Error(\"Request object is lacking an 'origin'\");\n    }\n\n    req.networkClientId = getNetworkClientIdForDomain(req.origin);\n    return next();\n  };\n};\n"]}
+\ No newline at end of file
+diff --git a/dist/chunk-7DSTEJNI.mjs b/dist/chunk-7DSTEJNI.mjs
+new file mode 100644
+index 0000000000000000000000000000000000000000..1902ab28e3c37d563704840e31fdbc885db5354c
+--- /dev/null
++++ b/dist/chunk-7DSTEJNI.mjs
+@@ -0,0 +1,284 @@
++var __accessCheck = (obj, member, msg) => {
++  if (!member.has(obj))
++    throw TypeError("Cannot " + msg);
++};
++var __privateGet = (obj, member, getter) => {
++  __accessCheck(obj, member, "read from private field");
++  return getter ? getter.call(obj) : member.get(obj);
++};
++var __privateAdd = (obj, member, value) => {
++  if (member.has(obj))
++    throw TypeError("Cannot add the same private member more than once");
++  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
++};
++var __privateSet = (obj, member, value, setter) => {
++  __accessCheck(obj, member, "write to private field");
++  setter ? setter.call(obj, value) : member.set(obj, value);
++  return value;
++};
++var __privateMethod = (obj, member, method) => {
++  __accessCheck(obj, member, "access private method");
++  return method;
++};
++
++// src/SelectedNetworkController.ts
++import { BaseController } from "@metamask/base-controller";
++import { createEventEmitterProxy } from "@metamask/swappable-obj-proxy";
++var controllerName = "SelectedNetworkController";
++var stateMetadata = {
++  domains: { persist: true, anonymous: false }
++};
++var getDefaultState = () => ({ domains: {} });
++var snapsPrefixes = ["npm:", "local:"];
++var METAMASK_DOMAIN = "metamask";
++var SelectedNetworkControllerActionTypes = {
++  getState: `${controllerName}:getState`,
++  getNetworkClientIdForDomain: `${controllerName}:getNetworkClientIdForDomain`,
++  setNetworkClientIdForDomain: `${controllerName}:setNetworkClientIdForDomain`
++};
++var SelectedNetworkControllerEventTypes = {
++  stateChange: `${controllerName}:stateChange`
++};
++var _domainProxyMap, _useRequestQueuePreference, _registerMessageHandlers, registerMessageHandlers_fn, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn, _domainHasPermissions, domainHasPermissions_fn, _resetAllPermissionedDomains, resetAllPermissionedDomains_fn;
++var SelectedNetworkController = class extends BaseController {
++  /**
++   * Construct a SelectedNetworkController controller.
++   *
++   * @param options - The controller options.
++   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
++   * @param options.state - The controllers initial state.
++   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.
++   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.
++   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.
++   */
++  constructor({
++    messenger,
++    state = getDefaultState(),
++    useRequestQueuePreference,
++    onPreferencesStateChange,
++    domainProxyMap
++  }) {
++    super({
++      name: controllerName,
++      metadata: stateMetadata,
++      messenger,
++      state
++    });
++    __privateAdd(this, _registerMessageHandlers);
++    __privateAdd(this, _setNetworkClientIdForDomain);
++    /**
++     * This method is used when a domain is removed from the PermissionsController.
++     * It will remove re-point the network proxy to the globally selected network in the domainProxyMap or, if no globally selected network client is available, delete the proxy.
++     *
++     * @param domain - The domain for which to unset the network client ID.
++     */
++    __privateAdd(this, _unsetNetworkClientIdForDomain);
++    __privateAdd(this, _domainHasPermissions);
++    // Loop through all domains and for those with permissions it points that domain's proxy
++    // to an unproxied instance of the globally selected network client.
++    // NOT the NetworkController's proxy of the globally selected networkClient
++    __privateAdd(this, _resetAllPermissionedDomains);
++    __privateAdd(this, _domainProxyMap, void 0);
++    __privateAdd(this, _useRequestQueuePreference, void 0);
++    __privateSet(this, _useRequestQueuePreference, useRequestQueuePreference);
++    __privateSet(this, _domainProxyMap, domainProxyMap);
++    __privateMethod(this, _registerMessageHandlers, registerMessageHandlers_fn).call(this);
++    this.messagingSystem.call("PermissionController:getSubjectNames").filter((domain) => this.state.domains[domain] === void 0).forEach(
++      (domain) => this.setNetworkClientIdForDomain(
++        domain,
++        this.messagingSystem.call("NetworkController:getState").selectedNetworkClientId
++      )
++    );
++    this.messagingSystem.subscribe(
++      "PermissionController:stateChange",
++      (_, patches) => {
++        patches.forEach(({ op, path }) => {
++          const isChangingSubject = path[0] === "subjects" && path[1] !== void 0;
++          if (isChangingSubject && typeof path[1] === "string") {
++            const domain = path[1];
++            if (op === "add" && this.state.domains[domain] === void 0) {
++              this.setNetworkClientIdForDomain(
++                domain,
++                this.messagingSystem.call("NetworkController:getState").selectedNetworkClientId
++              );
++            } else if (op === "remove" && this.state.domains[domain] !== void 0) {
++              __privateMethod(this, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn).call(this, domain);
++            }
++          }
++        });
++      }
++    );
++    this.messagingSystem.subscribe(
++      "NetworkController:stateChange",
++      ({ selectedNetworkClientId }, patches) => {
++        patches.forEach(({ op, path }) => {
++          if (op === "remove" && path[0] === "networkConfigurations") {
++            const removedNetworkClientId = path[1];
++            Object.entries(this.state.domains).forEach(
++              ([domain, networkClientIdForDomain]) => {
++                if (networkClientIdForDomain === removedNetworkClientId) {
++                  this.setNetworkClientIdForDomain(
++                    domain,
++                    selectedNetworkClientId
++                  );
++                }
++              }
++            );
++          }
++        });
++      }
++    );
++    onPreferencesStateChange(({ useRequestQueue }) => {
++      if (__privateGet(this, _useRequestQueuePreference) !== useRequestQueue) {
++        if (!useRequestQueue) {
++          Object.keys(this.state.domains).forEach((domain) => {
++            __privateMethod(this, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn).call(this, domain);
++          });
++        } else {
++          __privateMethod(this, _resetAllPermissionedDomains, resetAllPermissionedDomains_fn).call(this);
++        }
++        __privateSet(this, _useRequestQueuePreference, useRequestQueue);
++      }
++    });
++  }
++  setNetworkClientIdForDomain(domain, networkClientId) {
++    if (!__privateGet(this, _useRequestQueuePreference)) {
++      return;
++    }
++    if (domain === METAMASK_DOMAIN) {
++      throw new Error(
++        `NetworkClientId for domain "${METAMASK_DOMAIN}" cannot be set on the SelectedNetworkController`
++      );
++    }
++    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
++      return;
++    }
++    if (!__privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
++      throw new Error(
++        "NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions"
++      );
++    }
++    __privateMethod(this, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn).call(this, domain, networkClientId);
++  }
++  getNetworkClientIdForDomain(domain) {
++    const { selectedNetworkClientId: metamaskSelectedNetworkClientId } = this.messagingSystem.call("NetworkController:getState");
++    if (!__privateGet(this, _useRequestQueuePreference)) {
++      return metamaskSelectedNetworkClientId;
++    }
++    return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;
++  }
++  /**
++   * Accesses the provider and block tracker for the currently selected network.
++   *
++   * @param domain - the domain for the provider
++   * @returns The proxy and block tracker proxies.
++   */
++  getProviderAndBlockTracker(domain) {
++    if (domain === METAMASK_DOMAIN || snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
++      const networkClient = this.messagingSystem.call(
++        "NetworkController:getSelectedNetworkClient"
++      );
++      if (networkClient === void 0) {
++        throw new Error("Selected network not initialized");
++      }
++      return networkClient;
++    }
++    let networkProxy = __privateGet(this, _domainProxyMap).get(domain);
++    if (networkProxy === void 0) {
++      let networkClient;
++      if (__privateGet(this, _useRequestQueuePreference) && __privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
++        const networkClientId = this.getNetworkClientIdForDomain(domain);
++        networkClient = this.messagingSystem.call(
++          "NetworkController:getNetworkClientById",
++          networkClientId
++        );
++      } else {
++        networkClient = this.messagingSystem.call(
++          "NetworkController:getSelectedNetworkClient"
++        );
++        if (networkClient === void 0) {
++          throw new Error("Selected network not initialized");
++        }
++      }
++      networkProxy = {
++        provider: createEventEmitterProxy(networkClient.provider),
++        blockTracker: createEventEmitterProxy(networkClient.blockTracker, {
++          eventFilter: "skipInternal"
++        })
++      };
++      __privateGet(this, _domainProxyMap).set(domain, networkProxy);
++    }
++    return networkProxy;
++  }
++};
++_domainProxyMap = new WeakMap();
++_useRequestQueuePreference = new WeakMap();
++_registerMessageHandlers = new WeakSet();
++registerMessageHandlers_fn = function() {
++  this.messagingSystem.registerActionHandler(
++    SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
++    this.getNetworkClientIdForDomain.bind(this)
++  );
++  this.messagingSystem.registerActionHandler(
++    SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,
++    this.setNetworkClientIdForDomain.bind(this)
++  );
++};
++_setNetworkClientIdForDomain = new WeakSet();
++setNetworkClientIdForDomain_fn = function(domain, networkClientId) {
++  const networkClient = this.messagingSystem.call(
++    "NetworkController:getNetworkClientById",
++    networkClientId
++  );
++  const networkProxy = this.getProviderAndBlockTracker(domain);
++  networkProxy.provider.setTarget(networkClient.provider);
++  networkProxy.blockTracker.setTarget(networkClient.blockTracker);
++  this.update((state) => {
++    state.domains[domain] = networkClientId;
++  });
++};
++_unsetNetworkClientIdForDomain = new WeakSet();
++unsetNetworkClientIdForDomain_fn = function(domain) {
++  const globallySelectedNetworkClient = this.messagingSystem.call(
++    "NetworkController:getSelectedNetworkClient"
++  );
++  const networkProxy = __privateGet(this, _domainProxyMap).get(domain);
++  if (networkProxy && globallySelectedNetworkClient) {
++    networkProxy.provider.setTarget(globallySelectedNetworkClient.provider);
++    networkProxy.blockTracker.setTarget(
++      globallySelectedNetworkClient.blockTracker
++    );
++  } else if (networkProxy) {
++    __privateGet(this, _domainProxyMap).delete(domain);
++  }
++  this.update((state) => {
++    delete state.domains[domain];
++  });
++};
++_domainHasPermissions = new WeakSet();
++domainHasPermissions_fn = function(domain) {
++  return this.messagingSystem.call(
++    "PermissionController:hasPermissions",
++    domain
++  );
++};
++_resetAllPermissionedDomains = new WeakSet();
++resetAllPermissionedDomains_fn = function() {
++  __privateGet(this, _domainProxyMap).forEach((_, domain) => {
++    const { selectedNetworkClientId } = this.messagingSystem.call(
++      "NetworkController:getState"
++    );
++    if (__privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
++      __privateMethod(this, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn).call(this, domain, selectedNetworkClientId);
++    }
++  });
++};
++
++export {
++  controllerName,
++  METAMASK_DOMAIN,
++  SelectedNetworkControllerActionTypes,
++  SelectedNetworkControllerEventTypes,
++  SelectedNetworkController
++};
++//# sourceMappingURL=chunk-7DSTEJNI.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-7DSTEJNI.mjs.map b/dist/chunk-7DSTEJNI.mjs.map
+new file mode 100644
+index 0000000000000000000000000000000000000000..33fde9b65d7c89592b3754333e6c1f62a0d90f63
+--- /dev/null
++++ b/dist/chunk-7DSTEJNI.mjs.map
+@@ -0,0 +1 @@
++{"version":3,"sources":["../src/SelectedNetworkController.ts"],"sourcesContent":["import type { RestrictedControllerMessenger } from '@metamask/base-controller';\nimport { BaseController } from '@metamask/base-controller';\nimport type {\n  BlockTrackerProxy,\n  NetworkClientId,\n  NetworkControllerGetNetworkClientByIdAction,\n  NetworkControllerGetSelectedNetworkClientAction,\n  NetworkControllerGetStateAction,\n  NetworkControllerStateChangeEvent,\n  ProviderProxy,\n} from '@metamask/network-controller';\nimport type {\n  PermissionControllerStateChange,\n  GetSubjects as PermissionControllerGetSubjectsAction,\n  HasPermissions as PermissionControllerHasPermissions,\n} from '@metamask/permission-controller';\nimport { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';\nimport type { Patch } from 'immer';\n\nexport const controllerName = 'SelectedNetworkController';\n\nconst stateMetadata = {\n  domains: { persist: true, anonymous: false },\n};\n\nconst getDefaultState = () => ({ domains: {} });\n\n// npm and local are currently the only valid prefixes for snap domains\n// TODO: eventually we maybe want to pull this in from snaps-utils to ensure it stays in sync\n// For now it seems like overkill to add a dependency for this one constant\n// https://github.com/MetaMask/snaps/blob/2beee7803bfe9e540788a3558b546b9f55dc3cb4/packages/snaps-utils/src/types.ts#L120\nconst snapsPrefixes = ['npm:', 'local:'] as const;\n\nexport type Domain = string;\n\nexport const METAMASK_DOMAIN = 'metamask' as const;\n\nexport const SelectedNetworkControllerActionTypes = {\n  getState: `${controllerName}:getState` as const,\n  getNetworkClientIdForDomain:\n    `${controllerName}:getNetworkClientIdForDomain` as const,\n  setNetworkClientIdForDomain:\n    `${controllerName}:setNetworkClientIdForDomain` as const,\n};\n\nexport const SelectedNetworkControllerEventTypes = {\n  stateChange: `${controllerName}:stateChange` as const,\n};\n\nexport type SelectedNetworkControllerState = {\n  domains: Record<Domain, NetworkClientId>;\n};\n\nexport type SelectedNetworkControllerStateChangeEvent = {\n  type: typeof SelectedNetworkControllerEventTypes.stateChange;\n  payload: [SelectedNetworkControllerState, Patch[]];\n};\n\nexport type SelectedNetworkControllerGetSelectedNetworkStateAction = {\n  type: typeof SelectedNetworkControllerActionTypes.getState;\n  handler: () => SelectedNetworkControllerState;\n};\n\nexport type SelectedNetworkControllerGetNetworkClientIdForDomainAction = {\n  type: typeof SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain;\n  handler: SelectedNetworkController['getNetworkClientIdForDomain'];\n};\n\nexport type SelectedNetworkControllerSetNetworkClientIdForDomainAction = {\n  type: typeof SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain;\n  handler: SelectedNetworkController['setNetworkClientIdForDomain'];\n};\n\nexport type SelectedNetworkControllerActions =\n  | SelectedNetworkControllerGetSelectedNetworkStateAction\n  | SelectedNetworkControllerGetNetworkClientIdForDomainAction\n  | SelectedNetworkControllerSetNetworkClientIdForDomainAction;\n\nexport type AllowedActions =\n  | NetworkControllerGetNetworkClientByIdAction\n  | NetworkControllerGetSelectedNetworkClientAction\n  | NetworkControllerGetStateAction\n  | PermissionControllerHasPermissions\n  | PermissionControllerGetSubjectsAction;\n\nexport type SelectedNetworkControllerEvents =\n  SelectedNetworkControllerStateChangeEvent;\n\nexport type AllowedEvents =\n  | NetworkControllerStateChangeEvent\n  | PermissionControllerStateChange;\n\nexport type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<\n  typeof controllerName,\n  SelectedNetworkControllerActions | AllowedActions,\n  SelectedNetworkControllerEvents | AllowedEvents,\n  AllowedActions['type'],\n  AllowedEvents['type']\n>;\n\nexport type SelectedNetworkControllerOptions = {\n  state?: SelectedNetworkControllerState;\n  messenger: SelectedNetworkControllerMessenger;\n  useRequestQueuePreference: boolean;\n  onPreferencesStateChange: (\n    listener: (preferencesState: { useRequestQueue: boolean }) => void,\n  ) => void;\n  domainProxyMap: Map<Domain, NetworkProxy>;\n};\n\nexport type NetworkProxy = {\n  provider: ProviderProxy;\n  blockTracker: BlockTrackerProxy;\n};\n\n/**\n * Controller for getting and setting the network for a particular domain.\n */\nexport class SelectedNetworkController extends BaseController<\n  typeof controllerName,\n  SelectedNetworkControllerState,\n  SelectedNetworkControllerMessenger\n> {\n  #domainProxyMap: Map<Domain, NetworkProxy>;\n\n  #useRequestQueuePreference: boolean;\n\n  /**\n   * Construct a SelectedNetworkController controller.\n   *\n   * @param options - The controller options.\n   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.\n   * @param options.state - The controllers initial state.\n   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.\n   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.\n   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.\n   */\n  constructor({\n    messenger,\n    state = getDefaultState(),\n    useRequestQueuePreference,\n    onPreferencesStateChange,\n    domainProxyMap,\n  }: SelectedNetworkControllerOptions) {\n    super({\n      name: controllerName,\n      metadata: stateMetadata,\n      messenger,\n      state,\n    });\n    this.#useRequestQueuePreference = useRequestQueuePreference;\n    this.#domainProxyMap = domainProxyMap;\n    this.#registerMessageHandlers();\n\n    // this is fetching all the dapp permissions from the PermissionsController and looking for any domains that are not in domains state in this controller. Then we take any missing domains and add them to state here, setting it with the globally selected networkClientId (fetched from the NetworkController)\n    this.messagingSystem\n      .call('PermissionController:getSubjectNames')\n      .filter((domain) => this.state.domains[domain] === undefined)\n      .forEach((domain) =>\n        this.setNetworkClientIdForDomain(\n          domain,\n          this.messagingSystem.call('NetworkController:getState')\n            .selectedNetworkClientId,\n        ),\n      );\n\n    this.messagingSystem.subscribe(\n      'PermissionController:stateChange',\n      (_, patches) => {\n        patches.forEach(({ op, path }) => {\n          const isChangingSubject =\n            path[0] === 'subjects' && path[1] !== undefined;\n          if (isChangingSubject && typeof path[1] === 'string') {\n            const domain = path[1];\n            if (op === 'add' && this.state.domains[domain] === undefined) {\n              this.setNetworkClientIdForDomain(\n                domain,\n                this.messagingSystem.call('NetworkController:getState')\n                  .selectedNetworkClientId,\n              );\n            } else if (\n              op === 'remove' &&\n              this.state.domains[domain] !== undefined\n            ) {\n              this.#unsetNetworkClientIdForDomain(domain);\n            }\n          }\n        });\n      },\n    );\n\n    this.messagingSystem.subscribe(\n      'NetworkController:stateChange',\n      ({ selectedNetworkClientId }, patches) => {\n        patches.forEach(({ op, path }) => {\n          // if a network is removed, update the networkClientId for all domains that were using it to the selected network\n          if (op === 'remove' && path[0] === 'networkConfigurations') {\n            const removedNetworkClientId = path[1] as NetworkClientId;\n            Object.entries(this.state.domains).forEach(\n              ([domain, networkClientIdForDomain]) => {\n                if (networkClientIdForDomain === removedNetworkClientId) {\n                  this.setNetworkClientIdForDomain(\n                    domain,\n                    selectedNetworkClientId,\n                  );\n                }\n              },\n            );\n          }\n        });\n      },\n    );\n\n    onPreferencesStateChange(({ useRequestQueue }) => {\n      if (this.#useRequestQueuePreference !== useRequestQueue) {\n        if (!useRequestQueue) {\n          // Loop through all domains and points each domain's proxy\n          // to the NetworkController's own proxy of the globally selected networkClient\n          Object.keys(this.state.domains).forEach((domain) => {\n            this.#unsetNetworkClientIdForDomain(domain);\n          });\n        } else {\n          this.#resetAllPermissionedDomains();\n        }\n        this.#useRequestQueuePreference = useRequestQueue;\n      }\n    });\n  }\n\n  #registerMessageHandlers(): void {\n    this.messagingSystem.registerActionHandler(\n      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,\n      this.getNetworkClientIdForDomain.bind(this),\n    );\n    this.messagingSystem.registerActionHandler(\n      SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,\n      this.setNetworkClientIdForDomain.bind(this),\n    );\n  }\n\n  #setNetworkClientIdForDomain(\n    domain: Domain,\n    networkClientId: NetworkClientId,\n  ) {\n    const networkClient = this.messagingSystem.call(\n      'NetworkController:getNetworkClientById',\n      networkClientId,\n    );\n    const networkProxy = this.getProviderAndBlockTracker(domain);\n    networkProxy.provider.setTarget(networkClient.provider);\n    networkProxy.blockTracker.setTarget(networkClient.blockTracker);\n\n    this.update((state) => {\n      state.domains[domain] = networkClientId;\n    });\n  }\n\n  /**\n   * This method is used when a domain is removed from the PermissionsController.\n   * It will remove re-point the network proxy to the globally selected network in the domainProxyMap or, if no globally selected network client is available, delete the proxy.\n   *\n   * @param domain - The domain for which to unset the network client ID.\n   */\n  #unsetNetworkClientIdForDomain(domain: Domain) {\n    const globallySelectedNetworkClient = this.messagingSystem.call(\n      'NetworkController:getSelectedNetworkClient',\n    );\n    const networkProxy = this.#domainProxyMap.get(domain);\n    if (networkProxy && globallySelectedNetworkClient) {\n      networkProxy.provider.setTarget(globallySelectedNetworkClient.provider);\n      networkProxy.blockTracker.setTarget(\n        globallySelectedNetworkClient.blockTracker,\n      );\n    } else if (networkProxy) {\n      this.#domainProxyMap.delete(domain);\n    }\n    this.update((state) => {\n      delete state.domains[domain];\n    });\n  }\n\n  #domainHasPermissions(domain: Domain): boolean {\n    return this.messagingSystem.call(\n      'PermissionController:hasPermissions',\n      domain,\n    );\n  }\n\n  // Loop through all domains and for those with permissions it points that domain's proxy\n  // to an unproxied instance of the globally selected network client.\n  // NOT the NetworkController's proxy of the globally selected networkClient\n  #resetAllPermissionedDomains() {\n    this.#domainProxyMap.forEach((_: NetworkProxy, domain: string) => {\n      const { selectedNetworkClientId } = this.messagingSystem.call(\n        'NetworkController:getState',\n      );\n      // can't use public setNetworkClientIdForDomain because it will throw an error\n      // rather than simply skip if the domain doesn't have permissions which can happen\n      // in this case since proxies are added for each site the user visits\n      if (this.#domainHasPermissions(domain)) {\n        this.#setNetworkClientIdForDomain(domain, selectedNetworkClientId);\n      }\n    });\n  }\n\n  setNetworkClientIdForDomain(\n    domain: Domain,\n    networkClientId: NetworkClientId,\n  ) {\n    // Core PR: https://github.com/MetaMask/core/pull/4388\n    // Patch Branch: patch-selected-network-controller-13.0.0-setNetworkClient-guard\n    if (!this.#useRequestQueuePreference) {\n      return;\n    }\n    if (domain === METAMASK_DOMAIN) {\n      throw new Error(\n        `NetworkClientId for domain \"${METAMASK_DOMAIN}\" cannot be set on the SelectedNetworkController`,\n      );\n    }\n\n    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {\n      return;\n    }\n\n    if (!this.#domainHasPermissions(domain)) {\n      throw new Error(\n        'NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions',\n      );\n    }\n\n    this.#setNetworkClientIdForDomain(domain, networkClientId);\n  }\n\n  getNetworkClientIdForDomain(domain: Domain): NetworkClientId {\n    const { selectedNetworkClientId: metamaskSelectedNetworkClientId } =\n      this.messagingSystem.call('NetworkController:getState');\n    if (!this.#useRequestQueuePreference) {\n      return metamaskSelectedNetworkClientId;\n    }\n    return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;\n  }\n\n  /**\n   * Accesses the provider and block tracker for the currently selected network.\n   *\n   * @param domain - the domain for the provider\n   * @returns The proxy and block tracker proxies.\n   */\n  getProviderAndBlockTracker(domain: Domain): NetworkProxy {\n    // If the domain is 'metamask' or a snap, return the NetworkController's globally selected network client proxy\n    if (\n      domain === METAMASK_DOMAIN ||\n      snapsPrefixes.some((prefix) => domain.startsWith(prefix))\n    ) {\n      const networkClient = this.messagingSystem.call(\n        'NetworkController:getSelectedNetworkClient',\n      );\n      if (networkClient === undefined) {\n        throw new Error('Selected network not initialized');\n      }\n      return networkClient;\n    }\n\n    let networkProxy = this.#domainProxyMap.get(domain);\n    if (networkProxy === undefined) {\n      let networkClient;\n      if (\n        this.#useRequestQueuePreference &&\n        this.#domainHasPermissions(domain)\n      ) {\n        const networkClientId = this.getNetworkClientIdForDomain(domain);\n        networkClient = this.messagingSystem.call(\n          'NetworkController:getNetworkClientById',\n          networkClientId,\n        );\n      } else {\n        networkClient = this.messagingSystem.call(\n          'NetworkController:getSelectedNetworkClient',\n        );\n        if (networkClient === undefined) {\n          throw new Error('Selected network not initialized');\n        }\n      }\n      networkProxy = {\n        provider: createEventEmitterProxy(networkClient.provider),\n        blockTracker: createEventEmitterProxy(networkClient.blockTracker, {\n          eventFilter: 'skipInternal',\n        }),\n      };\n      this.#domainProxyMap.set(domain, networkProxy);\n    }\n    return networkProxy;\n  }\n}\n"],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;AACA,SAAS,sBAAsB;AAe/B,SAAS,+BAA+B;AAGjC,IAAM,iBAAiB;AAE9B,IAAM,gBAAgB;AAAA,EACpB,SAAS,EAAE,SAAS,MAAM,WAAW,MAAM;AAC7C;AAEA,IAAM,kBAAkB,OAAO,EAAE,SAAS,CAAC,EAAE;AAM7C,IAAM,gBAAgB,CAAC,QAAQ,QAAQ;AAIhC,IAAM,kBAAkB;AAExB,IAAM,uCAAuC;AAAA,EAClD,UAAU,GAAG,cAAc;AAAA,EAC3B,6BACE,GAAG,cAAc;AAAA,EACnB,6BACE,GAAG,cAAc;AACrB;AAEO,IAAM,sCAAsC;AAAA,EACjD,aAAa,GAAG,cAAc;AAChC;AA/CA;AAsHO,IAAM,4BAAN,cAAwC,eAI7C;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAeA,YAAY;AAAA,IACV;AAAA,IACA,QAAQ,gBAAgB;AAAA,IACxB;AAAA,IACA;AAAA,IACA;AAAA,EACF,GAAqC;AACnC,UAAM;AAAA,MACJ,MAAM;AAAA,MACN,UAAU;AAAA,MACV;AAAA,MACA;AAAA,IACF,CAAC;AAgFH;AAWA;AAuBA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAkBA;AAUA;AAAA;AAAA;AAAA;AAxKA;AAEA;AAyBE,uBAAK,4BAA6B;AAClC,uBAAK,iBAAkB;AACvB,0BAAK,sDAAL;AAGA,SAAK,gBACF,KAAK,sCAAsC,EAC3C,OAAO,CAAC,WAAW,KAAK,MAAM,QAAQ,MAAM,MAAM,MAAS,EAC3D;AAAA,MAAQ,CAAC,WACR,KAAK;AAAA,QACH;AAAA,QACA,KAAK,gBAAgB,KAAK,4BAA4B,EACnD;AAAA,MACL;AAAA,IACF;AAEF,SAAK,gBAAgB;AAAA,MACnB;AAAA,MACA,CAAC,GAAG,YAAY;AACd,gBAAQ,QAAQ,CAAC,EAAE,IAAI,KAAK,MAAM;AAChC,gBAAM,oBACJ,KAAK,CAAC,MAAM,cAAc,KAAK,CAAC,MAAM;AACxC,cAAI,qBAAqB,OAAO,KAAK,CAAC,MAAM,UAAU;AACpD,kBAAM,SAAS,KAAK,CAAC;AACrB,gBAAI,OAAO,SAAS,KAAK,MAAM,QAAQ,MAAM,MAAM,QAAW;AAC5D,mBAAK;AAAA,gBACH;AAAA,gBACA,KAAK,gBAAgB,KAAK,4BAA4B,EACnD;AAAA,cACL;AAAA,YACF,WACE,OAAO,YACP,KAAK,MAAM,QAAQ,MAAM,MAAM,QAC/B;AACA,oCAAK,kEAAL,WAAoC;AAAA,YACtC;AAAA,UACF;AAAA,QACF,CAAC;AAAA,MACH;AAAA,IACF;AAEA,SAAK,gBAAgB;AAAA,MACnB;AAAA,MACA,CAAC,EAAE,wBAAwB,GAAG,YAAY;AACxC,gBAAQ,QAAQ,CAAC,EAAE,IAAI,KAAK,MAAM;AAEhC,cAAI,OAAO,YAAY,KAAK,CAAC,MAAM,yBAAyB;AAC1D,kBAAM,yBAAyB,KAAK,CAAC;AACrC,mBAAO,QAAQ,KAAK,MAAM,OAAO,EAAE;AAAA,cACjC,CAAC,CAAC,QAAQ,wBAAwB,MAAM;AACtC,oBAAI,6BAA6B,wBAAwB;AACvD,uBAAK;AAAA,oBACH;AAAA,oBACA;AAAA,kBACF;AAAA,gBACF;AAAA,cACF;AAAA,YACF;AAAA,UACF;AAAA,QACF,CAAC;AAAA,MACH;AAAA,IACF;AAEA,6BAAyB,CAAC,EAAE,gBAAgB,MAAM;AAChD,UAAI,mBAAK,gCAA+B,iBAAiB;AACvD,YAAI,CAAC,iBAAiB;AAGpB,iBAAO,KAAK,KAAK,MAAM,OAAO,EAAE,QAAQ,CAAC,WAAW;AAClD,kCAAK,kEAAL,WAAoC;AAAA,UACtC,CAAC;AAAA,QACH,OAAO;AACL,gCAAK,8DAAL;AAAA,QACF;AACA,2BAAK,4BAA6B;AAAA,MACpC;AAAA,IACF,CAAC;AAAA,EACH;AAAA,EA8EA,4BACE,QACA,iBACA;AAGA,QAAI,CAAC,mBAAK,6BAA4B;AACpC;AAAA,IACF;AACA,QAAI,WAAW,iBAAiB;AAC9B,YAAM,IAAI;AAAA,QACR,+BAA+B,eAAe;AAAA,MAChD;AAAA,IACF;AAEA,QAAI,cAAc,KAAK,CAAC,WAAW,OAAO,WAAW,MAAM,CAAC,GAAG;AAC7D;AAAA,IACF;AAEA,QAAI,CAAC,sBAAK,gDAAL,WAA2B,SAAS;AACvC,YAAM,IAAI;AAAA,QACR;AAAA,MACF;AAAA,IACF;AAEA,0BAAK,8DAAL,WAAkC,QAAQ;AAAA,EAC5C;AAAA,EAEA,4BAA4B,QAAiC;AAC3D,UAAM,EAAE,yBAAyB,gCAAgC,IAC/D,KAAK,gBAAgB,KAAK,4BAA4B;AACxD,QAAI,CAAC,mBAAK,6BAA4B;AACpC,aAAO;AAAA,IACT;AACA,WAAO,KAAK,MAAM,QAAQ,MAAM,KAAK;AAAA,EACvC;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAQA,2BAA2B,QAA8B;AAEvD,QACE,WAAW,mBACX,cAAc,KAAK,CAAC,WAAW,OAAO,WAAW,MAAM,CAAC,GACxD;AACA,YAAM,gBAAgB,KAAK,gBAAgB;AAAA,QACzC;AAAA,MACF;AACA,UAAI,kBAAkB,QAAW;AAC/B,cAAM,IAAI,MAAM,kCAAkC;AAAA,MACpD;AACA,aAAO;AAAA,IACT;AAEA,QAAI,eAAe,mBAAK,iBAAgB,IAAI,MAAM;AAClD,QAAI,iBAAiB,QAAW;AAC9B,UAAI;AACJ,UACE,mBAAK,+BACL,sBAAK,gDAAL,WAA2B,SAC3B;AACA,cAAM,kBAAkB,KAAK,4BAA4B,MAAM;AAC/D,wBAAgB,KAAK,gBAAgB;AAAA,UACnC;AAAA,UACA;AAAA,QACF;AAAA,MACF,OAAO;AACL,wBAAgB,KAAK,gBAAgB;AAAA,UACnC;AAAA,QACF;AACA,YAAI,kBAAkB,QAAW;AAC/B,gBAAM,IAAI,MAAM,kCAAkC;AAAA,QACpD;AAAA,MACF;AACA,qBAAe;AAAA,QACb,UAAU,wBAAwB,cAAc,QAAQ;AAAA,QACxD,cAAc,wBAAwB,cAAc,cAAc;AAAA,UAChE,aAAa;AAAA,QACf,CAAC;AAAA,MACH;AACA,yBAAK,iBAAgB,IAAI,QAAQ,YAAY;AAAA,IAC/C;AACA,WAAO;AAAA,EACT;AACF;AA9QE;AAEA;AAwGA;AAAA,6BAAwB,WAAS;AAC/B,OAAK,gBAAgB;AAAA,IACnB,qCAAqC;AAAA,IACrC,KAAK,4BAA4B,KAAK,IAAI;AAAA,EAC5C;AACA,OAAK,gBAAgB;AAAA,IACnB,qCAAqC;AAAA,IACrC,KAAK,4BAA4B,KAAK,IAAI;AAAA,EAC5C;AACF;AAEA;AAAA,iCAA4B,SAC1B,QACA,iBACA;AACA,QAAM,gBAAgB,KAAK,gBAAgB;AAAA,IACzC;AAAA,IACA;AAAA,EACF;AACA,QAAM,eAAe,KAAK,2BAA2B,MAAM;AAC3D,eAAa,SAAS,UAAU,cAAc,QAAQ;AACtD,eAAa,aAAa,UAAU,cAAc,YAAY;AAE9D,OAAK,OAAO,CAAC,UAAU;AACrB,UAAM,QAAQ,MAAM,IAAI;AAAA,EAC1B,CAAC;AACH;AAQA;AAAA,mCAA8B,SAAC,QAAgB;AAC7C,QAAM,gCAAgC,KAAK,gBAAgB;AAAA,IACzD;AAAA,EACF;AACA,QAAM,eAAe,mBAAK,iBAAgB,IAAI,MAAM;AACpD,MAAI,gBAAgB,+BAA+B;AACjD,iBAAa,SAAS,UAAU,8BAA8B,QAAQ;AACtE,iBAAa,aAAa;AAAA,MACxB,8BAA8B;AAAA,IAChC;AAAA,EACF,WAAW,cAAc;AACvB,uBAAK,iBAAgB,OAAO,MAAM;AAAA,EACpC;AACA,OAAK,OAAO,CAAC,UAAU;AACrB,WAAO,MAAM,QAAQ,MAAM;AAAA,EAC7B,CAAC;AACH;AAEA;AAAA,0BAAqB,SAAC,QAAyB;AAC7C,SAAO,KAAK,gBAAgB;AAAA,IAC1B;AAAA,IACA;AAAA,EACF;AACF;AAKA;AAAA,iCAA4B,WAAG;AAC7B,qBAAK,iBAAgB,QAAQ,CAAC,GAAiB,WAAmB;AAChE,UAAM,EAAE,wBAAwB,IAAI,KAAK,gBAAgB;AAAA,MACvD;AAAA,IACF;AAIA,QAAI,sBAAK,gDAAL,WAA2B,SAAS;AACtC,4BAAK,8DAAL,WAAkC,QAAQ;AAAA,IAC5C;AAAA,EACF,CAAC;AACH;","names":[]}
+\ No newline at end of file
+diff --git a/dist/chunk-ANSSZMDI.js b/dist/chunk-ANSSZMDI.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..46fa6599a0d673a526cc2d054a47733fc0570e64
+--- /dev/null
++++ b/dist/chunk-ANSSZMDI.js
+@@ -0,0 +1,23 @@
++"use strict";Object.defineProperty(exports, "__esModule", {value: true});
++
++var _chunkCECZWJ42js = require('./chunk-CECZWJ42.js');
++
++// src/SelectedNetworkMiddleware.ts
++var createSelectedNetworkMiddleware = (messenger) => {
++  const getNetworkClientIdForDomain = (origin) => messenger.call(
++    _chunkCECZWJ42js.SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
++    origin
++  );
++  return (req, _, next) => {
++    if (!req.origin) {
++      throw new Error("Request object is lacking an 'origin'");
++    }
++    req.networkClientId = getNetworkClientIdForDomain(req.origin);
++    return next();
++  };
++};
++
++
++
++exports.createSelectedNetworkMiddleware = createSelectedNetworkMiddleware;
++//# sourceMappingURL=chunk-ANSSZMDI.js.map
+\ No newline at end of file
+diff --git a/dist/chunk-ANSSZMDI.js.map b/dist/chunk-ANSSZMDI.js.map
+new file mode 100644
+index 0000000000000000000000000000000000000000..9fe4c1fd6e9b12bfd9091833618334f2c931098f
+--- /dev/null
++++ b/dist/chunk-ANSSZMDI.js.map
+@@ -0,0 +1 @@
++{"version":3,"sources":["../src/SelectedNetworkMiddleware.ts"],"names":[],"mappings":";;;;;AAYO,IAAM,kCAAkC,CAC7C,cAC2C;AAC3C,QAAM,8BAA8B,CAAC,WACnC,UAAU;AAAA,IACR,qCAAqC;AAAA,IACrC;AAAA,EACF;AAEF,SAAO,CAAC,KAA8C,GAAG,SAAS;AAChE,QAAI,CAAC,IAAI,QAAQ;AACf,YAAM,IAAI,MAAM,uCAAuC;AAAA,IACzD;AAEA,QAAI,kBAAkB,4BAA4B,IAAI,MAAM;AAC5D,WAAO,KAAK;AAAA,EACd;AACF","sourcesContent":["import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';\nimport type { NetworkClientId } from '@metamask/network-controller';\nimport type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';\n\nimport type { SelectedNetworkControllerMessenger } from './SelectedNetworkController';\nimport { SelectedNetworkControllerActionTypes } from './SelectedNetworkController';\n\nexport type SelectedNetworkMiddlewareJsonRpcRequest = JsonRpcRequest & {\n  networkClientId?: NetworkClientId;\n  origin?: string;\n};\n\nexport const createSelectedNetworkMiddleware = (\n  messenger: SelectedNetworkControllerMessenger,\n): JsonRpcMiddleware<JsonRpcParams, Json> => {\n  const getNetworkClientIdForDomain = (origin: string) =>\n    messenger.call(\n      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,\n      origin,\n    );\n\n  return (req: SelectedNetworkMiddlewareJsonRpcRequest, _, next) => {\n    if (!req.origin) {\n      throw new Error(\"Request object is lacking an 'origin'\");\n    }\n\n    req.networkClientId = getNetworkClientIdForDomain(req.origin);\n    return next();\n  };\n};\n"]}
+\ No newline at end of file
+diff --git a/dist/chunk-CECZWJ42.js b/dist/chunk-CECZWJ42.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..3471ce2b3b927414a25b81b864ddad0cdaeeb26a
+--- /dev/null
++++ b/dist/chunk-CECZWJ42.js
+@@ -0,0 +1,284 @@
++"use strict";Object.defineProperty(exports, "__esModule", {value: true});var __accessCheck = (obj, member, msg) => {
++  if (!member.has(obj))
++    throw TypeError("Cannot " + msg);
++};
++var __privateGet = (obj, member, getter) => {
++  __accessCheck(obj, member, "read from private field");
++  return getter ? getter.call(obj) : member.get(obj);
++};
++var __privateAdd = (obj, member, value) => {
++  if (member.has(obj))
++    throw TypeError("Cannot add the same private member more than once");
++  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
++};
++var __privateSet = (obj, member, value, setter) => {
++  __accessCheck(obj, member, "write to private field");
++  setter ? setter.call(obj, value) : member.set(obj, value);
++  return value;
++};
++var __privateMethod = (obj, member, method) => {
++  __accessCheck(obj, member, "access private method");
++  return method;
++};
++
++// src/SelectedNetworkController.ts
++var _basecontroller = require('@metamask/base-controller');
++var _swappableobjproxy = require('@metamask/swappable-obj-proxy');
++var controllerName = "SelectedNetworkController";
++var stateMetadata = {
++  domains: { persist: true, anonymous: false }
++};
++var getDefaultState = () => ({ domains: {} });
++var snapsPrefixes = ["npm:", "local:"];
++var METAMASK_DOMAIN = "metamask";
++var SelectedNetworkControllerActionTypes = {
++  getState: `${controllerName}:getState`,
++  getNetworkClientIdForDomain: `${controllerName}:getNetworkClientIdForDomain`,
++  setNetworkClientIdForDomain: `${controllerName}:setNetworkClientIdForDomain`
++};
++var SelectedNetworkControllerEventTypes = {
++  stateChange: `${controllerName}:stateChange`
++};
++var _domainProxyMap, _useRequestQueuePreference, _registerMessageHandlers, registerMessageHandlers_fn, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn, _domainHasPermissions, domainHasPermissions_fn, _resetAllPermissionedDomains, resetAllPermissionedDomains_fn;
++var SelectedNetworkController = class extends _basecontroller.BaseController {
++  /**
++   * Construct a SelectedNetworkController controller.
++   *
++   * @param options - The controller options.
++   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
++   * @param options.state - The controllers initial state.
++   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.
++   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.
++   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.
++   */
++  constructor({
++    messenger,
++    state = getDefaultState(),
++    useRequestQueuePreference,
++    onPreferencesStateChange,
++    domainProxyMap
++  }) {
++    super({
++      name: controllerName,
++      metadata: stateMetadata,
++      messenger,
++      state
++    });
++    __privateAdd(this, _registerMessageHandlers);
++    __privateAdd(this, _setNetworkClientIdForDomain);
++    /**
++     * This method is used when a domain is removed from the PermissionsController.
++     * It will remove re-point the network proxy to the globally selected network in the domainProxyMap or, if no globally selected network client is available, delete the proxy.
++     *
++     * @param domain - The domain for which to unset the network client ID.
++     */
++    __privateAdd(this, _unsetNetworkClientIdForDomain);
++    __privateAdd(this, _domainHasPermissions);
++    // Loop through all domains and for those with permissions it points that domain's proxy
++    // to an unproxied instance of the globally selected network client.
++    // NOT the NetworkController's proxy of the globally selected networkClient
++    __privateAdd(this, _resetAllPermissionedDomains);
++    __privateAdd(this, _domainProxyMap, void 0);
++    __privateAdd(this, _useRequestQueuePreference, void 0);
++    __privateSet(this, _useRequestQueuePreference, useRequestQueuePreference);
++    __privateSet(this, _domainProxyMap, domainProxyMap);
++    __privateMethod(this, _registerMessageHandlers, registerMessageHandlers_fn).call(this);
++    this.messagingSystem.call("PermissionController:getSubjectNames").filter((domain) => this.state.domains[domain] === void 0).forEach(
++      (domain) => this.setNetworkClientIdForDomain(
++        domain,
++        this.messagingSystem.call("NetworkController:getState").selectedNetworkClientId
++      )
++    );
++    this.messagingSystem.subscribe(
++      "PermissionController:stateChange",
++      (_, patches) => {
++        patches.forEach(({ op, path }) => {
++          const isChangingSubject = path[0] === "subjects" && path[1] !== void 0;
++          if (isChangingSubject && typeof path[1] === "string") {
++            const domain = path[1];
++            if (op === "add" && this.state.domains[domain] === void 0) {
++              this.setNetworkClientIdForDomain(
++                domain,
++                this.messagingSystem.call("NetworkController:getState").selectedNetworkClientId
++              );
++            } else if (op === "remove" && this.state.domains[domain] !== void 0) {
++              __privateMethod(this, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn).call(this, domain);
++            }
++          }
++        });
++      }
++    );
++    this.messagingSystem.subscribe(
++      "NetworkController:stateChange",
++      ({ selectedNetworkClientId }, patches) => {
++        patches.forEach(({ op, path }) => {
++          if (op === "remove" && path[0] === "networkConfigurations") {
++            const removedNetworkClientId = path[1];
++            Object.entries(this.state.domains).forEach(
++              ([domain, networkClientIdForDomain]) => {
++                if (networkClientIdForDomain === removedNetworkClientId) {
++                  this.setNetworkClientIdForDomain(
++                    domain,
++                    selectedNetworkClientId
++                  );
++                }
++              }
++            );
++          }
++        });
++      }
++    );
++    onPreferencesStateChange(({ useRequestQueue }) => {
++      if (__privateGet(this, _useRequestQueuePreference) !== useRequestQueue) {
++        if (!useRequestQueue) {
++          Object.keys(this.state.domains).forEach((domain) => {
++            __privateMethod(this, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn).call(this, domain);
++          });
++        } else {
++          __privateMethod(this, _resetAllPermissionedDomains, resetAllPermissionedDomains_fn).call(this);
++        }
++        __privateSet(this, _useRequestQueuePreference, useRequestQueue);
++      }
++    });
++  }
++  setNetworkClientIdForDomain(domain, networkClientId) {
++    if (!__privateGet(this, _useRequestQueuePreference)) {
++      return;
++    }
++    if (domain === METAMASK_DOMAIN) {
++      throw new Error(
++        `NetworkClientId for domain "${METAMASK_DOMAIN}" cannot be set on the SelectedNetworkController`
++      );
++    }
++    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
++      return;
++    }
++    if (!__privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
++      throw new Error(
++        "NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions"
++      );
++    }
++    __privateMethod(this, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn).call(this, domain, networkClientId);
++  }
++  getNetworkClientIdForDomain(domain) {
++    const { selectedNetworkClientId: metamaskSelectedNetworkClientId } = this.messagingSystem.call("NetworkController:getState");
++    if (!__privateGet(this, _useRequestQueuePreference)) {
++      return metamaskSelectedNetworkClientId;
++    }
++    return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;
++  }
++  /**
++   * Accesses the provider and block tracker for the currently selected network.
++   *
++   * @param domain - the domain for the provider
++   * @returns The proxy and block tracker proxies.
++   */
++  getProviderAndBlockTracker(domain) {
++    if (domain === METAMASK_DOMAIN || snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
++      const networkClient = this.messagingSystem.call(
++        "NetworkController:getSelectedNetworkClient"
++      );
++      if (networkClient === void 0) {
++        throw new Error("Selected network not initialized");
++      }
++      return networkClient;
++    }
++    let networkProxy = __privateGet(this, _domainProxyMap).get(domain);
++    if (networkProxy === void 0) {
++      let networkClient;
++      if (__privateGet(this, _useRequestQueuePreference) && __privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
++        const networkClientId = this.getNetworkClientIdForDomain(domain);
++        networkClient = this.messagingSystem.call(
++          "NetworkController:getNetworkClientById",
++          networkClientId
++        );
++      } else {
++        networkClient = this.messagingSystem.call(
++          "NetworkController:getSelectedNetworkClient"
++        );
++        if (networkClient === void 0) {
++          throw new Error("Selected network not initialized");
++        }
++      }
++      networkProxy = {
++        provider: _swappableobjproxy.createEventEmitterProxy.call(void 0, networkClient.provider),
++        blockTracker: _swappableobjproxy.createEventEmitterProxy.call(void 0, networkClient.blockTracker, {
++          eventFilter: "skipInternal"
++        })
++      };
++      __privateGet(this, _domainProxyMap).set(domain, networkProxy);
++    }
++    return networkProxy;
++  }
++};
++_domainProxyMap = new WeakMap();
++_useRequestQueuePreference = new WeakMap();
++_registerMessageHandlers = new WeakSet();
++registerMessageHandlers_fn = function() {
++  this.messagingSystem.registerActionHandler(
++    SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
++    this.getNetworkClientIdForDomain.bind(this)
++  );
++  this.messagingSystem.registerActionHandler(
++    SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,
++    this.setNetworkClientIdForDomain.bind(this)
++  );
++};
++_setNetworkClientIdForDomain = new WeakSet();
++setNetworkClientIdForDomain_fn = function(domain, networkClientId) {
++  const networkClient = this.messagingSystem.call(
++    "NetworkController:getNetworkClientById",
++    networkClientId
++  );
++  const networkProxy = this.getProviderAndBlockTracker(domain);
++  networkProxy.provider.setTarget(networkClient.provider);
++  networkProxy.blockTracker.setTarget(networkClient.blockTracker);
++  this.update((state) => {
++    state.domains[domain] = networkClientId;
++  });
++};
++_unsetNetworkClientIdForDomain = new WeakSet();
++unsetNetworkClientIdForDomain_fn = function(domain) {
++  const globallySelectedNetworkClient = this.messagingSystem.call(
++    "NetworkController:getSelectedNetworkClient"
++  );
++  const networkProxy = __privateGet(this, _domainProxyMap).get(domain);
++  if (networkProxy && globallySelectedNetworkClient) {
++    networkProxy.provider.setTarget(globallySelectedNetworkClient.provider);
++    networkProxy.blockTracker.setTarget(
++      globallySelectedNetworkClient.blockTracker
++    );
++  } else if (networkProxy) {
++    __privateGet(this, _domainProxyMap).delete(domain);
++  }
++  this.update((state) => {
++    delete state.domains[domain];
++  });
++};
++_domainHasPermissions = new WeakSet();
++domainHasPermissions_fn = function(domain) {
++  return this.messagingSystem.call(
++    "PermissionController:hasPermissions",
++    domain
++  );
++};
++_resetAllPermissionedDomains = new WeakSet();
++resetAllPermissionedDomains_fn = function() {
++  __privateGet(this, _domainProxyMap).forEach((_, domain) => {
++    const { selectedNetworkClientId } = this.messagingSystem.call(
++      "NetworkController:getState"
++    );
++    if (__privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
++      __privateMethod(this, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn).call(this, domain, selectedNetworkClientId);
++    }
++  });
++};
++
++
++
++
++
++
++
++exports.controllerName = controllerName; exports.METAMASK_DOMAIN = METAMASK_DOMAIN; exports.SelectedNetworkControllerActionTypes = SelectedNetworkControllerActionTypes; exports.SelectedNetworkControllerEventTypes = SelectedNetworkControllerEventTypes; exports.SelectedNetworkController = SelectedNetworkController;
++//# sourceMappingURL=chunk-CECZWJ42.js.map
+\ No newline at end of file
+diff --git a/dist/chunk-CECZWJ42.js.map b/dist/chunk-CECZWJ42.js.map
+new file mode 100644
+index 0000000000000000000000000000000000000000..a2eab942638757819a9cb850057450500d22f9ed
+--- /dev/null
++++ b/dist/chunk-CECZWJ42.js.map
+@@ -0,0 +1 @@
++{"version":3,"sources":["../src/SelectedNetworkController.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;AACA,SAAS,sBAAsB;AAe/B,SAAS,+BAA+B;AAGjC,IAAM,iBAAiB;AAE9B,IAAM,gBAAgB;AAAA,EACpB,SAAS,EAAE,SAAS,MAAM,WAAW,MAAM;AAC7C;AAEA,IAAM,kBAAkB,OAAO,EAAE,SAAS,CAAC,EAAE;AAM7C,IAAM,gBAAgB,CAAC,QAAQ,QAAQ;AAIhC,IAAM,kBAAkB;AAExB,IAAM,uCAAuC;AAAA,EAClD,UAAU,GAAG,cAAc;AAAA,EAC3B,6BACE,GAAG,cAAc;AAAA,EACnB,6BACE,GAAG,cAAc;AACrB;AAEO,IAAM,sCAAsC;AAAA,EACjD,aAAa,GAAG,cAAc;AAChC;AA/CA;AAsHO,IAAM,4BAAN,cAAwC,eAI7C;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAeA,YAAY;AAAA,IACV;AAAA,IACA,QAAQ,gBAAgB;AAAA,IACxB;AAAA,IACA;AAAA,IACA;AAAA,EACF,GAAqC;AACnC,UAAM;AAAA,MACJ,MAAM;AAAA,MACN,UAAU;AAAA,MACV;AAAA,MACA;AAAA,IACF,CAAC;AAgFH;AAWA;AAuBA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAkBA;AAUA;AAAA;AAAA;AAAA;AAxKA;AAEA;AAyBE,uBAAK,4BAA6B;AAClC,uBAAK,iBAAkB;AACvB,0BAAK,sDAAL;AAGA,SAAK,gBACF,KAAK,sCAAsC,EAC3C,OAAO,CAAC,WAAW,KAAK,MAAM,QAAQ,MAAM,MAAM,MAAS,EAC3D;AAAA,MAAQ,CAAC,WACR,KAAK;AAAA,QACH;AAAA,QACA,KAAK,gBAAgB,KAAK,4BAA4B,EACnD;AAAA,MACL;AAAA,IACF;AAEF,SAAK,gBAAgB;AAAA,MACnB;AAAA,MACA,CAAC,GAAG,YAAY;AACd,gBAAQ,QAAQ,CAAC,EAAE,IAAI,KAAK,MAAM;AAChC,gBAAM,oBACJ,KAAK,CAAC,MAAM,cAAc,KAAK,CAAC,MAAM;AACxC,cAAI,qBAAqB,OAAO,KAAK,CAAC,MAAM,UAAU;AACpD,kBAAM,SAAS,KAAK,CAAC;AACrB,gBAAI,OAAO,SAAS,KAAK,MAAM,QAAQ,MAAM,MAAM,QAAW;AAC5D,mBAAK;AAAA,gBACH;AAAA,gBACA,KAAK,gBAAgB,KAAK,4BAA4B,EACnD;AAAA,cACL;AAAA,YACF,WACE,OAAO,YACP,KAAK,MAAM,QAAQ,MAAM,MAAM,QAC/B;AACA,oCAAK,kEAAL,WAAoC;AAAA,YACtC;AAAA,UACF;AAAA,QACF,CAAC;AAAA,MACH;AAAA,IACF;AAEA,SAAK,gBAAgB;AAAA,MACnB;AAAA,MACA,CAAC,EAAE,wBAAwB,GAAG,YAAY;AACxC,gBAAQ,QAAQ,CAAC,EAAE,IAAI,KAAK,MAAM;AAEhC,cAAI,OAAO,YAAY,KAAK,CAAC,MAAM,yBAAyB;AAC1D,kBAAM,yBAAyB,KAAK,CAAC;AACrC,mBAAO,QAAQ,KAAK,MAAM,OAAO,EAAE;AAAA,cACjC,CAAC,CAAC,QAAQ,wBAAwB,MAAM;AACtC,oBAAI,6BAA6B,wBAAwB;AACvD,uBAAK;AAAA,oBACH;AAAA,oBACA;AAAA,kBACF;AAAA,gBACF;AAAA,cACF;AAAA,YACF;AAAA,UACF;AAAA,QACF,CAAC;AAAA,MACH;AAAA,IACF;AAEA,6BAAyB,CAAC,EAAE,gBAAgB,MAAM;AAChD,UAAI,mBAAK,gCAA+B,iBAAiB;AACvD,YAAI,CAAC,iBAAiB;AAGpB,iBAAO,KAAK,KAAK,MAAM,OAAO,EAAE,QAAQ,CAAC,WAAW;AAClD,kCAAK,kEAAL,WAAoC;AAAA,UACtC,CAAC;AAAA,QACH,OAAO;AACL,gCAAK,8DAAL;AAAA,QACF;AACA,2BAAK,4BAA6B;AAAA,MACpC;AAAA,IACF,CAAC;AAAA,EACH;AAAA,EA8EA,4BACE,QACA,iBACA;AAGA,QAAI,CAAC,mBAAK,6BAA4B;AACpC;AAAA,IACF;AACA,QAAI,WAAW,iBAAiB;AAC9B,YAAM,IAAI;AAAA,QACR,+BAA+B,eAAe;AAAA,MAChD;AAAA,IACF;AAEA,QAAI,cAAc,KAAK,CAAC,WAAW,OAAO,WAAW,MAAM,CAAC,GAAG;AAC7D;AAAA,IACF;AAEA,QAAI,CAAC,sBAAK,gDAAL,WAA2B,SAAS;AACvC,YAAM,IAAI;AAAA,QACR;AAAA,MACF;AAAA,IACF;AAEA,0BAAK,8DAAL,WAAkC,QAAQ;AAAA,EAC5C;AAAA,EAEA,4BAA4B,QAAiC;AAC3D,UAAM,EAAE,yBAAyB,gCAAgC,IAC/D,KAAK,gBAAgB,KAAK,4BAA4B;AACxD,QAAI,CAAC,mBAAK,6BAA4B;AACpC,aAAO;AAAA,IACT;AACA,WAAO,KAAK,MAAM,QAAQ,MAAM,KAAK;AAAA,EACvC;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAQA,2BAA2B,QAA8B;AAEvD,QACE,WAAW,mBACX,cAAc,KAAK,CAAC,WAAW,OAAO,WAAW,MAAM,CAAC,GACxD;AACA,YAAM,gBAAgB,KAAK,gBAAgB;AAAA,QACzC;AAAA,MACF;AACA,UAAI,kBAAkB,QAAW;AAC/B,cAAM,IAAI,MAAM,kCAAkC;AAAA,MACpD;AACA,aAAO;AAAA,IACT;AAEA,QAAI,eAAe,mBAAK,iBAAgB,IAAI,MAAM;AAClD,QAAI,iBAAiB,QAAW;AAC9B,UAAI;AACJ,UACE,mBAAK,+BACL,sBAAK,gDAAL,WAA2B,SAC3B;AACA,cAAM,kBAAkB,KAAK,4BAA4B,MAAM;AAC/D,wBAAgB,KAAK,gBAAgB;AAAA,UACnC;AAAA,UACA;AAAA,QACF;AAAA,MACF,OAAO;AACL,wBAAgB,KAAK,gBAAgB;AAAA,UACnC;AAAA,QACF;AACA,YAAI,kBAAkB,QAAW;AAC/B,gBAAM,IAAI,MAAM,kCAAkC;AAAA,QACpD;AAAA,MACF;AACA,qBAAe;AAAA,QACb,UAAU,wBAAwB,cAAc,QAAQ;AAAA,QACxD,cAAc,wBAAwB,cAAc,cAAc;AAAA,UAChE,aAAa;AAAA,QACf,CAAC;AAAA,MACH;AACA,yBAAK,iBAAgB,IAAI,QAAQ,YAAY;AAAA,IAC/C;AACA,WAAO;AAAA,EACT;AACF;AA9QE;AAEA;AAwGA;AAAA,6BAAwB,WAAS;AAC/B,OAAK,gBAAgB;AAAA,IACnB,qCAAqC;AAAA,IACrC,KAAK,4BAA4B,KAAK,IAAI;AAAA,EAC5C;AACA,OAAK,gBAAgB;AAAA,IACnB,qCAAqC;AAAA,IACrC,KAAK,4BAA4B,KAAK,IAAI;AAAA,EAC5C;AACF;AAEA;AAAA,iCAA4B,SAC1B,QACA,iBACA;AACA,QAAM,gBAAgB,KAAK,gBAAgB;AAAA,IACzC;AAAA,IACA;AAAA,EACF;AACA,QAAM,eAAe,KAAK,2BAA2B,MAAM;AAC3D,eAAa,SAAS,UAAU,cAAc,QAAQ;AACtD,eAAa,aAAa,UAAU,cAAc,YAAY;AAE9D,OAAK,OAAO,CAAC,UAAU;AACrB,UAAM,QAAQ,MAAM,IAAI;AAAA,EAC1B,CAAC;AACH;AAQA;AAAA,mCAA8B,SAAC,QAAgB;AAC7C,QAAM,gCAAgC,KAAK,gBAAgB;AAAA,IACzD;AAAA,EACF;AACA,QAAM,eAAe,mBAAK,iBAAgB,IAAI,MAAM;AACpD,MAAI,gBAAgB,+BAA+B;AACjD,iBAAa,SAAS,UAAU,8BAA8B,QAAQ;AACtE,iBAAa,aAAa;AAAA,MACxB,8BAA8B;AAAA,IAChC;AAAA,EACF,WAAW,cAAc;AACvB,uBAAK,iBAAgB,OAAO,MAAM;AAAA,EACpC;AACA,OAAK,OAAO,CAAC,UAAU;AACrB,WAAO,MAAM,QAAQ,MAAM;AAAA,EAC7B,CAAC;AACH;AAEA;AAAA,0BAAqB,SAAC,QAAyB;AAC7C,SAAO,KAAK,gBAAgB;AAAA,IAC1B;AAAA,IACA;AAAA,EACF;AACF;AAKA;AAAA,iCAA4B,WAAG;AAC7B,qBAAK,iBAAgB,QAAQ,CAAC,GAAiB,WAAmB;AAChE,UAAM,EAAE,wBAAwB,IAAI,KAAK,gBAAgB;AAAA,MACvD;AAAA,IACF;AAIA,QAAI,sBAAK,gDAAL,WAA2B,SAAS;AACtC,4BAAK,8DAAL,WAAkC,QAAQ;AAAA,IAC5C;AAAA,EACF,CAAC;AACH","sourcesContent":["import type { RestrictedControllerMessenger } from '@metamask/base-controller';\nimport { BaseController } from '@metamask/base-controller';\nimport type {\n  BlockTrackerProxy,\n  NetworkClientId,\n  NetworkControllerGetNetworkClientByIdAction,\n  NetworkControllerGetSelectedNetworkClientAction,\n  NetworkControllerGetStateAction,\n  NetworkControllerStateChangeEvent,\n  ProviderProxy,\n} from '@metamask/network-controller';\nimport type {\n  PermissionControllerStateChange,\n  GetSubjects as PermissionControllerGetSubjectsAction,\n  HasPermissions as PermissionControllerHasPermissions,\n} from '@metamask/permission-controller';\nimport { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';\nimport type { Patch } from 'immer';\n\nexport const controllerName = 'SelectedNetworkController';\n\nconst stateMetadata = {\n  domains: { persist: true, anonymous: false },\n};\n\nconst getDefaultState = () => ({ domains: {} });\n\n// npm and local are currently the only valid prefixes for snap domains\n// TODO: eventually we maybe want to pull this in from snaps-utils to ensure it stays in sync\n// For now it seems like overkill to add a dependency for this one constant\n// https://github.com/MetaMask/snaps/blob/2beee7803bfe9e540788a3558b546b9f55dc3cb4/packages/snaps-utils/src/types.ts#L120\nconst snapsPrefixes = ['npm:', 'local:'] as const;\n\nexport type Domain = string;\n\nexport const METAMASK_DOMAIN = 'metamask' as const;\n\nexport const SelectedNetworkControllerActionTypes = {\n  getState: `${controllerName}:getState` as const,\n  getNetworkClientIdForDomain:\n    `${controllerName}:getNetworkClientIdForDomain` as const,\n  setNetworkClientIdForDomain:\n    `${controllerName}:setNetworkClientIdForDomain` as const,\n};\n\nexport const SelectedNetworkControllerEventTypes = {\n  stateChange: `${controllerName}:stateChange` as const,\n};\n\nexport type SelectedNetworkControllerState = {\n  domains: Record<Domain, NetworkClientId>;\n};\n\nexport type SelectedNetworkControllerStateChangeEvent = {\n  type: typeof SelectedNetworkControllerEventTypes.stateChange;\n  payload: [SelectedNetworkControllerState, Patch[]];\n};\n\nexport type SelectedNetworkControllerGetSelectedNetworkStateAction = {\n  type: typeof SelectedNetworkControllerActionTypes.getState;\n  handler: () => SelectedNetworkControllerState;\n};\n\nexport type SelectedNetworkControllerGetNetworkClientIdForDomainAction = {\n  type: typeof SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain;\n  handler: SelectedNetworkController['getNetworkClientIdForDomain'];\n};\n\nexport type SelectedNetworkControllerSetNetworkClientIdForDomainAction = {\n  type: typeof SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain;\n  handler: SelectedNetworkController['setNetworkClientIdForDomain'];\n};\n\nexport type SelectedNetworkControllerActions =\n  | SelectedNetworkControllerGetSelectedNetworkStateAction\n  | SelectedNetworkControllerGetNetworkClientIdForDomainAction\n  | SelectedNetworkControllerSetNetworkClientIdForDomainAction;\n\nexport type AllowedActions =\n  | NetworkControllerGetNetworkClientByIdAction\n  | NetworkControllerGetSelectedNetworkClientAction\n  | NetworkControllerGetStateAction\n  | PermissionControllerHasPermissions\n  | PermissionControllerGetSubjectsAction;\n\nexport type SelectedNetworkControllerEvents =\n  SelectedNetworkControllerStateChangeEvent;\n\nexport type AllowedEvents =\n  | NetworkControllerStateChangeEvent\n  | PermissionControllerStateChange;\n\nexport type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<\n  typeof controllerName,\n  SelectedNetworkControllerActions | AllowedActions,\n  SelectedNetworkControllerEvents | AllowedEvents,\n  AllowedActions['type'],\n  AllowedEvents['type']\n>;\n\nexport type SelectedNetworkControllerOptions = {\n  state?: SelectedNetworkControllerState;\n  messenger: SelectedNetworkControllerMessenger;\n  useRequestQueuePreference: boolean;\n  onPreferencesStateChange: (\n    listener: (preferencesState: { useRequestQueue: boolean }) => void,\n  ) => void;\n  domainProxyMap: Map<Domain, NetworkProxy>;\n};\n\nexport type NetworkProxy = {\n  provider: ProviderProxy;\n  blockTracker: BlockTrackerProxy;\n};\n\n/**\n * Controller for getting and setting the network for a particular domain.\n */\nexport class SelectedNetworkController extends BaseController<\n  typeof controllerName,\n  SelectedNetworkControllerState,\n  SelectedNetworkControllerMessenger\n> {\n  #domainProxyMap: Map<Domain, NetworkProxy>;\n\n  #useRequestQueuePreference: boolean;\n\n  /**\n   * Construct a SelectedNetworkController controller.\n   *\n   * @param options - The controller options.\n   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.\n   * @param options.state - The controllers initial state.\n   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.\n   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.\n   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.\n   */\n  constructor({\n    messenger,\n    state = getDefaultState(),\n    useRequestQueuePreference,\n    onPreferencesStateChange,\n    domainProxyMap,\n  }: SelectedNetworkControllerOptions) {\n    super({\n      name: controllerName,\n      metadata: stateMetadata,\n      messenger,\n      state,\n    });\n    this.#useRequestQueuePreference = useRequestQueuePreference;\n    this.#domainProxyMap = domainProxyMap;\n    this.#registerMessageHandlers();\n\n    // this is fetching all the dapp permissions from the PermissionsController and looking for any domains that are not in domains state in this controller. Then we take any missing domains and add them to state here, setting it with the globally selected networkClientId (fetched from the NetworkController)\n    this.messagingSystem\n      .call('PermissionController:getSubjectNames')\n      .filter((domain) => this.state.domains[domain] === undefined)\n      .forEach((domain) =>\n        this.setNetworkClientIdForDomain(\n          domain,\n          this.messagingSystem.call('NetworkController:getState')\n            .selectedNetworkClientId,\n        ),\n      );\n\n    this.messagingSystem.subscribe(\n      'PermissionController:stateChange',\n      (_, patches) => {\n        patches.forEach(({ op, path }) => {\n          const isChangingSubject =\n            path[0] === 'subjects' && path[1] !== undefined;\n          if (isChangingSubject && typeof path[1] === 'string') {\n            const domain = path[1];\n            if (op === 'add' && this.state.domains[domain] === undefined) {\n              this.setNetworkClientIdForDomain(\n                domain,\n                this.messagingSystem.call('NetworkController:getState')\n                  .selectedNetworkClientId,\n              );\n            } else if (\n              op === 'remove' &&\n              this.state.domains[domain] !== undefined\n            ) {\n              this.#unsetNetworkClientIdForDomain(domain);\n            }\n          }\n        });\n      },\n    );\n\n    this.messagingSystem.subscribe(\n      'NetworkController:stateChange',\n      ({ selectedNetworkClientId }, patches) => {\n        patches.forEach(({ op, path }) => {\n          // if a network is removed, update the networkClientId for all domains that were using it to the selected network\n          if (op === 'remove' && path[0] === 'networkConfigurations') {\n            const removedNetworkClientId = path[1] as NetworkClientId;\n            Object.entries(this.state.domains).forEach(\n              ([domain, networkClientIdForDomain]) => {\n                if (networkClientIdForDomain === removedNetworkClientId) {\n                  this.setNetworkClientIdForDomain(\n                    domain,\n                    selectedNetworkClientId,\n                  );\n                }\n              },\n            );\n          }\n        });\n      },\n    );\n\n    onPreferencesStateChange(({ useRequestQueue }) => {\n      if (this.#useRequestQueuePreference !== useRequestQueue) {\n        if (!useRequestQueue) {\n          // Loop through all domains and points each domain's proxy\n          // to the NetworkController's own proxy of the globally selected networkClient\n          Object.keys(this.state.domains).forEach((domain) => {\n            this.#unsetNetworkClientIdForDomain(domain);\n          });\n        } else {\n          this.#resetAllPermissionedDomains();\n        }\n        this.#useRequestQueuePreference = useRequestQueue;\n      }\n    });\n  }\n\n  #registerMessageHandlers(): void {\n    this.messagingSystem.registerActionHandler(\n      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,\n      this.getNetworkClientIdForDomain.bind(this),\n    );\n    this.messagingSystem.registerActionHandler(\n      SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,\n      this.setNetworkClientIdForDomain.bind(this),\n    );\n  }\n\n  #setNetworkClientIdForDomain(\n    domain: Domain,\n    networkClientId: NetworkClientId,\n  ) {\n    const networkClient = this.messagingSystem.call(\n      'NetworkController:getNetworkClientById',\n      networkClientId,\n    );\n    const networkProxy = this.getProviderAndBlockTracker(domain);\n    networkProxy.provider.setTarget(networkClient.provider);\n    networkProxy.blockTracker.setTarget(networkClient.blockTracker);\n\n    this.update((state) => {\n      state.domains[domain] = networkClientId;\n    });\n  }\n\n  /**\n   * This method is used when a domain is removed from the PermissionsController.\n   * It will remove re-point the network proxy to the globally selected network in the domainProxyMap or, if no globally selected network client is available, delete the proxy.\n   *\n   * @param domain - The domain for which to unset the network client ID.\n   */\n  #unsetNetworkClientIdForDomain(domain: Domain) {\n    const globallySelectedNetworkClient = this.messagingSystem.call(\n      'NetworkController:getSelectedNetworkClient',\n    );\n    const networkProxy = this.#domainProxyMap.get(domain);\n    if (networkProxy && globallySelectedNetworkClient) {\n      networkProxy.provider.setTarget(globallySelectedNetworkClient.provider);\n      networkProxy.blockTracker.setTarget(\n        globallySelectedNetworkClient.blockTracker,\n      );\n    } else if (networkProxy) {\n      this.#domainProxyMap.delete(domain);\n    }\n    this.update((state) => {\n      delete state.domains[domain];\n    });\n  }\n\n  #domainHasPermissions(domain: Domain): boolean {\n    return this.messagingSystem.call(\n      'PermissionController:hasPermissions',\n      domain,\n    );\n  }\n\n  // Loop through all domains and for those with permissions it points that domain's proxy\n  // to an unproxied instance of the globally selected network client.\n  // NOT the NetworkController's proxy of the globally selected networkClient\n  #resetAllPermissionedDomains() {\n    this.#domainProxyMap.forEach((_: NetworkProxy, domain: string) => {\n      const { selectedNetworkClientId } = this.messagingSystem.call(\n        'NetworkController:getState',\n      );\n      // can't use public setNetworkClientIdForDomain because it will throw an error\n      // rather than simply skip if the domain doesn't have permissions which can happen\n      // in this case since proxies are added for each site the user visits\n      if (this.#domainHasPermissions(domain)) {\n        this.#setNetworkClientIdForDomain(domain, selectedNetworkClientId);\n      }\n    });\n  }\n\n  setNetworkClientIdForDomain(\n    domain: Domain,\n    networkClientId: NetworkClientId,\n  ) {\n    // Core PR: https://github.com/MetaMask/core/pull/4388\n    // Patch Branch: patch-selected-network-controller-13.0.0-setNetworkClient-guard\n    if (!this.#useRequestQueuePreference) {\n      return;\n    }\n    if (domain === METAMASK_DOMAIN) {\n      throw new Error(\n        `NetworkClientId for domain \"${METAMASK_DOMAIN}\" cannot be set on the SelectedNetworkController`,\n      );\n    }\n\n    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {\n      return;\n    }\n\n    if (!this.#domainHasPermissions(domain)) {\n      throw new Error(\n        'NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions',\n      );\n    }\n\n    this.#setNetworkClientIdForDomain(domain, networkClientId);\n  }\n\n  getNetworkClientIdForDomain(domain: Domain): NetworkClientId {\n    const { selectedNetworkClientId: metamaskSelectedNetworkClientId } =\n      this.messagingSystem.call('NetworkController:getState');\n    if (!this.#useRequestQueuePreference) {\n      return metamaskSelectedNetworkClientId;\n    }\n    return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;\n  }\n\n  /**\n   * Accesses the provider and block tracker for the currently selected network.\n   *\n   * @param domain - the domain for the provider\n   * @returns The proxy and block tracker proxies.\n   */\n  getProviderAndBlockTracker(domain: Domain): NetworkProxy {\n    // If the domain is 'metamask' or a snap, return the NetworkController's globally selected network client proxy\n    if (\n      domain === METAMASK_DOMAIN ||\n      snapsPrefixes.some((prefix) => domain.startsWith(prefix))\n    ) {\n      const networkClient = this.messagingSystem.call(\n        'NetworkController:getSelectedNetworkClient',\n      );\n      if (networkClient === undefined) {\n        throw new Error('Selected network not initialized');\n      }\n      return networkClient;\n    }\n\n    let networkProxy = this.#domainProxyMap.get(domain);\n    if (networkProxy === undefined) {\n      let networkClient;\n      if (\n        this.#useRequestQueuePreference &&\n        this.#domainHasPermissions(domain)\n      ) {\n        const networkClientId = this.getNetworkClientIdForDomain(domain);\n        networkClient = this.messagingSystem.call(\n          'NetworkController:getNetworkClientById',\n          networkClientId,\n        );\n      } else {\n        networkClient = this.messagingSystem.call(\n          'NetworkController:getSelectedNetworkClient',\n        );\n        if (networkClient === undefined) {\n          throw new Error('Selected network not initialized');\n        }\n      }\n      networkProxy = {\n        provider: createEventEmitterProxy(networkClient.provider),\n        blockTracker: createEventEmitterProxy(networkClient.blockTracker, {\n          eventFilter: 'skipInternal',\n        }),\n      };\n      this.#domainProxyMap.set(domain, networkProxy);\n    }\n    return networkProxy;\n  }\n}\n"]}
+\ No newline at end of file
+diff --git a/dist/chunk-HFN7TKJS.mjs b/dist/chunk-HFN7TKJS.mjs
+new file mode 100644
+index 0000000000000000000000000000000000000000..6f4a4ec6b18571939d2b6c10ddb8ab4e5345389c
+--- /dev/null
++++ b/dist/chunk-HFN7TKJS.mjs
+@@ -0,0 +1,23 @@
++import {
++  SelectedNetworkControllerActionTypes
++} from "./chunk-7DSTEJNI.mjs";
++
++// src/SelectedNetworkMiddleware.ts
++var createSelectedNetworkMiddleware = (messenger) => {
++  const getNetworkClientIdForDomain = (origin) => messenger.call(
++    SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
++    origin
++  );
++  return (req, _, next) => {
++    if (!req.origin) {
++      throw new Error("Request object is lacking an 'origin'");
++    }
++    req.networkClientId = getNetworkClientIdForDomain(req.origin);
++    return next();
++  };
++};
++
++export {
++  createSelectedNetworkMiddleware
++};
++//# sourceMappingURL=chunk-HFN7TKJS.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-HFN7TKJS.mjs.map b/dist/chunk-HFN7TKJS.mjs.map
+new file mode 100644
+index 0000000000000000000000000000000000000000..fbcfd73d57f291b4f129caa47ef0c9614987cc30
+--- /dev/null
++++ b/dist/chunk-HFN7TKJS.mjs.map
+@@ -0,0 +1 @@
++{"version":3,"sources":["../src/SelectedNetworkMiddleware.ts"],"sourcesContent":["import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';\nimport type { NetworkClientId } from '@metamask/network-controller';\nimport type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';\n\nimport type { SelectedNetworkControllerMessenger } from './SelectedNetworkController';\nimport { SelectedNetworkControllerActionTypes } from './SelectedNetworkController';\n\nexport type SelectedNetworkMiddlewareJsonRpcRequest = JsonRpcRequest & {\n  networkClientId?: NetworkClientId;\n  origin?: string;\n};\n\nexport const createSelectedNetworkMiddleware = (\n  messenger: SelectedNetworkControllerMessenger,\n): JsonRpcMiddleware<JsonRpcParams, Json> => {\n  const getNetworkClientIdForDomain = (origin: string) =>\n    messenger.call(\n      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,\n      origin,\n    );\n\n  return (req: SelectedNetworkMiddlewareJsonRpcRequest, _, next) => {\n    if (!req.origin) {\n      throw new Error(\"Request object is lacking an 'origin'\");\n    }\n\n    req.networkClientId = getNetworkClientIdForDomain(req.origin);\n    return next();\n  };\n};\n"],"mappings":";;;;;AAYO,IAAM,kCAAkC,CAC7C,cAC2C;AAC3C,QAAM,8BAA8B,CAAC,WACnC,UAAU;AAAA,IACR,qCAAqC;AAAA,IACrC;AAAA,EACF;AAEF,SAAO,CAAC,KAA8C,GAAG,SAAS;AAChE,QAAI,CAAC,IAAI,QAAQ;AACf,YAAM,IAAI,MAAM,uCAAuC;AAAA,IACzD;AAEA,QAAI,kBAAkB,4BAA4B,IAAI,MAAM;AAC5D,WAAO,KAAK;AAAA,EACd;AACF;","names":[]}
+\ No newline at end of file
+diff --git a/dist/chunk-OGUVGN6R.js b/dist/chunk-OGUVGN6R.js
+deleted file mode 100644
+index 1fb2670b25d9230aa3b0d1d496223ccee8f48263..0000000000000000000000000000000000000000
+--- a/dist/chunk-OGUVGN6R.js
++++ /dev/null
+@@ -1,281 +0,0 @@
+-"use strict";Object.defineProperty(exports, "__esModule", {value: true});var __accessCheck = (obj, member, msg) => {
+-  if (!member.has(obj))
+-    throw TypeError("Cannot " + msg);
+-};
+-var __privateGet = (obj, member, getter) => {
+-  __accessCheck(obj, member, "read from private field");
+-  return getter ? getter.call(obj) : member.get(obj);
+-};
+-var __privateAdd = (obj, member, value) => {
+-  if (member.has(obj))
+-    throw TypeError("Cannot add the same private member more than once");
+-  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+-};
+-var __privateSet = (obj, member, value, setter) => {
+-  __accessCheck(obj, member, "write to private field");
+-  setter ? setter.call(obj, value) : member.set(obj, value);
+-  return value;
+-};
+-var __privateMethod = (obj, member, method) => {
+-  __accessCheck(obj, member, "access private method");
+-  return method;
+-};
+-
+-// src/SelectedNetworkController.ts
+-var _basecontroller = require('@metamask/base-controller');
+-var _swappableobjproxy = require('@metamask/swappable-obj-proxy');
+-var controllerName = "SelectedNetworkController";
+-var stateMetadata = {
+-  domains: { persist: true, anonymous: false }
+-};
+-var getDefaultState = () => ({ domains: {} });
+-var snapsPrefixes = ["npm:", "local:"];
+-var METAMASK_DOMAIN = "metamask";
+-var SelectedNetworkControllerActionTypes = {
+-  getState: `${controllerName}:getState`,
+-  getNetworkClientIdForDomain: `${controllerName}:getNetworkClientIdForDomain`,
+-  setNetworkClientIdForDomain: `${controllerName}:setNetworkClientIdForDomain`
+-};
+-var SelectedNetworkControllerEventTypes = {
+-  stateChange: `${controllerName}:stateChange`
+-};
+-var _domainProxyMap, _useRequestQueuePreference, _registerMessageHandlers, registerMessageHandlers_fn, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn, _domainHasPermissions, domainHasPermissions_fn, _resetAllPermissionedDomains, resetAllPermissionedDomains_fn;
+-var SelectedNetworkController = class extends _basecontroller.BaseController {
+-  /**
+-   * Construct a SelectedNetworkController controller.
+-   *
+-   * @param options - The controller options.
+-   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
+-   * @param options.state - The controllers initial state.
+-   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.
+-   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.
+-   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.
+-   */
+-  constructor({
+-    messenger,
+-    state = getDefaultState(),
+-    useRequestQueuePreference,
+-    onPreferencesStateChange,
+-    domainProxyMap
+-  }) {
+-    super({
+-      name: controllerName,
+-      metadata: stateMetadata,
+-      messenger,
+-      state
+-    });
+-    __privateAdd(this, _registerMessageHandlers);
+-    __privateAdd(this, _setNetworkClientIdForDomain);
+-    /**
+-     * This method is used when a domain is removed from the PermissionsController.
+-     * It will remove re-point the network proxy to the globally selected network in the domainProxyMap or, if no globally selected network client is available, delete the proxy.
+-     *
+-     * @param domain - The domain for which to unset the network client ID.
+-     */
+-    __privateAdd(this, _unsetNetworkClientIdForDomain);
+-    __privateAdd(this, _domainHasPermissions);
+-    // Loop through all domains and for those with permissions it points that domain's proxy
+-    // to an unproxied instance of the globally selected network client.
+-    // NOT the NetworkController's proxy of the globally selected networkClient
+-    __privateAdd(this, _resetAllPermissionedDomains);
+-    __privateAdd(this, _domainProxyMap, void 0);
+-    __privateAdd(this, _useRequestQueuePreference, void 0);
+-    __privateSet(this, _useRequestQueuePreference, useRequestQueuePreference);
+-    __privateSet(this, _domainProxyMap, domainProxyMap);
+-    __privateMethod(this, _registerMessageHandlers, registerMessageHandlers_fn).call(this);
+-    this.messagingSystem.call("PermissionController:getSubjectNames").filter((domain) => this.state.domains[domain] === void 0).forEach(
+-      (domain) => this.setNetworkClientIdForDomain(
+-        domain,
+-        this.messagingSystem.call("NetworkController:getState").selectedNetworkClientId
+-      )
+-    );
+-    this.messagingSystem.subscribe(
+-      "PermissionController:stateChange",
+-      (_, patches) => {
+-        patches.forEach(({ op, path }) => {
+-          const isChangingSubject = path[0] === "subjects" && path[1] !== void 0;
+-          if (isChangingSubject && typeof path[1] === "string") {
+-            const domain = path[1];
+-            if (op === "add" && this.state.domains[domain] === void 0) {
+-              this.setNetworkClientIdForDomain(
+-                domain,
+-                this.messagingSystem.call("NetworkController:getState").selectedNetworkClientId
+-              );
+-            } else if (op === "remove" && this.state.domains[domain] !== void 0) {
+-              __privateMethod(this, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn).call(this, domain);
+-            }
+-          }
+-        });
+-      }
+-    );
+-    this.messagingSystem.subscribe(
+-      "NetworkController:stateChange",
+-      ({ selectedNetworkClientId }, patches) => {
+-        patches.forEach(({ op, path }) => {
+-          if (op === "remove" && path[0] === "networkConfigurations") {
+-            const removedNetworkClientId = path[1];
+-            Object.entries(this.state.domains).forEach(
+-              ([domain, networkClientIdForDomain]) => {
+-                if (networkClientIdForDomain === removedNetworkClientId) {
+-                  this.setNetworkClientIdForDomain(
+-                    domain,
+-                    selectedNetworkClientId
+-                  );
+-                }
+-              }
+-            );
+-          }
+-        });
+-      }
+-    );
+-    onPreferencesStateChange(({ useRequestQueue }) => {
+-      if (__privateGet(this, _useRequestQueuePreference) !== useRequestQueue) {
+-        if (!useRequestQueue) {
+-          Object.keys(this.state.domains).forEach((domain) => {
+-            __privateMethod(this, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn).call(this, domain);
+-          });
+-        } else {
+-          __privateMethod(this, _resetAllPermissionedDomains, resetAllPermissionedDomains_fn).call(this);
+-        }
+-        __privateSet(this, _useRequestQueuePreference, useRequestQueue);
+-      }
+-    });
+-  }
+-  setNetworkClientIdForDomain(domain, networkClientId) {
+-    if (domain === METAMASK_DOMAIN) {
+-      throw new Error(
+-        `NetworkClientId for domain "${METAMASK_DOMAIN}" cannot be set on the SelectedNetworkController`
+-      );
+-    }
+-    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
+-      return;
+-    }
+-    if (!__privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
+-      throw new Error(
+-        "NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions"
+-      );
+-    }
+-    __privateMethod(this, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn).call(this, domain, networkClientId);
+-  }
+-  getNetworkClientIdForDomain(domain) {
+-    const { selectedNetworkClientId: metamaskSelectedNetworkClientId } = this.messagingSystem.call("NetworkController:getState");
+-    if (!__privateGet(this, _useRequestQueuePreference)) {
+-      return metamaskSelectedNetworkClientId;
+-    }
+-    return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;
+-  }
+-  /**
+-   * Accesses the provider and block tracker for the currently selected network.
+-   *
+-   * @param domain - the domain for the provider
+-   * @returns The proxy and block tracker proxies.
+-   */
+-  getProviderAndBlockTracker(domain) {
+-    if (domain === METAMASK_DOMAIN || snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
+-      const networkClient = this.messagingSystem.call(
+-        "NetworkController:getSelectedNetworkClient"
+-      );
+-      if (networkClient === void 0) {
+-        throw new Error("Selected network not initialized");
+-      }
+-      return networkClient;
+-    }
+-    let networkProxy = __privateGet(this, _domainProxyMap).get(domain);
+-    if (networkProxy === void 0) {
+-      let networkClient;
+-      if (__privateGet(this, _useRequestQueuePreference) && __privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
+-        const networkClientId = this.getNetworkClientIdForDomain(domain);
+-        networkClient = this.messagingSystem.call(
+-          "NetworkController:getNetworkClientById",
+-          networkClientId
+-        );
+-      } else {
+-        networkClient = this.messagingSystem.call(
+-          "NetworkController:getSelectedNetworkClient"
+-        );
+-        if (networkClient === void 0) {
+-          throw new Error("Selected network not initialized");
+-        }
+-      }
+-      networkProxy = {
+-        provider: _swappableobjproxy.createEventEmitterProxy.call(void 0, networkClient.provider),
+-        blockTracker: _swappableobjproxy.createEventEmitterProxy.call(void 0, networkClient.blockTracker, {
+-          eventFilter: "skipInternal"
+-        })
+-      };
+-      __privateGet(this, _domainProxyMap).set(domain, networkProxy);
+-    }
+-    return networkProxy;
+-  }
+-};
+-_domainProxyMap = new WeakMap();
+-_useRequestQueuePreference = new WeakMap();
+-_registerMessageHandlers = new WeakSet();
+-registerMessageHandlers_fn = function() {
+-  this.messagingSystem.registerActionHandler(
+-    SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
+-    this.getNetworkClientIdForDomain.bind(this)
+-  );
+-  this.messagingSystem.registerActionHandler(
+-    SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,
+-    this.setNetworkClientIdForDomain.bind(this)
+-  );
+-};
+-_setNetworkClientIdForDomain = new WeakSet();
+-setNetworkClientIdForDomain_fn = function(domain, networkClientId) {
+-  const networkClient = this.messagingSystem.call(
+-    "NetworkController:getNetworkClientById",
+-    networkClientId
+-  );
+-  const networkProxy = this.getProviderAndBlockTracker(domain);
+-  networkProxy.provider.setTarget(networkClient.provider);
+-  networkProxy.blockTracker.setTarget(networkClient.blockTracker);
+-  this.update((state) => {
+-    state.domains[domain] = networkClientId;
+-  });
+-};
+-_unsetNetworkClientIdForDomain = new WeakSet();
+-unsetNetworkClientIdForDomain_fn = function(domain) {
+-  const globallySelectedNetworkClient = this.messagingSystem.call(
+-    "NetworkController:getSelectedNetworkClient"
+-  );
+-  const networkProxy = __privateGet(this, _domainProxyMap).get(domain);
+-  if (networkProxy && globallySelectedNetworkClient) {
+-    networkProxy.provider.setTarget(globallySelectedNetworkClient.provider);
+-    networkProxy.blockTracker.setTarget(
+-      globallySelectedNetworkClient.blockTracker
+-    );
+-  } else if (networkProxy) {
+-    __privateGet(this, _domainProxyMap).delete(domain);
+-  }
+-  this.update((state) => {
+-    delete state.domains[domain];
+-  });
+-};
+-_domainHasPermissions = new WeakSet();
+-domainHasPermissions_fn = function(domain) {
+-  return this.messagingSystem.call(
+-    "PermissionController:hasPermissions",
+-    domain
+-  );
+-};
+-_resetAllPermissionedDomains = new WeakSet();
+-resetAllPermissionedDomains_fn = function() {
+-  __privateGet(this, _domainProxyMap).forEach((_, domain) => {
+-    const { selectedNetworkClientId } = this.messagingSystem.call(
+-      "NetworkController:getState"
+-    );
+-    if (__privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
+-      __privateMethod(this, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn).call(this, domain, selectedNetworkClientId);
+-    }
+-  });
+-};
+-
+-
+-
+-
+-
+-
+-
+-exports.controllerName = controllerName; exports.METAMASK_DOMAIN = METAMASK_DOMAIN; exports.SelectedNetworkControllerActionTypes = SelectedNetworkControllerActionTypes; exports.SelectedNetworkControllerEventTypes = SelectedNetworkControllerEventTypes; exports.SelectedNetworkController = SelectedNetworkController;
+-//# sourceMappingURL=chunk-OGUVGN6R.js.map
+\ No newline at end of file
+diff --git a/dist/chunk-OGUVGN6R.js.map b/dist/chunk-OGUVGN6R.js.map
+deleted file mode 100644
+index 4e38e02bd55874905ac6ea9c5874f01f102a7ff7..0000000000000000000000000000000000000000
+--- a/dist/chunk-OGUVGN6R.js.map
++++ /dev/null
+@@ -1 +0,0 @@
+-{"version":3,"sources":["../src/SelectedNetworkController.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;AACA,SAAS,sBAAsB;AAe/B,SAAS,+BAA+B;AAGjC,IAAM,iBAAiB;AAE9B,IAAM,gBAAgB;AAAA,EACpB,SAAS,EAAE,SAAS,MAAM,WAAW,MAAM;AAC7C;AAEA,IAAM,kBAAkB,OAAO,EAAE,SAAS,CAAC,EAAE;AAM7C,IAAM,gBAAgB,CAAC,QAAQ,QAAQ;AAIhC,IAAM,kBAAkB;AAExB,IAAM,uCAAuC;AAAA,EAClD,UAAU,GAAG,cAAc;AAAA,EAC3B,6BACE,GAAG,cAAc;AAAA,EACnB,6BACE,GAAG,cAAc;AACrB;AAEO,IAAM,sCAAsC;AAAA,EACjD,aAAa,GAAG,cAAc;AAChC;AA/CA;AAsHO,IAAM,4BAAN,cAAwC,eAI7C;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAeA,YAAY;AAAA,IACV;AAAA,IACA,QAAQ,gBAAgB;AAAA,IACxB;AAAA,IACA;AAAA,IACA;AAAA,EACF,GAAqC;AACnC,UAAM;AAAA,MACJ,MAAM;AAAA,MACN,UAAU;AAAA,MACV;AAAA,MACA;AAAA,IACF,CAAC;AAgFH;AAWA;AAuBA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAkBA;AAUA;AAAA;AAAA;AAAA;AAxKA;AAEA;AAyBE,uBAAK,4BAA6B;AAClC,uBAAK,iBAAkB;AACvB,0BAAK,sDAAL;AAGA,SAAK,gBACF,KAAK,sCAAsC,EAC3C,OAAO,CAAC,WAAW,KAAK,MAAM,QAAQ,MAAM,MAAM,MAAS,EAC3D;AAAA,MAAQ,CAAC,WACR,KAAK;AAAA,QACH;AAAA,QACA,KAAK,gBAAgB,KAAK,4BAA4B,EACnD;AAAA,MACL;AAAA,IACF;AAEF,SAAK,gBAAgB;AAAA,MACnB;AAAA,MACA,CAAC,GAAG,YAAY;AACd,gBAAQ,QAAQ,CAAC,EAAE,IAAI,KAAK,MAAM;AAChC,gBAAM,oBACJ,KAAK,CAAC,MAAM,cAAc,KAAK,CAAC,MAAM;AACxC,cAAI,qBAAqB,OAAO,KAAK,CAAC,MAAM,UAAU;AACpD,kBAAM,SAAS,KAAK,CAAC;AACrB,gBAAI,OAAO,SAAS,KAAK,MAAM,QAAQ,MAAM,MAAM,QAAW;AAC5D,mBAAK;AAAA,gBACH;AAAA,gBACA,KAAK,gBAAgB,KAAK,4BAA4B,EACnD;AAAA,cACL;AAAA,YACF,WACE,OAAO,YACP,KAAK,MAAM,QAAQ,MAAM,MAAM,QAC/B;AACA,oCAAK,kEAAL,WAAoC;AAAA,YACtC;AAAA,UACF;AAAA,QACF,CAAC;AAAA,MACH;AAAA,IACF;AAEA,SAAK,gBAAgB;AAAA,MACnB;AAAA,MACA,CAAC,EAAE,wBAAwB,GAAG,YAAY;AACxC,gBAAQ,QAAQ,CAAC,EAAE,IAAI,KAAK,MAAM;AAEhC,cAAI,OAAO,YAAY,KAAK,CAAC,MAAM,yBAAyB;AAC1D,kBAAM,yBAAyB,KAAK,CAAC;AACrC,mBAAO,QAAQ,KAAK,MAAM,OAAO,EAAE;AAAA,cACjC,CAAC,CAAC,QAAQ,wBAAwB,MAAM;AACtC,oBAAI,6BAA6B,wBAAwB;AACvD,uBAAK;AAAA,oBACH;AAAA,oBACA;AAAA,kBACF;AAAA,gBACF;AAAA,cACF;AAAA,YACF;AAAA,UACF;AAAA,QACF,CAAC;AAAA,MACH;AAAA,IACF;AAEA,6BAAyB,CAAC,EAAE,gBAAgB,MAAM;AAChD,UAAI,mBAAK,gCAA+B,iBAAiB;AACvD,YAAI,CAAC,iBAAiB;AAGpB,iBAAO,KAAK,KAAK,MAAM,OAAO,EAAE,QAAQ,CAAC,WAAW;AAClD,kCAAK,kEAAL,WAAoC;AAAA,UACtC,CAAC;AAAA,QACH,OAAO;AACL,gCAAK,8DAAL;AAAA,QACF;AACA,2BAAK,4BAA6B;AAAA,MACpC;AAAA,IACF,CAAC;AAAA,EACH;AAAA,EA8EA,4BACE,QACA,iBACA;AACA,QAAI,WAAW,iBAAiB;AAC9B,YAAM,IAAI;AAAA,QACR,+BAA+B,eAAe;AAAA,MAChD;AAAA,IACF;AAEA,QAAI,cAAc,KAAK,CAAC,WAAW,OAAO,WAAW,MAAM,CAAC,GAAG;AAC7D;AAAA,IACF;AAEA,QAAI,CAAC,sBAAK,gDAAL,WAA2B,SAAS;AACvC,YAAM,IAAI;AAAA,QACR;AAAA,MACF;AAAA,IACF;AAEA,0BAAK,8DAAL,WAAkC,QAAQ;AAAA,EAC5C;AAAA,EAEA,4BAA4B,QAAiC;AAC3D,UAAM,EAAE,yBAAyB,gCAAgC,IAC/D,KAAK,gBAAgB,KAAK,4BAA4B;AACxD,QAAI,CAAC,mBAAK,6BAA4B;AACpC,aAAO;AAAA,IACT;AACA,WAAO,KAAK,MAAM,QAAQ,MAAM,KAAK;AAAA,EACvC;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAQA,2BAA2B,QAA8B;AAEvD,QACE,WAAW,mBACX,cAAc,KAAK,CAAC,WAAW,OAAO,WAAW,MAAM,CAAC,GACxD;AACA,YAAM,gBAAgB,KAAK,gBAAgB;AAAA,QACzC;AAAA,MACF;AACA,UAAI,kBAAkB,QAAW;AAC/B,cAAM,IAAI,MAAM,kCAAkC;AAAA,MACpD;AACA,aAAO;AAAA,IACT;AAEA,QAAI,eAAe,mBAAK,iBAAgB,IAAI,MAAM;AAClD,QAAI,iBAAiB,QAAW;AAC9B,UAAI;AACJ,UACE,mBAAK,+BACL,sBAAK,gDAAL,WAA2B,SAC3B;AACA,cAAM,kBAAkB,KAAK,4BAA4B,MAAM;AAC/D,wBAAgB,KAAK,gBAAgB;AAAA,UACnC;AAAA,UACA;AAAA,QACF;AAAA,MACF,OAAO;AACL,wBAAgB,KAAK,gBAAgB;AAAA,UACnC;AAAA,QACF;AACA,YAAI,kBAAkB,QAAW;AAC/B,gBAAM,IAAI,MAAM,kCAAkC;AAAA,QACpD;AAAA,MACF;AACA,qBAAe;AAAA,QACb,UAAU,wBAAwB,cAAc,QAAQ;AAAA,QACxD,cAAc,wBAAwB,cAAc,cAAc;AAAA,UAChE,aAAa;AAAA,QACf,CAAC;AAAA,MACH;AACA,yBAAK,iBAAgB,IAAI,QAAQ,YAAY;AAAA,IAC/C;AACA,WAAO;AAAA,EACT;AACF;AAzQE;AAEA;AAwGA;AAAA,6BAAwB,WAAS;AAC/B,OAAK,gBAAgB;AAAA,IACnB,qCAAqC;AAAA,IACrC,KAAK,4BAA4B,KAAK,IAAI;AAAA,EAC5C;AACA,OAAK,gBAAgB;AAAA,IACnB,qCAAqC;AAAA,IACrC,KAAK,4BAA4B,KAAK,IAAI;AAAA,EAC5C;AACF;AAEA;AAAA,iCAA4B,SAC1B,QACA,iBACA;AACA,QAAM,gBAAgB,KAAK,gBAAgB;AAAA,IACzC;AAAA,IACA;AAAA,EACF;AACA,QAAM,eAAe,KAAK,2BAA2B,MAAM;AAC3D,eAAa,SAAS,UAAU,cAAc,QAAQ;AACtD,eAAa,aAAa,UAAU,cAAc,YAAY;AAE9D,OAAK,OAAO,CAAC,UAAU;AACrB,UAAM,QAAQ,MAAM,IAAI;AAAA,EAC1B,CAAC;AACH;AAQA;AAAA,mCAA8B,SAAC,QAAgB;AAC7C,QAAM,gCAAgC,KAAK,gBAAgB;AAAA,IACzD;AAAA,EACF;AACA,QAAM,eAAe,mBAAK,iBAAgB,IAAI,MAAM;AACpD,MAAI,gBAAgB,+BAA+B;AACjD,iBAAa,SAAS,UAAU,8BAA8B,QAAQ;AACtE,iBAAa,aAAa;AAAA,MACxB,8BAA8B;AAAA,IAChC;AAAA,EACF,WAAW,cAAc;AACvB,uBAAK,iBAAgB,OAAO,MAAM;AAAA,EACpC;AACA,OAAK,OAAO,CAAC,UAAU;AACrB,WAAO,MAAM,QAAQ,MAAM;AAAA,EAC7B,CAAC;AACH;AAEA;AAAA,0BAAqB,SAAC,QAAyB;AAC7C,SAAO,KAAK,gBAAgB;AAAA,IAC1B;AAAA,IACA;AAAA,EACF;AACF;AAKA;AAAA,iCAA4B,WAAG;AAC7B,qBAAK,iBAAgB,QAAQ,CAAC,GAAiB,WAAmB;AAChE,UAAM,EAAE,wBAAwB,IAAI,KAAK,gBAAgB;AAAA,MACvD;AAAA,IACF;AAIA,QAAI,sBAAK,gDAAL,WAA2B,SAAS;AACtC,4BAAK,8DAAL,WAAkC,QAAQ;AAAA,IAC5C;AAAA,EACF,CAAC;AACH","sourcesContent":["import type { RestrictedControllerMessenger } from '@metamask/base-controller';\nimport { BaseController } from '@metamask/base-controller';\nimport type {\n  BlockTrackerProxy,\n  NetworkClientId,\n  NetworkControllerGetNetworkClientByIdAction,\n  NetworkControllerGetSelectedNetworkClientAction,\n  NetworkControllerGetStateAction,\n  NetworkControllerStateChangeEvent,\n  ProviderProxy,\n} from '@metamask/network-controller';\nimport type {\n  PermissionControllerStateChange,\n  GetSubjects as PermissionControllerGetSubjectsAction,\n  HasPermissions as PermissionControllerHasPermissions,\n} from '@metamask/permission-controller';\nimport { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';\nimport type { Patch } from 'immer';\n\nexport const controllerName = 'SelectedNetworkController';\n\nconst stateMetadata = {\n  domains: { persist: true, anonymous: false },\n};\n\nconst getDefaultState = () => ({ domains: {} });\n\n// npm and local are currently the only valid prefixes for snap domains\n// TODO: eventually we maybe want to pull this in from snaps-utils to ensure it stays in sync\n// For now it seems like overkill to add a dependency for this one constant\n// https://github.com/MetaMask/snaps/blob/2beee7803bfe9e540788a3558b546b9f55dc3cb4/packages/snaps-utils/src/types.ts#L120\nconst snapsPrefixes = ['npm:', 'local:'] as const;\n\nexport type Domain = string;\n\nexport const METAMASK_DOMAIN = 'metamask' as const;\n\nexport const SelectedNetworkControllerActionTypes = {\n  getState: `${controllerName}:getState` as const,\n  getNetworkClientIdForDomain:\n    `${controllerName}:getNetworkClientIdForDomain` as const,\n  setNetworkClientIdForDomain:\n    `${controllerName}:setNetworkClientIdForDomain` as const,\n};\n\nexport const SelectedNetworkControllerEventTypes = {\n  stateChange: `${controllerName}:stateChange` as const,\n};\n\nexport type SelectedNetworkControllerState = {\n  domains: Record<Domain, NetworkClientId>;\n};\n\nexport type SelectedNetworkControllerStateChangeEvent = {\n  type: typeof SelectedNetworkControllerEventTypes.stateChange;\n  payload: [SelectedNetworkControllerState, Patch[]];\n};\n\nexport type SelectedNetworkControllerGetSelectedNetworkStateAction = {\n  type: typeof SelectedNetworkControllerActionTypes.getState;\n  handler: () => SelectedNetworkControllerState;\n};\n\nexport type SelectedNetworkControllerGetNetworkClientIdForDomainAction = {\n  type: typeof SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain;\n  handler: SelectedNetworkController['getNetworkClientIdForDomain'];\n};\n\nexport type SelectedNetworkControllerSetNetworkClientIdForDomainAction = {\n  type: typeof SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain;\n  handler: SelectedNetworkController['setNetworkClientIdForDomain'];\n};\n\nexport type SelectedNetworkControllerActions =\n  | SelectedNetworkControllerGetSelectedNetworkStateAction\n  | SelectedNetworkControllerGetNetworkClientIdForDomainAction\n  | SelectedNetworkControllerSetNetworkClientIdForDomainAction;\n\nexport type AllowedActions =\n  | NetworkControllerGetNetworkClientByIdAction\n  | NetworkControllerGetSelectedNetworkClientAction\n  | NetworkControllerGetStateAction\n  | PermissionControllerHasPermissions\n  | PermissionControllerGetSubjectsAction;\n\nexport type SelectedNetworkControllerEvents =\n  SelectedNetworkControllerStateChangeEvent;\n\nexport type AllowedEvents =\n  | NetworkControllerStateChangeEvent\n  | PermissionControllerStateChange;\n\nexport type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<\n  typeof controllerName,\n  SelectedNetworkControllerActions | AllowedActions,\n  SelectedNetworkControllerEvents | AllowedEvents,\n  AllowedActions['type'],\n  AllowedEvents['type']\n>;\n\nexport type SelectedNetworkControllerOptions = {\n  state?: SelectedNetworkControllerState;\n  messenger: SelectedNetworkControllerMessenger;\n  useRequestQueuePreference: boolean;\n  onPreferencesStateChange: (\n    listener: (preferencesState: { useRequestQueue: boolean }) => void,\n  ) => void;\n  domainProxyMap: Map<Domain, NetworkProxy>;\n};\n\nexport type NetworkProxy = {\n  provider: ProviderProxy;\n  blockTracker: BlockTrackerProxy;\n};\n\n/**\n * Controller for getting and setting the network for a particular domain.\n */\nexport class SelectedNetworkController extends BaseController<\n  typeof controllerName,\n  SelectedNetworkControllerState,\n  SelectedNetworkControllerMessenger\n> {\n  #domainProxyMap: Map<Domain, NetworkProxy>;\n\n  #useRequestQueuePreference: boolean;\n\n  /**\n   * Construct a SelectedNetworkController controller.\n   *\n   * @param options - The controller options.\n   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.\n   * @param options.state - The controllers initial state.\n   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.\n   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.\n   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.\n   */\n  constructor({\n    messenger,\n    state = getDefaultState(),\n    useRequestQueuePreference,\n    onPreferencesStateChange,\n    domainProxyMap,\n  }: SelectedNetworkControllerOptions) {\n    super({\n      name: controllerName,\n      metadata: stateMetadata,\n      messenger,\n      state,\n    });\n    this.#useRequestQueuePreference = useRequestQueuePreference;\n    this.#domainProxyMap = domainProxyMap;\n    this.#registerMessageHandlers();\n\n    // this is fetching all the dapp permissions from the PermissionsController and looking for any domains that are not in domains state in this controller. Then we take any missing domains and add them to state here, setting it with the globally selected networkClientId (fetched from the NetworkController)\n    this.messagingSystem\n      .call('PermissionController:getSubjectNames')\n      .filter((domain) => this.state.domains[domain] === undefined)\n      .forEach((domain) =>\n        this.setNetworkClientIdForDomain(\n          domain,\n          this.messagingSystem.call('NetworkController:getState')\n            .selectedNetworkClientId,\n        ),\n      );\n\n    this.messagingSystem.subscribe(\n      'PermissionController:stateChange',\n      (_, patches) => {\n        patches.forEach(({ op, path }) => {\n          const isChangingSubject =\n            path[0] === 'subjects' && path[1] !== undefined;\n          if (isChangingSubject && typeof path[1] === 'string') {\n            const domain = path[1];\n            if (op === 'add' && this.state.domains[domain] === undefined) {\n              this.setNetworkClientIdForDomain(\n                domain,\n                this.messagingSystem.call('NetworkController:getState')\n                  .selectedNetworkClientId,\n              );\n            } else if (\n              op === 'remove' &&\n              this.state.domains[domain] !== undefined\n            ) {\n              this.#unsetNetworkClientIdForDomain(domain);\n            }\n          }\n        });\n      },\n    );\n\n    this.messagingSystem.subscribe(\n      'NetworkController:stateChange',\n      ({ selectedNetworkClientId }, patches) => {\n        patches.forEach(({ op, path }) => {\n          // if a network is removed, update the networkClientId for all domains that were using it to the selected network\n          if (op === 'remove' && path[0] === 'networkConfigurations') {\n            const removedNetworkClientId = path[1] as NetworkClientId;\n            Object.entries(this.state.domains).forEach(\n              ([domain, networkClientIdForDomain]) => {\n                if (networkClientIdForDomain === removedNetworkClientId) {\n                  this.setNetworkClientIdForDomain(\n                    domain,\n                    selectedNetworkClientId,\n                  );\n                }\n              },\n            );\n          }\n        });\n      },\n    );\n\n    onPreferencesStateChange(({ useRequestQueue }) => {\n      if (this.#useRequestQueuePreference !== useRequestQueue) {\n        if (!useRequestQueue) {\n          // Loop through all domains and points each domain's proxy\n          // to the NetworkController's own proxy of the globally selected networkClient\n          Object.keys(this.state.domains).forEach((domain) => {\n            this.#unsetNetworkClientIdForDomain(domain);\n          });\n        } else {\n          this.#resetAllPermissionedDomains();\n        }\n        this.#useRequestQueuePreference = useRequestQueue;\n      }\n    });\n  }\n\n  #registerMessageHandlers(): void {\n    this.messagingSystem.registerActionHandler(\n      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,\n      this.getNetworkClientIdForDomain.bind(this),\n    );\n    this.messagingSystem.registerActionHandler(\n      SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,\n      this.setNetworkClientIdForDomain.bind(this),\n    );\n  }\n\n  #setNetworkClientIdForDomain(\n    domain: Domain,\n    networkClientId: NetworkClientId,\n  ) {\n    const networkClient = this.messagingSystem.call(\n      'NetworkController:getNetworkClientById',\n      networkClientId,\n    );\n    const networkProxy = this.getProviderAndBlockTracker(domain);\n    networkProxy.provider.setTarget(networkClient.provider);\n    networkProxy.blockTracker.setTarget(networkClient.blockTracker);\n\n    this.update((state) => {\n      state.domains[domain] = networkClientId;\n    });\n  }\n\n  /**\n   * This method is used when a domain is removed from the PermissionsController.\n   * It will remove re-point the network proxy to the globally selected network in the domainProxyMap or, if no globally selected network client is available, delete the proxy.\n   *\n   * @param domain - The domain for which to unset the network client ID.\n   */\n  #unsetNetworkClientIdForDomain(domain: Domain) {\n    const globallySelectedNetworkClient = this.messagingSystem.call(\n      'NetworkController:getSelectedNetworkClient',\n    );\n    const networkProxy = this.#domainProxyMap.get(domain);\n    if (networkProxy && globallySelectedNetworkClient) {\n      networkProxy.provider.setTarget(globallySelectedNetworkClient.provider);\n      networkProxy.blockTracker.setTarget(\n        globallySelectedNetworkClient.blockTracker,\n      );\n    } else if (networkProxy) {\n      this.#domainProxyMap.delete(domain);\n    }\n    this.update((state) => {\n      delete state.domains[domain];\n    });\n  }\n\n  #domainHasPermissions(domain: Domain): boolean {\n    return this.messagingSystem.call(\n      'PermissionController:hasPermissions',\n      domain,\n    );\n  }\n\n  // Loop through all domains and for those with permissions it points that domain's proxy\n  // to an unproxied instance of the globally selected network client.\n  // NOT the NetworkController's proxy of the globally selected networkClient\n  #resetAllPermissionedDomains() {\n    this.#domainProxyMap.forEach((_: NetworkProxy, domain: string) => {\n      const { selectedNetworkClientId } = this.messagingSystem.call(\n        'NetworkController:getState',\n      );\n      // can't use public setNetworkClientIdForDomain because it will throw an error\n      // rather than simply skip if the domain doesn't have permissions which can happen\n      // in this case since proxies are added for each site the user visits\n      if (this.#domainHasPermissions(domain)) {\n        this.#setNetworkClientIdForDomain(domain, selectedNetworkClientId);\n      }\n    });\n  }\n\n  setNetworkClientIdForDomain(\n    domain: Domain,\n    networkClientId: NetworkClientId,\n  ) {\n    if (domain === METAMASK_DOMAIN) {\n      throw new Error(\n        `NetworkClientId for domain \"${METAMASK_DOMAIN}\" cannot be set on the SelectedNetworkController`,\n      );\n    }\n\n    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {\n      return;\n    }\n\n    if (!this.#domainHasPermissions(domain)) {\n      throw new Error(\n        'NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions',\n      );\n    }\n\n    this.#setNetworkClientIdForDomain(domain, networkClientId);\n  }\n\n  getNetworkClientIdForDomain(domain: Domain): NetworkClientId {\n    const { selectedNetworkClientId: metamaskSelectedNetworkClientId } =\n      this.messagingSystem.call('NetworkController:getState');\n    if (!this.#useRequestQueuePreference) {\n      return metamaskSelectedNetworkClientId;\n    }\n    return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;\n  }\n\n  /**\n   * Accesses the provider and block tracker for the currently selected network.\n   *\n   * @param domain - the domain for the provider\n   * @returns The proxy and block tracker proxies.\n   */\n  getProviderAndBlockTracker(domain: Domain): NetworkProxy {\n    // If the domain is 'metamask' or a snap, return the NetworkController's globally selected network client proxy\n    if (\n      domain === METAMASK_DOMAIN ||\n      snapsPrefixes.some((prefix) => domain.startsWith(prefix))\n    ) {\n      const networkClient = this.messagingSystem.call(\n        'NetworkController:getSelectedNetworkClient',\n      );\n      if (networkClient === undefined) {\n        throw new Error('Selected network not initialized');\n      }\n      return networkClient;\n    }\n\n    let networkProxy = this.#domainProxyMap.get(domain);\n    if (networkProxy === undefined) {\n      let networkClient;\n      if (\n        this.#useRequestQueuePreference &&\n        this.#domainHasPermissions(domain)\n      ) {\n        const networkClientId = this.getNetworkClientIdForDomain(domain);\n        networkClient = this.messagingSystem.call(\n          'NetworkController:getNetworkClientById',\n          networkClientId,\n        );\n      } else {\n        networkClient = this.messagingSystem.call(\n          'NetworkController:getSelectedNetworkClient',\n        );\n        if (networkClient === undefined) {\n          throw new Error('Selected network not initialized');\n        }\n      }\n      networkProxy = {\n        provider: createEventEmitterProxy(networkClient.provider),\n        blockTracker: createEventEmitterProxy(networkClient.blockTracker, {\n          eventFilter: 'skipInternal',\n        }),\n      };\n      this.#domainProxyMap.set(domain, networkProxy);\n    }\n    return networkProxy;\n  }\n}\n"]}
+\ No newline at end of file
+diff --git a/dist/chunk-S4D42VCM.mjs b/dist/chunk-S4D42VCM.mjs
+deleted file mode 100644
+index a2a93432c8799383bef3bbe2cf3adf1ac3bda043..0000000000000000000000000000000000000000
+--- a/dist/chunk-S4D42VCM.mjs
++++ /dev/null
+@@ -1,281 +0,0 @@
+-var __accessCheck = (obj, member, msg) => {
+-  if (!member.has(obj))
+-    throw TypeError("Cannot " + msg);
+-};
+-var __privateGet = (obj, member, getter) => {
+-  __accessCheck(obj, member, "read from private field");
+-  return getter ? getter.call(obj) : member.get(obj);
+-};
+-var __privateAdd = (obj, member, value) => {
+-  if (member.has(obj))
+-    throw TypeError("Cannot add the same private member more than once");
+-  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+-};
+-var __privateSet = (obj, member, value, setter) => {
+-  __accessCheck(obj, member, "write to private field");
+-  setter ? setter.call(obj, value) : member.set(obj, value);
+-  return value;
+-};
+-var __privateMethod = (obj, member, method) => {
+-  __accessCheck(obj, member, "access private method");
+-  return method;
+-};
+-
+-// src/SelectedNetworkController.ts
+-import { BaseController } from "@metamask/base-controller";
+-import { createEventEmitterProxy } from "@metamask/swappable-obj-proxy";
+-var controllerName = "SelectedNetworkController";
+-var stateMetadata = {
+-  domains: { persist: true, anonymous: false }
+-};
+-var getDefaultState = () => ({ domains: {} });
+-var snapsPrefixes = ["npm:", "local:"];
+-var METAMASK_DOMAIN = "metamask";
+-var SelectedNetworkControllerActionTypes = {
+-  getState: `${controllerName}:getState`,
+-  getNetworkClientIdForDomain: `${controllerName}:getNetworkClientIdForDomain`,
+-  setNetworkClientIdForDomain: `${controllerName}:setNetworkClientIdForDomain`
+-};
+-var SelectedNetworkControllerEventTypes = {
+-  stateChange: `${controllerName}:stateChange`
+-};
+-var _domainProxyMap, _useRequestQueuePreference, _registerMessageHandlers, registerMessageHandlers_fn, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn, _domainHasPermissions, domainHasPermissions_fn, _resetAllPermissionedDomains, resetAllPermissionedDomains_fn;
+-var SelectedNetworkController = class extends BaseController {
+-  /**
+-   * Construct a SelectedNetworkController controller.
+-   *
+-   * @param options - The controller options.
+-   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
+-   * @param options.state - The controllers initial state.
+-   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.
+-   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.
+-   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.
+-   */
+-  constructor({
+-    messenger,
+-    state = getDefaultState(),
+-    useRequestQueuePreference,
+-    onPreferencesStateChange,
+-    domainProxyMap
+-  }) {
+-    super({
+-      name: controllerName,
+-      metadata: stateMetadata,
+-      messenger,
+-      state
+-    });
+-    __privateAdd(this, _registerMessageHandlers);
+-    __privateAdd(this, _setNetworkClientIdForDomain);
+-    /**
+-     * This method is used when a domain is removed from the PermissionsController.
+-     * It will remove re-point the network proxy to the globally selected network in the domainProxyMap or, if no globally selected network client is available, delete the proxy.
+-     *
+-     * @param domain - The domain for which to unset the network client ID.
+-     */
+-    __privateAdd(this, _unsetNetworkClientIdForDomain);
+-    __privateAdd(this, _domainHasPermissions);
+-    // Loop through all domains and for those with permissions it points that domain's proxy
+-    // to an unproxied instance of the globally selected network client.
+-    // NOT the NetworkController's proxy of the globally selected networkClient
+-    __privateAdd(this, _resetAllPermissionedDomains);
+-    __privateAdd(this, _domainProxyMap, void 0);
+-    __privateAdd(this, _useRequestQueuePreference, void 0);
+-    __privateSet(this, _useRequestQueuePreference, useRequestQueuePreference);
+-    __privateSet(this, _domainProxyMap, domainProxyMap);
+-    __privateMethod(this, _registerMessageHandlers, registerMessageHandlers_fn).call(this);
+-    this.messagingSystem.call("PermissionController:getSubjectNames").filter((domain) => this.state.domains[domain] === void 0).forEach(
+-      (domain) => this.setNetworkClientIdForDomain(
+-        domain,
+-        this.messagingSystem.call("NetworkController:getState").selectedNetworkClientId
+-      )
+-    );
+-    this.messagingSystem.subscribe(
+-      "PermissionController:stateChange",
+-      (_, patches) => {
+-        patches.forEach(({ op, path }) => {
+-          const isChangingSubject = path[0] === "subjects" && path[1] !== void 0;
+-          if (isChangingSubject && typeof path[1] === "string") {
+-            const domain = path[1];
+-            if (op === "add" && this.state.domains[domain] === void 0) {
+-              this.setNetworkClientIdForDomain(
+-                domain,
+-                this.messagingSystem.call("NetworkController:getState").selectedNetworkClientId
+-              );
+-            } else if (op === "remove" && this.state.domains[domain] !== void 0) {
+-              __privateMethod(this, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn).call(this, domain);
+-            }
+-          }
+-        });
+-      }
+-    );
+-    this.messagingSystem.subscribe(
+-      "NetworkController:stateChange",
+-      ({ selectedNetworkClientId }, patches) => {
+-        patches.forEach(({ op, path }) => {
+-          if (op === "remove" && path[0] === "networkConfigurations") {
+-            const removedNetworkClientId = path[1];
+-            Object.entries(this.state.domains).forEach(
+-              ([domain, networkClientIdForDomain]) => {
+-                if (networkClientIdForDomain === removedNetworkClientId) {
+-                  this.setNetworkClientIdForDomain(
+-                    domain,
+-                    selectedNetworkClientId
+-                  );
+-                }
+-              }
+-            );
+-          }
+-        });
+-      }
+-    );
+-    onPreferencesStateChange(({ useRequestQueue }) => {
+-      if (__privateGet(this, _useRequestQueuePreference) !== useRequestQueue) {
+-        if (!useRequestQueue) {
+-          Object.keys(this.state.domains).forEach((domain) => {
+-            __privateMethod(this, _unsetNetworkClientIdForDomain, unsetNetworkClientIdForDomain_fn).call(this, domain);
+-          });
+-        } else {
+-          __privateMethod(this, _resetAllPermissionedDomains, resetAllPermissionedDomains_fn).call(this);
+-        }
+-        __privateSet(this, _useRequestQueuePreference, useRequestQueue);
+-      }
+-    });
+-  }
+-  setNetworkClientIdForDomain(domain, networkClientId) {
+-    if (domain === METAMASK_DOMAIN) {
+-      throw new Error(
+-        `NetworkClientId for domain "${METAMASK_DOMAIN}" cannot be set on the SelectedNetworkController`
+-      );
+-    }
+-    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
+-      return;
+-    }
+-    if (!__privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
+-      throw new Error(
+-        "NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions"
+-      );
+-    }
+-    __privateMethod(this, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn).call(this, domain, networkClientId);
+-  }
+-  getNetworkClientIdForDomain(domain) {
+-    const { selectedNetworkClientId: metamaskSelectedNetworkClientId } = this.messagingSystem.call("NetworkController:getState");
+-    if (!__privateGet(this, _useRequestQueuePreference)) {
+-      return metamaskSelectedNetworkClientId;
+-    }
+-    return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;
+-  }
+-  /**
+-   * Accesses the provider and block tracker for the currently selected network.
+-   *
+-   * @param domain - the domain for the provider
+-   * @returns The proxy and block tracker proxies.
+-   */
+-  getProviderAndBlockTracker(domain) {
+-    if (domain === METAMASK_DOMAIN || snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
+-      const networkClient = this.messagingSystem.call(
+-        "NetworkController:getSelectedNetworkClient"
+-      );
+-      if (networkClient === void 0) {
+-        throw new Error("Selected network not initialized");
+-      }
+-      return networkClient;
+-    }
+-    let networkProxy = __privateGet(this, _domainProxyMap).get(domain);
+-    if (networkProxy === void 0) {
+-      let networkClient;
+-      if (__privateGet(this, _useRequestQueuePreference) && __privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
+-        const networkClientId = this.getNetworkClientIdForDomain(domain);
+-        networkClient = this.messagingSystem.call(
+-          "NetworkController:getNetworkClientById",
+-          networkClientId
+-        );
+-      } else {
+-        networkClient = this.messagingSystem.call(
+-          "NetworkController:getSelectedNetworkClient"
+-        );
+-        if (networkClient === void 0) {
+-          throw new Error("Selected network not initialized");
+-        }
+-      }
+-      networkProxy = {
+-        provider: createEventEmitterProxy(networkClient.provider),
+-        blockTracker: createEventEmitterProxy(networkClient.blockTracker, {
+-          eventFilter: "skipInternal"
+-        })
+-      };
+-      __privateGet(this, _domainProxyMap).set(domain, networkProxy);
+-    }
+-    return networkProxy;
+-  }
+-};
+-_domainProxyMap = new WeakMap();
+-_useRequestQueuePreference = new WeakMap();
+-_registerMessageHandlers = new WeakSet();
+-registerMessageHandlers_fn = function() {
+-  this.messagingSystem.registerActionHandler(
+-    SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
+-    this.getNetworkClientIdForDomain.bind(this)
+-  );
+-  this.messagingSystem.registerActionHandler(
+-    SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,
+-    this.setNetworkClientIdForDomain.bind(this)
+-  );
+-};
+-_setNetworkClientIdForDomain = new WeakSet();
+-setNetworkClientIdForDomain_fn = function(domain, networkClientId) {
+-  const networkClient = this.messagingSystem.call(
+-    "NetworkController:getNetworkClientById",
+-    networkClientId
+-  );
+-  const networkProxy = this.getProviderAndBlockTracker(domain);
+-  networkProxy.provider.setTarget(networkClient.provider);
+-  networkProxy.blockTracker.setTarget(networkClient.blockTracker);
+-  this.update((state) => {
+-    state.domains[domain] = networkClientId;
+-  });
+-};
+-_unsetNetworkClientIdForDomain = new WeakSet();
+-unsetNetworkClientIdForDomain_fn = function(domain) {
+-  const globallySelectedNetworkClient = this.messagingSystem.call(
+-    "NetworkController:getSelectedNetworkClient"
+-  );
+-  const networkProxy = __privateGet(this, _domainProxyMap).get(domain);
+-  if (networkProxy && globallySelectedNetworkClient) {
+-    networkProxy.provider.setTarget(globallySelectedNetworkClient.provider);
+-    networkProxy.blockTracker.setTarget(
+-      globallySelectedNetworkClient.blockTracker
+-    );
+-  } else if (networkProxy) {
+-    __privateGet(this, _domainProxyMap).delete(domain);
+-  }
+-  this.update((state) => {
+-    delete state.domains[domain];
+-  });
+-};
+-_domainHasPermissions = new WeakSet();
+-domainHasPermissions_fn = function(domain) {
+-  return this.messagingSystem.call(
+-    "PermissionController:hasPermissions",
+-    domain
+-  );
+-};
+-_resetAllPermissionedDomains = new WeakSet();
+-resetAllPermissionedDomains_fn = function() {
+-  __privateGet(this, _domainProxyMap).forEach((_, domain) => {
+-    const { selectedNetworkClientId } = this.messagingSystem.call(
+-      "NetworkController:getState"
+-    );
+-    if (__privateMethod(this, _domainHasPermissions, domainHasPermissions_fn).call(this, domain)) {
+-      __privateMethod(this, _setNetworkClientIdForDomain, setNetworkClientIdForDomain_fn).call(this, domain, selectedNetworkClientId);
+-    }
+-  });
+-};
+-
+-export {
+-  controllerName,
+-  METAMASK_DOMAIN,
+-  SelectedNetworkControllerActionTypes,
+-  SelectedNetworkControllerEventTypes,
+-  SelectedNetworkController
+-};
+-//# sourceMappingURL=chunk-S4D42VCM.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-S4D42VCM.mjs.map b/dist/chunk-S4D42VCM.mjs.map
+deleted file mode 100644
+index b05eba0cbdeb5af4729d92e7b8de695c2d2a75e3..0000000000000000000000000000000000000000
+--- a/dist/chunk-S4D42VCM.mjs.map
++++ /dev/null
+@@ -1 +0,0 @@
+-{"version":3,"sources":["../src/SelectedNetworkController.ts"],"sourcesContent":["import type { RestrictedControllerMessenger } from '@metamask/base-controller';\nimport { BaseController } from '@metamask/base-controller';\nimport type {\n  BlockTrackerProxy,\n  NetworkClientId,\n  NetworkControllerGetNetworkClientByIdAction,\n  NetworkControllerGetSelectedNetworkClientAction,\n  NetworkControllerGetStateAction,\n  NetworkControllerStateChangeEvent,\n  ProviderProxy,\n} from '@metamask/network-controller';\nimport type {\n  PermissionControllerStateChange,\n  GetSubjects as PermissionControllerGetSubjectsAction,\n  HasPermissions as PermissionControllerHasPermissions,\n} from '@metamask/permission-controller';\nimport { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';\nimport type { Patch } from 'immer';\n\nexport const controllerName = 'SelectedNetworkController';\n\nconst stateMetadata = {\n  domains: { persist: true, anonymous: false },\n};\n\nconst getDefaultState = () => ({ domains: {} });\n\n// npm and local are currently the only valid prefixes for snap domains\n// TODO: eventually we maybe want to pull this in from snaps-utils to ensure it stays in sync\n// For now it seems like overkill to add a dependency for this one constant\n// https://github.com/MetaMask/snaps/blob/2beee7803bfe9e540788a3558b546b9f55dc3cb4/packages/snaps-utils/src/types.ts#L120\nconst snapsPrefixes = ['npm:', 'local:'] as const;\n\nexport type Domain = string;\n\nexport const METAMASK_DOMAIN = 'metamask' as const;\n\nexport const SelectedNetworkControllerActionTypes = {\n  getState: `${controllerName}:getState` as const,\n  getNetworkClientIdForDomain:\n    `${controllerName}:getNetworkClientIdForDomain` as const,\n  setNetworkClientIdForDomain:\n    `${controllerName}:setNetworkClientIdForDomain` as const,\n};\n\nexport const SelectedNetworkControllerEventTypes = {\n  stateChange: `${controllerName}:stateChange` as const,\n};\n\nexport type SelectedNetworkControllerState = {\n  domains: Record<Domain, NetworkClientId>;\n};\n\nexport type SelectedNetworkControllerStateChangeEvent = {\n  type: typeof SelectedNetworkControllerEventTypes.stateChange;\n  payload: [SelectedNetworkControllerState, Patch[]];\n};\n\nexport type SelectedNetworkControllerGetSelectedNetworkStateAction = {\n  type: typeof SelectedNetworkControllerActionTypes.getState;\n  handler: () => SelectedNetworkControllerState;\n};\n\nexport type SelectedNetworkControllerGetNetworkClientIdForDomainAction = {\n  type: typeof SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain;\n  handler: SelectedNetworkController['getNetworkClientIdForDomain'];\n};\n\nexport type SelectedNetworkControllerSetNetworkClientIdForDomainAction = {\n  type: typeof SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain;\n  handler: SelectedNetworkController['setNetworkClientIdForDomain'];\n};\n\nexport type SelectedNetworkControllerActions =\n  | SelectedNetworkControllerGetSelectedNetworkStateAction\n  | SelectedNetworkControllerGetNetworkClientIdForDomainAction\n  | SelectedNetworkControllerSetNetworkClientIdForDomainAction;\n\nexport type AllowedActions =\n  | NetworkControllerGetNetworkClientByIdAction\n  | NetworkControllerGetSelectedNetworkClientAction\n  | NetworkControllerGetStateAction\n  | PermissionControllerHasPermissions\n  | PermissionControllerGetSubjectsAction;\n\nexport type SelectedNetworkControllerEvents =\n  SelectedNetworkControllerStateChangeEvent;\n\nexport type AllowedEvents =\n  | NetworkControllerStateChangeEvent\n  | PermissionControllerStateChange;\n\nexport type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<\n  typeof controllerName,\n  SelectedNetworkControllerActions | AllowedActions,\n  SelectedNetworkControllerEvents | AllowedEvents,\n  AllowedActions['type'],\n  AllowedEvents['type']\n>;\n\nexport type SelectedNetworkControllerOptions = {\n  state?: SelectedNetworkControllerState;\n  messenger: SelectedNetworkControllerMessenger;\n  useRequestQueuePreference: boolean;\n  onPreferencesStateChange: (\n    listener: (preferencesState: { useRequestQueue: boolean }) => void,\n  ) => void;\n  domainProxyMap: Map<Domain, NetworkProxy>;\n};\n\nexport type NetworkProxy = {\n  provider: ProviderProxy;\n  blockTracker: BlockTrackerProxy;\n};\n\n/**\n * Controller for getting and setting the network for a particular domain.\n */\nexport class SelectedNetworkController extends BaseController<\n  typeof controllerName,\n  SelectedNetworkControllerState,\n  SelectedNetworkControllerMessenger\n> {\n  #domainProxyMap: Map<Domain, NetworkProxy>;\n\n  #useRequestQueuePreference: boolean;\n\n  /**\n   * Construct a SelectedNetworkController controller.\n   *\n   * @param options - The controller options.\n   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.\n   * @param options.state - The controllers initial state.\n   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.\n   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.\n   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.\n   */\n  constructor({\n    messenger,\n    state = getDefaultState(),\n    useRequestQueuePreference,\n    onPreferencesStateChange,\n    domainProxyMap,\n  }: SelectedNetworkControllerOptions) {\n    super({\n      name: controllerName,\n      metadata: stateMetadata,\n      messenger,\n      state,\n    });\n    this.#useRequestQueuePreference = useRequestQueuePreference;\n    this.#domainProxyMap = domainProxyMap;\n    this.#registerMessageHandlers();\n\n    // this is fetching all the dapp permissions from the PermissionsController and looking for any domains that are not in domains state in this controller. Then we take any missing domains and add them to state here, setting it with the globally selected networkClientId (fetched from the NetworkController)\n    this.messagingSystem\n      .call('PermissionController:getSubjectNames')\n      .filter((domain) => this.state.domains[domain] === undefined)\n      .forEach((domain) =>\n        this.setNetworkClientIdForDomain(\n          domain,\n          this.messagingSystem.call('NetworkController:getState')\n            .selectedNetworkClientId,\n        ),\n      );\n\n    this.messagingSystem.subscribe(\n      'PermissionController:stateChange',\n      (_, patches) => {\n        patches.forEach(({ op, path }) => {\n          const isChangingSubject =\n            path[0] === 'subjects' && path[1] !== undefined;\n          if (isChangingSubject && typeof path[1] === 'string') {\n            const domain = path[1];\n            if (op === 'add' && this.state.domains[domain] === undefined) {\n              this.setNetworkClientIdForDomain(\n                domain,\n                this.messagingSystem.call('NetworkController:getState')\n                  .selectedNetworkClientId,\n              );\n            } else if (\n              op === 'remove' &&\n              this.state.domains[domain] !== undefined\n            ) {\n              this.#unsetNetworkClientIdForDomain(domain);\n            }\n          }\n        });\n      },\n    );\n\n    this.messagingSystem.subscribe(\n      'NetworkController:stateChange',\n      ({ selectedNetworkClientId }, patches) => {\n        patches.forEach(({ op, path }) => {\n          // if a network is removed, update the networkClientId for all domains that were using it to the selected network\n          if (op === 'remove' && path[0] === 'networkConfigurations') {\n            const removedNetworkClientId = path[1] as NetworkClientId;\n            Object.entries(this.state.domains).forEach(\n              ([domain, networkClientIdForDomain]) => {\n                if (networkClientIdForDomain === removedNetworkClientId) {\n                  this.setNetworkClientIdForDomain(\n                    domain,\n                    selectedNetworkClientId,\n                  );\n                }\n              },\n            );\n          }\n        });\n      },\n    );\n\n    onPreferencesStateChange(({ useRequestQueue }) => {\n      if (this.#useRequestQueuePreference !== useRequestQueue) {\n        if (!useRequestQueue) {\n          // Loop through all domains and points each domain's proxy\n          // to the NetworkController's own proxy of the globally selected networkClient\n          Object.keys(this.state.domains).forEach((domain) => {\n            this.#unsetNetworkClientIdForDomain(domain);\n          });\n        } else {\n          this.#resetAllPermissionedDomains();\n        }\n        this.#useRequestQueuePreference = useRequestQueue;\n      }\n    });\n  }\n\n  #registerMessageHandlers(): void {\n    this.messagingSystem.registerActionHandler(\n      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,\n      this.getNetworkClientIdForDomain.bind(this),\n    );\n    this.messagingSystem.registerActionHandler(\n      SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,\n      this.setNetworkClientIdForDomain.bind(this),\n    );\n  }\n\n  #setNetworkClientIdForDomain(\n    domain: Domain,\n    networkClientId: NetworkClientId,\n  ) {\n    const networkClient = this.messagingSystem.call(\n      'NetworkController:getNetworkClientById',\n      networkClientId,\n    );\n    const networkProxy = this.getProviderAndBlockTracker(domain);\n    networkProxy.provider.setTarget(networkClient.provider);\n    networkProxy.blockTracker.setTarget(networkClient.blockTracker);\n\n    this.update((state) => {\n      state.domains[domain] = networkClientId;\n    });\n  }\n\n  /**\n   * This method is used when a domain is removed from the PermissionsController.\n   * It will remove re-point the network proxy to the globally selected network in the domainProxyMap or, if no globally selected network client is available, delete the proxy.\n   *\n   * @param domain - The domain for which to unset the network client ID.\n   */\n  #unsetNetworkClientIdForDomain(domain: Domain) {\n    const globallySelectedNetworkClient = this.messagingSystem.call(\n      'NetworkController:getSelectedNetworkClient',\n    );\n    const networkProxy = this.#domainProxyMap.get(domain);\n    if (networkProxy && globallySelectedNetworkClient) {\n      networkProxy.provider.setTarget(globallySelectedNetworkClient.provider);\n      networkProxy.blockTracker.setTarget(\n        globallySelectedNetworkClient.blockTracker,\n      );\n    } else if (networkProxy) {\n      this.#domainProxyMap.delete(domain);\n    }\n    this.update((state) => {\n      delete state.domains[domain];\n    });\n  }\n\n  #domainHasPermissions(domain: Domain): boolean {\n    return this.messagingSystem.call(\n      'PermissionController:hasPermissions',\n      domain,\n    );\n  }\n\n  // Loop through all domains and for those with permissions it points that domain's proxy\n  // to an unproxied instance of the globally selected network client.\n  // NOT the NetworkController's proxy of the globally selected networkClient\n  #resetAllPermissionedDomains() {\n    this.#domainProxyMap.forEach((_: NetworkProxy, domain: string) => {\n      const { selectedNetworkClientId } = this.messagingSystem.call(\n        'NetworkController:getState',\n      );\n      // can't use public setNetworkClientIdForDomain because it will throw an error\n      // rather than simply skip if the domain doesn't have permissions which can happen\n      // in this case since proxies are added for each site the user visits\n      if (this.#domainHasPermissions(domain)) {\n        this.#setNetworkClientIdForDomain(domain, selectedNetworkClientId);\n      }\n    });\n  }\n\n  setNetworkClientIdForDomain(\n    domain: Domain,\n    networkClientId: NetworkClientId,\n  ) {\n    if (domain === METAMASK_DOMAIN) {\n      throw new Error(\n        `NetworkClientId for domain \"${METAMASK_DOMAIN}\" cannot be set on the SelectedNetworkController`,\n      );\n    }\n\n    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {\n      return;\n    }\n\n    if (!this.#domainHasPermissions(domain)) {\n      throw new Error(\n        'NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions',\n      );\n    }\n\n    this.#setNetworkClientIdForDomain(domain, networkClientId);\n  }\n\n  getNetworkClientIdForDomain(domain: Domain): NetworkClientId {\n    const { selectedNetworkClientId: metamaskSelectedNetworkClientId } =\n      this.messagingSystem.call('NetworkController:getState');\n    if (!this.#useRequestQueuePreference) {\n      return metamaskSelectedNetworkClientId;\n    }\n    return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;\n  }\n\n  /**\n   * Accesses the provider and block tracker for the currently selected network.\n   *\n   * @param domain - the domain for the provider\n   * @returns The proxy and block tracker proxies.\n   */\n  getProviderAndBlockTracker(domain: Domain): NetworkProxy {\n    // If the domain is 'metamask' or a snap, return the NetworkController's globally selected network client proxy\n    if (\n      domain === METAMASK_DOMAIN ||\n      snapsPrefixes.some((prefix) => domain.startsWith(prefix))\n    ) {\n      const networkClient = this.messagingSystem.call(\n        'NetworkController:getSelectedNetworkClient',\n      );\n      if (networkClient === undefined) {\n        throw new Error('Selected network not initialized');\n      }\n      return networkClient;\n    }\n\n    let networkProxy = this.#domainProxyMap.get(domain);\n    if (networkProxy === undefined) {\n      let networkClient;\n      if (\n        this.#useRequestQueuePreference &&\n        this.#domainHasPermissions(domain)\n      ) {\n        const networkClientId = this.getNetworkClientIdForDomain(domain);\n        networkClient = this.messagingSystem.call(\n          'NetworkController:getNetworkClientById',\n          networkClientId,\n        );\n      } else {\n        networkClient = this.messagingSystem.call(\n          'NetworkController:getSelectedNetworkClient',\n        );\n        if (networkClient === undefined) {\n          throw new Error('Selected network not initialized');\n        }\n      }\n      networkProxy = {\n        provider: createEventEmitterProxy(networkClient.provider),\n        blockTracker: createEventEmitterProxy(networkClient.blockTracker, {\n          eventFilter: 'skipInternal',\n        }),\n      };\n      this.#domainProxyMap.set(domain, networkProxy);\n    }\n    return networkProxy;\n  }\n}\n"],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;AACA,SAAS,sBAAsB;AAe/B,SAAS,+BAA+B;AAGjC,IAAM,iBAAiB;AAE9B,IAAM,gBAAgB;AAAA,EACpB,SAAS,EAAE,SAAS,MAAM,WAAW,MAAM;AAC7C;AAEA,IAAM,kBAAkB,OAAO,EAAE,SAAS,CAAC,EAAE;AAM7C,IAAM,gBAAgB,CAAC,QAAQ,QAAQ;AAIhC,IAAM,kBAAkB;AAExB,IAAM,uCAAuC;AAAA,EAClD,UAAU,GAAG,cAAc;AAAA,EAC3B,6BACE,GAAG,cAAc;AAAA,EACnB,6BACE,GAAG,cAAc;AACrB;AAEO,IAAM,sCAAsC;AAAA,EACjD,aAAa,GAAG,cAAc;AAChC;AA/CA;AAsHO,IAAM,4BAAN,cAAwC,eAI7C;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAeA,YAAY;AAAA,IACV;AAAA,IACA,QAAQ,gBAAgB;AAAA,IACxB;AAAA,IACA;AAAA,IACA;AAAA,EACF,GAAqC;AACnC,UAAM;AAAA,MACJ,MAAM;AAAA,MACN,UAAU;AAAA,MACV;AAAA,MACA;AAAA,IACF,CAAC;AAgFH;AAWA;AAuBA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAkBA;AAUA;AAAA;AAAA;AAAA;AAxKA;AAEA;AAyBE,uBAAK,4BAA6B;AAClC,uBAAK,iBAAkB;AACvB,0BAAK,sDAAL;AAGA,SAAK,gBACF,KAAK,sCAAsC,EAC3C,OAAO,CAAC,WAAW,KAAK,MAAM,QAAQ,MAAM,MAAM,MAAS,EAC3D;AAAA,MAAQ,CAAC,WACR,KAAK;AAAA,QACH;AAAA,QACA,KAAK,gBAAgB,KAAK,4BAA4B,EACnD;AAAA,MACL;AAAA,IACF;AAEF,SAAK,gBAAgB;AAAA,MACnB;AAAA,MACA,CAAC,GAAG,YAAY;AACd,gBAAQ,QAAQ,CAAC,EAAE,IAAI,KAAK,MAAM;AAChC,gBAAM,oBACJ,KAAK,CAAC,MAAM,cAAc,KAAK,CAAC,MAAM;AACxC,cAAI,qBAAqB,OAAO,KAAK,CAAC,MAAM,UAAU;AACpD,kBAAM,SAAS,KAAK,CAAC;AACrB,gBAAI,OAAO,SAAS,KAAK,MAAM,QAAQ,MAAM,MAAM,QAAW;AAC5D,mBAAK;AAAA,gBACH;AAAA,gBACA,KAAK,gBAAgB,KAAK,4BAA4B,EACnD;AAAA,cACL;AAAA,YACF,WACE,OAAO,YACP,KAAK,MAAM,QAAQ,MAAM,MAAM,QAC/B;AACA,oCAAK,kEAAL,WAAoC;AAAA,YACtC;AAAA,UACF;AAAA,QACF,CAAC;AAAA,MACH;AAAA,IACF;AAEA,SAAK,gBAAgB;AAAA,MACnB;AAAA,MACA,CAAC,EAAE,wBAAwB,GAAG,YAAY;AACxC,gBAAQ,QAAQ,CAAC,EAAE,IAAI,KAAK,MAAM;AAEhC,cAAI,OAAO,YAAY,KAAK,CAAC,MAAM,yBAAyB;AAC1D,kBAAM,yBAAyB,KAAK,CAAC;AACrC,mBAAO,QAAQ,KAAK,MAAM,OAAO,EAAE;AAAA,cACjC,CAAC,CAAC,QAAQ,wBAAwB,MAAM;AACtC,oBAAI,6BAA6B,wBAAwB;AACvD,uBAAK;AAAA,oBACH;AAAA,oBACA;AAAA,kBACF;AAAA,gBACF;AAAA,cACF;AAAA,YACF;AAAA,UACF;AAAA,QACF,CAAC;AAAA,MACH;AAAA,IACF;AAEA,6BAAyB,CAAC,EAAE,gBAAgB,MAAM;AAChD,UAAI,mBAAK,gCAA+B,iBAAiB;AACvD,YAAI,CAAC,iBAAiB;AAGpB,iBAAO,KAAK,KAAK,MAAM,OAAO,EAAE,QAAQ,CAAC,WAAW;AAClD,kCAAK,kEAAL,WAAoC;AAAA,UACtC,CAAC;AAAA,QACH,OAAO;AACL,gCAAK,8DAAL;AAAA,QACF;AACA,2BAAK,4BAA6B;AAAA,MACpC;AAAA,IACF,CAAC;AAAA,EACH;AAAA,EA8EA,4BACE,QACA,iBACA;AACA,QAAI,WAAW,iBAAiB;AAC9B,YAAM,IAAI;AAAA,QACR,+BAA+B,eAAe;AAAA,MAChD;AAAA,IACF;AAEA,QAAI,cAAc,KAAK,CAAC,WAAW,OAAO,WAAW,MAAM,CAAC,GAAG;AAC7D;AAAA,IACF;AAEA,QAAI,CAAC,sBAAK,gDAAL,WAA2B,SAAS;AACvC,YAAM,IAAI;AAAA,QACR;AAAA,MACF;AAAA,IACF;AAEA,0BAAK,8DAAL,WAAkC,QAAQ;AAAA,EAC5C;AAAA,EAEA,4BAA4B,QAAiC;AAC3D,UAAM,EAAE,yBAAyB,gCAAgC,IAC/D,KAAK,gBAAgB,KAAK,4BAA4B;AACxD,QAAI,CAAC,mBAAK,6BAA4B;AACpC,aAAO;AAAA,IACT;AACA,WAAO,KAAK,MAAM,QAAQ,MAAM,KAAK;AAAA,EACvC;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA,EAQA,2BAA2B,QAA8B;AAEvD,QACE,WAAW,mBACX,cAAc,KAAK,CAAC,WAAW,OAAO,WAAW,MAAM,CAAC,GACxD;AACA,YAAM,gBAAgB,KAAK,gBAAgB;AAAA,QACzC;AAAA,MACF;AACA,UAAI,kBAAkB,QAAW;AAC/B,cAAM,IAAI,MAAM,kCAAkC;AAAA,MACpD;AACA,aAAO;AAAA,IACT;AAEA,QAAI,eAAe,mBAAK,iBAAgB,IAAI,MAAM;AAClD,QAAI,iBAAiB,QAAW;AAC9B,UAAI;AACJ,UACE,mBAAK,+BACL,sBAAK,gDAAL,WAA2B,SAC3B;AACA,cAAM,kBAAkB,KAAK,4BAA4B,MAAM;AAC/D,wBAAgB,KAAK,gBAAgB;AAAA,UACnC;AAAA,UACA;AAAA,QACF;AAAA,MACF,OAAO;AACL,wBAAgB,KAAK,gBAAgB;AAAA,UACnC;AAAA,QACF;AACA,YAAI,kBAAkB,QAAW;AAC/B,gBAAM,IAAI,MAAM,kCAAkC;AAAA,QACpD;AAAA,MACF;AACA,qBAAe;AAAA,QACb,UAAU,wBAAwB,cAAc,QAAQ;AAAA,QACxD,cAAc,wBAAwB,cAAc,cAAc;AAAA,UAChE,aAAa;AAAA,QACf,CAAC;AAAA,MACH;AACA,yBAAK,iBAAgB,IAAI,QAAQ,YAAY;AAAA,IAC/C;AACA,WAAO;AAAA,EACT;AACF;AAzQE;AAEA;AAwGA;AAAA,6BAAwB,WAAS;AAC/B,OAAK,gBAAgB;AAAA,IACnB,qCAAqC;AAAA,IACrC,KAAK,4BAA4B,KAAK,IAAI;AAAA,EAC5C;AACA,OAAK,gBAAgB;AAAA,IACnB,qCAAqC;AAAA,IACrC,KAAK,4BAA4B,KAAK,IAAI;AAAA,EAC5C;AACF;AAEA;AAAA,iCAA4B,SAC1B,QACA,iBACA;AACA,QAAM,gBAAgB,KAAK,gBAAgB;AAAA,IACzC;AAAA,IACA;AAAA,EACF;AACA,QAAM,eAAe,KAAK,2BAA2B,MAAM;AAC3D,eAAa,SAAS,UAAU,cAAc,QAAQ;AACtD,eAAa,aAAa,UAAU,cAAc,YAAY;AAE9D,OAAK,OAAO,CAAC,UAAU;AACrB,UAAM,QAAQ,MAAM,IAAI;AAAA,EAC1B,CAAC;AACH;AAQA;AAAA,mCAA8B,SAAC,QAAgB;AAC7C,QAAM,gCAAgC,KAAK,gBAAgB;AAAA,IACzD;AAAA,EACF;AACA,QAAM,eAAe,mBAAK,iBAAgB,IAAI,MAAM;AACpD,MAAI,gBAAgB,+BAA+B;AACjD,iBAAa,SAAS,UAAU,8BAA8B,QAAQ;AACtE,iBAAa,aAAa;AAAA,MACxB,8BAA8B;AAAA,IAChC;AAAA,EACF,WAAW,cAAc;AACvB,uBAAK,iBAAgB,OAAO,MAAM;AAAA,EACpC;AACA,OAAK,OAAO,CAAC,UAAU;AACrB,WAAO,MAAM,QAAQ,MAAM;AAAA,EAC7B,CAAC;AACH;AAEA;AAAA,0BAAqB,SAAC,QAAyB;AAC7C,SAAO,KAAK,gBAAgB;AAAA,IAC1B;AAAA,IACA;AAAA,EACF;AACF;AAKA;AAAA,iCAA4B,WAAG;AAC7B,qBAAK,iBAAgB,QAAQ,CAAC,GAAiB,WAAmB;AAChE,UAAM,EAAE,wBAAwB,IAAI,KAAK,gBAAgB;AAAA,MACvD;AAAA,IACF;AAIA,QAAI,sBAAK,gDAAL,WAA2B,SAAS;AACtC,4BAAK,8DAAL,WAAkC,QAAQ;AAAA,IAC5C;AAAA,EACF,CAAC;AACH;","names":[]}
+\ No newline at end of file
+diff --git a/dist/chunk-ZY7ETPVE.mjs b/dist/chunk-ZY7ETPVE.mjs
+deleted file mode 100644
+index 50a21cfa6988a3e32a4c1a20f9113eaec7bf99ac..0000000000000000000000000000000000000000
+--- a/dist/chunk-ZY7ETPVE.mjs
++++ /dev/null
+@@ -1,23 +0,0 @@
+-import {
+-  SelectedNetworkControllerActionTypes
+-} from "./chunk-S4D42VCM.mjs";
+-
+-// src/SelectedNetworkMiddleware.ts
+-var createSelectedNetworkMiddleware = (messenger) => {
+-  const getNetworkClientIdForDomain = (origin) => messenger.call(
+-    SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
+-    origin
+-  );
+-  return (req, _, next) => {
+-    if (!req.origin) {
+-      throw new Error("Request object is lacking an 'origin'");
+-    }
+-    req.networkClientId = getNetworkClientIdForDomain(req.origin);
+-    return next();
+-  };
+-};
+-
+-export {
+-  createSelectedNetworkMiddleware
+-};
+-//# sourceMappingURL=chunk-ZY7ETPVE.mjs.map
+\ No newline at end of file
+diff --git a/dist/chunk-ZY7ETPVE.mjs.map b/dist/chunk-ZY7ETPVE.mjs.map
+deleted file mode 100644
+index fbcfd73d57f291b4f129caa47ef0c9614987cc30..0000000000000000000000000000000000000000
+--- a/dist/chunk-ZY7ETPVE.mjs.map
++++ /dev/null
+@@ -1 +0,0 @@
+-{"version":3,"sources":["../src/SelectedNetworkMiddleware.ts"],"sourcesContent":["import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';\nimport type { NetworkClientId } from '@metamask/network-controller';\nimport type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';\n\nimport type { SelectedNetworkControllerMessenger } from './SelectedNetworkController';\nimport { SelectedNetworkControllerActionTypes } from './SelectedNetworkController';\n\nexport type SelectedNetworkMiddlewareJsonRpcRequest = JsonRpcRequest & {\n  networkClientId?: NetworkClientId;\n  origin?: string;\n};\n\nexport const createSelectedNetworkMiddleware = (\n  messenger: SelectedNetworkControllerMessenger,\n): JsonRpcMiddleware<JsonRpcParams, Json> => {\n  const getNetworkClientIdForDomain = (origin: string) =>\n    messenger.call(\n      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,\n      origin,\n    );\n\n  return (req: SelectedNetworkMiddlewareJsonRpcRequest, _, next) => {\n    if (!req.origin) {\n      throw new Error(\"Request object is lacking an 'origin'\");\n    }\n\n    req.networkClientId = getNetworkClientIdForDomain(req.origin);\n    return next();\n  };\n};\n"],"mappings":";;;;;AAYO,IAAM,kCAAkC,CAC7C,cAC2C;AAC3C,QAAM,8BAA8B,CAAC,WACnC,UAAU;AAAA,IACR,qCAAqC;AAAA,IACrC;AAAA,EACF;AAEF,SAAO,CAAC,KAA8C,GAAG,SAAS;AAChE,QAAI,CAAC,IAAI,QAAQ;AACf,YAAM,IAAI,MAAM,uCAAuC;AAAA,IACzD;AAEA,QAAI,kBAAkB,4BAA4B,IAAI,MAAM;AAC5D,WAAO,KAAK;AAAA,EACd;AACF;","names":[]}
+\ No newline at end of file
+diff --git a/dist/index.js b/dist/index.js
+index 4c9b1798d88466e11abbcf1c0616f2617d73ab5a..cd71df24b3f6424f640c62ce8a7938fcf15ae480 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,17 +1,17 @@
+ "use strict";Object.defineProperty(exports, "__esModule", {value: true});
+ 
+-var _chunk6W2ETVOHjs = require('./chunk-6W2ETVOH.js');
++var _chunkANSSZMDIjs = require('./chunk-ANSSZMDI.js');
+ 
+ 
+ 
+ 
+ 
+-var _chunkOGUVGN6Rjs = require('./chunk-OGUVGN6R.js');
++var _chunkCECZWJ42js = require('./chunk-CECZWJ42.js');
+ 
+ 
+ 
+ 
+ 
+ 
+-exports.METAMASK_DOMAIN = _chunkOGUVGN6Rjs.METAMASK_DOMAIN; exports.SelectedNetworkController = _chunkOGUVGN6Rjs.SelectedNetworkController; exports.SelectedNetworkControllerActionTypes = _chunkOGUVGN6Rjs.SelectedNetworkControllerActionTypes; exports.SelectedNetworkControllerEventTypes = _chunkOGUVGN6Rjs.SelectedNetworkControllerEventTypes; exports.createSelectedNetworkMiddleware = _chunk6W2ETVOHjs.createSelectedNetworkMiddleware;
++exports.METAMASK_DOMAIN = _chunkCECZWJ42js.METAMASK_DOMAIN; exports.SelectedNetworkController = _chunkCECZWJ42js.SelectedNetworkController; exports.SelectedNetworkControllerActionTypes = _chunkCECZWJ42js.SelectedNetworkControllerActionTypes; exports.SelectedNetworkControllerEventTypes = _chunkCECZWJ42js.SelectedNetworkControllerEventTypes; exports.createSelectedNetworkMiddleware = _chunkANSSZMDIjs.createSelectedNetworkMiddleware;
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 8780cadd8a535b745960ebde8d7aa49989451ef6..0c7b103ca9cb6a604bf5f831bccef3002abd7c5f 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1,12 +1,12 @@
+ import {
+   createSelectedNetworkMiddleware
+-} from "./chunk-ZY7ETPVE.mjs";
++} from "./chunk-HFN7TKJS.mjs";
+ import {
+   METAMASK_DOMAIN,
+   SelectedNetworkController,
+   SelectedNetworkControllerActionTypes,
+   SelectedNetworkControllerEventTypes
+-} from "./chunk-S4D42VCM.mjs";
++} from "./chunk-7DSTEJNI.mjs";
+ export {
+   METAMASK_DOMAIN,
+   SelectedNetworkController,
+diff --git a/dist/tsconfig.build.tsbuildinfo b/dist/tsconfig.build.tsbuildinfo
+index 0f3a7a7e18a90ebf82da9962818a7e552c892d9c..8a2c9ef72e1d3a4302d4bda2c3e634414225fd17 100644
+--- a/dist/tsconfig.build.tsbuildinfo
++++ b/dist/tsconfig.build.tsbuildinfo
+@@ -1 +1 @@
+-{"program":{"fileNames":["../../../node_modules/typescript/lib/lib.es5.d.ts","../../../node_modules/typescript/lib/lib.es2015.d.ts","../../../node_modules/typescript/lib/lib.es2016.d.ts","../../../node_modules/typescript/lib/lib.es2017.d.ts","../../../node_modules/typescript/lib/lib.es2018.d.ts","../../../node_modules/typescript/lib/lib.es2019.d.ts","../../../node_modules/typescript/lib/lib.es2020.d.ts","../../../node_modules/typescript/lib/lib.dom.d.ts","../../../node_modules/typescript/lib/lib.es2015.core.d.ts","../../../node_modules/typescript/lib/lib.es2015.collection.d.ts","../../../node_modules/typescript/lib/lib.es2015.generator.d.ts","../../../node_modules/typescript/lib/lib.es2015.iterable.d.ts","../../../node_modules/typescript/lib/lib.es2015.promise.d.ts","../../../node_modules/typescript/lib/lib.es2015.proxy.d.ts","../../../node_modules/typescript/lib/lib.es2015.reflect.d.ts","../../../node_modules/typescript/lib/lib.es2015.symbol.d.ts","../../../node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts","../../../node_modules/typescript/lib/lib.es2016.array.include.d.ts","../../../node_modules/typescript/lib/lib.es2017.object.d.ts","../../../node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts","../../../node_modules/typescript/lib/lib.es2017.string.d.ts","../../../node_modules/typescript/lib/lib.es2017.intl.d.ts","../../../node_modules/typescript/lib/lib.es2017.typedarrays.d.ts","../../../node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts","../../../node_modules/typescript/lib/lib.es2018.asynciterable.d.ts","../../../node_modules/typescript/lib/lib.es2018.intl.d.ts","../../../node_modules/typescript/lib/lib.es2018.promise.d.ts","../../../node_modules/typescript/lib/lib.es2018.regexp.d.ts","../../../node_modules/typescript/lib/lib.es2019.array.d.ts","../../../node_modules/typescript/lib/lib.es2019.object.d.ts","../../../node_modules/typescript/lib/lib.es2019.string.d.ts","../../../node_modules/typescript/lib/lib.es2019.symbol.d.ts","../../../node_modules/typescript/lib/lib.es2019.intl.d.ts","../../../node_modules/typescript/lib/lib.es2020.bigint.d.ts","../../../node_modules/typescript/lib/lib.es2020.date.d.ts","../../../node_modules/typescript/lib/lib.es2020.promise.d.ts","../../../node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts","../../../node_modules/typescript/lib/lib.es2020.string.d.ts","../../../node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts","../../../node_modules/typescript/lib/lib.es2020.intl.d.ts","../../../node_modules/typescript/lib/lib.es2020.number.d.ts","../../../node_modules/typescript/lib/lib.esnext.intl.d.ts","../../../types/eth-ens-namehash.d.ts","../../../types/ethereum-ens-network-map.d.ts","../../../types/global.d.ts","../../../types/single-call-balance-checker-abi.d.ts","../../../types/@metamask/contract-metadata.d.ts","../../../types/@metamask/eth-hd-keyring.d.ts","../../../types/@metamask/eth-simple-keyring.d.ts","../../../types/@metamask/ethjs-provider-http.d.ts","../../../types/@metamask/ethjs-unit.d.ts","../../../types/@metamask/metamask-eth-abis.d.ts","../../../types/eth-json-rpc-infura/src/createprovider.d.ts","../../../types/eth-phishing-detect/src/config.json.d.ts","../../../types/eth-phishing-detect/src/detector.d.ts","../../base-controller/dist/types/basecontrollerv1.d.ts","../../../node_modules/superstruct/dist/error.d.ts","../../../node_modules/superstruct/dist/utils.d.ts","../../../node_modules/superstruct/dist/struct.d.ts","../../../node_modules/superstruct/dist/structs/coercions.d.ts","../../../node_modules/superstruct/dist/structs/refinements.d.ts","../../../node_modules/superstruct/dist/structs/types.d.ts","../../../node_modules/superstruct/dist/structs/utilities.d.ts","../../../node_modules/superstruct/dist/index.d.ts","../../../node_modules/@metamask/utils/dist/types/assert.d.ts","../../../node_modules/@metamask/utils/dist/types/base64.d.ts","../../../node_modules/@metamask/utils/dist/types/hex.d.ts","../../../node_modules/@metamask/utils/dist/types/bytes.d.ts","../../../node_modules/@metamask/utils/dist/types/caip-types.d.ts","../../../node_modules/@metamask/utils/dist/types/checksum.d.ts","../../../node_modules/@metamask/utils/dist/types/coercers.d.ts","../../../node_modules/@metamask/utils/dist/types/collections.d.ts","../../../node_modules/@metamask/utils/dist/types/encryption-types.d.ts","../../../node_modules/@metamask/utils/dist/types/errors.d.ts","../../../node_modules/@metamask/utils/dist/types/json.d.ts","../../../node_modules/@types/node/assert.d.ts","../../../node_modules/@types/node/assert/strict.d.ts","../../../node_modules/@types/node/globals.d.ts","../../../node_modules/@types/node/async_hooks.d.ts","../../../node_modules/@types/node/buffer.d.ts","../../../node_modules/@types/node/child_process.d.ts","../../../node_modules/@types/node/cluster.d.ts","../../../node_modules/@types/node/console.d.ts","../../../node_modules/@types/node/constants.d.ts","../../../node_modules/@types/node/crypto.d.ts","../../../node_modules/@types/node/dgram.d.ts","../../../node_modules/@types/node/diagnostics_channel.d.ts","../../../node_modules/@types/node/dns.d.ts","../../../node_modules/@types/node/dns/promises.d.ts","../../../node_modules/@types/node/domain.d.ts","../../../node_modules/@types/node/events.d.ts","../../../node_modules/@types/node/fs.d.ts","../../../node_modules/@types/node/fs/promises.d.ts","../../../node_modules/@types/node/http.d.ts","../../../node_modules/@types/node/http2.d.ts","../../../node_modules/@types/node/https.d.ts","../../../node_modules/@types/node/inspector.d.ts","../../../node_modules/@types/node/module.d.ts","../../../node_modules/@types/node/net.d.ts","../../../node_modules/@types/node/os.d.ts","../../../node_modules/@types/node/path.d.ts","../../../node_modules/@types/node/perf_hooks.d.ts","../../../node_modules/@types/node/process.d.ts","../../../node_modules/@types/node/punycode.d.ts","../../../node_modules/@types/node/querystring.d.ts","../../../node_modules/@types/node/readline.d.ts","../../../node_modules/@types/node/repl.d.ts","../../../node_modules/@types/node/stream.d.ts","../../../node_modules/@types/node/stream/promises.d.ts","../../../node_modules/@types/node/stream/consumers.d.ts","../../../node_modules/@types/node/stream/web.d.ts","../../../node_modules/@types/node/string_decoder.d.ts","../../../node_modules/@types/node/test.d.ts","../../../node_modules/@types/node/timers.d.ts","../../../node_modules/@types/node/timers/promises.d.ts","../../../node_modules/@types/node/tls.d.ts","../../../node_modules/@types/node/trace_events.d.ts","../../../node_modules/@types/node/tty.d.ts","../../../node_modules/@types/node/url.d.ts","../../../node_modules/@types/node/util.d.ts","../../../node_modules/@types/node/v8.d.ts","../../../node_modules/@types/node/vm.d.ts","../../../node_modules/@types/node/wasi.d.ts","../../../node_modules/@types/node/worker_threads.d.ts","../../../node_modules/@types/node/zlib.d.ts","../../../node_modules/@types/node/globals.global.d.ts","../../../node_modules/@types/node/index.d.ts","../../../node_modules/@ethereumjs/common/dist/enums.d.ts","../../../node_modules/@ethereumjs/common/dist/types.d.ts","../../../node_modules/buffer/index.d.ts","../../../node_modules/@ethereumjs/util/dist/constants.d.ts","../../../node_modules/@ethereumjs/util/dist/units.d.ts","../../../node_modules/@ethereumjs/util/dist/address.d.ts","../../../node_modules/@ethereumjs/util/dist/bytes.d.ts","../../../node_modules/@ethereumjs/util/dist/types.d.ts","../../../node_modules/@ethereumjs/util/dist/account.d.ts","../../../node_modules/@ethereumjs/util/dist/withdrawal.d.ts","../../../node_modules/@ethereumjs/util/dist/signature.d.ts","../../../node_modules/@ethereumjs/util/dist/encoding.d.ts","../../../node_modules/@ethereumjs/util/dist/asynceventemitter.d.ts","../../../node_modules/@ethereumjs/util/dist/internal.d.ts","../../../node_modules/@ethereumjs/util/dist/lock.d.ts","../../../node_modules/@ethereumjs/util/dist/provider.d.ts","../../../node_modules/@ethereumjs/util/dist/index.d.ts","../../../node_modules/@ethereumjs/common/dist/common.d.ts","../../../node_modules/@ethereumjs/common/dist/utils.d.ts","../../../node_modules/@ethereumjs/common/dist/index.d.ts","../../../node_modules/@ethereumjs/tx/dist/eip2930transaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/legacytransaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/types.d.ts","../../../node_modules/@ethereumjs/tx/dist/basetransaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/eip1559transaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/transactionfactory.d.ts","../../../node_modules/@ethereumjs/tx/dist/index.d.ts","../../../node_modules/@metamask/utils/dist/types/keyring.d.ts","../../../node_modules/@types/ms/index.d.ts","../../../node_modules/@types/debug/index.d.ts","../../../node_modules/@metamask/utils/dist/types/logging.d.ts","../../../node_modules/@metamask/utils/dist/types/misc.d.ts","../../../node_modules/@metamask/utils/dist/types/number.d.ts","../../../node_modules/@metamask/utils/dist/types/opaque.d.ts","../../../node_modules/@metamask/utils/dist/types/promise.d.ts","../../../node_modules/@metamask/utils/dist/types/time.d.ts","../../../node_modules/@metamask/utils/dist/types/transaction-types.d.ts","../../../node_modules/@metamask/utils/dist/types/versions.d.ts","../../../node_modules/@metamask/utils/dist/types/index.d.ts","../../../node_modules/immer/dist/utils/env.d.ts","../../../node_modules/immer/dist/utils/errors.d.ts","../../../node_modules/immer/dist/types/types-external.d.ts","../../../node_modules/immer/dist/types/types-internal.d.ts","../../../node_modules/immer/dist/utils/common.d.ts","../../../node_modules/immer/dist/utils/plugins.d.ts","../../../node_modules/immer/dist/core/scope.d.ts","../../../node_modules/immer/dist/core/finalize.d.ts","../../../node_modules/immer/dist/core/proxy.d.ts","../../../node_modules/immer/dist/core/immerclass.d.ts","../../../node_modules/immer/dist/core/current.d.ts","../../../node_modules/immer/dist/internal.d.ts","../../../node_modules/immer/dist/plugins/es5.d.ts","../../../node_modules/immer/dist/plugins/patches.d.ts","../../../node_modules/immer/dist/plugins/mapset.d.ts","../../../node_modules/immer/dist/plugins/all.d.ts","../../../node_modules/immer/dist/immer.d.ts","../../base-controller/dist/types/restrictedcontrollermessenger.d.ts","../../base-controller/dist/types/controllermessenger.d.ts","../../base-controller/dist/types/basecontrollerv2.d.ts","../../base-controller/dist/types/index.d.ts","../../controller-utils/dist/types/types.d.ts","../../controller-utils/dist/types/constants.d.ts","../../../node_modules/@metamask/eth-query/index.d.ts","../../../node_modules/@types/bn.js/index.d.ts","../../controller-utils/dist/types/util.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/abnf.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/utils.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/parsers.d.ts","../../controller-utils/dist/types/siwe.d.ts","../../controller-utils/dist/types/index.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/types.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/createeventemitterproxy.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/createswappableproxy.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/index.d.ts","../../network-controller/dist/types/constants.d.ts","../../../node_modules/@metamask/safe-event-emitter/index.d.ts","../../json-rpc-engine/dist/types/jsonrpcengine.d.ts","../../json-rpc-engine/dist/types/createasyncmiddleware.d.ts","../../json-rpc-engine/dist/types/createscaffoldmiddleware.d.ts","../../json-rpc-engine/dist/types/getuniqueid.d.ts","../../json-rpc-engine/dist/types/idremapmiddleware.d.ts","../../json-rpc-engine/dist/types/mergemiddleware.d.ts","../../json-rpc-engine/dist/types/index.d.ts","../../eth-json-rpc-provider/dist/types/safe-event-emitter-provider.d.ts","../../eth-json-rpc-provider/dist/types/provider-from-engine.d.ts","../../eth-json-rpc-provider/dist/types/provider-from-middleware.d.ts","../../eth-json-rpc-provider/dist/types/index.d.ts","../../../node_modules/eth-block-tracker/dist/blocktracker.d.ts","../../../node_modules/eth-block-tracker/dist/pollingblocktracker.d.ts","../../../node_modules/eth-block-tracker/dist/subscribeblocktracker.d.ts","../../../node_modules/eth-block-tracker/dist/index.d.ts","../../network-controller/dist/types/types.d.ts","../../network-controller/dist/types/create-auto-managed-network-client.d.ts","../../network-controller/dist/types/networkcontroller.d.ts","../../network-controller/dist/types/create-network-client.d.ts","../../network-controller/dist/types/index.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/utils.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/classes.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/errors.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/error-constants.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/index.d.ts","../../approval-controller/dist/types/approvalcontroller.d.ts","../../approval-controller/dist/types/errors.d.ts","../../approval-controller/dist/types/index.d.ts","../../permission-controller/dist/types/permission-middleware.d.ts","../../permission-controller/dist/types/subjectmetadatacontroller.d.ts","../../permission-controller/dist/types/permissioncontroller.d.ts","../../permission-controller/dist/types/permission.d.ts","../../permission-controller/dist/types/caveat.d.ts","../../permission-controller/dist/types/errors.d.ts","../../permission-controller/dist/types/utils.d.ts","../../permission-controller/dist/types/rpc-methods/getpermissions.d.ts","../../permission-controller/dist/types/rpc-methods/requestpermissions.d.ts","../../permission-controller/dist/types/rpc-methods/revokepermissions.d.ts","../../permission-controller/dist/types/rpc-methods/index.d.ts","../../permission-controller/dist/types/index.d.ts","../src/selectednetworkcontroller.ts","../src/selectednetworkmiddleware.ts","../src/index.ts","../../../node_modules/@babel/types/lib/index.d.ts","../../../node_modules/@types/babel__generator/index.d.ts","../../../node_modules/@babel/parser/typings/babel-parser.d.ts","../../../node_modules/@types/babel__template/index.d.ts","../../../node_modules/@types/babel__traverse/index.d.ts","../../../node_modules/@types/babel__core/index.d.ts","../../../node_modules/@types/deep-freeze-strict/index.d.ts","../../../node_modules/@types/eslint/helpers.d.ts","../../../node_modules/@types/estree/index.d.ts","../../../node_modules/@types/json-schema/index.d.ts","../../../node_modules/@types/eslint/index.d.ts","../../../node_modules/@types/graceful-fs/index.d.ts","../../../node_modules/@types/istanbul-lib-coverage/index.d.ts","../../../node_modules/@types/istanbul-lib-report/index.d.ts","../../../node_modules/@types/istanbul-reports/index.d.ts","../../../node_modules/chalk/index.d.ts","../../../node_modules/jest-diff/build/cleanupsemantic.d.ts","../../../node_modules/pretty-format/build/types.d.ts","../../../node_modules/pretty-format/build/index.d.ts","../../../node_modules/jest-diff/build/types.d.ts","../../../node_modules/jest-diff/build/difflines.d.ts","../../../node_modules/jest-diff/build/printdiffs.d.ts","../../../node_modules/jest-diff/build/index.d.ts","../../../node_modules/jest-matcher-utils/build/index.d.ts","../../../node_modules/@types/jest/index.d.ts","../../../node_modules/@types/jest-when/index.d.ts","../../../node_modules/@types/json5/index.d.ts","../../../node_modules/@types/lodash/common/common.d.ts","../../../node_modules/@types/lodash/common/array.d.ts","../../../node_modules/@types/lodash/common/collection.d.ts","../../../node_modules/@types/lodash/common/date.d.ts","../../../node_modules/@types/lodash/common/function.d.ts","../../../node_modules/@types/lodash/common/lang.d.ts","../../../node_modules/@types/lodash/common/math.d.ts","../../../node_modules/@types/lodash/common/number.d.ts","../../../node_modules/@types/lodash/common/object.d.ts","../../../node_modules/@types/lodash/common/seq.d.ts","../../../node_modules/@types/lodash/common/string.d.ts","../../../node_modules/@types/lodash/common/util.d.ts","../../../node_modules/@types/lodash/index.d.ts","../../../node_modules/@types/minimatch/index.d.ts","../../../node_modules/@types/parse-json/index.d.ts","../../../node_modules/@types/pbkdf2/index.d.ts","../../../node_modules/@types/prettier/index.d.ts","../../../node_modules/@types/punycode/index.d.ts","../../../node_modules/@types/readable-stream/node_modules/safe-buffer/index.d.ts","../../../node_modules/@types/readable-stream/index.d.ts","../../../node_modules/@types/secp256k1/index.d.ts","../../../node_modules/@types/semver/classes/semver.d.ts","../../../node_modules/@types/semver/functions/parse.d.ts","../../../node_modules/@types/semver/functions/valid.d.ts","../../../node_modules/@types/semver/functions/clean.d.ts","../../../node_modules/@types/semver/functions/inc.d.ts","../../../node_modules/@types/semver/functions/diff.d.ts","../../../node_modules/@types/semver/functions/major.d.ts","../../../node_modules/@types/semver/functions/minor.d.ts","../../../node_modules/@types/semver/functions/patch.d.ts","../../../node_modules/@types/semver/functions/prerelease.d.ts","../../../node_modules/@types/semver/functions/compare.d.ts","../../../node_modules/@types/semver/functions/rcompare.d.ts","../../../node_modules/@types/semver/functions/compare-loose.d.ts","../../../node_modules/@types/semver/functions/compare-build.d.ts","../../../node_modules/@types/semver/functions/sort.d.ts","../../../node_modules/@types/semver/functions/rsort.d.ts","../../../node_modules/@types/semver/functions/gt.d.ts","../../../node_modules/@types/semver/functions/lt.d.ts","../../../node_modules/@types/semver/functions/eq.d.ts","../../../node_modules/@types/semver/functions/neq.d.ts","../../../node_modules/@types/semver/functions/gte.d.ts","../../../node_modules/@types/semver/functions/lte.d.ts","../../../node_modules/@types/semver/functions/cmp.d.ts","../../../node_modules/@types/semver/functions/coerce.d.ts","../../../node_modules/@types/semver/classes/comparator.d.ts","../../../node_modules/@types/semver/classes/range.d.ts","../../../node_modules/@types/semver/functions/satisfies.d.ts","../../../node_modules/@types/semver/ranges/max-satisfying.d.ts","../../../node_modules/@types/semver/ranges/min-satisfying.d.ts","../../../node_modules/@types/semver/ranges/to-comparators.d.ts","../../../node_modules/@types/semver/ranges/min-version.d.ts","../../../node_modules/@types/semver/ranges/valid.d.ts","../../../node_modules/@types/semver/ranges/outside.d.ts","../../../node_modules/@types/semver/ranges/gtr.d.ts","../../../node_modules/@types/semver/ranges/ltr.d.ts","../../../node_modules/@types/semver/ranges/intersects.d.ts","../../../node_modules/@types/semver/ranges/simplify.d.ts","../../../node_modules/@types/semver/ranges/subset.d.ts","../../../node_modules/@types/semver/internals/identifiers.d.ts","../../../node_modules/@types/semver/index.d.ts","../../../node_modules/@types/sinonjs__fake-timers/index.d.ts","../../../node_modules/@types/sinon/index.d.ts","../../../node_modules/@types/stack-utils/index.d.ts","../../../node_modules/@types/uuid/index.d.ts","../../../node_modules/@types/yargs-parser/index.d.ts","../../../node_modules/@types/yargs/index.d.ts"],"fileInfos":[{"version":"8730f4bf322026ff5229336391a18bcaa1f94d4f82416c8b2f3954e2ccaae2ba","affectsGlobalScope":true},"dc47c4fa66b9b9890cf076304de2a9c5201e94b740cffdf09f87296d877d71f6","7a387c58583dfca701b6c85e0adaf43fb17d590fb16d5b2dc0a2fbd89f35c467","8a12173c586e95f4433e0c6dc446bc88346be73ffe9ca6eec7aa63c8f3dca7f9","5f4e733ced4e129482ae2186aae29fde948ab7182844c3a5a51dd346182c7b06","4b421cbfb3a38a27c279dec1e9112c3d1da296f77a1a85ddadf7e7a425d45d18","1fc5ab7a764205c68fa10d381b08417795fc73111d6dd16b5b1ed36badb743d9",{"version":"3aafcb693fe5b5c3bd277bd4c3a617b53db474fe498fc5df067c5603b1eebde7","affectsGlobalScope":true},{"version":"adb996790133eb33b33aadb9c09f15c2c575e71fb57a62de8bf74dbf59ec7dfb","affectsGlobalScope":true},{"version":"8cc8c5a3bac513368b0157f3d8b31cfdcfe78b56d3724f30f80ed9715e404af8","affectsGlobalScope":true},{"version":"cdccba9a388c2ee3fd6ad4018c640a471a6c060e96f1232062223063b0a5ac6a","affectsGlobalScope":true},{"version":"c5c05907c02476e4bde6b7e76a79ffcd948aedd14b6a8f56e4674221b0417398","affectsGlobalScope":true},{"version":"5f406584aef28a331c36523df688ca3650288d14f39c5d2e555c95f0d2ff8f6f","affectsGlobalScope":true},{"version":"22f230e544b35349cfb3bd9110b6ef37b41c6d6c43c3314a31bd0d9652fcec72","affectsGlobalScope":true},{"version":"7ea0b55f6b315cf9ac2ad622b0a7813315bb6e97bf4bb3fbf8f8affbca7dc695","affectsGlobalScope":true},{"version":"3013574108c36fd3aaca79764002b3717da09725a36a6fc02eac386593110f93","affectsGlobalScope":true},{"version":"eb26de841c52236d8222f87e9e6a235332e0788af8c87a71e9e210314300410a","affectsGlobalScope":true},{"version":"3be5a1453daa63e031d266bf342f3943603873d890ab8b9ada95e22389389006","affectsGlobalScope":true},{"version":"17bb1fc99591b00515502d264fa55dc8370c45c5298f4a5c2083557dccba5a2a","affectsGlobalScope":true},{"version":"7ce9f0bde3307ca1f944119f6365f2d776d281a393b576a18a2f2893a2d75c98","affectsGlobalScope":true},{"version":"6a6b173e739a6a99629a8594bfb294cc7329bfb7b227f12e1f7c11bc163b8577","affectsGlobalScope":true},{"version":"81cac4cbc92c0c839c70f8ffb94eb61e2d32dc1c3cf6d95844ca099463cf37ea","affectsGlobalScope":true},{"version":"b0124885ef82641903d232172577f2ceb5d3e60aed4da1153bab4221e1f6dd4e","affectsGlobalScope":true},{"version":"0eb85d6c590b0d577919a79e0084fa1744c1beba6fd0d4e951432fa1ede5510a","affectsGlobalScope":true},{"version":"da233fc1c8a377ba9e0bed690a73c290d843c2c3d23a7bd7ec5cd3d7d73ba1e0","affectsGlobalScope":true},{"version":"d154ea5bb7f7f9001ed9153e876b2d5b8f5c2bb9ec02b3ae0d239ec769f1f2ae","affectsGlobalScope":true},{"version":"bb2d3fb05a1d2ffbca947cc7cbc95d23e1d053d6595391bd325deb265a18d36c","affectsGlobalScope":true},{"version":"c80df75850fea5caa2afe43b9949338ce4e2de086f91713e9af1a06f973872b8","affectsGlobalScope":true},{"version":"9d57b2b5d15838ed094aa9ff1299eecef40b190722eb619bac4616657a05f951","affectsGlobalScope":true},{"version":"6c51b5dd26a2c31dbf37f00cfc32b2aa6a92e19c995aefb5b97a3a64f1ac99de","affectsGlobalScope":true},{"version":"6e7997ef61de3132e4d4b2250e75343f487903ddf5370e7ce33cf1b9db9a63ed","affectsGlobalScope":true},{"version":"2ad234885a4240522efccd77de6c7d99eecf9b4de0914adb9a35c0c22433f993","affectsGlobalScope":true},{"version":"5e5e095c4470c8bab227dbbc61374878ecead104c74ab9960d3adcccfee23205","affectsGlobalScope":true},{"version":"09aa50414b80c023553090e2f53827f007a301bc34b0495bfb2c3c08ab9ad1eb","affectsGlobalScope":true},{"version":"d7f680a43f8cd12a6b6122c07c54ba40952b0c8aa140dcfcf32eb9e6cb028596","affectsGlobalScope":true},{"version":"3787b83e297de7c315d55d4a7c546ae28e5f6c0a361b7a1dcec1f1f50a54ef11","affectsGlobalScope":true},{"version":"e7e8e1d368290e9295ef18ca23f405cf40d5456fa9f20db6373a61ca45f75f40","affectsGlobalScope":true},{"version":"faf0221ae0465363c842ce6aa8a0cbda5d9296940a8e26c86e04cc4081eea21e","affectsGlobalScope":true},{"version":"06393d13ea207a1bfe08ec8d7be562549c5e2da8983f2ee074e00002629d1871","affectsGlobalScope":true},{"version":"2768ef564cfc0689a1b76106c421a2909bdff0acbe87da010785adab80efdd5c","affectsGlobalScope":true},{"version":"b248e32ca52e8f5571390a4142558ae4f203ae2f94d5bac38a3084d529ef4e58","affectsGlobalScope":true},{"version":"52d1bb7ab7a3306fd0375c8bff560feed26ed676a5b0457fa8027b563aecb9a4","affectsGlobalScope":true},"70bbfaec021ac4a0c805374225b55d70887f987df8b8dd7711d79464bb7b4385","869089d60b67219f63e6aca810284c89bae1b384b5cbc7ce64e53d82ad223ed5",{"version":"18338b6a4b920ec7d49b4ffafcbf0fa8a86b4bfd432966efd722dab611157cf4","affectsGlobalScope":true},"62a0875a0397b35a2364f1d401c0ce17975dfa4d47bf6844de858ae04da349f9","ee7491d0318d1fafcba97d5b72b450eb52671570f7a4ecd9e8898d40eaae9472","e3e7d217d89b380c1f34395eadc9289542851b0f0a64007dfe1fb7cf7423d24e","fd79909e93b4d50fd0ed9f3d39ddf8ba0653290bac25c295aac49f6befbd081b","345a9cc2945406f53051cd0e9b51f82e1e53929848eab046fdda91ee8aa7da31","9debe2de883da37a914e5e784a7be54c201b8f1d783822ad6f443ff409a5ea21","dee5d5c5440cda1f3668f11809a5503c30db0476ad117dd450f7ba5a45300e8f","f5e396c1424c391078c866d6f84afe0b4d2f7f85a160b9c756cd63b5b1775d93","5caa6f4fff16066d377d4e254f6c34c16540da3809cd66cd626a303bc33c419f","730d055528bdf12c8524870bb33d237991be9084c57634e56e5d8075f6605e02","75b22c74010ba649de1a1676a4c4b8b5bb4294fecd05089e2094429b16d7840c","e475453e7140e95542332943d3052fe4c7430ad1efce42b3e9157f1fee8cbc5f","ebfdf904255ce746c9d30117c2edef355fb19bf7650478d2405f39f0e4f302e6","f3f63b48addb8e2ea9d20bb671c3c306413b3daa39996d0ae52f63d8e32158e1","a50599c08934a62f11657bdbe0dc929ab66da1b1f09974408fd9a33ec1bb8060","5a20e7d6c630b91be15e9b837853173829d00273197481dc8d3e94df61105a71","8d478048d71cc16f806d4b71b252ecb67c7444ccf4f4b09b29a312712184f859","b4000a0a525fa921e896cbdb32ae802c9684f0fd371b5fc69e7310f7918cc2c3","9df4662ca3dbc2522bc115833ee04faa1afbb4e249a85ef4a0a09c621346bd08","b25d9065cf1c1f537a140bbc508e953ed2262f77134574c432d206ff36f4bdbf","1b103313097041aa9cd705a682c652f08613cb5cf8663321061c0902f845e81c","68ccec8662818911d8a12b8ed028bc5729fb4f1d34793c4701265ba60bc73cf4","5f85b8b79dc4d36af672c035b2beb71545de63a5d60bccbeee64c260941672ab","b3d48529ae61dc27d0bfbfa2cb3e0dff8189644bd155bdf5df1e8e14669f7043","40fe4b689225816b31fe5794c0fbf3534568819709e40295ead998a2bc1ab237","f65b5e33b9ad545a1eebbd6afe857314725ad42aaf069913e33f928ab3e4990a","fb6f2a87beb7fb1f4c2b762d0c76a9459fc91f557231569b0ee21399e22aa13d","31c858dc85996fac4b7fa944e1016d5c72f514930a72357ab5001097bf6511c7","3de30a871b3340be8b679c52aa12f90dd1c8c60874517be58968fdbcc4d79445","6fd985bd31eaf77542625306fb0404d32bff978990f0a06428e5f0b9a3b58109","34693fb4a5e771e11668219221344dd1bd7d8b77ed005a1c1d965fb559be8406","7394959e5a741b185456e1ef5d64599c36c60a323207450991e7a42e08911419",{"version":"e44ea2d6b7b853f6c81482416db43dafc11944561b810e469ae423085511ce7e","affectsGlobalScope":true},"f51b4042a3ac86f1f707500a9768f88d0b0c1fc3f3e45a73333283dea720cdc6",{"version":"a7289d79eb84a59d2475b4d0136b4404be3cfdd17c3ea46b9194add1d645df01","affectsGlobalScope":true},"0bb26fa2a90ee890eed57ee812c71fa84d3d07850163ec4a204de86412cc57c1","132ca47da601c60141dd6f10bd08c70d0620177e5638439df2464ec3945b6d98",{"version":"55d2bbae076fed7269c3e16faeb32f988f558427b7a1c3bf04aa7551ab86ae90","affectsGlobalScope":true},"a40826e8476694e90da94aa008283a7de50d1dafd37beada623863f1901cb7fb","cf83847c9264dcd592b6c89c1542925b899b277228687f3638614e3fa784cf76","3a41ebe7f089d50f447466b35b6cabb8b584c0994fc9809d0cd0a4ebc41e1239","7693b90b3075deaccafd5efb467bf9f2b747a3075be888652ef73e64396d8628","0c42d6cba77d9ad1cf45256ccb8489aa502fe2dbee1ec9048a29d49f5d532e73","2cf89c17245db65d175d4ef699cd68187516f9b3ae5c572fc0b9ad60f35dc223","5f20d20b7607174caf1a6da9141aeb9f2142159ae2410ca30c7a0fccd1d19c99",{"version":"a34d65f61ec5aac5b53502c8b0bd4e00d217bccb95bf94d449e2571baa11fb8c","affectsGlobalScope":true},"8d42e5af5fb0a96a77e135ce84cc60636c9bad39d9dba043a4efe9d1bdeb3cc3","56fcc451e9065eb121c9cc4c1b9994a816306f3b0b3b1fce7ad59f0ac97a9999","8a6f12b74d3e6c4f5e1b918cb8e64ae16bc6756cf0d48bcc28a28e1bf26ca0cd","c3759b5bc5cc40f5988d86a497741a80fa91258629ae50a2b3735e774cd377cc","bf268a0aea37ad4ae3b7a9b58559190b6fc01ea16a31e35cd05817a0a60f895a","45dd82fb5aea9b12b2a90b427b28f3a014e8b2ee9b74087a5ab882841cb5fbc5",{"version":"d7dad6db394a3d9f7b49755e4b610fbf8ed6eb0c9810ae5f1a119f6b5d76de45","affectsGlobalScope":true},"48b2f9302651eb31acd5be69bb4e6b35797a7fcd6b77391d10a4ccadf7dc3609","0c8c917ef15498c827bd494a0ef365e9f76deb211f8acbb86932e20489310788","dd67d2b5e4e8a182a38de8e69fb736945eaa4588e0909c14e01a14bd3cc1fd1e",{"version":"9cdc2c6144b03822c9842505d09945bcf813b86827fdb260dd7586b63abc19bf","affectsGlobalScope":true},{"version":"2923dee3c897f03e91b54a210cdbefea7290562f0ac4b948667d4c9ee844b79e","affectsGlobalScope":true},"79169698d09a2be54b14f3bcad2575b414bf3525063fde0a1e4fcd5d6efd380e","051d939bcf77caa3cef3282708ab3a6fdfb741a7366e1d74a9e7603b67417ec3","0be79b3ff0f16b6c2f9bc8c4cc7097ea417d8d67f8267f7e1eec8e32b548c2ff","1c61ffa3a71b77363b30d19832c269ef62fba787f5610cac7254728d3b69ab2e","a234d62ae81d012ebf23898a45672edf3e5c93ecf5a438a42b96c08dd68cde43","269929a24b2816343a178008ac9ae9248304d92a8ba8e233055e0ed6dbe6ef71","09ed02a725db002693236b6dfc49b2c6eb5557be1421d7fbe4f07cfe38211d92","09d801ff4a303d4976d4b9cb94af3a9097c4a70345e662d176975872d2998e51","c8558b01389b5f7610ac293aa612ccea2ae64d83af43b49f8142f190be1f414c","c40fdf7b2e18df49ce0568e37f0292c12807a0748be79e272745e7216bed2606",{"version":"b10b426c56e220b5093bf8a2446ee47af47263b7b1a03f4b18e42326b231b111","affectsGlobalScope":true},"4e228e78c1e9b0a75c70588d59288f63a6258e8b1fe4a67b0c53fe03461421d9","b4635ef36bee17e1304337d591c3b6b461ecdbc1876d0effbe6a581e62201fe5","205d50c24359ead003dc537b9b65d2a64208dfdffe368f403cf9e0357831db9e","1265fddcd0c68be9d2a3b29805d0280484c961264dd95e0b675f7bd91f777e78",{"version":"e4507242542bd499238f693d88b2d32e22177cc508854625f87bcc9bc3fa1256","affectsGlobalScope":true},{"version":"d942354e4966a98d3a92d1b1af0b4ac06f33af3f88116743e2c304c027ca26ef","affectsGlobalScope":true},"39f0808e5be3cb38674726c21fe2eb453c55e48a901679b4ce30fef85549b892","6afd66a7432ef100027ea110449e874196381e019e30eda7e7d8ca390366b7a8","befb8a9a78ac99d8fbc3ed392810489a7b90760c7a58934e8f1c8538f581cff3","e670bdf01540d35c170fae68edfd2f288eff909936780c379d6a9103b787b22c","867f95abf1df444aab146b19847391fc2f922a55f6a970a27ed8226766cee29f",{"version":"ab9b9a36e5284fd8d3bf2f7d5fcbc60052f25f27e4d20954782099282c60d23e","affectsGlobalScope":true},"88003d9ab15507806f41b120be6d407c1afe566c2f6689ebe3a034dd5ec0c8dc","175323e2a79a6076e0bada8a390d535a3ea817158bf1b1f46e31efca9028a0a2","7a10053aadc19335532a4d02756db4865974fd69bea5439ddcc5bfdf062d9476","4967529644e391115ca5592184d4b63980569adf60ee685f968fd59ab1557188","aed9e712a9b168345362e8f3a949f16c99ca1e05d21328f05735dfdbb24414ef","b04fe6922ed3db93afdbd49cdda8576aa75f744592fceea96fb0d5f32158c4f5","ed8d6c8de90fc2a4faaebc28e91f2469928738efd5208fb75ade0fa607e892b7","d7c52b198d680fe65b1a8d1b001f0173ffa2536ca2e7082431d726ce1f6714cd","c07f251e1c4e415a838e5498380b55cfea94f3513229de292d2aa85ae52fc3e9","0ed401424892d6bf294a5374efe512d6951b54a71e5dd0290c55b6d0d915f6f7","b945be6da6a3616ef3a250bfe223362b1c7c6872e775b0c4d82a1bf7a28ff902","beea49237dd7c7110fabf3c7509919c9cb9da841d847c53cac162dc3479e2f87","0f45f8a529c450d8f394106cc622bff79e44a1716e1ac9c3cc68b43f7ecf65ee","c624ce90b04c27ce4f318ba6330d39bde3d4e306f0f497ce78d4bda5ab8e22ca","9b8253aa5cb2c82d505f72afdbf96e83b15cc6b9a6f4fadbbbab46210d5f1977","86a8f52e4b1ac49155e889376bcfa8528a634c90c27fec65aa0e949f77b740c5","aab5dd41c1e2316cc0b42a7dd15684f8582d5a1d16c0516276a2a8a7d0fecd9c","59948226626ee210045296ba1fc6cb0fe748d1ff613204e08e7157ab6862dee7","ec3e54d8b713c170fdc8110a7e4a6a97513a7ab6b05ac9e1100cb064d2bb7349","43beb30ecb39a603fde4376554887310b0699f25f7f39c5c91e3147b51bb3a26","666b77d7f06f49da114b090a399abbfa66d5b6c01a3fd9dc4f063a52ace28507","31997714a93fbc570f52d47d6a8ebfb021a34a68ea9ba58bbb69cdec9565657e","6032e4262822160128e644de3fc4410bcd7517c2f137525fd2623d2bb23cb0d3","8bd5c9b1016629c144fd228983395b9dbf0676a576716bc3d316cab612c33cd5","2ed90bd3925b23aed8f859ffd0e885250be0424ca2b57e9866dabef152e1d6b7","93f6bd17d92dab9db7897e1430a5aeaa03bcf51623156213d8397710367a76ce","3f62b770a42e8c47c7008726f95aa383e69d97e85e680d237b99fcb0ee601dd8","5b84cfe78028c35c3bb89c042f18bf08d09da11e82d275c378ae4d07d8477e6c","980d21b0081cbf81774083b1e3a46f4bbdcd2b68858df0f66d7fad9c82bc34bc","6a9c5127096b35264eb7cd21b2417bfc1d42cceca9ba4ce2bb0c3410b7816042","93b7325b49dfbf613d940ed0e471216657b2d77459dac34f1b5b1678f08f884c","b17f3bb7d8333479c7e45e5f3d876761b9bca58f97594eca3f6a944fd825e632","3c1f1236cce6d6e0c4e2c1b4371e6f72d7c14842ecd76a98ed0748ee5730c8f3","6d7f58d5ea72d7834946fd7104a734dc7d40661be8b2e1eaced1ddce3268ebaf","4c26222991e6c97d5a8f541d4f2c67585eda9e8b33cf9f52931b098045236e88","277983d414aa99d78655186c3ee1e1c38c302e336aff1d77b47fcdc39d8273fe","47383b45796d525a4039cd22d2840ac55a1ff03a43d027f7f867ba7314a9cf53","6548773b3abbc18de29176c2141f766d4e437e40596ee480447abf83575445ad","6ddd27af0436ce59dd4c1896e2bfdb2bdb2529847d078b83ce67a144dff05491","816264799aef3fd5a09a3b6c25217d5ec26a9dfc7465eac7d6073bcdc7d88f3f","4df0891b133884cd9ed752d31c7d0ec0a09234e9ed5394abffd3c660761598db","b603b62d3dcd31ef757dc7339b4fa8acdbca318b0fb9ac485f9a1351955615f9","e642bd47b75ad6b53cbf0dfd7ddfa0f120bd10193f0c58ec37d87b59bf604aca","be90b24d2ee6f875ce3aaa482e7c41a54278856b03d04212681c4032df62baf9","78f5ff400b3cb37e7b90eef1ff311253ed31c8cb66505e9828fad099bffde021","372c47090e1131305d163469a895ff2938f33fa73aad988df31cd31743f9efb6","71c67dc6987bdbd5599353f90009ff825dd7db0450ef9a0aee5bb0c574d18512","6f12403b5eca6ae7ca8e3efe3eeb9c683b06ce3e3844ccfd04098d83cd7e4957","282c535df88175d64d9df4550d2fd1176fd940c1c6822f1e7584003237f179d3","c3a4752cf103e4c6034d5bd449c8f9d5e7b352d22a5f8f9a41a8efb11646f9c2","11a9e38611ac3c77c74240c58b6bd64a0032128b29354e999650f1de1e034b1c","4ed103ca6fff9cb244f7c4b86d1eb28ce8069c32db720784329946731badb5bb","d738f282842970e058672663311c6875482ee36607c88b98ffb6604fba99cb2a","ec859cd8226aa623e41bbb47c249a55ee16dc1b8647359585244d57d3a5ed0c7","8891c6e959d253a66434ff5dc9ae46058fb3493e84b4ca39f710ef2d350656b1","c4463cf02535444dcbc3e67ecd29f1972490f74e49957d6fd4282a1013796ba6","0cb0a957ff02de0b25fd0f3f37130ca7f22d1e0dea256569c714c1f73c6791f8","2f5075dc512d51786b1ba3b1696565641dfaae3ac854f5f13d61fa12ef81a47e","ca3353cc82b1981f0d25d71d7432d583a6ef882ccdea82d65fbe49af37be51cb","50679a8e27aacf72f8c40bcab15d7ef5e83494089b4726b83eec4554344d5cdc","45351e0d51780b6f4088277a4457b9879506ee2720a887de232df0f1efcb33d8","5d697a4b315cc5bb3042ae869abffd10c3b0d7b182cda0e4c45d8819937e5796","563fa27fdaec8f195b84f71a7af0ef48d30d5cc830575db86da86a63a470c8e6","6ee58aa536dabb19b09bc036f1abe83feb51e13d63b23d30b2d0631a2de99b8f","8aceb205dcc6f814ad99635baf1e40b6e01d06d3fe27b72fd766c6d0b8c0c600","299567f84bfedd1468dca2755a829cb19e607a6811673788807dc8921e211bc9","795d9fb85aad92221504db74dd179b506bd189bba0c104426f7e7bb8a66ffee5","1311bc194e0a69fe61031e852c1c0b439e2a2a3d1d5e2d8ff795499b9f283459","4b7ce19369d7e7fae76720c2c6c7f671bf3fa0f7093edb864f1ac358ca7c456c","c972ef44deca1fa8fab465915ffa00f82e126aacf3dfc8979c03b1b066ce5bb6","30285a1011c6d6b52f3ba3abb0a984be8148c05cdefb8eb6eb562335a3991f35","8e7adb22c0adecf7464861fc58ae3fc617b41ffbd70c97aa8493dc0966a82273","755f3cd1d9c1b564cff090e3b0e29200ae55690a91b87cb9e7a64c2dbeb314d3","d6bb7e0a6877b7856c183bff13d09dd9ae599ea43c6f6b33d3d5f72a830ed460","f1b51ae93c762d7c43f559933cd4842dd870367e8d92e90704ffa685dd5b29a3","3f450762fd7c34ed545e738abccb0af6a703572a10521643cf8fc88e3724c99c","fcc8beef29f39f09b1d9c9f99c42f9fed605ab1c28d2a630185f732b9ba53763","d6e6620a30d582182acc3f0a992a0c311adc589f111096aea11ab83fc09a5ccc","6213b8f686f56beab22b59a0f468590fd3a4c5fa931236a017efeca91d7c9584","c451cec9a588b1f105a5ea2c6063d4fca112b9d70105cacdadda0e1ef67e9379","cb047832dc68f5a2c41c62c5e95ddcacbae3a8b034d40cd15319a8cb7f25104a","980336ccdfc3c08f3c3b201aa6662e6016e20f15847f8465b68f3e8e67b4665c","5a3493939995f46ff3d9073cd534fb8961c3bf4e08c71db27066ff03d906dea8","bb5a2ac327605ebebf831c469b05bd34a33a6a46ee8c1edd9f3310aad32cf6a1","bf5d041f2440b4a9391e2b5eb3b8d94cbf1e3b8ff4703b6539d4e65e758c8f37","8516469eb90e723b0eb03df1be098f7e6a4709f6f48fd4532868d20a0a934f6e","d60e9ab369a72d234aac49adbe2900d8ef1408a6ea4db552cf2a48c9d8d6a1bc","0ebb4698803f01e2e7df6acce572fff068f4a20c47221721dafd70a27e372831","a12eaa942232703a8a8477a2f240ad5a2c26c595012ea8f128224e77984099c4","4070c2f1c3434fcf84886e04d30d82cd650ee443e53b82b404b144175cf8741e","2cea9689efa8591732096235abe7f084fc29c92badd5b0897a5e876b77e71887","4ed4e504126014fee13aaef5e3fc140f2ff7031ff3a8b5386717905820ea2d09","8129a34006218a6f3cdc81bbd438d5429eb18b08b4338a26977ac3b4df129d75","30d2170e1a718b5035611af55e3618b4ba8f42f0749bb52ee593da6082c4e2ce","98ef38666d88ec9699a722053e07ede65d3042f693fe7ff8c786e53dbb6fd43b","a3b8b6be7620897d1e481e8650c980a210a138fceb6e710eaf95fd9dd0dfe94a","12c89d0e32758c120a569045f21cf5b77244f86792611ced8de7f86b37e77781","9f9e5bae412fa5909fae636d6733aee27a108cc2ed5b13980611016336774d3c","662fe197bba64bd3f17ee118058cd2d0d2dbe33d7c0c865fd6365d90bfc44e1e","030519c351f800551cac2658038804969ca4584d2c0175a710602ac234ca1340","0278a6939ca83cd040b08ff8c5fc7838b6693ddc52f22526bf158e6b10e0246c","c2d6206e5ba4fd3063b01218c2b3b997afc1cfbeb49fcee991fa8595842ce53d","29c188a2c660f99f1b4835022e011c4268d7af989d4b7dda33c0a69ca1a777f8","1ed0bf138e87912d741e28333b58cbf814ae863783b3b404d2454cbabb9c5fc0","3452ee7d8ef0b1bbd47b2a56924a1dc3c79dc84a19d212e9dc496f92e4943aa0","99510e20e3d4816e283e59e8f0f31f603b2f026648240ffdb1ca9f24be678419","037d1fbeb96dc35600814be14d0fbf31acf35f1d7b443ea33514937de69c2bf2","64d1859b7dd9f419ba08e064c2b16b1a5edde0316d6c2bb1833c9381d4dffc3d","69b0f96ca137c0dba05f321a159141ad36f79cfba2fffcc29d131e280275e6f2","7bb64cf513a2b1cf7a94f81ca201f3d76a9b17af556f0cfc4e2707443e6caa66","a9add2a29da4cd0b617ae89f196b3f2172a031aeb086922cdf097236eef8b008","99afac3e6e683ee3111e499f9919953e9489cb39cad74363717aa3805e91db51","c49f92b83968f4ee0b6026396a9b6e2d6fee8b660d08a90efb03355ce3433a7a","4fdc6afe4d7ef6aeb32ac0818d47e99f98a31d0696abc4cb2af489c78ac1ba1d","d73d5a0e854037d43781b2d5d33f4b95ee509e0ddede677aade79fbee6a97cdc","35d14e1ae04be300828b1a1614316b9312a009cfd5e29fa56f94c2a9f60b12df","d160fe745f9c3b72d7b9036fdb2b6b500a520d43e36bb842c927b6fe59ea2c23",{"version":"4a415bf08be658b3f7ab2c2754a077e36a32e08aabb73aad26de47a45c0fa81e","signature":"3a4f9e7087c566703447928d15c234bd0bcc63a2a50b6ec39ed37c9bc0342310"},{"version":"506bcad28e45e13c23c2c25c9691e0dc42d8755a0e24b9a48586f51b5bebae8f","signature":"3a12771c76c5ed979438dc0e390224bd3d8661bcbea18114f77c4c6d9de5b8b2"},{"version":"6fbdb35bc3b9cfb225c48108b5bacb5c0d67bbcb677cf13b912e15a852551023","signature":"ee06131adf64c6cd201de36563174cff0e160b81438be186a7bd85e6c2b54fa7"},"a5aaeca001d2f69093d04aac4db321e4c338fd9b20cbc4f0b0af3dc6ae0f235b","cc957354aa3c94c9961ebf46282cfde1e81d107fc5785a61f62c67f1dd3ac2eb","8041cfce439ff29d339742389de04c136e3029d6b1817f07b2d7fcbfb7534990","93de1c6dab503f053efe8d304cb522bb3a89feab8c98f307a674a4fae04773e9","29a46d003ca3c721e6405f00dee7e3de91b14e09701eba5d887bf76fb2d47d38","069bebfee29864e3955378107e243508b163e77ab10de6a5ee03ae06939f0bb9","9990f9e566bc3c2c6e38df81294fb756e7f5b7b0e5bb17ab75384e190548b4b6",{"version":"64d4b35c5456adf258d2cf56c341e203a073253f229ef3208fc0d5020253b241","affectsGlobalScope":true},"ee7d8894904b465b072be0d2e4b45cf6b887cdba16a467645c4e200982ece7ea","f3d8c757e148ad968f0d98697987db363070abada5f503da3c06aefd9d4248c1","df95e00612c1faa5e0e7ef0dba589b18665bbeb3221db2b6cee1fe4d0e61921f","afe73051ff6a03a9565cbd8ebb0e956ee3df5e913ad5c1ded64218aabfa3dcb5","8b06ac3faeacb8484d84ddb44571d8f410697f98d7bfa86c0fda60373a9f5215","7eb06594824ada538b1d8b48c3925a83e7db792f47a081a62cf3e5c4e23cf0ee","f5638f7c2f12a9a1a57b5c41b3c1ea7db3876c003bab68e6a57afd6bcc169af0","0d14fa22c41fdc7277e6f71473b20ebc07f40f00e38875142335d5b63cdfc9d2","d8aab31ba8e618cc3eea10b0945de81cb93b7e8150a013a482332263b9305322","462bccdf75fcafc1ae8c30400c9425e1a4681db5d605d1a0edb4f990a54d8094","5923d8facbac6ecf7c84739a5c701a57af94a6f6648d6229a6c768cf28f0f8cb","7adecb2c3238794c378d336a8182d4c3dd2c4fa6fa1785e2797a3db550edea62","dc12dc0e5aa06f4e1a7692149b78f89116af823b9e1f1e4eae140cd3e0e674e6","1bfc6565b90c8771615cd8cfcf9b36efc0275e5e83ac7d9181307e96eb495161","8a8a96898906f065f296665e411f51010b51372fa260d5373bf9f64356703190","7f82ef88bdb67d9a850dd1c7cd2d690f33e0f0acd208e3c9eba086f3670d4f73",{"version":"ccfd8774cd9b929f63ff7dcf657977eb0652e3547f1fcac1b3a1dc5db22d4d58","affectsGlobalScope":true},"d92dc90fecd2552db74d8dc3c6fb4db9145b2aa0efe2c127236ba035969068d4","96d14f21b7652903852eef49379d04dbda28c16ed36468f8c9fa08f7c14c9538","675e702f2032766a91eeadee64f51014c64688525da99dccd8178f0c599f13a8","458111fc89d11d2151277c822dfdc1a28fa5b6b2493cf942e37d4cd0a6ee5f22","19c816167e076e7c24f074389c6cf3ed87bdbb917d1ea439ca281f9d26db2439","187119ff4f9553676a884e296089e131e8cc01691c546273b1d0089c3533ce42","febf0b2de54781102b00f61653b21377390a048fbf5262718c91860d11ff34a6","98f9d826db9cd99d27a01a59ee5f22863df00ccf1aaf43e1d7db80ebf716f7c3","0aaef8cded245bf5036a7a40b65622dd6c4da71f7a35343112edbe112b348a1e","00baffbe8a2f2e4875367479489b5d43b5fc1429ecb4a4cc98cfc3009095f52a","dcd91d3b697cb650b95db5471189b99815af5db2a1cd28760f91e0b12ede8ed5","3c92b6dfd43cc1c2485d9eba5ff0b74a19bb8725b692773ef1d66dac48cda4bd","3cf0d343c2276842a5b617f22ba82af6322c7cfe8bb52238ffc0c491a3c21019","df996e25faa505f85aeb294d15ebe61b399cf1d1e49959cdfaf2cc0815c203f9",{"version":"f2eff8704452659641164876c1ef0df4174659ce7311b0665798ea3f556fa9ad","affectsGlobalScope":true},"8841e2aa774b89bd23302dede20663306dc1b9902431ac64b24be8b8d0e3f649","2b8264b2fefd7367e0f20e2c04eed5d3038831fe00f5efbc110ff0131aab899b","a73a445c1e0a6d0f8b48e8eb22dc9d647896783a7f8991cbbc31c0d94bf1f5a2","d88a5e779faf033be3d52142a04fbe1cb96009868e3bbdd296b2bc6c59e06c0e","cd1d2f103b79002cd94b85a640a103f094227a2c4c53bc8af1fdbf4e13d9729e","5e379df3d61561c2ed7789b5995b9ba2143bbba21a905e2381e16efe7d1fa424","f07a137bbe2de7a122c37bfea00e761975fb264c49f18003d398d71b3fb35a5f","3dce33e7eb25594863b8e615f14a45ab98190d85953436750644212d8a18c066","2b93035328f7778d200252681c1d86285d501ed424825a18f81e4c3028aa51d9","2ac9c8332c5f8510b8bdd571f8271e0f39b0577714d5e95c1e79a12b2616f069","42c21aa963e7b86fa00801d96e88b36803188018d5ad91db2a9101bccd40b3ff","d31eb848cdebb4c55b4893b335a7c0cca95ad66dee13cbb7d0893810c0a9c301","b9f96255e1048ed2ea33ec553122716f0e57fc1c3ad778e9aa15f5b46547bd23","7a9e0a564fee396cacf706523b5aeed96e04c6b871a8bebefad78499fbffc5bc","906c751ef5822ec0dadcea2f0e9db64a33fb4ee926cc9f7efa38afe5d5371b2a","5387c049e9702f2d2d7ece1a74836a14b47fbebe9bbeb19f94c580a37c855351","c68391fb9efad5d99ff332c65b1606248c4e4a9f1dd9a087204242b56c7126d6","e9cf02252d3a0ced987d24845dcb1f11c1be5541f17e5daa44c6de2d18138d0c","e8b02b879754d85f48489294f99147aeccc352c760d95a6fe2b6e49cd400b2fe","9f6908ab3d8a86c68b86e38578afc7095114e66b2fc36a2a96e9252aac3998e0","0eedb2344442b143ddcd788f87096961cd8572b64f10b4afc3356aa0460171c6","71405cc70f183d029cc5018375f6c35117ffdaf11846c35ebf85ee3956b1b2a6","c68baff4d8ba346130e9753cefe2e487a16731bf17e05fdacc81e8c9a26aae9d","2cd15528d8bb5d0453aa339b4b52e0696e8b07e790c153831c642c3dea5ac8af","479d622e66283ffa9883fbc33e441f7fc928b2277ff30aacbec7b7761b4e9579","ade307876dc5ca267ca308d09e737b611505e015c535863f22420a11fffc1c54","f8cdefa3e0dee639eccbe9794b46f90291e5fd3989fcba60d2f08fde56179fb9","86c5a62f99aac7053976e317dbe9acb2eaf903aaf3d2e5bb1cafe5c2df7b37a8","2b300954ce01a8343866f737656e13243e86e5baef51bd0631b21dcef1f6e954","a2d409a9ffd872d6b9d78ead00baa116bbc73cfa959fce9a2f29d3227876b2a1","b288936f560cd71f4a6002953290de9ff8dfbfbf37f5a9391be5c83322324898","61178a781ef82e0ff54f9430397e71e8f365fc1e3725e0e5346f2de7b0d50dfa","6a6ccb37feb3aad32d9be026a3337db195979cd5727a616fc0f557e974101a54","c649ea79205c029a02272ef55b7ab14ada0903db26144d2205021f24727ac7a3","38e2b02897c6357bbcff729ef84c736727b45cc152abe95a7567caccdfad2a1d","d6610ea7e0b1a7686dba062a1e5544dd7d34140f4545305b7c6afaebfb348341","3dee35db743bdba2c8d19aece7ac049bde6fa587e195d86547c882784e6ba34c","b15e55c5fa977c2f25ca0b1db52cfa2d1fd4bf0baf90a8b90d4a7678ca462ff1","f41d30972724714763a2698ae949fbc463afb203b5fa7c4ad7e4de0871129a17","843dd7b6a7c6269fd43827303f5cbe65c1fecabc30b4670a50d5a15d57daeeb9","f06d8b8567ee9fd799bf7f806efe93b67683ef24f4dea5b23ef12edff4434d9d","6017384f697ff38bc3ef6a546df5b230c3c31329db84cbfe686c83bec011e2b2","e1a5b30d9248549ca0c0bb1d653bafae20c64c4aa5928cc4cd3017b55c2177b0","a593632d5878f17295bd53e1c77f27bf4c15212822f764a2bfc1702f4b413fa0","a868a534ba1c2ca9060b8a13b0ffbbbf78b4be7b0ff80d8c75b02773f7192c29","da7545aba8f54a50fde23e2ede00158dc8112560d934cee58098dfb03aae9b9d","34baf65cfee92f110d6653322e2120c2d368ee64b3c7981dff08ed105c4f19b0","a1a261624efb3a00ff346b13580f70f3463b8cdcc58b60f5793ff11785d52cab","f83b320cceccfc48457a818d18fc9a006ab18d0bdd727aa2c2e73dc1b4a45e98","9d92b037978bb9525bc4b673ebddd443277542e010c0aef019c03a170ccdaa73","b0d10e46cfe3f6c476b69af02eaa38e4ccc7430221ce3109ae84bb9fb8282298","fab58e600970e66547644a44bc9918e3223aa2cbd9e8763cec004b2cfb48827e","70e9a18da08294f75bf23e46c7d69e67634c0765d355887b9b41f0d959e1426e","ed44ba6b95f08b758748be7902e0cc54178b1337c56d0e2469c77b03f63ac73b"],"options":{"composite":true,"declaration":true,"declarationMap":true,"emitDeclarationOnly":true,"esModuleInterop":true,"inlineSources":true,"module":1,"outDir":"./types","rootDir":"../src","sourceMap":true,"strict":true,"target":7},"fileIdsList":[[120,247],[120],[91,120,127,128,129,144],[120,128,129,145,146],[120,127,128],[120,127,144,147,150],[120,127,147,150,151],[120,148,149,150,152,153],[120,127,150],[120,127,144,147,148,149,152],[120,127,135],[120,127],[91,120,127],[80,120,127],[120,131,132,133,134,135,136,137,138,139,140,141,142,143],[120,127,133,134],[120,127,133,135],[120,166,224],[120,224,225],[120,224,225,226,227],[120,166],[120,198],[120,198,199,200],[64,120],[67,120],[64,67,120],[65,66,67,68,69,70,71,72,73,74,75,120,155,158,159,160,161,162,163,164,165],[58,64,65,120],[67,73,75,120,154],[120,157],[67,68,120],[64,120,161],[120,193,194],[120,247,248,249,250,251],[120,247,249],[120,156],[120,254,255,256],[92,120,127],[120,259],[120,260],[120,271],[120,265,270],[120,274,276,277,278,279,280,281,282,283,284,285,286],[120,274,275,277,278,279,280,281,282,283,284,285,286],[120,275,276,277,278,279,280,281,282,283,284,285,286],[120,274,275,276,278,279,280,281,282,283,284,285,286],[120,274,275,276,277,279,280,281,282,283,284,285,286],[120,274,275,276,277,278,280,281,282,283,284,285,286],[120,274,275,276,277,278,279,281,282,283,284,285,286],[120,274,275,276,277,278,279,280,282,283,284,285,286],[120,274,275,276,277,278,279,280,281,283,284,285,286],[120,274,275,276,277,278,279,280,281,282,284,285,286],[120,274,275,276,277,278,279,280,281,282,283,285,286],[120,274,275,276,277,278,279,280,281,282,283,284,286],[120,274,275,276,277,278,279,280,281,282,283,284,285],[76,120],[79,120],[80,85,111,120],[81,91,92,99,108,119,120],[81,82,91,99,120],[83,120],[84,85,92,100,120],[85,108,116,120],[86,88,91,99,120],[87,120],[88,89,120],[90,91,120],[91,120],[91,92,93,108,119,120],[91,92,93,108,120],[91,94,99,108,119,120],[91,92,94,95,99,108,116,119,120],[94,96,108,116,119,120],[76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126],[91,97,120],[98,119,120,124],[88,91,99,108,120],[100,120],[101,120],[79,102,120],[103,118,120,124],[104,120],[105,120],[91,106,120],[106,107,120,122],[80,91,108,109,110,120],[80,108,110,120],[108,109,120],[111,120],[112,120],[91,114,115,120],[114,115,120],[85,99,116,120],[117,120],[99,118,120],[80,94,105,119,120],[85,120],[108,120,121],[120,122],[120,123],[80,85,91,93,102,108,119,120,122,124],[108,120,125],[120,127,292],[120,295,334],[120,295,319,334],[120,334],[120,295],[120,295,320,334],[120,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,320,321,322,323,324,325,326,327,328,329,330,331,332,333],[120,320,334],[120,335],[120,339],[120,203],[120,215,216,217],[120,203,214,215],[120,178],[120,178,179,180,181,182],[120,167,168,169,170,171,172,173,174,175,176,177],[120,263,266],[120,263,266,267,268],[120,265],[120,262,269],[120,264],[57,59,60,61,62,63,120],[57,58,120],[59,120],[58,59,120],[57,59,120],[120,166,187,228],[120,229,230],[120,166,183,184,185],[120,184],[56,120,184,185,186],[120,185],[120,188],[120,188,189,192,196],[120,195],[120,166,190,191],[120,211,212,213],[120,210,211],[120,166,210,211],[120,166,203,210],[120,166,204],[120,204,205,206,207,208,209],[120,166,203],[120,219],[120,202,219,221,222],[120,166,187,190,197,201,202,219,220],[120,166,197,214,218],[120,166,235],[120,166,228,235],[120,233,234,235,236,237,238,242],[120,166,210,243],[120,166,187,197,233,234,236],[120,166,187,197,231,232,233,235,236],[120,234,235,238],[120,239,240,241,243],[120,235,238],[120,166,235,238],[120,166,187,234],[120,166,210,235,236],[120,244,245],[120,183,187,201,223,243],[120,166,210,223,244],[244,245],[183,187,223,243],[166,210,223,244]],"referencedMap":[[249,1],[247,2],[145,3],[128,2],[147,4],[129,5],[146,2],[151,6],[152,7],[148,7],[154,8],[149,7],[153,9],[150,10],[136,11],[133,12],[140,13],[134,11],[131,14],[139,2],[144,15],[141,2],[142,2],[143,2],[138,12],[135,16],[132,2],[137,17],[190,2],[225,18],[227,2],[226,19],[228,20],[224,21],[203,13],[199,22],[200,22],[201,23],[198,2],[65,24],[66,24],[68,25],[69,24],[70,24],[71,26],[72,2],[73,2],[74,2],[67,24],[166,27],[75,28],[155,29],[158,30],[159,2],[160,2],[161,2],[162,2],[163,2],[164,31],[165,32],[193,2],[195,33],[194,2],[252,34],[248,1],[250,35],[251,1],[191,12],[157,36],[253,2],[254,2],[257,37],[255,2],[258,38],[259,2],[260,39],[261,40],[272,41],[271,42],[256,2],[273,2],[275,43],[276,44],[274,45],[277,46],[278,47],[279,48],[280,49],[281,50],[282,51],[283,52],[284,53],[285,54],[286,55],[287,2],[156,2],[76,56],[77,56],[79,57],[80,58],[81,59],[82,60],[83,61],[84,62],[85,63],[86,64],[87,65],[88,66],[89,66],[90,67],[91,68],[92,69],[93,70],[78,2],[126,2],[94,71],[95,72],[96,73],[127,74],[97,75],[98,76],[99,77],[100,78],[101,79],[102,80],[103,81],[104,82],[105,83],[106,84],[107,85],[108,86],[110,87],[109,88],[111,89],[112,90],[113,2],[114,91],[115,92],[116,93],[117,94],[118,95],[119,96],[120,97],[121,98],[122,99],[123,100],[124,101],[125,102],[288,2],[289,12],[290,2],[291,2],[293,103],[292,2],[294,12],[319,104],[320,105],[295,106],[298,106],[317,104],[318,104],[308,104],[307,107],[305,104],[300,104],[313,104],[311,104],[315,104],[299,104],[312,104],[316,104],[301,104],[302,104],[314,104],[296,104],[303,104],[304,104],[306,104],[310,104],[321,108],[309,104],[297,104],[334,109],[333,2],[328,108],[330,110],[329,108],[322,108],[323,108],[325,108],[327,108],[331,110],[332,110],[324,110],[326,110],[336,111],[335,2],[337,2],[338,2],[339,2],[340,112],[130,2],[262,2],[215,113],[218,114],[216,115],[217,115],[177,2],[174,116],[176,116],[175,116],[173,116],[183,117],[178,118],[182,2],[179,2],[181,2],[180,2],[169,116],[170,116],[171,116],[167,2],[168,2],[172,116],[263,2],[267,119],[269,120],[268,119],[266,121],[270,122],[265,123],[264,2],[57,2],[64,124],[59,125],[60,126],[61,126],[62,127],[63,127],[58,128],[8,2],[10,2],[9,2],[2,2],[11,2],[12,2],[13,2],[14,2],[15,2],[16,2],[17,2],[18,2],[3,2],[4,2],[22,2],[19,2],[20,2],[21,2],[23,2],[24,2],[25,2],[5,2],[26,2],[27,2],[28,2],[29,2],[6,2],[33,2],[30,2],[31,2],[32,2],[34,2],[7,2],[35,2],[40,2],[41,2],[36,2],[37,2],[38,2],[39,2],[1,2],[42,2],[229,129],[230,2],[231,130],[56,2],[186,131],[185,132],[187,133],[184,134],[189,135],[197,136],[196,137],[188,2],[192,138],[214,139],[212,140],[213,141],[211,142],[205,143],[206,143],[207,2],[208,143],[210,144],[204,145],[209,143],[202,2],[220,146],[222,146],[223,147],[221,148],[219,149],[236,150],[237,151],[243,152],[232,153],[235,154],[234,155],[239,156],[242,157],[240,158],[241,159],[233,160],[238,161],[246,162],[244,163],[245,164],[47,2],[48,2],[49,2],[50,2],[51,2],[52,2],[43,2],[53,2],[54,2],[55,2],[44,2],[45,2],[46,2]],"exportedModulesMap":[[249,1],[247,2],[145,3],[128,2],[147,4],[129,5],[146,2],[151,6],[152,7],[148,7],[154,8],[149,7],[153,9],[150,10],[136,11],[133,12],[140,13],[134,11],[131,14],[139,2],[144,15],[141,2],[142,2],[143,2],[138,12],[135,16],[132,2],[137,17],[190,2],[225,18],[227,2],[226,19],[228,20],[224,21],[203,13],[199,22],[200,22],[201,23],[198,2],[65,24],[66,24],[68,25],[69,24],[70,24],[71,26],[72,2],[73,2],[74,2],[67,24],[166,27],[75,28],[155,29],[158,30],[159,2],[160,2],[161,2],[162,2],[163,2],[164,31],[165,32],[193,2],[195,33],[194,2],[252,34],[248,1],[250,35],[251,1],[191,12],[157,36],[253,2],[254,2],[257,37],[255,2],[258,38],[259,2],[260,39],[261,40],[272,41],[271,42],[256,2],[273,2],[275,43],[276,44],[274,45],[277,46],[278,47],[279,48],[280,49],[281,50],[282,51],[283,52],[284,53],[285,54],[286,55],[287,2],[156,2],[76,56],[77,56],[79,57],[80,58],[81,59],[82,60],[83,61],[84,62],[85,63],[86,64],[87,65],[88,66],[89,66],[90,67],[91,68],[92,69],[93,70],[78,2],[126,2],[94,71],[95,72],[96,73],[127,74],[97,75],[98,76],[99,77],[100,78],[101,79],[102,80],[103,81],[104,82],[105,83],[106,84],[107,85],[108,86],[110,87],[109,88],[111,89],[112,90],[113,2],[114,91],[115,92],[116,93],[117,94],[118,95],[119,96],[120,97],[121,98],[122,99],[123,100],[124,101],[125,102],[288,2],[289,12],[290,2],[291,2],[293,103],[292,2],[294,12],[319,104],[320,105],[295,106],[298,106],[317,104],[318,104],[308,104],[307,107],[305,104],[300,104],[313,104],[311,104],[315,104],[299,104],[312,104],[316,104],[301,104],[302,104],[314,104],[296,104],[303,104],[304,104],[306,104],[310,104],[321,108],[309,104],[297,104],[334,109],[333,2],[328,108],[330,110],[329,108],[322,108],[323,108],[325,108],[327,108],[331,110],[332,110],[324,110],[326,110],[336,111],[335,2],[337,2],[338,2],[339,2],[340,112],[130,2],[262,2],[215,113],[218,114],[216,115],[217,115],[177,2],[174,116],[176,116],[175,116],[173,116],[183,117],[178,118],[182,2],[179,2],[181,2],[180,2],[169,116],[170,116],[171,116],[167,2],[168,2],[172,116],[263,2],[267,119],[269,120],[268,119],[266,121],[270,122],[265,123],[264,2],[57,2],[64,124],[59,125],[60,126],[61,126],[62,127],[63,127],[58,128],[8,2],[10,2],[9,2],[2,2],[11,2],[12,2],[13,2],[14,2],[15,2],[16,2],[17,2],[18,2],[3,2],[4,2],[22,2],[19,2],[20,2],[21,2],[23,2],[24,2],[25,2],[5,2],[26,2],[27,2],[28,2],[29,2],[6,2],[33,2],[30,2],[31,2],[32,2],[34,2],[7,2],[35,2],[40,2],[41,2],[36,2],[37,2],[38,2],[39,2],[1,2],[42,2],[229,129],[230,2],[231,130],[56,2],[186,131],[185,132],[187,133],[184,134],[189,135],[197,136],[196,137],[188,2],[192,138],[214,139],[212,140],[213,141],[211,142],[205,143],[206,143],[207,2],[208,143],[210,144],[204,145],[209,143],[202,2],[220,146],[222,146],[223,147],[221,148],[219,149],[236,150],[237,151],[243,152],[232,153],[235,154],[234,155],[239,156],[242,157],[240,158],[241,159],[233,160],[238,161],[246,165],[244,166],[245,167],[47,2],[48,2],[49,2],[50,2],[51,2],[52,2],[43,2],[53,2],[54,2],[55,2],[44,2],[45,2],[46,2]],"semanticDiagnosticsPerFile":[249,247,145,128,147,129,146,151,152,148,154,149,153,150,136,133,140,134,131,139,144,141,142,143,138,135,132,137,190,225,227,226,228,224,203,199,200,201,198,65,66,68,69,70,71,72,73,74,67,166,75,155,158,159,160,161,162,163,164,165,193,195,194,252,248,250,251,191,157,253,254,257,255,258,259,260,261,272,271,256,273,275,276,274,277,278,279,280,281,282,283,284,285,286,287,156,76,77,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,78,126,94,95,96,127,97,98,99,100,101,102,103,104,105,106,107,108,110,109,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,288,289,290,291,293,292,294,319,320,295,298,317,318,308,307,305,300,313,311,315,299,312,316,301,302,314,296,303,304,306,310,321,309,297,334,333,328,330,329,322,323,325,327,331,332,324,326,336,335,337,338,339,340,130,262,215,218,216,217,177,174,176,175,173,183,178,182,179,181,180,169,170,171,167,168,172,263,267,269,268,266,270,265,264,57,64,59,60,61,62,63,58,8,10,9,2,11,12,13,14,15,16,17,18,3,4,22,19,20,21,23,24,25,5,26,27,28,29,6,33,30,31,32,34,7,35,40,41,36,37,38,39,1,42,229,230,231,56,186,185,187,184,189,197,196,188,192,214,212,213,211,205,206,207,208,210,204,209,202,220,222,223,221,219,236,237,243,232,235,234,239,242,240,241,233,238,246,244,245,47,48,49,50,51,52,43,53,54,55,44,45,46],"latestChangedDtsFile":"./types/index.d.ts"},"version":"4.9.5"}
+\ No newline at end of file
++{"program":{"fileNames":["../../../node_modules/typescript/lib/lib.es5.d.ts","../../../node_modules/typescript/lib/lib.es2015.d.ts","../../../node_modules/typescript/lib/lib.es2016.d.ts","../../../node_modules/typescript/lib/lib.es2017.d.ts","../../../node_modules/typescript/lib/lib.es2018.d.ts","../../../node_modules/typescript/lib/lib.es2019.d.ts","../../../node_modules/typescript/lib/lib.es2020.d.ts","../../../node_modules/typescript/lib/lib.dom.d.ts","../../../node_modules/typescript/lib/lib.es2015.core.d.ts","../../../node_modules/typescript/lib/lib.es2015.collection.d.ts","../../../node_modules/typescript/lib/lib.es2015.generator.d.ts","../../../node_modules/typescript/lib/lib.es2015.iterable.d.ts","../../../node_modules/typescript/lib/lib.es2015.promise.d.ts","../../../node_modules/typescript/lib/lib.es2015.proxy.d.ts","../../../node_modules/typescript/lib/lib.es2015.reflect.d.ts","../../../node_modules/typescript/lib/lib.es2015.symbol.d.ts","../../../node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts","../../../node_modules/typescript/lib/lib.es2016.array.include.d.ts","../../../node_modules/typescript/lib/lib.es2017.object.d.ts","../../../node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts","../../../node_modules/typescript/lib/lib.es2017.string.d.ts","../../../node_modules/typescript/lib/lib.es2017.intl.d.ts","../../../node_modules/typescript/lib/lib.es2017.typedarrays.d.ts","../../../node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts","../../../node_modules/typescript/lib/lib.es2018.asynciterable.d.ts","../../../node_modules/typescript/lib/lib.es2018.intl.d.ts","../../../node_modules/typescript/lib/lib.es2018.promise.d.ts","../../../node_modules/typescript/lib/lib.es2018.regexp.d.ts","../../../node_modules/typescript/lib/lib.es2019.array.d.ts","../../../node_modules/typescript/lib/lib.es2019.object.d.ts","../../../node_modules/typescript/lib/lib.es2019.string.d.ts","../../../node_modules/typescript/lib/lib.es2019.symbol.d.ts","../../../node_modules/typescript/lib/lib.es2019.intl.d.ts","../../../node_modules/typescript/lib/lib.es2020.bigint.d.ts","../../../node_modules/typescript/lib/lib.es2020.date.d.ts","../../../node_modules/typescript/lib/lib.es2020.promise.d.ts","../../../node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts","../../../node_modules/typescript/lib/lib.es2020.string.d.ts","../../../node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts","../../../node_modules/typescript/lib/lib.es2020.intl.d.ts","../../../node_modules/typescript/lib/lib.es2020.number.d.ts","../../../node_modules/typescript/lib/lib.esnext.intl.d.ts","../../../types/eth-ens-namehash.d.ts","../../../types/ethereum-ens-network-map.d.ts","../../../types/global.d.ts","../../../types/single-call-balance-checker-abi.d.ts","../../../types/@metamask/contract-metadata.d.ts","../../../types/@metamask/eth-hd-keyring.d.ts","../../../types/@metamask/eth-simple-keyring.d.ts","../../../types/@metamask/ethjs-provider-http.d.ts","../../../types/@metamask/ethjs-unit.d.ts","../../../types/@metamask/metamask-eth-abis.d.ts","../../../types/eth-json-rpc-infura/src/createProvider.d.ts","../../../types/eth-phishing-detect/src/config.json.d.ts","../../../types/eth-phishing-detect/src/detector.d.ts","../../base-controller/dist/types/BaseControllerV1.d.ts","../../../node_modules/superstruct/dist/error.d.ts","../../../node_modules/superstruct/dist/utils.d.ts","../../../node_modules/superstruct/dist/struct.d.ts","../../../node_modules/superstruct/dist/structs/coercions.d.ts","../../../node_modules/superstruct/dist/structs/refinements.d.ts","../../../node_modules/superstruct/dist/structs/types.d.ts","../../../node_modules/superstruct/dist/structs/utilities.d.ts","../../../node_modules/superstruct/dist/index.d.ts","../../../node_modules/@metamask/utils/dist/types/assert.d.ts","../../../node_modules/@metamask/utils/dist/types/base64.d.ts","../../../node_modules/@metamask/utils/dist/types/hex.d.ts","../../../node_modules/@metamask/utils/dist/types/bytes.d.ts","../../../node_modules/@metamask/utils/dist/types/caip-types.d.ts","../../../node_modules/@metamask/utils/dist/types/checksum.d.ts","../../../node_modules/@metamask/utils/dist/types/coercers.d.ts","../../../node_modules/@metamask/utils/dist/types/collections.d.ts","../../../node_modules/@metamask/utils/dist/types/encryption-types.d.ts","../../../node_modules/@metamask/utils/dist/types/errors.d.ts","../../../node_modules/@metamask/utils/dist/types/json.d.ts","../../../node_modules/@types/node/assert.d.ts","../../../node_modules/@types/node/assert/strict.d.ts","../../../node_modules/@types/node/globals.d.ts","../../../node_modules/@types/node/async_hooks.d.ts","../../../node_modules/@types/node/buffer.d.ts","../../../node_modules/@types/node/child_process.d.ts","../../../node_modules/@types/node/cluster.d.ts","../../../node_modules/@types/node/console.d.ts","../../../node_modules/@types/node/constants.d.ts","../../../node_modules/@types/node/crypto.d.ts","../../../node_modules/@types/node/dgram.d.ts","../../../node_modules/@types/node/diagnostics_channel.d.ts","../../../node_modules/@types/node/dns.d.ts","../../../node_modules/@types/node/dns/promises.d.ts","../../../node_modules/@types/node/domain.d.ts","../../../node_modules/@types/node/events.d.ts","../../../node_modules/@types/node/fs.d.ts","../../../node_modules/@types/node/fs/promises.d.ts","../../../node_modules/@types/node/http.d.ts","../../../node_modules/@types/node/http2.d.ts","../../../node_modules/@types/node/https.d.ts","../../../node_modules/@types/node/inspector.d.ts","../../../node_modules/@types/node/module.d.ts","../../../node_modules/@types/node/net.d.ts","../../../node_modules/@types/node/os.d.ts","../../../node_modules/@types/node/path.d.ts","../../../node_modules/@types/node/perf_hooks.d.ts","../../../node_modules/@types/node/process.d.ts","../../../node_modules/@types/node/punycode.d.ts","../../../node_modules/@types/node/querystring.d.ts","../../../node_modules/@types/node/readline.d.ts","../../../node_modules/@types/node/repl.d.ts","../../../node_modules/@types/node/stream.d.ts","../../../node_modules/@types/node/stream/promises.d.ts","../../../node_modules/@types/node/stream/consumers.d.ts","../../../node_modules/@types/node/stream/web.d.ts","../../../node_modules/@types/node/string_decoder.d.ts","../../../node_modules/@types/node/test.d.ts","../../../node_modules/@types/node/timers.d.ts","../../../node_modules/@types/node/timers/promises.d.ts","../../../node_modules/@types/node/tls.d.ts","../../../node_modules/@types/node/trace_events.d.ts","../../../node_modules/@types/node/tty.d.ts","../../../node_modules/@types/node/url.d.ts","../../../node_modules/@types/node/util.d.ts","../../../node_modules/@types/node/v8.d.ts","../../../node_modules/@types/node/vm.d.ts","../../../node_modules/@types/node/wasi.d.ts","../../../node_modules/@types/node/worker_threads.d.ts","../../../node_modules/@types/node/zlib.d.ts","../../../node_modules/@types/node/globals.global.d.ts","../../../node_modules/@types/node/index.d.ts","../../../node_modules/@ethereumjs/common/dist/enums.d.ts","../../../node_modules/@ethereumjs/common/dist/types.d.ts","../../../node_modules/buffer/index.d.ts","../../../node_modules/@ethereumjs/util/dist/constants.d.ts","../../../node_modules/@ethereumjs/util/dist/units.d.ts","../../../node_modules/@ethereumjs/util/dist/address.d.ts","../../../node_modules/@ethereumjs/util/dist/bytes.d.ts","../../../node_modules/@ethereumjs/util/dist/types.d.ts","../../../node_modules/@ethereumjs/util/dist/account.d.ts","../../../node_modules/@ethereumjs/util/dist/withdrawal.d.ts","../../../node_modules/@ethereumjs/util/dist/signature.d.ts","../../../node_modules/@ethereumjs/util/dist/encoding.d.ts","../../../node_modules/@ethereumjs/util/dist/asyncEventEmitter.d.ts","../../../node_modules/@ethereumjs/util/dist/internal.d.ts","../../../node_modules/@ethereumjs/util/dist/lock.d.ts","../../../node_modules/@ethereumjs/util/dist/provider.d.ts","../../../node_modules/@ethereumjs/util/dist/index.d.ts","../../../node_modules/@ethereumjs/common/dist/common.d.ts","../../../node_modules/@ethereumjs/common/dist/utils.d.ts","../../../node_modules/@ethereumjs/common/dist/index.d.ts","../../../node_modules/@ethereumjs/tx/dist/eip2930Transaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/legacyTransaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/types.d.ts","../../../node_modules/@ethereumjs/tx/dist/baseTransaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/eip1559Transaction.d.ts","../../../node_modules/@ethereumjs/tx/dist/transactionFactory.d.ts","../../../node_modules/@ethereumjs/tx/dist/index.d.ts","../../../node_modules/@metamask/utils/dist/types/keyring.d.ts","../../../node_modules/@types/ms/index.d.ts","../../../node_modules/@types/debug/index.d.ts","../../../node_modules/@metamask/utils/dist/types/logging.d.ts","../../../node_modules/@metamask/utils/dist/types/misc.d.ts","../../../node_modules/@metamask/utils/dist/types/number.d.ts","../../../node_modules/@metamask/utils/dist/types/opaque.d.ts","../../../node_modules/@metamask/utils/dist/types/promise.d.ts","../../../node_modules/@metamask/utils/dist/types/time.d.ts","../../../node_modules/@metamask/utils/dist/types/transaction-types.d.ts","../../../node_modules/@metamask/utils/dist/types/versions.d.ts","../../../node_modules/@metamask/utils/dist/types/index.d.ts","../../../node_modules/immer/dist/utils/env.d.ts","../../../node_modules/immer/dist/utils/errors.d.ts","../../../node_modules/immer/dist/types/types-external.d.ts","../../../node_modules/immer/dist/types/types-internal.d.ts","../../../node_modules/immer/dist/utils/common.d.ts","../../../node_modules/immer/dist/utils/plugins.d.ts","../../../node_modules/immer/dist/core/scope.d.ts","../../../node_modules/immer/dist/core/finalize.d.ts","../../../node_modules/immer/dist/core/proxy.d.ts","../../../node_modules/immer/dist/core/immerClass.d.ts","../../../node_modules/immer/dist/core/current.d.ts","../../../node_modules/immer/dist/internal.d.ts","../../../node_modules/immer/dist/plugins/es5.d.ts","../../../node_modules/immer/dist/plugins/patches.d.ts","../../../node_modules/immer/dist/plugins/mapset.d.ts","../../../node_modules/immer/dist/plugins/all.d.ts","../../../node_modules/immer/dist/immer.d.ts","../../base-controller/dist/types/RestrictedControllerMessenger.d.ts","../../base-controller/dist/types/ControllerMessenger.d.ts","../../base-controller/dist/types/BaseControllerV2.d.ts","../../base-controller/dist/types/index.d.ts","../../controller-utils/dist/types/types.d.ts","../../controller-utils/dist/types/constants.d.ts","../../../node_modules/@metamask/eth-query/index.d.ts","../../../node_modules/@types/bn.js/index.d.ts","../../controller-utils/dist/types/util.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/abnf.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/utils.d.ts","../../../node_modules/@spruceid/siwe-parser/dist/parsers.d.ts","../../controller-utils/dist/types/siwe.d.ts","../../controller-utils/dist/types/index.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/types.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/createEventEmitterProxy.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/createSwappableProxy.d.ts","../../../node_modules/@metamask/swappable-obj-proxy/dist/index.d.ts","../../network-controller/dist/types/constants.d.ts","../../../node_modules/@metamask/safe-event-emitter/index.d.ts","../../json-rpc-engine/dist/types/JsonRpcEngine.d.ts","../../json-rpc-engine/dist/types/createAsyncMiddleware.d.ts","../../json-rpc-engine/dist/types/createScaffoldMiddleware.d.ts","../../json-rpc-engine/dist/types/getUniqueId.d.ts","../../json-rpc-engine/dist/types/idRemapMiddleware.d.ts","../../json-rpc-engine/dist/types/mergeMiddleware.d.ts","../../json-rpc-engine/dist/types/index.d.ts","../../eth-json-rpc-provider/dist/types/safe-event-emitter-provider.d.ts","../../eth-json-rpc-provider/dist/types/provider-from-engine.d.ts","../../eth-json-rpc-provider/dist/types/provider-from-middleware.d.ts","../../eth-json-rpc-provider/dist/types/index.d.ts","../../../node_modules/eth-block-tracker/dist/BlockTracker.d.ts","../../../node_modules/eth-block-tracker/dist/PollingBlockTracker.d.ts","../../../node_modules/eth-block-tracker/dist/SubscribeBlockTracker.d.ts","../../../node_modules/eth-block-tracker/dist/index.d.ts","../../network-controller/dist/types/types.d.ts","../../network-controller/dist/types/create-auto-managed-network-client.d.ts","../../network-controller/dist/types/NetworkController.d.ts","../../network-controller/dist/types/create-network-client.d.ts","../../network-controller/dist/types/index.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/utils.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/classes.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/errors.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/error-constants.d.ts","../../../node_modules/@metamask/rpc-errors/dist/types/index.d.ts","../../approval-controller/dist/types/ApprovalController.d.ts","../../approval-controller/dist/types/errors.d.ts","../../approval-controller/dist/types/index.d.ts","../../permission-controller/dist/types/permission-middleware.d.ts","../../permission-controller/dist/types/SubjectMetadataController.d.ts","../../permission-controller/dist/types/PermissionController.d.ts","../../permission-controller/dist/types/Permission.d.ts","../../permission-controller/dist/types/Caveat.d.ts","../../permission-controller/dist/types/errors.d.ts","../../permission-controller/dist/types/utils.d.ts","../../permission-controller/dist/types/rpc-methods/getPermissions.d.ts","../../permission-controller/dist/types/rpc-methods/requestPermissions.d.ts","../../permission-controller/dist/types/rpc-methods/revokePermissions.d.ts","../../permission-controller/dist/types/rpc-methods/index.d.ts","../../permission-controller/dist/types/index.d.ts","../src/SelectedNetworkController.ts","../src/SelectedNetworkMiddleware.ts","../src/index.ts","../../../node_modules/@babel/types/lib/index.d.ts","../../../node_modules/@types/babel__generator/index.d.ts","../../../node_modules/@babel/parser/typings/babel-parser.d.ts","../../../node_modules/@types/babel__template/index.d.ts","../../../node_modules/@types/babel__traverse/index.d.ts","../../../node_modules/@types/babel__core/index.d.ts","../../../node_modules/@types/deep-freeze-strict/index.d.ts","../../../node_modules/@types/eslint/helpers.d.ts","../../../node_modules/@types/estree/index.d.ts","../../../node_modules/@types/json-schema/index.d.ts","../../../node_modules/@types/eslint/index.d.ts","../../../node_modules/@types/graceful-fs/index.d.ts","../../../node_modules/@types/istanbul-lib-coverage/index.d.ts","../../../node_modules/@types/istanbul-lib-report/index.d.ts","../../../node_modules/@types/istanbul-reports/index.d.ts","../../../node_modules/chalk/index.d.ts","../../../node_modules/jest-diff/build/cleanupSemantic.d.ts","../../../node_modules/pretty-format/build/types.d.ts","../../../node_modules/pretty-format/build/index.d.ts","../../../node_modules/jest-diff/build/types.d.ts","../../../node_modules/jest-diff/build/diffLines.d.ts","../../../node_modules/jest-diff/build/printDiffs.d.ts","../../../node_modules/jest-diff/build/index.d.ts","../../../node_modules/jest-matcher-utils/build/index.d.ts","../../../node_modules/@types/jest/index.d.ts","../../../node_modules/@types/jest-when/index.d.ts","../../../node_modules/@types/json5/index.d.ts","../../../node_modules/@types/lodash/common/common.d.ts","../../../node_modules/@types/lodash/common/array.d.ts","../../../node_modules/@types/lodash/common/collection.d.ts","../../../node_modules/@types/lodash/common/date.d.ts","../../../node_modules/@types/lodash/common/function.d.ts","../../../node_modules/@types/lodash/common/lang.d.ts","../../../node_modules/@types/lodash/common/math.d.ts","../../../node_modules/@types/lodash/common/number.d.ts","../../../node_modules/@types/lodash/common/object.d.ts","../../../node_modules/@types/lodash/common/seq.d.ts","../../../node_modules/@types/lodash/common/string.d.ts","../../../node_modules/@types/lodash/common/util.d.ts","../../../node_modules/@types/lodash/index.d.ts","../../../node_modules/@types/minimatch/index.d.ts","../../../node_modules/@types/parse-json/index.d.ts","../../../node_modules/@types/pbkdf2/index.d.ts","../../../node_modules/@types/prettier/index.d.ts","../../../node_modules/@types/punycode/index.d.ts","../../../node_modules/@types/readable-stream/node_modules/safe-buffer/index.d.ts","../../../node_modules/@types/readable-stream/index.d.ts","../../../node_modules/@types/secp256k1/index.d.ts","../../../node_modules/@types/semver/classes/semver.d.ts","../../../node_modules/@types/semver/functions/parse.d.ts","../../../node_modules/@types/semver/functions/valid.d.ts","../../../node_modules/@types/semver/functions/clean.d.ts","../../../node_modules/@types/semver/functions/inc.d.ts","../../../node_modules/@types/semver/functions/diff.d.ts","../../../node_modules/@types/semver/functions/major.d.ts","../../../node_modules/@types/semver/functions/minor.d.ts","../../../node_modules/@types/semver/functions/patch.d.ts","../../../node_modules/@types/semver/functions/prerelease.d.ts","../../../node_modules/@types/semver/functions/compare.d.ts","../../../node_modules/@types/semver/functions/rcompare.d.ts","../../../node_modules/@types/semver/functions/compare-loose.d.ts","../../../node_modules/@types/semver/functions/compare-build.d.ts","../../../node_modules/@types/semver/functions/sort.d.ts","../../../node_modules/@types/semver/functions/rsort.d.ts","../../../node_modules/@types/semver/functions/gt.d.ts","../../../node_modules/@types/semver/functions/lt.d.ts","../../../node_modules/@types/semver/functions/eq.d.ts","../../../node_modules/@types/semver/functions/neq.d.ts","../../../node_modules/@types/semver/functions/gte.d.ts","../../../node_modules/@types/semver/functions/lte.d.ts","../../../node_modules/@types/semver/functions/cmp.d.ts","../../../node_modules/@types/semver/functions/coerce.d.ts","../../../node_modules/@types/semver/classes/comparator.d.ts","../../../node_modules/@types/semver/classes/range.d.ts","../../../node_modules/@types/semver/functions/satisfies.d.ts","../../../node_modules/@types/semver/ranges/max-satisfying.d.ts","../../../node_modules/@types/semver/ranges/min-satisfying.d.ts","../../../node_modules/@types/semver/ranges/to-comparators.d.ts","../../../node_modules/@types/semver/ranges/min-version.d.ts","../../../node_modules/@types/semver/ranges/valid.d.ts","../../../node_modules/@types/semver/ranges/outside.d.ts","../../../node_modules/@types/semver/ranges/gtr.d.ts","../../../node_modules/@types/semver/ranges/ltr.d.ts","../../../node_modules/@types/semver/ranges/intersects.d.ts","../../../node_modules/@types/semver/ranges/simplify.d.ts","../../../node_modules/@types/semver/ranges/subset.d.ts","../../../node_modules/@types/semver/internals/identifiers.d.ts","../../../node_modules/@types/semver/index.d.ts","../../../node_modules/@types/sinonjs__fake-timers/index.d.ts","../../../node_modules/@types/sinon/index.d.ts","../../../node_modules/@types/stack-utils/index.d.ts","../../../node_modules/@types/uuid/index.d.ts","../../../node_modules/@types/yargs-parser/index.d.ts","../../../node_modules/@types/yargs/index.d.ts"],"fileInfos":[{"version":"8730f4bf322026ff5229336391a18bcaa1f94d4f82416c8b2f3954e2ccaae2ba","affectsGlobalScope":true},"dc47c4fa66b9b9890cf076304de2a9c5201e94b740cffdf09f87296d877d71f6","7a387c58583dfca701b6c85e0adaf43fb17d590fb16d5b2dc0a2fbd89f35c467","8a12173c586e95f4433e0c6dc446bc88346be73ffe9ca6eec7aa63c8f3dca7f9","5f4e733ced4e129482ae2186aae29fde948ab7182844c3a5a51dd346182c7b06","4b421cbfb3a38a27c279dec1e9112c3d1da296f77a1a85ddadf7e7a425d45d18","1fc5ab7a764205c68fa10d381b08417795fc73111d6dd16b5b1ed36badb743d9",{"version":"3aafcb693fe5b5c3bd277bd4c3a617b53db474fe498fc5df067c5603b1eebde7","affectsGlobalScope":true},{"version":"adb996790133eb33b33aadb9c09f15c2c575e71fb57a62de8bf74dbf59ec7dfb","affectsGlobalScope":true},{"version":"8cc8c5a3bac513368b0157f3d8b31cfdcfe78b56d3724f30f80ed9715e404af8","affectsGlobalScope":true},{"version":"cdccba9a388c2ee3fd6ad4018c640a471a6c060e96f1232062223063b0a5ac6a","affectsGlobalScope":true},{"version":"c5c05907c02476e4bde6b7e76a79ffcd948aedd14b6a8f56e4674221b0417398","affectsGlobalScope":true},{"version":"5f406584aef28a331c36523df688ca3650288d14f39c5d2e555c95f0d2ff8f6f","affectsGlobalScope":true},{"version":"22f230e544b35349cfb3bd9110b6ef37b41c6d6c43c3314a31bd0d9652fcec72","affectsGlobalScope":true},{"version":"7ea0b55f6b315cf9ac2ad622b0a7813315bb6e97bf4bb3fbf8f8affbca7dc695","affectsGlobalScope":true},{"version":"3013574108c36fd3aaca79764002b3717da09725a36a6fc02eac386593110f93","affectsGlobalScope":true},{"version":"eb26de841c52236d8222f87e9e6a235332e0788af8c87a71e9e210314300410a","affectsGlobalScope":true},{"version":"3be5a1453daa63e031d266bf342f3943603873d890ab8b9ada95e22389389006","affectsGlobalScope":true},{"version":"17bb1fc99591b00515502d264fa55dc8370c45c5298f4a5c2083557dccba5a2a","affectsGlobalScope":true},{"version":"7ce9f0bde3307ca1f944119f6365f2d776d281a393b576a18a2f2893a2d75c98","affectsGlobalScope":true},{"version":"6a6b173e739a6a99629a8594bfb294cc7329bfb7b227f12e1f7c11bc163b8577","affectsGlobalScope":true},{"version":"81cac4cbc92c0c839c70f8ffb94eb61e2d32dc1c3cf6d95844ca099463cf37ea","affectsGlobalScope":true},{"version":"b0124885ef82641903d232172577f2ceb5d3e60aed4da1153bab4221e1f6dd4e","affectsGlobalScope":true},{"version":"0eb85d6c590b0d577919a79e0084fa1744c1beba6fd0d4e951432fa1ede5510a","affectsGlobalScope":true},{"version":"da233fc1c8a377ba9e0bed690a73c290d843c2c3d23a7bd7ec5cd3d7d73ba1e0","affectsGlobalScope":true},{"version":"d154ea5bb7f7f9001ed9153e876b2d5b8f5c2bb9ec02b3ae0d239ec769f1f2ae","affectsGlobalScope":true},{"version":"bb2d3fb05a1d2ffbca947cc7cbc95d23e1d053d6595391bd325deb265a18d36c","affectsGlobalScope":true},{"version":"c80df75850fea5caa2afe43b9949338ce4e2de086f91713e9af1a06f973872b8","affectsGlobalScope":true},{"version":"9d57b2b5d15838ed094aa9ff1299eecef40b190722eb619bac4616657a05f951","affectsGlobalScope":true},{"version":"6c51b5dd26a2c31dbf37f00cfc32b2aa6a92e19c995aefb5b97a3a64f1ac99de","affectsGlobalScope":true},{"version":"6e7997ef61de3132e4d4b2250e75343f487903ddf5370e7ce33cf1b9db9a63ed","affectsGlobalScope":true},{"version":"2ad234885a4240522efccd77de6c7d99eecf9b4de0914adb9a35c0c22433f993","affectsGlobalScope":true},{"version":"5e5e095c4470c8bab227dbbc61374878ecead104c74ab9960d3adcccfee23205","affectsGlobalScope":true},{"version":"09aa50414b80c023553090e2f53827f007a301bc34b0495bfb2c3c08ab9ad1eb","affectsGlobalScope":true},{"version":"d7f680a43f8cd12a6b6122c07c54ba40952b0c8aa140dcfcf32eb9e6cb028596","affectsGlobalScope":true},{"version":"3787b83e297de7c315d55d4a7c546ae28e5f6c0a361b7a1dcec1f1f50a54ef11","affectsGlobalScope":true},{"version":"e7e8e1d368290e9295ef18ca23f405cf40d5456fa9f20db6373a61ca45f75f40","affectsGlobalScope":true},{"version":"faf0221ae0465363c842ce6aa8a0cbda5d9296940a8e26c86e04cc4081eea21e","affectsGlobalScope":true},{"version":"06393d13ea207a1bfe08ec8d7be562549c5e2da8983f2ee074e00002629d1871","affectsGlobalScope":true},{"version":"2768ef564cfc0689a1b76106c421a2909bdff0acbe87da010785adab80efdd5c","affectsGlobalScope":true},{"version":"b248e32ca52e8f5571390a4142558ae4f203ae2f94d5bac38a3084d529ef4e58","affectsGlobalScope":true},{"version":"52d1bb7ab7a3306fd0375c8bff560feed26ed676a5b0457fa8027b563aecb9a4","affectsGlobalScope":true},"70bbfaec021ac4a0c805374225b55d70887f987df8b8dd7711d79464bb7b4385","869089d60b67219f63e6aca810284c89bae1b384b5cbc7ce64e53d82ad223ed5",{"version":"18338b6a4b920ec7d49b4ffafcbf0fa8a86b4bfd432966efd722dab611157cf4","affectsGlobalScope":true},"62a0875a0397b35a2364f1d401c0ce17975dfa4d47bf6844de858ae04da349f9","ee7491d0318d1fafcba97d5b72b450eb52671570f7a4ecd9e8898d40eaae9472","e3e7d217d89b380c1f34395eadc9289542851b0f0a64007dfe1fb7cf7423d24e","fd79909e93b4d50fd0ed9f3d39ddf8ba0653290bac25c295aac49f6befbd081b","345a9cc2945406f53051cd0e9b51f82e1e53929848eab046fdda91ee8aa7da31","9debe2de883da37a914e5e784a7be54c201b8f1d783822ad6f443ff409a5ea21","dee5d5c5440cda1f3668f11809a5503c30db0476ad117dd450f7ba5a45300e8f","f5e396c1424c391078c866d6f84afe0b4d2f7f85a160b9c756cd63b5b1775d93","5caa6f4fff16066d377d4e254f6c34c16540da3809cd66cd626a303bc33c419f","730d055528bdf12c8524870bb33d237991be9084c57634e56e5d8075f6605e02","75b22c74010ba649de1a1676a4c4b8b5bb4294fecd05089e2094429b16d7840c","e475453e7140e95542332943d3052fe4c7430ad1efce42b3e9157f1fee8cbc5f","ebfdf904255ce746c9d30117c2edef355fb19bf7650478d2405f39f0e4f302e6","f3f63b48addb8e2ea9d20bb671c3c306413b3daa39996d0ae52f63d8e32158e1","a50599c08934a62f11657bdbe0dc929ab66da1b1f09974408fd9a33ec1bb8060","5a20e7d6c630b91be15e9b837853173829d00273197481dc8d3e94df61105a71","8d478048d71cc16f806d4b71b252ecb67c7444ccf4f4b09b29a312712184f859","b4000a0a525fa921e896cbdb32ae802c9684f0fd371b5fc69e7310f7918cc2c3","9df4662ca3dbc2522bc115833ee04faa1afbb4e249a85ef4a0a09c621346bd08","b25d9065cf1c1f537a140bbc508e953ed2262f77134574c432d206ff36f4bdbf","1b103313097041aa9cd705a682c652f08613cb5cf8663321061c0902f845e81c","68ccec8662818911d8a12b8ed028bc5729fb4f1d34793c4701265ba60bc73cf4","5f85b8b79dc4d36af672c035b2beb71545de63a5d60bccbeee64c260941672ab","b3d48529ae61dc27d0bfbfa2cb3e0dff8189644bd155bdf5df1e8e14669f7043","40fe4b689225816b31fe5794c0fbf3534568819709e40295ead998a2bc1ab237","f65b5e33b9ad545a1eebbd6afe857314725ad42aaf069913e33f928ab3e4990a","fb6f2a87beb7fb1f4c2b762d0c76a9459fc91f557231569b0ee21399e22aa13d","31c858dc85996fac4b7fa944e1016d5c72f514930a72357ab5001097bf6511c7","3de30a871b3340be8b679c52aa12f90dd1c8c60874517be58968fdbcc4d79445","6fd985bd31eaf77542625306fb0404d32bff978990f0a06428e5f0b9a3b58109","34693fb4a5e771e11668219221344dd1bd7d8b77ed005a1c1d965fb559be8406","7394959e5a741b185456e1ef5d64599c36c60a323207450991e7a42e08911419",{"version":"e44ea2d6b7b853f6c81482416db43dafc11944561b810e469ae423085511ce7e","affectsGlobalScope":true},"f51b4042a3ac86f1f707500a9768f88d0b0c1fc3f3e45a73333283dea720cdc6",{"version":"a7289d79eb84a59d2475b4d0136b4404be3cfdd17c3ea46b9194add1d645df01","affectsGlobalScope":true},"0bb26fa2a90ee890eed57ee812c71fa84d3d07850163ec4a204de86412cc57c1","132ca47da601c60141dd6f10bd08c70d0620177e5638439df2464ec3945b6d98",{"version":"55d2bbae076fed7269c3e16faeb32f988f558427b7a1c3bf04aa7551ab86ae90","affectsGlobalScope":true},"a40826e8476694e90da94aa008283a7de50d1dafd37beada623863f1901cb7fb","cf83847c9264dcd592b6c89c1542925b899b277228687f3638614e3fa784cf76","3a41ebe7f089d50f447466b35b6cabb8b584c0994fc9809d0cd0a4ebc41e1239","7693b90b3075deaccafd5efb467bf9f2b747a3075be888652ef73e64396d8628","0c42d6cba77d9ad1cf45256ccb8489aa502fe2dbee1ec9048a29d49f5d532e73","2cf89c17245db65d175d4ef699cd68187516f9b3ae5c572fc0b9ad60f35dc223","5f20d20b7607174caf1a6da9141aeb9f2142159ae2410ca30c7a0fccd1d19c99",{"version":"a34d65f61ec5aac5b53502c8b0bd4e00d217bccb95bf94d449e2571baa11fb8c","affectsGlobalScope":true},"8d42e5af5fb0a96a77e135ce84cc60636c9bad39d9dba043a4efe9d1bdeb3cc3","56fcc451e9065eb121c9cc4c1b9994a816306f3b0b3b1fce7ad59f0ac97a9999","8a6f12b74d3e6c4f5e1b918cb8e64ae16bc6756cf0d48bcc28a28e1bf26ca0cd","c3759b5bc5cc40f5988d86a497741a80fa91258629ae50a2b3735e774cd377cc","bf268a0aea37ad4ae3b7a9b58559190b6fc01ea16a31e35cd05817a0a60f895a","45dd82fb5aea9b12b2a90b427b28f3a014e8b2ee9b74087a5ab882841cb5fbc5",{"version":"d7dad6db394a3d9f7b49755e4b610fbf8ed6eb0c9810ae5f1a119f6b5d76de45","affectsGlobalScope":true},"48b2f9302651eb31acd5be69bb4e6b35797a7fcd6b77391d10a4ccadf7dc3609","0c8c917ef15498c827bd494a0ef365e9f76deb211f8acbb86932e20489310788","dd67d2b5e4e8a182a38de8e69fb736945eaa4588e0909c14e01a14bd3cc1fd1e",{"version":"9cdc2c6144b03822c9842505d09945bcf813b86827fdb260dd7586b63abc19bf","affectsGlobalScope":true},{"version":"2923dee3c897f03e91b54a210cdbefea7290562f0ac4b948667d4c9ee844b79e","affectsGlobalScope":true},"79169698d09a2be54b14f3bcad2575b414bf3525063fde0a1e4fcd5d6efd380e","051d939bcf77caa3cef3282708ab3a6fdfb741a7366e1d74a9e7603b67417ec3","0be79b3ff0f16b6c2f9bc8c4cc7097ea417d8d67f8267f7e1eec8e32b548c2ff","1c61ffa3a71b77363b30d19832c269ef62fba787f5610cac7254728d3b69ab2e","a234d62ae81d012ebf23898a45672edf3e5c93ecf5a438a42b96c08dd68cde43","269929a24b2816343a178008ac9ae9248304d92a8ba8e233055e0ed6dbe6ef71","09ed02a725db002693236b6dfc49b2c6eb5557be1421d7fbe4f07cfe38211d92","09d801ff4a303d4976d4b9cb94af3a9097c4a70345e662d176975872d2998e51","c8558b01389b5f7610ac293aa612ccea2ae64d83af43b49f8142f190be1f414c","c40fdf7b2e18df49ce0568e37f0292c12807a0748be79e272745e7216bed2606",{"version":"b10b426c56e220b5093bf8a2446ee47af47263b7b1a03f4b18e42326b231b111","affectsGlobalScope":true},"4e228e78c1e9b0a75c70588d59288f63a6258e8b1fe4a67b0c53fe03461421d9","b4635ef36bee17e1304337d591c3b6b461ecdbc1876d0effbe6a581e62201fe5","205d50c24359ead003dc537b9b65d2a64208dfdffe368f403cf9e0357831db9e","1265fddcd0c68be9d2a3b29805d0280484c961264dd95e0b675f7bd91f777e78",{"version":"e4507242542bd499238f693d88b2d32e22177cc508854625f87bcc9bc3fa1256","affectsGlobalScope":true},{"version":"d942354e4966a98d3a92d1b1af0b4ac06f33af3f88116743e2c304c027ca26ef","affectsGlobalScope":true},"39f0808e5be3cb38674726c21fe2eb453c55e48a901679b4ce30fef85549b892","6afd66a7432ef100027ea110449e874196381e019e30eda7e7d8ca390366b7a8","befb8a9a78ac99d8fbc3ed392810489a7b90760c7a58934e8f1c8538f581cff3","e670bdf01540d35c170fae68edfd2f288eff909936780c379d6a9103b787b22c","867f95abf1df444aab146b19847391fc2f922a55f6a970a27ed8226766cee29f",{"version":"ab9b9a36e5284fd8d3bf2f7d5fcbc60052f25f27e4d20954782099282c60d23e","affectsGlobalScope":true},"88003d9ab15507806f41b120be6d407c1afe566c2f6689ebe3a034dd5ec0c8dc","175323e2a79a6076e0bada8a390d535a3ea817158bf1b1f46e31efca9028a0a2","7a10053aadc19335532a4d02756db4865974fd69bea5439ddcc5bfdf062d9476","4967529644e391115ca5592184d4b63980569adf60ee685f968fd59ab1557188","aed9e712a9b168345362e8f3a949f16c99ca1e05d21328f05735dfdbb24414ef","b04fe6922ed3db93afdbd49cdda8576aa75f744592fceea96fb0d5f32158c4f5","ed8d6c8de90fc2a4faaebc28e91f2469928738efd5208fb75ade0fa607e892b7","d7c52b198d680fe65b1a8d1b001f0173ffa2536ca2e7082431d726ce1f6714cd","c07f251e1c4e415a838e5498380b55cfea94f3513229de292d2aa85ae52fc3e9","0ed401424892d6bf294a5374efe512d6951b54a71e5dd0290c55b6d0d915f6f7","b945be6da6a3616ef3a250bfe223362b1c7c6872e775b0c4d82a1bf7a28ff902","beea49237dd7c7110fabf3c7509919c9cb9da841d847c53cac162dc3479e2f87","0f45f8a529c450d8f394106cc622bff79e44a1716e1ac9c3cc68b43f7ecf65ee","c624ce90b04c27ce4f318ba6330d39bde3d4e306f0f497ce78d4bda5ab8e22ca","9b8253aa5cb2c82d505f72afdbf96e83b15cc6b9a6f4fadbbbab46210d5f1977","86a8f52e4b1ac49155e889376bcfa8528a634c90c27fec65aa0e949f77b740c5","aab5dd41c1e2316cc0b42a7dd15684f8582d5a1d16c0516276a2a8a7d0fecd9c","59948226626ee210045296ba1fc6cb0fe748d1ff613204e08e7157ab6862dee7","ec3e54d8b713c170fdc8110a7e4a6a97513a7ab6b05ac9e1100cb064d2bb7349","43beb30ecb39a603fde4376554887310b0699f25f7f39c5c91e3147b51bb3a26","666b77d7f06f49da114b090a399abbfa66d5b6c01a3fd9dc4f063a52ace28507","31997714a93fbc570f52d47d6a8ebfb021a34a68ea9ba58bbb69cdec9565657e","6032e4262822160128e644de3fc4410bcd7517c2f137525fd2623d2bb23cb0d3","8bd5c9b1016629c144fd228983395b9dbf0676a576716bc3d316cab612c33cd5","2ed90bd3925b23aed8f859ffd0e885250be0424ca2b57e9866dabef152e1d6b7","93f6bd17d92dab9db7897e1430a5aeaa03bcf51623156213d8397710367a76ce","3f62b770a42e8c47c7008726f95aa383e69d97e85e680d237b99fcb0ee601dd8","5b84cfe78028c35c3bb89c042f18bf08d09da11e82d275c378ae4d07d8477e6c","980d21b0081cbf81774083b1e3a46f4bbdcd2b68858df0f66d7fad9c82bc34bc","6a9c5127096b35264eb7cd21b2417bfc1d42cceca9ba4ce2bb0c3410b7816042","93b7325b49dfbf613d940ed0e471216657b2d77459dac34f1b5b1678f08f884c","b17f3bb7d8333479c7e45e5f3d876761b9bca58f97594eca3f6a944fd825e632","3c1f1236cce6d6e0c4e2c1b4371e6f72d7c14842ecd76a98ed0748ee5730c8f3","6d7f58d5ea72d7834946fd7104a734dc7d40661be8b2e1eaced1ddce3268ebaf","4c26222991e6c97d5a8f541d4f2c67585eda9e8b33cf9f52931b098045236e88","277983d414aa99d78655186c3ee1e1c38c302e336aff1d77b47fcdc39d8273fe","47383b45796d525a4039cd22d2840ac55a1ff03a43d027f7f867ba7314a9cf53","6548773b3abbc18de29176c2141f766d4e437e40596ee480447abf83575445ad","6ddd27af0436ce59dd4c1896e2bfdb2bdb2529847d078b83ce67a144dff05491","816264799aef3fd5a09a3b6c25217d5ec26a9dfc7465eac7d6073bcdc7d88f3f","4df0891b133884cd9ed752d31c7d0ec0a09234e9ed5394abffd3c660761598db","b603b62d3dcd31ef757dc7339b4fa8acdbca318b0fb9ac485f9a1351955615f9","e642bd47b75ad6b53cbf0dfd7ddfa0f120bd10193f0c58ec37d87b59bf604aca","be90b24d2ee6f875ce3aaa482e7c41a54278856b03d04212681c4032df62baf9","78f5ff400b3cb37e7b90eef1ff311253ed31c8cb66505e9828fad099bffde021","372c47090e1131305d163469a895ff2938f33fa73aad988df31cd31743f9efb6","71c67dc6987bdbd5599353f90009ff825dd7db0450ef9a0aee5bb0c574d18512","6f12403b5eca6ae7ca8e3efe3eeb9c683b06ce3e3844ccfd04098d83cd7e4957","282c535df88175d64d9df4550d2fd1176fd940c1c6822f1e7584003237f179d3","c3a4752cf103e4c6034d5bd449c8f9d5e7b352d22a5f8f9a41a8efb11646f9c2","11a9e38611ac3c77c74240c58b6bd64a0032128b29354e999650f1de1e034b1c","4ed103ca6fff9cb244f7c4b86d1eb28ce8069c32db720784329946731badb5bb","d738f282842970e058672663311c6875482ee36607c88b98ffb6604fba99cb2a","ec859cd8226aa623e41bbb47c249a55ee16dc1b8647359585244d57d3a5ed0c7","8891c6e959d253a66434ff5dc9ae46058fb3493e84b4ca39f710ef2d350656b1","c4463cf02535444dcbc3e67ecd29f1972490f74e49957d6fd4282a1013796ba6","0cb0a957ff02de0b25fd0f3f37130ca7f22d1e0dea256569c714c1f73c6791f8","2f5075dc512d51786b1ba3b1696565641dfaae3ac854f5f13d61fa12ef81a47e","ca3353cc82b1981f0d25d71d7432d583a6ef882ccdea82d65fbe49af37be51cb","50679a8e27aacf72f8c40bcab15d7ef5e83494089b4726b83eec4554344d5cdc","45351e0d51780b6f4088277a4457b9879506ee2720a887de232df0f1efcb33d8","5d697a4b315cc5bb3042ae869abffd10c3b0d7b182cda0e4c45d8819937e5796","563fa27fdaec8f195b84f71a7af0ef48d30d5cc830575db86da86a63a470c8e6","6ee58aa536dabb19b09bc036f1abe83feb51e13d63b23d30b2d0631a2de99b8f","8aceb205dcc6f814ad99635baf1e40b6e01d06d3fe27b72fd766c6d0b8c0c600","299567f84bfedd1468dca2755a829cb19e607a6811673788807dc8921e211bc9","795d9fb85aad92221504db74dd179b506bd189bba0c104426f7e7bb8a66ffee5","1311bc194e0a69fe61031e852c1c0b439e2a2a3d1d5e2d8ff795499b9f283459","4b7ce19369d7e7fae76720c2c6c7f671bf3fa0f7093edb864f1ac358ca7c456c","c972ef44deca1fa8fab465915ffa00f82e126aacf3dfc8979c03b1b066ce5bb6","30285a1011c6d6b52f3ba3abb0a984be8148c05cdefb8eb6eb562335a3991f35","8e7adb22c0adecf7464861fc58ae3fc617b41ffbd70c97aa8493dc0966a82273","755f3cd1d9c1b564cff090e3b0e29200ae55690a91b87cb9e7a64c2dbeb314d3","d6bb7e0a6877b7856c183bff13d09dd9ae599ea43c6f6b33d3d5f72a830ed460","f1b51ae93c762d7c43f559933cd4842dd870367e8d92e90704ffa685dd5b29a3","3f450762fd7c34ed545e738abccb0af6a703572a10521643cf8fc88e3724c99c","fcc8beef29f39f09b1d9c9f99c42f9fed605ab1c28d2a630185f732b9ba53763","d6e6620a30d582182acc3f0a992a0c311adc589f111096aea11ab83fc09a5ccc","6213b8f686f56beab22b59a0f468590fd3a4c5fa931236a017efeca91d7c9584","c451cec9a588b1f105a5ea2c6063d4fca112b9d70105cacdadda0e1ef67e9379","cb047832dc68f5a2c41c62c5e95ddcacbae3a8b034d40cd15319a8cb7f25104a","980336ccdfc3c08f3c3b201aa6662e6016e20f15847f8465b68f3e8e67b4665c","5a3493939995f46ff3d9073cd534fb8961c3bf4e08c71db27066ff03d906dea8","bb5a2ac327605ebebf831c469b05bd34a33a6a46ee8c1edd9f3310aad32cf6a1","bf5d041f2440b4a9391e2b5eb3b8d94cbf1e3b8ff4703b6539d4e65e758c8f37","8516469eb90e723b0eb03df1be098f7e6a4709f6f48fd4532868d20a0a934f6e","d60e9ab369a72d234aac49adbe2900d8ef1408a6ea4db552cf2a48c9d8d6a1bc","0ebb4698803f01e2e7df6acce572fff068f4a20c47221721dafd70a27e372831","a12eaa942232703a8a8477a2f240ad5a2c26c595012ea8f128224e77984099c4","4070c2f1c3434fcf84886e04d30d82cd650ee443e53b82b404b144175cf8741e","2cea9689efa8591732096235abe7f084fc29c92badd5b0897a5e876b77e71887","4ed4e504126014fee13aaef5e3fc140f2ff7031ff3a8b5386717905820ea2d09","8129a34006218a6f3cdc81bbd438d5429eb18b08b4338a26977ac3b4df129d75","30d2170e1a718b5035611af55e3618b4ba8f42f0749bb52ee593da6082c4e2ce","98ef38666d88ec9699a722053e07ede65d3042f693fe7ff8c786e53dbb6fd43b","a3b8b6be7620897d1e481e8650c980a210a138fceb6e710eaf95fd9dd0dfe94a","12c89d0e32758c120a569045f21cf5b77244f86792611ced8de7f86b37e77781","9f9e5bae412fa5909fae636d6733aee27a108cc2ed5b13980611016336774d3c","662fe197bba64bd3f17ee118058cd2d0d2dbe33d7c0c865fd6365d90bfc44e1e","030519c351f800551cac2658038804969ca4584d2c0175a710602ac234ca1340","0278a6939ca83cd040b08ff8c5fc7838b6693ddc52f22526bf158e6b10e0246c","c2d6206e5ba4fd3063b01218c2b3b997afc1cfbeb49fcee991fa8595842ce53d","29c188a2c660f99f1b4835022e011c4268d7af989d4b7dda33c0a69ca1a777f8","1ed0bf138e87912d741e28333b58cbf814ae863783b3b404d2454cbabb9c5fc0","3452ee7d8ef0b1bbd47b2a56924a1dc3c79dc84a19d212e9dc496f92e4943aa0","99510e20e3d4816e283e59e8f0f31f603b2f026648240ffdb1ca9f24be678419","037d1fbeb96dc35600814be14d0fbf31acf35f1d7b443ea33514937de69c2bf2","64d1859b7dd9f419ba08e064c2b16b1a5edde0316d6c2bb1833c9381d4dffc3d","69b0f96ca137c0dba05f321a159141ad36f79cfba2fffcc29d131e280275e6f2","7bb64cf513a2b1cf7a94f81ca201f3d76a9b17af556f0cfc4e2707443e6caa66","a9add2a29da4cd0b617ae89f196b3f2172a031aeb086922cdf097236eef8b008","99afac3e6e683ee3111e499f9919953e9489cb39cad74363717aa3805e91db51","c49f92b83968f4ee0b6026396a9b6e2d6fee8b660d08a90efb03355ce3433a7a","4fdc6afe4d7ef6aeb32ac0818d47e99f98a31d0696abc4cb2af489c78ac1ba1d","d73d5a0e854037d43781b2d5d33f4b95ee509e0ddede677aade79fbee6a97cdc","35d14e1ae04be300828b1a1614316b9312a009cfd5e29fa56f94c2a9f60b12df","d160fe745f9c3b72d7b9036fdb2b6b500a520d43e36bb842c927b6fe59ea2c23",{"version":"4a6571cadd05e8087a34f7ca44f63a8f61aa5fcca650f0a577febc4877b3c34f","signature":"3a4f9e7087c566703447928d15c234bd0bcc63a2a50b6ec39ed37c9bc0342310"},{"version":"506bcad28e45e13c23c2c25c9691e0dc42d8755a0e24b9a48586f51b5bebae8f","signature":"3a12771c76c5ed979438dc0e390224bd3d8661bcbea18114f77c4c6d9de5b8b2"},{"version":"6fbdb35bc3b9cfb225c48108b5bacb5c0d67bbcb677cf13b912e15a852551023","signature":"ee06131adf64c6cd201de36563174cff0e160b81438be186a7bd85e6c2b54fa7"},"a5aaeca001d2f69093d04aac4db321e4c338fd9b20cbc4f0b0af3dc6ae0f235b","cc957354aa3c94c9961ebf46282cfde1e81d107fc5785a61f62c67f1dd3ac2eb","8041cfce439ff29d339742389de04c136e3029d6b1817f07b2d7fcbfb7534990","93de1c6dab503f053efe8d304cb522bb3a89feab8c98f307a674a4fae04773e9","29a46d003ca3c721e6405f00dee7e3de91b14e09701eba5d887bf76fb2d47d38","069bebfee29864e3955378107e243508b163e77ab10de6a5ee03ae06939f0bb9","9990f9e566bc3c2c6e38df81294fb756e7f5b7b0e5bb17ab75384e190548b4b6",{"version":"64d4b35c5456adf258d2cf56c341e203a073253f229ef3208fc0d5020253b241","affectsGlobalScope":true},"ee7d8894904b465b072be0d2e4b45cf6b887cdba16a467645c4e200982ece7ea","f3d8c757e148ad968f0d98697987db363070abada5f503da3c06aefd9d4248c1","df95e00612c1faa5e0e7ef0dba589b18665bbeb3221db2b6cee1fe4d0e61921f","afe73051ff6a03a9565cbd8ebb0e956ee3df5e913ad5c1ded64218aabfa3dcb5","8b06ac3faeacb8484d84ddb44571d8f410697f98d7bfa86c0fda60373a9f5215","7eb06594824ada538b1d8b48c3925a83e7db792f47a081a62cf3e5c4e23cf0ee","f5638f7c2f12a9a1a57b5c41b3c1ea7db3876c003bab68e6a57afd6bcc169af0","0d14fa22c41fdc7277e6f71473b20ebc07f40f00e38875142335d5b63cdfc9d2","d8aab31ba8e618cc3eea10b0945de81cb93b7e8150a013a482332263b9305322","462bccdf75fcafc1ae8c30400c9425e1a4681db5d605d1a0edb4f990a54d8094","5923d8facbac6ecf7c84739a5c701a57af94a6f6648d6229a6c768cf28f0f8cb","7adecb2c3238794c378d336a8182d4c3dd2c4fa6fa1785e2797a3db550edea62","dc12dc0e5aa06f4e1a7692149b78f89116af823b9e1f1e4eae140cd3e0e674e6","1bfc6565b90c8771615cd8cfcf9b36efc0275e5e83ac7d9181307e96eb495161","8a8a96898906f065f296665e411f51010b51372fa260d5373bf9f64356703190","7f82ef88bdb67d9a850dd1c7cd2d690f33e0f0acd208e3c9eba086f3670d4f73",{"version":"ccfd8774cd9b929f63ff7dcf657977eb0652e3547f1fcac1b3a1dc5db22d4d58","affectsGlobalScope":true},"d92dc90fecd2552db74d8dc3c6fb4db9145b2aa0efe2c127236ba035969068d4","96d14f21b7652903852eef49379d04dbda28c16ed36468f8c9fa08f7c14c9538","675e702f2032766a91eeadee64f51014c64688525da99dccd8178f0c599f13a8","458111fc89d11d2151277c822dfdc1a28fa5b6b2493cf942e37d4cd0a6ee5f22","19c816167e076e7c24f074389c6cf3ed87bdbb917d1ea439ca281f9d26db2439","187119ff4f9553676a884e296089e131e8cc01691c546273b1d0089c3533ce42","febf0b2de54781102b00f61653b21377390a048fbf5262718c91860d11ff34a6","98f9d826db9cd99d27a01a59ee5f22863df00ccf1aaf43e1d7db80ebf716f7c3","0aaef8cded245bf5036a7a40b65622dd6c4da71f7a35343112edbe112b348a1e","00baffbe8a2f2e4875367479489b5d43b5fc1429ecb4a4cc98cfc3009095f52a","dcd91d3b697cb650b95db5471189b99815af5db2a1cd28760f91e0b12ede8ed5","3c92b6dfd43cc1c2485d9eba5ff0b74a19bb8725b692773ef1d66dac48cda4bd","3cf0d343c2276842a5b617f22ba82af6322c7cfe8bb52238ffc0c491a3c21019","df996e25faa505f85aeb294d15ebe61b399cf1d1e49959cdfaf2cc0815c203f9",{"version":"f2eff8704452659641164876c1ef0df4174659ce7311b0665798ea3f556fa9ad","affectsGlobalScope":true},"8841e2aa774b89bd23302dede20663306dc1b9902431ac64b24be8b8d0e3f649","2b8264b2fefd7367e0f20e2c04eed5d3038831fe00f5efbc110ff0131aab899b","a73a445c1e0a6d0f8b48e8eb22dc9d647896783a7f8991cbbc31c0d94bf1f5a2","d88a5e779faf033be3d52142a04fbe1cb96009868e3bbdd296b2bc6c59e06c0e","cd1d2f103b79002cd94b85a640a103f094227a2c4c53bc8af1fdbf4e13d9729e","5e379df3d61561c2ed7789b5995b9ba2143bbba21a905e2381e16efe7d1fa424","f07a137bbe2de7a122c37bfea00e761975fb264c49f18003d398d71b3fb35a5f","3dce33e7eb25594863b8e615f14a45ab98190d85953436750644212d8a18c066","2b93035328f7778d200252681c1d86285d501ed424825a18f81e4c3028aa51d9","2ac9c8332c5f8510b8bdd571f8271e0f39b0577714d5e95c1e79a12b2616f069","42c21aa963e7b86fa00801d96e88b36803188018d5ad91db2a9101bccd40b3ff","d31eb848cdebb4c55b4893b335a7c0cca95ad66dee13cbb7d0893810c0a9c301","b9f96255e1048ed2ea33ec553122716f0e57fc1c3ad778e9aa15f5b46547bd23","7a9e0a564fee396cacf706523b5aeed96e04c6b871a8bebefad78499fbffc5bc","906c751ef5822ec0dadcea2f0e9db64a33fb4ee926cc9f7efa38afe5d5371b2a","5387c049e9702f2d2d7ece1a74836a14b47fbebe9bbeb19f94c580a37c855351","c68391fb9efad5d99ff332c65b1606248c4e4a9f1dd9a087204242b56c7126d6","e9cf02252d3a0ced987d24845dcb1f11c1be5541f17e5daa44c6de2d18138d0c","e8b02b879754d85f48489294f99147aeccc352c760d95a6fe2b6e49cd400b2fe","9f6908ab3d8a86c68b86e38578afc7095114e66b2fc36a2a96e9252aac3998e0","0eedb2344442b143ddcd788f87096961cd8572b64f10b4afc3356aa0460171c6","71405cc70f183d029cc5018375f6c35117ffdaf11846c35ebf85ee3956b1b2a6","c68baff4d8ba346130e9753cefe2e487a16731bf17e05fdacc81e8c9a26aae9d","2cd15528d8bb5d0453aa339b4b52e0696e8b07e790c153831c642c3dea5ac8af","479d622e66283ffa9883fbc33e441f7fc928b2277ff30aacbec7b7761b4e9579","ade307876dc5ca267ca308d09e737b611505e015c535863f22420a11fffc1c54","f8cdefa3e0dee639eccbe9794b46f90291e5fd3989fcba60d2f08fde56179fb9","86c5a62f99aac7053976e317dbe9acb2eaf903aaf3d2e5bb1cafe5c2df7b37a8","2b300954ce01a8343866f737656e13243e86e5baef51bd0631b21dcef1f6e954","a2d409a9ffd872d6b9d78ead00baa116bbc73cfa959fce9a2f29d3227876b2a1","b288936f560cd71f4a6002953290de9ff8dfbfbf37f5a9391be5c83322324898","61178a781ef82e0ff54f9430397e71e8f365fc1e3725e0e5346f2de7b0d50dfa","6a6ccb37feb3aad32d9be026a3337db195979cd5727a616fc0f557e974101a54","c649ea79205c029a02272ef55b7ab14ada0903db26144d2205021f24727ac7a3","38e2b02897c6357bbcff729ef84c736727b45cc152abe95a7567caccdfad2a1d","d6610ea7e0b1a7686dba062a1e5544dd7d34140f4545305b7c6afaebfb348341","3dee35db743bdba2c8d19aece7ac049bde6fa587e195d86547c882784e6ba34c","b15e55c5fa977c2f25ca0b1db52cfa2d1fd4bf0baf90a8b90d4a7678ca462ff1","f41d30972724714763a2698ae949fbc463afb203b5fa7c4ad7e4de0871129a17","843dd7b6a7c6269fd43827303f5cbe65c1fecabc30b4670a50d5a15d57daeeb9","f06d8b8567ee9fd799bf7f806efe93b67683ef24f4dea5b23ef12edff4434d9d","6017384f697ff38bc3ef6a546df5b230c3c31329db84cbfe686c83bec011e2b2","e1a5b30d9248549ca0c0bb1d653bafae20c64c4aa5928cc4cd3017b55c2177b0","a593632d5878f17295bd53e1c77f27bf4c15212822f764a2bfc1702f4b413fa0","a868a534ba1c2ca9060b8a13b0ffbbbf78b4be7b0ff80d8c75b02773f7192c29","da7545aba8f54a50fde23e2ede00158dc8112560d934cee58098dfb03aae9b9d","34baf65cfee92f110d6653322e2120c2d368ee64b3c7981dff08ed105c4f19b0","a1a261624efb3a00ff346b13580f70f3463b8cdcc58b60f5793ff11785d52cab","f83b320cceccfc48457a818d18fc9a006ab18d0bdd727aa2c2e73dc1b4a45e98","9d92b037978bb9525bc4b673ebddd443277542e010c0aef019c03a170ccdaa73","b0d10e46cfe3f6c476b69af02eaa38e4ccc7430221ce3109ae84bb9fb8282298","fab58e600970e66547644a44bc9918e3223aa2cbd9e8763cec004b2cfb48827e","70e9a18da08294f75bf23e46c7d69e67634c0765d355887b9b41f0d959e1426e","ed44ba6b95f08b758748be7902e0cc54178b1337c56d0e2469c77b03f63ac73b"],"options":{"composite":true,"declaration":true,"declarationMap":true,"emitDeclarationOnly":true,"esModuleInterop":true,"inlineSources":true,"module":1,"outDir":"./types","rootDir":"../src","sourceMap":true,"strict":true,"target":7},"fileIdsList":[[120,247],[120],[91,120,127,128,129,144],[120,128,129,145,146],[120,127,128],[120,127,144,147,150],[120,127,147,150,151],[120,148,149,150,152,153],[120,127,150],[120,127,144,147,148,149,152],[120,127,135],[120,127],[91,120,127],[80,120,127],[120,131,132,133,134,135,136,137,138,139,140,141,142,143],[120,127,133,134],[120,127,133,135],[120,166,224],[120,224,225],[120,224,225,226,227],[120,166],[120,198],[120,198,199,200],[64,120],[67,120],[64,67,120],[65,66,67,68,69,70,71,72,73,74,75,120,155,158,159,160,161,162,163,164,165],[58,64,65,120],[67,73,75,120,154],[120,157],[67,68,120],[64,120,161],[120,193,194],[120,247,248,249,250,251],[120,247,249],[120,156],[120,254,255,256],[92,120,127],[120,259],[120,260],[120,271],[120,265,270],[120,274,276,277,278,279,280,281,282,283,284,285,286],[120,274,275,277,278,279,280,281,282,283,284,285,286],[120,275,276,277,278,279,280,281,282,283,284,285,286],[120,274,275,276,278,279,280,281,282,283,284,285,286],[120,274,275,276,277,279,280,281,282,283,284,285,286],[120,274,275,276,277,278,280,281,282,283,284,285,286],[120,274,275,276,277,278,279,281,282,283,284,285,286],[120,274,275,276,277,278,279,280,282,283,284,285,286],[120,274,275,276,277,278,279,280,281,283,284,285,286],[120,274,275,276,277,278,279,280,281,282,284,285,286],[120,274,275,276,277,278,279,280,281,282,283,285,286],[120,274,275,276,277,278,279,280,281,282,283,284,286],[120,274,275,276,277,278,279,280,281,282,283,284,285],[76,120],[79,120],[80,85,111,120],[81,91,92,99,108,119,120],[81,82,91,99,120],[83,120],[84,85,92,100,120],[85,108,116,120],[86,88,91,99,120],[87,120],[88,89,120],[90,91,120],[91,120],[91,92,93,108,119,120],[91,92,93,108,120],[91,94,99,108,119,120],[91,92,94,95,99,108,116,119,120],[94,96,108,116,119,120],[76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126],[91,97,120],[98,119,120,124],[88,91,99,108,120],[100,120],[101,120],[79,102,120],[103,118,120,124],[104,120],[105,120],[91,106,120],[106,107,120,122],[80,91,108,109,110,120],[80,108,110,120],[108,109,120],[111,120],[112,120],[91,114,115,120],[114,115,120],[85,99,116,120],[117,120],[99,118,120],[80,94,105,119,120],[85,120],[108,120,121],[120,122],[120,123],[80,85,91,93,102,108,119,120,122,124],[108,120,125],[120,127,292],[120,295,334],[120,295,319,334],[120,334],[120,295],[120,295,320,334],[120,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,320,321,322,323,324,325,326,327,328,329,330,331,332,333],[120,320,334],[120,335],[120,339],[120,203],[120,203,214,215],[120,215,216,217],[120,178],[120,178,179,180,181,182],[120,167,168,169,170,171,172,173,174,175,176,177],[120,263,266],[120,263,266,267,268],[120,265],[120,262,269],[120,264],[57,59,60,61,62,63,120],[57,58,120],[59,120],[58,59,120],[57,59,120],[120,166,187,228],[120,229,230],[120,166,183,184,185],[120,184],[120,185],[56,120,184,185,186],[120,188],[120,188,189,192,196],[120,195],[120,166,190,191],[120,211,212,213],[120,210,211],[120,166,210,211],[120,166,203,210],[120,166,203],[120,166,204],[120,204,205,206,207,208,209],[120,166,187,190,197,201,202,219,220],[120,219],[120,202,219,221,222],[120,166,197,214,218],[120,166,235],[120,166,187,197,233,234,236],[120,166,187,197,231,232,233,235,236],[120,166,187,234],[120,166,228,235],[120,233,234,235,236,237,238,242],[120,166,210,243],[120,234,235,238],[120,239,240,241,243],[120,235,238],[120,166,235,238],[120,166,210,235,236],[120,183,187,201,223,243],[120,166,210,223,244],[120,244,245],[183,187,223,243],[166,210,223,244],[244,245]],"referencedMap":[[249,1],[247,2],[145,3],[128,2],[147,4],[129,5],[146,2],[151,6],[152,7],[148,7],[154,8],[149,7],[153,9],[150,10],[136,11],[133,12],[140,13],[134,11],[131,14],[139,2],[144,15],[141,2],[142,2],[143,2],[138,12],[135,16],[132,2],[137,17],[190,2],[225,18],[227,2],[226,19],[228,20],[224,21],[203,13],[199,22],[200,22],[201,23],[198,2],[65,24],[66,24],[68,25],[69,24],[70,24],[71,26],[72,2],[73,2],[74,2],[67,24],[166,27],[75,28],[155,29],[158,30],[159,2],[160,2],[161,2],[162,2],[163,2],[164,31],[165,32],[193,2],[195,33],[194,2],[252,34],[248,1],[250,35],[251,1],[191,12],[157,36],[253,2],[254,2],[257,37],[255,2],[258,38],[259,2],[260,39],[261,40],[272,41],[271,42],[256,2],[273,2],[275,43],[276,44],[274,45],[277,46],[278,47],[279,48],[280,49],[281,50],[282,51],[283,52],[284,53],[285,54],[286,55],[287,2],[156,2],[76,56],[77,56],[79,57],[80,58],[81,59],[82,60],[83,61],[84,62],[85,63],[86,64],[87,65],[88,66],[89,66],[90,67],[91,68],[92,69],[93,70],[78,2],[126,2],[94,71],[95,72],[96,73],[127,74],[97,75],[98,76],[99,77],[100,78],[101,79],[102,80],[103,81],[104,82],[105,83],[106,84],[107,85],[108,86],[110,87],[109,88],[111,89],[112,90],[113,2],[114,91],[115,92],[116,93],[117,94],[118,95],[119,96],[120,97],[121,98],[122,99],[123,100],[124,101],[125,102],[288,2],[289,12],[290,2],[291,2],[293,103],[292,2],[294,12],[319,104],[320,105],[295,106],[298,106],[317,104],[318,104],[308,104],[307,107],[305,104],[300,104],[313,104],[311,104],[315,104],[299,104],[312,104],[316,104],[301,104],[302,104],[314,104],[296,104],[303,104],[304,104],[306,104],[310,104],[321,108],[309,104],[297,104],[334,109],[333,2],[328,108],[330,110],[329,108],[322,108],[323,108],[325,108],[327,108],[331,110],[332,110],[324,110],[326,110],[336,111],[335,2],[337,2],[338,2],[339,2],[340,112],[130,2],[262,2],[215,113],[216,114],[217,114],[218,115],[177,2],[174,116],[176,116],[175,116],[173,116],[183,117],[178,118],[182,2],[179,2],[181,2],[180,2],[169,116],[170,116],[171,116],[167,2],[168,2],[172,116],[263,2],[267,119],[269,120],[268,119],[266,121],[270,122],[265,123],[264,2],[57,2],[64,124],[59,125],[60,126],[61,126],[62,127],[63,127],[58,128],[8,2],[10,2],[9,2],[2,2],[11,2],[12,2],[13,2],[14,2],[15,2],[16,2],[17,2],[18,2],[3,2],[4,2],[22,2],[19,2],[20,2],[21,2],[23,2],[24,2],[25,2],[5,2],[26,2],[27,2],[28,2],[29,2],[6,2],[33,2],[30,2],[31,2],[32,2],[34,2],[7,2],[35,2],[40,2],[41,2],[36,2],[37,2],[38,2],[39,2],[1,2],[42,2],[229,129],[230,2],[231,130],[56,2],[186,131],[185,132],[184,133],[187,134],[189,135],[197,136],[196,137],[188,2],[192,138],[214,139],[212,140],[213,141],[211,142],[204,143],[205,144],[206,144],[207,2],[208,144],[210,145],[209,144],[221,146],[202,2],[220,147],[222,147],[223,148],[219,149],[236,150],[235,151],[234,152],[233,153],[237,154],[243,155],[232,156],[239,157],[242,158],[240,159],[241,160],[238,161],[244,162],[245,163],[246,164],[47,2],[48,2],[49,2],[50,2],[51,2],[52,2],[43,2],[53,2],[54,2],[55,2],[44,2],[45,2],[46,2]],"exportedModulesMap":[[249,1],[247,2],[145,3],[128,2],[147,4],[129,5],[146,2],[151,6],[152,7],[148,7],[154,8],[149,7],[153,9],[150,10],[136,11],[133,12],[140,13],[134,11],[131,14],[139,2],[144,15],[141,2],[142,2],[143,2],[138,12],[135,16],[132,2],[137,17],[190,2],[225,18],[227,2],[226,19],[228,20],[224,21],[203,13],[199,22],[200,22],[201,23],[198,2],[65,24],[66,24],[68,25],[69,24],[70,24],[71,26],[72,2],[73,2],[74,2],[67,24],[166,27],[75,28],[155,29],[158,30],[159,2],[160,2],[161,2],[162,2],[163,2],[164,31],[165,32],[193,2],[195,33],[194,2],[252,34],[248,1],[250,35],[251,1],[191,12],[157,36],[253,2],[254,2],[257,37],[255,2],[258,38],[259,2],[260,39],[261,40],[272,41],[271,42],[256,2],[273,2],[275,43],[276,44],[274,45],[277,46],[278,47],[279,48],[280,49],[281,50],[282,51],[283,52],[284,53],[285,54],[286,55],[287,2],[156,2],[76,56],[77,56],[79,57],[80,58],[81,59],[82,60],[83,61],[84,62],[85,63],[86,64],[87,65],[88,66],[89,66],[90,67],[91,68],[92,69],[93,70],[78,2],[126,2],[94,71],[95,72],[96,73],[127,74],[97,75],[98,76],[99,77],[100,78],[101,79],[102,80],[103,81],[104,82],[105,83],[106,84],[107,85],[108,86],[110,87],[109,88],[111,89],[112,90],[113,2],[114,91],[115,92],[116,93],[117,94],[118,95],[119,96],[120,97],[121,98],[122,99],[123,100],[124,101],[125,102],[288,2],[289,12],[290,2],[291,2],[293,103],[292,2],[294,12],[319,104],[320,105],[295,106],[298,106],[317,104],[318,104],[308,104],[307,107],[305,104],[300,104],[313,104],[311,104],[315,104],[299,104],[312,104],[316,104],[301,104],[302,104],[314,104],[296,104],[303,104],[304,104],[306,104],[310,104],[321,108],[309,104],[297,104],[334,109],[333,2],[328,108],[330,110],[329,108],[322,108],[323,108],[325,108],[327,108],[331,110],[332,110],[324,110],[326,110],[336,111],[335,2],[337,2],[338,2],[339,2],[340,112],[130,2],[262,2],[215,113],[216,114],[217,114],[218,115],[177,2],[174,116],[176,116],[175,116],[173,116],[183,117],[178,118],[182,2],[179,2],[181,2],[180,2],[169,116],[170,116],[171,116],[167,2],[168,2],[172,116],[263,2],[267,119],[269,120],[268,119],[266,121],[270,122],[265,123],[264,2],[57,2],[64,124],[59,125],[60,126],[61,126],[62,127],[63,127],[58,128],[8,2],[10,2],[9,2],[2,2],[11,2],[12,2],[13,2],[14,2],[15,2],[16,2],[17,2],[18,2],[3,2],[4,2],[22,2],[19,2],[20,2],[21,2],[23,2],[24,2],[25,2],[5,2],[26,2],[27,2],[28,2],[29,2],[6,2],[33,2],[30,2],[31,2],[32,2],[34,2],[7,2],[35,2],[40,2],[41,2],[36,2],[37,2],[38,2],[39,2],[1,2],[42,2],[229,129],[230,2],[231,130],[56,2],[186,131],[185,132],[184,133],[187,134],[189,135],[197,136],[196,137],[188,2],[192,138],[214,139],[212,140],[213,141],[211,142],[204,143],[205,144],[206,144],[207,2],[208,144],[210,145],[209,144],[221,146],[202,2],[220,147],[222,147],[223,148],[219,149],[236,150],[235,151],[234,152],[233,153],[237,154],[243,155],[232,156],[239,157],[242,158],[240,159],[241,160],[238,161],[244,165],[245,166],[246,167],[47,2],[48,2],[49,2],[50,2],[51,2],[52,2],[43,2],[53,2],[54,2],[55,2],[44,2],[45,2],[46,2]],"semanticDiagnosticsPerFile":[249,247,145,128,147,129,146,151,152,148,154,149,153,150,136,133,140,134,131,139,144,141,142,143,138,135,132,137,190,225,227,226,228,224,203,199,200,201,198,65,66,68,69,70,71,72,73,74,67,166,75,155,158,159,160,161,162,163,164,165,193,195,194,252,248,250,251,191,157,253,254,257,255,258,259,260,261,272,271,256,273,275,276,274,277,278,279,280,281,282,283,284,285,286,287,156,76,77,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,78,126,94,95,96,127,97,98,99,100,101,102,103,104,105,106,107,108,110,109,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,288,289,290,291,293,292,294,319,320,295,298,317,318,308,307,305,300,313,311,315,299,312,316,301,302,314,296,303,304,306,310,321,309,297,334,333,328,330,329,322,323,325,327,331,332,324,326,336,335,337,338,339,340,130,262,215,216,217,218,177,174,176,175,173,183,178,182,179,181,180,169,170,171,167,168,172,263,267,269,268,266,270,265,264,57,64,59,60,61,62,63,58,8,10,9,2,11,12,13,14,15,16,17,18,3,4,22,19,20,21,23,24,25,5,26,27,28,29,6,33,30,31,32,34,7,35,40,41,36,37,38,39,1,42,229,230,231,56,186,185,184,187,189,197,196,188,192,214,212,213,211,204,205,206,207,208,210,209,221,202,220,222,223,219,236,235,234,233,237,243,232,239,242,240,241,238,244,245,246,47,48,49,50,51,52,43,53,54,55,44,45,46],"latestChangedDtsFile":"./types/index.d.ts"},"version":"4.9.5"}
+\ No newline at end of file
+diff --git a/dist/types/SelectedNetworkController.d.ts.map b/dist/types/SelectedNetworkController.d.ts.map
+index f9de27de6d312eeb12e583354bd0df73b08598a4..eb0dcc3cd8563769606ae8c6748d2ad1bd5665c1 100644
+--- a/dist/types/SelectedNetworkController.d.ts.map
++++ b/dist/types/SelectedNetworkController.d.ts.map
+@@ -1 +1 @@
+-{"version":3,"file":"SelectedNetworkController.d.ts","sourceRoot":"","sources":["../../src/SelectedNetworkController.ts"],"names":[],"mappings":"AAAA,OAAO,KAAK,EAAE,6BAA6B,EAAE,MAAM,2BAA2B,CAAC;AAC/E,OAAO,EAAE,cAAc,EAAE,MAAM,2BAA2B,CAAC;AAC3D,OAAO,KAAK,EACV,iBAAiB,EACjB,eAAe,EACf,2CAA2C,EAC3C,+CAA+C,EAC/C,+BAA+B,EAC/B,iCAAiC,EACjC,aAAa,EACd,MAAM,8BAA8B,CAAC;AACtC,OAAO,KAAK,EACV,+BAA+B,EAC/B,WAAW,IAAI,qCAAqC,EACpD,cAAc,IAAI,kCAAkC,EACrD,MAAM,iCAAiC,CAAC;AAEzC,OAAO,KAAK,EAAE,KAAK,EAAE,MAAM,OAAO,CAAC;AAEnC,eAAO,MAAM,cAAc,8BAA8B,CAAC;AAc1D,MAAM,MAAM,MAAM,GAAG,MAAM,CAAC;AAE5B,eAAO,MAAM,eAAe,YAAsB,CAAC;AAEnD,eAAO,MAAM,oCAAoC;;;;CAMhD,CAAC;AAEF,eAAO,MAAM,mCAAmC;;CAE/C,CAAC;AAEF,MAAM,MAAM,8BAA8B,GAAG;IAC3C,OAAO,EAAE,MAAM,CAAC,MAAM,EAAE,eAAe,CAAC,CAAC;CAC1C,CAAC;AAEF,MAAM,MAAM,yCAAyC,GAAG;IACtD,IAAI,EAAE,OAAO,mCAAmC,CAAC,WAAW,CAAC;IAC7D,OAAO,EAAE,CAAC,8BAA8B,EAAE,KAAK,EAAE,CAAC,CAAC;CACpD,CAAC;AAEF,MAAM,MAAM,sDAAsD,GAAG;IACnE,IAAI,EAAE,OAAO,oCAAoC,CAAC,QAAQ,CAAC;IAC3D,OAAO,EAAE,MAAM,8BAA8B,CAAC;CAC/C,CAAC;AAEF,MAAM,MAAM,0DAA0D,GAAG;IACvE,IAAI,EAAE,OAAO,oCAAoC,CAAC,2BAA2B,CAAC;IAC9E,OAAO,EAAE,yBAAyB,CAAC,6BAA6B,CAAC,CAAC;CACnE,CAAC;AAEF,MAAM,MAAM,0DAA0D,GAAG;IACvE,IAAI,EAAE,OAAO,oCAAoC,CAAC,2BAA2B,CAAC;IAC9E,OAAO,EAAE,yBAAyB,CAAC,6BAA6B,CAAC,CAAC;CACnE,CAAC;AAEF,MAAM,MAAM,gCAAgC,GACxC,sDAAsD,GACtD,0DAA0D,GAC1D,0DAA0D,CAAC;AAE/D,MAAM,MAAM,cAAc,GACtB,2CAA2C,GAC3C,+CAA+C,GAC/C,+BAA+B,GAC/B,kCAAkC,GAClC,qCAAqC,CAAC;AAE1C,MAAM,MAAM,+BAA+B,GACzC,yCAAyC,CAAC;AAE5C,MAAM,MAAM,aAAa,GACrB,iCAAiC,GACjC,+BAA+B,CAAC;AAEpC,MAAM,MAAM,kCAAkC,GAAG,6BAA6B,CAC5E,OAAO,cAAc,EACrB,gCAAgC,GAAG,cAAc,EACjD,+BAA+B,GAAG,aAAa,EAC/C,cAAc,CAAC,MAAM,CAAC,EACtB,aAAa,CAAC,MAAM,CAAC,CACtB,CAAC;AAEF,MAAM,MAAM,gCAAgC,GAAG;IAC7C,KAAK,CAAC,EAAE,8BAA8B,CAAC;IACvC,SAAS,EAAE,kCAAkC,CAAC;IAC9C,yBAAyB,EAAE,OAAO,CAAC;IACnC,wBAAwB,EAAE,CACxB,QAAQ,EAAE,CAAC,gBAAgB,EAAE;QAAE,eAAe,EAAE,OAAO,CAAA;KAAE,KAAK,IAAI,KAC/D,IAAI,CAAC;IACV,cAAc,EAAE,GAAG,CAAC,MAAM,EAAE,YAAY,CAAC,CAAC;CAC3C,CAAC;AAEF,MAAM,MAAM,YAAY,GAAG;IACzB,QAAQ,EAAE,aAAa,CAAC;IACxB,YAAY,EAAE,iBAAiB,CAAC;CACjC,CAAC;AAEF;;GAEG;AACH,qBAAa,yBAA0B,SAAQ,cAAc,CAC3D,OAAO,cAAc,EACrB,8BAA8B,EAC9B,kCAAkC,CACnC;;IAKC;;;;;;;;;OASG;gBACS,EACV,SAAS,EACT,KAAyB,EACzB,yBAAyB,EACzB,wBAAwB,EACxB,cAAc,GACf,EAAE,gCAAgC;IAkKnC,2BAA2B,CACzB,MAAM,EAAE,MAAM,EACd,eAAe,EAAE,eAAe;IAqBlC,2BAA2B,CAAC,MAAM,EAAE,MAAM,GAAG,eAAe;IAS5D;;;;;OAKG;IACH,0BAA0B,CAAC,MAAM,EAAE,MAAM,GAAG,YAAY;CA6CzD"}
+\ No newline at end of file
++{"version":3,"file":"SelectedNetworkController.d.ts","sourceRoot":"","sources":["../../src/SelectedNetworkController.ts"],"names":[],"mappings":"AAAA,OAAO,KAAK,EAAE,6BAA6B,EAAE,MAAM,2BAA2B,CAAC;AAC/E,OAAO,EAAE,cAAc,EAAE,MAAM,2BAA2B,CAAC;AAC3D,OAAO,KAAK,EACV,iBAAiB,EACjB,eAAe,EACf,2CAA2C,EAC3C,+CAA+C,EAC/C,+BAA+B,EAC/B,iCAAiC,EACjC,aAAa,EACd,MAAM,8BAA8B,CAAC;AACtC,OAAO,KAAK,EACV,+BAA+B,EAC/B,WAAW,IAAI,qCAAqC,EACpD,cAAc,IAAI,kCAAkC,EACrD,MAAM,iCAAiC,CAAC;AAEzC,OAAO,KAAK,EAAE,KAAK,EAAE,MAAM,OAAO,CAAC;AAEnC,eAAO,MAAM,cAAc,8BAA8B,CAAC;AAc1D,MAAM,MAAM,MAAM,GAAG,MAAM,CAAC;AAE5B,eAAO,MAAM,eAAe,YAAsB,CAAC;AAEnD,eAAO,MAAM,oCAAoC;;;;CAMhD,CAAC;AAEF,eAAO,MAAM,mCAAmC;;CAE/C,CAAC;AAEF,MAAM,MAAM,8BAA8B,GAAG;IAC3C,OAAO,EAAE,MAAM,CAAC,MAAM,EAAE,eAAe,CAAC,CAAC;CAC1C,CAAC;AAEF,MAAM,MAAM,yCAAyC,GAAG;IACtD,IAAI,EAAE,OAAO,mCAAmC,CAAC,WAAW,CAAC;IAC7D,OAAO,EAAE,CAAC,8BAA8B,EAAE,KAAK,EAAE,CAAC,CAAC;CACpD,CAAC;AAEF,MAAM,MAAM,sDAAsD,GAAG;IACnE,IAAI,EAAE,OAAO,oCAAoC,CAAC,QAAQ,CAAC;IAC3D,OAAO,EAAE,MAAM,8BAA8B,CAAC;CAC/C,CAAC;AAEF,MAAM,MAAM,0DAA0D,GAAG;IACvE,IAAI,EAAE,OAAO,oCAAoC,CAAC,2BAA2B,CAAC;IAC9E,OAAO,EAAE,yBAAyB,CAAC,6BAA6B,CAAC,CAAC;CACnE,CAAC;AAEF,MAAM,MAAM,0DAA0D,GAAG;IACvE,IAAI,EAAE,OAAO,oCAAoC,CAAC,2BAA2B,CAAC;IAC9E,OAAO,EAAE,yBAAyB,CAAC,6BAA6B,CAAC,CAAC;CACnE,CAAC;AAEF,MAAM,MAAM,gCAAgC,GACxC,sDAAsD,GACtD,0DAA0D,GAC1D,0DAA0D,CAAC;AAE/D,MAAM,MAAM,cAAc,GACtB,2CAA2C,GAC3C,+CAA+C,GAC/C,+BAA+B,GAC/B,kCAAkC,GAClC,qCAAqC,CAAC;AAE1C,MAAM,MAAM,+BAA+B,GACzC,yCAAyC,CAAC;AAE5C,MAAM,MAAM,aAAa,GACrB,iCAAiC,GACjC,+BAA+B,CAAC;AAEpC,MAAM,MAAM,kCAAkC,GAAG,6BAA6B,CAC5E,OAAO,cAAc,EACrB,gCAAgC,GAAG,cAAc,EACjD,+BAA+B,GAAG,aAAa,EAC/C,cAAc,CAAC,MAAM,CAAC,EACtB,aAAa,CAAC,MAAM,CAAC,CACtB,CAAC;AAEF,MAAM,MAAM,gCAAgC,GAAG;IAC7C,KAAK,CAAC,EAAE,8BAA8B,CAAC;IACvC,SAAS,EAAE,kCAAkC,CAAC;IAC9C,yBAAyB,EAAE,OAAO,CAAC;IACnC,wBAAwB,EAAE,CACxB,QAAQ,EAAE,CAAC,gBAAgB,EAAE;QAAE,eAAe,EAAE,OAAO,CAAA;KAAE,KAAK,IAAI,KAC/D,IAAI,CAAC;IACV,cAAc,EAAE,GAAG,CAAC,MAAM,EAAE,YAAY,CAAC,CAAC;CAC3C,CAAC;AAEF,MAAM,MAAM,YAAY,GAAG;IACzB,QAAQ,EAAE,aAAa,CAAC;IACxB,YAAY,EAAE,iBAAiB,CAAC;CACjC,CAAC;AAEF;;GAEG;AACH,qBAAa,yBAA0B,SAAQ,cAAc,CAC3D,OAAO,cAAc,EACrB,8BAA8B,EAC9B,kCAAkC,CACnC;;IAKC;;;;;;;;;OASG;gBACS,EACV,SAAS,EACT,KAAyB,EACzB,yBAAyB,EACzB,wBAAwB,EACxB,cAAc,GACf,EAAE,gCAAgC;IAkKnC,2BAA2B,CACzB,MAAM,EAAE,MAAM,EACd,eAAe,EAAE,eAAe;IA0BlC,2BAA2B,CAAC,MAAM,EAAE,MAAM,GAAG,eAAe;IAS5D;;;;;OAKG;IACH,0BAA0B,CAAC,MAAM,EAAE,MAAM,GAAG,YAAY;CA6CzD"}
+\ No newline at end of file

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "@metamask/rate-limit-controller": "^5.0.1",
     "@metamask/safe-event-emitter": "^3.1.1",
     "@metamask/scure-bip39": "^2.0.3",
-    "@metamask/selected-network-controller": "^13.0.0",
+    "@metamask/selected-network-controller": "patch:@metamask/selected-network-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-selected-network-controller-npm-13.0.0-b0f6db473a.patch",
     "@metamask/signature-controller": "^14.0.1",
     "@metamask/smart-transactions-controller": "^10.1.2",
     "@metamask/snaps-controllers": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6138,7 +6138,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@npm:^13.0.0":
+"@metamask/selected-network-controller@npm:13.0.0":
   version: 13.0.0
   resolution: "@metamask/selected-network-controller@npm:13.0.0"
   dependencies:
@@ -6152,6 +6152,23 @@ __metadata:
     "@metamask/network-controller": ^18.0.0
     "@metamask/permission-controller": ^9.0.0
   checksum: 10/bebb6798ea9b7f12535f1997b69ef4aa7669c245566dfbb8c6729d9e497c8a0dc52ddd42db09defc6acba3ea82d2eaddead149f05ce4730bc4096eae0cb71750
+  languageName: node
+  linkType: hard
+
+"@metamask/selected-network-controller@patch:@metamask/selected-network-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-selected-network-controller-npm-13.0.0-b0f6db473a.patch":
+  version: 13.0.0
+  resolution: "@metamask/selected-network-controller@patch:@metamask/selected-network-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-selected-network-controller-npm-13.0.0-b0f6db473a.patch::version=13.0.0&hash=276e75"
+  dependencies:
+    "@metamask/base-controller": "npm:^5.0.2"
+    "@metamask/json-rpc-engine": "npm:^8.0.2"
+    "@metamask/network-controller": "npm:^18.1.0"
+    "@metamask/permission-controller": "npm:^9.0.2"
+    "@metamask/swappable-obj-proxy": "npm:^2.2.0"
+    "@metamask/utils": "npm:^8.3.0"
+  peerDependencies:
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/permission-controller": ^9.0.0
+  checksum: 10/e081cb32e1600dee1879299a960a84b2839c21ca158e5ab178e43abc56b94dd6a253f9f20c7658a99d6a9b768834e4c81abb911351f8f3225ba71171c7b02f5a
   languageName: node
   linkType: hard
 
@@ -25086,7 +25103,7 @@ __metadata:
     "@metamask/rate-limit-controller": "npm:^5.0.1"
     "@metamask/safe-event-emitter": "npm:^3.1.1"
     "@metamask/scure-bip39": "npm:^2.0.3"
-    "@metamask/selected-network-controller": "npm:^13.0.0"
+    "@metamask/selected-network-controller": "patch:@metamask/selected-network-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-selected-network-controller-npm-13.0.0-b0f6db473a.patch"
     "@metamask/signature-controller": "npm:^14.0.1"
     "@metamask/smart-transactions-controller": "npm:^10.1.2"
     "@metamask/snaps-controllers": "npm:^9.0.0"


### PR DESCRIPTION
This patch reapplies the changes previously patched on v11.16.8:
https://github.com/MetaMask/metamask-extension/pull/25127

This patch needed to be updated for v13 of the selected network controller. I made a mistake in merge conflict resolution and am instead updating these packages in this separate commit.

The core branch that was used to generate the patch can be seen here: https://github.com/MetaMask/core/pull/new/patch-selected-network-controller-13.0.0-setNetworkClient-guard

~~This patch reapplies the changes previously patched on v11.16.7 and v11.16.8:
https://github.com/MetaMask/metamask-extension/pull/25046
https://github.com/MetaMask/metamask-extension/pull/25127

These patches needed to be updated for v13 of the selected network controller. I made a mistake in merge conflict resolution and am instead updating these packages in this separate commit.

The core branch that was used to generate the patch can be seen here: https://github.com/MetaMask/core/pull/new/patch-selected-network-controller-13.0.0-setNetworkClient-guard~~