### PR TITLE
fix: Remove special reject button case from api spec tests

### DIFF
--- a/test/e2e/api-specs/ConfirmationRejectionRule.ts
+++ b/test/e2e/api-specs/ConfirmationRejectionRule.ts
@@ -110,7 +110,7 @@ export class ConfirmationsRejectRule implements Rule {
             await this.driver.waitUntilXWindowHandles(3);
             await this.driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-            let text = 'Cancel';
+            const text = 'Cancel';
 
             await this.driver.findClickableElements({
               text: 'Cancel',

--- a/test/e2e/api-specs/ConfirmationRejectionRule.ts
+++ b/test/e2e/api-specs/ConfirmationRejectionRule.ts
@@ -23,17 +23,12 @@ export class ConfirmationsRejectRule implements Rule {
 
   private only: string[];
 
-  private rejectButtonInsteadOfCancel: string[];
-
   private requiresEthAccountsPermission: string[];
 
   constructor(options: ConfirmationsRejectRuleOptions) {
     this.driver = options.driver;
     this.only = options.only;
-    this.rejectButtonInsteadOfCancel = [
-      'personal_sign',
-      'eth_signTypedData_v4',
-    ];
+
     this.requiresEthAccountsPermission = [
       'personal_sign',
       'eth_signTypedData_v4',
@@ -116,18 +111,12 @@ export class ConfirmationsRejectRule implements Rule {
             await this.driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
             let text = 'Cancel';
-            if (this.rejectButtonInsteadOfCancel.includes(call.methodName)) {
-              await this.driver.findClickableElements({
-                text: 'Reject',
-                tag: 'button',
-              });
-              text = 'Reject';
-            } else {
-              await this.driver.findClickableElements({
-                text: 'Cancel',
-                tag: 'button',
-              });
-            }
+
+            await this.driver.findClickableElements({
+              text: 'Cancel',
+              tag: 'button',
+            });
+
             const screenshot = await this.driver.driver.takeScreenshot();
             call.attachments = call.attachments || [];
             call.attachments.push({


### PR DESCRIPTION
## **Description**

Merging https://github.com/MetaMask/metamask-extension/pull/25769 toggled on the signatures redesign by default for all tests. This change resulted in `api-spec` tests failing.

The fix is removing the logic for conditionally expect a "Reject" button instead of the default "Cancel" for some confirmations. In the redesign all signatures share the same footer.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26048?quickstart=1)

## **Related issues**

No issue created for this test failure

## **Manual testing steps**

Create a test build, then run `yarn test:api-specs`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
