### PR TITLE
feat: Adding state per window in e2e, excluding null state

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1072,14 +1072,19 @@ class Driver {
       const windowHandles = await this.driver.getAllWindowHandles();
       for (const handle of windowHandles) {
         await this.driver.switchTo().window(handle);
-        const screenshot = await this.driver.takeScreenshot();
-        await fs.writeFile(
-          `${filepathBase}-screenshot-${windowHandles.indexOf(handle) + 1}.png`,
-          screenshot,
-          {
-            encoding: 'base64',
-          },
-        );
+        const windowTitle = await this.driver.getTitle();
+        if (windowTitle !== 'MetaMask Offscreen Page') {
+          const screenshot = await this.driver.takeScreenshot();
+          await fs.writeFile(
+            `${filepathBase}-screenshot-${
+              windowHandles.indexOf(handle) + 1
+            }.png`,
+            screenshot,
+            {
+              encoding: 'base64',
+            },
+          );
+        }
       }
     } catch (e) {
       console.error('Failed to take screenshot', e);


### PR DESCRIPTION
A suggestion from @hjetpoluru, this PR aims to add better context to artifacts by logging state from multiple windows, as well as removing state artifacts that are null. This is similar to #25453.
Also fixes an mv3 offscreen issue found by @HowardBraham. The runner would get hung up on taking a screenshot if it was the offscreen window.
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25900?quickstart=1)

## **Related issues**

Fixes: #25874

## **Manual testing steps**

1. Run a failing e2e test
2. Verify that the test-failure-state.json artifact are now numbered and the number matches the relevant screenshot

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
