### PR TITLE
fix: Restore `responsive` e2e driver option

### DIFF
--- a/test/e2e/tests/account/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/account/metamask-responsive-ui.spec.js
@@ -11,7 +11,7 @@ const FixtureBuilder = require('../../fixture-builder');
 
 describe('MetaMask Responsive UI', function () {
   it('Creating a new wallet @no-mmi', async function () {
-    const driverOptions = { openDevToolsForTabs: true };
+    const driverOptions = { responsive: true };
 
     await withFixtures(
       {
@@ -81,7 +81,7 @@ describe('MetaMask Responsive UI', function () {
   });
 
   it('Importing existing wallet from lock page', async function () {
-    const driverOptions = { openDevToolsForTabs: true };
+    const driverOptions = { responsive: true };
 
     await withFixtures(
       {
@@ -115,7 +115,7 @@ describe('MetaMask Responsive UI', function () {
   });
 
   it('Send Transaction from responsive window', async function () {
-    const driverOptions = { openDevToolsForTabs: true };
+    const driverOptions = { responsive: true };
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/swap-send/swap-send-test-utils.ts
+++ b/test/e2e/tests/swap-send/swap-send-test-utils.ts
@@ -266,9 +266,7 @@ export const getSwapSendFixtures = (
 ) => {
   const ETH_CONVERSION_RATE_USD = 3010;
   return {
-    driverOptions: {
-      openDevToolsForTabs: true,
-    },
+    driverOptions: { responsive: true },
     fixtures: new FixtureBuilder()
       .withPreferencesController({
         featureFlags: {},

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -24,6 +24,7 @@ function getProxyServer(proxyPort) {
 class ChromeDriver {
   static async build({
     openDevToolsForTabs,
+    responsive,
     constrainWindowSize,
     port,
     proxyPort,
@@ -43,7 +44,7 @@ class ChromeDriver {
       args.push(`load-extension=${process.cwd()}/dist/chrome`);
     }
 
-    if (openDevToolsForTabs) {
+    if (responsive || openDevToolsForTabs) {
       args.push('--auto-open-devtools-for-tabs');
     }
 

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -44,13 +44,9 @@ class ChromeDriver {
       args.push(`load-extension=${process.cwd()}/dist/chrome`);
     }
 
-<<<<<<< HEAD
-    if (responsive || openDevToolsForTabs) {
-=======
     // When "responsive" is enabled, open dev tools to force a smaller viewport
     // The minimum window width on Chrome is too large, this is how we're forcing the viewport to be smaller
-    if (openDevToolsForTabs  || responsive) {
->>>>>>> be7aa5e4a8 (Update test/e2e/webdriver/chrome.js)
+    if (openDevToolsForTabs || responsive) {
       args.push('--auto-open-devtools-for-tabs');
     }
 

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -44,7 +44,13 @@ class ChromeDriver {
       args.push(`load-extension=${process.cwd()}/dist/chrome`);
     }
 
+<<<<<<< HEAD
     if (responsive || openDevToolsForTabs) {
+=======
+    // When "responsive" is enabled, open dev tools to force a smaller viewport
+    // The minimum window width on Chrome is too large, this is how we're forcing the viewport to be smaller
+    if (openDevToolsForTabs  || responsive) {
+>>>>>>> be7aa5e4a8 (Update test/e2e/webdriver/chrome.js)
       args.push('--auto-open-devtools-for-tabs');
     }
 

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -6,6 +6,7 @@ const FirefoxDriver = require('./firefox');
 async function buildWebDriver({
   responsive,
   openDevToolsForTabs,
+  constrainWindowSize,
   port,
   timeOut,
   proxyPort,

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -4,9 +4,9 @@ const ChromeDriver = require('./chrome');
 const FirefoxDriver = require('./firefox');
 
 async function buildWebDriver({
+  responsive,
   openDevToolsForTabs,
   port,
-  constrainWindowSize,
   timeOut,
   proxyPort,
 } = {}) {
@@ -17,6 +17,7 @@ async function buildWebDriver({
     extensionId,
     extensionUrl,
   } = await buildBrowserWebDriver(browser, {
+    responsive,
     openDevToolsForTabs,
     port,
     constrainWindowSize,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In https://github.com/MetaMask/metamask-extension/pull/18347, we changed the driver option `responsive` to `openDevToolsForTabs`. This was because we had a new test suite that intended to test browser behaviour related to Service Worker restart on manifest v3 builds. Later changes to chrome's mv3 implementation meant that service worker no longer restarted, and those e2e tests no longer exist (`test/e2e/mv3/service-worker-restart.spec.js`).

However, this change had an unwanted side effect on another test suite (`test/e2e/tests/metamask-responsive-ui.spec.js`). As @Gudahtt puts it in a slack message:

> It looks like in this PR, the responsive option in the Chrome webdriver was replaced with openDevToolsForTabs. This is functionally what that option did, but this doesn't match the semantic purpose for why the browser opened the dev tools.

> Browser driver options are shared between the Firefox and Chrome drivers, so now they don't match. The test suite meant to test our UI in a small viewport is now passing in the openDevToolsForTabs option, but this doesn't work for the Firefox browser because it doesn't recognize that option. So the tests are "passing" but they aren't actually running the steps that are meant to be under test.

This PR reverts the option to its original name.






[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25932?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
