### PR TITLE
fix: Multichain: UX: Check for transactions on all networks and QueuedRequestCount

### DIFF
--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -200,7 +200,7 @@ export default class Routes extends Component {
     networkToAutomaticallySwitchTo: PropTypes.object,
     neverShowSwitchedNetworkMessage: PropTypes.bool.isRequired,
     automaticallySwitchNetwork: PropTypes.func.isRequired,
-    unapprovedTransactions: PropTypes.number.isRequired,
+    totalUnapprovedConfirmationCount: PropTypes.number.isRequired,
     currentExtensionPopupId: PropTypes.number,
     useRequestQueue: PropTypes.bool,
     showSurveyToast: PropTypes.bool.isRequired,
@@ -253,7 +253,7 @@ export default class Routes extends Component {
       account,
       networkToAutomaticallySwitchTo,
       activeTabOrigin,
-      unapprovedTransactions,
+      totalUnapprovedConfirmationCount,
       isUnlocked,
       useRequestQueue,
       currentExtensionPopupId,
@@ -267,13 +267,13 @@ export default class Routes extends Component {
     }
 
     // Automatically switch the network if the user
-    // no longer has unapprovedTransactions and they
+    // no longer has unapproved transactions and they
     // should be on a different network for the
     // currently active tab's dapp
     if (
       networkToAutomaticallySwitchTo &&
-      unapprovedTransactions === 0 &&
-      (prevProps.unapprovedTransactions > 0 ||
+      totalUnapprovedConfirmationCount === 0 &&
+      (prevProps.totalUnapprovedConfirmationCount > 0 ||
         (prevProps.isUnlocked === false && isUnlocked))
     ) {
       this.props.automaticallySwitchNetwork(

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -134,7 +134,7 @@ function mapStateToProps(state) {
     useNftDetection,
     showNftEnablementToast,
     networkToAutomaticallySwitchTo,
-    unapprovedTransactions:
+    totalUnapprovedConfirmationCount:
       getNumberOfAllUnapprovedTransactionsAndMessages(state),
     neverShowSwitchedNetworkMessage: getNeverShowSwitchedNetworkMessage(state),
     currentExtensionPopupId: state.metamask.currentExtensionPopupId,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -105,6 +105,7 @@ import { PRIVACY_POLICY_DATE } from '../helpers/constants/privacy-policy';
 import { ENVIRONMENT_TYPE_POPUP } from '../../shared/constants/app';
 import { SECURITY_PROVIDER_SUPPORTED_CHAIN_IDS } from '../../shared/constants/security-provider';
 import {
+  getAllUnapprovedTransactions,
   getCurrentNetworkTransactions,
   getUnapprovedTransactions,
 } from './transactions';
@@ -1778,7 +1779,9 @@ export function getShowRecoveryPhraseReminder(state) {
  * @returns Number of unapproved transactions
  */
 export function getNumberOfAllUnapprovedTransactionsAndMessages(state) {
-  const unapprovedTxs = getUnapprovedTransactions(state);
+  const unapprovedTxs = getAllUnapprovedTransactions(state);
+  const queuedRequestCount = getQueuedRequestCount(state);
+
   const allUnapprovedMessages = {
     ...unapprovedTxs,
     ...state.metamask.unapprovedMsgs,
@@ -1788,7 +1791,7 @@ export function getNumberOfAllUnapprovedTransactionsAndMessages(state) {
     ...state.metamask.unapprovedTypedMessages,
   };
   const numUnapprovedMessages = Object.keys(allUnapprovedMessages).length;
-  return numUnapprovedMessages;
+  return numUnapprovedMessages + queuedRequestCount;
 }
 
 export const getCurrentNetwork = createDeepEqualSelector(

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -227,6 +227,51 @@ describe('Selectors', () => {
       ).toStrictEqual(0);
     });
 
+    it('returns correct number of unapproved transactions and queued requests', () => {
+      expect(
+        selectors.getNumberOfAllUnapprovedTransactionsAndMessages({
+          metamask: {
+            queuedRequestCount: 5,
+            transactions: [
+              {
+                id: 0,
+                chainId: CHAIN_IDS.MAINNET,
+                time: 0,
+                txParams: {
+                  from: '0xAddress',
+                  to: '0xRecipient',
+                },
+                status: TransactionStatus.unapproved,
+              },
+              {
+                id: 1,
+                chainId: CHAIN_IDS.MAINNET,
+                time: 0,
+                txParams: {
+                  from: '0xAddress',
+                  to: '0xRecipient',
+                },
+                status: TransactionStatus.unapproved,
+              },
+            ],
+            unapprovedMsgs: {
+              2: {
+                id: 2,
+                msgParams: {
+                  from: '0xAddress',
+                  data: '0xData',
+                  origin: 'origin',
+                },
+                time: 1,
+                status: TransactionStatus.unapproved,
+                type: 'eth_sign',
+              },
+            },
+          },
+        }),
+      ).toStrictEqual(8);
+    });
+
     it('returns correct number of unapproved transactions and messages', () => {
       expect(
         selectors.getNumberOfAllUnapprovedTransactionsAndMessages({
@@ -287,6 +332,8 @@ describe('Selectors', () => {
         domains: {
           [SELECTED_ORIGIN]: SELECTED_ORIGIN_NETWORK_ID,
         },
+        queuedRequestCount: 0,
+        transactions: [],
         providerConfig: {
           ...mockState.metamask.networkConfigurations
             .testNetworkConfigurationId,
@@ -312,6 +359,42 @@ describe('Selectors', () => {
             ...state.metamask.providerConfig,
             id: NETWORK_TYPES.LINEA_SEPOLIA,
           },
+        },
+      });
+      expect(networkToSwitchTo).toBe(null);
+    });
+
+    it('should return no network to switch to because there are pending transactions', () => {
+      const networkToSwitchTo = selectors.getNetworkToAutomaticallySwitchTo({
+        ...state,
+        metamask: {
+          ...state.metamask,
+          providerConfig: {
+            ...state.metamask.providerConfig,
+            id: NETWORK_TYPES.LINEA_SEPOLIA,
+          },
+          transactions: [
+            {
+              id: 0,
+              chainId: CHAIN_IDS.MAINNET,
+              status: TransactionStatus.approved,
+            },
+          ],
+        },
+      });
+      expect(networkToSwitchTo).toBe(null);
+    });
+
+    it('should return no network to switch to because there are queued requests', () => {
+      const networkToSwitchTo = selectors.getNetworkToAutomaticallySwitchTo({
+        ...state,
+        metamask: {
+          ...state.metamask,
+          providerConfig: {
+            ...state.metamask.providerConfig,
+            id: NETWORK_TYPES.LINEA_SEPOLIA,
+          },
+          queuedRequestCount: 1,
         },
       });
       expect(networkToSwitchTo).toBe(null);

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -15,7 +15,10 @@ import { hexToDecimal } from '../../shared/modules/conversion.utils';
 import { getProviderConfig } from '../ducks/metamask/metamask';
 import { getCurrentChainId, getSelectedInternalAccount } from './selectors';
 import { hasPendingApprovals, getApprovalRequestsByType } from './approvals';
-import { createDeepEqualSelector } from './util';
+import {
+  createDeepEqualSelector,
+  filterAndShapeUnapprovedTransactions,
+} from './util';
 
 const INVALID_INITIAL_TRANSACTION_TYPES = [
   TransactionType.cancel,
@@ -56,15 +59,22 @@ export const getCurrentNetworkTransactions = createDeepEqualSelector(
 export const getUnapprovedTransactions = createDeepEqualSelector(
   (state) => {
     const currentNetworkTransactions = getCurrentNetworkTransactions(state);
+    return filterAndShapeUnapprovedTransactions(currentNetworkTransactions);
+  },
+  (transactions) => transactions,
+);
 
-    return currentNetworkTransactions
-      .filter(
-        (transaction) => transaction.status === TransactionStatus.unapproved,
-      )
-      .reduce((result, transaction) => {
-        result[transaction.id] = transaction;
-        return result;
-      }, {});
+// Unlike `getUnapprovedTransactions` and `getCurrentNetworkTransactions`
+// returns the total number of unapproved transactions on all networks
+export const getAllUnapprovedTransactions = createDeepEqualSelector(
+  (state) => {
+    const { transactions } = state.metamask || [];
+    if (!transactions?.length) {
+      return [];
+    }
+
+    const sortedTransactions = transactions.sort((a, b) => a.time - b.time);
+    return filterAndShapeUnapprovedTransactions(sortedTransactions);
   },
   (transactions) => transactions,
 );

--- a/ui/selectors/util.js
+++ b/ui/selectors/util.js
@@ -1,3 +1,4 @@
+import { TransactionStatus } from '@metamask/transaction-controller';
 import { isEqual } from 'lodash';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 
@@ -5,3 +6,12 @@ export const createDeepEqualSelector = createSelectorCreator(
   defaultMemoize,
   isEqual,
 );
+
+export const filterAndShapeUnapprovedTransactions = (transactions) => {
+  return transactions
+    .filter(({ status }) => status === TransactionStatus.unapproved)
+    .reduce((result, transaction) => {
+      result[transaction.id] = transaction;
+      return result;
+    }, {});
+};


### PR DESCRIPTION
## **Description**

There's a case where there could be a race condition between the `QueuedRequestController`'s network switching and the Routes' network switching.  The root issue is that the use of `getUnapprovedTransactions` only gets transactions on the `current` chain, thus triggering Routes to switch networks once the last transaction of the current chain is done, but there could be more transactions on other chains which we should allow QRC to handle network switching for.

Thus, this PR lets QRC control network switching until there are absolutely no transactions or queued requests left.

[This PR includes an **E2E](https://github.com/MetaMask/metamask-extension/pull/25536)** for the scenario where there are multiple queued transactions but since this is a race issue, it's difficult to reproduce in a provable E2E

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25614?quickstart=1)

## **Related issues**

Possibly related: https://github.com/MetaMask/metamask-extension/issues/25596

## **Manual testing steps**

1. Open `Tab 1`, connect to `Uniswap` on `Ethereum Mainnet`
2. Open `Tab 2`, connect to `PancakeSwap` on `BNB Chain`
3. Open `Tab 3`, connect to `Test Dapp` on `Sepolia`
4. Initiate a swap on `Tab 1` and `Tab 2` *BUT DO NOT CONFIRM IT, JUST MOVE ON TO THE NEXT TAB*
5. Initiate a send on `Tab 3` *BUT DO NOT CONFIRM IT*
6. On the confirmation screen, you should still see the first confirmation from `Tab 1` (`Uniswap`) on `Ethereum Mainnet`; confirm or reject it.  See the confirmation window close
7. A new confirmation popup should come up with the `PancakeSwap`/ `Tab 2` confirmation on `BNB` chain; confirm or reject it.  See the confirmation window close
8. See one last confirmation screen pop up for the `Tab 3` / `Test Dapp` send on `Sepolia`.  Confirm or reject it.

Create transactions on different networks, reject and/or confirm them, click around between popup and notification window, ensure nothing unexpected occurs


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
