### PR TITLE
feat: Move ENABLE_CONFIRMATION_REDESIGN feature flag to the developer…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,13 +158,6 @@ workflows:
       - prep-build-test-mv2:
           requires:
             - prep-deps
-      - prep-build-confirmation-redesign-test:
-          requires:
-            - prep-deps
-      - prep-build-confirmation-redesign-test-mv2:
-          <<: *develop_master_rc_only
-          requires:
-            - prep-deps
       - prep-build-test-flask:
           requires:
             - prep-deps
@@ -199,18 +192,10 @@ workflows:
           requires:
             - prep-build-test
             - get-changed-files-with-git-diff
-      - test-e2e-chrome-confirmation-redesign:
-          requires:
-            - prep-build-confirmation-redesign-test
-            - get-changed-files-with-git-diff
       - test-e2e-firefox:
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff
-      - test-e2e-firefox-confirmation-redesign:
-          <<: *develop_master_rc_only
-          requires:
-            - prep-build-confirmation-redesign-test-mv2
       - test-e2e-chrome-rpc:
           requires:
             - prep-build-test
@@ -304,8 +289,6 @@ workflows:
             - test-mozilla-lint-flask-mv2
             - test-e2e-chrome
             - test-e2e-chrome-multiple-providers
-            - test-e2e-chrome-confirmation-redesign
-            - test-e2e-firefox-confirmation-redesign
             - test-e2e-firefox
             - test-e2e-chrome-flask
             - test-e2e-firefox-flask
@@ -893,50 +876,6 @@ jobs:
             - dist-test-mv2
             - builds-test-mv2
 
-  prep-build-confirmation-redesign-test:
-    executor: node-linux-medium
-    steps:
-      - run: *shallow-git-clone
-      - run: corepack enable
-      - attach_workspace:
-          at: .
-      - run:
-          name: Build extension for testing
-          command: ENABLE_CONFIRMATION_REDESIGN="true" yarn build:test
-      - run:
-          name: Move test build to 'dist-test' to avoid conflict with production build
-          command: mv ./dist ./dist-test-confirmations
-      - run:
-          name: Move test zips to 'builds-test' to avoid conflict with production build
-          command: mv ./builds ./builds-test-confirmations
-      - persist_to_workspace:
-          root: .
-          paths:
-            - dist-test-confirmations
-            - builds-test-confirmations
-
-  prep-build-confirmation-redesign-test-mv2:
-    executor: node-linux-medium
-    steps:
-      - run: *shallow-git-clone
-      - run: corepack enable
-      - attach_workspace:
-          at: .
-      - run:
-          name: Build extension for testing
-          command: ENABLE_CONFIRMATION_REDESIGN="true" yarn build:test:mv2
-      - run:
-          name: Move test build to 'dist-test-confirmations-mv2' to avoid conflict with production build
-          command: mv ./dist ./dist-test-confirmations-mv2
-      - run:
-          name: Move test zips to 'builds-test-confirmations-mv2' to avoid conflict with production build
-          command: mv ./builds ./builds-test-confirmations-mv2
-      - persist_to_workspace:
-          root: .
-          paths:
-            - dist-test-confirmations-mv2
-            - builds-test-confirmations-mv2
-
   prep-build-storybook:
     executor: node-linux-medium
     steps:
@@ -1132,36 +1071,6 @@ jobs:
               timeout 20m yarn test:e2e:chrome --retries 1
             fi
           no_output_timeout: 5m
-      - store_artifacts:
-          path: test-artifacts
-          destination: test-artifacts
-      - store_test_results:
-          path: test/test-results/e2e
-
-  test-e2e-chrome-confirmation-redesign:
-    executor: node-browsers-medium-plus
-    parallelism: 20
-    steps:
-      - run: *shallow-git-clone
-      - run: sudo corepack enable
-      - attach_workspace:
-          at: .
-      - run:
-          name: Move test build to dist
-          command: mv ./dist-test-confirmations ./dist
-      - run:
-          name: Move test zips to builds
-          command: mv ./builds-test-confirmations ./builds
-      - run:
-          name: test:e2e:chrome-confirmation-redesign
-          command: |
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:chrome:confirmation-redesign --retries 1
-            fi
-          no_output_timeout: 5m
-          environment:
-            ENABLE_CONFIRMATION_REDESIGN: 'true'
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -1453,37 +1362,6 @@ jobs:
               timeout 20m yarn test:e2e:firefox --retries 1
             fi
           no_output_timeout: 5m
-      - store_artifacts:
-          path: test-artifacts
-          destination: test-artifacts
-      - store_test_results:
-          path: test/test-results/e2e
-
-  test-e2e-firefox-confirmation-redesign:
-    executor: node-browsers-medium-plus
-    parallelism: 20
-    steps:
-      - run: *shallow-git-clone
-      - run: sudo corepack enable
-      - attach_workspace:
-          at: .
-      - run:
-          name: Move test build to dist
-          command: mv ./dist-test-confirmations-mv2 ./dist
-      - run:
-          name: Move test zips to builds
-          command: mv ./builds-test-confirmations-mv2 ./builds
-      - run:
-          name: test:e2e:firefox-confirmation-redesign
-          command: |
-            export ENABLE_MV3=false
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:firefox --retries 1
-            fi
-          no_output_timeout: 5m
-          environment:
-            ENABLE_CONFIRMATION_REDESIGN: 'true'
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1527,6 +1527,12 @@
   "developerOptions": {
     "message": "Developer Options"
   },
+  "developerOptionsEnableConfirmationsRedesignDescription": {
+    "message": "Enables or disables the confirmations redesign feature currently in development"
+  },
+  "developerOptionsEnableConfirmationsRedesignTitle": {
+    "message": "Confirmations Redesign"
+  },
   "developerOptionsNetworkMenuRedesignDescription": {
     "message": "Toggles the new design of the Networks menu"
   },

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -95,6 +95,7 @@ export default class PreferencesController {
         featureNotificationsEnabled: false,
         showTokenAutodetectModal: null,
         showNftAutodetectModal: null, // null because we want to show the modal only the first time
+        isRedesignedConfirmationsDeveloperEnabled: false,
       },
       // ENS decentralized website resolution
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -308,6 +308,15 @@ describe('preferences controller', () => {
     });
   });
 
