### PR TITLE
fix: caveat mutations for non-EVM accounts

### DIFF
--- a/app/scripts/controllers/permissions/caveat-mutators.js
+++ b/app/scripts/controllers/permissions/caveat-mutators.js
@@ -1,6 +1,6 @@
 import { CaveatMutatorOperation } from '@metamask/permission-controller';
-import { toChecksumAddress } from 'ethereumjs-util';
 import { CaveatTypes } from '../../../../shared/constants/permissions';
+import { normalizeSafeAddress } from '../../lib/multichain/address';
 
 /**
  * Factories that construct caveat mutator functions that are passed to
@@ -27,9 +27,9 @@ export const CaveatMutatorFactories = {
  * account permissions.
  */
 function removeAccount(targetAccount, existingAccounts) {
-  const checkSumTargetAccount = toChecksumAddress(targetAccount);
+  const checkSumTargetAccount = normalizeSafeAddress(targetAccount);
   const newAccounts = existingAccounts.filter(
-    (address) => toChecksumAddress(address) !== checkSumTargetAccount,
+    (address) => normalizeSafeAddress(address) !== checkSumTargetAccount,
   );
 
   if (newAccounts.length === existingAccounts.length) {

--- a/app/scripts/controllers/permissions/caveat-mutators.test.js
+++ b/app/scripts/controllers/permissions/caveat-mutators.test.js
@@ -2,6 +2,10 @@ import { CaveatMutatorOperation } from '@metamask/permission-controller';
 import { CaveatTypes } from '../../../../shared/constants/permissions';
 import { CaveatMutatorFactories } from './caveat-mutators';
 
+const address1 = '0xbf16f7f5db8ae6af2512399bace3101debbde7fc';
+const address2 = '0xb6d5abeca51bfc3d53d00afed06b17eeea32ecdf';
+const nonEvmAddress = 'bc1qdkwac3em6mvlur4fatn2g4q050f4kkqadrsmnp';
+
 describe('caveat mutators', () => {
   describe('restrictReturnedAccounts', () => {
     const { removeAccount } =
@@ -9,31 +13,53 @@ describe('caveat mutators', () => {
 
     describe('removeAccount', () => {
       it('returns the no-op operation if the target account is not permitted', () => {
-        expect(removeAccount('0x2', ['0x1'])).toStrictEqual({
+        expect(removeAccount(address2, [address1])).toStrictEqual({
           operation: CaveatMutatorOperation.noop,
         });
       });
 
       it('returns the update operation and a new value if the target account is permitted', () => {
-        expect(removeAccount('0x2', ['0x1', '0x2'])).toStrictEqual({
+        expect(removeAccount(address2, [address1, address2])).toStrictEqual({
           operation: CaveatMutatorOperation.updateValue,
-          value: ['0x1'],
+          value: [address1],
         });
       });
 
       it('returns the revoke permission operation the target account is the only permitted account', () => {
-        expect(removeAccount('0x1', ['0x1'])).toStrictEqual({
+        expect(removeAccount(address1, [address1])).toStrictEqual({
           operation: CaveatMutatorOperation.revokePermission,
         });
       });
 
       it('returns the revoke permission operation even if the target account is a checksummed address', () => {
-        expect(
-          removeAccount('0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAee5', [
-            '0x95222290dd7278aa3ddd389cc1e1d165cc4baee5',
-          ]),
-        ).toStrictEqual({
+        const address3 = '0x95222290dd7278aa3ddd389cc1e1d165cc4baee5';
+        const checksummedAddress3 =
+          '0x95222290dd7278AA3DDd389cc1E1d165Cc4BaeE5';
+        expect(removeAccount(checksummedAddress3, [address3])).toStrictEqual({
           operation: CaveatMutatorOperation.revokePermission,
+        });
+      });
+
+      describe('Multichain behaviour', () => {
+        it('returns the no-op operation if the target account is not permitted', () => {
+          expect(removeAccount(address2, [nonEvmAddress])).toStrictEqual({
+            operation: CaveatMutatorOperation.noop,
+          });
+        });
+
+        it('can revoke permission for non-EVM addresses', () => {
+          expect(removeAccount(nonEvmAddress, [nonEvmAddress])).toStrictEqual({
+            operation: CaveatMutatorOperation.revokePermission,
+          });
+        });
+
+        it('returns the update operation and a new value if the target non-EVM account is permitted', () => {
+          expect(
+            removeAccount(nonEvmAddress, [address1, nonEvmAddress]),
+          ).toStrictEqual({
+            operation: CaveatMutatorOperation.updateValue,
+            value: [address1],
+          });
         });
       });
     });

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.component.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.component.js
@@ -16,7 +16,7 @@ export default class ConfirmRemoveAccount extends Component {
   static propTypes = {
     hideModal: PropTypes.func.isRequired,
     removeAccount: PropTypes.func.isRequired,
-    account: InternalAccountPropType.isRequired,
+    account: InternalAccountPropType,
     network: MultichainNetworkPropType.isRequired,
   };
 

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.component.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.component.js
@@ -16,7 +16,7 @@ export default class ConfirmRemoveAccount extends Component {
   static propTypes = {
     hideModal: PropTypes.func.isRequired,
     removeAccount: PropTypes.func.isRequired,
-    account: InternalAccountPropType,
+    account: InternalAccountPropType.isRequired,
     network: MultichainNetworkPropType.isRequired,
   };
 

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -94,7 +94,7 @@ export const InternalAccountPropType = PropTypes.shape({
     }).isRequired,
   }).isRequired,
   type: PropTypes.string.isRequired,
-}).isRequired;
+});
 
 export function getMultichainNetworkProviders(
   _state: MultichainState,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an edge case were the account removal of non EVM accounts is broken if there was an existing EVM dapp permission 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create BTC account
2. Switch to evm account
3. Connect to a dapp
4. Remove the BTC account successfully. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
