### PR TITLE
fix (cherry-pick for v12.0.0): remove/disable profile syncing for existing users migration

### DIFF
--- a/app/scripts/controllers/user-storage/user-storage-controller.ts
+++ b/app/scripts/controllers/user-storage/user-storage-controller.ts
@@ -27,7 +27,7 @@ export type UserStorageControllerState = {
   /**
    * Condition used by UI and to determine if we can use some of the User Storage methods.
    */
-  isProfileSyncingEnabled: boolean;
+  isProfileSyncingEnabled: boolean | null;
   /**
    * Loading state for the profile syncing update
    */

--- a/app/scripts/migrations/120.1.test.ts
+++ b/app/scripts/migrations/120.1.test.ts
@@ -1,0 +1,75 @@
+import { migrate, version } from './120.1';
+
+const oldVersion = 120;
+
+describe('migration #120.1', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('sets isProfileSyncingEnabled to null', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        UserStorageController: {
+          isProfileSyncingEnabled: true,
+          isProfileSyncingUpdateLoading: false,
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data.UserStorageController).toStrictEqual({
+      isProfileSyncingEnabled: null,
+      isProfileSyncingUpdateLoading: false,
+    });
+  });
+
+  it('initializes a default user storage state if it did not exist before', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        OtherController: {},
+      },
+    };
+
+    const expectedStorageData = {
+      OtherController: {},
+      UserStorageController: {
+        isProfileSyncingEnabled: null,
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(expectedStorageData);
+  });
+
+  it('should do nothing if existing UserStorageController state is malformed', async () => {
+    const actAssertInvalidUserStorageState = async (state: unknown) => {
+      const oldStorage = {
+        meta: { version: oldVersion },
+        data: {
+          OtherController: {},
+          UserStorageController: state,
+        },
+      };
+
+      const newStorage = await migrate(oldStorage);
+      expect(newStorage.data).toStrictEqual(oldStorage.data);
+    };
+
+    actAssertInvalidUserStorageState('user storage state is not an object');
+    actAssertInvalidUserStorageState({
+      // missing the isProfileSyncingEnabled field
+      isProfileSyncingUpdateLoading: false,
+    });
+  });
+});

--- a/app/scripts/migrations/120.1.ts
+++ b/app/scripts/migrations/120.1.ts
@@ -1,0 +1,52 @@
+import { cloneDeep, isObject } from 'lodash';
+import { hasProperty } from '@metamask/utils';
+import { captureException } from '@sentry/browser';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 120.1;
+
+/**
+ * Add a default value for importTime in the InternalAccount
+ *
+ * @param originalVersionedData
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  // Existing users who do not have UserStorageController state.
+  // Provide some initial state & nullify `isProfileSyncingEnabled`
+  if (!hasProperty(state, 'UserStorageController')) {
+    state.UserStorageController = {
+      isProfileSyncingEnabled: null,
+    };
+    return state;
+  }
+
+  if (
+    !isObject(state.UserStorageController) ||
+    !hasProperty(state.UserStorageController, 'isProfileSyncingEnabled')
+  ) {
+    captureException(
+      `Migration ${version}: Invalid UserStorageController state: ${typeof state.UserStorageController}`,
+    );
+    return state;
+  }
+
+  // Existing users who do have UserStorageController state.
+  // nullify `isProfileSyncingEnabled`
+  state.UserStorageController.isProfileSyncingEnabled = null;
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -131,6 +131,7 @@ const migrations = [
   require('./118'),
   require('./119'),
   require('./120'),
+  require('./120.1'),
 ];
 
 export default migrations;

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -289,7 +289,7 @@
   },
   "UserOperationController": { "userOperations": "object" },
   "UserStorageController": {
-    "isProfileSyncingEnabled": true,
+    "isProfileSyncingEnabled": null,
     "isProfileSyncingUpdateLoading": "boolean"
   }
 }

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -193,7 +193,7 @@
     "nameSources": "object",
     "userOperations": "object",
     "isSignedIn": "boolean",
-    "isProfileSyncingEnabled": true,
+    "isProfileSyncingEnabled": null,
     "isProfileSyncingUpdateLoading": "boolean",
     "subscriptionAccountsSeen": "object",
     "isMetamaskNotificationsFeatureSeen": "boolean",


### PR DESCRIPTION
## **Description**

This is a cherry pick for https://github.com/MetaMask/metamask-extension/pull/26004 (https://github.com/MetaMask/metamask-extension/commit/afe1120f00bb40af1398586563fdcb45d17fb3ea)

Ensures that existing users will not have profile syncing enabled (must opt into profile syncing)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26021?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
