### PR TITLE
cherry-pick: fix blockaid report url in redesigned pages

### DIFF
--- a/app/scripts/lib/ppom/types.ts
+++ b/app/scripts/lib/ppom/types.ts
@@ -1,4 +1,5 @@
 export type SecurityAlertResponse = {
+  block?: number;
   description?: string;
   features?: string[];
   providerRequestsCount?: Record<string, number>;

--- a/ui/ducks/confirm-alerts/confirm-alerts.ts
+++ b/ui/ducks/confirm-alerts/confirm-alerts.ts
@@ -52,6 +52,11 @@ export type Alert = {
    * The severity of the alert.
    */
   severity: AlertSeverity;
+
+  /**
+   * URL to report issue.
+   */
+  reportUrl?: string;
 };
 
 /**

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -44,6 +44,7 @@ function ConfirmBannerAlert({ ownerId }: { ownerId: string }) {
         severity={highestSeverity}
         provider={hasMultipleAlerts ? undefined : singleAlert.provider}
         details={hasMultipleAlerts ? undefined : singleAlert.alertDetails}
+        reportUrl={singleAlert.reportUrl}
       />
     </Box>
   );

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlert.test.ts
@@ -92,6 +92,7 @@ describe('useBlockaidAlert', () => {
       provider: SecurityProvider.Blockaid,
       reason: 'This is a deceptive request',
     };
+
     const { result } = renderHookWithProvider(() => useBlockaidAlert(), {
       ...mockExpectedState,
       metamask: {
@@ -102,6 +103,8 @@ describe('useBlockaidAlert', () => {
       },
     });
     expect(result.current).toHaveLength(1);
+    expect(result.current[0].reportUrl).toBeDefined();
+    delete result.current[0].reportUrl;
     expect(result.current[0]).toStrictEqual(alertResponseExpected);
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlert.ts
@@ -1,13 +1,24 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import BlockaidPackage from '@blockaid/ppom_release/package.json';
 
-import { BlockaidResultType } from '../../../../../shared/constants/security-provider';
+import {
+  BlockaidResultType,
+  FALSE_POSITIVE_REPORT_BASE_URL,
+  SECURITY_PROVIDER_UTM_SOURCE,
+} from '../../../../../shared/constants/security-provider';
+import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
+import { NETWORK_TO_NAME_MAP } from '../../../../../shared/constants/network';
 import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
+import { getCurrentChainId } from '../../../../selectors';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { SecurityAlertResponse } from '../../types/confirm';
-import { isSignatureTransactionType } from '../../utils';
 import useCurrentConfirmation from '../useCurrentConfirmation';
 import { normalizeProviderAlert } from './utils';
+import { isSignatureTransactionType } from '../../utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const zlib = require('zlib');
 
 type SignatureSecurityAlertResponsesState = {
   metamask: {
@@ -21,12 +32,47 @@ const useBlockaidAlerts = (): Alert[] => {
   const securityAlertResponse =
     currentConfirmation?.securityAlertResponse as SecurityAlertResponse;
 
+  const selectorChainId = useSelector(getCurrentChainId);
+
   const signatureSecurityAlertResponse = useSelector(
     (state: SignatureSecurityAlertResponsesState) =>
       state.metamask.signatureSecurityAlertResponses?.[
         securityAlertResponse?.securityAlertId as string
       ],
   );
+
+  let stringifiedJSONData: string | undefined;
+
+  if (securityAlertResponse && currentConfirmation) {
+    const {
+      block,
+      features,
+      reason,
+      result_type: resultType,
+    } = securityAlertResponse as SecurityAlertResponse;
+    const { chainId, msgParams, origin, type, txParams } = currentConfirmation;
+
+    const isFailedResultType = resultType === BlockaidResultType.Errored;
+
+    const reportData = {
+      blockNumber: block,
+      blockaidVersion: BlockaidPackage.version,
+      chain: (NETWORK_TO_NAME_MAP as Record<string, string>)[
+        chainId ?? selectorChainId
+      ],
+      classification: isFailedResultType ? 'error' : reason,
+      domain:
+        origin ??
+        (msgParams as { origin: string })?.origin ??
+        (txParams as { origin: string })?.origin,
+      jsonRpcMethod: type,
+      jsonRpcParams: JSON.stringify(txParams ?? msgParams),
+      resultType: isFailedResultType ? BlockaidResultType.Errored : resultType,
+      reproduce: JSON.stringify(features),
+    };
+
+    stringifiedJSONData = JSON.stringify(reportData);
+  }
 
   const alerts = useMemo<Alert[]>(() => {
     if (!isSignatureTransactionType(currentConfirmation)) {
@@ -42,7 +88,19 @@ const useBlockaidAlerts = (): Alert[] => {
       return [];
     }
 
-    return [normalizeProviderAlert(signatureSecurityAlertResponse, t)];
+    let reportUrl = ZENDESK_URLS.SUPPORT_URL;
+    if (stringifiedJSONData) {
+      const encodedData =
+        zlib?.gzipSync?.(stringifiedJSONData) ?? stringifiedJSONData;
+
+      reportUrl = `${FALSE_POSITIVE_REPORT_BASE_URL}?data=${encodeURIComponent(
+        encodedData.toString('base64'),
+      )}&utm_source=${SECURITY_PROVIDER_UTM_SOURCE}`;
+    }
+
+    return [
+      normalizeProviderAlert(signatureSecurityAlertResponse, t, reportUrl),
+    ];
   }, [currentConfirmation, signatureSecurityAlertResponse]);
 
   return alerts;

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlert.ts
@@ -13,9 +13,9 @@ import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
 import { getCurrentChainId } from '../../../../selectors';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { SecurityAlertResponse } from '../../types/confirm';
+import { isSignatureTransactionType } from '../../utils';
 import useCurrentConfirmation from '../useCurrentConfirmation';
 import { normalizeProviderAlert } from './utils';
-import { isSignatureTransactionType } from '../../utils';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const zlib = require('zlib');

--- a/ui/pages/confirmations/hooks/alerts/utils.ts
+++ b/ui/pages/confirmations/hooks/alerts/utils.ts
@@ -38,11 +38,13 @@ export function getProviderAlertSeverity(
  *
  * @param securityAlertResponse - The security alert response to normalize.
  * @param t - The translation function.
+ * @param reportUrl - URL to report.
  * @returns The normalized Alert object.
  */
 export function normalizeProviderAlert(
   securityAlertResponse: SecurityAlertResponse,
   t: ReturnType<typeof useI18nContext>,
+  reportUrl?: string,
 ): Alert {
   return {
     key: securityAlertResponse.securityAlertId || '',
@@ -61,5 +63,6 @@ export function normalizeProviderAlert(
       ] || REASON_TO_DESCRIPTION_TKEY.other,
     ),
     provider: SecurityProvider.Blockaid, // TODO: Remove this once we support more providers and implement a way to determine it.
+    reportUrl,
   };
 }

--- a/ui/pages/confirmations/types/confirm.ts
+++ b/ui/pages/confirmations/types/confirm.ts
@@ -11,6 +11,7 @@ export type TypedSignDataV1Type = {
 }[];
 
 export type SecurityAlertResponse = {
+  block?: number;
   reason: string;
   features?: string[];
   result_type: string;


### PR DESCRIPTION
## **Description**

Fix blockaid reportUrl in redesigned pages.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25656

## **Manual testing steps**

1. Go to malicious permit page
2. Check report url

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
