### PR TITLE
fix: add eth_signTypedData and eth_signTypedData_v3 to `methodsRequiringNetworkSwitch`

### DIFF
--- a/shared/constants/methods-tags.ts
+++ b/shared/constants/methods-tags.ts
@@ -12,6 +12,8 @@ export const methodsRequiringNetworkSwitch = [
   'wallet_switchEthereumChain',
   'wallet_addEthereumChain',
   'wallet_watchAsset',
+  'eth_signTypedData',
+  'eth_signTypedData_v3',
   'eth_signTypedData_v4',
   'personal_sign',
 ] as const;

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
@@ -8,6 +8,7 @@ const {
   regularDelayMs,
   defaultGanacheOptions,
   switchToNotificationWindow,
+  WINDOW_TITLES,
 } = require('../../helpers');
 
 describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
@@ -52,7 +53,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.delay(regularDelayMs);
 
-        await switchToNotificationWindow(driver);
+        await switchToNotificationWindow(driver, 2);
 
         await driver.clickElement({
           text: 'Next',
@@ -66,6 +67,9 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           css: '[data-testid="page-container-footer-next"]',
         });
 
+        await driver.waitUntilXWindowHandles(2);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+
         // Open Dapp Two
         await openDapp(driver, undefined, DAPP_ONE_URL);
 
@@ -75,7 +79,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.delay(regularDelayMs);
 
