### PR TITLE
fix: (cherry-pick)(Version v12.1.0) Error: new BigNumber() more than 15 digits feat: apply ellipsis #25741 

### DIFF
--- a/shared/modules/transaction.utils.test.js
+++ b/shared/modules/transaction.utils.test.js
@@ -395,6 +395,21 @@ describe('Transaction.utils', function () {
         const result = parseTypedDataMessage('{"test": "dummy"}');
         expect(result.test).toBe('dummy');
       });
+
+      it('parses message.value as a string', () => {
+        const result = parseTypedDataMessage(
+          '{"test": "dummy", "message": { "value": 3000123} }',
+        );
+        expect(result.message.value).toBe('3000123');
+      });
+
+      it('parses message.value such that it does not lose precision', () => {
+        const result = parseTypedDataMessage(
+          '{"test": "dummy", "message": { "value": 30001231231212312138768} }',
+        );
+        expect(result.message.value).toBe('30001231231212312138768');
+      });
+
       it('throw error for invalid typedDataMessage', () => {
         expect(() => {
           parseTypedDataMessage('');

--- a/shared/modules/transaction.utils.ts
+++ b/shared/modules/transaction.utils.ts
@@ -282,5 +282,40 @@ export async function determineTransactionAssetType(
   return { assetType: AssetType.native, tokenStandard: TokenStandard.none };
 }
 
-export const parseTypedDataMessage = (dataToParse: string) =>
-  JSON.parse(dataToParse);
+const REGEX_MESSAGE_VALUE_LARGE =
+  /"message"\s*:\s*\{[^}]*"value"\s*:\s*(\d{15,})/u;
+
+function extractLargeMessageValue(dataToParse: string): string | undefined {
+  if (typeof dataToParse !== 'string') {
+    return undefined;
+  }
+  return dataToParse.match(REGEX_MESSAGE_VALUE_LARGE)?.[1];
+}
+
+/**
+ * JSON.parse has a limitation which coerces values to scientific notation if numbers are greator than
+ * Number.MAX_SAFE_INTEGER. This can cause a loss in precision.
+ *
+ * Aside from precision concerns, if the value returned was a large number greator than 15 digits,
+ * e.g. 3.000123123123121e+26, passing the value to BigNumber will throw the error:
+ * Error: new BigNumber() number type has more than 15 significant digits
+ *
+ * Note that using JSON.parse reviver cannot help since the value will be coerced by the time it
+ * reaches the reviver function.
+ *
+ * This function has a workaround to extract the large value from the message and replace
+ * the message value with the string value.
+ *
+ * @param dataToParse
+ * @returns
+ */
+export const parseTypedDataMessage = (dataToParse: string) => {
+  const result = JSON.parse(dataToParse);
+
+  const messageValue = extractLargeMessageValue(dataToParse);
+  if (result.message?.value) {
+    result.message.value = messageValue || String(result.message.value);
+  }
+
+  return result;
+};

--- a/ui/components/app/confirm/info/row/text.tsx
+++ b/ui/components/app/confirm/info/row/text.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { I18nContext } from '../../../../../contexts/i18n';
 import {
   AlignItems,
+  BlockSize,
   Display,
   FlexWrap,
   IconColor,
@@ -10,8 +11,18 @@ import {
 import { Box, ButtonIcon, IconName, Text } from '../../../../component-library';
 import Tooltip from '../../../../ui/tooltip';
 
-const InfoText = ({ text }: { text: string }) => (
-  <Text color={TextColor.inherit} style={{ whiteSpace: 'pre-wrap' }}>
+const InfoText = ({
+  isEllipsis,
+  text,
+}: {
+  isEllipsis: boolean;
+  text: string;
+}) => (
+  <Text
+    color={TextColor.inherit}
+    style={isEllipsis ? {} : { whiteSpace: 'pre-wrap' }}
+    ellipsis={isEllipsis}
+  >
     {text}
   </Text>
 );
@@ -20,12 +31,14 @@ export type ConfirmInfoRowTextProps = {
   text: string;
   onEditClick?: () => void;
   editIconClassName?: string;
+  isEllipsis?: boolean;
   tooltip?: string;
 };
 
 export const ConfirmInfoRowText: React.FC<ConfirmInfoRowTextProps> = ({
   text,
   onEditClick,
+  isEllipsis = false,
   editIconClassName,
   tooltip,
 }) => {
@@ -39,6 +52,7 @@ export const ConfirmInfoRowText: React.FC<ConfirmInfoRowTextProps> = ({
       alignItems={AlignItems.center}
       flexWrap={FlexWrap.Wrap}
       gap={2}
+      minWidth={BlockSize.Zero}
     >
       {tooltip ? (
         <Tooltip
@@ -47,10 +61,10 @@ export const ConfirmInfoRowText: React.FC<ConfirmInfoRowTextProps> = ({
           wrapperStyle={{ minWidth: 0 }}
           interactive
         >
-          <InfoText text={text} />
+          <InfoText isEllipsis={isEllipsis} text={text} />
         </Tooltip>
       ) : (
-        <InfoText text={text} />
+        <InfoText isEllipsis={isEllipsis} text={text} />
       )}
       {isEditable ? (
         <ButtonIcon

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Info renders info section for personal sign request 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -223,7 +223,7 @@ exports[`Info renders info section for typed sign request 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -270,7 +270,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -383,7 +383,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -480,7 +480,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -136,7 +136,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/siwe-sign/__snapshots__/siwe-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/siwe-sign/__snapshots__/siwe-sign.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -40,7 +40,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -64,7 +64,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -159,7 +159,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -183,7 +183,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -207,7 +207,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -255,7 +255,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -284,7 +284,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -308,7 +308,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -332,7 +332,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -427,7 +427,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -451,7 +451,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -475,7 +475,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -523,7 +523,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -547,7 +547,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -557,7 +557,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+      class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
     >
       <p
         class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/confirm/info/shared/advanced-details/__snapshots__/advanced-details.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/advanced-details/__snapshots__/advanced-details.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`<AdvancedDetails /> does not render component for advanced transaction 
         </div>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -82,7 +82,7 @@ exports[`<AdvancedDetails /> renders component for advanced transaction details 
         </div>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -118,7 +118,7 @@ exports[`<AdvancedDetails /> renders component for advanced transaction details 
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -108,7 +108,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -395,7 +395,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <div
                   style="min-width: 0;"
@@ -409,8 +409,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
                     tabindex="0"
                   >
                     <p
-                      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre-wrap;"
+                      class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-inherit"
                     >
                       3,000
                     </p>
@@ -432,7 +431,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -624,7 +623,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -671,7 +670,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -784,7 +783,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -881,7 +880,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -1047,7 +1046,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -1094,7 +1093,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -1207,7 +1206,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -1304,7 +1303,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -1470,7 +1469,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -1501,7 +1500,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -1541,7 +1540,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -1830,7 +1829,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                         </p>
                       </div>
                       <div
-                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                       >
                         <p
                           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/__snapshots__/permit-simulation.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/__snapshots__/permit-simulation.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`PermitSimulation renders component correctly 1`] = `
         </div>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -59,13 +59,13 @@ exports[`PermitSimulation renders component correctly 1`] = `
       </div>
       <div
         class="mm-box"
-        style="margin-left: auto;"
+        style="margin-left: auto; max-width: 100%;"
       >
         <div
           class="mm-box mm-box--display-flex"
         >
           <div
-            class="mm-box mm-box--margin-inline-end-1 mm-box--display-inline"
+            class="mm-box mm-box--margin-inline-end-1 mm-box--display-inline mm-box--min-width-0"
           >
             <div
               style="min-width: 0;"
@@ -79,7 +79,7 @@ exports[`PermitSimulation renders component correctly 1`] = `
                 tabindex="0"
               >
                 <p
-                  class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--padding-inline-2 mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
+                  class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-2 mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
                 >
                   30
                 </p>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
@@ -16,6 +16,7 @@ import { Box, Text } from '../../../../../../../components/component-library';
 import Tooltip from '../../../../../../../components/ui/tooltip';
 import {
   BackgroundColor,
+  BlockSize,
   BorderRadius,
   Display,
   TextAlign,
@@ -52,10 +53,15 @@ const PermitSimulation: React.FC<{
   }, [exchangeRate, value]);
 
   const { tokenValue, tokenValueMaxPrecision } = useMemo(() => {
-    const valueBN = new BigNumber(value / Math.pow(10, tokenDecimals));
+    const valueBN = new BigNumber(value);
+    const diviserBN = new BigNumber(10).pow(tokenDecimals);
+    const resultBn = valueBN.div(diviserBN);
+
+    // FIXME - Precision may be lost for large values when using formatAmount
+    /** @see {@link https://github.com/MetaMask/metamask-extension/issues/25755} */
     return {
-      tokenValue: formatAmount('en-US', valueBN),
-      tokenValueMaxPrecision: formatAmountMaxPrecision('en-US', valueBN),
+      tokenValue: formatAmount('en-US', resultBn),
+      tokenValueMaxPrecision: formatAmountMaxPrecision('en-US', resultBn),
     };
   }, [tokenDecimals, value]);
 
@@ -68,9 +74,13 @@ const PermitSimulation: React.FC<{
         <ConfirmInfoRowText text={t('permitSimulationDetailInfo')} />
       </ConfirmInfoRow>
       <ConfirmInfoRow label={t('approve')}>
-        <Box style={{ marginLeft: 'auto' }}>
+        <Box style={{ marginLeft: 'auto', maxWidth: '100%' }}>
           <Box display={Display.Flex}>
-            <Box display={Display.Inline} marginInlineEnd={1}>
+            <Box
+              display={Display.Inline}
+              marginInlineEnd={1}
+              minWidth={BlockSize.Zero}
+            >
               <Tooltip
                 position="bottom"
                 title={tokenValueMaxPrecision}
@@ -82,6 +92,7 @@ const PermitSimulation: React.FC<{
                   borderRadius={BorderRadius.XL}
                   paddingInline={2}
                   textAlign={TextAlign.Center}
+                  ellipsis
                 >
                   {tokenValue}
                 </Text>

--- a/ui/pages/confirmations/components/confirm/row/__snapshots__/dataTree.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/__snapshots__/dataTree.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DataTree correctly renders reverse strings 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -43,7 +43,7 @@ exports[`DataTree correctly renders reverse strings 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -76,7 +76,7 @@ exports[`DataTree should match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -116,7 +116,7 @@ exports[`DataTree should match snapshot 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -334,7 +334,7 @@ exports[`DataTree should match snapshot 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -593,7 +593,7 @@ exports[`DataTree should match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -626,7 +626,7 @@ exports[`DataTree should match snapshot for permit signature type 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -648,7 +648,7 @@ exports[`DataTree should match snapshot for permit signature type 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -670,7 +670,7 @@ exports[`DataTree should match snapshot for permit signature type 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -692,7 +692,7 @@ exports[`DataTree should match snapshot for permit signature type 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/confirm/row/dataTree.tsx
+++ b/ui/pages/confirmations/components/confirm/row/dataTree.tsx
@@ -81,13 +81,18 @@ const DataField = memo(
       );
     }
     if (isPermit && label === 'value') {
-      const valueBN = new BigNumber(
-        parseInt(value, 10) / Math.pow(10, tokenDecimals),
-      );
-      const tokenValue = formatAmount('en-US', valueBN);
+      const valueBN = new BigNumber(value);
+      const diviserBN = new BigNumber(10).pow(tokenDecimals);
+      const resultBn = valueBN.div(diviserBN);
+
+      // FIXME - Precision may be lost for large values when using formatAmount
+      /** @see {@link https://github.com/MetaMask/metamask-extension/issues/25755} */
+      const tokenValue = formatAmount('en-US', resultBn);
       const tokenValueMaxPrecision = formatAmountMaxPrecision('en-US', valueBN);
+
       return (
         <ConfirmInfoRowText
+          isEllipsis={true}
           text={tokenValue}
           tooltip={tokenValueMaxPrecision}
         />

--- a/ui/pages/confirmations/components/confirm/row/typed-sign-data-v1/__snapshots__/typedSignDataV1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/typed-sign-data-v1/__snapshots__/typedSignDataV1.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -50,7 +50,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/confirm/row/typed-sign-data/__snapshots__/typedSignData.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/typed-sign-data/__snapshots__/typedSignData.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -50,7 +50,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -90,7 +90,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -379,7 +379,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/components/simulation-details/formatAmount.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/formatAmount.test.ts
@@ -37,6 +37,15 @@ describe('formatAmount', () => {
     [47361034.006, '47,361,034'],
     ['12130982923409.5', '12,130,982,923,410'],
     ['1213098292340944.5', '1,213,098,292,340,945'],
+    // Precision is lost after the value is greator than Number.MAX_SAFE_INTEGER. The digits after
+    // the 15th digit become 0's.
+    // TODO fix the precision
+    /** @see {@link https://github.com/MetaMask/metamask-extension/issues/25755} */
+    ['30001231231212312138768', '30,001,231,231,212,312,000,000'],
+    [
+      '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+      '115,792,089,237,316,200,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000',
+    ],
   ])(
     'formats amount greater than or equal to 1 with appropriate decimal precision (%s => %s)',
     (amount: number, expected: string) => {

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`Confirm matches snapshot for personal signature type 1`] = `
                 </p>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -497,7 +497,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                     </p>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -528,7 +528,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                         </p>
                       </div>
                       <div
-                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                       >
                         <p
                           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -568,7 +568,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                             </p>
                           </div>
                           <div
-                            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                           >
                             <p
                               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -857,7 +857,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                                 </p>
                               </div>
                               <div
-                                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
+                                class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
                               >
                                 <p
                                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/pages/confirmations/confirm/stories/utils.tsx
+++ b/ui/pages/confirmations/confirm/stories/utils.tsx
@@ -30,7 +30,11 @@ export function ConfirmStoryTemplate(
     confirm: {
       currentConfirmation,
     },
-    metamask: { ...mockState.metamask, ...metamaskState },
+    metamask: {
+      ...mockState.metamask,
+      ...metamaskState,
+      useTransactionSimulations: true,
+    },
   });
 
   return (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cherry-pick https://github.com/MetaMask/metamask-extension/pull/25741 for Version-v12.1.0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25800?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2730 (ellipsis)
Fixes: https://github.com/MetaMask/metamask-extension/issues/25751 (Error)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
