### PR TITLE
fix: Skip blockaid validation for SIWE signature types

### DIFF
--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -3,6 +3,8 @@ import {
   JsonRpcRequestStruct,
   JsonRpcResponseStruct,
 } from '@metamask/utils';
+import * as ControllerUtils from '@metamask/controller-utils';
+
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 
 import {
@@ -200,6 +202,35 @@ describe('PPOMMiddleware', () => {
       { ...JsonRpcResponseStruct },
       () => undefined,
     );
+
+    expect(req.securityAlertResponse).toBeUndefined();
+    expect(validateRequestWithPPOM).not.toHaveBeenCalled();
+  });
+
+  it('does not do validation for SIWE signature', async () => {
+    const middlewareFunction = createMiddleware({
+      securityAlertsEnabled: false,
+    });
+
+    const req = {
+      method: 'personal_sign',
+      params: [
+        '0x6d6574616d61736b2e6769746875622e696f2077616e747320796f7520746f207369676e20696e207769746820796f757220457468657265756d206163636f756e743a0a3078393335653733656462396666353265323362616337663765303433613165636430366430353437370a0a492061636365707420746865204d6574614d61736b205465726d73206f6620536572766963653a2068747470733a2f2f636f6d6d756e6974792e6d6574616d61736b2e696f2f746f730a0a5552493a2068747470733a2f2f6d6574616d61736b2e6769746875622e696f0a56657273696f6e3a20310a436861696e2049443a20310a4e6f6e63653a2033323839313735370a4973737565642041743a20323032312d30392d33305431363a32353a32342e3030305a',
+        '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+        'Example password',
+      ],
+      jsonrpc: '2.0',
+      id: 2974202441,
+      origin: 'https://metamask.github.io',
+      networkClientId: 'mainnet',
+      tabId: 1048745900,
+      securityAlertResponse: undefined,
+    };
+    jest
+      .spyOn(ControllerUtils, 'detectSIWE')
+      .mockReturnValue({ isSIWEMessage: false, parsedMessage: null });
+
+    await middlewareFunction(req, undefined, () => undefined);
 
     expect(req.securityAlertResponse).toBeUndefined();
     expect(validateRequestWithPPOM).not.toHaveBeenCalled();

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -50,8 +50,7 @@ const createMiddleware = (
   const preferenceController = {
     store: {
       getState: () => ({
-        securityAlertsEnabled:
-          securityAlertsEnabled === undefined ?? securityAlertsEnabled,
+        securityAlertsEnabled: securityAlertsEnabled ?? true,
       }),
     },
   };
@@ -226,9 +225,25 @@ describe('PPOMMiddleware', () => {
       tabId: 1048745900,
       securityAlertResponse: undefined,
     };
-    jest
-      .spyOn(ControllerUtils, 'detectSIWE')
-      .mockReturnValue({ isSIWEMessage: false, parsedMessage: null });
+    jest.spyOn(ControllerUtils, 'detectSIWE').mockReturnValue({
+      isSIWEMessage: true,
+      parsedMessage: {
+        address: '0x935e73edb9ff52e23bac7f7e049a1ecd06d05477',
+        chainId: 1,
+        domain: 'metamask.github.io',
+        expirationTime: null,
+        issuedAt: '2021-09-30T16:25:24.000Z',
+        nonce: '32891757',
+        notBefore: '2022-03-17T12:45:13.610Z',
+        requestId: 'some_id',
+        scheme: null,
+        statement:
+          'I accept the MetaMask Terms of Service: https://community.metamask.io/tos',
+        uri: 'https://metamask.github.io',
+        version: '1',
+        resources: null,
+      },
+    });
 
     await middlewareFunction(req, undefined, () => undefined);
 

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -209,7 +209,7 @@ describe('PPOMMiddleware', () => {
 
   it('does not do validation for SIWE signature', async () => {
     const middlewareFunction = createMiddleware({
-      securityAlertsEnabled: false,
+      securityAlertsEnabled: true,
     });
 
     const req = {

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -6,6 +6,7 @@ import {
   JsonRpcRequest,
   JsonRpcResponse,
 } from '@metamask/utils';
+import { detectSIWE } from '@metamask/controller-utils';
 
 import { SIGNING_METHODS } from '../../../../shared/constants/transaction';
 import { PreferencesController } from '../../controllers/preferences';
@@ -73,6 +74,11 @@ export function createPPOMMiddleware<
         !CONFIRMATION_METHODS.includes(req.method) ||
         !SECURITY_PROVIDER_SUPPORTED_CHAIN_IDS.includes(chainId)
       ) {
+        return;
+      }
+
+      const { isSIWEMessage } = detectSIWE({ data: req?.params?.[0] });
+      if (isSIWEMessage) {
         return;
       }
 


### PR DESCRIPTION
## **Description**

Skip blockaid validation for SIWE signatures 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24189

## **Manual testing steps**

1. Go to test dapp
2. Submit SIWE signature
3. Blockaid validation should not be done for SIWE signatures

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
