### PR TITLE
Cherry-pick d721e7f (PR #25500) to V12.1.0

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -672,6 +672,14 @@ const openDapp = async (driver, contract = null, dappURL = DAPP_URL) => {
     : await driver.openNewPage(dappURL);
 };
 
+const openDappConnectionsPage = async (driver) => {
+  await driver.openNewPage(
+    `${driver.extensionUrl}/home.html#connections/${encodeURIComponent(
+      DAPP_URL,
+    )}`,
+  );
+};
+
 const createDappTransaction = async (driver, transaction) => {
   await openDapp(
     driver,
@@ -1150,6 +1158,7 @@ module.exports = {
   importWrongSRPOnboardingFlow,
   testSRPDropdownIterations,
   openDapp,
+  openDappConnectionsPage,
   createDappTransaction,
   switchToOrOpenDapp,
   connectToDapp,

--- a/test/e2e/tests/multichain/connection-page.spec.js
+++ b/test/e2e/tests/multichain/connection-page.spec.js
@@ -183,4 +183,37 @@ describe('Connections page', function () {
       },
     );
   });
+
+  // Skipped until issue where firefox connecting to dapp is resolved.
+  // it('shows that the account is connected to the dapp', async function () {
+  //   await withFixtures(
+  //     {
+  //       dapp: true,
+  //       fixtures: new FixtureBuilder().build(),
+  //       title: this.test.fullTitle(),
+  //       ganacheOptions: defaultGanacheOptions,
+  //     },
+  //     async ({ driver, ganacheServer }) => {
+  //       const ACCOUNT = '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1';
+  //       const SHORTENED_ACCOUNT = shortenAddress(ACCOUNT);
+  //       await logInWithBalanceValidation(driver, ganacheServer);
+  //       await openDappConnectionsPage(driver);
+  //       // Verify that there are no connected accounts
+  //       await driver.assertElementNotPresent(
+  //         '[data-testid="account-list-address"]',
+  //       );
+
+  //       await connectToDapp(driver);
+  //       await openDappConnectionsPage(driver);
+
+  //       const account = await driver.findElement(
+  //         '[data-testid="account-list-address"]',
+  //       );
+  //       const accountAddress = await account.getText();
+
+  //       // Dapp should contain single connected account address
+  //       assert.strictEqual(accountAddress, SHORTENED_ACCOUNT);
+  //     },
+  //   );
+  // });
 });

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -262,6 +262,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         >
           <p
             class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+            data-testid="account-list-address"
           >
             bc1qn3s...5eker
           </p>
@@ -557,6 +558,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         >
           <p
             class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+            data-testid="account-list-address"
           >
             0x0DCD5...3E7bc
           </p>

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -320,7 +320,11 @@ export const AccountListItem = ({
           justifyContent={JustifyContent.spaceBetween}
         >
           <Box display={Display.Flex} alignItems={AlignItems.center}>
-            <Text variant={TextVariant.bodySm} color={Color.textAlternative}>
+            <Text
+              variant={TextVariant.bodySm}
+              color={Color.textAlternative}
+              data-testid="account-list-address"
+            >
               {shortenAddress(normalizeSafeAddress(account.address))}
             </Text>
           </Box>

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -41,6 +41,7 @@ import { GlobalMenu } from '../global-menu';
 import {
   getSelectedInternalAccount,
   getTestNetworkBackgroundColor,
+  getOriginOfCurrentTab,
 } from '../../../selectors';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
@@ -80,6 +81,7 @@ export const AppHeaderUnlockedContent = ({
   const t = useI18nContext();
   const history = useHistory();
   const dispatch = useDispatch();
+  const origin = useSelector(getOriginOfCurrentTab);
   const [accountOptionsMenuOpen, setAccountOptionsMenuOpen] = useState(false);
   const testNetworkBackgroundColor = useSelector(getTestNetworkBackgroundColor);
 

--- a/ui/components/multichain/connected-site-menu/connected-site-menu.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.js
@@ -137,5 +137,5 @@ ConnectedSiteMenu.propTypes = {
   /**
    *  Disable the connected site menu if the account is non-evm
    */
-  disabled: PropTypes.boolean,
+  disabled: PropTypes.bool,
 };

--- a/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
+++ b/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
@@ -317,6 +317,7 @@ exports[`Connections Content should render correctly 1`] = `
                 >
                   <p
                     class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                    data-testid="account-list-address"
                   >
                     0x0DCD5...3E7bc
                   </p>

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -489,6 +489,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                         >
                           <p
                             class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                            data-testid="account-list-address"
                           >
                             0x0
                           </p>

--- a/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
@@ -265,6 +265,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="account-list-address"
             >
               0x0DCD5...3E7bc
             </p>
@@ -561,6 +562,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="account-list-address"
             >
               0xEC1Ad...9251B
             </p>
@@ -857,6 +859,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="account-list-address"
             >
               0xc42ED...D8813
             </p>
@@ -1162,6 +1165,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="account-list-address"
             >
               0xeB9e6...64823
             </p>
@@ -1458,6 +1462,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="account-list-address"
             >
               0xb5526...FEe5D
             </p>
@@ -1767,6 +1772,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              data-testid="account-list-address"
             >
               0xca8f1...Cf281
             </p>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -361,6 +361,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                       >
                         <p
                           class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                          data-testid="account-list-address"
                         >
                           0x0DCD5...3E7bc
                         </p>


### PR DESCRIPTION
This PR cherry-picks the commit [d721e7f](https://github.com/MetaMask/metamask-extension/commit/d721e7f7b1d7a915624fb14050a8b4037c524d96) (https://github.com/MetaMask/metamask-extension/pull/25500) into the release v12.1.0

Fixes https://github.com/MetaMask/metamask-extension/issues/25844