### PR TITLE
lavamoat error fix in production mode

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -74,6 +74,7 @@ defineAndRunBuildTasks().catch((error) => {
 
 async function defineAndRunBuildTasks() {
   const {
+
     applyLavaMoat,
     buildType,
     entryTask,
@@ -95,6 +96,10 @@ async function defineAndRunBuildTasks() {
 
     let scuttleGlobalThisExceptions = [
       // globals used by different mm deps outside of lm compartment
+      'Boolean',
+      'setTimeout',
+      'clearTimeout',
+      'toString',
       'Proxy',
       'toString',
       'getComputedStyle',


### PR DESCRIPTION


the reason for the change is lavamoat throw error in production when metamask is cloned and added as an extension after following [this](https://github.com/MetaMask/metamask-extension?tab=readme-ov-file#building-on-your-local-machine)


Fixes:

the issue is raised [here](https://community.metamask.io/t/metamask-buttons-not-responding-after-cloning-the-repository/29010/8) which is solved now by making changes in metamask-extension/development/build/index.js. Lavamoat was throwing errors which was resolved now
