### PR TITLE
fix: Hide MMI Account Mistmatch BannerAlert from Sign-in with Ethereum (SIWE) Redesign Page

### DIFF
--- a/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.test.tsx
+++ b/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.test.tsx
@@ -64,8 +64,9 @@ describe('MMISignatureMismatchBanner', () => {
       address,
     )})`;
 
-    const { getByText } = render();
+    const { container, getByText } = render();
 
+    expect(container.querySelector('.mm-banner-alert')).toBeInTheDocument();
     expect(getByText(mismatchAccountText)).toBeInTheDocument();
   });
 

--- a/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.test.tsx
+++ b/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { EthAccountType, EthMethod } from '@metamask/keyring-api';
-import { unapprovedPersonalSignMsg } from '../../../../test/data/confirmations/personal_sign';
+import {
+  unapprovedPersonalSignMsg,
+  signatureRequestSIWE,
+} from '../../../../test/data/confirmations/personal_sign';
 import mockState from '../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import { shortenAddress } from '../../../helpers/utils/util';
@@ -23,7 +26,11 @@ const selectedAccount = {
 
 const address = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 
-const render = () => {
+/**
+ * @param opt
+ * @param opt.currentConfirmationProps - props to override default currentConfirmation
+ */
+const render = ({ currentConfirmationProps = {} } = {}) => {
   const internalAccounts = {
     accounts: {
       ...mockState.metamask.internalAccounts.accounts,
@@ -41,6 +48,7 @@ const render = () => {
       currentConfirmation: {
         ...unapprovedPersonalSignMsg,
         msgParams: { ...unapprovedPersonalSignMsg.msgParams, from: address },
+        ...currentConfirmationProps,
       },
     },
   });
@@ -59,5 +67,15 @@ describe('MMISignatureMismatchBanner', () => {
     const { getByText } = render();
 
     expect(getByText(mismatchAccountText)).toBeInTheDocument();
+  });
+
+  it('should not display for Sign-in with Ethereum signatures', () => {
+    const { container } = render({
+      currentConfirmationProps: {
+        ...signatureRequestSIWE,
+      },
+    });
+
+    expect(container.querySelector('.mm-banner-alert')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.tsx
+++ b/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../helpers/utils/util';
 import { BannerAlert } from '../../component-library';
 import { SignatureRequestType } from '../../../pages/confirmations/types/confirm';
+import { isSIWESignatureRequest } from '../../../pages/confirmations/utils/confirm';
 
 const MMISignatureMismatchBanner: React.FC = memo(() => {
   const t = useI18nContext();
@@ -27,7 +28,7 @@ const MMISignatureMismatchBanner: React.FC = memo(() => {
      * SIWE has its own account mismatch alert that checks the selected address and the address
      * in the parsed message rather than the selected address and the from address
      */
-    const isSIWE = Boolean(currentConfirmation?.msgParams?.siwe?.isSIWEMessage);
+    const isSIWE = isSIWESignatureRequest(currentConfirmation);
 
     if (
       !currentConfirmation ||

--- a/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.tsx
+++ b/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.tsx
@@ -23,9 +23,15 @@ const MMISignatureMismatchBanner: React.FC = memo(() => {
   const allAccounts = useSelector(accountsWithSendEtherInfoSelector);
 
   const fromAccount = useMemo(() => {
-    // todo: as we add SIWE signatures to new designs we may need to exclude it from here
+    /**
+     * SIWE has its own account mismatch alert that checks the selected address and the address
+     * in the parsed message rather than the selected address and the from address
+     */
+    const isSIWE = Boolean(currentConfirmation?.msgParams?.siwe?.isSIWEMessage);
+
     if (
       !currentConfirmation ||
+      isSIWE ||
       (currentConfirmation.type !== TransactionType.personalSign &&
         currentConfirmation.type !== TransactionType.signTypedData) ||
       !currentConfirmation.msgParams


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25662?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25661

## **Manual testing steps**

1. Go to test-dapp
2. Connect with an account
3. Open MM and change the account
4. Test SIWE and observe no MMI account mismatch banner. Bad Account should still display account mismatch row alerts

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
