### PR TITLE
fix: vertically align asset image

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
@@ -13,29 +13,33 @@ exports[`AssetPicker matches snapshot 1`] = `
         class="mm-box mm-box--display-flex mm-box--gap-3 mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-badge-wrapper mm-box--display-inline-block"
+          class="mm-box mm-box--display-flex"
         >
           <div
-            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
-          >
-            <img
-              aria-hidden="true"
-              class="mm-avatar-token__token-image--blurred"
-              src="./images/eth_logo.svg"
-            />
-            <img
-              alt="NATIVE TICKER logo"
-              class="mm-avatar-token__token-image--size-reduced"
-              src="./images/eth_logo.svg"
-            />
-          </div>
-          <div
-            class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-top-right"
+            class="mm-box mm-badge-wrapper mm-box--display-inline-block"
           >
             <div
-              class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
             >
-              ?
+              <img
+                aria-hidden="true"
+                class="mm-avatar-token__token-image--blurred"
+                src="./images/eth_logo.svg"
+              />
+              <img
+                alt="NATIVE TICKER logo"
+                class="mm-avatar-token__token-image--size-reduced"
+                src="./images/eth_logo.svg"
+              />
+            </div>
+            <div
+              class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-top-right"
+            >
+              <div
+                class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              >
+                ?
+              </div>
             </div>
           </div>
         </div>
@@ -80,20 +84,24 @@ exports[`AssetPicker render if disabled 1`] = `
         class="mm-box mm-box--display-flex mm-box--gap-3 mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-badge-wrapper mm-box--display-inline-block"
+          class="mm-box mm-box--display-flex"
         >
           <div
-            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
-          >
-            s
-          </div>
-          <div
-            class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-top-right"
+            class="mm-box mm-badge-wrapper mm-box--display-inline-block"
           >
             <div
-              class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+              class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
             >
-              ?
+              s
+            </div>
+            <div
+              class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-top-right"
+            >
+              <div
+                class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+              >
+                ?
+              </div>
             </div>
           </div>
         </div>

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -179,30 +179,32 @@ export function AssetPicker({
         title={handleAssetPickerTitle()}
       >
         <Box display={Display.Flex} alignItems={AlignItems.center} gap={3}>
-          <BadgeWrapper
-            badge={
-              <AvatarNetwork
-                size={AvatarNetworkSize.Xs}
-                name={currentNetwork?.nickname}
-                src={currentNetwork?.rpcPrefs?.imageUrl}
-                backgroundColor={testNetworkBackgroundColor}
-                borderColor={
-                  primaryTokenImage
-                    ? BorderColor.borderMuted
-                    : BorderColor.borderDefault
-                }
+          <Box display={Display.Flex}>
+            <BadgeWrapper
+              badge={
+                <AvatarNetwork
+                  size={AvatarNetworkSize.Xs}
+                  name={currentNetwork?.nickname}
+                  src={currentNetwork?.rpcPrefs?.imageUrl}
+                  backgroundColor={testNetworkBackgroundColor}
+                  borderColor={
+                    primaryTokenImage
+                      ? BorderColor.borderMuted
+                      : BorderColor.borderDefault
+                  }
+                />
+              }
+            >
+              <AvatarToken
+                borderRadius={isNFT ? BorderRadius.LG : BorderRadius.full}
+                src={primaryTokenImage}
+                size={AvatarTokenSize.Md}
+                showHalo={!isNFT}
+                name={symbol}
+                {...(isNFT && { backgroundColor: BackgroundColor.transparent })}
               />
-            }
-          >
-            <AvatarToken
-              borderRadius={isNFT ? BorderRadius.LG : BorderRadius.full}
-              src={primaryTokenImage}
-              size={AvatarTokenSize.Md}
-              showHalo={!isNFT}
-              name={symbol}
-              {...(isNFT && { backgroundColor: BackgroundColor.transparent })}
-            />
-          </BadgeWrapper>
+            </BadgeWrapper>
+          </Box>
 
           <Tooltip disabled={!isSymbolLong} title={symbol} position="bottom">
             <Text className="asset-picker__symbol" variant={TextVariant.bodyMd}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In #25470, the `BadgeWrapper` was implemented for the send flow. By default, this component uses `inline-block` styling and `align-self: start` to allow the network icon and asset icon to maintain alignment; this prevents the existing flex box styling from being applied.

This is mitigated by wrapping the component in a `Box` component.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25988?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to send page
2. Select a recipient
3. Ensure that the token image is vertically aligned
4. Switch to an NFT
5. Ensure that the NFT image is vertically aligned


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="365" alt="Screenshot 2024-07-19 at 1 58 15 PM" src="https://github.com/user-attachments/assets/a1cd7f6d-ec76-444e-bd7d-0bc8cf8732f4">

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="365" alt="Screenshot 2024-07-19 at 1 59 48 PM" src="https://github.com/user-attachments/assets/a9eda763-2469-43bc-8edb-3dfa959caf51">

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
