### PR TITLE
ci: Trimming the gitdiff output before writing to output file

### DIFF
--- a/.circleci/scripts/git-diff-develop.ts
+++ b/.circleci/scripts/git-diff-develop.ts
@@ -86,7 +86,7 @@ async function storeGitDiffOutput() {
 
     // Store the output of git diff
     const outputPath = path.resolve(outputDir, 'changed-files.txt');
-    fs.writeFileSync(outputPath, diffOutput);
+    fs.writeFileSync(outputPath, diffOutput.trim());
 
     console.log(`Git diff results saved to ${outputPath}`);
     process.exit(0);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR ensures there is no trailing whitespace in `changed-files` before being persisted to workspace.
This was causing some issues on the Crowdin branch

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26057?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Checkout this  branch
2. Remove the trim()
3. Run `CIRCLE_BRANCH='ci-empty-string-git-diff-trim' yarn tsx .circleci/scripts/git-diff-develop.ts`
4. Verify there's whitespace at the end of file.
5. Add back the trim()
6. Run `CIRCLE_BRANCH='ci-empty-string-git-diff-trim' yarn tsx .circleci/scripts/git-diff-develop.ts`
7. Verify the trailing whitespace is gone.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
