### PR TITLE
fix: flaky test `Create BTC Account cannot create multiple BTC accounts...`

### DIFF
--- a/test/e2e/accounts/common.ts
+++ b/test/e2e/accounts/common.ts
@@ -383,5 +383,8 @@ export async function createBtcAccount(driver: Driver) {
     text: messages.addNewBitcoinAccount.message,
     tag: 'button',
   });
-  await driver.clickElement({ text: 'Create', tag: 'button' });
+  await driver.clickElementAndWaitToDisappear({
+    text: 'Create',
+    tag: 'button',
+  });
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The Create BTC Account test is flaky as after clicking `Create` for creating a BTC account the popover remains some seconds visible, making that the subsequent click is obscured by it.
We fix this by using the `clickElementAndWaitToDisappear` method, which ensures that the popup is closed before proceeding.


```
driver] Called 'clickElement' with arguments [{"text":"Create","tag":"button"}]
[driver] Called 'delay' with arguments [500]
[driver] Called 'clickElement' with arguments ["[data-testid=\"account-menu-icon\"]"]
Failure on testcase: 'Create BTC Account cannot create multiple BTC accounts', for more information see the artifacts tab in CI

ElementClickInterceptedError: Element <button class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-base--ellipsis multichain-account-picker mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--gap-2 mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"> is not clickable at point (576,112) because another element <label class="mm-box mm-text mm-label mm-label--html-for mm-form-text-field__label mm-text--body-md mm-text--font-weight-medium mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"> obscures it


Executing testcase: 'Create BTC Account can cancel the removal of BTC acc
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25861?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25862

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

See artifacts, where the popup is still open

![image](https://github.com/user-attachments/assets/9f2a2d1b-58cb-49fc-9f99-45d12f0b5f01)



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
