### PR TITLE
fix: tweak spacing in send asset picker

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`AssetPicker matches snapshot 1`] = `
         class="mm-box mm-box--display-flex mm-box--gap-3 mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-badge-wrapper mm-box--margin-right-3 mm-box--display-inline-block"
+          class="mm-box mm-badge-wrapper mm-box--display-inline-block"
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
@@ -80,7 +80,7 @@ exports[`AssetPicker render if disabled 1`] = `
         class="mm-box mm-box--display-flex mm-box--gap-3 mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-badge-wrapper mm-box--margin-right-3 mm-box--display-inline-block"
+          class="mm-box mm-badge-wrapper mm-box--display-inline-block"
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -179,7 +179,6 @@ export function AssetPicker({
                 }
               />
             }
-            marginRight={3}
           >
             <AvatarToken
               borderRadius={isNFT ? BorderRadius.LG : BorderRadius.full}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The token symbol send page's asset picker is not vertically aligned with other dropdowns on the page. This PR removes an unneeded margin introduced in #25470.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25576?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to send page
2. Ensure asset picker is spaced correctly and vertically aligned with other components

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="379" alt="Screenshot 2024-06-27 at 5 55 08 PM" src="https://github.com/MetaMask/metamask-extension/assets/44588480/638e53d6-df84-4f0d-a855-6e5d8c63529a">


<!-- [screenshots/recordings] -->

### **After**

<img width="379" alt="Screenshot 2024-06-27 at 5 58 37 PM" src="https://github.com/MetaMask/metamask-extension/assets/44588480/bb98dfe9-dadb-4307-aa4a-d796e9f94554">


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
