### PR TITLE
feat: Add Snap UI Radio component

### DIFF
--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -32,6 +32,7 @@ import { SnapUIInput } from '../snaps/snap-ui-input';
 import { SnapUIForm } from '../snaps/snap-ui-form';
 import { SnapUIButton } from '../snaps/snap-ui-button';
 import { SnapUIDropdown } from '../snaps/snap-ui-dropdown';
+import { SnapUIRadioGroup } from '../snaps/snap-ui-radio-group';
 import { SnapUICheckbox } from '../snaps/snap-ui-checkbox';
 import { SnapUITooltip } from '../snaps/snap-ui-tooltip';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
@@ -87,6 +88,7 @@ export const safeComponentList = {
   SnapUIButton,
   SnapUIForm,
   SnapUIDropdown,
+  SnapUIRadioGroup,
   SnapUICheckbox,
   SnapUITooltip,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/ui/components/app/snaps/snap-ui-radio-group/index.ts
+++ b/ui/components/app/snaps/snap-ui-radio-group/index.ts
@@ -1,0 +1,1 @@
+export * from './snap-ui-radio-group';

--- a/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
+++ b/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
@@ -1,0 +1,91 @@
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import { useSnapInterfaceContext } from '../../../../contexts/snaps';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+  TextVariant,
+} from '../../../../helpers/constants/design-system';
+import {
+  Box,
+  HelpText,
+  HelpTextSeverity,
+  Label,
+  Text,
+} from '../../../component-library';
+
+export type SnapUIRadioProps = {
+  name: string;
+  label?: string;
+  error?: string;
+  options: { name: string; value: string }[];
+  form?: string;
+};
+
+export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioProps> = ({
+  name,
+  label,
+  error,
+  form,
+  ...props
+}) => {
+  const { handleInputChange, getValue } = useSnapInterfaceContext();
+
+  const initialValue = getValue<string>(name, form);
+
+  const [value, setValue] = useState(initialValue ?? '');
+
+  type RadioOptions = [{ value: string; name: string }];
+
+  useEffect(() => {
+    if (initialValue) {
+      setValue(initialValue);
+    }
+  }, [initialValue]);
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue);
+    handleInputChange(name, newValue, form);
+  };
+
+  const displayRadioOptions = (options: RadioOptions) => {
+    return options.map((option: { value: string; name: string }) => {
+      return (
+        <Box display={Display.Flex} alignItems={AlignItems.center}>
+          <input
+            type="radio"
+            id={option.name}
+            name={name}
+            value={option.value}
+            checked={value === option.value}
+            onChange={() => handleChange(option.value)}
+          />
+          <Text
+            as="label"
+            htmlFor={option.name}
+            variant={TextVariant.bodyMd}
+            marginLeft={1}
+          >
+            {option.name}
+          </Text>
+        </Box>
+      );
+    });
+  };
+
+  return (
+    <Box
+      className="snap-ui-renderer__radio"
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+    >
+      {label && <Label htmlFor={name}>{label}</Label>}
+      {displayRadioOptions(props.options as RadioOptions)}
+      {error && (
+        <HelpText severity={HelpTextSeverity.Danger} marginTop={1}>
+          {error}
+        </HelpText>
+      )}
+    </Box>
+  );
+};

--- a/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
+++ b/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
@@ -14,11 +14,13 @@ import {
   Text,
 } from '../../../component-library';
 
+export type SnapUIRadioOption = { value: string; name: string };
+
 export type SnapUIRadioProps = {
   name: string;
   label?: string;
   error?: string;
-  options: { name: string; value: string }[];
+  options: SnapUIRadioOption[];
   form?: string;
 };
 
