### PR TITLE
feat: support creation of Bitcoin testnet accounts

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -283,6 +283,9 @@
   "addNewBitcoinAccount": {
     "message": "Add a new Bitcoin account (Beta)"
   },
+  "addNewBitcoinTestnetAccount": {
+    "message": "Add a new Bitcoin account (testnet)"
+  },
   "addNewToken": {
     "message": "Add new token"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -771,9 +771,6 @@
   "bitcoinSupportToggleTitle": {
     "message": "Enable \"Add a new Bitcoin account (Beta)\""
   },
-  "bitcoinTestnetSupportSectionTitle": {
-    "message": "Bitcoin"
-  },
   "bitcoinTestnetSupportToggleDescription": {
     "message": "Turning on this feature will give you the option to add a Bitcoin Account for test network. "
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -284,7 +284,7 @@
     "message": "Add a new Bitcoin account (Beta)"
   },
   "addNewBitcoinTestnetAccount": {
-    "message": "Add a new Bitcoin account (testnet)"
+    "message": "Add a new Bitcoin account (Testnet)"
   },
   "addNewToken": {
     "message": "Add new token"
@@ -770,6 +770,15 @@
   },
   "bitcoinSupportToggleTitle": {
     "message": "Enable \"Add a new Bitcoin account (Beta)\""
+  },
+  "bitcoinTestnetSupportSectionTitle": {
+    "message": "Bitcoin"
+  },
+  "bitcoinTestnetSupportToggleDescription": {
+    "message": "Turning on this feature will give you the option to add a Bitcoin Account for test network. "
+  },
+  "bitcoinTestnetSupportToggleTitle": {
+    "message": "Enable \"Add a new Bitcoin account (Testnet)\""
   },
   "blockExplorerAccountAction": {
     "message": "Account",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -772,7 +772,7 @@
     "message": "Enable \"Add a new Bitcoin account (Beta)\""
   },
   "bitcoinTestnetSupportToggleDescription": {
-    "message": "Turning on this feature will give you the option to add a Bitcoin Account for test network. "
+    "message": "Turning on this feature will give you the option to add a Bitcoin Account for the test network."
   },
   "bitcoinTestnetSupportToggleTitle": {
     "message": "Enable \"Add a new Bitcoin account (Testnet)\""

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -62,6 +62,7 @@ export default class PreferencesController {
       openSeaEnabled: true, // todo set this to true
       securityAlertsEnabled: true,
       bitcoinSupportEnabled: false,
+      bitcoinTestnetSupportEnabled: false,
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       addSnapAccountEnabled: false,
       ///: END:ONLY_INCLUDE_IF
@@ -295,11 +296,23 @@ export default class PreferencesController {
    * Setter for the `bitcoinSupportEnabled` property.
    *
    * @param {boolean} bitcoinSupportEnabled - Whether or not the user wants to
-   * enable the "Add a new Bitcoin account" button.
+   * enable the "Add a new Bitcoin account (Beta)" button.
    */
   setBitcoinSupportEnabled(bitcoinSupportEnabled) {
     this.store.updateState({
       bitcoinSupportEnabled,
+    });
+  }
+
+  /**
+   * Setter for the `bitcoinTestnetSupportEnabled` property.
+   *
+   * @param {boolean} bitcoinTestnetSupportEnabled - Whether or not the user wants to
+   * enable the "Add a new Bitcoin testnet account (Beta)" button.
+   */
+  setBitcoinTestnetSupportEnabled(bitcoinTestnetSupportEnabled) {
+    this.store.updateState({
+      bitcoinTestnetSupportEnabled,
     });
   }
 

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -308,7 +308,7 @@ export default class PreferencesController {
    * Setter for the `bitcoinTestnetSupportEnabled` property.
    *
    * @param {boolean} bitcoinTestnetSupportEnabled - Whether or not the user wants to
-   * enable the "Add a new Bitcoin testnet account (Beta)" button.
+   * enable the "Add a new Bitcoin account (Testnet)" button.
    */
   setBitcoinTestnetSupportEnabled(bitcoinTestnetSupportEnabled) {
     this.store.updateState({

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -425,6 +425,7 @@ export const SENTRY_UI_STATE = {
     confirmationExchangeRates: true,
     useSafeChainsListValidation: true,
     bitcoinSupportEnabled: false,
+    bitcoinTestnetSupportEnabled: false,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     addSnapAccountEnabled: false,
     snapsAddSnapAccountModalDismissed: false,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3021,6 +3021,10 @@ export default class MetamaskController extends EventEmitter {
         preferencesController.setBitcoinSupportEnabled.bind(
           preferencesController,
         ),
+      setBitcoinTestnetSupportEnabled:
+        preferencesController.setBitcoinTestnetSupportEnabled.bind(
+          preferencesController,
+        ),
       setUseExternalNameSources:
         preferencesController.setUseExternalNameSources.bind(
           preferencesController,

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -513,6 +513,7 @@ export enum MetaMetricsEventName {
   AppWindowExpanded = 'App Window Expanded',
   BridgeLinkClicked = 'Bridge Link Clicked',
   BitcoinSupportToggled = 'Bitcoin Support Toggled',
+  BitcoinTestnetSupportToggled = 'Bitcoin Testnet Support Toggled',
   DappViewed = 'Dapp Viewed',
   DecryptionApproved = 'Decryption Approved',
   DecryptionRejected = 'Decryption Rejected',

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -1881,6 +1881,7 @@
     ],
     "addSnapAccountEnabled": false,
     "bitcoinSupportEnabled": false,
+    "bitcoinTestnetSupportEnabled": false,
     "pendingApprovals": {
       "testApprovalId": {
         "id": "testApprovalId",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -185,6 +185,7 @@
     "openSeaEnabled": false,
     "securityAlertsEnabled": "boolean",
     "bitcoinSupportEnabled": "boolean",
+    "bitcoinTestnetSupportEnabled": "boolean",
     "addSnapAccountEnabled": "boolean",
     "advancedGasFee": {},
     "featureFlags": {},

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -123,6 +123,7 @@
     "securityAlertsEnabled": "boolean",
     "addSnapAccountEnabled": "boolean",
     "bitcoinSupportEnabled": "boolean",
+    "bitcoinTestnetSupportEnabled": "boolean",
     "advancedGasFee": {},
     "incomingTransactionsPreferences": {},
     "identities": "object",

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -71,8 +71,8 @@ import {
   hasCreatedBtcMainnetAccount,
   hasCreatedBtcTestnetAccount,
 } from '../../../selectors/accounts';
-///: END:ONLY_INCLUDE_IF
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
+///: END:ONLY_INCLUDE_IF
 import { HiddenAccountList } from './hidden-account-list';
 
 const ACTION_MODES = {

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -69,6 +69,7 @@ import { getAccountLabel } from '../../../helpers/utils/accounts';
 import { hasCreatedBtcMainnetAccount } from '../../../selectors/accounts';
 ///: END:ONLY_INCLUDE_IF
 import { HiddenAccountList } from './hidden-account-list';
+import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 
 const ACTION_MODES = {
   // Displays the search box and account list
@@ -80,6 +81,8 @@ const ACTION_MODES = {
   ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   // Displays the add account form controls (for bitcoin account)
   ADD_BITCOIN: 'add-bitcoin',
+  // Same but for testnet
+  ADD_BITCOIN_TESTNET: 'add-bitcoin-testnet',
   ///: END:ONLY_INCLUDE_IF
   // Displays the import account form controls
   IMPORT: 'import',
@@ -98,6 +101,8 @@ export const getActionTitle = (t, actionMode) => {
       return t('addAccount');
     ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
     case ACTION_MODES.ADD_BITCOIN:
+      return t('addAccount');
+    case ACTION_MODES.ADD_BITCOIN_TESTNET:
       return t('addAccount');
     ///: END:ONLY_INCLUDE_IF
     case ACTION_MODES.MENU:
@@ -161,6 +166,10 @@ export const AccountListMenu = ({
   );
   ///: END:ONLY_INCLUDE_IF
 
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  const isBtcTestnetEnabled = true; // TODO: Use a feature flag for this?
+  ///: END:ONLY_INCLUDE_IF
+
   const [searchQuery, setSearchQuery] = useState('');
   const [actionMode, setActionMode] = useState(ACTION_MODES.LIST);
 
@@ -219,10 +228,33 @@ export const AccountListMenu = ({
           </Box>
         ) : null}
         {
+          // Bitcoin mainnet:
           ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
           bitcoinSupportEnabled && actionMode === ACTION_MODES.ADD_BITCOIN ? (
             <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
               <CreateBtcAccount
+                defaultAccountName='Bitcoin Account'
+                network={MultichainNetworks.BITCOIN}
+                onActionComplete={(confirmed) => {
+                  if (confirmed) {
+                    onClose();
+                  } else {
+                    setActionMode(ACTION_MODES.LIST);
+                  }
+                }}
+              />
+            </Box>
+          ) : null
+          ///: END:ONLY_INCLUDE_IF
+        }
+        {
+          // Bitcoin testnet:
+          ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+          isBtcTestnetEnabled && actionMode === ACTION_MODES.ADD_BITCOIN_TESTNET ? (
+            <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
+              <CreateBtcAccount
+                defaultAccountName='Bitcoin Testnet Account'
+                network={MultichainNetworks.BITCOIN_TESTNET}
                 onActionComplete={(confirmed) => {
                   if (confirmed) {
                     onClose();
@@ -301,6 +333,22 @@ export const AccountListMenu = ({
                   </ButtonLink>
                 </Box>
               ) : null
+              ///: END:ONLY_INCLUDE_IF
+            }
+            {
+              ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+              <Box marginTop={4}>
+                <ButtonLink
+                  size={Size.SM}
+                  startIconName={IconName.Add}
+                  onClick={() => {
+                    setActionMode(ACTION_MODES.ADD_BITCOIN_TESTNET);
+                  }}
+                  data-testid="multichain-account-menu-popover-add-account-testnet"
+                >
+                  {t('addNewBitcoinTestnetAccount')}
+                </ButtonLink>
+              </Box>
               ///: END:ONLY_INCLUDE_IF
             }
             <Box marginTop={4}>

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -48,6 +48,7 @@ import {
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   getIsBitcoinSupportEnabled,
+  getIsBitcoinTestnetSupportEnabled,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
 import { setSelectedAccount } from '../../../store/actions';
@@ -66,10 +67,13 @@ import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { getAccountLabel } from '../../../helpers/utils/accounts';
 ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
-import { hasCreatedBtcMainnetAccount } from '../../../selectors/accounts';
+import {
+  hasCreatedBtcMainnetAccount,
+  hasCreatedBtcTestnetAccount,
+} from '../../../selectors/accounts';
 ///: END:ONLY_INCLUDE_IF
-import { HiddenAccountList } from './hidden-account-list';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
+import { HiddenAccountList } from './hidden-account-list';
 
 const ACTION_MODES = {
   // Displays the search box and account list
@@ -161,13 +165,15 @@ export const AccountListMenu = ({
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   const bitcoinSupportEnabled = useSelector(getIsBitcoinSupportEnabled);
+  const bitcoinTestnetSupportEnabled = useSelector(
+    getIsBitcoinTestnetSupportEnabled,
+  );
   const isBtcMainnetAccountAlreadyCreated = useSelector(
     hasCreatedBtcMainnetAccount,
   );
-  ///: END:ONLY_INCLUDE_IF
-
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
-  const isBtcTestnetEnabled = true; // TODO: Use a feature flag for this?
+  const isBtcTestnetAccountAlreadyCreated = useSelector(
+    hasCreatedBtcTestnetAccount,
+  );
   ///: END:ONLY_INCLUDE_IF
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -233,7 +239,7 @@ export const AccountListMenu = ({
           bitcoinSupportEnabled && actionMode === ACTION_MODES.ADD_BITCOIN ? (
             <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
               <CreateBtcAccount
-                defaultAccountName='Bitcoin Account'
+                defaultAccountName="Bitcoin Account"
                 network={MultichainNetworks.BITCOIN}
                 onActionComplete={(confirmed) => {
                   if (confirmed) {
@@ -250,10 +256,11 @@ export const AccountListMenu = ({
         {
           // Bitcoin testnet:
           ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
-          isBtcTestnetEnabled && actionMode === ACTION_MODES.ADD_BITCOIN_TESTNET ? (
+          bitcoinTestnetSupportEnabled &&
+          actionMode === ACTION_MODES.ADD_BITCOIN_TESTNET ? (
             <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
               <CreateBtcAccount
-                defaultAccountName='Bitcoin Testnet Account'
+                defaultAccountName="Bitcoin Testnet Account"
                 network={MultichainNetworks.BITCOIN_TESTNET}
                 onActionComplete={(confirmed) => {
                   if (confirmed) {
@@ -337,18 +344,21 @@ export const AccountListMenu = ({
             }
             {
               ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
-              <Box marginTop={4}>
-                <ButtonLink
-                  size={Size.SM}
-                  startIconName={IconName.Add}
-                  onClick={() => {
-                    setActionMode(ACTION_MODES.ADD_BITCOIN_TESTNET);
-                  }}
-                  data-testid="multichain-account-menu-popover-add-account-testnet"
-                >
-                  {t('addNewBitcoinTestnetAccount')}
-                </ButtonLink>
-              </Box>
+              bitcoinTestnetSupportEnabled ? (
+                <Box marginTop={4}>
+                  <ButtonLink
+                    disabled={isBtcTestnetAccountAlreadyCreated}
+                    size={Size.SM}
+                    startIconName={IconName.Add}
+                    onClick={() => {
+                      setActionMode(ACTION_MODES.ADD_BITCOIN_TESTNET);
+                    }}
+                    data-testid="multichain-account-menu-popover-add-account-testnet"
+                  >
+                    {t('addNewBitcoinTestnetAccount')}
+                  </ButtonLink>
+                </Box>
+              ) : null
               ///: END:ONLY_INCLUDE_IF
             }
             <Box marginTop={4}>

--- a/ui/components/multichain/create-btc-account/create-btc-account.stories.js
+++ b/ui/components/multichain/create-btc-account/create-btc-account.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { CreateBtcAccount } from '.';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
+import { CreateBtcAccount } from '.';
 
 export default {
   title: 'Components/Multichain/CreateBtcAccount',

--- a/ui/components/multichain/create-btc-account/create-btc-account.stories.js
+++ b/ui/components/multichain/create-btc-account/create-btc-account.stories.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import { CreateBtcAccount } from '.';
+import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 
 export default {
   title: 'Components/Multichain/CreateBtcAccount',
   component: CreateBtcAccount,
+  args: {
+    defaultAccountName: 'Bitcoin Account',
+    network: MultichainNetworks.BITCOIN,
+  },
 };
 
 export const DefaultStory = (args) => <CreateBtcAccount {...args} />;

--- a/ui/components/multichain/create-btc-account/create-btc-account.test.tsx
+++ b/ui/components/multichain/create-btc-account/create-btc-account.test.tsx
@@ -11,7 +11,11 @@ import { CreateBtcAccount } from '.';
 const render = (props = { onActionComplete: jest.fn() }) => {
   const store = configureStore(mockState);
   return renderWithProvider(
-    <CreateBtcAccount network={MultichainNetworks.BITCOIN} {...props} />,
+    <CreateBtcAccount
+      network={MultichainNetworks.BITCOIN}
+      defaultAccountName="Bitcoin Account"
+      {...props}
+    />,
     store,
   );
 };

--- a/ui/components/multichain/create-btc-account/create-btc-account.test.tsx
+++ b/ui/components/multichain/create-btc-account/create-btc-account.test.tsx
@@ -10,7 +10,10 @@ import { CreateBtcAccount } from '.';
 
 const render = (props = { onActionComplete: jest.fn() }) => {
   const store = configureStore(mockState);
-  return renderWithProvider(<CreateBtcAccount network={MultichainNetworks.BITCOIN} {...props} />, store);
+  return renderWithProvider(
+    <CreateBtcAccount network={MultichainNetworks.BITCOIN} {...props} />,
+    store,
+  );
 };
 
 const ACCOUNT_NAME = 'Bitcoin Account';

--- a/ui/components/multichain/create-btc-account/create-btc-account.test.tsx
+++ b/ui/components/multichain/create-btc-account/create-btc-account.test.tsx
@@ -10,7 +10,7 @@ import { CreateBtcAccount } from '.';
 
 const render = (props = { onActionComplete: jest.fn() }) => {
   const store = configureStore(mockState);
-  return renderWithProvider(<CreateBtcAccount {...props} />, store);
+  return renderWithProvider(<CreateBtcAccount network={MultichainNetworks.BITCOIN} {...props} />, store);
 };
 
 const ACCOUNT_NAME = 'Bitcoin Account';

--- a/ui/components/multichain/create-btc-account/create-btc-account.tsx
+++ b/ui/components/multichain/create-btc-account/create-btc-account.tsx
@@ -21,7 +21,7 @@ type CreateBtcAccountOptions = {
   /**
    * Default account name
    */
-  defaultAccountName?: string;
+  defaultAccountName: string;
 };
 
 export const CreateBtcAccount = ({
@@ -55,7 +55,7 @@ export const CreateBtcAccount = ({
   };
 
   const getNextAvailableAccountName = async (_accounts: InternalAccount[]) => {
-    return defaultAccountName ?? 'Bitcoin Account';
+    return defaultAccountName;
   };
 
   return (

--- a/ui/components/multichain/create-btc-account/create-btc-account.tsx
+++ b/ui/components/multichain/create-btc-account/create-btc-account.tsx
@@ -8,16 +8,27 @@ import {
   setAccountLabel,
   forceUpdateMetamaskState,
 } from '../../../store/actions';
+import { CaipChainId } from '@metamask/utils';
 
 type CreateBtcAccountOptions = {
   /**
    * Callback called once the account has been created
    */
   onActionComplete: (completed: boolean) => Promise<void>;
+  /**
+   * CAIP-2 chain ID
+   */
+  network: MultichainNetworks,
+  /**
+   * Default account name
+   */
+  defaultAccountName?: string,
 };
 
 export const CreateBtcAccount = ({
   onActionComplete,
+  defaultAccountName,
+  network,
 }: CreateBtcAccountOptions) => {
   const dispatch = useDispatch();
 
@@ -25,7 +36,7 @@ export const CreateBtcAccount = ({
     // Trigger the Snap account creation flow
     const client = new KeyringClient(new BitcoinWalletSnapSender());
     const account = await client.createAccount({
-      scope: MultichainNetworks.BITCOIN,
+      scope: network,
     });
 
     // TODO: Use the new Snap account creation flow that also include account renaming
@@ -45,7 +56,7 @@ export const CreateBtcAccount = ({
   };
 
   const getNextAvailableAccountName = async (_accounts: InternalAccount[]) => {
-    return 'Bitcoin Account';
+    return defaultAccountName ?? 'Bitcoin Account';
   };
 
   return (

--- a/ui/components/multichain/create-btc-account/create-btc-account.tsx
+++ b/ui/components/multichain/create-btc-account/create-btc-account.tsx
@@ -8,7 +8,6 @@ import {
   setAccountLabel,
   forceUpdateMetamaskState,
 } from '../../../store/actions';
-import { CaipChainId } from '@metamask/utils';
 
 type CreateBtcAccountOptions = {
   /**
@@ -18,11 +17,11 @@ type CreateBtcAccountOptions = {
   /**
    * CAIP-2 chain ID
    */
-  network: MultichainNetworks,
+  network: MultichainNetworks;
   /**
    * Default account name
    */
-  defaultAccountName?: string,
+  defaultAccountName?: string;
 };
 
 export const CreateBtcAccount = ({

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.tsx
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.tsx
@@ -32,6 +32,8 @@ import {
 type ExperimentalTabProps = {
   bitcoinSupportEnabled: boolean;
   setBitcoinSupportEnabled: (value: boolean) => void;
+  bitcoinTestnetSupportEnabled: boolean;
+  setBitcoinTestnetSupportEnabled: (value: boolean) => void;
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   addSnapAccountEnabled: boolean;
   setAddSnapAccountEnabled: (value: boolean) => void;
@@ -241,7 +243,12 @@ export default class ExperimentalTab extends PureComponent<ExperimentalTabProps>
   // we should remove it for the feature release
   renderBitcoinSupport() {
     const { t, trackEvent } = this.context;
-    const { bitcoinSupportEnabled, setBitcoinSupportEnabled } = this.props;
+    const {
+      bitcoinSupportEnabled,
+      setBitcoinSupportEnabled,
+      bitcoinTestnetSupportEnabled,
+      setBitcoinTestnetSupportEnabled,
+    } = this.props;
 
     return (
       <>
@@ -269,6 +276,17 @@ export default class ExperimentalTab extends PureComponent<ExperimentalTabProps>
             setBitcoinSupportEnabled(!value);
           },
           toggleDataTestId: 'bitcoin-support-toggle',
+          toggleOffLabel: t('off'),
+          toggleOnLabel: t('on'),
+        })}
+        {this.renderToggleSection({
+          title: t('bitcoinTestnetSupportToggleTitle'),
+          description: t('bitcoinTestnetSupportToggleDescription'),
+          toggleValue: bitcoinTestnetSupportEnabled,
+          toggleCallback: (value) => {
+            setBitcoinTestnetSupportEnabled(!value);
+          },
+          toggleDataTestId: 'bitcoin-testnet-accounts-toggle',
           toggleOffLabel: t('off'),
           toggleOnLabel: t('on'),
         })}

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.tsx
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.tsx
@@ -284,6 +284,13 @@ export default class ExperimentalTab extends PureComponent<ExperimentalTabProps>
           description: t('bitcoinTestnetSupportToggleDescription'),
           toggleValue: bitcoinTestnetSupportEnabled,
           toggleCallback: (value) => {
+            trackEvent({
+              event: MetaMetricsEventName.BitcoinTestnetSupportToggled,
+              category: MetaMetricsEventCategory.Settings,
+              properties: {
+                enabled: !value,
+              },
+            });
             setBitcoinTestnetSupportEnabled(!value);
           },
           toggleDataTestId: 'bitcoin-testnet-accounts-toggle',

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.ts
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.ts
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import {
   setBitcoinSupportEnabled,
+  setBitcoinTestnetSupportEnabled,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   setAddSnapAccountEnabled,
   ///: END:ONLY_INCLUDE_IF
@@ -13,6 +14,7 @@ import {
 } from '../../../store/actions';
 import {
   getIsBitcoinSupportEnabled,
+  getIsBitcoinTestnetSupportEnabled,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   getIsAddSnapAccountEnabled,
   ///: END:ONLY_INCLUDE_IF
@@ -32,6 +34,7 @@ const mapStateToProps = (state: MetaMaskReduxState) => {
   const featureNotificationsEnabled = getFeatureNotificationsEnabled(state);
   return {
     bitcoinSupportEnabled: getIsBitcoinSupportEnabled(state),
+    bitcoinTestnetSupportEnabled: getIsBitcoinTestnetSupportEnabled(state),
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     addSnapAccountEnabled: getIsAddSnapAccountEnabled(state),
     ///: END:ONLY_INCLUDE_IF
@@ -46,6 +49,8 @@ const mapDispatchToProps = (dispatch: MetaMaskReduxDispatch) => {
   return {
     setBitcoinSupportEnabled: (value: boolean) =>
       setBitcoinSupportEnabled(value),
+    setBitcoinTestnetSupportEnabled: (value: boolean) =>
+      setBitcoinTestnetSupportEnabled(value),
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     setAddSnapAccountEnabled: (value: boolean) =>
       setAddSnapAccountEnabled(value),

--- a/ui/pages/settings/experimental-tab/experimental-tab.test.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.test.js
@@ -30,7 +30,7 @@ describe('ExperimentalTab', () => {
     const { getAllByRole } = render();
     const toggle = getAllByRole('checkbox');
 
-    expect(toggle).toHaveLength(5);
+    expect(toggle).toHaveLength(6);
   });
 
   it('enables add account snap', async () => {

--- a/ui/selectors/accounts.test.ts
+++ b/ui/selectors/accounts.test.ts
@@ -3,12 +3,14 @@ import {
   MOCK_ACCOUNT_EOA,
   MOCK_ACCOUNT_ERC4337,
   MOCK_ACCOUNT_BIP122_P2WPKH,
+  MOCK_ACCOUNT_BIP122_P2WPKH_TESTNET,
 } from '../../test/data/mock-accounts';
 import {
   AccountsState,
   isSelectedInternalAccountEth,
   isSelectedInternalAccountBtc,
   hasCreatedBtcMainnetAccount,
+  hasCreatedBtcTestnetAccount,
 } from './accounts';
 
 const MOCK_STATE: AccountsState = {
@@ -100,6 +102,41 @@ describe('Accounts Selectors', () => {
           internalAccounts: {
             selectedAccount: MOCK_ACCOUNT_EOA.id,
             accounts: [MOCK_ACCOUNT_EOA],
+          },
+        },
+      };
+
+      expect(isSelectedInternalAccountBtc(state)).toBe(false);
+    });
+  });
+
+  describe('hasCreatedBtcTestnetAccount', () => {
+    it('returns true if the BTC testnet account has been created', () => {
+      const state: AccountsState = {
+        metamask: {
+          // No-op for this test, but might be required in the future:
+          ...MOCK_STATE.metamask,
+          internalAccounts: {
+            selectedAccount: MOCK_ACCOUNT_BIP122_P2WPKH.id,
+            accounts: [
+              MOCK_ACCOUNT_BIP122_P2WPKH,
+              MOCK_ACCOUNT_BIP122_P2WPKH_TESTNET,
+            ],
+          },
+        },
+      };
+
+      expect(hasCreatedBtcTestnetAccount(state)).toBe(true);
+    });
+
+    it('returns false if the BTC testnet account has not been created yet', () => {
+      const state: AccountsState = {
+        metamask: {
+          // No-op for this test, but might be required in the future:
+          ...MOCK_STATE.metamask,
+          internalAccounts: {
+            selectedAccount: MOCK_ACCOUNT_BIP122_P2WPKH.id,
+            accounts: [MOCK_ACCOUNT_BIP122_P2WPKH],
           },
         },
       };

--- a/ui/selectors/accounts.ts
+++ b/ui/selectors/accounts.ts
@@ -33,11 +33,11 @@ export function isSelectedInternalAccountBtc(state: AccountsState) {
 
 function hasCreatedBtcAccount(
   state: AccountsState,
-  isAddress: (address: string) => boolean,
+  isAddressCallback: (address: string) => boolean,
 ) {
   const accounts = getInternalAccounts(state);
   return accounts.some((account) => {
-    return isBtcAccount(account) && isAddress(account.address);
+    return isBtcAccount(account) && isAddressCallback(account.address);
   });
 }
 

--- a/ui/selectors/accounts.ts
+++ b/ui/selectors/accounts.ts
@@ -4,7 +4,10 @@ import {
   InternalAccount,
 } from '@metamask/keyring-api';
 import { AccountsControllerState } from '@metamask/accounts-controller';
-import { isBtcMainnetAddress } from '../../shared/lib/multichain';
+import {
+  isBtcMainnetAddress,
+  isBtcTestnetAddress,
+} from '../../shared/lib/multichain';
 import { getSelectedInternalAccount, getInternalAccounts } from './selectors';
 
 export type AccountsState = {
@@ -28,11 +31,20 @@ export function isSelectedInternalAccountBtc(state: AccountsState) {
   return isBtcAccount(getSelectedInternalAccount(state));
 }
 
-export function hasCreatedBtcMainnetAccount(state: AccountsState) {
+function hasCreatedBtcAccount(
+  state: AccountsState,
+  isAddress: (address: string) => boolean,
+) {
   const accounts = getInternalAccounts(state);
   return accounts.some((account) => {
-    // Since we might wanna support testnet accounts later, we do
-    // want to make this one very explicit and check for mainnet addresses!
-    return isBtcAccount(account) && isBtcMainnetAddress(account.address);
+    return isBtcAccount(account) && isAddress(account.address);
   });
+}
+
+export function hasCreatedBtcMainnetAccount(state: AccountsState) {
+  return hasCreatedBtcAccount(state, isBtcMainnetAddress);
+}
+
+export function hasCreatedBtcTestnetAccount(state: AccountsState) {
+  return hasCreatedBtcAccount(state, isBtcTestnetAddress);
 }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2303,6 +2303,16 @@ export function getIsBitcoinSupportEnabled(state) {
   return state.metamask.bitcoinSupportEnabled;
 }
 
+/**
+ * Get the state of the `bitcoinTestnetSupportEnabled` flag.
+ *
+ * @param {*} state
+ * @returns The state of the `bitcoinTestnetSupportEnabled` flag.
+ */
+export function getIsBitcoinTestnetSupportEnabled(state) {
+  return state.metamask.bitcoinTestnetSupportEnabled;
+}
+
 export function getIsCustomNetwork(state) {
   const chainId = getCurrentChainId(state);
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4971,6 +4971,14 @@ export async function setBitcoinSupportEnabled(value: boolean) {
   }
 }
 
+export async function setBitcoinTestnetSupportEnabled(value: boolean) {
+  try {
+    await submitRequestToBackground('setBitcoinTestnetSupportEnabled', [value]);
+  } catch (error) {
+    logErrorWithMessage(error);
+  }
+}
+
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 export async function setAddSnapAccountEnabled(value: boolean): Promise<void> {
   try {


### PR DESCRIPTION
## **Description**

Adds support of testnet account within the extension following the same pattern than for mainnet accounts with a feature flag.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25772?quickstart=1)

## **Related issues**

Fixes: **https://github.com/MetaMask/accounts-planning/issues/511**

## **Manual testing steps**

1. Run `yarn start:flask`
2. Go to the experimental settings tab
3. Enable the "Bitcoin testnet support" toggle
4. Click on the account menu list (on top)
5. You should now see a "Add a new Bitcoin account (Testnet)"
6. Click this button and follow the flow
7. You should now see a testnet account (starting with `tb1q...`)

## **Screenshots/Recordings**

https://github.com/MetaMask/metamask-extension/assets/569258/b59b9fc5-dc85-4b5f-87be-38e42256b243

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
