### PR TITLE
fix: Stop runaway `accountTracker` polling when all instances of metamask are closed

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6173,13 +6173,13 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * A method that is called by the background when all instances of metamask are closed.
-   * Currently used to stop polling in the gasFeeController.
    */
   onClientClosed() {
     try {
       this.gasFeeController.stopAllPolling();
       this.currencyRateController.stopAllPolling();
       this.appStateController.clearPollingTokens();
+      this.accountTracker.stopAllPolling();
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
## **Description**

In the v12 beta build there is an issue where

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25909?quickstart=1)

## **Related issues**

See: https://consensys.slack.com/archives/C07CGH75GFN/p1721233816417369

## **Manual testing steps**
To repro the bug:
1. Start a dev build on develop (or start up the v12 beta build)
2. Open the service worker dev console
3. Open and close the pop up
4. Go to the `network` tab of the dev console and see that requests titled `rpc` (if you click in you'll see they're `eth_blockNumber`, `eth_call` and `eth_getBlockNumber` requests) continue to occur ever ~20 seconds.

now to see that its fixed, open a dev build on this branch and repeat steps 2-4 and notice that there are no requests happening in the background after the UI is closed

## **Screenshots/Recordings**

### **Before**

### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
