### PR TITLE
fix: allow ramps dev environment on Flask

### DIFF
--- a/app/scripts/lib/snap-keyring/keyring-snaps-permissions.test.ts
+++ b/app/scripts/lib/snap-keyring/keyring-snaps-permissions.test.ts
@@ -8,6 +8,12 @@ import {
   keyringSnapPermissionsBuilder,
 } from './keyring-snaps-permissions';
 
+const PORTFOLIO_ORIGINS: string[] = [
+  'https://portfolio.metamask.io',
+  'https://dev.portfolio.metamask.io',
+  'https://ramps-dev.portfolio.metamask.io',
+];
+
 describe('keyringSnapPermissionsBuilder', () => {
   const mockController = new SubjectMetadataController({
     subjectCacheLimit: 100,
@@ -26,7 +32,8 @@ describe('keyringSnapPermissionsBuilder', () => {
   });
 
   describe('Portfolio origin', () => {
-    it('returns the methods Portfolio can call', () => {
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(PORTFOLIO_ORIGINS)('returns the methods Portfolio can call', () => {
       const permissions = keyringSnapPermissionsBuilder(
         mockController,
         'https://portfolio.metamask.io',
@@ -39,7 +46,8 @@ describe('keyringSnapPermissionsBuilder', () => {
       ]);
     });
 
-    it('cannot create an account', () => {
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(PORTFOLIO_ORIGINS)('cannot create an account', () => {
       const permissions = keyringSnapPermissionsBuilder(
         mockController,
         'https://portfolio.metamask.io',
@@ -47,7 +55,8 @@ describe('keyringSnapPermissionsBuilder', () => {
       expect(permissions()).not.toContain(KeyringRpcMethod.CreateAccount);
     });
 
-    it('can submit a request', () => {
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(PORTFOLIO_ORIGINS)('can submit a request', () => {
       const permissions = keyringSnapPermissionsBuilder(
         mockController,
         'https://portfolio.metamask.io',

--- a/app/scripts/lib/snap-keyring/keyring-snaps-permissions.test.ts
+++ b/app/scripts/lib/snap-keyring/keyring-snaps-permissions.test.ts
@@ -33,34 +33,37 @@ describe('keyringSnapPermissionsBuilder', () => {
 
   describe('Portfolio origin', () => {
     // @ts-expect-error This is missing from the Mocha type definitions
-    it.each(PORTFOLIO_ORIGINS)('returns the methods Portfolio can call', () => {
-      const permissions = keyringSnapPermissionsBuilder(
-        mockController,
-        'https://portfolio.metamask.io',
-      );
-      expect(permissions()).toStrictEqual([
-        KeyringRpcMethod.ListAccounts,
-        KeyringRpcMethod.GetAccount,
-        KeyringRpcMethod.GetAccountBalances,
-        KeyringRpcMethod.SubmitRequest,
-      ]);
-    });
+    it.each(PORTFOLIO_ORIGINS)(
+      'returns the methods that can be called by %s',
+      (origin: string) => {
+        const permissions = keyringSnapPermissionsBuilder(
+          mockController,
+          origin,
+        );
+        expect(permissions()).toStrictEqual([
+          KeyringRpcMethod.ListAccounts,
+          KeyringRpcMethod.GetAccount,
+          KeyringRpcMethod.GetAccountBalances,
+          KeyringRpcMethod.SubmitRequest,
+        ]);
+      },
+    );
 
     // @ts-expect-error This is missing from the Mocha type definitions
-    it.each(PORTFOLIO_ORIGINS)('cannot create an account', () => {
-      const permissions = keyringSnapPermissionsBuilder(
-        mockController,
-        'https://portfolio.metamask.io',
-      );
-      expect(permissions()).not.toContain(KeyringRpcMethod.CreateAccount);
-    });
+    it.each(PORTFOLIO_ORIGINS)(
+      '%s cannot create an account',
+      (origin: string) => {
+        const permissions = keyringSnapPermissionsBuilder(
+          mockController,
+          origin,
+        );
+        expect(permissions()).not.toContain(KeyringRpcMethod.CreateAccount);
+      },
+    );
 
     // @ts-expect-error This is missing from the Mocha type definitions
-    it.each(PORTFOLIO_ORIGINS)('can submit a request', () => {
-      const permissions = keyringSnapPermissionsBuilder(
-        mockController,
-        'https://portfolio.metamask.io',
-      );
+    it.each(PORTFOLIO_ORIGINS)('%s can submit a request', (origin: string) => {
+      const permissions = keyringSnapPermissionsBuilder(mockController, origin);
       expect(permissions()).toContain(KeyringRpcMethod.SubmitRequest);
     });
   });

--- a/app/scripts/lib/snap-keyring/keyring-snaps-permissions.ts
+++ b/app/scripts/lib/snap-keyring/keyring-snaps-permissions.ts
@@ -7,7 +7,7 @@ import { KeyringRpcMethod } from '@metamask/keyring-api';
 /**
  * The origins of the Portfolio dapp.
  */
-const PORTFOLIO_ORIGINS = [
+const PORTFOLIO_ORIGINS: string[] = [
   'https://portfolio.metamask.io',
   ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   'https://dev.portfolio.metamask.io',

--- a/app/scripts/lib/snap-keyring/keyring-snaps-permissions.ts
+++ b/app/scripts/lib/snap-keyring/keyring-snaps-permissions.ts
@@ -10,6 +10,7 @@ import { KeyringRpcMethod } from '@metamask/keyring-api';
 const PORTFOLIO_ORIGINS = [
   'https://portfolio.metamask.io',
   ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  'https://dev.portfolio.metamask.io',
   'https://ramps-dev.portfolio.metamask.io',
   ///: END:ONLY_INCLUDE_IF
 ];

--- a/app/scripts/lib/snap-keyring/keyring-snaps-permissions.ts
+++ b/app/scripts/lib/snap-keyring/keyring-snaps-permissions.ts
@@ -5,9 +5,14 @@ import {
 import { KeyringRpcMethod } from '@metamask/keyring-api';
 
 /**
- * The origin of the Portfolio dapp.
+ * The origins of the Portfolio dapp.
  */
-const PORTFOLIO_ORIGIN = 'https://portfolio.metamask.io';
+const PORTFOLIO_ORIGINS = [
+  'https://portfolio.metamask.io',
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  'https://ramps-dev.portfolio.metamask.io',
+  ///: END:ONLY_INCLUDE_IF
+];
 
 /**
  * List of keyring methods MetaMask can call.
@@ -94,7 +99,7 @@ export function keyringSnapPermissionsBuilder(
       return METAMASK_ALLOWED_METHODS;
     }
 
-    if (origin === PORTFOLIO_ORIGIN) {
+    if (PORTFOLIO_ORIGINS.includes(origin)) {
       return PORTFOLIO_ALLOWED_METHODS;
     }
 


### PR DESCRIPTION
## **Description**

Allow `https://ramps-dev.portfolio.metamask.io` send requests to non-EVM account Snaps on Flask.

## **Related issues**

Fixes: <https://github.com/MetaMask/accounts-planning/issues/509>

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
