### PR TITLE
chore: removed unused getCustodianAccountsByAddress method

### DIFF
--- a/app/scripts/controllers/mmi-controller.test.ts
+++ b/app/scripts/controllers/mmi-controller.test.ts
@@ -456,26 +456,6 @@ describe('MMIController', function () {
     });
   });
 
-  describe('getCustodianAccountsByAddress', () => {
-    it('should return custodian accounts by address', async () => {
-      CUSTODIAN_TYPES['MOCK-CUSTODIAN-TYPE'] = {
-        keyringClass: { type: 'mock-keyring-class' },
-      };
-      mmiController.addKeyringIfNotExists = jest.fn().mockResolvedValue({
-        getCustodianAccounts: jest.fn().mockResolvedValue(['account1']),
-      });
-
-      const result = await mmiController.getCustodianAccountsByAddress(
-        'token',
-        'envName',
-        'address',
-        'mock-custodian-type',
-      );
-
-      expect(result).toEqual(['account1']);
-    });
-  });
-
   describe('getCustodianTransactionDeepLink', () => {
     it('should return a transaction deep link', async () => {
       mmiController.custodyController.getCustodyTypeByAddress = jest

--- a/app/scripts/controllers/mmi-controller.ts
+++ b/app/scripts/controllers/mmi-controller.ts
@@ -570,33 +570,6 @@ export default class MMIController extends EventEmitter {
     return accounts;
   }
 
-  async getCustodianAccountsByAddress(
-    token: string,
-    envName: string,
-    address: string,
-    custodianType: string,
-  ) {
-    let keyring;
-
-    if (custodianType) {
-      const custodian = CUSTODIAN_TYPES[custodianType.toUpperCase()];
-      if (!custodian) {
-        throw new Error('No such custodian');
-      }
-
-      keyring = await this.addKeyringIfNotExists(custodian.keyringClass.type);
-    } else {
-      throw new Error('No custodian specified');
-    }
-
-    const accounts = await keyring.getCustodianAccounts(
-      token,
-      envName,
-      address,
-    );
-    return accounts;
-  }
-
   async getCustodianTransactionDeepLink(address: string, txId: string) {
     const custodyType = this.custodyController.getCustodyTypeByAddress(
       toChecksumHexAddress(address),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3419,10 +3419,6 @@ export default class MetamaskController extends EventEmitter {
       getCustodianAccounts: this.mmiController.getCustodianAccounts.bind(
         this.mmiController,
       ),
-      getCustodianAccountsByAddress:
-        this.mmiController.getCustodianAccountsByAddress.bind(
-          this.mmiController,
-        ),
       getCustodianTransactionDeepLink:
         this.mmiController.getCustodianTransactionDeepLink.bind(
           this.mmiController,

--- a/ui/store/institutional/institution-background.test.js
+++ b/ui/store/institutional/institution-background.test.js
@@ -33,7 +33,6 @@ describe('Institution Actions', () => {
       const actionsMock = {
         connectCustodyAddresses: jest.fn(),
         getCustodianAccounts: jest.fn(),
-        getCustodianAccountsByAddress: jest.fn(),
         getCustodianTransactionDeepLink: jest.fn(),
         getCustodianConfirmDeepLink: jest.fn(),
         getCustodianSignMessageDeepLink: jest.fn(),
@@ -66,14 +65,6 @@ describe('Institution Actions', () => {
         'custody',
         'getNonImportedAccounts',
         {},
-      );
-      mmiActions.getCustodianAccountsByAddress(
-        'jwt',
-        'envName',
-        'address',
-        'custody',
-        {},
-        4,
       );
       mmiActions.getMmiConfiguration({
         portfolio: {

--- a/ui/store/institutional/institution-background.ts
+++ b/ui/store/institutional/institution-background.ts
@@ -172,19 +172,6 @@ export function mmiActionsFactory() {
         forceUpdateMetamaskState,
         'Getting custodian accounts...',
       ),
-    // TODO (Bernardo) - It doesn't look like this is being used
-    getCustodianAccountsByAddress: (
-      jwt: string,
-      envName: string,
-      address: string,
-      custody: string,
-    ) =>
-      createAsyncAction(
-        'getCustodianAccountsByAddress',
-        [jwt, envName, address, custody],
-        forceUpdateMetamaskState,
-        'Getting custodian accounts...',
-      ),
     getCustodianTransactionDeepLink: (address: string, txId: string) =>
       createAsyncAction(
         'getCustodianTransactionDeepLink',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We currently have the getCustodianAccountsByAddress being passed in: 

`ui/store/institutional/institution-background.ts`

But it doesn’t seem to be of any use.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
