### PR TITLE
fix: Flaky  "Signature Approved Event" e2e test

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -1004,11 +1004,10 @@ async function clickSignOnSignatureConfirmation({
  * @param {WebDriver} driver
  */
 async function validateContractDetails(driver) {
-  const verifyContractDetailsButton = await driver.findElement(
-    '.signature-request-content__verify-contract-details',
-  );
+  const verifyDetailsBtnSelector =
+    '.signature-request-content__verify-contract-details';
 
-  await verifyContractDetailsButton.click();
+  await driver.clickElement(verifyDetailsBtnSelector);
   await driver.clickElement({ text: 'Got it', tag: 'button' });
 
   // Approve signing typed data

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -1008,7 +1008,7 @@ async function validateContractDetails(driver) {
     '.signature-request-content__verify-contract-details',
   );
 
-  verifyContractDetailsButton.click();
+  await verifyContractDetailsButton.click();
   await driver.clickElement({ text: 'Got it', tag: 'button' });
 
   // Approve signing typed data


### PR DESCRIPTION
## **Description**

Fixes flaky "Signature Approved Event" tests by awaiting a click event



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26040?quickstart=1)

## **Related issues**

Fixes: #26036

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
