### PR TITLE
fix: track token detection enabled

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2322,12 +2322,20 @@ export default class MetamaskController extends EventEmitter {
     // post onboarding emit detectTokens event
     const preferencesControllerState =
       this.preferencesController.store.getState();
-    const { useTokenDetection } = preferencesControllerState ?? {};
+    const { useTokenDetection, useNftDetection } =
+      preferencesControllerState ?? {};
     this.metaMetricsController.trackEvent({
       category: MetaMetricsEventCategory.Onboarding,
       event: MetaMetricsUserTrait.TokenDetectionEnabled,
       properties: {
         [MetaMetricsUserTrait.TokenDetectionEnabled]: useTokenDetection,
+      },
+    });
+    this.metaMetricsController.trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsUserTrait.NftAutodetectionEnabled,
+      properties: {
+        [MetaMetricsUserTrait.NftAutodetectionEnabled]: useNftDetection,
       },
     });
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -187,6 +187,7 @@ import {
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
+  MetaMetricsUserTrait,
 } from '../../shared/constants/metametrics';
 import { LOG_EVENT } from '../../shared/constants/logs';
 
@@ -2317,6 +2318,18 @@ export default class MetamaskController extends EventEmitter {
     if (usePhishDetect) {
       this.phishingController.maybeUpdateState();
     }
+
+    // post onboarding emit detectTokens event
+    const preferencesControllerState =
+      this.preferencesController.store.getState();
+    const { useTokenDetection } = preferencesControllerState ?? {};
+    this.metaMetricsController.trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsUserTrait.TokenDetectionEnabled,
+      properties: {
+        [MetaMetricsUserTrait.TokenDetectionEnabled]: useTokenDetection,
+      },
+    });
   }
 
   triggerNetworkrequests() {

--- a/test/e2e/tests/metrics/nft-detection-metrics.spec.js
+++ b/test/e2e/tests/metrics/nft-detection-metrics.spec.js
@@ -1,0 +1,115 @@
+const { strict: assert } = require('assert');
+const {
+  defaultGanacheOptions,
+  withFixtures,
+  WALLET_PASSWORD,
+  onboardingBeginCreateNewWallet,
+  onboardingChooseMetametricsOption,
+  onboardingCreatePassword,
+  onboardingRevealAndConfirmSRP,
+  onboardingCompleteWalletCreation,
+  onboardingPinExtension,
+  getEventPayloads,
+} = require('../../helpers');
+const FixtureBuilder = require('../../fixture-builder');
+
+/**
+ * mocks the segment api multiple times for specific payloads that we expect to
+ * see when these tests are run. In this case we are looking for
+ * 'Permissions Requested' and 'Permissions Received'. Do not use the constants
+ * from the metrics constants files, because if these change we want a strong
+ * indicator to our data team that the shape of data will change.
+ *
+ * @param {import('mockttp').Mockttp} mockServer
+ * @returns {Promise<import('mockttp/dist/pluggable-admin').MockttpClientResponse>[]}
+ */
+async function mockSegment(mockServer) {
+  return [
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'Wallet Setup Selected' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'Wallet Created' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'nft_autodetection_enabled' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+  ];
+}
+
+describe('Nft detection event @no-mmi', function () {
+  it('is sent when onboarding user', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true })
+          .withMetaMetricsController({
+            metaMetricsId: 'fake-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .withPreferencesController({
+            useTokenDetection: true,
+            useNftDetection: true,
+          })
+          .build(),
+        defaultGanacheOptions,
+        title: this.test.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+
+        await onboardingBeginCreateNewWallet(driver);
+        await onboardingChooseMetametricsOption(driver, true);
+        await onboardingCreatePassword(driver, WALLET_PASSWORD);
+        await onboardingRevealAndConfirmSRP(driver);
+        await onboardingCompleteWalletCreation(driver);
+        await onboardingPinExtension(driver);
+
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 3);
+        assert.deepStrictEqual(events[0].properties, {
+          account_type: 'metamask',
+          category: 'Onboarding',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'fullscreen',
+        });
+        assert.deepStrictEqual(events[1].properties, {
+          method: 'create',
+          category: 'Onboarding',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'fullscreen',
+        });
+        assert.deepStrictEqual(events[2].properties, {
+          nft_autodetection_enabled: true,
+          category: 'Onboarding',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+      },
+    );
+  });
+});

