### PR TITLE
feat: new network flow e2e tests

### DIFF
--- a/test/e2e/tests/multichain/network/add-custom-network.spec.ts
+++ b/test/e2e/tests/multichain/network/add-custom-network.spec.ts
@@ -132,6 +132,9 @@ describe('Add custom network', function () {
   });
 
   it('should show suggestion name and symbol', async function () {
+    if (!process.env.ENABLE_NETWORK_UI_REDESIGN) {
+      return;
+    }
     async function mockRPCURLAndChainId(mockServer: Mockttp) {
       return [
         await mockServer
@@ -191,6 +194,9 @@ describe('Add custom network', function () {
   });
 
   it('should throw error for invalid RPC URL', async function () {
+    if (!process.env.ENABLE_NETWORK_UI_REDESIGN) {
+      return;
+    }
     async function mockRPCURLAndChainId(mockServer: Mockttp) {
       return [
         await mockServer
@@ -240,6 +246,9 @@ describe('Add custom network', function () {
   });
 
   it('rpc url should not be associated with another network and should match with chainID', async function () {
+    if (!process.env.ENABLE_NETWORK_UI_REDESIGN) {
+      return;
+    }
     async function mockRPCURLAndChainId(mockServer: Mockttp) {
       return [
         await mockServer

--- a/test/e2e/tests/multichain/network/add-custom-network.spec.ts
+++ b/test/e2e/tests/multichain/network/add-custom-network.spec.ts
@@ -1,0 +1,300 @@
+import { strict as assert } from 'assert';
+import { Context } from 'mocha';
+import { toHex } from '@metamask/controller-utils';
+import { Mockttp } from 'mockttp';
+import {
+  defaultGanacheOptions,
+  unlockWallet,
+  withFixtures,
+} from '../../../helpers';
+import FixtureBuilder from '../../../fixture-builder';
+import { Driver } from '../../../webdriver/driver';
+
+const TEST_CHAIN_ID = toHex(100);
+
+const selectors = {
+  suggestedTickerForXDAI: {
+    css: '[data-testid="network-form-ticker-suggestion"]',
+    text: 'Suggested ticker symbol:\nXDAI',
+  },
+  suggestedNameForXDAI: {
+    css: '[data-testid="network-form-name-suggestion"]',
+    text: 'Suggested name:\nGnosis',
+  },
+  networkNameInputField: '[data-testid="network-form-network-name"]',
+  rpcUrlInputField: '[data-testid="network-form-rpc-url"]',
+  chainIdInputField: '[data-testid="network-form-chain-id"]',
+  tickerInputField: '[data-testid="network-form-ticker-input"]',
+  explorerInputField: '[data-testid="network-form-block-explorer-url"]',
+};
+
+describe('Add custom network', function () {
+  const networkURL = 'https://responsive-rpc.test';
+  const networkNAME = 'Ethereum Mainnet';
+  const currencySYMBOL = 'ETH';
+  const blockExplorerURL = 'https://bscscan.com';
+
+  it('should add custom network', async () => {
+    if (!process.env.ENABLE_NETWORK_UI_REDESIGN) {
+      return;
+    }
+    async function mockRPCURLAndChainId(mockServer: Mockttp) {
+      return [
+        await mockServer
+          .forPost('https://responsive-rpc.test/')
+          .thenCallback(() => ({
+            statusCode: 200,
+            json: {
+              id: '1694444405781',
+              jsonrpc: '2.0',
+              result: TEST_CHAIN_ID,
+            },
+          })),
+      ];
+    }
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .withPreferencesController({ useSafeChainsListValidation: false })
+          .build(),
+        testSpecificMock: mockRPCURLAndChainId,
+      },
+
+      async ({ driver }: { driver: Driver }) => {
+        await unlockWallet(driver);
+
+        await driver.clickElement('[data-testid="network-display"]');
+        await driver.clickElement('[data-testid="add-custom-network"]');
+
+        // fill the add network form
+        const networkNameInputField = await driver.waitForSelector(
+          '[data-testid="network-form-network-name"]',
+        );
+        await networkNameInputField.sendKeys(networkNAME);
+
+        const rpcUrlInputField = await driver.waitForSelector(
+          '[data-testid="network-form-rpc-url"]',
+        );
+        await rpcUrlInputField.sendKeys(networkURL);
+
+        const chainIdInputField = await driver.waitForSelector(
+          '[data-testid="network-form-chain-id"]',
+        );
+        await chainIdInputField.sendKeys('100');
+
+        const symbolInputField = await driver.waitForSelector(
+          '[data-testid="network-form-ticker-input"]',
+        );
+        await symbolInputField.sendKeys(currencySYMBOL);
+
+        const blockExplorerInputField = await driver.waitForSelector(
+          '[data-testid="network-form-block-explorer-url"]',
+        );
+        await blockExplorerInputField.sendKeys(blockExplorerURL);
+
+        await driver.clickElement({ tag: 'button', text: 'Next' });
+
+        // verify network details
+        const title = await driver.findElement({
+          text: 'Ethereum Mainnet',
+        });
+        assert.equal(
+          await title.getText(),
+          'Ethereum Mainnet',
+          'Title of popup should be selected network',
+        );
+
+        await driver.clickElement({ tag: 'a', text: 'View all details' });
+        const networkDetailsLabels = await driver.findElements('dd');
+        assert.equal(
+          await networkDetailsLabels[8].getText(),
+          blockExplorerURL,
+          'Block Explorer URL is not correct',
+        );
+
+        await driver.clickElement({ tag: 'button', text: 'Close' });
+        await driver.clickElement('[data-testid="confirmation-submit-button"]');
+
+        // verify network switched
+        const networkDisplayed = await driver.findElement({
+          tag: 'span',
+          text: 'Ethereum Mainnet',
+        });
+        assert.equal(
+          await networkDisplayed.getText(),
+          'Ethereum Mainnet',
+          'You have not switched to Arbitrum Network',
+        );
+      },
+    );
+  });
+
+  it('should show suggestion name and symbol', async function () {
+    async function mockRPCURLAndChainId(mockServer: Mockttp) {
+      return [
+        await mockServer
+          .forPost('https://responsive-rpc.test/')
+          .thenCallback(() => ({
+            statusCode: 200,
+            json: {
+              id: '1694444405781',
+              jsonrpc: '2.0',
+              result: TEST_CHAIN_ID,
+            },
+          })),
+      ];
+    }
+
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: (this as Context).test?.fullTitle(),
+        testSpecificMock: mockRPCURLAndChainId,
+      },
+
+      async ({ driver }: { driver: Driver }) => {
+        await unlockWallet(driver);
+
+        await driver.clickElement('[data-testid="network-display"]');
+        await driver.clickElement('[data-testid="add-custom-network"]');
+
+        await driver.fill(selectors.networkNameInputField, 'Ethereum mainnet');
+        await driver.fill(
+          selectors.rpcUrlInputField,
+          'https://responsive-rpc.test',
+        );
+        await driver.fill(selectors.chainIdInputField, TEST_CHAIN_ID);
+        await driver.fill(selectors.tickerInputField, 'XDAI2');
+        await driver.fill(selectors.explorerInputField, 'https://test.com');
+
+        const suggestedName = await driver.findElement(
+          selectors.suggestedNameForXDAI.css,
+        );
+
+        const suggestedTicker = await driver.findElement(
+          selectors.suggestedTickerForXDAI.css,
+        );
+
+        const suggestedNameText = await suggestedName.getText();
+        const suggestedTickerText = await suggestedTicker.getText();
+
+        assert.equal(suggestedNameText, selectors.suggestedNameForXDAI.text);
+        assert.equal(
+          suggestedTickerText,
+          selectors.suggestedTickerForXDAI.text,
+        );
+      },
+    );
+  });
+
+  it('should throw error for invalid RPC URL', async function () {
+    async function mockRPCURLAndChainId(mockServer: Mockttp) {
+      return [
+        await mockServer
+          .forPost('https://responsive-rpc.test/')
+          .thenCallback(() => ({
+            statusCode: 200,
+            json: {
+              id: '1694444405781',
+              jsonrpc: '2.0',
+              result: TEST_CHAIN_ID,
+            },
+          })),
+      ];
+    }
+
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: (this as Context).test?.fullTitle(),
+        testSpecificMock: mockRPCURLAndChainId,
+      },
+
+      async ({ driver }: { driver: Driver }) => {
+        await unlockWallet(driver);
+
+        await driver.clickElement('[data-testid="network-display"]');
+        await driver.clickElement('[data-testid="add-custom-network"]');
+
+        await driver.fill(selectors.networkNameInputField, 'Ethereum mainnet');
+        await driver.fill(selectors.rpcUrlInputField, 'test');
+        await driver.fill(selectors.chainIdInputField, TEST_CHAIN_ID);
+        await driver.fill(selectors.tickerInputField, 'XDAI2');
+
+        const rpcUrlError = await driver.findElement(
+          '[data-testid="network-form-rpc-url-error"]',
+        );
+
+        const rpcUrlErrorText = await rpcUrlError.getText();
+
+        assert.equal(
+          rpcUrlErrorText,
+          'URLs require the appropriate HTTP/HTTPS prefix.',
+        );
+      },
+    );
+  });
+
+  it('rpc url should not be associated with another network and should match with chainID', async function () {
+    async function mockRPCURLAndChainId(mockServer: Mockttp) {
+      return [
+        await mockServer
+          .forPost('https://responsive-rpc.test/')
+          .thenCallback(() => ({
+            statusCode: 200,
+            json: {
+              id: '1694444405781',
+              jsonrpc: '2.0',
+              result: TEST_CHAIN_ID,
+            },
+          })),
+      ];
+    }
+
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: (this as Context).test?.fullTitle(),
+        testSpecificMock: mockRPCURLAndChainId,
+      },
+
+      async ({ driver }: { driver: Driver }) => {
+        await unlockWallet(driver);
+
+        await driver.clickElement('[data-testid="network-display"]');
+        await driver.clickElement('[data-testid="add-custom-network"]');
+
+        await driver.fill(selectors.networkNameInputField, 'Ethereum mainnet');
+        await driver.fill(selectors.rpcUrlInputField, 'http://localhost:8545');
+        await driver.fill(selectors.chainIdInputField, TEST_CHAIN_ID);
+        await driver.fill(selectors.tickerInputField, 'XDAI');
+
+        const rpcUrlError = await driver.findElement(
+          '[data-testid="network-form-rpc-url-error"]',
+        );
+
+        const chainIdError = await driver.findElement(
+          '[data-testid="network-form-chain-id-error"]',
+        );
+
+        const rpcUrlErrorText = await rpcUrlError.getText();
+        const chainIdErrorText = await chainIdError.getText();
+
+        assert.equal(
+          rpcUrlErrorText,
+          'This URL is associated with another chain ID.',
+        );
+
+        assert.equal(
+          chainIdErrorText,
+          'This chain ID doesn’t match the network name.',
+        );
+      },
+    );
+  });
+});

--- a/test/e2e/tests/multichain/network/add-network.spec.ts
+++ b/test/e2e/tests/multichain/network/add-network.spec.ts
@@ -1,0 +1,137 @@
+import { strict as assert } from 'assert';
+import { Context } from 'mocha';
+import {
+  defaultGanacheOptions,
+  unlockWallet,
+  withFixtures,
+} from '../../../helpers';
+import FixtureBuilder from '../../../fixture-builder';
+import { Driver } from '../../../webdriver/driver';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+
+describe('Add popular network', function () {
+  const chainIdMainnet = CHAIN_IDS.MAINNET;
+  const chainID = '42161';
+  const networkURL = 'https://arbitrum-mainnet.infura.io';
+  const networkNAME = 'Arbitrum One';
+  const currencySYMBOL = 'ETH';
+  const blockExplorerURL = 'https://explorer.arbitrum.io';
+
+  const fixtures = {
+    fixtures: new FixtureBuilder({ inputChainId: chainIdMainnet }).build(),
+    ganacheOptions: {
+      ...defaultGanacheOptions,
+      chainId: parseInt(chainIdMainnet, 16),
+    },
+  };
+
+  it('add popular network', async function () {
+    if (!process.env.ENABLE_NETWORK_UI_REDESIGN) {
+      return;
+    }
+    await withFixtures(
+      {
+        ...fixtures,
+        title: (this as Context).test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await unlockWallet(driver);
+
+        await driver.clickElement('[data-testid="network-display"]');
+        await driver.clickElement('[data-testid="test-add-button-0"]');
+
+        await driver.findElement({
+          text: 'Want to add this network?',
+        });
+
+        // verify network details
+        const title = await driver.findElement({
+          text: 'Arbitrum One',
+        });
+        assert.equal(
+          await title.getText(),
+          'Arbitrum One',
+          'Title of popup should be selected network',
+        );
+        const [networkName, networkUrl, chainIdElement, currencySymbol] =
+          await driver.findElements('.definition-list dd');
+        assert.equal(
+          await networkName.getText(),
+          networkNAME,
+          'Network name is not correctly displayed',
+        );
+        assert.equal(
+          await networkUrl.getText(),
+          networkURL,
+          'Network Url is not correctly displayed',
+        );
+        assert.equal(
+          await chainIdElement.getText(),
+          chainID.toString(),
+          'Chain Id is not correctly displayed',
+        );
+        assert.equal(
+          await currencySymbol.getText(),
+          currencySYMBOL,
+          'Currency symbol is not correctly displayed',
+        );
+        await driver.clickElement({ tag: 'a', text: 'View all details' });
+        const networkDetailsLabels = await driver.findElements('dd');
+        assert.equal(
+          await networkDetailsLabels[8].getText(),
+          blockExplorerURL,
+          'Block Explorer URL is not correct',
+        );
+        await driver.clickElement({ tag: 'button', text: 'Close' });
+        await driver.clickElement('[data-testid="confirmation-submit-button"]');
+
+        // verify network switched
+        const networkDisplayed = await driver.findElement({
+          tag: 'span',
+          text: 'Arbitrum One',
+        });
+        assert.equal(
+          await networkDisplayed.getText(),
+          'Arbitrum One',
+          'You have not switched to Arbitrum Network',
+        );
+      },
+    );
+  });
+
+  it('search for network', async function () {
+    if (!process.env.ENABLE_NETWORK_UI_REDESIGN) {
+      return;
+    }
+    await withFixtures(
+      {
+        ...fixtures,
+        title: (this as Context).test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await unlockWallet(driver);
+
+        await driver.clickElement('[data-testid="network-display"]');
+
+        // Search for Arbitrum
+        const searchInputField = await driver.waitForSelector(
+          '[data-testid="network-redesign-modal-search-input"]',
+        );
+        await searchInputField.sendKeys('Arbitrum');
+
+        // verify searched network
+        const networkDisplayed = await driver.findElement({
+          tag: 'p',
+          text: 'Arbitrum One',
+        });
+        assert.equal(await networkDisplayed.getText(), 'Arbitrum One');
+        // should filter popular network
+        assert.notEqual(await networkDisplayed.getText(), 'BNB');
+        // should filter enabled network
+        assert.notEqual(await networkDisplayed.getText(), 'Ethereum');
+        // should filter testnet
+        assert.notEqual(await networkDisplayed.getText(), 'Sepolia');
+      },
+    );
+  });
+});

--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -527,6 +527,7 @@ export const NetworkListMenu = ({ onClose }) => {
             <ButtonSecondary
               size={ButtonSecondarySize.Lg}
               startIconName={IconName.Add}
+              data-testid="add-custom-network"
               block
               onClick={() => {
                 if (!networkMenuRedesign) {

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.test.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.test.tsx
@@ -105,7 +105,7 @@ describe('PopularNetworkList', () => {
     };
 
     render(<PopularNetworkList {...props} />);
-    const addButton = screen.getByTestId('test-add-button');
+    const addButton = screen.getByTestId('test-add-button-0');
     fireEvent.click(addButton);
 
     expect(useDispatchMock).toHaveBeenCalled();

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -161,7 +161,7 @@ const PopularNetworkList = ({
                 type={ButtonVariant.Link}
                 className="add-network__add-button"
                 variant={ButtonVariant.Link}
-                data-testid="test-add-button"
+                data-testid={`test-add-button-${index}`}
                 onClick={async () => {
                   dispatch(toggleNetworkMenu());
                   await dispatch(

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -210,6 +210,7 @@ const NetworksForm = ({
           url: 'https://chainid.network/chains.json',
           functionName: 'getSafeChainsList',
         });
+
         Object.values(BUILT_IN_NETWORKS).forEach((network) => {
           const index = chainList.findIndex(
             (chain) =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Certainly! Here is the PR description in Markdown format:

---

### PR Description

#### Summary

This PR introduces new end-to-end (E2E) tests for the "Add popular network" feature in our application. The tests cover multiple scenarios to ensure the robustness and reliability of the network addition functionality, particularly focusing on popular and custom network configurations.

The following E2E tests have been added:

1. **Add Popular Network**
   - Adds the Arbitrum One network using the redesigned network UI.
   - Verifies network details such as network name, URL, chain ID, and currency symbol.
   - Confirms the network switch to the newly added network.

2. **Search for Network**
   - Searches for the Arbitrum One network using the search functionality in the network redesign modal.
   - Verifies that the search results display the correct network.

3. **Add Custom Network**
   - Adds a custom network (Ethereum Mainnet) using the redesigned network UI.
   - Fills in the network form with details such as network name, RPC URL, chain ID, currency symbol, and block explorer URL.
   - Verifies network details and confirms the network switch.

4. **Show Suggestion Name and Symbol**
   - Ensures the UI suggests the correct name and ticker symbol for the XDAI network when adding a custom network.

5. **Throw Error for Invalid RPC URL**
   - Tests the validation for an invalid RPC URL and verifies the appropriate error message is displayed.

6. **RPC URL Should Not Be Associated with Another Network**
   - Checks that the RPC URL is not associated with another network and matches the specified chain ID, ensuring the correct error messages are shown.

#### Dependencies

- This PR depends on the network UI redesign feature being enabled. Ensure that the `ENABLE_NETWORK_UI_REDESIGN` environment variable is set accordingly.


Please review and provide any feedback or additional requirements for the tests. Thank you!

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25885?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ensure the network UI redesign feature is enabled.
2. Run the E2E test suite using the command:
   ```bash
   ENABLE_NETWORK_UI_REDESIGN=1 yarn test:e2e:single test/e2e/tests/multichain/network/add-network.spec.ts --browser firefox
   ```
3. Verify that all new tests pass without errors.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
