### PR TITLE
fix: snap flakiness on `installSnapSimpleKeyring` function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,6 @@ workflows:
             - prep-build-test-flask
             - get-changed-files-with-git-diff
       - test-e2e-firefox-flask:
-          <<: *develop_master_rc_only
           requires:
             - prep-build-test-flask-mv2
       - test-e2e-chrome-mmi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,6 @@ workflows:
           requires:
             - prep-deps
       - prep-build-test-flask-mv2:
-          <<: *develop_master_rc_only
           requires:
             - prep-deps
       - prep-build-test-mmi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ workflows:
           requires:
             - prep-deps
       - prep-build-test-flask-mv2:
+          <<: *develop_master_rc_only
           requires:
             - prep-deps
       - prep-build-test-mmi:
@@ -216,6 +217,7 @@ workflows:
             - prep-build-test-flask
             - get-changed-files-with-git-diff
       - test-e2e-firefox-flask:
+          <<: *develop_master_rc_only
           requires:
             - prep-build-test-flask-mv2
       - test-e2e-chrome-mmi:

--- a/test/e2e/accounts/common.ts
+++ b/test/e2e/accounts/common.ts
@@ -86,6 +86,9 @@ export async function installSnapSimpleKeyring(
     tag: 'button',
   });
 
+  // Wait until popup is closed before proceeding
+  await driver.waitUntilXWindowHandles(2);
+
   await driver.switchToWindowWithTitle(WINDOW_TITLES.SnapSimpleKeyringDapp);
 
   await driver.waitForSelector({

--- a/test/e2e/accounts/create-snap-account.spec.ts
+++ b/test/e2e/accounts/create-snap-account.spec.ts
@@ -49,6 +49,9 @@ describe('Create Snap Account', function (this: Suite) {
           tag: 'button',
         });
 
+        // Wait until popup is closed before proceeding
+        await driver.waitUntilXWindowHandles(2);
+
         // move back to the Snap window to test the create account flow
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.SnapSimpleKeyringDapp,
@@ -127,6 +130,9 @@ describe('Create Snap Account', function (this: Suite) {
           text: 'OK',
           tag: 'button',
         });
+
+        // Wait until popup is closed before proceeding
+        await driver.waitUntilXWindowHandles(2);
 
         // move back to the Snap window to test the create account flow
         await driver.switchToWindowWithTitle(
@@ -219,6 +225,9 @@ describe('Create Snap Account', function (this: Suite) {
           text: 'OK',
           tag: 'button',
         });
+
+        // Wait until popup is closed before proceeding
+        await driver.waitUntilXWindowHandles(2);
 
         // move back to the Snap window to test the create account flow
         await driver.switchToWindowWithTitle(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a race condition where we click `Create Account` on the snap dapp, before the popup for Connecting hasn't been closed (see video below). This causes that the click for Create Account has no effect and the dialog never opens, with the error:
`Error: No window with title: MetaMask Dialog` - example of failure [here](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/92347/workflows/a12a664d-4eb8-4c49-a57c-1e58cb49361f/jobs/3437511/tests) in the Remove Account Snap

The fix is to wait until the popup is closed before continue.
This source of flakiness can affect several snap tests (all the tests that use the `installSnapSimpleKeyring` function).

Note: this does not mitigate the current Snap Account issues that we see on ci, but does fix a source of flakiness introduced in this function (I've been able to reproduce the flakiness locally and saw mitigated after the fix, for the Remove Account test).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26039?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
Notice how, we start interacting with the dapp again, but the popup hasn't been closed yet (second ~22)

https://github.com/user-attachments/assets/fbfe4281-9b1a-4311-bca3-6e746e965109




<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
