### PR TITLE
fix: show current network if domains are undefined

### DIFF
--- a/test/e2e/tests/multichain/all-permissions-page.spec.js
+++ b/test/e2e/tests/multichain/all-permissions-page.spec.js
@@ -1,0 +1,98 @@
+const { strict: assert } = require('assert');
+const {
+  withFixtures,
+  WINDOW_TITLES,
+  connectToDapp,
+  logInWithBalanceValidation,
+  defaultGanacheOptions,
+} = require('../../helpers');
+const FixtureBuilder = require('../../fixture-builder');
+
+describe('Permissions Page', function () {
+  it('should show connected site permissions when a single dapp is connected', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder().build(),
+        title: this.test.fullTitle(),
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async ({ driver, ganacheServer }) => {
+        await logInWithBalanceValidation(driver, ganacheServer);
+        await connectToDapp(driver);
+
+        // close test dapp window to avoid future confusion
+        const windowHandles = await driver.getAllWindowHandles();
+        await driver.closeWindowHandle(windowHandles[1]);
+        // disconnect dapp in fullscreen view
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+        await driver.clickElement(
+          '[data-testid ="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'All Permissions', tag: 'div' });
+        await driver.clickElementAndWaitToDisappear({
+          text: 'Got it',
+          tag: 'button',
+        });
+        const connectedDapp = await driver.isElementPresent({
+          text: '127.0.0.1:8080',
+          tag: 'p',
+        });
+        assert.ok(connectedDapp, 'Account connected to Dapp1');
+      },
+    );
+  });
+
+  it('should show all permissions listed when experimental settings toggle is off', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder().build(),
+        title: this.test.fullTitle(),
+        ganacheOptions: defaultGanacheOptions,
+      },
+      async ({ driver, ganacheServer }) => {
+        await logInWithBalanceValidation(driver, ganacheServer);
+        await connectToDapp(driver);
+
+        // close test dapp window to avoid future confusion
+        const windowHandles = await driver.getAllWindowHandles();
+        await driver.closeWindowHandle(windowHandles[1]);
+        // disconnect dapp in fullscreen view
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.clickElement({
+          text: 'Experimental',
+          tag: 'div',
+        });
+
+        await driver.clickElement(
+          '[data-testid="experimental-setting-toggle-request-queue"] label',
+        );
+        await driver.clickElement(
+          '.settings-page__header__title-container__close-button',
+        );
+        await driver.clickElement(
+          '[data-testid ="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'All Permissions', tag: 'div' });
+        await driver.clickElementAndWaitToDisappear({
+          text: 'Got it',
+          tag: 'button',
+        });
+        const connectedDapp = await driver.isElementPresent({
+          text: '127.0.0.1:8080',
+          tag: 'p',
+        });
+        assert.ok(connectedDapp, 'Account connected to Dapp1');
+      },
+    );
+  });
+});

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1504,24 +1504,6 @@ export const getConnectedSitesList = createDeepEqualSelector(
   },
 );
 
-export const getConnectedSitesListWithNetworkInfo = createDeepEqualSelector(
-  getConnectedSitesList,
-  getAllDomains,
-  getAllNetworks,
-  (sitesList, domains, networks) => {
-    Object.keys(sitesList).forEach((siteKey) => {
-      const connectedNetwork = networks.find(
-        (network) => network.id === domains[siteKey],
-      );
-      // For the testnets, if we do not have an image, we will have a fallback string
-      sitesList[siteKey].networkIconUrl =
-        connectedNetwork.rpcPrefs?.imageUrl || '';
-      sitesList[siteKey].networkName = connectedNetwork.nickname;
-    });
-    return sitesList;
-  },
-);
-
 export const getConnectedSnapsList = createDeepEqualSelector(
   getSnapsList,
   (snapsData) => {
@@ -1832,6 +1814,26 @@ export const getCurrentNetwork = createDeepEqualSelector(
         ? (network) => network.id === providerConfig.id
         : (network) => network.id === providerConfig.type;
     return allNetworks.find(filter);
+  },
+);
+
+export const getConnectedSitesListWithNetworkInfo = createDeepEqualSelector(
+  getConnectedSitesList,
+  getAllDomains,
+  getAllNetworks,
+  getCurrentNetwork,
+  (sitesList, domains, networks, currentNetwork) => {
+    Object.keys(sitesList).forEach((siteKey) => {
+      const connectedNetwork = networks.find(
+        (network) => network.id === domains[siteKey],
+      );
+      console.log(currentNetwork)
+      // For the testnets, if we do not have an image, we will have a fallback string
+      sitesList[siteKey].networkIconUrl =
+        connectedNetwork?.rpcPrefs?.imageUrl || connectedNetwork?.rpcPrefs?.imageUrl || '';
+      sitesList[siteKey].networkName = connectedNetwork?.nickname || connectedNetwork?.nickname || '';
+    });
+    return sitesList;
   },
 );
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1827,11 +1827,13 @@ export const getConnectedSitesListWithNetworkInfo = createDeepEqualSelector(
       const connectedNetwork = networks.find(
         (network) => network.id === domains[siteKey],
       );
-      console.log(currentNetwork)
       // For the testnets, if we do not have an image, we will have a fallback string
       sitesList[siteKey].networkIconUrl =
-        connectedNetwork?.rpcPrefs?.imageUrl || connectedNetwork?.rpcPrefs?.imageUrl || '';
-      sitesList[siteKey].networkName = connectedNetwork?.nickname || connectedNetwork?.nickname || '';
+        connectedNetwork?.rpcPrefs?.imageUrl ||
+        currentNetwork?.rpcPrefs?.imageUrl ||
+        '';
+      sitesList[siteKey].networkName =
+        connectedNetwork?.nickname || currentNetwork?.nickname || '';
     });
     return sitesList;
   },


### PR DESCRIPTION
If Experimental settings `Select Networks for each site` is off, the domains are undefined. In this case, the fallback network should be the current network.

## **Related issues**

Fixes: [#25887](https://github.com/MetaMask/metamask-extension/issues/25887)

## **Manual testing steps**

1. Connect MetaMask to Dapp
2. Go to Permissions, check the logo of network is specific to connected network
3. Turn the experimental setting off, Go back to all permissions page. Now the network logo should be same as globally selected network for all the dapps

## **Screenshots/Recordings**


### **Before**

![Screenshot 2024-07-19 at 12 06 29 AM](https://github.com/user-attachments/assets/53fc2ee5-2c0f-46ff-892c-3ee48ad28a6d)

### **After**

https://github.com/user-attachments/assets/fe0bed9e-c050-4ab8-8607-bf933e1eac63



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
