### PR TITLE
ci: Disabling non-lint CI on the l10n_crowdin_action branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,6 +384,10 @@ workflows:
       - test-lint:
           requires:
             - prep-deps
+      - all-tests-pass:
+          requires:
+            - test-lint
+            - validate-locales-only
 
 jobs:
   trigger-beta-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,8 +384,6 @@ workflows:
       - test-lint:
           requires:
             - prep-deps
-            - get-changed-files-with-git-diff
-            - validate-locales-only
 
 jobs:
   trigger-beta-build:
@@ -533,7 +531,7 @@ jobs:
           at: .
       - run:
           name:
-          command: npx tsx .circleci/scripts/validate-locales-only.ts
+          command: yarn tsx .circleci/scripts/validate-locales-only.ts
 
   validate-lavamoat-allow-scripts:
     executor: node-browsers-small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,21 +101,6 @@ aliases:
       fi
 
 workflows:
-  locales_only:
-    when:
-      matches:
-        pattern: /^l10n_crowdin_action$/
-        value: << pipeline.git.branch >>
-    jobs:
-      - prep-deps
-      - get-changed-files-with-git-diff:
-          <<: *exclude_develop_master_rc
-          requires:
-            - prep-deps
-      - validate-locales-only:
-          requires:
-            - get-changed-files-with-git-diff
-
   test_and_release:
     when:
       not:
@@ -381,6 +366,24 @@ workflows:
               only: develop
           requires:
             - prep-build-ts-migration-dashboard
+
+  locales_only:
+    when:
+      matches:
+        pattern: /^l10n_crowdin_action$/
+        value: << pipeline.git.branch >>
+    jobs:
+      - prep-deps
+      - get-changed-files-with-git-diff:
+          <<: *exclude_develop_master_rc
+          requires:
+            - prep-deps
+      - validate-locales-only:
+          requires:
+            - get-changed-files-with-git-diff
+      - test-lint:
+          requires:
+            - prep-deps
 
 jobs:
   trigger-beta-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ workflows:
   locales_only:
     when:
       matches:
-        pattern: /^test_l10n_crowdin_action$/
+        pattern: /^l10n_crowdin_action$/
         value: << pipeline.git.branch >>
     jobs:
       - prep-deps
@@ -120,7 +120,7 @@ workflows:
     when:
       not:
         matches:
-            pattern: /^test_l10n_crowdin_action$/
+            pattern: /^l10n_crowdin_action$/
             value: << pipeline.git.branch >>
     jobs:
       - create_release_pull_request:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,10 +102,9 @@ aliases:
 
 workflows:
   locales_only:
-    filters:
-      branches:
-        only:
-          - test_l10n_crowdin_action
+    when:
+      condition:
+        equal: [<< pipeline.git.branch >>, 'test_l10n_crowdin_action']
     jobs:
       - prep-deps
       - test-lint:
@@ -113,10 +112,9 @@ workflows:
             - prep-deps
 
   test_and_release:
-    filters:
-      branches:
-        ignore:
-          - test_l10n_crowdin_action
+    unless:
+      condition:
+        equal: [<< pipeline.git.branch >>, 'test_l10n_crowdin_action']
     jobs:
       - create_release_pull_request:
           <<: *rc_branch_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
     when:
       not:
         matches:
-          pattern: /^test_l10n_crowdin_action$/
+          pattern: /^l10n_crowdin_action$/
           value: << pipeline.git.branch >>
     jobs:
       - create_release_pull_request:
@@ -370,7 +370,7 @@ workflows:
   locales_only:
     when:
       matches:
-        pattern: /^test_l10n_crowdin_action$/
+        pattern: /^l10n_crowdin_action$/
         value: << pipeline.git.branch >>
     jobs:
       - prep-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,22 @@ aliases:
       fi
 
 workflows:
+  locales_only:
+    filters:
+      branches:
+        only:
+          - test_l10n_crowdin_action
+    jobs:
+      - prep-deps
+      - test-lint:
+          requires:
+            - prep-deps
+
   test_and_release:
+    filters:
+      branches:
+        ignore:
+          - test_l10n_crowdin_action
     jobs:
       - create_release_pull_request:
           <<: *rc_branch_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
     when:
       not:
         matches:
-            pattern: /^test_l10n_crowdin_action$/
+            pattern: /^l10n_crowdin_action$/
             value: << pipeline.git.branch >>
     jobs:
       - create_release_pull_request:
@@ -370,7 +370,7 @@ workflows:
   locales_only:
     when:
       matches:
-        pattern: /^test_l10n_crowdin_action$/
+        pattern: /^l10n_crowdin_action$/
         value: << pipeline.git.branch >>
     jobs:
       - prep-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,13 +60,6 @@ exclude_develop_master_rc: &exclude_develop_master_rc
         - develop
         - master
         - /^Version-v(\d+)[.](\d+)[.](\d+)/
-
-exclude_locales_only_workflow: &exclude_locales_only_workflow
-  filters:
-    branches:
-      ignore:
-        - /^test_l10n_crowdin_action$/
-
 aliases:
   # Shallow Git Clone
   - &shallow-git-clone
@@ -125,9 +118,7 @@ workflows:
       - check-pr-tag
       - prep-deps
       - get-changed-files-with-git-diff:
-          <<:
-            - *exclude_develop_master_rc
-            - *exclude_locales_only_workflow
+          <<: *exclude_develop_master_rc
           requires:
             - prep-deps
       - test-deps-audit:
@@ -384,9 +375,7 @@ workflows:
     jobs:
       - prep-deps
       - get-changed-files-with-git-diff:
-          <<:
-            - *exclude_develop_master_rc
-            - *exclude_locales_only_workflow
+          <<: *exclude_develop_master_rc
           requires:
             - prep-deps
       - validate-locales-only:
@@ -395,6 +384,8 @@ workflows:
       - test-lint:
           requires:
             - prep-deps
+            - get-changed-files-with-git-diff
+            - validate-locales-only
 
 jobs:
   trigger-beta-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
     when:
       not:
         matches:
-          pattern: /^l10n_crowdin_action$/
+          pattern: /^test_l10n_crowdin_action$/
           value: << pipeline.git.branch >>
     jobs:
       - create_release_pull_request:
@@ -370,7 +370,7 @@ workflows:
   locales_only:
     when:
       matches:
-        pattern: /^l10n_crowdin_action$/
+        pattern: /^test_l10n_crowdin_action$/
         value: << pipeline.git.branch >>
     jobs:
       - prep-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,9 +532,7 @@ jobs:
       - run: sudo corepack enable
       - attach_workspace:
           at: .
-      - run:
-          name:
-          command: yarn tsx .circleci/scripts/validate-locales-only.ts
+      - run: yarn tsx .circleci/scripts/validate-locales-only.ts
 
   validate-lavamoat-allow-scripts:
     executor: node-browsers-small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,8 @@ workflows:
     when:
       not:
         matches:
-            pattern: /^l10n_crowdin_action$/
-            value: << pipeline.git.branch >>
+          pattern: /^l10n_crowdin_action$/
+          value: << pipeline.git.branch >>
     jobs:
       - create_release_pull_request:
           <<: *rc_branch_only
@@ -375,7 +375,6 @@ workflows:
     jobs:
       - prep-deps
       - get-changed-files-with-git-diff:
-          <<: *exclude_develop_master_rc
           requires:
             - prep-deps
       - validate-locales-only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,10 +103,9 @@ aliases:
 workflows:
   locales_only:
     when:
-      condition:
-          matches:
-            pattern: /^test_l10n_crowdin_action$/
-            value: << pipeline.git.branch >>
+      matches:
+        pattern: /^test_l10n_crowdin_action$/
+        value: << pipeline.git.branch >>
     jobs:
       - prep-deps
       - test-lint:
