### PR TITLE
chore: Patch security issue in snaps-utils

### DIFF
--- a/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch
+++ b/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch
@@ -1,0 +1,30 @@
+diff --git a/dist/chunk-37VHIRUJ.js b/dist/chunk-37VHIRUJ.js
+index a909a4ef20305665a07db5c25b4a9ff7eb0a447e..98dd75bf33a9716dc6cca96a38d184645f6ec033 100644
+--- a/dist/chunk-37VHIRUJ.js
++++ b/dist/chunk-37VHIRUJ.js
+@@ -53,8 +53,8 @@ function assertIsKeyringOrigins(value, ErrorWrapper) {
+ }
+ function createOriginRegExp(matcher) {
+   const escaped = matcher.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+-  const regex = escaped.replace(/\*/gu, ".*");
+-  return RegExp(regex, "u");
++  const regex = escaped.replace(/\\\*/gu, '.*');
++  return RegExp(`${regex}$`, 'u');
+ }
+ function checkAllowedOrigin(matcher, origin) {
+   if (matcher === "*" || matcher === origin) {
+diff --git a/dist/chunk-K2OTEZZZ.mjs b/dist/chunk-K2OTEZZZ.mjs
+index 15be5da7563a5bdf464d7e9c28ed6f04863e378a..7f38bf328e71c1feb2b8850ba050ce9e55801668 100644
+--- a/dist/chunk-K2OTEZZZ.mjs
++++ b/dist/chunk-K2OTEZZZ.mjs
+@@ -53,8 +53,8 @@ function assertIsKeyringOrigins(value, ErrorWrapper) {
+ }
+ function createOriginRegExp(matcher) {
+   const escaped = matcher.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+-  const regex = escaped.replace(/\*/gu, ".*");
+-  return RegExp(regex, "u");
++  const regex = escaped.replace(/\\\*/gu, '.*');
++  return RegExp(`${regex}$`, 'u');
+ }
+ function checkAllowedOrigin(matcher, origin) {
+   if (matcher === "*" || matcher === origin) {

--- a/package.json
+++ b/package.json
@@ -257,7 +257,11 @@
     "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A18.1.2#~/.yarn/patches/@metamask-network-controller-npm-18.1.2-1bcb8d8610.patch",
     "@solana/web3.js/rpc-websockets": "^8.0.1",
     "@metamask/nonce-tracker@npm:^5.0.0": "patch:@metamask/nonce-tracker@npm%3A5.0.0#~/.yarn/patches/@metamask-nonce-tracker-npm-5.0.0-d81478218e.patch",
-    "@metamask/gas-fee-controller@npm:^15.1.1": "patch:@metamask/gas-fee-controller@npm%3A15.1.2#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch"
+    "@metamask/gas-fee-controller@npm:^15.1.1": "patch:@metamask/gas-fee-controller@npm%3A15.1.2#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.2-db4d2976aa.patch",
+    "@metamask/snaps-utils@npm:^7.6.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch",
+    "@metamask/snaps-utils@npm:^7.4.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch",
+    "@metamask/snaps-utils@npm:^7.5.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch",
+    "@metamask/snaps-utils@npm:^7.1.0": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.24.0#~/.yarn/patches/@babel-runtime-npm-7.24.0-7eb1dd11a2.patch",
@@ -340,7 +344,7 @@
     "@metamask/snaps-execution-environments": "^6.4.0",
     "@metamask/snaps-rpc-methods": "^9.1.3",
     "@metamask/snaps-sdk": "^5.0.0",
-    "@metamask/snaps-utils": "^7.6.0",
+    "@metamask/snaps-utils": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch",
     "@metamask/transaction-controller": "^32.0.0",
     "@metamask/user-operation-controller": "^10.0.0",
     "@metamask/utils": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6356,7 +6356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^7.1.0, @metamask/snaps-utils@npm:^7.4.0, @metamask/snaps-utils@npm:^7.5.0, @metamask/snaps-utils@npm:^7.6.0":
+"@metamask/snaps-utils@npm:7.6.0":
   version: 7.6.0
   resolution: "@metamask/snaps-utils@npm:7.6.0"
   dependencies:
@@ -6384,6 +6384,37 @@ __metadata:
     superstruct: "npm:^1.0.3"
     validate-npm-package-name: "npm:^5.0.0"
   checksum: 10/e81e0185ab1678822b47e400c4422023449be1641bea7ce3d679386257545091ecc73c9a4626c0ed585d93d9fe3a1354dc8e4b8310c27c33871f7fb0bb029506
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-utils@patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch":
+  version: 7.6.0
+  resolution: "@metamask/snaps-utils@patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch::version=7.6.0&hash=5f2735"
+  dependencies:
+    "@babel/core": "npm:^7.23.2"
+    "@babel/types": "npm:^7.23.0"
+    "@metamask/base-controller": "npm:^6.0.0"
+    "@metamask/key-tree": "npm:^9.1.1"
+    "@metamask/permission-controller": "npm:^10.0.0"
+    "@metamask/rpc-errors": "npm:^6.2.1"
+    "@metamask/slip44": "npm:^3.1.0"
+    "@metamask/snaps-registry": "npm:^3.1.0"
+    "@metamask/snaps-sdk": "npm:^5.0.0"
+    "@metamask/utils": "npm:^8.3.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.1"
+    chalk: "npm:^4.1.2"
+    cron-parser: "npm:^4.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    fast-xml-parser: "npm:^4.3.4"
+    marked: "npm:^12.0.1"
+    rfdc: "npm:^1.3.0"
+    semver: "npm:^7.5.4"
+    ses: "npm:^1.1.0"
+    superstruct: "npm:^1.0.3"
+    validate-npm-package-name: "npm:^5.0.0"
+  checksum: 10/73cbed809f410375347fa4360475dbb8154a3fa0a6276af33e1094be85f5b804dddf22b2065853d5f91069d173681b8c7e06312f0f7f9831fe5bb22b298419dc
   languageName: node
   linkType: hard
 
@@ -25110,7 +25141,7 @@ __metadata:
     "@metamask/snaps-execution-environments": "npm:^6.4.0"
     "@metamask/snaps-rpc-methods": "npm:^9.1.3"
     "@metamask/snaps-sdk": "npm:^5.0.0"
-    "@metamask/snaps-utils": "npm:^7.6.0"
+    "@metamask/snaps-utils": "patch:@metamask/snaps-utils@npm%3A7.6.0#~/.yarn/patches/@metamask-snaps-utils-npm-7.6.0-5569b09766.patch"
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:^8.4.0"
     "@metamask/transaction-controller": "npm:^32.0.0"


### PR DESCRIPTION
## **Description**

This adds a patch for MetaMask/snaps#2576, which fixes a security issue in the origin validation in Snaps.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25823?quickstart=1)