@@ -35,8 +37,6 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioProps> = ({
 
   const [value, setValue] = useState(initialValue ?? '');
 
-  type RadioOptions = [{ value: string; name: string }];
-
   useEffect(() => {
     if (initialValue && value !== initialValue) {
       setValue(initialValue);
@@ -48,8 +48,8 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioProps> = ({
     handleInputChange(name, newValue, form);
   };
 
-  const displayRadioOptions = (options: RadioOptions) => {
-    return options.map((option: { value: string; name: string }) => {
+  const displayRadioOptions = (options: SnapUIRadioOption[]) => {
+    return options.map((option: SnapUIRadioOption) => {
       return (
         <Box display={Display.Flex} alignItems={AlignItems.center}>
           <input
@@ -80,7 +80,7 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioProps> = ({
       flexDirection={FlexDirection.Column}
     >
       {label && <Label htmlFor={name}>{label}</Label>}
-      {displayRadioOptions(props.options as RadioOptions)}
+      {displayRadioOptions(props.options)}
       {error && (
         <HelpText severity={HelpTextSeverity.Danger} marginTop={1}>
           {error}

--- a/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
+++ b/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
@@ -38,7 +38,7 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioProps> = ({
   type RadioOptions = [{ value: string; name: string }];
 
   useEffect(() => {
-    if (initialValue) {
+    if (initialValue && value !== initialValue) {
       setValue(initialValue);
     }
   }, [initialValue]);

--- a/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
+++ b/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
@@ -16,7 +16,7 @@ import {
 
 export type SnapUIRadioOption = { value: string; name: string };
 
-export type SnapUIRadioProps = {
+export type SnapUIRadioGroupProps = {
   name: string;
   label?: string;
   error?: string;
@@ -24,7 +24,7 @@ export type SnapUIRadioProps = {
   form?: string;
 };
 
-export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioProps> = ({
+export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
   name,
   label,
   error,
@@ -33,7 +33,7 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioProps> = ({
 }) => {
   const { handleInputChange, getValue } = useSnapInterfaceContext();
 
-  const initialValue = getValue<string>(name, form);
+  const initialValue = getValue(name, form) as string;
 
   const [value, setValue] = useState(initialValue ?? '');
 

--- a/ui/components/app/snaps/snap-ui-renderer/components/field.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/field.ts
@@ -4,11 +4,13 @@ import {
   ButtonElement,
   JSXElement,
   DropdownElement,
+  RadioGroupElement,
   CheckboxElement,
 } from '@metamask/snaps-sdk/jsx';
 import { getJsxChildren } from '@metamask/snaps-utils';
 import { button as buttonFn } from './button';
 import { dropdown as dropdownFn } from './dropdown';
+import { radioGroup as radioGroupFn } from './radioGroup';
 import { checkbox as checkboxFn } from './checkbox';
 import { UIComponentFactory, UIComponentParams } from './types';
 
@@ -78,6 +80,24 @@ export const field: UIComponentFactory<FieldElement> = ({ element, form }) => {
           id: dropdown.props.name,
           label: element.props.label,
           name: dropdown.props.name,
+          form,
+          error: element.props.error,
+        },
+      };
+    }
+
+    case 'RadioGroup': {
+      const radioGroup = child as RadioGroupElement;
+      const radioGroupMapped = radioGroupFn({
+        element: radioGroup,
+      } as UIComponentParams<RadioGroupElement>);
+      return {
+        element: 'SnapUIRadioGroup',
+        props: {
+          ...radioGroupMapped.props,
+          id: radioGroup.props.name,
+          label: element.props.label,
+          name: radioGroup.props.name,
           form,
           error: element.props.error,
         },

--- a/ui/components/app/snaps/snap-ui-renderer/components/index.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/index.ts
@@ -41,7 +41,7 @@ export const COMPONENT_MAPPING = {
   Link: link,
   Field: field,
   Dropdown: dropdown,
-  Radio: radioGroup,
+  RadioGroup: radioGroup,
   Value: value,
   Checkbox: checkbox,
   Tooltip: tooltip,

--- a/ui/components/app/snaps/snap-ui-renderer/components/index.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/index.ts
@@ -16,6 +16,7 @@ import { italic } from './italic';
 import { link } from './link';
 import { field } from './field';
 import { dropdown } from './dropdown';
+import { radioGroup } from './radioGroup';
 import { value } from './value';
 import { checkbox } from './checkbox';
 import { tooltip } from './tooltip';
@@ -40,6 +41,7 @@ export const COMPONENT_MAPPING = {
   Link: link,
   Field: field,
   Dropdown: dropdown,
+  Radio: radioGroup,
   Value: value,
   Checkbox: checkbox,
   Tooltip: tooltip,

--- a/ui/components/app/snaps/snap-ui-renderer/components/radioGroup.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/radioGroup.ts
@@ -1,0 +1,26 @@
+import { RadioGroupElement, RadioElement } from '@metamask/snaps-sdk/jsx';
+import { getJsxChildren } from '@metamask/snaps-utils';
+
+import { UIComponentFactory } from './types';
+
+export const radioGroup: UIComponentFactory<RadioGroupElement> = ({
+  element,
+  form,
+}) => {
+  const children = getJsxChildren(element) as RadioElement[];
+
+  const options = children.map((child) => ({
+    value: child.props.value,
+    name: child.props.children,
+  }));
+
+  return {
+    element: 'SnapUIRadioGroup',
+    props: {
+      id: element.props.name,
+      name: element.props.name,
+      form,
+      options,
+    },
+  };
+};

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.test.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.test.js
@@ -1,7 +1,7 @@
 import { JSXElementStruct } from '@metamask/snaps-sdk/jsx';
 import { COMPONENT_MAPPING } from './components';
 
-const EXCLUDED_COMPONENTS = ['Option'];
+const EXCLUDED_COMPONENTS = ['Option', 'Radio'];
 
 describe('Snap UI mapping', () => {
   it('supports all exposed components', () => {

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -89,7 +89,7 @@ export const mapToTemplate = (params: MapToTemplateParams): UIComponent => {
   const { type, key } = params.element;
   const elementKey = key ?? generateKey(params.map, params.element);
   const mapped = COMPONENT_MAPPING[
-    type as Exclude<JSXElement['type'], 'Option'>
+    type as Exclude<JSXElement['type'], 'Option' | 'Radio'>
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ](params as any);


### PR DESCRIPTION
### Waiting on release of: https://github.com/MetaMask/snaps/pull/2592

## **Description**
This PR integrates new Radio components for Snap UI.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26181?quickstart=1)

## **Related issues**
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1571

## **Manual testing steps**
1. Go to `Test Snaps` and install `Interactive UI Snap`.
2. Run Interactive UI Snap by creating a dialog.
3. Check that radio options are available in the UI and confirm their functionality. (Latest Test Snaps needs to be released before this is possible, use `main` branch in Snaps repo and run locally if necessary)

## **Screenshots/Recordings**
### **Before**
Nothing to show. Radio options were not available before.

### **After**
![Screenshot 2024-07-29 at 11 29 00](https://github.com/user-attachments/assets/f978ffc5-9c50-4031-a001-4af46f7674fe)
![Screenshot 2024-07-29 at 11 29 17](https://github.com/user-attachments/assets/b8659e75-af9c-455f-a1f1-9fd87b59e35e)
![Screenshot 2024-07-29 at 11 29 40](https://github.com/user-attachments/assets/4d86e1d2-858d-41e8-b383-6c17b711ad1f)

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
