### PR TITLE
fix: mitigate race condition and flakiness for delete metametrics test

### DIFF
--- a/test/e2e/tests/metrics/delete-metametrics-data.spec.ts
+++ b/test/e2e/tests/metrics/delete-metametrics-data.spec.ts
@@ -207,7 +207,7 @@ describe('Delete MetaMetrics Data @no-mmi', function (this: Suite) {
           rowLocators.deleteMetaMetricsDataButton,
         );
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await (deleteMetaMetricsDataButton as any).waitForElementState(
+        await (deleteMetaMetricsDataButtonRefreshed as any).waitForElementState(
           'disabled',
         );
         assert.equal(

--- a/test/e2e/tests/metrics/delete-metametrics-data.spec.ts
+++ b/test/e2e/tests/metrics/delete-metametrics-data.spec.ts
@@ -178,7 +178,11 @@ describe('Delete MetaMetrics Data @no-mmi', function (this: Suite) {
 
         await driver.findElement(rowLocators.deletMetaMetricsSettings);
         await driver.clickElement(rowLocators.deleteMetaMetricsDataButton);
-        await driver.clickElement(rowLocators.clearButton);
+
+        // there is a race condition, where we need to wait before clicking clear button otherwise an error is thrown in the background
+        // we cannot wait for a UI conditon, so we a delay to mitigate this until another solution is found
+        await driver.delay(3000);
+        await driver.clickElementAndWaitToDisappear(rowLocators.clearButton);
 
         const deleteMetaMetricsDataButton = await driver.findElement(
           rowLocators.deleteMetaMetricsDataButton,
@@ -201,6 +205,10 @@ describe('Delete MetaMetrics Data @no-mmi', function (this: Suite) {
 
         const deleteMetaMetricsDataButtonRefreshed = await driver.findElement(
           rowLocators.deleteMetaMetricsDataButton,
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (deleteMetaMetricsDataButton as any).waitForElementState(
+          'disabled',
         );
         assert.equal(
           await deleteMetaMetricsDataButtonRefreshed.isEnabled(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25945?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