@@ -115,9 +114,8 @@ workflows:
 
   test_and_release:
     when:
-      condition:
-        not:
-          matches:
+      not:
+        matches:
             pattern: /^test_l10n_crowdin_action$/
             value: << pipeline.git.branch >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
     when:
       not:
         matches:
-            pattern: /^l10n_crowdin_action$/
+            pattern: /^test_l10n_crowdin_action$/
             value: << pipeline.git.branch >>
     jobs:
       - create_release_pull_request:
@@ -370,7 +370,7 @@ workflows:
   locales_only:
     when:
       matches:
-        pattern: /^l10n_crowdin_action$/
+        pattern: /^test_l10n_crowdin_action$/
         value: << pipeline.git.branch >>
     jobs:
       - prep-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,13 @@ exclude_develop_master_rc: &exclude_develop_master_rc
         - develop
         - master
         - /^Version-v(\d+)[.](\d+)[.](\d+)/
+
+exclude_locales_only_workflow: &exclude_locales_only_workflow
+  filters:
+    branches:
+      ignore:
+        - /^test_l10n_crowdin_action$/
+
 aliases:
   # Shallow Git Clone
   - &shallow-git-clone
@@ -118,7 +125,9 @@ workflows:
       - check-pr-tag
       - prep-deps
       - get-changed-files-with-git-diff:
-          <<: *exclude_develop_master_rc
+          <<:
+            - *exclude_develop_master_rc
+            - *exclude_locales_only_workflow
           requires:
             - prep-deps
       - test-deps-audit:
@@ -375,7 +384,9 @@ workflows:
     jobs:
       - prep-deps
       - get-changed-files-with-git-diff:
-          <<: *exclude_develop_master_rc
+          <<:
+            - *exclude_develop_master_rc
+            - *exclude_locales_only_workflow
           requires:
             - prep-deps
       - validate-locales-only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,9 @@ workflows:
   locales_only:
     when:
       condition:
-        equal: [<< pipeline.git.branch >>, 'test_l10n_crowdin_action']
+          matches:
+            pattern: /^test_l10n_crowdin_action$/
+            value: << pipeline.git.branch >>
     jobs:
       - prep-deps
       - test-lint:
@@ -112,9 +114,12 @@ workflows:
             - prep-deps
 
   test_and_release:
-    unless:
+    when:
       condition:
-        equal: [<< pipeline.git.branch >>, 'test_l10n_crowdin_action']
+        not:
+          matches:
+            pattern: /^test_l10n_crowdin_action$/
+            value: << pipeline.git.branch >>
     jobs:
       - create_release_pull_request:
           <<: *rc_branch_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,9 +108,13 @@ workflows:
         value: << pipeline.git.branch >>
     jobs:
       - prep-deps
-      - test-lint:
+      - get-changed-files-with-git-diff:
+          <<: *exclude_develop_master_rc
           requires:
             - prep-deps
+      - validate-locales-only:
+          requires:
+            - get-changed-files-with-git-diff
 
   test_and_release:
     when:
@@ -514,6 +518,17 @@ jobs:
           root: .
           paths:
             - changed-files
+
+  validate-locales-only:
+    executor: node-browsers-small
+    steps:
+      - run: *shallow-git-clone
+      - run: sudo corepack enable
+      - attach_workspace:
+          at: .
+      - run:
+          name:
+          command: npx tsx .circleci/scripts/validate-locales-only.ts
 
   validate-lavamoat-allow-scripts:
     executor: node-browsers-small

