### PR TITLE
Revert "chore: tweak send page styling (#25982)"

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Senden"
   },
+  "sendAToken": {
+    "message": "Token senden"
+  },
   "sendBugReport": {
     "message": "Übermitteln Sie uns einen Fehlerbericht."
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Αποστολή"
   },
+  "sendAToken": {
+    "message": "Στείλτε ένα token"
+  },
   "sendBugReport": {
     "message": "Στείλτε μας μια αναφορά σφάλματος."
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4669,6 +4669,9 @@
   "send": {
     "message": "Send"
   },
+  "sendAToken": {
+    "message": "Send a token"
+  },
   "sendBugReport": {
     "message": "Send us a bug report."
   },

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Enviar"
   },
+  "sendAToken": {
+    "message": "Enviar un token"
+  },
   "sendBugReport": {
     "message": "Envíenos un informe de error."
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Envoyer"
   },
+  "sendAToken": {
+    "message": "Envoyer un jeton"
+  },
   "sendBugReport": {
     "message": "Envoyez-nous un rapport de bogue."
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "भेजें"
   },
+  "sendAToken": {
+    "message": "एक टोकन भेजें"
+  },
   "sendBugReport": {
     "message": "हमें एक बग रिपोर्ट भेजें।"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Kirim"
   },
+  "sendAToken": {
+    "message": "Kirimkan token"
+  },
   "sendBugReport": {
     "message": "Kirimi kami laporan bug."
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "送金"
   },
+  "sendAToken": {
+    "message": "トークンを送信"
+  },
   "sendBugReport": {
     "message": "バグの報告をお送りください。"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "보내기"
   },
+  "sendAToken": {
+    "message": "토큰 보내기"
+  },
   "sendBugReport": {
     "message": "버그 리포트 전송"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Enviar"
   },
+  "sendAToken": {
+    "message": "Enviar um token"
+  },
   "sendBugReport": {
     "message": "Envie-nos um relatório de bugs."
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Отправить"
   },
+  "sendAToken": {
+    "message": "Отправить токен"
+  },
   "sendBugReport": {
     "message": "Отправьте нам отчет об ошибке."
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Magpadala"
   },
+  "sendAToken": {
+    "message": "Magpadala ng token"
+  },
   "sendBugReport": {
     "message": "Padalhan kami ng ulat ng bug."
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Gönder"
   },
+  "sendAToken": {
+    "message": "Bir token gönder"
+  },
   "sendBugReport": {
     "message": "Bize bir hata raporu gönder."
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "Gửi"
   },
+  "sendAToken": {
+    "message": "Gửi token"
+  },
   "sendBugReport": {
     "message": "Gửi báo cáo lỗi."
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -4584,6 +4584,9 @@
   "send": {
     "message": "发送"
   },
+  "sendAToken": {
+    "message": "发送代币"
+  },
   "sendBugReport": {
     "message": "向我们发送错误报告。"
   },

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -273,14 +273,8 @@ export function AssetPickerModal({
   ]);
 
   const Search = useCallback(
-    ({
-      isNFTSearch = false,
-      props,
-    }: {
-      isNFTSearch?: boolean;
-      props?: React.ComponentProps<typeof Box>;
-    }) => (
-      <Box padding={4} {...props}>
+    ({ isNFTSearch = false }: { isNFTSearch?: boolean }) => (
+      <Box padding={1} paddingLeft={4} paddingRight={4}>
         <TextFieldSearch
           borderRadius={BorderRadius.LG}
           placeholder={t(isNFTSearch ? 'searchNfts' : 'searchTokens')}
@@ -301,6 +295,7 @@ export function AssetPickerModal({
           }}
           endAccessory={null}
           size={TextFieldSearchSize.Lg}
+          marginBottom={1}
         />
       </Box>
     ),
@@ -316,7 +311,7 @@ export function AssetPickerModal({
     >
       <ModalOverlay />
       <ModalContent modalDialogProps={{ padding: 0 }}>
-        <ModalHeader paddingBottom={2} onClose={onClose}>
+        <ModalHeader onClose={onClose}>
           <Text variant={TextVariant.headingSm} textAlign={TextAlign.Center}>
             {t(isDest ? 'sendSelectReceiveAsset' : 'sendSelectSendAsset')}
           </Text>
@@ -327,7 +322,7 @@ export function AssetPickerModal({
             gap={1}
             alignItems={AlignItems.center}
             marginInline="auto"
-            marginBottom={3}
+            marginBottom={4}
           >
             <AvatarToken
               borderRadius={BorderRadius.full}
@@ -342,7 +337,7 @@ export function AssetPickerModal({
         <Box className="modal-tab__wrapper">
           {isDest ? (
             <>
-              <Search props={{ paddingTop: 1 }} />
+              <Search />
               <AssetList
                 handleAssetChange={handleAssetChange}
                 asset={asset}
@@ -357,6 +352,8 @@ export function AssetPickerModal({
               tabsClassName="modal-tab__tabs"
             >
               {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 <Tab
                   activeClassName="modal-tab__tab--active"
                   className="modal-tab__tab"
@@ -374,6 +371,8 @@ export function AssetPickerModal({
               }
 
               {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 <Tab
                   activeClassName="modal-tab__tab--active"
                   className="modal-tab__tab"

--- a/ui/components/multichain/pages/page/components/header/header.tsx
+++ b/ui/components/multichain/pages/page/components/header/header.tsx
@@ -30,10 +30,6 @@ interface HeaderProps extends StyleUtilityProps {
    * Additional CSS class provided to the footer
    */
   className?: string;
-  /**
-   * Additional props to pass to the text
-   */
-  textProps?: React.ComponentProps<typeof Text>;
 }
 
 export const Header = ({
@@ -41,7 +37,6 @@ export const Header = ({
   endAccessory = null,
   startAccessory = null,
   className = '',
-  textProps,
   ...props
 }: HeaderProps) => {
   return (
@@ -61,7 +56,6 @@ export const Header = ({
         paddingInlineStart={8}
         paddingInlineEnd={8}
         ellipsis
-        {...textProps}
       >
         {children}
       </Text>

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -28,11 +28,11 @@ exports[`SendPage render and initialization should render correctly even when a 
         <div
           class="mm-box"
         >
-          <h4
-            class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
+          <p
+            class="mm-box mm-text mm-text--body-md-bold mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
-            Send
-          </h4>
+            Send a token
+          </p>
         </div>
       </div>
       <div

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -58,7 +58,6 @@ import { AssetPickerAmount } from '../..';
 import useUpdateSwapsState from '../../../../pages/swaps/hooks/useUpdateSwapsState';
 import { getIsDraftSwapAndSend } from '../../../../ducks/send/helpers';
 import { smartTransactionsListSelector } from '../../../../selectors';
-import { TextVariant } from '../../../../helpers/constants/design-system';
 import {
   SendPageAccountPicker,
   SendPageRecipientContent,
@@ -302,9 +301,6 @@ export const SendPage = () => {
   return (
     <Page className="multichain-send-page">
       <Header
-        textProps={{
-          variant: TextVariant.headingSm,
-        }}
         startAccessory={
           <ButtonIcon
             size={ButtonIconSize.Sm}
@@ -314,7 +310,7 @@ export const SendPage = () => {
           />
         }
       >
-        {t('send')}
+        {t('sendAToken')}
       </Header>
       <Content>
         <SendPageAccountPicker />


### PR DESCRIPTION
This reverts commit ef38d626ccbf39cb98199b0af48731a2d19e4f28.


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26088?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
