### PR TITLE
feat: Show the Close extension button on the Smart Transaction Status Page for a pending dapp transaction

### DIFF
--- a/ui/pages/smart-transactions/smart-transaction-status-page/__snapshots__/smart-transactions-status-page.test.js.snap
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/__snapshots__/smart-transactions-status-page.test.js.snap
@@ -363,6 +363,12 @@ exports[`SmartTransactionStatusPage renders the "pending" STX status for a dapp 
       >
         You may close this window anytime.
       </p>
+      <button
+        class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-secondary mm-text--body-md-medium mm-box--margin-top-3 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
+        data-testid="smart-transaction-status-page-footer-close-button"
+      >
+        Close extension
+      </button>
     </div>
   </div>
 </div>

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
@@ -276,15 +276,13 @@ const PortfolioSmartTransactionStatusUrl = ({
 
 const CloseExtensionButton = ({
   isDapp,
-  isSmartTransactionPending,
   onCloseExtension,
 }: {
   isDapp: boolean;
-  isSmartTransactionPending: boolean;
   onCloseExtension: () => void;
 }) => {
   const t = useI18nContext();
-  if (!isDapp || isSmartTransactionPending) {
+  if (!isDapp) {
     return null;
   }
   return (
@@ -370,7 +368,6 @@ const SmartTransactionsStatusPageFooter = ({
       />
       <CloseExtensionButton
         isDapp={isDapp}
-        isSmartTransactionPending={isSmartTransactionPending}
         onCloseExtension={onCloseExtension}
       />
       <ViewActivityButton isDapp={isDapp} onViewActivity={onViewActivity} />

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transactions-status-page.test.js
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transactions-status-page.test.js
@@ -175,6 +175,7 @@ describe('SmartTransactionStatusPage', () => {
       queryByText('You may close this window anytime.'),
     ).toBeInTheDocument();
     expect(queryByText('View transaction')).toBeInTheDocument();
+    expect(queryByText('Close extension')).toBeInTheDocument();
     expect(queryByText('View activity')).not.toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });


### PR DESCRIPTION
## **Description**
Shows the Close extension button on the Smart Transaction Status Page for a pending dapp transaction. Previously it only showed up for a dapp transaction when it wasn't pending.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25965?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enable smart transactions in settings
2. Send a dapp transaction, e.g. on Sepolia
3. You will see the `Close extension` button on the status page

## **Screenshots/Recordings**

<img width="358" alt="image" src="https://github.com/user-attachments/assets/fc1e5d04-f5b8-4258-bcbd-3b0bfd5db4e1">

<img width="359" alt="image" src="https://github.com/user-attachments/assets/5134f795-541f-4e72-9933-3a2fedb1cd48">


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
