### PR TITLE
fix: password reset

### DIFF
--- a/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch
+++ b/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch
@@ -1,8 +1,18 @@
 diff --git a/dist/chunk-52QZQQKP.mjs b/dist/chunk-52QZQQKP.mjs
-index 934f432c8013a6af5303726e1495bed2335fa078..16fadadd331cfe3cb7622b3fd8367d10f2f9b993 100644
+index 934f432c8013a6af5303726e1495bed2335fa078..6b1c669ea838dd819e3c88357d69f378e18886f1 100644
 --- a/dist/chunk-52QZQQKP.mjs
 +++ b/dist/chunk-52QZQQKP.mjs
-@@ -582,6 +582,18 @@ var KeyringController = class extends BaseController {
+@@ -2,7 +2,8 @@ import {
+   __privateAdd,
+   __privateGet,
+   __privateMethod,
+-  __privateSet
++  __privateSet,
++  KeyringControllerError
+ } from "./chunk-NAAWD7HX.mjs";
+ 
+ // src/KeyringController.ts
+@@ -582,6 +583,18 @@ var KeyringController = class extends BaseController {
        })
      );
      serializedKeyrings.push(...__privateGet(this, _unsupportedKeyrings));
@@ -21,7 +31,7 @@ index 934f432c8013a6af5303726e1495bed2335fa078..16fadadd331cfe3cb7622b3fd8367d10
      let vault;
      let newEncryptionKey;
      if (__privateGet(this, _cacheEncryptionKey)) {
-@@ -706,9 +718,13 @@ var KeyringController = class extends BaseController {
+@@ -706,9 +719,13 @@ var KeyringController = class extends BaseController {
    async setLocked() {
      __privateMethod(this, _unsubscribeFromQRKeyringsEvents, unsubscribeFromQRKeyringsEvents_fn).call(this);
      __privateSet(this, _password, void 0);
@@ -35,7 +45,7 @@ index 934f432c8013a6af5303726e1495bed2335fa078..16fadadd331cfe3cb7622b3fd8367d10
      });
      await __privateMethod(this, _clearKeyrings, clearKeyrings_fn).call(this);
      this.messagingSystem.publish(`${name}:lock`);
-@@ -1087,9 +1103,16 @@ getKeyringBuilderForType_fn = function(type) {
+@@ -1087,9 +1104,16 @@ getKeyringBuilderForType_fn = function(type) {
  };
  _addQRKeyring = new WeakSet();
  addQRKeyring_fn = async function() {
@@ -55,7 +65,7 @@ index 934f432c8013a6af5303726e1495bed2335fa078..16fadadd331cfe3cb7622b3fd8367d10
    const accounts = await qrKeyring.getAccounts();
    await __privateMethod(this, _checkForDuplicate, checkForDuplicate_fn).call(this, "QR Hardware Wallet Device" /* qr */, accounts);
    __privateGet(this, _keyrings).push(qrKeyring);
-@@ -1120,6 +1143,12 @@ createNewVaultWithKeyring_fn = async function(password, keyring) {
+@@ -1120,6 +1144,12 @@ createNewVaultWithKeyring_fn = async function(password, keyring) {
    if (typeof password !== "string") {
      throw new TypeError("KeyringController - Password must be of type string." /* WrongPasswordType */);
    }

--- a/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch
+++ b/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch
@@ -1,37 +1,41 @@
 diff --git a/dist/chunk-52QZQQKP.mjs b/dist/chunk-52QZQQKP.mjs
-index 934f432c8013a6af5303726e1495bed2335fa078..8de2560fe81dfc3dbfef83dd0079482306c425d9 100644
+index 934f432c8013a6af5303726e1495bed2335fa078..16fadadd331cfe3cb7622b3fd8367d10f2f9b993 100644
 --- a/dist/chunk-52QZQQKP.mjs
 +++ b/dist/chunk-52QZQQKP.mjs
-@@ -2,7 +2,8 @@ import {
-   __privateAdd,
-   __privateGet,
-   __privateMethod,
--  __privateSet
-+  __privateSet,
-+  KeyringControllerError
- } from "./chunk-NAAWD7HX.mjs";
- 
- // src/KeyringController.ts
-@@ -582,6 +583,18 @@ var KeyringController = class extends BaseController {
+@@ -582,6 +582,18 @@ var KeyringController = class extends BaseController {
        })
      );
      serializedKeyrings.push(...__privateGet(this, _unsupportedKeyrings));
 +    /**
-+     * ============================== PATCH INFORMATION ==============================
-+     * The HD keyring is the default keyring for all wallets if this keyring is missing
-+     * for some reason we should avoid saving the keyrings
-+     *
-+     * The upstream fix is here: https://github.com/MetaMask/core/pull/4168
-+     *
-+     * This patch can be found on the core branch `extension-keyring-controller-v13-patch`
-+     */
++    * ============================== PATCH INFORMATION ==============================
++    * The HD keyring is the default keyring for all wallets if this keyring is missing
++    * for some reason we should avoid saving the keyrings
++    *
++    * The upstream fix is here: https://github.com/MetaMask/core/pull/4168
++    *
++    * This patch can be found on the core branch `extension-keyring-controller-v13-patch`
++    */
 +    if (!serializedKeyrings.some((keyring) => keyring.type === KeyringTypes.hd)) {
 +      throw new Error(KeyringControllerError.NoHdKeyring);
 +    }
      let vault;
      let newEncryptionKey;
      if (__privateGet(this, _cacheEncryptionKey)) {
-@@ -1087,9 +1100,16 @@ getKeyringBuilderForType_fn = function(type) {
+@@ -706,9 +718,13 @@ var KeyringController = class extends BaseController {
+   async setLocked() {
+     __privateMethod(this, _unsubscribeFromQRKeyringsEvents, unsubscribeFromQRKeyringsEvents_fn).call(this);
+     __privateSet(this, _password, void 0);
++    // Needed to ensure that the encryption key/salt are always generated with the latest password
++    // TODO: Remove this patch once https://github.com/MetaMask/core/pull/4514 is shipped in the keyring-controller
+     this.update((state) => {
+       state.isUnlocked = false;
+       state.keyrings = [];
++      delete state.encryptionKey;
++      delete state.encryptionSalt;
+     });
+     await __privateMethod(this, _clearKeyrings, clearKeyrings_fn).call(this);
+     this.messagingSystem.publish(`${name}:lock`);
+@@ -1087,9 +1103,16 @@ getKeyringBuilderForType_fn = function(type) {
  };
  _addQRKeyring = new WeakSet();
  addQRKeyring_fn = async function() {
@@ -39,18 +43,31 @@ index 934f432c8013a6af5303726e1495bed2335fa078..8de2560fe81dfc3dbfef83dd00794823
 -    accounts: []
 -  });
 +  /**
-+   * Patch for @metamask/keyring-controller v13.0.0
-+   * Below code change will fix the issue 23804, The intial code added a empty accounts as argument when creating a new QR keyring.
-+   * cause the new Keystone MetamaskKeyring default properties all are undefined during deserialise() process.
-+   * Please refer to PR 23903 for detail.
-+   *
-+   * This patch can be found on the core branch `extension-keyring-controller-v13-patch`
-+   */
++  * Patch for @metamask/keyring-controller v13.0.0
++  * Below code change will fix the issue 23804, The intial code added a empty accounts as argument when creating a new QR keyring.
++  * cause the new Keystone MetamaskKeyring default properties all are undefined during deserialise() process.
++  * Please refer to PR 23903 for detail.
++  *
++  * This patch can be found on the core branch `extension-keyring-controller-v13-patch`
++  */
 +  // @ts-expect-error See patch note
 +  const qrKeyring = await __privateMethod(this, _newKeyring, newKeyring_fn).call(this, "QR Hardware Wallet Device");
    const accounts = await qrKeyring.getAccounts();
    await __privateMethod(this, _checkForDuplicate, checkForDuplicate_fn).call(this, "QR Hardware Wallet Device" /* qr */, accounts);
    __privateGet(this, _keyrings).push(qrKeyring);
+@@ -1120,6 +1143,12 @@ createNewVaultWithKeyring_fn = async function(password, keyring) {
+   if (typeof password !== "string") {
+     throw new TypeError("KeyringController - Password must be of type string." /* WrongPasswordType */);
+   }
++  // Needed to ensure that the encryption key/salt are always generated with the latest password
++  // TODO: Remove this patch once https://github.com/MetaMask/core/pull/4514 is shipped in the keyring-controller
++  this.update((state) => {
++    delete state.encryptionKey;
++    delete state.encryptionSalt;
++  });
+   __privateSet(this, _password, password);
+   await __privateMethod(this, _clearKeyrings, clearKeyrings_fn).call(this);
+   await __privateMethod(this, _createKeyringWithFirstAccount, createKeyringWithFirstAccount_fn).call(this, keyring.type, keyring.opts);
 diff --git a/dist/chunk-CHLPTPMZ.js b/dist/chunk-CHLPTPMZ.js
 index bef1a8e9dd5efe426f8aaaba1fe4501b124f7e87..7b48c000e54708da2a689e2d6cb1b61a279f1205 100644
 --- a/dist/chunk-CHLPTPMZ.js
@@ -64,7 +81,7 @@ index bef1a8e9dd5efe426f8aaaba1fe4501b124f7e87..7b48c000e54708da2a689e2d6cb1b61a
  })(KeyringControllerError || {});
  
 diff --git a/dist/chunk-GXM4O6HW.js b/dist/chunk-GXM4O6HW.js
-index f7539e2e6354f418cbb095cc1a2cda01a5bdeae6..978f4426536c594568ecc56f1c27881db4bfa861 100644
+index f7539e2e6354f418cbb095cc1a2cda01a5bdeae6..38318ed5c8940b1d25840077b7287541f33c3cb8 100644
 --- a/dist/chunk-GXM4O6HW.js
 +++ b/dist/chunk-GXM4O6HW.js
 @@ -582,6 +582,18 @@ var KeyringController = class extends _basecontroller.BaseController {
@@ -86,7 +103,21 @@ index f7539e2e6354f418cbb095cc1a2cda01a5bdeae6..978f4426536c594568ecc56f1c27881d
      let vault;
      let newEncryptionKey;
      if (_chunkCHLPTPMZjs.__privateGet.call(void 0, this, _cacheEncryptionKey)) {
-@@ -1087,9 +1099,16 @@ getKeyringBuilderForType_fn = function(type) {
+@@ -706,9 +718,13 @@ var KeyringController = class extends _basecontroller.BaseController {
+   async setLocked() {
+     _chunkCHLPTPMZjs.__privateMethod.call(void 0, this, _unsubscribeFromQRKeyringsEvents, unsubscribeFromQRKeyringsEvents_fn).call(this);
+     _chunkCHLPTPMZjs.__privateSet.call(void 0, this, _password, void 0);
++    // Needed to ensure that the encryption key/salt are always generated with the latest password
++    // TODO: Remove this patch once https://github.com/MetaMask/core/pull/4514 is shipped in the keyring-controller
+     this.update((state) => {
+       state.isUnlocked = false;
+       state.keyrings = [];
++      delete state.encryptionKey;
++      delete state.encryptionSalt;
+     });
+     await _chunkCHLPTPMZjs.__privateMethod.call(void 0, this, _clearKeyrings, clearKeyrings_fn).call(this);
+     this.messagingSystem.publish(`${name}:lock`);
+@@ -1087,9 +1103,16 @@ getKeyringBuilderForType_fn = function(type) {
  };
  _addQRKeyring = new WeakSet();
  addQRKeyring_fn = async function() {
@@ -94,18 +125,31 @@ index f7539e2e6354f418cbb095cc1a2cda01a5bdeae6..978f4426536c594568ecc56f1c27881d
 -    accounts: []
 -  });
 +  /**
-+   * Patch for @metamask/keyring-controller v13.0.0
-+   * Below code change will fix the issue 23804, The intial code added a empty accounts as argument when creating a new QR keyring.
-+   * cause the new Keystone MetamaskKeyring default properties all are undefined during deserialise() process.
-+   * Please refer to PR 23903 for detail.
-+   *
-+   * This patch can be found on the core branch `extension-keyring-controller-v13-patch`
-+   */
++  * Patch for @metamask/keyring-controller v13.0.0
++  * Below code change will fix the issue 23804, The intial code added a empty accounts as argument when creating a new QR keyring.
++  * cause the new Keystone MetamaskKeyring default properties all are undefined during deserialise() process.
++  * Please refer to PR 23903 for detail.
++  *
++  * This patch can be found on the core branch `extension-keyring-controller-v13-patch`
++  */
 +  // @ts-expect-error See patch note
 +  const qrKeyring = await _chunkCHLPTPMZjs.__privateMethod.call(void 0, this, _newKeyring, newKeyring_fn).call(this, "QR Hardware Wallet Device");
    const accounts = await qrKeyring.getAccounts();
    await _chunkCHLPTPMZjs.__privateMethod.call(void 0, this, _checkForDuplicate, checkForDuplicate_fn).call(this, "QR Hardware Wallet Device" /* qr */, accounts);
    _chunkCHLPTPMZjs.__privateGet.call(void 0, this, _keyrings).push(qrKeyring);
+@@ -1120,6 +1143,12 @@ createNewVaultWithKeyring_fn = async function(password, keyring) {
+   if (typeof password !== "string") {
+     throw new TypeError("KeyringController - Password must be of type string." /* WrongPasswordType */);
+   }
++  // Needed to ensure that the encryption key/salt are always generated with the latest password
++  // TODO: Remove this patch once https://github.com/MetaMask/core/pull/4514 is shipped in the keyring-controller
++  this.update((state) => {
++    delete state.encryptionKey;
++    delete state.encryptionSalt;
++  });
+   _chunkCHLPTPMZjs.__privateSet.call(void 0, this, _password, password);
+   await _chunkCHLPTPMZjs.__privateMethod.call(void 0, this, _clearKeyrings, clearKeyrings_fn).call(this);
+   await _chunkCHLPTPMZjs.__privateMethod.call(void 0, this, _createKeyringWithFirstAccount, createKeyringWithFirstAccount_fn).call(this, keyring.type, keyring.opts);
 diff --git a/dist/chunk-NAAWD7HX.mjs b/dist/chunk-NAAWD7HX.mjs
 index b5de23aabec9d502e8e6423480ffaaff26257bfc..a0c027a7c13828883ec5c05cbb7eab92c41f0dc3 100644
 --- a/dist/chunk-NAAWD7HX.mjs

--- a/package.json
+++ b/package.json
@@ -262,7 +262,8 @@
     "@metamask/snaps-utils@npm:^7.6.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch",
     "@metamask/snaps-utils@npm:^7.4.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch",
     "@metamask/snaps-utils@npm:^7.5.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch",
-    "@metamask/snaps-utils@npm:^7.1.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch"
+    "@metamask/snaps-utils@npm:^7.1.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch",
+    "@metamask/keyring-controller@npm:^16.0.0": "patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.24.0#~/.yarn/patches/@babel-runtime-npm-7.24.0-7eb1dd11a2.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5605,7 +5605,7 @@ __metadata:
 
 "@metamask/keyring-controller@patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch":
   version: 15.0.0
-  resolution: "@metamask/keyring-controller@patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch::version=15.0.0&hash=79dc4b"
+  resolution: "@metamask/keyring-controller@patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch::version=15.0.0&hash=ec3cbc"
   dependencies:
     "@ethereumjs/util": "npm:^8.1.0"
     "@keystonehq/metamask-airgapped-keyring": "npm:^0.13.1"
@@ -5620,7 +5620,7 @@ __metadata:
     async-mutex: "npm:^0.2.6"
     ethereumjs-wallet: "npm:^1.0.1"
     immer: "npm:^9.0.6"
-  checksum: 10/4dc9d5d6fc1e399a41284c723c4a29f32195bc87fdc81a1554c6c8bd4b3046b443c7c9e90ff077bffda5e1f97e35e9722e43fc2791256bbd55482bf47954cae1
+  checksum: 10/6dfcd42d29f8052edce152ab161b4e1e3c177cdace4a85212a0fd3d1ad143a3d93d684c8e38c8cbb17a4dddba25c16eb26d3d3dd494a54446c2cc1a37cedf46f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5603,30 +5603,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-controller@npm:^16.0.0":
-  version: 16.0.0
-  resolution: "@metamask/keyring-controller@npm:16.0.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^8.1.0"
-    "@keystonehq/metamask-airgapped-keyring": "npm:^0.13.1"
-    "@metamask/base-controller": "npm:^5.0.2"
-    "@metamask/browser-passworder": "npm:^4.3.0"
-    "@metamask/eth-hd-keyring": "npm:^7.0.1"
-    "@metamask/eth-sig-util": "npm:^7.0.1"
-    "@metamask/eth-simple-keyring": "npm:^6.0.1"
-    "@metamask/keyring-api": "npm:^6.0.0"
-    "@metamask/message-manager": "npm:^8.0.2"
-    "@metamask/utils": "npm:^8.3.0"
-    async-mutex: "npm:^0.2.6"
-    ethereumjs-wallet: "npm:^1.0.1"
-    immer: "npm:^9.0.6"
-  checksum: 10/33c10f4c61acfa0f8de7a3d90c2dfc63be1d137866653254e3d5f68dbf4ee886415e2ab620009e5b82c2a112bfab6d09653f5ad16adeccecd87b89f1f1fa0b7c
-  languageName: node
-  linkType: hard
-
 "@metamask/keyring-controller@patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch":
   version: 15.0.0
-  resolution: "@metamask/keyring-controller@patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch::version=15.0.0&hash=3f5b2f"
+  resolution: "@metamask/keyring-controller@patch:@metamask/keyring-controller@npm%3A15.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-15.0.0-fa070ce311.patch::version=15.0.0&hash=79dc4b"
   dependencies:
     "@ethereumjs/util": "npm:^8.1.0"
     "@keystonehq/metamask-airgapped-keyring": "npm:^0.13.1"
@@ -5641,7 +5620,7 @@ __metadata:
     async-mutex: "npm:^0.2.6"
     ethereumjs-wallet: "npm:^1.0.1"
     immer: "npm:^9.0.6"
-  checksum: 10/76116ea6ba8b85e1d3117f4ceebc31d27e591402d77afa9451f661e629b7c3a697d8fdf3b2a7ec536abf3d30d98fe92d2404c5356a2e8656c9886c38589b04f3
+  checksum: 10/4dc9d5d6fc1e399a41284c723c4a29f32195bc87fdc81a1554c6c8bd4b3046b443c7c9e90ff077bffda5e1f97e35e9722e43fc2791256bbd55482bf47954cae1
   languageName: node
   linkType: hard
 
@@ -5681,7 +5660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/message-manager@npm:^8.0.1, @metamask/message-manager@npm:^8.0.2":
+"@metamask/message-manager@npm:^8.0.1":
   version: 8.0.2
   resolution: "@metamask/message-manager@npm:8.0.2"
   dependencies:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
- This fix addresses a user facing bug in production
- When a user locks the wallet and goes through the forget password flow, the wallet is not accessible with the new password. Instead the user must use the old password to unlock the wallet.
- This is a bug in the keyring controller because the encryptionKey gets generated with the old password and is not reset when the user locks the wallet and generates a new password.
2. What is the improvement/solution?
- This fix patches the keyring controller such that when the user locks the wallet the encryption key gets cleared
- We also clear the encryption key  in the`#createNewVaultWithKeyring` to ensure  a new encryption key is generated with the new password when the user logs in again and submitPassword is called.
- This patch will be removed once [this PR](https://github.com/MetaMask/core/pull/4514) ships in the keyring controller library

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25787?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25696

## **Manual testing steps**

- Open the extension
- Proceed to Forget password flow
- Paste your secret recovery phrase
- Set a new different password
- Proceed to Restore your Wallet
- After entering the account, lock it and try to login with the new password
- It will throw an Invalid password error

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/22918444/a63ef8fc-5ddf-40c7-b097-d2af29265765

### **After**

https://github.com/MetaMask/metamask-extension/assets/22918444/a963397e-dd69-41c7-9012-566ccdfce7c2


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