-        await switchToNotificationWindow(driver, 4);
+        await switchToNotificationWindow(driver, 3);
 
         await driver.clickElement({
           text: 'Next',
@@ -91,8 +95,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.switchToWindowWithUrl(DAPP_URL);
 
-        // need to switch chain with API
-        // switchEthereumChain request
+        // switch chain for Dapp One
         const switchEthereumChainRequest = JSON.stringify({
           jsonrpc: '2.0',
           method: 'wallet_switchEthereumChain',
@@ -104,7 +107,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           `window.ethereum.request(${switchEthereumChainRequest})`,
         );
 
-        await switchToNotificationWindow(driver, 4);
+        await switchToNotificationWindow(driver, 3);
 
         await driver.clickElement({ text: 'Switch network', tag: 'button' });
 
@@ -118,7 +121,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         // signTypedData request
         await driver.clickElement('#signTypedData');
 
-        await switchToNotificationWindow(driver, 4);
+        await switchToNotificationWindow(driver, 3);
 
         // Check correct network on the send confirmation.
         await driver.findElement({
@@ -128,7 +131,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
 
-        await switchToNotificationWindow(driver, 4);
+        await switchToNotificationWindow(driver, 3);
 
         // Check correct network on the signTypedData confirmation.
         await driver.findElement({

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
@@ -7,12 +7,11 @@ const {
   DAPP_ONE_URL,
   regularDelayMs,
   defaultGanacheOptions,
-  switchToNotificationWindow,
   WINDOW_TITLES,
 } = require('../../helpers');
 
 describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
-  it('should queue signTypedData tx after eth_sendTransaction confirmation and signTypedData confirmation should target the correct network after eth_sendTransaction is confirmed', async function () {
+  it('should queue signTypedData tx after eth_sendTransaction confirmation and signTypedData confirmation should target the correct network after eth_sendTransaction is confirmed @no-mmi', async function () {
     const port = 8546;
     const chainId = 1338;
     await withFixtures(
@@ -53,7 +52,8 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.delay(regularDelayMs);
 
-        await switchToNotificationWindow(driver, 2);
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         await driver.clickElement({
           text: 'Next',
@@ -79,7 +79,8 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.delay(regularDelayMs);
 
-        await switchToNotificationWindow(driver, 3);
+        await driver.waitUntilXWindowHandles(4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         await driver.clickElement({
           text: 'Next',
@@ -107,7 +108,8 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           `window.ethereum.request(${switchEthereumChainRequest})`,
         );
 
-        await switchToNotificationWindow(driver, 3);
+        await driver.waitUntilXWindowHandles(4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         await driver.clickElement({ text: 'Switch network', tag: 'button' });
 
@@ -121,7 +123,8 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         // signTypedData request
         await driver.clickElement('#signTypedData');
 
-        await switchToNotificationWindow(driver, 3);
+        await driver.waitUntilXWindowHandles(4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // Check correct network on the send confirmation.
         await driver.findElement({
@@ -131,7 +134,8 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
 
-        await switchToNotificationWindow(driver, 3);
+        await driver.waitUntilXWindowHandles(4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // Check correct network on the signTypedData confirmation.
         await driver.findElement({

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
@@ -1,0 +1,142 @@
+const FixtureBuilder = require('../../fixture-builder');
+const {
+  withFixtures,
+  openDapp,
+  unlockWallet,
+  DAPP_URL,
+  DAPP_ONE_URL,
+  regularDelayMs,
+  WINDOW_TITLES,
+  defaultGanacheOptions,
+  switchToNotificationWindow,
+} = require('../../helpers');
+
+describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
+  it('should queue signTypedData tx after eth_sendTransaction confirmation and signTypedData confirmation should target the correct network after eth_sendTransaction is confirmed', async function () {
+    const port = 8546;
+    const chainId = 1338;
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerTripleGanache()
+          .withPreferencesControllerUseRequestQueueEnabled()
+          .withSelectedNetworkControllerPerDomain()
+          .build(),
+        dappOptions: { numberOfDapps: 2 },
+        ganacheOptions: {
+          ...defaultGanacheOptions,
+          concurrent: [
+            {
+              port,
+              chainId,
+              ganacheOptions2: defaultGanacheOptions,
+            },
+            {
+              port: 7777,
+              chainId: 1000,
+              ganacheOptions2: defaultGanacheOptions,
+            },
+          ],
+        },
+        title: this.test.fullTitle(),
+      },
+      async ({ driver }) => {
+        await unlockWallet(driver);
+
+        // Open Dapp One
+        await openDapp(driver, undefined, DAPP_URL);
+
+        // Connect to dapp
+        await driver.findClickableElement({ text: 'Connect', tag: 'button' });
+        await driver.clickElement('#connectButton');
+
+        await driver.delay(regularDelayMs);
+
+        await switchToNotificationWindow(driver);
+
+        await driver.clickElement({
+          text: 'Next',
+          tag: 'button',
+          css: '[data-testid="page-container-footer-next"]',
+        });
+
+        await driver.clickElement({
+          text: 'Confirm',
+          tag: 'button',
+          css: '[data-testid="page-container-footer-next"]',
+        });
+
+        // Open Dapp Two
+        await openDapp(driver, undefined, DAPP_ONE_URL);
+
+        // Connect to dapp 2
+        await driver.findClickableElement({ text: 'Connect', tag: 'button' });
+        await driver.clickElement('#connectButton');
+
+        await driver.delay(regularDelayMs);
+
+        await switchToNotificationWindow(driver, 4);
+
+        await driver.clickElement({
+          text: 'Next',
+          tag: 'button',
+          css: '[data-testid="page-container-footer-next"]',
+        });
+
+        await driver.clickElement({
+          text: 'Confirm',
+          tag: 'button',
+          css: '[data-testid="page-container-footer-next"]',
+        });
+
+        await driver.switchToWindowWithUrl(DAPP_URL);
+
+        // need to switch chain with API
+        // switchEthereumChain request
+        const switchEthereumChainRequest = JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: '0x3e8' }],
+        });
+
+        // Initiate switchEthereumChain on Dapp one
+        await driver.executeScript(
+          `window.ethereum.request(${switchEthereumChainRequest})`,
+        );
+
+        await switchToNotificationWindow(driver, 4);
+
+        await driver.clickElement({ text: 'Switch network', tag: 'button' });
+
+        await driver.switchToWindowWithUrl(DAPP_URL);
+
+        // eth_sendTransaction request
+        await driver.clickElement('#sendButton');
+
+        await driver.switchToWindowWithUrl(DAPP_ONE_URL);
+
+        // signTypedData request
+        await driver.clickElement('#signTypedData');
+
+        await switchToNotificationWindow(driver, 4);
+
+        // Check correct network on the send confirmation.
+        await driver.findElement({
+          css: '[data-testid="network-display"]',
+          text: 'Localhost 7777',
+        });
+
+        await driver.clickElement({ text: 'Confirm', tag: 'button' });
+
+        await switchToNotificationWindow(driver, 4);
+
+        // Check correct network on the signTypedData confirmation.
+        await driver.findElement({
+          css: '[data-testid="signature-request-network-display"]',
+          text: 'Localhost 8545',
+        });
+      },
+    );
+  });
+});

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
@@ -6,7 +6,6 @@ const {
   DAPP_URL,
   DAPP_ONE_URL,
   regularDelayMs,
-  WINDOW_TITLES,
   defaultGanacheOptions,
   switchToNotificationWindow,
 } = require('../../helpers');

--- a/ui/components/app/network-account-balance-header/network-account-balance-header.js
+++ b/ui/components/app/network-account-balance-header/network-account-balance-header.js
@@ -68,6 +68,7 @@ export default function NetworkAccountBalanceHeader({
             variant={TextVariant.bodySm}
             as="h6"
             color={TextColor.textAlternative}
+            data-testid="signature-request-network-display"
           >
             {networkName}
           </Text>

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -83,6 +83,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
               >
                 <h6
                   class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                  data-testid="signature-request-network-display"
                 >
                   Ethereum Mainnet
                 </h6>
@@ -295,6 +296,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
             >
               <h6
                 class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                data-testid="signature-request-network-display"
               >
                 Ethereum Mainnet
               </h6>

--- a/ui/pages/confirmations/components/signature-request-header/__snapshots__/signature-request-header.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request-header/__snapshots__/signature-request-header.test.js.snap
@@ -71,6 +71,7 @@ exports[`SignatureRequestHeader should match snapshot 1`] = `
       >
         <h6
           class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          data-testid="signature-request-network-display"
         >
           goerli
         </h6>

--- a/ui/pages/confirmations/components/signature-request-original/__snapshots__/signature-request-original.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request-original/__snapshots__/signature-request-original.test.js.snap
@@ -147,6 +147,7 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
           >
             <h6
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="signature-request-network-display"
             >
               goerli
             </h6>

--- a/ui/pages/confirmations/components/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
@@ -144,6 +144,7 @@ exports[`SignatureRequestSIWE (Sign in with Ethereum) should match snapshot 1`] 
         >
           <h6
             class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+            data-testid="signature-request-network-display"
           >
             goerli
           </h6>

--- a/ui/pages/confirmations/components/signature-request/__snapshots__/signature-request.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request/__snapshots__/signature-request.test.js.snap
@@ -144,6 +144,7 @@ exports[`Signature Request Component render should match snapshot when we are us
           >
             <h6
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="signature-request-network-display"
             >
               Localhost 8545
             </h6>
@@ -916,6 +917,7 @@ exports[`Signature Request Component render should match snapshot when we want t
           >
             <h6
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="signature-request-network-display"
             >
               Localhost 8545
             </h6>

--- a/ui/pages/confirmations/confirm-signature-request/__snapshots__/index.test.js.snap
+++ b/ui/pages/confirmations/confirm-signature-request/__snapshots__/index.test.js.snap
@@ -144,6 +144,7 @@ exports[`Confirm Signature Request Component render should match snapshot 1`] = 
           >
             <h6
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="signature-request-network-display"
             >
               Goerli test network
             </h6>

--- a/ui/pages/confirmations/token-allowance/__snapshots__/token-allowance.test.js.snap
+++ b/ui/pages/confirmations/token-allowance/__snapshots__/token-allowance.test.js.snap
@@ -163,6 +163,7 @@ exports[`TokenAllowancePage when mounted should match snapshot 1`] = `
         >
           <h6
             class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+            data-testid="signature-request-network-display"
           >
             mainnet
           </h6>


### PR DESCRIPTION
## **Description**

Though signature requests like `personal_sign`, `eth_signTypedData`, `eth_signTypedData_v3` and  `eth_signTypedData_v4` do not depend on state of network connections, these confirmations do use  nicknames/addressbook state which is dependent on globally selected network state for parsing signatures and injecting nicknaming where possible. The queueing system introduced with Amon Hen v1 (v12.0.0 release) introduces certain conditions in which these signature confirmations will be rendered on the wrong network. Though this doesn't actually result in faulty signatures, we should switch to the appropriate/expected network for the UX reasons described above. Adding `eth_signTypedData_v3` and `eth_signTypedData` to the `methodsRequiringNetworkSwitch` array will cause the network to switch to the selected network for the requesting origin before initializing the confirmation. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25562?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25528
See this slack thread: https://consensys.slack.com/archives/C06FXU326RL/p1719429561925649?thread_ts=1719415715.492249&cid=C06FXU326RL
## **Manual testing steps**
 See videos below 👇 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/MetaMask/metamask-extension/assets/34557516/3e32fce7-046c-4856-893d-a85083877327


### **After**

<!-- [screenshots/recordings] -->

https://github.com/MetaMask/metamask-extension/assets/34557516/306d88aa-f5f3-4eae-a8e9-30b621c02626


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
