### PR TITLE
fix: data passed over to false positive blockaid report

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlert.ts
@@ -43,13 +43,13 @@ const useBlockaidAlerts = (): Alert[] => {
 
   let stringifiedJSONData: string | undefined;
 
-  if (securityAlertResponse && currentConfirmation) {
+  if (signatureSecurityAlertResponse && currentConfirmation) {
     const {
       block,
       features,
       reason,
       result_type: resultType,
-    } = securityAlertResponse as SecurityAlertResponse;
+    } = signatureSecurityAlertResponse as SecurityAlertResponse;
     const { chainId, msgParams, origin, type, txParams } = currentConfirmation;
 
     const isFailedResultType = resultType === BlockaidResultType.Errored;


### PR DESCRIPTION
## **Description**
Blockaid false positive portal does not show all fields. This issue is happening only in branch `12.0.0` and is relate d to previous cherry-pick PR: https://github.com/MetaMask/metamask-extension/pull/25743

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25830

## **Manual testing steps**

1. Go to the test dapp
2. Trigger a malicious permit
3. Click Blockaid details
4. Click Report
5. See report missing fields

## **Screenshots/Recordings**
<img width="1510" alt="Screenshot 2024-07-16 at 3 56 00 PM" src="https://github.com/user-attachments/assets/fa26f9ee-e38c-4f0a-978a-39af70efb48b">

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
