### PR TITLE
fix: flaky test `Test Snap Get Locale test snap_getLocale functionality`

### DIFF
--- a/test/e2e/snaps/test-snap-get-locale.spec.js
+++ b/test/e2e/snaps/test-snap-get-locale.spec.js
@@ -112,8 +112,9 @@ describe('Test Snap Get Locale', function () {
         // try to select dansk from the list
         await driver.clickElement({ text: 'Dansk', tag: 'option' });
 
-        // mitigate flakiness: the loading spinner appears 2 times
-        await driver.assertElementNotPresent('.loading-overlay');
+        // there are 2 re-renders which cause flakiness (issue #25651)
+        // the delay can be removed once the issue is fixed in the app level
+        await driver.delay(1000);
         await driver.assertElementNotPresent('.loading-overlay');
 
         // click on the global action menu

--- a/test/e2e/snaps/test-snap-get-locale.spec.js
+++ b/test/e2e/snaps/test-snap-get-locale.spec.js
@@ -28,6 +28,9 @@ describe('Test Snap Get Locale', function () {
           tag: 'h2',
         });
 
+        const dialogButton = await driver.findElement('#connectgetlocale');
+        await driver.scrollToElement(dialogButton);
+        await driver.delay(1000);
         await driver.clickElement('#connectgetlocale');
 
         // switch to metamask extension and click connect

--- a/test/e2e/snaps/test-snap-get-locale.spec.js
+++ b/test/e2e/snaps/test-snap-get-locale.spec.js
@@ -112,6 +112,8 @@ describe('Test Snap Get Locale', function () {
         // try to select dansk from the list
         await driver.clickElement({ text: 'Dansk', tag: 'option' });
 
+        // mitigate flakiness: the loading spinner appears 2 times
+        await driver.assertElementNotPresent('.loading-overlay');
         await driver.assertElementNotPresent('.loading-overlay');
 
         // click on the global action menu

--- a/test/e2e/snaps/test-snap-get-locale.spec.js
+++ b/test/e2e/snaps/test-snap-get-locale.spec.js
@@ -28,9 +28,6 @@ describe('Test Snap Get Locale', function () {
           tag: 'h2',
         });
 
-        const dialogButton = await driver.findElement('#connectgetlocale');
-        await driver.scrollToElement(dialogButton);
-        await driver.delay(1000);
         await driver.clickElement('#connectgetlocale');
 
         // switch to metamask extension and click connect
@@ -88,9 +85,6 @@ describe('Test Snap Get Locale', function () {
         );
 
         // click on the global action menu
-        await driver.waitForSelector(
-          '[data-testid="account-options-menu-button"]',
-        );
         await driver.clickElement(
           '[data-testid="account-options-menu-button"]',
         );
@@ -115,10 +109,9 @@ describe('Test Snap Get Locale', function () {
         // try to select dansk from the list
         await driver.clickElement({ text: 'Dansk', tag: 'option' });
 
+        await driver.assertElementNotPresent('.loading-overlay');
+
         // click on the global action menu
-        await driver.waitForSelector(
-          '[data-testid="account-options-menu-button"]',
-        );
         await driver.clickElement(
           '[data-testid="account-options-menu-button"]',
         );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes the snap test for get locale. The problem is that there is a race condition where, after changing the language, we click on the account menu and to the Snaps option, while metamask is being on a loading state, making that the click take no effect as the component re-renders after the click, and the subsequent element cannot be found. 

An additional problem is that whenever we change locale, the loading spinner appears not only once but twice, meaning that there are 2 re-renders (see video). This seems an issue in the app level and should also be fixed there.
I've opened an issue for that [here](https://github.com/MetaMask/metamask-extension/issues/25651).

See actions and error and also check screenshot below:

```
[driver] Called 'clickElement' with arguments [{"text":"Dansk","tag":"option"}]
[driver] Called 'waitForSelector' with arguments ["[data-testid=\"account-options-menu-button\"]"]
[driver] Called 'clickElement' with arguments ["[data-testid=\"account-options-menu-button\"]"]
[driver] Called 'clickElement' with arguments [{"text":"Snaps","tag":"div"}]
[driver] Called 'waitForSelector' with arguments [{"text":"Oversættelses Eksempel Snap"}]
Failure on testcase: 'Test Snap Get Locale test snap_getLocale functionality', for more information see the artifacts tab in CI

TimeoutError: Waiting for element to be located By(xpath, //*[contains(text(), "Oversættelses Eksempel Snap")])
```

- ci error https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/90228/workflows/f19f6577-350b-42d4-a99c-93667540dec6/jobs/3343510

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25648?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25650

## **Manual testing steps**

1. Check ci. Note: thanks to the quality gate, this test is run multiple times in ci in this branch

## **Screenshots/Recordings**


![Screenshot from 2024-07-03 10-06-51](https://github.com/MetaMask/metamask-extension/assets/54408225/4c9ebe33-1fe1-498d-84f5-b6d4f30a7be5)

I've added a delay so we can see the behaviour more clearly: see how a spinner appears twice,  so the app re-renders x2 times

https://github.com/MetaMask/metamask-extension/assets/54408225/b30dae1a-26f0-4133-a0a0-51c3d3017228




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
