### PR TITLE
feat: Enable hardware wallets for smart transactions in swaps

### DIFF
--- a/app/scripts/lib/transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/transaction/smart-transactions.test.ts
@@ -110,6 +110,7 @@ describe('submitSmartTransactionHook', () => {
       smartTransactionsController: createSmartTransactionsControllerMock(),
       transactionController: createTransactionControllerMock(),
       isSmartTransaction: true,
+      isHardwareWallet: false,
       controllerMessenger: createSmartTransactionsControllerMessengerMock(),
       featureFlags: {
         extensionActive: true,
@@ -144,6 +145,13 @@ describe('submitSmartTransactionHook', () => {
   it('falls back to regular transaction submit if the transaction type is "swapApproval"', async () => {
     const request: SubmitSmartTransactionRequestMocked = createRequest();
     request.transactionMeta.type = TransactionType.swapApproval;
+    const result = await submitSmartTransactionHook(request);
+    expect(result).toEqual({ transactionHash: undefined });
+  });
+
+  it('falls back to regular transaction submit if a hardware wallet is used', async () => {
+    const request: SubmitSmartTransactionRequestMocked = createRequest();
+    request.isHardwareWallet = true;
     const result = await submitSmartTransactionHook(request);
     expect(result).toEqual({ transactionHash: undefined });
   });

--- a/app/scripts/lib/transaction/smart-transactions.ts
+++ b/app/scripts/lib/transaction/smart-transactions.ts
@@ -63,6 +63,7 @@ export type SubmitSmartTransactionRequest = {
   smartTransactionsController: SmartTransactionsController;
   transactionController: TransactionController;
   isSmartTransaction: boolean;
+  isHardwareWallet: boolean;
   controllerMessenger: SmartTransactionsControllerMessenger;
   featureFlags: FeatureFlags;
 };
@@ -90,6 +91,8 @@ class SmartTransactionHook {
 
   #isSmartTransaction: boolean;
 
+  #isHardwareWallet: boolean;
+
   #smartTransactionsController: SmartTransactionsController;
 
   #transactionController: TransactionController;
@@ -104,6 +107,7 @@ class SmartTransactionHook {
       smartTransactionsController,
       transactionController,
       isSmartTransaction,
+      isHardwareWallet,
       controllerMessenger,
       featureFlags,
     } = request;
@@ -113,6 +117,7 @@ class SmartTransactionHook {
     this.#smartTransactionsController = smartTransactionsController;
     this.#transactionController = transactionController;
     this.#isSmartTransaction = isSmartTransaction;
+    this.#isHardwareWallet = isHardwareWallet;
     this.#controllerMessenger = controllerMessenger;
     this.#featureFlags = featureFlags;
     this.#isDapp = transactionMeta.origin !== ORIGIN_METAMASK;
@@ -132,6 +137,7 @@ class SmartTransactionHook {
     const useRegularTransactionSubmit = { transactionHash: undefined };
     if (
       !this.#isSmartTransaction ||
+      this.#isHardwareWallet ||
       isUnsupportedTransactionTypeForSmartTransaction
     ) {
       return useRegularTransactionSubmit;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -205,6 +205,7 @@ import { isManifestV3 } from '../../shared/modules/mv3.utils';
 import { convertNetworkId } from '../../shared/modules/network.utils';
 import {
   getIsSmartTransaction,
+  isHardwareWallet,
   getFeatureFlagsByChainId,
   getSmartTransactionsOptInStatus,
   getCurrentChainSupportsSmartTransactions,
@@ -6748,6 +6749,7 @@ export default class MetamaskController extends EventEmitter {
       smartTransactionsController: this.smartTransactionsController,
       controllerMessenger: this.controllerMessenger,
       isSmartTransaction,
+      isHardwareWallet: isHardwareWallet(state),
       featureFlags,
     });
   }

--- a/shared/modules/selectors/account.ts
+++ b/shared/modules/selectors/account.ts
@@ -1,0 +1,3 @@
+import { isHardwareWallet } from '../../../ui/selectors/selectors';
+
+export { isHardwareWallet };

--- a/shared/modules/selectors/index.test.ts
+++ b/shared/modules/selectors/index.test.ts
@@ -129,7 +129,7 @@ describe('Selectors', () => {
       expect(getSmartTransactionsEnabled(state)).toBe(false);
     });
 
-    it('returns false if feature flag is enabled, is a HW and is Ethereum network', () => {
+    it('returns true if feature flag is enabled, is a HW and is Ethereum network', () => {
       const state = createSwapsMockStore();
       const newState = {
         ...state,
@@ -150,7 +150,7 @@ describe('Selectors', () => {
           },
         },
       };
-      expect(getSmartTransactionsEnabled(newState)).toBe(false);
+      expect(getSmartTransactionsEnabled(newState)).toBe(true);
     });
 
     it('returns false if feature flag is enabled, not a HW and is Polygon network', () => {

--- a/shared/modules/selectors/index.ts
+++ b/shared/modules/selectors/index.ts
@@ -2,3 +2,4 @@ export * from './smart-transactions';
 export * from './feature-flags';
 export * from './token-auto-detect';
 export * from './nft-auto-detect';
+export * from './account';

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -227,8 +227,7 @@ export function isHardwareWallet(state) {
  */
 export function accountSupportsSmartTx(state) {
   const accountType = getAccountType(state);
-
-  return Boolean(accountType !== 'hardware' && accountType !== 'snap');
+  return Boolean(accountType !== 'snap');
 }
 
 /**

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -898,6 +898,46 @@ describe('Selectors', () => {
       const mockStateWithTrezor = modifyStateWithHWKeyring(KeyringType.trezor);
       expect(selectors.isHardwareWallet(mockStateWithTrezor)).toBe(true);
     });
+
+    it('returns true if it is a Lattice HW wallet', () => {
+      const mockStateWithLattice = modifyStateWithHWKeyring(
+        KeyringType.lattice,
+      );
+      expect(selectors.isHardwareWallet(mockStateWithLattice)).toBe(true);
+    });
+
+    it('returns true if it is a QR HW wallet', () => {
+      const mockStateWithQr = modifyStateWithHWKeyring(KeyringType.qr);
+      expect(selectors.isHardwareWallet(mockStateWithQr)).toBe(true);
+    });
+  });
+
+  describe('#accountSupportsSmartTx', () => {
+    it('returns false if the account type is "snap"', () => {
+      const state = {
+        metamask: {
+          internalAccounts: {
+            accounts: {
+              'mock-id-1': {
+                address: '0x987654321',
+                metadata: {
+                  name: 'Account 1',
+                  keyring: {
+                    type: 'Snap Keyring',
+                  },
+                },
+              },
+            },
+            selectedAccount: 'mock-id-1',
+          },
+        },
+      };
+      expect(selectors.accountSupportsSmartTx(state)).toBe(false);
+    });
+
+    it('returns true if the account type is not "snap"', () => {
+      expect(selectors.accountSupportsSmartTx(mockState)).toBe(true);
+    });
   });
 
   describe('#getHardwareWalletType', () => {


### PR DESCRIPTION
## **Description**
This enables hardware wallets to be used with smart transactions in MetaMask swaps.

Updated event props for some events will be in an upcoming PR.

## **Related issues**

Fixes:

## **Manual testing steps**

1. When a HW wallet is used in swaps on Ethereum Mainnet and smart transactions are enabled in settings, a transaction will be send as a smart transaction.
2. For all other transaction types smart transactions will remain disabled for now if a user uses a HW wallet.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
