### PR TITLE
feat: Migration #122 set redesignedConfirmationsEnabled to true (#25769)

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -246,6 +246,8 @@ export const SENTRY_BACKGROUND_STATE = {
     preferences: {
       autoLockTimeLimit: true,
       hideZeroBalanceTokens: true,
+      redesignedConfirmationsEnabled: true,
+      isRedesignedConfirmationsDeveloperEnabled: false,
       showExtensionInFullSizeView: true,
       showFiatInTestnets: true,
       showTestNetworks: true,

--- a/app/scripts/migrations/122.test.ts
+++ b/app/scripts/migrations/122.test.ts
@@ -1,0 +1,74 @@
+import { migrate, version } from './122';
+
+const oldVersion = 121;
+
+describe('migration #122', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: oldVersion,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  describe('set redesignedConfirmationsEnabled to true in PreferencesController', () => {
+    it('sets redesignedConfirmationsEnabled to true', async () => {
+      const oldStorage = {
+        PreferencesController: {
+          preferences: {
+            redesignedConfirmationsEnabled: false,
+          },
+        },
+      };
+
+      const expectedState = {
+        PreferencesController: {
+          preferences: {
+            redesignedConfirmationsEnabled: true,
+          },
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: oldStorage,
+      });
+
+      expect(transformedState.data).toEqual(expectedState);
+    });
+
+    it(
+      'sets redesignedConfirmationsEnabled to true even with original preferences object in the' +
+        'state',
+      async () => {
+        const oldStorage = {
+          PreferencesController: {},
+        };
+
+        const expectedState = {
+          PreferencesController: {
+            preferences: {
+              redesignedConfirmationsEnabled: true,
+            },
+          },
+        };
+
+        const transformedState = await migrate({
+          meta: { version: oldVersion },
+          data: oldStorage,
+        });
+
+        expect(transformedState.data).toEqual(expectedState);
+      },
+    );
+  });
+});

--- a/app/scripts/migrations/122.ts
+++ b/app/scripts/migrations/122.ts
@@ -1,0 +1,50 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 122;
+
+/**
+ * This migration sets preference redesignedConfirmationsEnabled to true
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+// TODO: Replace `any` with specific type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformState(state: Record<string, any>) {
+  if (!hasProperty(state, 'PreferencesController')) {
+    return;
+  }
+
+  if (!isObject(state.PreferencesController)) {
+    const controllerType = typeof state.PreferencesController;
+    global.sentry?.captureException?.(
+      new Error(`state.PreferencesController is type: ${controllerType}`),
+    );
+  }
+
+  if (!isObject(state.PreferencesController?.preferences)) {
+    state.PreferencesController = {
+      preferences: {},
+    };
+  }
+
+  state.PreferencesController.preferences.redesignedConfirmationsEnabled = true;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -132,6 +132,8 @@ const migrations = [
   require('./119'),
   require('./120'),
   require('./121'),
+  require('./122'),
+  require('./123'),
 ];
 
 export default migrations;

--- a/test/e2e/accounts/snap-account-signatures-and-disconnects.spec.ts
+++ b/test/e2e/accounts/snap-account-signatures-and-disconnects.spec.ts
@@ -1,6 +1,10 @@
 import { Suite } from 'mocha';
 import FixtureBuilder from '../fixture-builder';
-import { withFixtures, multipleGanacheOptions } from '../helpers';
+import {
+  withFixtures,
+  multipleGanacheOptions,
+  tempToggleSettingRedesignedConfirmations,
+} from '../helpers';
 import { Driver } from '../webdriver/driver';
 import {
   installSnapSimpleKeyring,
@@ -26,6 +30,8 @@ describe('Snap Account Signatures and Disconnects', function (this: Suite) {
         await installSnapSimpleKeyring(driver, isAsyncFlow);
 
         const newPublicKey = await makeNewAccountAndSwitch(driver);
+
+        await tempToggleSettingRedesignedConfirmations(driver);
 
         // open the Test Dapp and connect Account 2 to it
         await connectAccountToTestDapp(driver);

--- a/test/e2e/accounts/snap-account-signatures.spec.ts
+++ b/test/e2e/accounts/snap-account-signatures.spec.ts
@@ -1,5 +1,9 @@
 import { Suite } from 'mocha';
-import { openDapp, withFixtures } from '../helpers';
+import {
+  openDapp,
+  tempToggleSettingRedesignedConfirmations,
+  withFixtures,
+} from '../helpers';
 import { Driver } from '../webdriver/driver';
 import {
   accountSnapFixtures,
@@ -26,6 +30,8 @@ describe('Snap Account Signatures', function (this: Suite) {
           await installSnapSimpleKeyring(driver, isAsyncFlow);
 
           const newPublicKey = await makeNewAccountAndSwitch(driver);
+
+          await tempToggleSettingRedesignedConfirmations(driver);
 
           await openDapp(driver);
 

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -1140,6 +1140,59 @@ async function initBundler(bundlerServer, ganacheServer, usePaymaster) {
   }
 }
 
+async function removeSelectedAccount(driver) {
+  await driver.clickElement('[data-testid="account-menu-icon"]');
+  await driver.clickElement(
+    '.multichain-account-list-item--selected [data-testid="account-list-item-menu-button"]',
+  );
+  await driver.clickElement('[data-testid="account-list-menu-remove"]');
+  await driver.clickElement({ text: 'Remove', tag: 'button' });
+}
+
+async function getSelectedAccountAddress(driver) {
+  await driver.clickElement('[data-testid="account-options-menu-button"]');
+  await driver.clickElement('[data-testid="account-list-menu-details"]');
+  const accountAddress = await (
+    await driver.findElement('[data-testid="address-copy-button-text"]')
+  ).getText();
+  await driver.clickElement('.mm-box button[aria-label="Close"]');
+
+  return accountAddress;
+}
+
+/**
+ * Rather than using the FixtureBuilder#withPreferencesController to set the setting
+ * we need to manually set the setting because the migration #122 overrides this.
+ * We should be able to remove this when we delete the redesignedConfirmationsEnabled setting.
+ *
+ * @param driver
+ */
+async function tempToggleSettingRedesignedConfirmations(driver) {
+  // Ensure we are on the extension window
+  await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
+
+  // Open settings menu button
+  const accountOptionsMenuSelector =
+    '[data-testid="account-options-menu-button"]';
+  await driver.waitForSelector(accountOptionsMenuSelector);
+  await driver.clickElement(accountOptionsMenuSelector);
+
+  // Click settings from dropdown menu
+  await driver.clickElement('[data-testid="global-menu-settings"]');
+
+  // Click Experimental tab
+  const experimentalTabRawLocator = {
+    text: 'Experimental',
+    tag: 'div',
+  };
+  await driver.clickElement(experimentalTabRawLocator);
+
+  // Click redesignedConfirmationsEnabled toggle
+  await driver.clickElement(
+    '[data-testid="toggle-redesigned-confirmations-container"]',
+  );
+}
+
 module.exports = {
   DAPP_HOST_ADDRESS,
   DAPP_URL,
@@ -1207,4 +1260,7 @@ module.exports = {
   editGasFeeForm,
   clickNestedButton,
   defaultGanacheOptionsForType2Transactions,
+  removeSelectedAccount,
+  getSelectedAccountAddress,
+  tempToggleSettingRedesignedConfirmations,
 };

--- a/test/e2e/snaps/test-snap-siginsights.spec.js
+++ b/test/e2e/snaps/test-snap-siginsights.spec.js
@@ -5,6 +5,7 @@ const {
   openDapp,
   unlockWallet,
   switchToNotificationWindow,
+  tempToggleSettingRedesignedConfirmations,
   WINDOW_TITLES,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
@@ -29,6 +30,7 @@ describe('Test Snap Signature Insights', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
 
         // navigate to test snaps page and connect
         await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);

--- a/test/e2e/tests/dapp-interactions/signin-with-ethereum.spec.js
+++ b/test/e2e/tests/dapp-interactions/signin-with-ethereum.spec.js
@@ -4,6 +4,7 @@ const {
   withFixtures,
   openDapp,
   DAPP_URL,
+  tempToggleSettingRedesignedConfirmations,
   unlockWallet,
   WINDOW_TITLES,
 } = require('../../helpers');
@@ -28,6 +29,7 @@ describe('Sign in with ethereum', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
 
         // Create a signin with ethereum request in test dapp
         await openDapp(driver);

--- a/test/e2e/tests/metrics/signature-approved.spec.js
+++ b/test/e2e/tests/metrics/signature-approved.spec.js
@@ -8,6 +8,7 @@ const {
   unlockWallet,
   getEventPayloads,
   clickSignOnSignatureConfirmation,
+  tempToggleSettingRedesignedConfirmations,
   validateContractDetails,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
@@ -65,6 +66,7 @@ describe('Signature Approved Event @no-mmi', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request
@@ -116,6 +118,7 @@ describe('Signature Approved Event @no-mmi', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request
@@ -163,6 +166,7 @@ describe('Signature Approved Event @no-mmi', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request
@@ -209,6 +213,7 @@ describe('Signature Approved Event @no-mmi', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request
@@ -260,6 +265,7 @@ describe('Signature Approved Event @no-mmi', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -202,7 +202,9 @@
       "smartTransactionsOptInStatus": false,
       "useNativeCurrencyAsPrimaryCurrency": true,
       "petnamesEnabled": true,
-      "showTokenAutodetectModal": "boolean"
+      "showTokenAutodetectModal": "boolean",
+      "redesignedConfirmationsEnabled": true,
+      "isRedesignedConfirmationsDeveloperEnabled": "boolean"
     },
     "ipfsGateway": "string",
     "isIpfsGatewayEnabled": "boolean",
@@ -272,7 +274,8 @@
       "swapsQuotePrefetchingRefreshTime": 60000,
       "swapsStxBatchStatusRefreshTime": 10000,
       "swapsStxGetTransactionsRefreshTime": 10000,
-      "swapsStxMaxFeeMultiplier": 2
+      "swapsStxMaxFeeMultiplier": 2,
+      "swapsFeatureFlags": {}
     }
   },
   "TokenListController": {

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -34,7 +34,9 @@
       "smartTransactionsOptInStatus": false,
       "useNativeCurrencyAsPrimaryCurrency": true,
       "petnamesEnabled": true,
-      "showTokenAutodetectModal": "boolean"
+      "showTokenAutodetectModal": "boolean",
+      "redesignedConfirmationsEnabled": true,
+      "isRedesignedConfirmationsDeveloperEnabled": "boolean"
     },
     "firstTimeFlowType": "import",
     "completedOnboarding": true,
@@ -61,11 +63,6 @@
     },
     "connectedStatusPopoverHasBeenShown": true,
     "defaultHomeActiveTabName": null,
-    "bridgeState": {
-      "bridgeFeatureFlags": {
-        "extensionSupport": "boolean"
-      }
-    },
     "browserEnvironment": { "os": "string", "browser": "string" },
     "popupGasPollTokens": "object",
     "notificationGasPollTokens": "object",
@@ -121,8 +118,9 @@
     "useRequestQueue": true,
     "openSeaEnabled": false,
     "securityAlertsEnabled": "boolean",
-    "addSnapAccountEnabled": "boolean",
     "bitcoinSupportEnabled": "boolean",
+    "bitcoinTestnetSupportEnabled": "boolean",
+    "addSnapAccountEnabled": "boolean",
     "advancedGasFee": {},
     "incomingTransactionsPreferences": {},
     "identities": "object",
@@ -252,8 +250,10 @@
       "swapsQuotePrefetchingRefreshTime": 60000,
       "swapsStxBatchStatusRefreshTime": 10000,
       "swapsStxGetTransactionsRefreshTime": 10000,
-      "swapsStxMaxFeeMultiplier": 2
+      "swapsStxMaxFeeMultiplier": 2,
+      "swapsFeatureFlags": {}
     },
+    "bridgeState": { "bridgeFeatureFlags": { "extensionSupport": "boolean" } },
     "ensEntries": "object",
     "ensResolutionsByAddress": "object",
     "pendingApprovals": "object",

--- a/test/e2e/tests/petnames/petnames-signatures.spec.js
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.js
@@ -2,6 +2,7 @@ const {
   openDapp,
   switchToNotificationWindow,
   withFixtures,
+  tempToggleSettingRedesignedConfirmations,
   unlockWallet,
   defaultGanacheOptions,
 } = require('../../helpers');
@@ -108,6 +109,7 @@ describe('Petnames - Signatures', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
         await openDapp(driver);
         await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V3);
         await switchToNotificationWindow(driver, 3);
@@ -144,6 +146,7 @@ describe('Petnames - Signatures', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
         await openDapp(driver);
         await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
         await switchToNotificationWindow(driver, 3);
@@ -185,6 +188,7 @@ describe('Petnames - Signatures', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
         await openDapp(driver);
         await openTestSnaps(driver);
         await installNameLookupSnap(driver);

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
@@ -7,6 +7,7 @@ const {
   DAPP_ONE_URL,
   regularDelayMs,
   defaultGanacheOptions,
+  tempToggleSettingRedesignedConfirmations,
   WINDOW_TITLES,
 } = require('../../helpers');
 
@@ -42,6 +43,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
 
         // Open Dapp One
         await openDapp(driver, undefined, DAPP_URL);

--- a/test/e2e/tests/request-queuing/ui.spec.js
+++ b/test/e2e/tests/request-queuing/ui.spec.js
@@ -11,6 +11,7 @@ const {
   WINDOW_TITLES,
   defaultGanacheOptions,
   switchToNotificationWindow,
+  tempToggleSettingRedesignedConfirmations,
   veryLargeDelayMs,
   DAPP_TWO_URL,
 } = require('../../helpers');
@@ -457,6 +458,7 @@ describe('Request-queue UI changes', function () {
       },
       async ({ driver, ganacheServer, secondaryGanacheServer }) => {
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
 
         // Navigate to extension home screen
         await driver.navigate(PAGES.HOME);

--- a/test/e2e/tests/signature/personal-sign.spec.js
+++ b/test/e2e/tests/signature/personal-sign.spec.js
@@ -4,6 +4,7 @@ const {
   withFixtures,
   openDapp,
   regularDelayMs,
+  tempToggleSettingRedesignedConfirmations,
   unlockWallet,
   WINDOW_TITLES,
 } = require('../../helpers');
@@ -24,6 +25,7 @@ describe('Personal sign', function () {
         const addresses = await ganacheServer.getAccounts();
         const publicAddress = addresses[0];
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
 
         await openDapp(driver);
         await driver.clickElement('#personalSign');
@@ -47,6 +49,7 @@ describe('Personal sign', function () {
       },
     );
   });
+
   it('can queue multiple personal signs and confirm', async function () {
     await withFixtures(
       {
@@ -61,6 +64,7 @@ describe('Personal sign', function () {
         const addresses = await ganacheServer.getAccounts();
         const publicAddress = addresses[0];
         await unlockWallet(driver);
+        await tempToggleSettingRedesignedConfirmations(driver);
 
         await openDapp(driver);
         // Create personal sign

--- a/test/e2e/tests/signature/signature-request.spec.js
+++ b/test/e2e/tests/signature/signature-request.spec.js
@@ -5,6 +5,7 @@ const {
   openDapp,
   DAPP_URL,
   defaultGanacheOptions,
+  tempToggleSettingRedesignedConfirmations,
   unlockWallet,
   WINDOW_TITLES,
 } = require('../../helpers');
@@ -77,6 +78,7 @@ describe('Sign Typed Data Signature Request', function () {
           const addresses = await ganacheServer.getAccounts();
           const publicAddress = addresses[0];
           await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
 
           await openDapp(driver);
 
@@ -137,6 +139,7 @@ describe('Sign Typed Data Signature Request', function () {
           const addresses = await ganacheServer.getAccounts();
           const publicAddress = addresses[0];
           await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
 
           await openDapp(driver);
 
@@ -212,6 +215,7 @@ describe('Sign Typed Data Signature Request', function () {
         },
         async ({ driver }) => {
           await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
 
           await openDapp(driver);
 
@@ -237,6 +241,8 @@ describe('Sign Typed Data Signature Request', function () {
 
           // switch to the Dapp and verify the rejection was successful
           await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
+
+          await driver.waitForSelector(data.verifyRejectionResultId);
           const rejectionResult = await driver.findElement(
             data.verifyRejectionResultId,
           );
@@ -263,6 +269,7 @@ describe('Sign Typed Data Signature Request', function () {
         },
         async ({ driver }) => {
           await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
 
           await openDapp(driver);
 
@@ -306,6 +313,8 @@ describe('Sign Typed Data Signature Request', function () {
 
           // switch to the Dapp and verify the rejection was successful
           await driver.switchToWindowWithTitle('E2E Test Dapp');
+
+          await driver.waitForSelector(data.verifyRejectionResultId);
           const rejectionResult = await driver.findElement(
             data.verifyRejectionResultId,
           );

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -876,7 +876,10 @@ class Driver {
       await this.delay(delayStep);
       timeElapsed += delayStep;
     }
-    throw new Error('waitUntilXWindowHandles timed out polling window handles');
+
+    throw new Error(
+      `waitUntilXWindowHandles timed out polling window handles. Expected: ${x}, Actual: ${windowHandles.length}`,
+    );
   }
 
   /**

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.tsx
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.tsx
@@ -147,6 +147,7 @@ export default class ExperimentalTab extends PureComponent<ExperimentalTabProps>
       description: t('redesignedConfirmationsToggleDescription'),
       toggleValue: redesignedConfirmationsEnabled,
       toggleCallback: (value) => setRedesignedConfirmationsEnabled(!value),
+      toggleContainerDataTestId: 'toggle-redesigned-confirmations-container',
       toggleDataTestId: 'toggle-redesigned-confirmations',
       toggleOffLabel: t('off'),
       toggleOnLabel: t('on'),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26092?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
