### PR TITLE
refactor: replace typography with text component in signature request original component

### DIFF
--- a/ui/pages/confirmations/components/signature-request-original/__snapshots__/signature-request-original.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request-original/__snapshots__/signature-request-original.test.js.snap
@@ -147,7 +147,6 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
           >
             <h6
               class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
-              data-testid="signature-request-network-display"
             >
               goerli
             </h6>
@@ -203,7 +202,7 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
               </div>
             </div>
             <span
-              class="mm-box mm-text chip__label mm-text--body-sm mm-box--color-text-alternative"
+              class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography chip__label typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative"
             >
               https://happydapp.website/governance?futarchy=true
             </span>

--- a/ui/pages/confirmations/components/signature-request-original/signature-request-original.component.js
+++ b/ui/pages/confirmations/components/signature-request-original/signature-request-original.component.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ObjectInspector } from 'react-inspector';
 import { ethErrors, serializeError } from 'eth-rpc-errors';
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SubjectType } from '@metamask/permission-controller';
+///: END:ONLY_INCLUDE_IF
 import LedgerInstructionField from '../ledger-instruction-field';
 import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 import {
@@ -42,15 +44,20 @@ import {
   ///: END:ONLY_INCLUDE_IF
 } from '../../../../components/component-library';
 
+///: BEGIN:ONLY_INCLUDE_IF(blockaid)
 import BlockaidBannerAlert from '../security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
+///: END:ONLY_INCLUDE_IF
+
 import ConfirmPageContainerNavigation from '../confirm-page-container/confirm-page-container-navigation';
 import SecurityProviderBannerMessage from '../security-provider-banner-message/security-provider-banner-message';
 
 import SignatureRequestHeader from '../signature-request-header';
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import SnapLegacyAuthorshipHeader from '../../../../components/app/snaps/snap-legacy-authorship-header';
 import InsightWarnings from '../../../../components/app/snaps/insight-warnings';
+///: END:ONLY_INCLUDE_IF
 import { BlockaidResultType } from '../../../../../shared/constants/security-provider';
-import { QueuedRequestsBannerAlert } from '../../confirmation/components/queued-requests-banner-alert';
+import { BlockaidUnavailableBannerAlert } from '../blockaid-unavailable-banner-alert/blockaid-unavailable-banner-alert';
 import SignatureRequestOriginalWarning from './signature-request-original-warning';
 
 export default class SignatureRequestOriginal extends Component {
@@ -83,12 +90,16 @@ export default class SignatureRequestOriginal extends Component {
     selectedAccount: PropTypes.object,
     mmiOnSignCallback: PropTypes.func,
     ///: END:ONLY_INCLUDE_IF
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     warnings: PropTypes.array,
+    ///: END:ONLY_INCLUDE_IF
   };
 
   state = {
     showSignatureRequestWarning: false,
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     showSignatureInsights: false,
+    ///: END:ONLY_INCLUDE_IF
   };
 
   renderTypedData = (data) => {
@@ -140,18 +151,22 @@ export default class SignatureRequestOriginal extends Component {
 
     return (
       <div className="request-signature__body">
-        <BlockaidBannerAlert
-          txData={txData}
-          marginTop={4}
-          marginLeft={4}
-          marginRight={4}
-        />
+        {
+          ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
+          <BlockaidBannerAlert
+            txData={txData}
+            marginTop={4}
+            marginLeft={4}
+            marginRight={4}
+          />
+          ///: END:ONLY_INCLUDE_IF
+        }
         {isSuspiciousResponse(txData?.securityProviderResponse) && (
           <SecurityProviderBannerMessage
             securityProviderResponse={txData.securityProviderResponse}
           />
         )}
-        <QueuedRequestsBannerAlert />
+        <BlockaidUnavailableBannerAlert />
         {
           ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
           this.props.selectedAccount.address ===
@@ -182,6 +197,7 @@ export default class SignatureRequestOriginal extends Component {
         <div className="request-signature__origin">
           {
             // Use legacy authorship header for snaps
+            ///: BEGIN:ONLY_INCLUDE_IF(snaps)
             targetSubjectMetadata?.subjectType === SubjectType.Snap ? (
               <SnapLegacyAuthorshipHeader
                 snapId={targetSubjectMetadata.origin}
@@ -189,6 +205,7 @@ export default class SignatureRequestOriginal extends Component {
                 marginRight={4}
               />
             ) : (
+              ///: END:ONLY_INCLUDE_IF
               <SiteOrigin
                 title={txData.msgParams.origin}
                 siteOrigin={txData.msgParams.origin}
@@ -199,7 +216,9 @@ export default class SignatureRequestOriginal extends Component {
                 }
                 chip
               />
+              ///: BEGIN:ONLY_INCLUDE_IF(snaps)
             )
+            ///: END:ONLY_INCLUDE_IF
           }
         </div>
         <Typography
@@ -292,7 +311,9 @@ export default class SignatureRequestOriginal extends Component {
       txData,
       hardwareWalletRequiresConnection,
       rejectPendingApproval,
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       warnings,
+      ///: END:ONLY_INCLUDE_IF
     } = this.props;
     const { t } = this.context;
 
@@ -316,11 +337,11 @@ export default class SignatureRequestOriginal extends Component {
           if (txData.type === MESSAGE_TYPE.ETH_SIGN) {
             return this.setState({ showSignatureRequestWarning: true });
           }
-
+          ///: BEGIN:ONLY_INCLUDE_IF(snaps)
           if (warnings?.length >= 1) {
             return this.setState({ showSignatureInsights: true });
           }
-
+          ///: END:ONLY_INCLUDE_IF
           return await this.onSubmit();
         }}
         disabled={
@@ -360,7 +381,9 @@ export default class SignatureRequestOriginal extends Component {
       messagesCount,
       fromAccount: { address, name },
       txData,
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       warnings,
+      ///: END:ONLY_INCLUDE_IF
     } = this.props;
     const { showSignatureRequestWarning } = this.state;
     const { t } = this.context;
@@ -386,18 +409,22 @@ export default class SignatureRequestOriginal extends Component {
             senderAddress={address}
             name={name}
             onSubmit={async () => {
+              ///: BEGIN:ONLY_INCLUDE_IF(snaps)
               if (warnings?.length >= 1) {
                 return this.setState({
                   showSignatureInsights: true,
                   showSignatureRequestWarning: false,
                 });
               }
-
+              ///: END:ONLY_INCLUDE_IF
               return await this.onSubmit();
             }}
             onCancel={async (event) => await this.onCancel(event)}
           />
         )}
+        {
+          ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+        }
         {this.state.showSignatureInsights && (
           <InsightWarnings
             warnings={warnings}
@@ -412,6 +439,9 @@ export default class SignatureRequestOriginal extends Component {
             }}
           />
         )}
+        {
+          ///: END:ONLY_INCLUDE_IF
+        }
         {this.renderFooter()}
         {messagesCount > 1 ? (
           <ButtonLink


### PR DESCRIPTION
## **Description**

This pull request migrates the `Typography` component to the `Text` component in the `signature-request-original.component.js` file. The reason for this change is to align with the updated design specifications and improve the consistency of the codebase. The improvement includes replacing the old `Typography` component with the new `Text` component, ensuring the correct usage of `TextVariant` and other related enums.

Devin Run Link: https://preview.devin.ai/devin/603cd12e77ea42838afb65610cc55388

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25300?quickstart=1)

## **Related issues**

Partially Fixes: https://github.com/MetaMask/metamask-extension/issues/17670

## **Manual testing steps**

1. Go to the latest build of storybook in this PR
2. Check if `SignatureRequestOriginal` is getting rendered properly

## **Screenshots/Recordings**

### **Before**

<img width="1654" alt="Screenshot 2024-06-13 at 21 02 41" src="https://github.com/MetaMask/metamask-extension/assets/168687171/fed47f20-b23c-4b38-b725-1e74bf1ff306">
<img width="1654" alt="Screenshot 2024-06-13 at 21 02 46" src="https://github.com/MetaMask/metamask-extension/assets/168687171/53426eb6-a8c6-4c73-8ac2-964fb4d2cdce">
<img width="1654" alt="Screenshot 2024-06-13 at 21 02 50" src="https://github.com/MetaMask/metamask-extension/assets/168687171/d60bcb6a-da7c-4908-98d2-5a4bc58efcea">
<img width="1654" alt="Screenshot 2024-06-13 at 21 02 54" src="https://github.com/MetaMask/metamask-extension/assets/168687171/efd19911-c011-4ebf-a89c-c85968e248e3">

### **After**
<img width="1654" alt="Screenshot 2024-06-13 at 20 52 53" src="https://github.com/MetaMask/metamask-extension/assets/168687171/a624b8ce-52e0-4d25-9119-9f2253242226">
<img width="1654" alt="Screenshot 2024-06-13 at 20 53 04" src="https://github.com/MetaMask/metamask-extension/assets/168687171/8832a0b9-440c-45ed-8023-539aecfa70f3">
<img width="1654" alt="Screenshot 2024-06-13 at 20 53 11" src="https://github.com/MetaMask/metamask-extension/assets/168687171/8ecdc8cd-e029-41f0-9820-03a2a1ae89ca">
<img width="1654" alt="Screenshot 2024-06-13 at 20 53 16" src="https://github.com/MetaMask/metamask-extension/assets/168687171/cfe9be99-93f8-4a2f-93a3-c8bfecf05f2a">

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
