### PR TITLE
feat: Enable SIWE Signature Redesign

### DIFF
--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
@@ -188,17 +188,4 @@ describe('useCurrentConfirmation', () => {
 
     expect(currentConfirmation).toBeUndefined();
   });
-
-  it('returns undefined if message is SIWE', () => {
-    const currentConfirmation = runHook({
-      message: {
-        ...MESSAGE_MOCK,
-        msgParams: { siwe: { isSIWEMessage: true } },
-      },
-      pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.PersonalSign }],
-      redesignedConfirmationsEnabled: true,
-    });
-
-    expect(currentConfirmation).toBeUndefined();
-  });
 });

--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.ts
@@ -54,20 +54,10 @@ const useCurrentConfirmation = () => {
     pendingApproval?.type as ApprovalType,
   );
 
-  const isSIWE =
-    pendingApproval?.type === TransactionType.personalSign &&
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (signatureMessage?.msgParams as any)?.siwe?.isSIWEMessage;
-
   return useMemo(() => {
     if (
       !redesignedConfirmationsEnabled ||
-      (!isCorrectTransactionType && !isCorrectApprovalType) ||
-      /**
-       * @todo remove isSIWE check when we want to enable SIWE in redesigned confirmations
-       * @see {@link https://github.com/MetaMask/metamask-extension/issues/24617}
-       */
-      isSIWE
+      (!isCorrectTransactionType && !isCorrectApprovalType)
     ) {
       return { currentConfirmation: undefined };
     }
@@ -80,7 +70,6 @@ const useCurrentConfirmation = () => {
     redesignedConfirmationsEnabled,
     isCorrectTransactionType,
     isCorrectApprovalType,
-    isSIWE,
     transactionMetadata,
     signatureMessage,
   ]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Enable SIWE Signature Redesign pages

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25660?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24617

## **Manual testing steps**

1. yarn start
2. go to test-dapp
3. test SIWE buttons

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="320" src="https://github.com/MetaMask/metamask-extension/assets/20778143/41bf0b7b-575a-4cbd-a209-6d1319a0ef88">

### **After**

<img width="320" src="https://github.com/MetaMask/metamask-extension/assets/20778143/561b9752-57d5-4dff-b4f3-a731cf11ec34"> 
<img width="320" src="https://github.com/MetaMask/metamask-extension/assets/20778143/22bdb870-95e9-480a-b3ac-adfbcf0952ce">

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
