### PR TITLE
use findNetworkClientIdByChainId hook to get the networkClientId for caip-27 handler

### DIFF
--- a/app/scripts/lib/multichain-api/provider-request.js
+++ b/app/scripts/lib/multichain-api/provider-request.js
@@ -13,16 +13,17 @@ export async function providerRequestHandler(
     return end(new Error('missing CAIP-25 endowment'));
   }
 
+  const chainId = scope.split(':')[1];
+
+  if (!chainId) {
+    return end(new Error('missing chainId'));
+  }
+
   let networkClientId;
-  switch (scope) {
-    case 'eip155:1':
-      networkClientId = 'mainnet';
-      break;
-    case 'eip155:11155111':
-      networkClientId = 'sepolia';
-      break;
-    default:
-      networkClientId = hooks.getSelectedNetworkClientId();
+  networkClientId = hooks.findNetworkClientIdByChainId(chainId);
+
+  if (!networkClientId) {
+    networkClientId = hooks.getSelectedNetworkClientId();
   }
 
   console.log(

--- a/app/scripts/lib/multichain-api/provider-request.js
+++ b/app/scripts/lib/multichain-api/provider-request.js
@@ -1,4 +1,15 @@
+import { numberToHex } from '@metamask/utils';
 import { Caip25EndowmentPermissionName } from './caip25permissions';
+
+const paramsToArray = (params) => {
+  const arr = [];
+  for (const key in params) {
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      arr.push(params[key]);
+    }
+  }
+  return arr;
+};
 
 export async function providerRequestHandler(
   request,
@@ -7,7 +18,9 @@ export async function providerRequestHandler(
   end,
   hooks,
 ) {
-  const { scope, request: wrappedRequest } = request.params;
+  const [scope, wrappedRequest] = Array.isArray(request.params)
+    ? request.params
+    : paramsToArray(request.params);
 
   if (!hooks.hasPermission(request.origin, Caip25EndowmentPermissionName)) {
     return end(new Error('missing CAIP-25 endowment'));
@@ -20,7 +33,9 @@ export async function providerRequestHandler(
   }
 
   let networkClientId;
-  networkClientId = hooks.findNetworkClientIdByChainId(chainId);
+  networkClientId = hooks.findNetworkClientIdByChainId(
+    numberToHex(parseInt(chainId, 10)),
+  );
 
   if (!networkClientId) {
     networkClientId = hooks.getSelectedNetworkClientId();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5597,6 +5597,7 @@ export default class MetamaskController extends EventEmitter {
     engine.push(createLoggerMiddleware({ origin }));
 
     engine.push((req, _res, next, end) => {
+      console.log('Received request:', req)
       if (
         ![
           MESSAGE_TYPE.PROVIDER_AUTHORIZE,
@@ -5623,6 +5624,10 @@ export default class MetamaskController extends EventEmitter {
         },
         [MESSAGE_TYPE.PROVIDER_REQUEST]: (request, response, next, end) => {
           return providerRequestHandler(request, response, next, end, {
+            findNetworkClientIdByChainId:
+              this.networkController.findNetworkClientIdByChainId.bind(
+                this.networkController,
+              ),
             hasPermission: this.permissionController.hasPermission.bind(
               this.permissionController,
             ),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5597,7 +5597,6 @@ export default class MetamaskController extends EventEmitter {
     engine.push(createLoggerMiddleware({ origin }));
 
     engine.push((req, _res, next, end) => {
-      console.log('Received request:', req)
       if (
         ![
           MESSAGE_TYPE.PROVIDER_AUTHORIZE,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
this uses the findNetworkClientIdByChainId hook to get the networkClientId for caip-27 handler
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25582?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
