### PR TITLE
test: UX: Multichain: Add E2E for signaling network change from Network menu to dapp

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -233,8 +233,25 @@ async function start() {
 async function queryCurrentActiveTab(windowType) {
   // At the time of writing we only have the `activeTab` permission which means
   // that this query will only succeed in the popup context (i.e. after a "browserAction")
-  if (windowType !== ENVIRONMENT_TYPE_POPUP) {
+  if (windowType !== ENVIRONMENT_TYPE_POPUP && !process.env.IN_TEST) {
     return {};
+  }
+
+  // Shims the activeTab for E2E test runs
+  if (process.env.IN_TEST) {
+    const mockUrlString = 'http://127.0.0.1:8080';
+    const { origin: mockOrigin, protocol: mockProtocol } = new URL(
+      mockUrlString,
+    );
+    const mockActiveTab = {
+      id: 'mock-site',
+      title: 'Mock site',
+      origin: mockOrigin,
+      protocol: mockProtocol,
+      url: mockUrlString,
+    };
+
+    return mockActiveTab;
   }
 
   const tabs = await browser.tabs


### PR DESCRIPTION
## **Description**

Adds an end to end test to test that the network menu signals to dapps a network change

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25593?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Connect to test dapp with Sepolia
2. Open MetaMask, change to Mainnet
3. See test dapp switch to Mainnet

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
