### PR TITLE
feat: Add metrics event for advanced details section toggling

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -156,6 +156,7 @@ describe('Transaction metrics', () => {
       transaction_speed_up: false,
       transaction_type: TransactionType.simpleSend,
       ui_customizations: null,
+      transaction_advanced_view: null,
     };
 
     expectedSensitiveProperties = {

--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -75,6 +75,7 @@ const mockTransactionMetricsRequest = {
   getRedesignedConfirmationsEnabled: jest.fn(),
   getMethodData: jest.fn(),
   getIsRedesignedConfirmationsDeveloperEnabled: jest.fn(),
+  getIsConfirmationAdvancedDetailsOpen: jest.fn(),
 } as TransactionMetricsRequest;
 
 describe('Transaction metrics', () => {

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -94,6 +94,7 @@ export type TransactionMetricsRequest = {
   getRedesignedConfirmationsEnabled: () => boolean;
   getMethodData: (data: string) => Promise<{ name: string }>;
   getIsRedesignedConfirmationsDeveloperEnabled: () => boolean;
+  getIsConfirmationAdvancedDetailsOpen: () => boolean;
 };
 
 export const METRICS_STATUS_FAILED = 'failed on-chain';
@@ -966,6 +967,7 @@ async function buildEventFragmentProperties({
   }
 
   const uiCustomizations = [];
+  let isAdvancedDetailsOpen = null;
 
   /** securityProviderResponse is used by the OpenSea <> Blockaid provider */
   // eslint-disable-next-line no-lonely-if
@@ -1003,6 +1005,9 @@ async function buildEventFragmentProperties({
     uiCustomizations.push(
       MetaMetricsEventUiCustomization.RedesignedConfirmation,
     );
+
+    isAdvancedDetailsOpen =
+      transactionMetricsRequest.getIsConfirmationAdvancedDetailsOpen();
   }
   const smartTransactionMetricsProperties =
     getSmartTransactionMetricsProperties(
@@ -1034,6 +1039,7 @@ async function buildEventFragmentProperties({
     ...blockaidProperties,
     // ui_customizations must come after ...blockaidProperties
     ui_customizations: uiCustomizations.length > 0 ? uiCustomizations : null,
+    transaction_advanced_view: isAdvancedDetailsOpen,
     ...smartTransactionMetricsProperties,
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6110,6 +6110,10 @@ export default class MetamaskController extends EventEmitter {
         return this.preferencesController.store.getState().preferences
           .isRedesignedConfirmationsDeveloperEnabled;
       },
+      getIsConfirmationAdvancedDetailsOpen: () => {
+        return this.preferencesController.store.getState().preferences
+          .showConfirmationAdvancedDetails;
+      },
     };
     return {
       ...controllerActions,

--- a/shared/modules/metametrics.test.ts
+++ b/shared/modules/metametrics.test.ts
@@ -42,6 +42,7 @@ const createTransactionMetricsRequest = (customProps = {}) => {
     getRedesignedConfirmationsEnabled: jest.fn(),
     getMethodData: jest.fn(),
     getIsRedesignedConfirmationsDeveloperEnabled: jest.fn(),
+    getIsConfirmationAdvancedDetailsOpen: jest.fn(),
     ...customProps,
   } as TransactionMetricsRequest;
 };

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -67,35 +67,45 @@ describe('Metrics @no-mmi', function () {
 
         const events = await getEventPayloads(driver, mockedEndpoints);
 
+        assert.equal(events.length, 16);
+
         // deployment tx -- no ui_customizations
         assert.equal(
           events[0].event,
           AnonymousTransactionMetaMetricsEvent.added,
         );
         assert.equal(events[0].properties.ui_customizations, null);
+        assert.equal(events[0].properties.transaction_advanced_view, null);
         assert.equal(events[1].event, TransactionMetaMetricsEvent.added);
         assert.equal(events[1].properties.ui_customizations, null);
+        assert.equal(events[1].properties.transaction_advanced_view, null);
         assert.equal(
           events[2].event,
           AnonymousTransactionMetaMetricsEvent.submitted,
         );
         assert.equal(events[2].properties.ui_customizations, null);
+        assert.equal(events[2].properties.transaction_advanced_view, null);
         assert.equal(events[3].event, TransactionMetaMetricsEvent.submitted);
         assert.equal(events[3].properties.ui_customizations, null);
+        assert.equal(events[3].properties.transaction_advanced_view, null);
         assert.equal(
           events[4].event,
           AnonymousTransactionMetaMetricsEvent.approved,
         );
         assert.equal(events[4].properties.ui_customizations, null);
+        assert.equal(events[4].properties.transaction_advanced_view, null);
         assert.equal(events[5].event, TransactionMetaMetricsEvent.approved);
         assert.equal(events[5].properties.ui_customizations, null);
+        assert.equal(events[5].properties.transaction_advanced_view, null);
         assert.equal(
           events[6].event,
           AnonymousTransactionMetaMetricsEvent.finalized,
         );
         assert.equal(events[6].properties.ui_customizations, null);
+        assert.equal(events[6].properties.transaction_advanced_view, null);
         assert.equal(events[7].event, TransactionMetaMetricsEvent.finalized);
         assert.equal(events[7].properties.ui_customizations, null);
+        assert.equal(events[7].properties.transaction_advanced_view, null);
 
         // deposit tx (contract interaction) -- ui_customizations is set
         assert.equal(
@@ -106,11 +116,13 @@ describe('Metrics @no-mmi', function () {
           events[8].properties.ui_customizations[0],
           'redesigned_confirmation',
         );
+        assert.equal(events[8].properties.transaction_advanced_view, undefined);
         assert.equal(events[9].event, TransactionMetaMetricsEvent.added);
         assert.equal(
           events[9].properties.ui_customizations[0],
           'redesigned_confirmation',
         );
+        assert.equal(events[9].properties.transaction_advanced_view, undefined);
         assert.equal(
           events[10].event,
           AnonymousTransactionMetaMetricsEvent.submitted,
@@ -119,11 +131,13 @@ describe('Metrics @no-mmi', function () {
           events[10].properties.ui_customizations[0],
           'redesigned_confirmation',
         );
+        assert.equal(events[10].properties.transaction_advanced_view, true);
         assert.equal(events[11].event, TransactionMetaMetricsEvent.submitted);
         assert.equal(
           events[11].properties.ui_customizations[0],
           'redesigned_confirmation',
         );
+        assert.equal(events[11].properties.transaction_advanced_view, true);
         assert.equal(
           events[12].event,
           AnonymousTransactionMetaMetricsEvent.approved,
@@ -132,11 +146,13 @@ describe('Metrics @no-mmi', function () {
           events[12].properties.ui_customizations[0],
           'redesigned_confirmation',
         );
+        assert.equal(events[12].properties.transaction_advanced_view, true);
         assert.equal(events[13].event, TransactionMetaMetricsEvent.approved);
         assert.equal(
           events[13].properties.ui_customizations[0],
           'redesigned_confirmation',
         );
+        assert.equal(events[13].properties.transaction_advanced_view, true);
         assert.equal(
           events[14].event,
           AnonymousTransactionMetaMetricsEvent.finalized,
@@ -145,62 +161,13 @@ describe('Metrics @no-mmi', function () {
           events[14].properties.ui_customizations[0],
           'redesigned_confirmation',
         );
+        assert.equal(events[14].properties.transaction_advanced_view, true);
         assert.equal(events[15].event, TransactionMetaMetricsEvent.finalized);
         assert.equal(
           events[15].properties.ui_customizations[0],
           'redesigned_confirmation',
         );
-      },
-    );
-  });
-
-  it('Sends a contract interaction type 2 transaction (EIP1559) while sending the event for advanced details toggling', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withPreferencesController({
-            preferences: {
-              redesignedConfirmationsEnabled: true,
-              isRedesignedConfirmationsDeveloperEnabled: true,
-            },
-          })
-          .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
-            participateInMetaMetrics: true,
-          })
-          .build(),
-        ganacheOptions: defaultGanacheOptionsForType2Transactions,
-        title: this.test?.fullTitle(),
-        testSpecificMock: advancedDetailsMocks,
-      },
-      async ({
-        driver,
-        mockedEndpoint: mockedEndpoints,
-      }: {
-        driver: Driver;
-        mockedEndpoint: MockedEndpoint;
-      }) => {
-        await unlockWallet(driver);
-
-        await openDapp(driver);
-
-        await createContractDeploymentTransaction(driver);
-        await confirmContractDeploymentTransaction(driver);
-
-        await createDepositTransaction(driver);
-
-        await driver.waitUntilXWindowHandles(3);
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await confirmDepositTransaction(driver);
-
-        const events = await getEventPayloads(driver, mockedEndpoints);
-
-        assert.equal(events.length, 1);
-
-        assert.equal(events[0].event, 'Transaction Advanced View');
-        assert.equal(events[0].properties.transaction_advanced_view, true);
+        assert.equal(events[15].properties.transaction_advanced_view, true);
       },
     );
   });
@@ -213,10 +180,6 @@ async function mockedTrackedEvent(mockServer: MockttpServer, event: string) {
       batch: [{ type: 'track', event }],
     })
     .thenCallback(() => ({ statusCode: 200 }));
-}
-
-async function advancedDetailsMocks(server: MockttpServer) {
-  return [await mockedTrackedEvent(server, 'Transaction Advanced View')];
 }
 
 async function mocks(server: MockttpServer) {

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -12,7 +12,6 @@ import {
   createContractDeploymentTransaction,
   createDepositTransaction,
 } from './shared';
-import { Mockttp } from '../../../mock-e2e';
 
 const {
   defaultGanacheOptionsForType2Transactions,

--- a/ui/pages/confirmations/components/confirm/header/header-info.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header-info.tsx
@@ -64,12 +64,6 @@ const HeaderInfo = () => {
   );
 
   const setShowAdvancedDetails = (value: boolean): void => {
-    trackEvent({
-      event: 'Transaction Advanced View',
-      category: MetaMetricsEventCategory.Confirmations,
-      properties: { transaction_advanced_view: value },
-    });
-
     dispatch(setConfirmationAdvancedDetailsOpen(value));
   };
 

--- a/ui/pages/confirmations/components/confirm/header/header-info.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header-info.tsx
@@ -1,5 +1,5 @@
 import { TransactionType } from '@metamask/transaction-controller';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   MetaMetricsEventCategory,
@@ -54,6 +54,7 @@ import { isSignatureTransactionType } from '../../../utils/confirm';
 
 const HeaderInfo = () => {
   const dispatch = useDispatch();
+  const trackEvent = useContext(MetaMetricsContext);
 
   const useBlockie = useSelector(getUseBlockie);
   const [showAccountInfo, setShowAccountInfo] = React.useState(false);
@@ -61,12 +62,14 @@ const HeaderInfo = () => {
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
-  const { updateTransactionEventFragment, fragment } =
-    useTransactionEventFragment();
 
-  console.log({ fragment });
   const setShowAdvancedDetails = (value: boolean): void => {
-    // ...fragment
+    trackEvent({
+      event: 'Transaction Advanced View',
+      category: MetaMetricsEventCategory.Confirmations,
+      properties: { transaction_advanced_view: value },
+    });
+
     dispatch(setConfirmationAdvancedDetailsOpen(value));
   };
 
@@ -75,7 +78,6 @@ const HeaderInfo = () => {
     useConfirmationRecipientInfo();
 
   const t = useI18nContext();
-  const trackEvent = useContext(MetaMetricsContext);
 
   const { balance: balanceToUse } = useBalance(fromAddress);
 

--- a/ui/pages/confirmations/components/confirm/header/header-info.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header-info.tsx
@@ -1,5 +1,5 @@
 import { TransactionType } from '@metamask/transaction-controller';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   MetaMetricsEventCategory,
@@ -46,7 +46,6 @@ import {
 import { setConfirmationAdvancedDetailsOpen } from '../../../../../store/actions';
 import { useBalance } from '../../../hooks/useBalance';
 import useConfirmationRecipientInfo from '../../../hooks/useConfirmationRecipientInfo';
-import { useTransactionEventFragment } from '../../../hooks/useTransactionEventFragment';
 import { selectConfirmationAdvancedDetailsOpen } from '../../../selectors/preferences';
 import { SignatureRequestType } from '../../../types/confirm';
 import { REDESIGN_TRANSACTION_TYPES } from '../../../utils';

--- a/ui/pages/confirmations/components/confirm/header/header-info.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header-info.tsx
@@ -46,6 +46,7 @@ import {
 import { setConfirmationAdvancedDetailsOpen } from '../../../../../store/actions';
 import { useBalance } from '../../../hooks/useBalance';
 import useConfirmationRecipientInfo from '../../../hooks/useConfirmationRecipientInfo';
+import { useTransactionEventFragment } from '../../../hooks/useTransactionEventFragment';
 import { selectConfirmationAdvancedDetailsOpen } from '../../../selectors/preferences';
 import { SignatureRequestType } from '../../../types/confirm';
 import { REDESIGN_TRANSACTION_TYPES } from '../../../utils';
@@ -60,7 +61,12 @@ const HeaderInfo = () => {
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
+  const { updateTransactionEventFragment, fragment } =
+    useTransactionEventFragment();
+
+  console.log({ fragment });
   const setShowAdvancedDetails = (value: boolean): void => {
+    // ...fragment
     dispatch(setConfirmationAdvancedDetailsOpen(value));
   };
 

--- a/ui/pages/confirmations/hooks/useTransactionEventFragment.js
+++ b/ui/pages/confirmations/hooks/useTransactionEventFragment.js
@@ -37,5 +37,6 @@ export const useTransactionEventFragment = () => {
 
   return {
     updateTransactionEventFragment,
+    fragment,
   };
 };

--- a/ui/pages/confirmations/hooks/useTransactionEventFragment.js
+++ b/ui/pages/confirmations/hooks/useTransactionEventFragment.js
@@ -35,8 +35,5 @@ export const useTransactionEventFragment = () => {
     [fragmentExists, gasTransactionId],
   );
 
-  return {
-    updateTransactionEventFragment,
-    fragment,
-  };
+  return { updateTransactionEventFragment };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We recently introduced the advanced details toggle for redesigned transactions. This PR adds a metrics event that gets fired every time that toggle is pressed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26083?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2736

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
