### PR TITLE
feat: Migration #122 set useTransactionSimulations to true

### DIFF
--- a/app/scripts/migrations/122.test.ts
+++ b/app/scripts/migrations/122.test.ts
@@ -1,0 +1,66 @@
+import { migrate, version } from './122';
+
+const oldVersion = 121;
+
+describe('migration #122', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: oldVersion,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  describe('set useTransactionSimulations to true in PreferencesController', () => {
+    it('sets useTransactionSimulations to true', async () => {
+      const oldStorage = {
+        PreferencesController: {
+          useTransactionSimulations: false,
+        },
+      };
+
+      const expectedState = {
+        PreferencesController: {
+          useTransactionSimulations: true,
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: oldStorage,
+      });
+
+      expect(transformedState.data).toEqual(expectedState);
+    });
+
+    it('should not update useTransactionSimulations value if it was set true in initial state', async () => {
+      const oldStorage = {
+        PreferencesController: {
+          useTransactionSimulations: true,
+        },
+      };
+
+      const expectedState = {
+        PreferencesController: {
+          useTransactionSimulations: true,
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: oldStorage,
+      });
+
+      expect(transformedState.data).toEqual(expectedState);
+    });
+  });
+});

--- a/app/scripts/migrations/122.ts
+++ b/app/scripts/migrations/122.ts
@@ -1,0 +1,51 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 122;
+
+/**
+ * This migration sets preference useTransactionSimulations to true
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+// TODO: Replace `any` with specific type
+function transformState(state: Record<string, any>) {
+  if (!hasProperty(state, 'PreferencesController')) {
+    return state;
+  }
+
+  if (!isObject(state.PreferencesController)) {
+    const controllerType = typeof state.PreferencesController;
+    global.sentry?.captureException?.(
+      new Error(`state.PreferencesController is type: ${controllerType}`),
+    );
+    state.PreferencesController = {};
+  }
+
+  if (
+    state.PreferencesController.useTransactionSimulations === false ||
+    state.PreferencesController.useTransactionSimulations === undefined
+  ) {
+    state.PreferencesController.useTransactionSimulations = true;
+  }
+
+  return state;
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This migration sets useTransactionSimulations to true. Some users may have explicitly turned off the experimental setting, which this migration will reset to true. This is intentional as we also plan to remove the setting in an upcoming release. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25768?quickstart=1)

## **Related issues**

## **Manual testing steps**

1. Turn off the Experimental > Improved signature redesign setting
2. Run newest version with migration
3. Observe setting has been turned on

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
