### PR TITLE
fix: flaky test: Check the toggle for hex data

### DIFF
--- a/test/e2e/tests/settings/show-hex-data.spec.js
+++ b/test/e2e/tests/settings/show-hex-data.spec.js
@@ -8,7 +8,8 @@ const FixtureBuilder = require('../../fixture-builder');
 
 const selectors = {
   accountOptionsMenu: '[data-testid="account-options-menu-button"]',
-  settingsDiv: { text: 'Settings', tag: 'div' },
+  settingsDiv: '[data-testid="global-menu-settings"]',
+  portfolioMenuOption: '[data-testid="global-menu-mmi-portfolio"]',
   advancedDiv: { text: 'Advanced', tag: 'div' },
   hexDataToggle: '[data-testid="advanced-setting-hex-data"] .toggle-button',
   appHeaderLogo: '[data-testid="app-header-logo"]',
@@ -31,8 +32,13 @@ const inputData = {
 // Function to click elements in sequence
 async function clickElementsInSequence(driver, clickSelectors) {
   for (const selector of clickSelectors) {
-    await driver.waitForSelector(selector);
-    await driver.clickElement(selector);
+    if (process.env.MMI && selector === selectors.settingsDiv) {
+      await driver.waitForSelector(selectors.portfolioMenuOption);
+      await driver.clickElement(selector);
+    } else {
+      await driver.waitForSelector(selector);
+      await driver.clickElement(selector);
+    }
   }
 }
 

--- a/test/e2e/tests/settings/show-hex-data.spec.js
+++ b/test/e2e/tests/settings/show-hex-data.spec.js
@@ -34,11 +34,10 @@ async function clickElementsInSequence(driver, clickSelectors) {
   for (const selector of clickSelectors) {
     if (process.env.MMI && selector === selectors.settingsDiv) {
       await driver.waitForSelector(selectors.portfolioMenuOption);
-      await driver.clickElement(selector);
     } else {
       await driver.waitForSelector(selector);
-      await driver.clickElement(selector);
     }
+    await driver.clickElement(selector);
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR is to fix the flaky test occurring in the mmi build, where the dynamic menu option 'Portfolio Dashboard' is loaded and hence added the conditional wait only for the mmi build.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25899?quickstart=1)

## **Related issues**

Fixes: #24660

## **Manual testing steps**

Run locally or in codespace the test using below command:-
yarn
yarn build:test:mmi
yarn test:e2e:single test/e2e/tests/settings/show-hex-data.spec.js --browser=chrome --debug --leave-running

Note:- Set the variable process.env.MMI = 'true' at the spec file when executing locally. 

Validate the CI for mmi should pass.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
