### PR TITLE
Sj/caip multichain getinternal

### DIFF
--- a/app/scripts/lib/multichain-api/caip25permissions.ts
+++ b/app/scripts/lib/multichain-api/caip25permissions.ts
@@ -69,10 +69,8 @@ const specificationBuilder: PermissionSpecificationBuilder<
   Caip25EndowmentSpecification
 > = ({
   findNetworkClientIdByChainId,
-  getInternalAccounts,
 }: {
   findNetworkClientIdByChainId: (chainId: Hex) => NetworkClientId;
-  getInternalAccounts: () => InternalAccount[];
 }) => {
   return {
     permissionType: PermissionType.Endowment,
@@ -100,7 +98,6 @@ const specificationBuilder: PermissionSpecificationBuilder<
 
       const processedScopes = processScopes(requiredScopes, optionalScopes, {
         findNetworkClientIdByChainId,
-        getInternalAccounts,
       });
 
       assert.deepEqual(requiredScopes, processedScopes.flattenedRequiredScopes);

--- a/app/scripts/lib/multichain-api/provider-authorize.js
+++ b/app/scripts/lib/multichain-api/provider-authorize.js
@@ -45,7 +45,7 @@ export async function providerAuthorizeHandler(req, res, _next, end, hooks) {
     },
   } = req;
 
-  const { findNetworkClientIdByChainId, getInternalAccounts } = hooks;
+  const { findNetworkClientIdByChainId } = hooks;
 
   if (Object.keys(restParams).length !== 0) {
     return end(
@@ -76,7 +76,7 @@ export async function providerAuthorizeHandler(req, res, _next, end, hooks) {
     const { flattenedRequiredScopes, flattenedOptionalScopes } = processScopes(
       requiredScopes,
       optionalScopes,
-      { findNetworkClientIdByChainId, getInternalAccounts },
+      { findNetworkClientIdByChainId },
     );
 
     Object.keys(flattenedRequiredScopes).forEach((scope) => {

--- a/app/scripts/lib/multichain-api/provider-authorize.test.js
+++ b/app/scripts/lib/multichain-api/provider-authorize.test.js
@@ -55,17 +55,10 @@ const createMockedHandler = () => {
   ]);
   const grantPermissions = jest.fn().mockResolvedValue(undefined);
   const findNetworkClientIdByChainId = jest.fn().mockReturnValue('mainnet');
-  const getInternalAccounts = jest.fn().mockReturnValue([
-    {
-      type: 'eip155:eoa',
-      address: '0xdeadbeef',
-    },
-  ]);
   const response = {};
   const handler = (request) =>
     providerAuthorizeHandler(request, response, next, end, {
       findNetworkClientIdByChainId,
-      getInternalAccounts,
       requestPermissions,
       grantPermissions,
     });
@@ -75,7 +68,6 @@ const createMockedHandler = () => {
     next,
     end,
     findNetworkClientIdByChainId,
-    getInternalAccounts,
     requestPermissions,
     grantPermissions,
     handler,
@@ -126,8 +118,7 @@ describe('provider_authorize', () => {
   });
 
   it('processes the scopes', async () => {
-    const { handler, findNetworkClientIdByChainId, getInternalAccounts } =
-      createMockedHandler();
+    const { handler, findNetworkClientIdByChainId } = createMockedHandler();
     await handler({
       ...baseRequest,
       params: {
@@ -141,7 +132,7 @@ describe('provider_authorize', () => {
     expect(processScopes).toHaveBeenCalledWith(
       baseRequest.params.requiredScopes,
       { foo: 'bar' },
-      { findNetworkClientIdByChainId, getInternalAccounts },
+      { findNetworkClientIdByChainId },
     );
   });
 

--- a/app/scripts/lib/multichain-api/scope/assert.test.ts
+++ b/app/scripts/lib/multichain-api/scope/assert.test.ts
@@ -29,7 +29,6 @@ describe('Scope Assert', () => {
         try {
           assertScopeSupported('scopeString', validScopeObject, {
             findNetworkClientIdByChainId,
-            getInternalAccounts,
           });
         } catch (err) {
           // noop
@@ -45,7 +44,6 @@ describe('Scope Assert', () => {
         expect(() => {
           assertScopeSupported('scopeString', validScopeObject, {
             findNetworkClientIdByChainId,
-            getInternalAccounts,
           });
         }).toThrow(
           new EthereumRpcError(5100, 'Requested chains are not supported'),
@@ -86,7 +84,6 @@ describe('Scope Assert', () => {
             },
             {
               findNetworkClientIdByChainId,
-              getInternalAccounts,
             },
           );
         } catch (err) {
@@ -109,7 +106,6 @@ describe('Scope Assert', () => {
             },
             {
               findNetworkClientIdByChainId,
-              getInternalAccounts,
             },
           );
         }).toThrow(
@@ -117,48 +113,6 @@ describe('Scope Assert', () => {
             5102,
             'Requested notifications are not supported',
           ),
-        );
-      });
-
-      it('checks if the accounts are supported', () => {
-        try {
-          assertScopeSupported(
-            'scopeString',
-            {
-              ...validScopeObject,
-              accounts: ['eip155:1:0xdeadbeef'],
-            },
-            {
-              findNetworkClientIdByChainId,
-              getInternalAccounts,
-            },
-          );
-        } catch (err) {
-          // noop
-        }
-
-        expect(MockSupported.isSupportedAccount).toHaveBeenCalledWith(
-          'eip155:1:0xdeadbeef',
-          getInternalAccounts,
-        );
-      });
-
-      it('throws an error if there are unsupported accounts', () => {
-        MockSupported.isSupportedAccount.mockReturnValue(false);
-        expect(() => {
-          assertScopeSupported(
-            'scopeString',
-            {
-              ...validScopeObject,
-              accounts: ['eip155:1:0xdeadbeef'],
-            },
-            {
-              findNetworkClientIdByChainId,
-              getInternalAccounts,
-            },
-          );
-        }).toThrow(
-          new EthereumRpcError(5103, 'Requested accounts are not supported'),
         );
       });
 
@@ -176,7 +130,6 @@ describe('Scope Assert', () => {
             },
             {
               findNetworkClientIdByChainId,
-              getInternalAccounts,
             },
           ),
         ).toBeUndefined();
@@ -194,7 +147,6 @@ describe('Scope Assert', () => {
           {},
           {
             findNetworkClientIdByChainId,
-            getInternalAccounts,
           },
         );
       }).toThrow(new EthereumRpcError(5100, 'Unknown error with request'));
@@ -210,7 +162,6 @@ describe('Scope Assert', () => {
           },
           {
             findNetworkClientIdByChainId,
-            getInternalAccounts,
           },
         );
       }).toThrow(
@@ -229,7 +180,6 @@ describe('Scope Assert', () => {
           },
           {
             findNetworkClientIdByChainId,
-            getInternalAccounts,
           },
         ),
       ).toBeUndefined();

--- a/app/scripts/lib/multichain-api/scope/assert.ts
+++ b/app/scripts/lib/multichain-api/scope/assert.ts
@@ -1,13 +1,8 @@
 import MetaMaskOpenRPCDocument from '@metamask/api-specs';
 import { NetworkClientId } from '@metamask/network-controller';
 import { Hex } from '@metamask/utils';
-import { InternalAccount } from '@metamask/keyring-api';
 import { EthereumRpcError } from 'eth-rpc-errors';
-import {
-  isSupportedAccount,
-  isSupportedNotification,
-  isSupportedScopeString,
-} from './supported';
+import { isSupportedNotification, isSupportedScopeString } from './supported';
 import { ScopeObject, ScopesObject } from './scope';
 
 const validRpcMethods = MetaMaskOpenRPCDocument.methods.map(({ name }) => name);
@@ -17,13 +12,11 @@ export const assertScopeSupported = (
   scopeObject: ScopeObject,
   {
     findNetworkClientIdByChainId,
-    getInternalAccounts,
   }: {
     findNetworkClientIdByChainId: (chainId: Hex) => NetworkClientId;
-    getInternalAccounts: () => InternalAccount[];
   },
 ) => {
-  const { methods, notifications, accounts } = scopeObject;
+  const { methods, notifications } = scopeObject;
   if (!isSupportedScopeString(scopeString, findNetworkClientIdByChainId)) {
     throw new EthereumRpcError(5100, 'Requested chains are not supported');
   }
@@ -63,27 +56,14 @@ export const assertScopeSupported = (
     );
   }
 
-  if (accounts) {
-    const accountsSupported = accounts.every((account) =>
-      isSupportedAccount(account, getInternalAccounts),
-    );
-
-    if (!accountsSupported) {
-      // TODO: There is no error code or message specified in the CAIP-25 spec for when accounts are not supported
-      // The below is made up
-      throw new EthereumRpcError(5103, 'Requested accounts are not supported');
-    }
-  }
 };
 
 export const assertScopesSupported = (
   scopes: ScopesObject,
   {
     findNetworkClientIdByChainId,
-    getInternalAccounts,
   }: {
     findNetworkClientIdByChainId: (chainId: Hex) => NetworkClientId;
-    getInternalAccounts: () => InternalAccount[];
   },
 ) => {
   // TODO: Should we be less strict validating optional scopes? As in we can
@@ -97,7 +77,6 @@ export const assertScopesSupported = (
   for (const [scopeString, scopeObject] of Object.entries(scopes)) {
     assertScopeSupported(scopeString, scopeObject, {
       findNetworkClientIdByChainId,
-      getInternalAccounts,
     });
   }
 };

--- a/app/scripts/lib/multichain-api/scope/authorization.test.ts
+++ b/app/scripts/lib/multichain-api/scope/authorization.test.ts
@@ -31,7 +31,6 @@ describe('Scope Authorization', () => {
 
   describe('processScopes', () => {
     const findNetworkClientIdByChainId = jest.fn();
-    const getInternalAccounts = jest.fn();
 
     it('validates the scopes', () => {
       try {
@@ -44,7 +43,6 @@ describe('Scope Authorization', () => {
           },
           {
             findNetworkClientIdByChainId,
-            getInternalAccounts,
           },
         );
       } catch (err) {
@@ -75,7 +73,6 @@ describe('Scope Authorization', () => {
         {},
         {
           findNetworkClientIdByChainId,
-          getInternalAccounts,
         },
       );
       expect(MockTransform.flattenMergeScopes).toHaveBeenCalledWith({
@@ -105,21 +102,18 @@ describe('Scope Authorization', () => {
         {},
         {
           findNetworkClientIdByChainId,
-          getInternalAccounts,
         },
       );
       expect(MockAssert.assertScopesSupported).toHaveBeenCalledWith(
         { 'eip155:1': validScopeObject, transformed: true },
         {
           findNetworkClientIdByChainId,
-          getInternalAccounts,
         },
       );
       expect(MockAssert.assertScopesSupported).toHaveBeenCalledWith(
         { 'eip155:5': validScopeObject, transformed: true },
         {
           findNetworkClientIdByChainId,
-          getInternalAccounts,
         },
       );
     });
@@ -143,7 +137,6 @@ describe('Scope Authorization', () => {
           {},
           {
             findNetworkClientIdByChainId,
-            getInternalAccounts,
           },
         );
       }).toThrow(new Error('unsupported scopes'));
@@ -169,7 +162,6 @@ describe('Scope Authorization', () => {
           {},
           {
             findNetworkClientIdByChainId,
-            getInternalAccounts,
           },
         ),
       ).toStrictEqual({

--- a/app/scripts/lib/multichain-api/scope/authorization.ts
+++ b/app/scripts/lib/multichain-api/scope/authorization.ts
@@ -1,4 +1,3 @@
-import { InternalAccount } from '@metamask/keyring-api';
 import { NetworkClientId } from '@metamask/network-controller';
 import { Hex } from '@metamask/utils';
 import { validateScopes } from './validation';
@@ -25,10 +24,8 @@ export const processScopes = (
   optionalScopes: ScopesObject,
   {
     findNetworkClientIdByChainId,
-    getInternalAccounts,
   }: {
     findNetworkClientIdByChainId: (chainId: Hex) => NetworkClientId;
-    getInternalAccounts: () => InternalAccount[];
   },
 ) => {
   const { validRequiredScopes, validOptionalScopes } = validateScopes(
@@ -42,11 +39,9 @@ export const processScopes = (
 
   assertScopesSupported(flattenedRequiredScopes, {
     findNetworkClientIdByChainId,
-    getInternalAccounts,
   });
   assertScopesSupported(flattenedOptionalScopes, {
     findNetworkClientIdByChainId,
-    getInternalAccounts,
   });
 
   return {

--- a/app/scripts/lib/multichain-api/scope/supported.test.ts
+++ b/app/scripts/lib/multichain-api/scope/supported.test.ts
@@ -1,8 +1,4 @@
-import {
-  isSupportedAccount,
-  isSupportedNotification,
-  isSupportedScopeString,
-} from './supported';
+import { isSupportedNotification, isSupportedScopeString } from './supported';
 
 describe('Scope Support', () => {
   it('isSupportedNotification', () => {
@@ -44,59 +40,6 @@ describe('Scope Support', () => {
         });
       expect(
         isSupportedScopeString('eip155:1', findNetworkClientIdByChainIdMock),
-      ).toStrictEqual(false);
-    });
-  });
-
-  describe('isSupportedAccount', () => {
-    it('returns false for non-ethereum namespaces', () => {
-      expect(isSupportedAccount('wallet:1:0x1', jest.fn())).toStrictEqual(
-        false,
-      );
-      expect(
-        isSupportedAccount(
-          'bip122:000000000019d6689c085ae165831e93:0x1',
-          jest.fn(),
-        ),
-      ).toStrictEqual(false);
-      expect(
-        isSupportedAccount('cosmos:cosmoshub-2:0x1', jest.fn()),
-      ).toStrictEqual(false);
-    });
-
-    it('returns true for ethereum eoa accounts', () => {
-      const getInternalAccountsMock = jest.fn().mockReturnValue([
-        {
-          type: 'eip155:eoa',
-          address: '0xdeadbeef',
-        },
-      ]);
-      expect(
-        isSupportedAccount('eip155:1:0xdeadbeef', getInternalAccountsMock),
-      ).toStrictEqual(true);
-    });
-
-    it('returns true for ethereum erc4337 accounts', () => {
-      const getInternalAccountsMock = jest.fn().mockReturnValue([
-        {
-          type: 'eip155:erc4337',
-          address: '0xdeadbeef',
-        },
-      ]);
-      expect(
-        isSupportedAccount('eip155:1:0xdeadbeef', getInternalAccountsMock),
-      ).toStrictEqual(true);
-    });
-
-    it('returns false for other ethereum account types', () => {
-      const getInternalAccountsMock = jest.fn().mockReturnValue([
-        {
-          type: 'eip155:other',
-          address: '0xdeadbeef',
-        },
-      ]);
-      expect(
-        isSupportedAccount('eip155:1:0xdeadbeef', getInternalAccountsMock),
       ).toStrictEqual(false);
     });
   });

--- a/app/scripts/lib/multichain-api/scope/validation.ts
+++ b/app/scripts/lib/multichain-api/scope/validation.ts
@@ -67,22 +67,6 @@ export const isValidScope = (
     return false;
   }
 
-  // Note we are not validating the chainId here, only the namespace
-  // const areAccountsValid = (accounts || []).every((account) => {
-  //   try {
-  //     return parseCaipAccountId(account).chain.namespace === namespace;
-  //   } catch (e) {
-  //     // parsing caipAccountId failed
-  //     console.log(e);
-  //     return false;
-  //   }
-  // });
-
-  // if (!areAccountsValid) {
-  //   return false;
-  // }
-  // not validating rpcDocuments or rpcEndpoints currently
-
   // unexpected properties found on scopeObject
   if (Object.keys(restScopeObject).length !== 0) {
     return false;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Currently we don’t believe account validation is necessary since we will only ever take accounts that are sourced from the keyring.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25836?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
