### PR TITLE
fix: reject permig signature request if verifyingContract address is invalid hex address

### DIFF
--- a/app/scripts/lib/createConfirmationValidationMiddleware.test.js
+++ b/app/scripts/lib/createConfirmationValidationMiddleware.test.js
@@ -1,0 +1,131 @@
+import { errorCodes } from 'eth-rpc-errors';
+
+import { MESSAGE_TYPE } from '../../../shared/constants/app';
+import {
+  BlockaidReason,
+  BlockaidResultType,
+} from '../../../shared/constants/security-provider';
+import createConfirmationValidationMiddleware from './createConfirmationValidationMiddleware';
+
+const appStateController = {
+  store: {
+    getState: () => ({
+      signatureSecurityAlertResponses: {
+        1: {
+          result_type: BlockaidResultType.Malicious,
+          reason: BlockaidReason.maliciousDomain,
+        },
+      },
+    }),
+  },
+  getSignatureSecurityAlertResponse: (id) => {
+    return appStateController.store.getState().signatureSecurityAlertResponses[
+      id
+    ];
+  },
+};
+
+const createHandler = () => createConfirmationValidationMiddleware();
+
+function getNext(timeout = 500) {
+  let deferred;
+  const promise = new Promise((resolve) => {
+    deferred = {
+      resolve,
+    };
+  });
+  const cb = () => deferred.resolve();
+  let triggerNext;
+  setTimeout(() => {
+    deferred.resolve();
+  }, timeout);
+  return {
+    executeMiddlewareStack: async () => {
+      if (triggerNext) {
+        triggerNext(() => cb());
+      }
+      return await deferred.resolve();
+    },
+    promise,
+    next: (postReqHandler) => {
+      triggerNext = postReqHandler;
+    },
+  };
+}
+
+const from = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+
+const getMsgParams = (verifyingContract) => ({
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ],
+    Permit: [
+      { name: 'owner', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+    ],
+  },
+  primaryType: 'Permit',
+  domain: {
+    name: 'MyToken',
+    version: '1',
+    verifyingContract:
+      verifyingContract ?? '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    chainId: '0x1',
+  },
+  message: {
+    owner: from,
+    spender: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+    value: 3000,
+    nonce: 0,
+    deadline: 50000000000,
+  },
+});
+
+describe('createConfirmationValidationMiddleware', () => {
+  it('should not return error if request is permit with valid sender address', async () => {
+    const req = {
+      method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
+      params: [from, JSON.stringify(getMsgParams())],
+    };
+
+    const res = {
+      error: null,
+    };
+
+    const { executeMiddlewareStack, next } = getNext();
+    const handler = createHandler();
+    handler(req, res, next);
+    await executeMiddlewareStack();
+    expect(res.error).toBeNull();
+  });
+
+  it('should return error if request is permit with invalid sender address', async () => {
+    const req = {
+      method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
+      params: [
+        from,
+        JSON.stringify(
+          getMsgParams('917551056842671309452305380979543736893630245704'),
+        ),
+      ],
+    };
+
+    const res = {
+      error: null,
+    };
+
+    const { executeMiddlewareStack, next } = getNext();
+    const handler = createHandler();
+    handler(req, res, next);
+    await executeMiddlewareStack();
+    expect(res.error.code).toBe(errorCodes.rpc.invalidRequest);
+    expect(res.error.message).toBe('Invalid request.');
+  });
+});

--- a/app/scripts/lib/createConfirmationValidationMiddleware.test.js
+++ b/app/scripts/lib/createConfirmationValidationMiddleware.test.js
@@ -89,7 +89,7 @@ const getMsgParams = (verifyingContract) => ({
 });
 
 describe('createConfirmationValidationMiddleware', () => {
-  it('should not return error if request is permit with valid sender address', async () => {
+  it('should not return error if request is permit with valid verifyingContract address', async () => {
     const req = {
       method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
       params: [from, JSON.stringify(getMsgParams())],
@@ -106,7 +106,7 @@ describe('createConfirmationValidationMiddleware', () => {
     expect(res.error).toBeNull();
   });
 
-  it('should return error if request is permit with invalid sender address', async () => {
+  it('should return error if request is permit with invalid verifyingContract address', async () => {
     const req = {
       method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
       params: [

--- a/app/scripts/lib/createConfirmationValidationMiddleware.ts
+++ b/app/scripts/lib/createConfirmationValidationMiddleware.ts
@@ -1,0 +1,53 @@
+import { errorCodes } from 'eth-rpc-errors';
+import { isValidAddress } from 'ethereumjs-util';
+import { isValidHexAddress, JsonRpcRequest } from '@metamask/utils';
+import { JsonRpcMiddleware } from 'json-rpc-engine';
+
+import { MESSAGE_TYPE } from '../../../shared/constants/app';
+import { parseTypedDataMessage } from '../../../shared/modules/transaction.utils';
+
+import { EIP712_PRIMARY_TYPE_PERMIT } from '../../../shared/constants/transaction';
+
+/**
+ * Returns a middleware that validated incoming confirmations
+ */
+
+export default function createConfirmationValidationMiddleware(): JsonRpcMiddleware<
+  Request,
+  void
+> {
+  return async function confirmationValidationMiddleware(
+    req: JsonRpcRequest,
+    res,
+    next,
+  ) {
+    const { method, params } = req;
+
+    let data;
+    if (isValidAddress(params?.[1])) {
+      data = params?.[0];
+    } else {
+      data = params?.[1];
+    }
+
+    if (method === MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4) {
+      const {
+        domain: { verifyingContract },
+        primaryType,
+      } = parseTypedDataMessage(data);
+      if (
+        primaryType === EIP712_PRIMARY_TYPE_PERMIT &&
+        !isValidHexAddress(verifyingContract)
+      ) {
+        res.error = {
+          code: errorCodes.rpc.invalidRequest,
+          message: 'Invalid request.',
+        };
+      }
+    }
+
+    next(async (callback) => {
+      return callback();
+    });
+  };
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -327,6 +327,7 @@ import createEvmMethodsToNonEvmAccountReqFilterMiddleware from './lib/createEvmM
 import { isEthAddress } from './lib/multichain/address';
 import BridgeController from './controllers/bridge';
 import { decodeTransactionData } from './lib/transaction/decode/util';
+import createConfirmationValidationMiddleware from './lib/createConfirmationValidationMiddleware';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -5240,6 +5241,8 @@ export default class MetamaskController extends EventEmitter {
         appStateController: this.appStateController,
       }),
     );
+
+    engine.push(createConfirmationValidationMiddleware());
 
     engine.push(createUnsupportedMethodMiddleware());
 


### PR DESCRIPTION
## **Description**

Reject permit signature confirmation request if verifyingContract address is not valid hex value.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25733

## **Manual testing steps**

1. Go to test dapp
2. Submit permit with integer address
3. It should be rejected

## **Screenshots/Recordings**
<img width="904" alt="Screenshot 2024-07-17 at 4 30 19 PM" src="https://github.com/user-attachments/assets/623f0c19-227b-4af8-a060-b117cde8902c">

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
