### PR TITLE
fix: blockaid report url in redesigned pages

### DIFF
--- a/app/scripts/lib/ppom/types.ts
+++ b/app/scripts/lib/ppom/types.ts
@@ -1,6 +1,7 @@
 import { SecurityAlertSource } from '../../../../shared/constants/security-provider';
 
 export type SecurityAlertResponse = {
+  block?: number;
   description?: string;
   features?: string[];
   providerRequestsCount?: Record<string, number>;

--- a/ui/ducks/confirm-alerts/confirm-alerts.ts
+++ b/ui/ducks/confirm-alerts/confirm-alerts.ts
@@ -52,6 +52,11 @@ export type Alert = {
    * The severity of the alert.
    */
   severity: AlertSeverity;
+
+  /**
+   * URL to report issue.
+   */
+  reportUrl?: string;
 };
 
 /**

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -48,6 +48,7 @@ function ConfirmBannerAlert({ ownerId }: { ownerId: string }) {
         severity={highestSeverity}
         provider={hasMultipleAlerts ? undefined : singleAlert.provider}
         details={hasMultipleAlerts ? undefined : singleAlert.alertDetails}
+        reportUrl={singleAlert.reportUrl}
       />
     </Box>
   );

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.test.ts
@@ -55,8 +55,6 @@ const EXPECTED_ALERT = {
   alertDetails: mockSecurityAlertResponse.features,
   provider: SecurityProvider.Blockaid,
   reason: 'This is a deceptive request',
-  reportUrl:
-    'https://blockaid-false-positive-portal.metamask.io?data=H4sIAAAAAAAAE0WMsQoCMRBEf0W2jgcnNvoBWl0jYmNE1mT1VsNtyCaFiP9uooXV8OYN84JLEPdA9gdKyjLBGvpu2a3AgBuRG2%2BFUuBWBFTlKzvMv2UmzfNEqJUM3Gvsohsoj%2BKrjfVRJgxn5VvzibSEvH9GqnLAwI6l6FfEJL641h8tbAhzSTTrLZg%2FLSyc4P0BKqZNZ7AAAAA%3D&utm_source=metamask-ppom',
 };
 
 describe('useBlockaidAlerts', () => {
@@ -80,6 +78,8 @@ describe('useBlockaidAlerts', () => {
     });
 
     expect(result.current).toHaveLength(1);
+    expect(result.current[0].reportUrl).toBeDefined();
+    delete result.current[0].reportUrl;
     expect(result.current[0]).toStrictEqual(EXPECTED_ALERT);
   });
 
@@ -97,6 +97,8 @@ describe('useBlockaidAlerts', () => {
     });
 
     expect(result.current).toHaveLength(1);
+    expect(result.current[0].reportUrl).toBeDefined();
+    delete result.current[0].reportUrl;
     expect(result.current[0]).toStrictEqual(EXPECTED_ALERT);
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.test.ts
@@ -55,6 +55,8 @@ const EXPECTED_ALERT = {
   alertDetails: mockSecurityAlertResponse.features,
   provider: SecurityProvider.Blockaid,
   reason: 'This is a deceptive request',
+  reportUrl:
+    'https://blockaid-false-positive-portal.metamask.io?data=H4sIAAAAAAAAE0WMsQoCMRBEf0W2jgcnNvoBWl0jYmNE1mT1VsNtyCaFiP9uooXV8OYN84JLEPdA9gdKyjLBGvpu2a3AgBuRG2%2BFUuBWBFTlKzvMv2UmzfNEqJUM3Gvsohsoj%2BKrjfVRJgxn5VvzibSEvH9GqnLAwI6l6FfEJL641h8tbAhzSTTrLZg%2FLSyc4P0BKqZNZ7AAAAA%3D&utm_source=metamask-ppom',
 };
 
 describe('useBlockaidAlerts', () => {

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
@@ -1,12 +1,20 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import BlockaidPackage from '@blockaid/ppom_release/package.json';
 
 import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { BlockaidResultType } from '../../../../../shared/constants/security-provider';
+import {
+  BlockaidResultType,
+  FALSE_POSITIVE_REPORT_BASE_URL,
+  SECURITY_PROVIDER_UTM_SOURCE,
+} from '../../../../../shared/constants/security-provider';
+import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
+import { NETWORK_TO_NAME_MAP } from '../../../../../shared/constants/network';
 import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
+import { getCurrentChainId } from '../../../../selectors';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   REDESIGN_TRANSACTION_TYPES,
@@ -18,6 +26,9 @@ import {
 } from '../../selectors';
 import { SecurityAlertResponse } from '../../types/confirm';
 import { normalizeProviderAlert } from './utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const zlib = require('zlib');
 
 const SUPPORTED_TRANSACTION_TYPES = [
   ...SIGNATURE_TRANSACTION_TYPES,
@@ -43,6 +54,8 @@ const useBlockaidAlerts = (): Alert[] => {
     currentConfirmationSelector,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) as Record<string, any>;
+
+  const selectorChainId = useSelector(getCurrentChainId);
 
   const securityAlertId = currentConfirmation?.securityAlertResponse
     ?.securityAlertId as string;
@@ -73,6 +86,36 @@ const useBlockaidAlerts = (): Alert[] => {
     securityAlertResponse?.result_type as BlockaidResultType,
   );
 
+  let jsonData: string | undefined;
+
+  if (securityAlertResponse && currentConfirmation) {
+    const {
+      block,
+      features,
+      reason,
+      result_type: resultType,
+    } = securityAlertResponse;
+    const { chainId, msgParams, origin, type, txParams } = currentConfirmation;
+
+    const isFailedResultType = resultType === BlockaidResultType.Errored;
+
+    const reportData = {
+      blockNumber: block,
+      blockaidVersion: BlockaidPackage.version,
+      chain: (NETWORK_TO_NAME_MAP as Record<string, string>)[
+        chainId ?? selectorChainId
+      ],
+      classification: isFailedResultType ? 'error' : reason,
+      domain: origin ?? msgParams?.origin ?? origin,
+      jsonRpcMethod: type,
+      jsonRpcParams: JSON.stringify(txParams ?? msgParams),
+      resultType: isFailedResultType ? BlockaidResultType.Errored : resultType,
+      reproduce: JSON.stringify(features),
+    };
+
+    jsonData = JSON.stringify(reportData);
+  }
+
   return useMemo<Alert[]>(() => {
     if (
       !isTransactionTypeSupported ||
@@ -82,11 +125,21 @@ const useBlockaidAlerts = (): Alert[] => {
       return [];
     }
 
-    return [normalizeProviderAlert(securityAlertResponse, t)];
+    let reportUrl = ZENDESK_URLS.SUPPORT_URL;
+    if (jsonData) {
+      const encodedData = zlib?.gzipSync?.(jsonData) ?? jsonData;
+
+      reportUrl = `${FALSE_POSITIVE_REPORT_BASE_URL}?data=${encodeURIComponent(
+        encodedData.toString('base64'),
+      )}&utm_source=${SECURITY_PROVIDER_UTM_SOURCE}`;
+    }
+
+    return [normalizeProviderAlert(securityAlertResponse, t, reportUrl)];
   }, [
     isTransactionTypeSupported,
     isResultTypeIgnored,
     securityAlertResponse,
+    jsonData,
     t,
   ]);
 };

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
@@ -94,7 +94,7 @@ const useBlockaidAlerts = (): Alert[] => {
       features,
       reason,
       result_type: resultType,
-    } = securityAlertResponse;
+    } = securityAlertResponse as SecurityAlertResponse;
     const { chainId, msgParams, origin, type, txParams } = currentConfirmation;
 
     const isFailedResultType = resultType === BlockaidResultType.Errored;

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
@@ -86,7 +86,7 @@ const useBlockaidAlerts = (): Alert[] => {
     securityAlertResponse?.result_type as BlockaidResultType,
   );
 
-  let jsonData: string | undefined;
+  let stringifiedJSONData: string | undefined;
 
   if (securityAlertResponse && currentConfirmation) {
     const {
@@ -113,7 +113,7 @@ const useBlockaidAlerts = (): Alert[] => {
       reproduce: JSON.stringify(features),
     };
 
-    jsonData = JSON.stringify(reportData);
+    stringifiedJSONData = JSON.stringify(reportData);
   }
 
   return useMemo<Alert[]>(() => {
@@ -126,8 +126,9 @@ const useBlockaidAlerts = (): Alert[] => {
     }
 
     let reportUrl = ZENDESK_URLS.SUPPORT_URL;
-    if (jsonData) {
-      const encodedData = zlib?.gzipSync?.(jsonData) ?? jsonData;
+    if (stringifiedJSONData) {
+      const encodedData =
+        zlib?.gzipSync?.(stringifiedJSONData) ?? stringifiedJSONData;
 
       reportUrl = `${FALSE_POSITIVE_REPORT_BASE_URL}?data=${encodeURIComponent(
         encodedData.toString('base64'),
@@ -139,7 +140,7 @@ const useBlockaidAlerts = (): Alert[] => {
     isTransactionTypeSupported,
     isResultTypeIgnored,
     securityAlertResponse,
-    jsonData,
+    stringifiedJSONData,
     t,
   ]);
 };

--- a/ui/pages/confirmations/hooks/alerts/utils.ts
+++ b/ui/pages/confirmations/hooks/alerts/utils.ts
@@ -38,11 +38,13 @@ export function getProviderAlertSeverity(
  *
  * @param securityAlertResponse - The security alert response to normalize.
  * @param t - The translation function.
+ * @param reportUrl - URL to report.
  * @returns The normalized Alert object.
  */
 export function normalizeProviderAlert(
   securityAlertResponse: SecurityAlertResponse,
   t: ReturnType<typeof useI18nContext>,
+  reportUrl?: string,
 ): Alert {
   return {
     key: securityAlertResponse.securityAlertId || '',
@@ -61,5 +63,6 @@ export function normalizeProviderAlert(
       ] || REASON_TO_DESCRIPTION_TKEY.other,
     ),
     provider: SecurityProvider.Blockaid, // TODO: Remove this once we support more providers and implement a way to determine it.
+    reportUrl,
   };
 }

--- a/ui/pages/confirmations/types/confirm.ts
+++ b/ui/pages/confirmations/types/confirm.ts
@@ -14,6 +14,7 @@ export type TypedSignDataV1Type = {
 }[];
 
 export type SecurityAlertResponse = {
+  block?: number;
   reason: string;
   features?: string[];
   result_type: string;


### PR DESCRIPTION
## **Description**

Fix blockaid reportUrl in redesigned pages.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25656

## **Manual testing steps**

1. Go to malicious permit page
2. Check report url

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
