### PR TITLE
fix: remove accounts validation and get the accounts from requestPerm…

### DIFF
--- a/app/scripts/lib/multichain-api/caip25permissions.ts
+++ b/app/scripts/lib/multichain-api/caip25permissions.ts
@@ -14,8 +14,12 @@ import {
 import type { Hex, NonEmptyArray } from '@metamask/utils';
 import { NetworkClientId } from '@metamask/network-controller';
 import { InternalAccount } from '@metamask/keyring-api';
-import { processScopes } from './provider-authorize';
-import { Caip25Authorization, Scope, ScopesObject } from './authorization';
+import {
+  Scope,
+  Caip25Authorization,
+  processScopes,
+  ScopesObject,
+} from './scope';
 
 export type Caip25CaveatValue = {
   requiredScopes: ScopesObject;

--- a/app/scripts/lib/multichain-api/scope/validation.ts
+++ b/app/scripts/lib/multichain-api/scope/validation.ts
@@ -68,19 +68,19 @@ export const isValidScope = (
   }
 
   // Note we are not validating the chainId here, only the namespace
-  const areAccountsValid = (accounts || []).every((account) => {
-    try {
-      return parseCaipAccountId(account).chain.namespace === namespace;
-    } catch (e) {
-      // parsing caipAccountId failed
-      console.log(e);
-      return false;
-    }
-  });
+  // const areAccountsValid = (accounts || []).every((account) => {
+  //   try {
+  //     return parseCaipAccountId(account).chain.namespace === namespace;
+  //   } catch (e) {
+  //     // parsing caipAccountId failed
+  //     console.log(e);
+  //     return false;
+  //   }
+  // });
 
-  if (!areAccountsValid) {
-    return false;
-  }
+  // if (!areAccountsValid) {
+  //   return false;
+  // }
   // not validating rpcDocuments or rpcEndpoints currently
 
   // unexpected properties found on scopeObject


### PR DESCRIPTION
…issions popup for now


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25773?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
