### PR TITLE
fix: failingt e2e `Click bridge button from asset page @no-mmi loads portfolio tab when flag is turned off`

### DIFF
--- a/test/e2e/tests/bridge/bridge-click-from-asset-overview.spec.ts
+++ b/test/e2e/tests/bridge/bridge-click-from-asset-overview.spec.ts
@@ -8,7 +8,8 @@ import { BridgePage, getBridgeFixtures } from './bridge-test-utils';
 describe('Click bridge button from asset page @no-mmi', function (this: Suite) {
   it('loads portfolio tab when flag is turned off', async function () {
     await withFixtures(
-      getBridgeFixtures(this.test?.fullTitle()),
+      // withErc20 param is false, as we test it manually below
+      getBridgeFixtures(this.test?.fullTitle(), undefined, false),
       async ({
         driver,
         ganacheServer,

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -108,15 +108,21 @@ export class BridgePage {
 export const getBridgeFixtures = (
   title?: string,
   testSpecificMock?: (server: Mockttp) => Promise<void>,
+  withErc20: boolean = true,
 ) => {
+  const fixtureBuilder = new FixtureBuilder({
+    inputChainId: CHAIN_IDS.MAINNET,
+  }).withNetworkControllerOnMainnet();
+
+  if (withErc20) {
+    fixtureBuilder.withTokensControllerERC20();
+  }
+
   return {
     driverOptions: {
       openDevToolsForTabs: true,
     },
-    fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
-      .withNetworkControllerOnMainnet()
-      .withTokensControllerERC20()
-      .build(),
+    fixtures: fixtureBuilder.build(),
     testSpecificMock,
     smartContract: SMART_CONTRACTS.HST,
     ganacheOptions: generateGanacheOptions({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is failing since we are trying to manually add a token which is already added using fixtures.
See ci failure [here](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/89950/workflows/6dce2bee-4cdf-4118-9fea-9ddc10f25096/jobs/3330074/tests).


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25607?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25608

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

![image](https://github.com/MetaMask/metamask-extension/assets/54408225/4519217f-e01d-48ba-a515-b483fc952854)


Failure and fix:


https://github.com/MetaMask/metamask-extension/assets/54408225/423f628b-e902-444c-815b-1aa05f824aa8



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
