### PR TITLE
chore: Update `actions/cache` from v3 to v4

### DIFF
--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Generate Attributions
         run: yarn attributions:generate
       - name: Cache attributions file
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: attribution.txt
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -113,7 +113,7 @@ jobs:
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Restore attributions file
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: attribution.txt
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Update LavaMoat build policy
         run: yarn lavamoat:build:auto
       - name: Cache build policy
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: lavamoat/build-system
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -109,7 +109,7 @@ jobs:
       - name: Setup environment
         uses: metamask/github-tools/.github/actions/setup-environment@main
       - name: Restore build policy
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: lavamoat/build-system
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -119,7 +119,7 @@ jobs:
         env:
           INFURA_PROJECT_ID: 00000000000
       - name: Cache ${{ matrix.build-type }} application policy
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: lavamoat/browserify/${{ matrix.build-type }}
           key: cache-${{ matrix.build-type }}-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -149,7 +149,7 @@ jobs:
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Restore build policy
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: lavamoat/build-system
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -158,25 +158,25 @@ jobs:
       # Ensure this is synchronized with the list above in the "update-lavamoat-webapp-policy" job
       # and with the build type list in `builds.yml`
       - name: Restore main application policy
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: lavamoat/browserify/main
           key: cache-main-${{ needs.prepare.outputs.COMMIT_SHA }}
           fail-on-cache-miss: true
       - name: Restore beta application policy
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: lavamoat/browserify/beta
           key: cache-beta-${{ needs.prepare.outputs.COMMIT_SHA }}
           fail-on-cache-miss: true
       - name: Restore flask application policy
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: lavamoat/browserify/flask
           key: cache-flask-${{ needs.prepare.outputs.COMMIT_SHA }}
           fail-on-cache-miss: true
       - name: Restore mmi application policy
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: lavamoat/browserify/mmi
           key: cache-mmi-${{ needs.prepare.outputs.COMMIT_SHA }}


### PR DESCRIPTION
## **Description**

This resolves this warning, which was shown on all runs of both affected workflows:
>The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/cache/save@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Example: https://github.com/MetaMask/metamask-extension/actions/runs/10046473531

The only breaking change is that Node.js v20 is now the default runtime. See https://github.com/actions/cache/releases/tag/v4.0.0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26020?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

No way to test until after merging. After merging, we can check that the affected workflows still work correctly, and that they no longer contain the quoted error.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