--- a/.circleci/scripts/validate-locales-only.ts
+++ b/.circleci/scripts/validate-locales-only.ts
@@ -28,6 +28,7 @@ async function validateChangedFiles() {
   const changedFiles = await readChangedFiles();
   const invalidFiles = changedFiles.filter((file) => !file.startsWith('app/_locales/'));
   if (invalidFiles.length > 0) {
+    console.log('Changed Files:', changedFiles);
     console.error('Invalid files found:', invalidFiles);
     process.exit(1);
   }

--- a/.circleci/scripts/validate-locales-only.ts
+++ b/.circleci/scripts/validate-locales-only.ts
@@ -11,7 +11,7 @@ const CHANGED_FILES_PATH = path.join(
 /**
  * Reads the list of changed files from the git diff file.
  *
- * @returns {Promise<string[]>} An array of changed file paths.
+ * @returns An array of changed file paths.
  */
 async function readChangedFiles(): Promise<string[]>{
   try {

--- a/.circleci/scripts/validate-locales-only.ts
+++ b/.circleci/scripts/validate-locales-only.ts
@@ -1,36 +1,16 @@
-const fs = require('fs').promises;
-const path = require('path');
-
-const BASE_PATH = path.resolve(__dirname, '..', '..');
-const CHANGED_FILES_PATH = path.join(
-  BASE_PATH,
-  'changed-files',
-  'changed-files.txt',
-);
-
-/**
- * Reads the list of changed files from the git diff file.
- *
- * @returns An array of changed file paths.
- */
-async function readChangedFiles(): Promise<string[]> {
-  try {
-    const data = await fs.readFile(CHANGED_FILES_PATH, 'utf8');
-    const changedFiles = data.split('\n');
-    return changedFiles;
-  } catch (error) {
-    console.error('Error reading from file:', error);
-    return [];
-  }
-}
+const { readChangedFiles } = require('../../test/e2e/changedFilesUtil.js');
 
 /**
  * Verifies that all changed files are in the /_locales/ directory.
  * Fails the build if any changed files are outside of the /_locales/ directory.
  * Fails if no changed files are detected.
  */
-async function validateChangedFiles() {
+async function validateLocalesOnlyChangedFiles() {
   const changedFiles = await readChangedFiles();
+  if (!changedFiles) {
+    console.error('Failure: Unable to read changed files.');
+    process.exit(1);
+  }
   const invalidFiles = changedFiles.filter(
     (file) => !file.startsWith('app/_locales/'),
   );
@@ -51,4 +31,4 @@ async function validateChangedFiles() {
   }
 }
 
-validateChangedFiles();
+validateLocalesOnlyChangedFiles();

--- a/.circleci/scripts/validate-locales-only.ts
+++ b/.circleci/scripts/validate-locales-only.ts
@@ -7,8 +7,8 @@ const { readChangedFiles } = require('../../test/e2e/changedFilesUtil.js');
  */
 async function validateLocalesOnlyChangedFiles() {
   const changedFiles = await readChangedFiles();
-  if (!changedFiles) {
-    console.error('Failure: Unable to read changed files.');
+  if (!changedFiles || changedFiles.length === 0) {
+    console.error('Failure: No changed files detected.');
     process.exit(1);
   }
   const invalidFiles = changedFiles.filter(
@@ -21,9 +21,6 @@ async function validateLocalesOnlyChangedFiles() {
       '\n Invalid Files:',
       invalidFiles,
     );
-    process.exit(1);
-  } else if (changedFiles.length === 0) {
-    console.error('Failure: No changed files detected.');
     process.exit(1);
   } else {
     console.log('Passed validation');

--- a/.circleci/scripts/validate-locales-only.ts
+++ b/.circleci/scripts/validate-locales-only.ts
@@ -13,7 +13,7 @@ const CHANGED_FILES_PATH = path.join(
  *
  * @returns An array of changed file paths.
  */
-async function readChangedFiles(): Promise<string[]>{
+async function readChangedFiles(): Promise<string[]> {
   try {
     const data = await fs.readFile(CHANGED_FILES_PATH, 'utf8');
     const changedFiles = data.split('\n');
@@ -31,12 +31,18 @@ async function readChangedFiles(): Promise<string[]>{
  */
 async function validateChangedFiles() {
   const changedFiles = await readChangedFiles();
-  const invalidFiles = changedFiles.filter((file) => !file.startsWith('app/_locales/'));
+  const invalidFiles = changedFiles.filter(
+    (file) => !file.startsWith('app/_locales/'),
+  );
   if (invalidFiles.length > 0) {
-    console.error('Failure: Changed files must be in the /_locales/ directory.\n Changed Files:', changedFiles, '\n Invalid Files:', invalidFiles);
+    console.error(
+      'Failure: Changed files must be in the /_locales/ directory.\n Changed Files:',
+      changedFiles,
+      '\n Invalid Files:',
+      invalidFiles,
+    );
     process.exit(1);
-  }
-  else if (changedFiles.length === 0) {
+  } else if (changedFiles.length === 0) {
     console.error('Failure: No changed files detected.');
     process.exit(1);
   } else {

--- a/.circleci/scripts/validate-locales-only.ts
+++ b/.circleci/scripts/validate-locales-only.ts
@@ -1,0 +1,40 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const BASE_PATH = path.resolve(__dirname, '..', '..');
+const CHANGED_FILES_PATH = path.join(
+  BASE_PATH,
+  'changed-files',
+  'changed-files.txt',
+);
+
+/**
+ * Reads the list of changed files from the git diff file.
+ *
+ * @returns {Promise<string[]>} An array of changed file paths.
+ */
+async function readChangedFiles(): Promise<string[]>{
+  try {
+    const data = await fs.readFile(CHANGED_FILES_PATH, 'utf8');
+    const changedFiles = data.split('\n');
+    return changedFiles;
+  } catch (error) {
+    console.error('Error reading from file:', error);
+    return [];
+  }
+}
+
+async function validateChangedFiles() {
+  const changedFiles = await readChangedFiles();
+  const invalidFiles = changedFiles.filter((file) => !file.startsWith('app/_locales/'));
+  if (invalidFiles.length > 0) {
+    console.error('Invalid files found:', invalidFiles);
+    process.exit(1);
+  }
+  else {
+    console.log('All changed files are in the /_locales/ directory.');
+    process.exit(0);
+  }
+}
+
+validateChangedFiles();

--- a/.circleci/scripts/validate-locales-only.ts
+++ b/.circleci/scripts/validate-locales-only.ts
@@ -24,16 +24,23 @@ async function readChangedFiles(): Promise<string[]>{
   }
 }
 
+/**
+ * Verifies that all changed files are in the /_locales/ directory.
+ * Fails the build if any changed files are outside of the /_locales/ directory.
+ * Fails if no changed files are detected.
+ */
 async function validateChangedFiles() {
   const changedFiles = await readChangedFiles();
   const invalidFiles = changedFiles.filter((file) => !file.startsWith('app/_locales/'));
   if (invalidFiles.length > 0) {
-    console.log('Changed Files:', changedFiles);
-    console.error('Invalid files found:', invalidFiles);
+    console.error('Failure: Changed files must be in the /_locales/ directory.\n Changed Files:', changedFiles, '\n Invalid Files:', invalidFiles);
     process.exit(1);
   }
-  else {
-    console.log('All changed files are in the /_locales/ directory.');
+  else if (changedFiles.length === 0) {
+    console.error('Failure: No changed files detected.');
+    process.exit(1);
+  } else {
+    console.log('Passed validation');
     process.exit(0);
   }
 }

--- a/test/e2e/changedFilesUtil.js
+++ b/test/e2e/changedFilesUtil.js
@@ -41,4 +41,4 @@ async function filterE2eChangedFiles() {
   return e2eChangedFiles;
 }
 
-module.exports = { filterE2eChangedFiles };
+module.exports = { filterE2eChangedFiles, readChangedFiles };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Adds a new workflow to reduce the CI cost of pipelines from the translations branch `l10n_crowdin_action`.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25809?quickstart=1)

## **Related issues**

Fixes: #25770 


## **Manual testing steps**
1. Verify that the l10n_crowdin_action branch only runs the prep-deps, get-changed-files-with-git-diff, validate-locales-only, and test-lint.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
