### PR TITLE
fix(snaps): Fix alignment of install origin is `snap-authorship-expanded`

### DIFF
--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -16,6 +16,7 @@ import {
   FontWeight,
   JustifyContent,
   OverflowWrap,
+  TextAlign,
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
@@ -179,7 +180,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
               flexDirection={FlexDirection.Column}
               alignItems={AlignItems.flexEnd}
             >
-              <Text>{installOrigin.host}</Text>
+              <Text textAlign={TextAlign.End}>{installOrigin.host}</Text>
               <Text color={Color.textMuted}>
                 {t('installedOn', [
                   formatDate(installInfo.date, 'dd MMM yyyy'),


### PR DESCRIPTION
## **Description**

This fixes the expanded authorship install origin being left aligned when the text takes more than a line.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25583?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Install a snap with a long install origin
2. Go to the snap's settings page
3. Look at the install origin

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/13910212/3d6689a0-8e78-458e-bfe4-28094f893f61)

### **After**

![Screenshot 2024-06-28 at 17 04 27](https://github.com/MetaMask/metamask-extension/assets/13910212/660431d2-434f-4df4-ae08-aad6fb9e2c27)


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