+  describe('isRedesignedConfirmationsFeatureEnabled', () => {
+    it('isRedesignedConfirmationsFeatureEnabled should default to false', () => {
+      expect(
+        preferencesController.store.getState().preferences
+          .isRedesignedConfirmationsDeveloperEnabled,
+      ).toStrictEqual(false);
+    });
+  });
+
   describe('setUseSafeChainsListValidation', function () {
     it('should default to true', function () {
       const state = preferencesController.store.getState();

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -246,6 +246,7 @@ export const SENTRY_BACKGROUND_STATE = {
     preferences: {
       autoLockTimeLimit: true,
       hideZeroBalanceTokens: true,
+      isRedesignedConfirmationsDeveloperEnabled: false,
       showExtensionInFullSizeView: true,
       showFiatInTestnets: true,
       showTestNetworks: true,

--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -73,6 +73,7 @@ const mockTransactionMetricsRequest = {
   getIsSmartTransaction: jest.fn(),
   getSmartTransactionByMinedTxHash: jest.fn(),
   getRedesignedConfirmationsEnabled: jest.fn(),
+  getIsRedesignedConfirmationsDeveloperEnabled: jest.fn(),
 } as TransactionMetricsRequest;
 
 describe('Transaction metrics', () => {

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -92,6 +92,7 @@ export type TransactionMetricsRequest = {
     txhash: string | undefined,
   ) => SmartTransaction;
   getRedesignedConfirmationsEnabled: () => boolean;
+  getIsRedesignedConfirmationsDeveloperEnabled: () => boolean;
 };
 
 export const METRICS_STATUS_FAILED = 'failed on-chain';
@@ -980,6 +981,7 @@ async function buildEventFragmentProperties({
     uiCustomizations.push(MetaMetricsEventUiCustomization.GasEstimationFailed);
   }
   const isRedesignedConfirmationsDeveloperSettingEnabled =
+    transactionMetricsRequest.getIsRedesignedConfirmationsDeveloperEnabled() ||
     process.env.ENABLE_CONFIRMATION_REDESIGN;
 
   const isRedesignedConfirmationsUserSettingEnabled =

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5973,6 +5973,10 @@ export default class MetamaskController extends EventEmitter {
       getRedesignedConfirmationsEnabled: () => {
         return this.preferencesController.getRedesignedConfirmationsEnabled;
       },
+      getIsRedesignedConfirmationsDeveloperEnabled: () => {
+        return this.preferencesController.store.getState().preferences
+          .isRedesignedConfirmationsDeveloperEnabled;
+      },
     };
     return {
       ...controllerActions,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "test:e2e:mmi:visual:update": "./test/e2e/playwright/mmi/scripts/run-visual-test.sh update",
     "test:e2e:swap": "yarn playwright test --project=swap",
     "test:e2e:pw:report": "yarn playwright show-report public/playwright/playwright-reports/html",
-    "test:e2e:chrome:confirmation-redesign": "ENABLE_CONFIRMATION_REDESIGN=true SELENIUM_BROWSER=chrome node test/e2e/run-all.js",
     "test:e2e:chrome:rpc": "SELENIUM_BROWSER=chrome node test/e2e/run-all.js --rpc",
     "test:e2e:chrome:multi-provider": "MULTIPROVIDER=true SELENIUM_BROWSER=chrome node test/e2e/run-all.js --multi-provider",
     "test:e2e:firefox": "SELENIUM_BROWSER=firefox node test/e2e/run-all.js",

--- a/shared/modules/metametrics.test.ts
+++ b/shared/modules/metametrics.test.ts
@@ -40,6 +40,7 @@ const createTransactionMetricsRequest = (customProps = {}) => {
     getIsSmartTransaction: jest.fn(),
     getSmartTransactionByMinedTxHash: jest.fn(),
     getRedesignedConfirmationsEnabled: jest.fn(),
+    getIsRedesignedConfirmationsDeveloperEnabled: jest.fn(),
     ...customProps,
   } as TransactionMetricsRequest;
 };

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -366,6 +366,7 @@
     },
     "preferences": {
       "hideZeroBalanceTokens": false,
+      "isRedesignedConfirmationsDeveloperEnabled": false,
       "showExtensionInFullSizeView": false,
       "showFiatInTestnets": false,
       "showTestNetworks": true,

--- a/test/e2e/default-fixture.js
+++ b/test/e2e/default-fixture.js
@@ -209,6 +209,7 @@ function defaultFixture(inputChainId = CHAIN_IDS.LOCALHOST) {
           useNativeCurrencyAsPrimaryCurrency: true,
           petnamesEnabled: true,
           showTokenAutodetectModal: false,
+          isRedesignedConfirmationsDeveloperEnabled: false,
         },
         selectedAddress: '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
         theme: 'light',

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -88,6 +88,7 @@ function onboardingFixture() {
           useNativeCurrencyAsPrimaryCurrency: true,
           petnamesEnabled: true,
           showTokenAutodetectModal: false,
+          isRedesignedConfirmationsDeveloperEnabled: false,
         },
         useExternalServices: true,
         theme: 'light',

--- a/test/e2e/tests/confirmations/signatures/permit.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/permit.spec.ts
@@ -14,12 +14,8 @@ import {
 import { Ganache } from '../../../seeder/ganache';
 import { Driver } from '../../../webdriver/driver';
 
-describe('Confirmation Signature - Permit', function (this: Suite) {
-  if (!process.env.ENABLE_CONFIRMATION_REDESIGN) {
-    return;
-  }
-
-  it('initiates and confirms', async function () {
+describe('Confirmation Signature - Permit @no-mmi', function (this: Suite) {
+  it('initiates and confirms and emits the correct events', async function () {
     await withRedesignConfirmationFixtures(
       this.test?.fullTitle(),
       async ({

--- a/test/e2e/tests/confirmations/signatures/personal-sign.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/personal-sign.spec.ts
@@ -11,11 +11,7 @@ import {
 import { Ganache } from '../../../seeder/ganache';
 import { Driver } from '../../../webdriver/driver';
 
-describe('Confirmation Signature - Personal Sign', function (this: Suite) {
-  if (!process.env.ENABLE_CONFIRMATION_REDESIGN) {
-    return;
-  }
-
+describe('Confirmation Signature - Personal Sign @no-mmi', function (this: Suite) {
   it('initiates and confirms', async function () {
     await withRedesignConfirmationFixtures(
       this.test?.fullTitle(),

--- a/test/e2e/tests/confirmations/signatures/sign-typed-data-v3.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/sign-typed-data-v3.spec.ts
@@ -14,11 +14,7 @@ import {
 import { Ganache } from '../../../seeder/ganache';
 import { Driver } from '../../../webdriver/driver';
 
-describe('Confirmation Signature - Sign Typed Data V3', function (this: Suite) {
-  if (!process.env.ENABLE_CONFIRMATION_REDESIGN) {
-    return;
-  }
-
+describe('Confirmation Signature - Sign Typed Data V3 @no-mmi', function (this: Suite) {
   it('initiates and confirms', async function () {
     await withRedesignConfirmationFixtures(
       this.test?.fullTitle(),

--- a/test/e2e/tests/confirmations/signatures/sign-typed-data-v4.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/sign-typed-data-v4.spec.ts
@@ -14,11 +14,7 @@ import {
 import { Ganache } from '../../../seeder/ganache';
 import { Driver } from '../../../webdriver/driver';
 
-describe('Confirmation Signature - Sign Typed Data V4', function (this: Suite) {
-  if (!process.env.ENABLE_CONFIRMATION_REDESIGN) {
-    return;
-  }
-
+describe('Confirmation Signature - Sign Typed Data V4 @no-mmi', function (this: Suite) {
   it('initiates and confirms', async function () {
     await withRedesignConfirmationFixtures(
       this.test?.fullTitle(),

--- a/test/e2e/tests/confirmations/signatures/sign-typed-data.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/sign-typed-data.spec.ts
@@ -11,11 +11,7 @@ import {
 import { Ganache } from '../../../seeder/ganache';
 import { Driver } from '../../../webdriver/driver';
 
-describe('Confirmation Signature - Sign Typed Data', function (this: Suite) {
-  if (!process.env.ENABLE_CONFIRMATION_REDESIGN) {
-    return;
-  }
-
+describe('Confirmation Signature - Sign Typed Data @no-mmi', function (this: Suite) {
   it('initiates and confirms', async function () {
     await withRedesignConfirmationFixtures(
       this.test?.fullTitle(),

--- a/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
@@ -27,11 +27,7 @@ const { CHAIN_IDS } = require('../../../../../shared/constants/network');
 describe('Confirmation Redesign Contract Interaction Component', function () {
   const smartContract = SMART_CONTRACTS.PIGGYBANK;
 
-  if (!process.env.ENABLE_CONFIRMATION_REDESIGN) {
-    return;
-  }
-
-  describe('Create a deposit transaction', function () {
+  describe('Create a deposit transaction @no-mmi', function () {
     it(`Sends a contract interaction type 0 transaction (Legacy)`, async function () {
       await withFixtures(
         {
@@ -39,7 +35,10 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
-              preferences: { redesignedConfirmationsEnabled: true },
+              preferences: {
+                redesignedConfirmationsEnabled: true,
+                isRedesignedConfirmationsDeveloperEnabled: true,
+              },
             })
             .build(),
           ganacheOptions: defaultGanacheOptions,
@@ -62,7 +61,10 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
-              preferences: { redesignedConfirmationsEnabled: true },
+              preferences: {
+                redesignedConfirmationsEnabled: true,
+                isRedesignedConfirmationsDeveloperEnabled: true,
+              },
             })
             .build(),
           ganacheOptions: defaultGanacheOptionsForType2Transactions,
@@ -85,7 +87,10 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.OPTIMISM })
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
-              preferences: { redesignedConfirmationsEnabled: true },
+              preferences: {
+                redesignedConfirmationsEnabled: true,
+                isRedesignedConfirmationsDeveloperEnabled: true,
+              },
             })
             .withTransactionControllerOPLayer2Transaction()
             .build(),
@@ -110,7 +115,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     });
   });
 
-  describe('Custom nonce editing', function () {
+  describe('Custom nonce editing @no-mmi', function () {
     it('Sends a contract interaction type 2 transaction without custom nonce editing (EIP1559)', async function () {
       await withFixtures(
         {
@@ -118,7 +123,10 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
-              preferences: { redesignedConfirmationsEnabled: true },
+              preferences: {
+                redesignedConfirmationsEnabled: true,
+                isRedesignedConfirmationsDeveloperEnabled: true,
+              },
             })
             .build(),
           ganacheOptions: defaultGanacheOptionsForType2Transactions,
@@ -145,7 +153,10 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
-              preferences: { redesignedConfirmationsEnabled: true },
+              preferences: {
+                redesignedConfirmationsEnabled: true,
+                isRedesignedConfirmationsDeveloperEnabled: true,
+              },
             })
             .build(),
           ganacheOptions: defaultGanacheOptionsForType2Transactions,
@@ -171,7 +182,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     });
   });
 
-  describe('Advanced Gas Details', function () {
+  describe('Advanced Gas Details @no-mmi', function () {
     it('Sends a contract interaction type 2 transaction (EIP1559) and checks the advanced gas details', async function () {
       await withFixtures(
         {
@@ -179,7 +190,10 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
-              preferences: { redesignedConfirmationsEnabled: true },
+              preferences: {
+                redesignedConfirmationsEnabled: true,
+                isRedesignedConfirmationsDeveloperEnabled: true,
+              },
             })
             .build(),
           ganacheOptions: defaultGanacheOptionsForType2Transactions,
@@ -212,7 +226,10 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.OPTIMISM })
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
-              preferences: { redesignedConfirmationsEnabled: true },
+              preferences: {
+                redesignedConfirmationsEnabled: true,
+                isRedesignedConfirmationsDeveloperEnabled: true,
+              },
             })
             .withTransactionControllerOPLayer2Transaction()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -23,11 +23,7 @@ const {
 } = require('../../../helpers');
 const FixtureBuilder = require('../../../fixture-builder');
 
-describe('Metrics', function () {
-  if (!process.env.ENABLE_CONFIRMATION_REDESIGN) {
-    return;
-  }
-
+describe('Metrics @no-mmi', function () {
   it('Sends a contract interaction type 2 transaction (EIP1559) with the right properties in the metric events', async function () {
     await withFixtures(
       {
@@ -35,7 +31,10 @@ describe('Metrics', function () {
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({
-            preferences: { redesignedConfirmationsEnabled: true },
+            preferences: {
+              redesignedConfirmationsEnabled: true,
+              isRedesignedConfirmationsDeveloperEnabled: true,
+            },
           })
           .withMetaMetricsController({
             metaMetricsId: 'fake-metrics-id',

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -202,7 +202,8 @@
       "smartTransactionsOptInStatus": false,
       "useNativeCurrencyAsPrimaryCurrency": true,
       "petnamesEnabled": true,
-      "showTokenAutodetectModal": "boolean"
+      "showTokenAutodetectModal": "boolean",
+      "isRedesignedConfirmationsDeveloperEnabled": "boolean"
     },
     "ipfsGateway": "string",
     "isIpfsGatewayEnabled": "boolean",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -34,7 +34,8 @@
       "smartTransactionsOptInStatus": false,
       "useNativeCurrencyAsPrimaryCurrency": true,
       "petnamesEnabled": true,
-      "showTokenAutodetectModal": "boolean"
+      "showTokenAutodetectModal": "boolean",
+      "isRedesignedConfirmationsDeveloperEnabled": "boolean"
     },
     "firstTimeFlowType": "import",
     "completedOnboarding": true,
@@ -87,7 +88,6 @@
     "nftsDropdownState": {},
     "termsOfUseLastAgreed": "number",
     "qrHardware": {},
-    "queuedRequestCount": 0,
     "usedNetworks": { "0x1": true, "0x5": true, "0x539": true },
     "snapsInstallPrivacyWarningShown": true,
     "surveyLinkLastClickedOrClosed": "object",
@@ -214,6 +214,7 @@
     "isFetchingMetamaskNotifications": "boolean",
     "isUpdatingMetamaskNotificationsAccount": "object",
     "isCheckingAccountsPresence": "boolean",
+    "queuedRequestCount": 0,
     "fcmToken": "string",
     "accounts": "object",
     "accountsByChainId": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -40,14 +40,14 @@
       "recoveryPhraseReminderLastShown": "number",
       "showTestnetMessageInDropdown": true,
       "trezorModel": null,
+      "newPrivacyPolicyToastClickedOrClosed": "boolean",
+      "newPrivacyPolicyToastShownDate": "number",
       "usedNetworks": {
         "0x1": true,
         "0xe708": true,
         "0x5": true,
         "0x539": true
       },
-      "newPrivacyPolicyToastClickedOrClosed": "boolean",
-      "newPrivacyPolicyToastShownDate": "number",
       "snapsInstallPrivacyWarningShown": true
     },
     "CurrencyController": {
@@ -118,7 +118,8 @@
         "smartTransactionsOptInStatus": false,
         "useNativeCurrencyAsPrimaryCurrency": true,
         "petnamesEnabled": true,
-        "showTokenAutodetectModal": "boolean"
+        "showTokenAutodetectModal": "boolean",
+        "isRedesignedConfirmationsDeveloperEnabled": "boolean"
       },
       "selectedAddress": "string",
       "theme": "light",
@@ -131,9 +132,7 @@
       "useMultiAccountBalanceChecker": true,
       "useRequestQueue": true
     },
-    "QueuedRequestController": {
-      "queuedRequestCount": 0
-    },
+    "QueuedRequestController": { "queuedRequestCount": 0 },
     "SelectedNetworkController": { "domains": "object" },
     "SmartTransactionsController": {
       "smartTransactionsState": {

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -40,14 +40,14 @@
       "recoveryPhraseReminderLastShown": "number",
       "showTestnetMessageInDropdown": true,
       "trezorModel": null,
+      "newPrivacyPolicyToastClickedOrClosed": "boolean",
+      "newPrivacyPolicyToastShownDate": "number",
       "usedNetworks": {
         "0x1": true,
         "0xe708": true,
         "0x5": true,
         "0x539": true
       },
-      "newPrivacyPolicyToastClickedOrClosed": "boolean",
-      "newPrivacyPolicyToastShownDate": "number",
       "snapsInstallPrivacyWarningShown": true
     },
     "CurrencyController": {
@@ -118,7 +118,8 @@
         "smartTransactionsOptInStatus": false,
         "useNativeCurrencyAsPrimaryCurrency": true,
         "petnamesEnabled": true,
-        "showTokenAutodetectModal": "boolean"
+        "showTokenAutodetectModal": "boolean",
+        "isRedesignedConfirmationsDeveloperEnabled": "boolean"
       },
       "selectedAddress": "string",
       "theme": "light",
@@ -131,9 +132,7 @@
       "useMultiAccountBalanceChecker": true,
       "useRequestQueue": true
     },
-    "QueuedRequestController": {
-      "queuedRequestCount": 0
-    },
+    "QueuedRequestController": { "queuedRequestCount": 0 },
     "SelectedNetworkController": { "domains": "object" },
     "SmartTransactionsController": {
       "smartTransactionsState": {

--- a/test/env.js
+++ b/test/env.js
@@ -13,5 +13,5 @@ process.env.NOTIFICATIONS_SERVICE_URL =
   'https://mock-test-notifications-api.metamask.io';
 process.env.PUSH_NOTIFICATIONS_SERVICE_URL =
   'https://mock-test-push-notifications-api.metamask.io';
-process.env.ENABLE_CONFIRMATION_REDESIGN = 'true';
 process.env.PORTFOLIO_URL = 'https://portfolio.test';
+process.env.ENABLE_CONFIRMATION_REDESIGN = 'true';

--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
@@ -56,12 +56,14 @@ function buildState({
   pendingApprovals,
   redesignedConfirmationsEnabled,
   transaction,
+  isRedesignedConfirmationsDeveloperEnabled,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   message?: Partial<AbstractMessage & { msgParams: any }>;
   pendingApprovals?: Partial<ApprovalRequest<Record<string, Json>>>[];
   redesignedConfirmationsEnabled?: boolean;
   transaction?: Partial<TransactionMeta>;
+  isRedesignedConfirmationsDeveloperEnabled?: boolean;
 }) {
   return {
     ...mockState,
@@ -70,6 +72,8 @@ function buildState({
       pendingApprovals: pendingApprovals ? arrayToIdMap(pendingApprovals) : {},
       preferences: {
         redesignedConfirmationsEnabled,
+        isRedesignedConfirmationsDeveloperEnabled:
+          isRedesignedConfirmationsDeveloperEnabled || false,
       },
       transactions: transaction ? [transaction] : [],
       unapprovedPersonalMsgs: message
@@ -112,6 +116,7 @@ describe('useCurrentConfirmation', () => {
       pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.Transaction }],
       redesignedConfirmationsEnabled: true,
       transaction: TRANSACTION_MOCK,
+      isRedesignedConfirmationsDeveloperEnabled: true,
     });
 
     expect(currentConfirmation).toStrictEqual(TRANSACTION_MOCK);
@@ -152,6 +157,7 @@ describe('useCurrentConfirmation', () => {
       message: MESSAGE_MOCK,
       pendingApprovals: [APPROVAL_MOCK],
       redesignedConfirmationsEnabled: false,
+      isRedesignedConfirmationsDeveloperEnabled: false,
     });
 
     expect(currentConfirmation).toBeUndefined();
@@ -172,6 +178,7 @@ describe('useCurrentConfirmation', () => {
       pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.Transaction }],
       redesignedConfirmationsEnabled: true,
       transaction: { ...TRANSACTION_MOCK, type: TransactionType.cancel },
+      isRedesignedConfirmationsDeveloperEnabled: true,
     });
 
     expect(currentConfirmation).toBeUndefined();
@@ -195,5 +202,98 @@ describe('useCurrentConfirmation', () => {
     });
 
     expect(currentConfirmation).toBeUndefined();
+  });
+
+  it('returns undefined if message is SIWE', () => {
+    const currentConfirmation = runHook({
+      message: {
+        ...MESSAGE_MOCK,
+        msgParams: { siwe: { isSIWEMessage: true } },
+      },
+      pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.PersonalSign }],
+      redesignedConfirmationsEnabled: true,
+    });
+
+    expect(currentConfirmation).toBeUndefined();
+  });
+
+  it('returns undefined if developer and user settings are enabled and transaction has incorrect type', () => {
+    const currentConfirmation = runHook({
+      pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.Transaction }],
+      redesignedConfirmationsEnabled: true,
+      transaction: { ...TRANSACTION_MOCK, type: TransactionType.cancel },
+      isRedesignedConfirmationsDeveloperEnabled: true,
+    });
+
+    expect(currentConfirmation).toBeUndefined();
+  });
+
+  it('returns undefined if redesign developer setting and user setting are disabled and transaction has correct type', () => {
+    const currentConfirmation = runHook({
+      pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.Transaction }],
+      redesignedConfirmationsEnabled: false,
+      transaction: {
+        ...TRANSACTION_MOCK,
+        type: TransactionType.contractInteraction,
+      },
+      isRedesignedConfirmationsDeveloperEnabled: false,
+    });
+
+    expect(currentConfirmation).toBeUndefined();
+  });
+
+  it('returns if redesign developer and user settings are enabled and transaction has correct type', () => {
+    const currentConfirmation = runHook({
+      pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.Transaction }],
+      transaction: {
+        ...TRANSACTION_MOCK,
+        type: TransactionType.contractInteraction,
+      },
+      redesignedConfirmationsEnabled: true,
+      isRedesignedConfirmationsDeveloperEnabled: true,
+    });
+
+    expect(currentConfirmation).toStrictEqual(TRANSACTION_MOCK);
+  });
+
+  it('returns if env var and user settings are enabled and transaction has correct type', () => {
+    const currentConfirmation = runHook({
+      pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.Transaction }],
+      transaction: {
+        ...TRANSACTION_MOCK,
+        type: TransactionType.contractInteraction,
+      },
+      redesignedConfirmationsEnabled: true,
+      isRedesignedConfirmationsDeveloperEnabled: true,
+    });
+
+    expect(currentConfirmation).toStrictEqual(TRANSACTION_MOCK);
+  });
+
+  describe('useCurrentConfirmation with env var', () => {
+    beforeAll(() => {
+      jest.resetModules();
+      process.env.ENABLE_CONFIRMATION_REDESIGN = 'false';
+    });
+
+    afterAll(() => {
+      process.env.ENABLE_CONFIRMATION_REDESIGN = 'true';
+    });
+
+    it('returns undefined if redesign developer setting is disabled, user setting is enabled and transaction has correct type', () => {
+      const currentConfirmation = runHook({
+        pendingApprovals: [
+          { ...APPROVAL_MOCK, type: ApprovalType.Transaction },
+        ],
+        redesignedConfirmationsEnabled: true,
+        transaction: {
+          ...TRANSACTION_MOCK,
+          type: TransactionType.contractInteraction,
+        },
+        isRedesignedConfirmationsDeveloperEnabled: false,
+      });
+
+      expect(currentConfirmation).toBeUndefined();
+    });
   });
 });

--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.ts
@@ -8,6 +8,7 @@ import { ApprovalType } from '@metamask/controller-utils';
 import { useMemo } from 'react';
 import {
   ApprovalsMetaMaskState,
+  getIsRedesignedConfirmationsDeveloperEnabled,
   getRedesignedConfirmationsEnabled,
   getUnapprovedTransaction,
   latestPendingConfirmationSelector,
@@ -29,9 +30,17 @@ const useCurrentConfirmation = () => {
   const latestPendingApproval = useSelector(latestPendingConfirmationSelector);
   const confirmationId = paramsConfirmationId ?? latestPendingApproval?.id;
 
-  const redesignedConfirmationsEnabled = useSelector(
+  const isRedesignedConfirmationsUserSettingEnabled = useSelector(
     getRedesignedConfirmationsEnabled,
   );
+
+  const isRedesignedConfirmationsDeveloperEnabled = useSelector(
+    getIsRedesignedConfirmationsDeveloperEnabled,
+  );
+
+  const isRedesignedConfirmationsDeveloperSettingEnabled =
+    process.env.ENABLE_CONFIRMATION_REDESIGN === 'true' ||
+    isRedesignedConfirmationsDeveloperEnabled;
 
   const pendingApproval = useSelector((state) =>
     selectPendingApproval(state as ApprovalsMetaMaskState, confirmationId),
@@ -46,19 +55,28 @@ const useCurrentConfirmation = () => {
     selectUnapprovedMessage(state, confirmationId),
   );
 
-  const isCorrectTransactionType = REDESIGN_TRANSACTION_TYPES.includes(
-    transactionMetadata?.type as TransactionType,
-  );
+  const isCorrectTransactionType =
+    isRedesignedConfirmationsDeveloperSettingEnabled &&
+    REDESIGN_TRANSACTION_TYPES.includes(
+      transactionMetadata?.type as TransactionType,
+    );
 
   const isCorrectApprovalType = REDESIGN_APPROVAL_TYPES.includes(
     pendingApproval?.type as ApprovalType,
   );
 
+  const isSIWE =
+    pendingApproval?.type === TransactionType.personalSign &&
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (signatureMessage?.msgParams as any)?.siwe?.isSIWEMessage;
+
+  const shouldUseRedesign =
+    isRedesignedConfirmationsUserSettingEnabled &&
+    (isCorrectApprovalType || isCorrectTransactionType) &&
+    !isSIWE;
+
   return useMemo(() => {
-    if (
-      !redesignedConfirmationsEnabled ||
-      (!isCorrectTransactionType && !isCorrectApprovalType)
-    ) {
+    if (!shouldUseRedesign) {
       return { currentConfirmation: undefined };
     }
 
@@ -66,13 +84,7 @@ const useCurrentConfirmation = () => {
       transactionMetadata ?? signatureMessage ?? undefined;
 
     return { currentConfirmation };
-  }, [
-    redesignedConfirmationsEnabled,
-    isCorrectTransactionType,
-    isCorrectApprovalType,
-    transactionMetadata,
-    signatureMessage,
-  ]);
+  }, [transactionMetadata, signatureMessage, shouldUseRedesign]);
 };
 
 export default useCurrentConfirmation;

--- a/ui/pages/confirmations/selectors/confirm.test.ts
+++ b/ui/pages/confirmations/selectors/confirm.test.ts
@@ -9,6 +9,7 @@ import { ConfirmMetamaskState, SecurityAlertResponse } from '../types/confirm';
 import {
   currentConfirmationSelector,
   currentSignatureRequestSecurityResponseSelector,
+  getIsRedesignedConfirmationsDeveloperEnabled,
   latestPendingConfirmationSelector,
   pendingConfirmationsSelector,
 } from './confirm';
@@ -109,6 +110,32 @@ describe('confirm selectors', () => {
         currentSignatureRequestSecurityResponseSelector(sigMockState);
 
       expect(result).toStrictEqual(SECURITY_ALERT_RESPONSE_MOCK);
+    });
+  });
+
+  describe('#getIsRedesignedConfirmationsDeveloperEnabled', () => {
+    it('returns true if redesigned confirmations developer setting is enabled', () => {
+      const mockState = {
+        metamask: {
+          preferences: {
+            isRedesignedConfirmationsDeveloperEnabled: true,
+          },
+        },
+      };
+      const result = getIsRedesignedConfirmationsDeveloperEnabled(mockState);
+      expect(result).toBe(true);
+    });
+
+    it('returns false if redesigned confirmations developer setting is disabled', () => {
+      const mockState = {
+        metamask: {
+          preferences: {
+            isRedesignedConfirmationsDeveloperEnabled: false,
+          },
+        },
+      };
+      const result = getIsRedesignedConfirmationsDeveloperEnabled(mockState);
+      expect(result).toBe(false);
     });
   });
 });

--- a/ui/pages/confirmations/selectors/confirm.ts
+++ b/ui/pages/confirmations/selectors/confirm.ts
@@ -9,6 +9,7 @@ import {
 } from '../types/confirm';
 import { createDeepEqualSelector } from '../../../selectors/util';
 import { isSignatureTransactionType } from '../utils';
+import { getPreferences } from '../../../selectors/selectors';
 
 const ConfirmationApprovalTypes = [
   ApprovalType.EthSign,
@@ -68,3 +69,8 @@ export const currentSignatureRequestSecurityResponseSelector = (
 
   return state.metamask.signatureSecurityAlertResponses?.[securityAlertId];
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getIsRedesignedConfirmationsDeveloperEnabled(state: any) {
+  return getPreferences(state).isRedesignedConfirmationsDeveloperEnabled;
+}

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -2,7 +2,6 @@ import { ApprovalRequest } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 import { TransactionType } from '@metamask/transaction-controller';
 import { Json } from '@metamask/utils';
-
 import { EIP712_PRIMARY_TYPE_PERMIT } from '../../../../shared/constants/transaction';
 import { parseTypedDataMessage } from '../../../../shared/modules/transaction.utils';
 import { sanitizeMessage } from '../../../helpers/utils/util';
@@ -14,11 +13,7 @@ export const REDESIGN_APPROVAL_TYPES = [
   ApprovalType.PersonalSign,
 ];
 
-export const REDESIGN_TRANSACTION_TYPES = [
-  ...(process.env.ENABLE_CONFIRMATION_REDESIGN
-    ? [TransactionType.contractInteraction]
-    : []),
-] as const;
+export const REDESIGN_TRANSACTION_TYPES = [TransactionType.contractInteraction];
 
 const SIGNATURE_APPROVAL_TYPES = [
   ApprovalType.EthSign,

--- a/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
+++ b/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
@@ -237,6 +237,76 @@ exports[`Develop options tab should match snapshot 1`] = `
           </label>
         </div>
       </div>
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <div
+            class="settings-page__content-description"
+          >
+            <span>
+              Confirmations Redesign
+            </span>
+            <div
+              class="settings-page__content-description"
+            >
+              Enables or disables the confirmations redesign feature currently in development
+            </div>
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <label
+            class="toggle-button toggle-button--off"
+            tabindex="0"
+          >
+            <div
+              style="display: flex; width: 52px; align-items: center; justify-content: flex-start; position: relative; cursor: pointer; background-color: transparent; border: 0px; padding: 0px; user-select: none;"
+            >
+              <div
+                style="width: 40px; height: 24px; padding: 0px; border-radius: 26px; display: flex; align-items: center; justify-content: center; background-color: rgb(132, 140, 150);"
+              >
+                <div
+                  style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgb(250, 250, 250); margin-top: auto; margin-bottom: auto; line-height: 0; opacity: 0; width: 26px; height: 20px; left: 4px;"
+                />
+                <div
+                  style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgba(255, 255, 255, 0.6); bottom: 0px; margin-top: auto; margin-bottom: auto; padding-right: 5px; line-height: 0; width: 26px; height: 20px; opacity: 1;"
+                />
+              </div>
+              <div
+                style="position: absolute; height: 100%; top: 0px; left: 0px; display: flex; flex: 1; align-self: stretch; align-items: center; justify-content: flex-start;"
+              >
+                <div
+                  style="width: 18px; height: 18px; display: flex; align-self: center; box-shadow: var(--shadow-size-xs) var(--color-shadow-default); border-radius: 50%; box-sizing: border-box; position: relative; background-color: rgb(255, 255, 255); left: 3px;"
+                />
+              </div>
+              <input
+                data-testid="developer-options-enable-confirmations-redesign-toggle"
+                style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
+                type="checkbox"
+                value="false"
+              />
+            </div>
+            <div
+              class="toggle-button__status"
+            >
+              <span
+                class="toggle-button__label-off"
+              >
+                Off
+              </span>
+              <span
+                class="toggle-button__label-on"
+              >
+                On
+              </span>
+            </div>
+          </label>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
 import {
@@ -19,7 +19,6 @@ import {
   JustifyContent,
   AlignItems,
 } from '../../../helpers/constants/design-system';
-import ToggleButton from '../../../components/ui/toggle-button';
 import { ONBOARDING_SECURE_YOUR_WALLET_ROUTE } from '../../../helpers/constants/routes';
 import {
   getNumberOfSettingRoutesInTab,
@@ -31,19 +30,30 @@ import {
   resetOnboarding,
   resetViewedNotifications,
   setServiceWorkerKeepAlivePreference,
+  setRedesignedConfirmationsDeveloperEnabled,
 } from '../../../store/actions';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
+import { getIsRedesignedConfirmationsDeveloperEnabled } from '../../confirmations/selectors/confirm';
+import ToggleRow from './developer-options-toggle-row-component';
 
 const DeveloperOptionsTab = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const history = useHistory();
 
+  const redesignConfirmationsFeatureToggle = useSelector(
+    getIsRedesignedConfirmationsDeveloperEnabled,
+  );
+
   const [hasResetAnnouncements, setHasResetAnnouncements] = useState(false);
   const [hasResetOnboarding, setHasResetOnboarding] = useState(false);
   const [isServiceWorkerKeptAlive, setIsServiceWorkerKeptAlive] =
     useState(true);
+  const [
+    isRedesignedConfirmationsFeatureEnabled,
+    setIsRedesignedConfirmationsFeatureEnabled,
+  ] = useState(redesignConfirmationsFeatureToggle);
   const [enableNetworkRedesign, setEnableNetworkRedesign] = useState(
     // eslint-disable-next-line
     /* @ts-expect-error: Avoids error from window property not existing */
@@ -89,6 +99,13 @@ const DeveloperOptionsTab = () => {
   ): Promise<void> => {
     await dispatch(setServiceWorkerKeepAlivePreference(value));
     setIsServiceWorkerKeptAlive(value);
+  };
+
+  const setEnableConfirmationsRedesignEnabled = async (
+    value: boolean,
+  ): Promise<void> => {
+    await dispatch(setRedesignedConfirmationsDeveloperEnabled(value));
+    await setIsRedesignedConfirmationsFeatureEnabled(value);
   };
 
   const renderAnnouncementReset = () => {
@@ -188,70 +205,49 @@ const DeveloperOptionsTab = () => {
 
   const renderServiceWorkerKeepAliveToggle = () => {
     return (
-      <Box
-        ref={settingsRefs[3] as React.RefObject<HTMLDivElement>}
-        className="settings-page__content-row"
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
-        gap={4}
-      >
-        <div className="settings-page__content-item">
-          <div className="settings-page__content-description">
-            <span>{t('serviceWorkerKeepAlive')}</span>
-            <div className="settings-page__content-description">
-              {t('developerOptionsServiceWorkerKeepAlive')}
-            </div>
-          </div>
-        </div>
-
-        <div className="settings-page__content-item-col">
-          <ToggleButton
-            value={isServiceWorkerKeptAlive}
-            onToggle={(value) => handleToggleServiceWorkerAlive(!value)}
-            offLabel={t('off')}
-            onLabel={t('on')}
-            dataTestId="developer-options-service-worker-alive-toggle"
-          />
-        </div>
-      </Box>
+      <ToggleRow
+        title={t('serviceWorkerKeepAlive')}
+        description={t('developerOptionsServiceWorkerKeepAlive')}
+        isEnabled={isServiceWorkerKeptAlive}
+        onToggle={(value) => handleToggleServiceWorkerAlive(!value)}
+        dataTestId="developer-options-service-worker-alive-toggle"
+        settingsRef={settingsRefs[3] as React.RefObject<HTMLDivElement>}
+      />
     );
   };
 
   const renderNetworkMenuRedesign = () => {
     return (
-      <Box
-        ref={settingsRefs[4] as React.RefObject<HTMLDivElement>}
-        className="settings-page__content-row"
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
-        gap={4}
-      >
-        <div className="settings-page__content-item">
-          <div className="settings-page__content-description">
-            <span>{t('developerOptionsNetworkMenuRedesignTitle')}</span>
-            <div className="settings-page__content-description">
-              {t('developerOptionsNetworkMenuRedesignDescription')}
-            </div>
-          </div>
-        </div>
+      <ToggleRow
+        title={t('developerOptionsNetworkMenuRedesignTitle')}
+        description={t('developerOptionsNetworkMenuRedesignDescription')}
+        isEnabled={enableNetworkRedesign}
+        onToggle={(value) => {
+          setEnableNetworkRedesign(!value);
+          // eslint-disable-next-line
+          /* @ts-expect-error: Avoids error from window property not existing */
+          window.metamaskFeatureFlags.networkMenuRedesign = !value;
+        }}
+        dataTestId="developer-options-network-redesign"
+        settingsRef={settingsRefs[4] as React.RefObject<HTMLDivElement>}
+      />
+    );
+  };
 
-        <div className="settings-page__content-item-col">
-          <ToggleButton
-            value={enableNetworkRedesign}
-            onToggle={(value) => {
-              setEnableNetworkRedesign(!value);
-              // eslint-disable-next-line
-              /* @ts-expect-error: Avoids error from window property not existing */
-              window.metamaskFeatureFlags.networkMenuRedesign = !value;
-            }}
-            offLabel={t('off')}
-            onLabel={t('on')}
-            dataTestId="developer-options-network-redesign"
-          />
-        </div>
-      </Box>
+  const renderEnableConfirmationsRedesignToggle = () => {
+    return (
+      <ToggleRow
+        title={t('developerOptionsEnableConfirmationsRedesignTitle')}
+        description={t(
+          'developerOptionsEnableConfirmationsRedesignDescription',
+        )}
+        isEnabled={isRedesignedConfirmationsFeatureEnabled}
+        onToggle={(value: boolean) =>
+          setEnableConfirmationsRedesignEnabled(!value)
+        }
+        dataTestId="developer-options-enable-confirmations-redesign-toggle"
+        settingsRef={settingsRefs[5] as React.RefObject<HTMLDivElement>}
+      />
     );
   };
 
@@ -274,6 +270,7 @@ const DeveloperOptionsTab = () => {
         {renderOnboardingReset()}
         {renderServiceWorkerKeepAliveToggle()}
         {renderNetworkMenuRedesign()}
+        {renderEnableConfirmationsRedesignToggle()}
       </div>
     </div>
   );

--- a/ui/pages/settings/developer-options-tab/developer-options-toggle-row-component.test.tsx
+++ b/ui/pages/settings/developer-options-tab/developer-options-toggle-row-component.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { renderWithProvider } from '../../../../test/jest/rendering';
+import mockState from '../../../../test/data/mock-state.json'; // Adjust the path based on your actual file location
+import ToggleRow from './developer-options-toggle-row-component';
+
+describe('ToggleFeatureRow Component', () => {
+  const mockTitle = 'Test Title';
+  const mockDescription = 'Test Description';
+  const mockDataTestId = 'Test id';
+  const mockSettingsRef = { current: document.createElement('div') };
+
+  const mockStore = configureMockStore([thunk])(mockState);
+
+  it('renders ToggleFeatureRow correctly', () => {
+    const { getByText, getByTestId } = renderWithProvider(
+      <ToggleRow
+        title={mockTitle}
+        description={mockDescription}
+        isEnabled={true}
+        onToggle={() => {
+          //* eslint-disable-next-line @typescript-eslint/no-empty-function
+        }}
+        dataTestId={mockDataTestId}
+        settingsRef={mockSettingsRef}
+      />,
+      mockStore,
+    );
+
+    expect(getByText(mockTitle)).toBeInTheDocument();
+    expect(getByText(mockDescription)).toBeInTheDocument();
+    expect(getByTestId(mockDataTestId)).toBeInTheDocument();
+  });
+});

--- a/ui/pages/settings/developer-options-tab/developer-options-toggle-row-component.tsx
+++ b/ui/pages/settings/developer-options-tab/developer-options-toggle-row-component.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Box } from '../../../components/component-library';
+import {
+  Display,
+  FlexDirection,
+  JustifyContent,
+} from '../../../helpers/constants/design-system';
+import ToggleButton from '../../../components/ui/toggle-button';
+
+const ToggleRow = ({
+  title,
+  description,
+  isEnabled,
+  onToggle,
+  dataTestId,
+  settingsRef,
+}: {
+  title: string;
+  description: string;
+  isEnabled: boolean;
+  onToggle: (value: boolean) => void;
+  dataTestId: string;
+  settingsRef: React.RefObject<HTMLDivElement>;
+}) => {
+  return (
+    <Box
+      ref={settingsRef}
+      className="settings-page__content-row"
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      justifyContent={JustifyContent.spaceBetween}
+      gap={4}
+    >
+      <div className="settings-page__content-item">
+        <div className="settings-page__content-description">
+          <span>{title}</span>
+          <div className="settings-page__content-description">
+            {description}
+          </div>
+        </div>
+      </div>
+
+      <div className="settings-page__content-item-col">
+        <ToggleButton
+          value={isEnabled}
+          onToggle={onToggle}
+          offLabel="Off"
+          onLabel="On"
+          dataTestId={dataTestId}
+        />
+      </div>
+    </Box>
+  );
+};
+
+export default ToggleRow;

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3090,6 +3090,10 @@ export function setShowExtensionInFullSizeView(value: boolean) {
   return setPreference('showExtensionInFullSizeView', value);
 }
 
+export function setRedesignedConfirmationsDeveloperEnabled(value: boolean) {
+  return setPreference('isRedesignedConfirmationsDeveloperEnabled', value);
+}
+
 export function setSmartTransactionsOptInStatus(
   value: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {


### PR DESCRIPTION
… settings page #25520


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26095?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
