### PR TITLE
fix: map the supported block explorers (#25908)

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -3214,7 +3214,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Auf $1 ansehen",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Benachrichtigungen"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -3214,7 +3214,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Προβολή σε $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Ειδοποιήσεις"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3263,7 +3263,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "View on $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Notifications"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -3211,7 +3211,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Ver en $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Notificaciones"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -3214,7 +3214,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Consulter sur $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Notifications"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -3211,7 +3211,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "$1 पर देखें",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "सूचनाएं"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -3214,7 +3214,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Lihat di $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Notifikasi"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -3211,7 +3211,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "$1で表示",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "通知"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -3211,7 +3211,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "$1에서 보기",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "알림"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -3214,7 +3214,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Ver em $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Notificações"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -3214,7 +3214,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Смотреть на $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Уведомления"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -3211,7 +3211,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Tingnan sa $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Mga Abiso"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -3214,7 +3214,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "$1 üzerinde görüntüle",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Bildirimler"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -3211,7 +3211,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "Xem trên $1",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "Thông báo"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -3211,7 +3211,7 @@
   },
   "notificationTransactionSuccessView": {
     "message": "在 $1 上查看",
-    "description": "Additional content in browser notification that appears when a transaction is confirmed and has a block explorer URL"
+    "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
   "notifications": {
     "message": "通知"

--- a/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx
+++ b/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx
@@ -26,7 +26,7 @@ export const NotificationDetailBlockExplorerButton = ({
   const t = useI18nContext();
 
   const chainIdHex = decimalToHex(chainId);
-  const { nativeBlockExplorerUrl } = getNetworkDetailsByChainId(
+  const { blockExplorerConfig } = getNetworkDetailsByChainId(
     `0x${chainIdHex}` as keyof typeof CHAIN_IDS,
   );
 
@@ -36,7 +36,21 @@ export const NotificationDetailBlockExplorerButton = ({
   }, [defaultNetworks]);
 
   const blockExplorerUrl =
-    defaultNetwork?.rpcPrefs?.blockExplorerUrl ?? nativeBlockExplorerUrl;
+    defaultNetwork?.rpcPrefs?.blockExplorerUrl ?? blockExplorerConfig?.url;
+
+  const getBlockExplorerButtonText = () => {
+    if (defaultNetwork?.rpcPrefs?.blockExplorerUrl) {
+      return t('notificationItemCheckBlockExplorer');
+    }
+    if (blockExplorerConfig?.name) {
+      return t('notificationTransactionSuccessView', [
+        blockExplorerConfig.name,
+      ]);
+    }
+    return t('notificationItemCheckBlockExplorer');
+  };
+
+  const blockExplorerButtonText = getBlockExplorerButtonText();
 
   if (!blockExplorerUrl) {
     return null;
@@ -46,7 +60,7 @@ export const NotificationDetailBlockExplorerButton = ({
     <NotificationDetailButton
       notification={notification}
       variant={ButtonVariant.Secondary}
-      text={t('notificationItemCheckBlockExplorer') || ''}
+      text={blockExplorerButtonText}
       href={`${blockExplorerUrl}/tx/${txHash}`}
       id={id}
       isExternal={true}

--- a/ui/helpers/constants/metamask-notifications/metamask-notifications.ts
+++ b/ui/helpers/constants/metamask-notifications/metamask-notifications.ts
@@ -1,0 +1,53 @@
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+
+/**
+ * Configuration for a block explorer.
+ *
+ * @property {string} url - The URL of the block explorer.
+ * @property {string} name - The name of the block explorer.
+ */
+export type BlockExplorerConfig = {
+  url: string;
+  name: string;
+};
+
+/**
+ * Map of all supported block explorers for notifications.
+ */
+export const SUPPORTED_NOTIFICATION_BLOCK_EXPLORERS = {
+  // ETHEREUM
+  [CHAIN_IDS.MAINNET]: {
+    url: 'https://etherscan.io',
+    name: 'Etherscan',
+  },
+  // OPTIMISM
+  [CHAIN_IDS.OPTIMISM]: {
+    url: 'https://optimistic.etherscan.io',
+    name: 'Optimistic Etherscan',
+  },
+  // BSC
+  [CHAIN_IDS.BSC]: {
+    url: 'https://bscscan.com',
+    name: 'BscScan',
+  },
+  // POLYGON
+  [CHAIN_IDS.POLYGON]: {
+    url: 'https://polygonscan.com',
+    name: 'PolygonScan',
+  },
+  // ARBITRUM
+  [CHAIN_IDS.ARBITRUM]: {
+    url: 'https://arbiscan.io',
+    name: 'Arbiscan',
+  },
+  // AVALANCHE
+  [CHAIN_IDS.AVALANCHE]: {
+    url: 'https://snowtrace.io',
+    name: 'Snowtrace',
+  },
+  // LINEA
+  [CHAIN_IDS.LINEA_MAINNET]: {
+    url: 'https://lineascan.build',
+    name: 'LineaScan',
+  },
+} as const;

--- a/ui/helpers/utils/notification.util.ts
+++ b/ui/helpers/utils/notification.util.ts
@@ -5,7 +5,6 @@ import {
   CHAIN_IDS,
   CHAIN_ID_TO_CURRENCY_SYMBOL_MAP,
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
-  ETHERSCAN_SUPPORTED_NETWORKS,
   NETWORK_TO_NAME_MAP,
   FEATURED_RPCS,
   MAINNET_RPC_URL,
@@ -16,16 +15,64 @@ import {
   LINEA_MAINNET_RPC_URL,
   LOCALHOST_RPC_URL,
 } from '../../../shared/constants/network';
+import { SUPPORTED_NOTIFICATION_BLOCK_EXPLORERS } from '../constants/metamask-notifications/metamask-notifications';
 import { calcTokenAmount } from '../../../shared/lib/transactions-controller-utils';
 import type {
   OnChainRawNotification,
   OnChainRawNotificationsWithNetworkFields,
 } from '../../../app/scripts/controllers/metamask-notifications/types/on-chain-notification/on-chain-notification';
+import type { BlockExplorerConfig } from '../constants/metamask-notifications/metamask-notifications';
 import {
   hexWEIToDecGWEI,
   hexWEIToDecETH,
   decimalToHex,
 } from '../../../shared/modules/conversion.utils';
+
+/**
+ * Type guard to ensure a key is present in an object.
+ *
+ * @param object - The object to check.
+ * @param key - The key to check for.
+ * @returns True if the key is present, false otherwise.
+ */
+function isKey<T extends object>(object: T, key: PropertyKey): key is keyof T {
+  return key in object;
+}
+
+/**
+ * Checks if 2 date objects are on the same day
+ *
+ * @param currentDate
+ * @param dateToCheck
+ * @returns boolean if dates are same day.
+ */
+const isSameDay = (currentDate: Date, dateToCheck: Date) =>
+  currentDate.getFullYear() === dateToCheck.getFullYear() &&
+  currentDate.getMonth() === dateToCheck.getMonth() &&
+  currentDate.getDate() === dateToCheck.getDate();
+
+/**
+ * Checks if a date is "yesterday" from the current date
+ *
+ * @param currentDate
+ * @param dateToCheck
+ * @returns boolean if dates were "yesterday"
+ */
+const isYesterday = (currentDate: Date, dateToCheck: Date) => {
+  const yesterday = new Date(currentDate);
+  yesterday.setDate(currentDate.getDate() - 1);
+  return isSameDay(yesterday, dateToCheck);
+};
+
+/**
+ * Checks if 2 date objects are in the same year.
+ *
+ * @param currentDate
+ * @param dateToCheck
+ * @returns boolean if dates were in same year
+ */
+const isSameYear = (currentDate: Date, dateToCheck: Date) =>
+  currentDate.getFullYear() === dateToCheck.getFullYear();
 
 /**
  * Formats a given date into different formats based on how much time has elapsed since that date.
@@ -34,11 +81,10 @@ import {
  * @returns The formatted date.
  */
 export function formatMenuItemDate(date: Date) {
-  const elapsed = Math.abs(Date.now() - date.getTime());
-  const diffDays = elapsed / (1000 * 60 * 60 * 24);
+  const currentDate = new Date();
 
-  // E.g. Yesterday
-  if (diffDays < 1) {
+  // E.g. 12:21
+  if (isSameDay(currentDate, date)) {
     return new Intl.DateTimeFormat('en', {
       hour: 'numeric',
       minute: 'numeric',
@@ -46,8 +92,8 @@ export function formatMenuItemDate(date: Date) {
     }).format(date);
   }
 
-  // E.g. 12:21
-  if (Math.floor(diffDays) === 1) {
+  // E.g. Yesterday
+  if (isYesterday(currentDate, date)) {
     return new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(
       -1,
       'day',
@@ -55,7 +101,7 @@ export function formatMenuItemDate(date: Date) {
   }
 
   // E.g. 21 Oct
-  if (diffDays > 1 && diffDays < 365) {
+  if (isSameYear(currentDate, date)) {
     return new Intl.DateTimeFormat('en', {
       month: 'short',
       day: 'numeric',
@@ -267,7 +313,7 @@ export function getNetworkDetailsByChainId(chainId?: keyof typeof CHAIN_IDS): {
   nativeCurrencySymbol: string;
   nativeCurrencyLogo: string;
   nativeCurrencyAddress: string;
-  nativeBlockExplorerUrl?: string;
+  blockExplorerConfig?: BlockExplorerConfig;
 } {
   const fullNativeCurrencyName =
     NETWORK_TO_NAME_MAP[chainId as keyof typeof NETWORK_TO_NAME_MAP] ?? '';
@@ -281,22 +327,16 @@ export function getNetworkDetailsByChainId(chainId?: keyof typeof CHAIN_IDS): {
       chainId as keyof typeof CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP
     ];
   const nativeCurrencyAddress = '0x0000000000000000000000000000000000000000';
-
   const blockExplorerConfig =
-    ETHERSCAN_SUPPORTED_NETWORKS[
-      chainId as keyof typeof ETHERSCAN_SUPPORTED_NETWORKS
-    ];
-  let nativeBlockExplorerUrl;
-  if (blockExplorerConfig) {
-    nativeBlockExplorerUrl = `https://www.${blockExplorerConfig.domain}`;
-  }
-
+    chainId && isKey(SUPPORTED_NOTIFICATION_BLOCK_EXPLORERS, chainId)
+      ? SUPPORTED_NOTIFICATION_BLOCK_EXPLORERS[chainId]
+      : undefined;
   return {
     nativeCurrencyName,
     nativeCurrencySymbol,
     nativeCurrencyLogo,
     nativeCurrencyAddress,
-    nativeBlockExplorerUrl,
+    blockExplorerConfig,
   };
 }
 
@@ -375,9 +415,14 @@ export const getNetworkFees = async (notification: OnChainRawNotification) => {
   }
 
   const chainId = decimalToHex(notification.chain_id);
-  const provider = new JsonRpcProvider(
-    getRpcUrlByChainId(`0x${chainId}` as HexChainId),
-  );
+  const rpcUrl = getRpcUrlByChainId(`0x${chainId}` as HexChainId);
+  const connection = {
+    url: rpcUrl,
+    headers: {
+      'Infura-Source': 'metamask/metamask',
+    },
+  };
+  const provider = new JsonRpcProvider(connection);
 
   if (!provider) {
     throw new Error(`No provider found for chainId ${chainId}`);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

This PR introduces a new object to map the block explorers needed to display certain details of the notifications. The created object is intentionally as simple as possible. The goal of the notifications team is to define a more complete object in a shared library among the different clients to correctly render notifications where necessary.

[![Open in GitHub
Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25908?quickstart=1)

Fixes:
- https://github.com/MetaMask/metamask-extension/issues/25882
- https://github.com/MetaMask/metamask-extension/issues/25880
- https://github.com/MetaMask/metamask-extension/issues/25878
- https://github.com/MetaMask/metamask-extension/issues/25881

1. Go to this page... 2.
3.

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!-- [screenshots/recordings] -->

<!-- [screenshots/recordings] -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26030?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
