### PR TITLE
fix: Fix permssions for `update-attributions` workflow

### DIFF
--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
@@ -146,8 +146,6 @@ jobs:
           git config --global user.email 'metamaskbot@users.noreply.github.com'
           git commit -am "Update Attributions"
           git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
       - name: Post comment
         run: |
           if [[ $HAS_CHANGES == 'true' ]]


### PR DESCRIPTION
## **Description**

The `update-attributions` workflow was using a low-privilege token for checking out the repository. The checkout step is what determines which credentials are used upon `push`. The later step with `git push` was failing with a HTTP 403 response despite having a token declared with write access, because `git push` uses the credentials setup during checkout.

Example failure: https://github.com/MetaMask/metamask-extension/actions/runs/10046473531

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26019?quickstart=1)

## **Related issues**

Relates to https://github.com/MetaMask/MetaMask-planning/issues/1947

## **Manual testing steps**

We can't easily test this until after it's merged. Once this is merged, we can see that it works by using the command `@metamaskbot update-attributions`. We can see that the changes made here reflect how the `update-policies` workflow works, which uses the same type of authorization.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