--- a/test/e2e/tests/metrics/token-detection-metrics.spec.js
+++ b/test/e2e/tests/metrics/token-detection-metrics.spec.js
@@ -1,0 +1,112 @@
+const { strict: assert } = require('assert');
+const {
+  defaultGanacheOptions,
+  withFixtures,
+  WALLET_PASSWORD,
+  onboardingBeginCreateNewWallet,
+  onboardingChooseMetametricsOption,
+  onboardingCreatePassword,
+  onboardingRevealAndConfirmSRP,
+  onboardingCompleteWalletCreation,
+  onboardingPinExtension,
+  getEventPayloads,
+} = require('../../helpers');
+const FixtureBuilder = require('../../fixture-builder');
+
+/**
+ * mocks the segment api multiple times for specific payloads that we expect to
+ * see when these tests are run. In this case we are looking for
+ * 'Permissions Requested' and 'Permissions Received'. Do not use the constants
+ * from the metrics constants files, because if these change we want a strong
+ * indicator to our data team that the shape of data will change.
+ *
+ * @param {import('mockttp').Mockttp} mockServer
+ * @returns {Promise<import('mockttp/dist/pluggable-admin').MockttpClientResponse>[]}
+ */
+async function mockSegment(mockServer) {
+  return [
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'Wallet Setup Selected' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'Wallet Created' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'token_detection_enabled' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+  ];
+}
+
+describe('Token detection event @no-mmi', function () {
+  it('is sent when onboarding user', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true })
+          .withMetaMetricsController({
+            metaMetricsId: 'fake-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .withPreferencesController({ useTokenDetection: true })
+          .build(),
+        defaultGanacheOptions,
+        title: this.test.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+
+        await onboardingBeginCreateNewWallet(driver);
+        await onboardingChooseMetametricsOption(driver, true);
+        await onboardingCreatePassword(driver, WALLET_PASSWORD);
+        await onboardingRevealAndConfirmSRP(driver);
+        await onboardingCompleteWalletCreation(driver);
+        await onboardingPinExtension(driver);
+
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 3);
+        assert.deepStrictEqual(events[0].properties, {
+          account_type: 'metamask',
+          category: 'Onboarding',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'fullscreen',
+        });
+        assert.deepStrictEqual(events[1].properties, {
+          method: 'create',
+          category: 'Onboarding',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'fullscreen',
+        });
+        assert.deepStrictEqual(events[2].properties, {
+          token_detection_enabled: true,
+          category: 'Onboarding',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+      },
+    );
+  });
+});


### PR DESCRIPTION
## **Description**

This PR adds tracking for `token_detection_enabled` metric after onboarding.

Token auto detection was set by default to true for new users in this [PR](https://github.com/MetaMask/metamask-extension/pull/23700);
But recently, we has reports that there were no upticks in mixpanel for dashboards tracking event: `token_detection_enabled`.

When the user first imports MM, the value of [useTokenDetection](https://github.com/MetaMask/metamask-extension/blob/9f95f30cea54d2711798f673614ffb2e54cc071c/app/scripts/controllers/metametrics.js#L821) in `currentTraits` object in  `_buildUserTraitsObject` fct is true.

When it tries to [updateStore](https://github.com/MetaMask/metamask-extension/blob/9f95f30cea54d2711798f673614ffb2e54cc071c/app/scripts/controllers/metametrics.js#L846) in this line; 
It has tokenDetection value set to true but the event is [not emitted](https://github.com/MetaMask/metamask-extension/blob/9f95f30cea54d2711798f673614ffb2e54cc071c/app/scripts/controllers/metametrics.js#L414) because we did not dispatch yet the action setParticipateInMetaMetrics. Which is done after the user clicks (confirm or I agree) after creating a new wallet or importing with SRP.

After participateInMetaMetrics is set to true it will no longer pick up our event because it will be true in both `previousUserTraits` and `currentTraits` (https://github.com/MetaMask/metamask-extension/blob/9f95f30cea54d2711798f673614ffb2e54cc071c/app/scripts/controllers/metametrics.js#L845)

This PR adds trackEvent inside `postOnboardingInitialization` for  `MetaMetricsUserTrait.TokenDetectionEnabled`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25822?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Import MM
2. Open background to check events
3. Go through onboarding 
4. Once onboarding is completed you should be able to see in networks tab an event `token_detection_enabled` set to true

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/73efc2ba-9f0b-4e26-a317-cb1902525a9d




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
