### PR TITLE
refactor: add unlock checks for notification related controllers

### DIFF
--- a/app/scripts/controllers/authentication/authentication-controller.ts
+++ b/app/scripts/controllers/authentication/authentication-controller.ts
@@ -119,7 +119,7 @@ export default class AuthenticationController extends BaseController<
   #isUnlocked = false;
 
   #keyringController = {
-    setupLockedState: () => {
+    setupLockedStateSubscriptions: () => {
       const { isUnlocked } = this.messagingSystem.call(
         'KeyringController:getState',
       );
@@ -157,7 +157,7 @@ export default class AuthenticationController extends BaseController<
 
     this.#metametrics = metametrics;
 
-    this.#keyringController.setupLockedState();
+    this.#keyringController.setupLockedStateSubscriptions();
     this.#registerMessageHandlers();
   }
 

--- a/app/scripts/controllers/metamask-notifications/metamask-notifications.test.ts
+++ b/app/scripts/controllers/metamask-notifications/metamask-notifications.test.ts
@@ -50,6 +50,10 @@ import * as OnChainNotifications from './services/onchain-notifications';
 import { UserStorage } from './types/user-storage/user-storage';
 import * as MetamaskNotificationsUtils from './utils/utils';
 
+// Mock type used for testing purposes
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MockVar = any;
+
 describe('metamask-notifications - constructor()', () => {
   test('initializes state & override state', () => {
     const controller1 = new MetamaskNotificationsController({
@@ -627,6 +631,7 @@ function mockNotificationMessenger() {
     name: 'MetamaskNotificationsController',
     allowedActions: [
       'KeyringController:getAccounts',
+      'KeyringController:getState',
       'AuthenticationController:getBearerToken',
       'AuthenticationController:isSignedIn',
       'PushPlatformNotificationsController:disablePushNotifications',
@@ -639,6 +644,8 @@ function mockNotificationMessenger() {
     ],
     allowedEvents: [
       'KeyringController:stateChange',
+      'KeyringController:lock',
+      'KeyringController:unlock',
       'PushPlatformNotificationsController:onNewNotifications',
     ],
   });
@@ -733,6 +740,10 @@ function mockNotificationMessenger() {
 
     if (actionType === 'UserStorageController:performSetStorage') {
       return mockPerformSetStorage(params[0], params[1]);
+    }
+
+    if (actionType === 'KeyringController:getState') {
+      return { isUnlocked: true } as MockVar;
     }
 
     function exhaustedMessengerMocks(action: never) {

--- a/app/scripts/controllers/metamask-notifications/metamask-notifications.ts
+++ b/app/scripts/controllers/metamask-notifications/metamask-notifications.ts
@@ -2,7 +2,6 @@ import {
   BaseController,
   RestrictedControllerMessenger,
   ControllerGetStateAction,
-  ControllerStateChangeEvent,
   StateMetadata,
 } from '@metamask/base-controller';
 import log from 'loglevel';
@@ -10,6 +9,9 @@ import { toChecksumHexAddress } from '@metamask/controller-utils';
 import {
   KeyringControllerGetAccountsAction,
   KeyringControllerStateChangeEvent,
+  KeyringControllerGetStateAction,
+  KeyringControllerLockEvent,
+  KeyringControllerUnlockEvent,
 } from '@metamask/keyring-controller';
 import {
   AuthenticationControllerGetBearerToken,
@@ -196,6 +198,7 @@ export type Actions =
 export type AllowedActions =
   // Keyring Controller Requests
   | KeyringControllerGetAccountsAction
+  | KeyringControllerGetStateAction
   // Auth Controller Requests
   | AuthenticationControllerGetBearerToken
   | AuthenticationControllerIsSignedIn
@@ -210,25 +213,25 @@ export type AllowedActions =
   | PushPlatformNotificationsControllerUpdateTriggerPushNotifications;
 
 // Events
-export type MetamaskNotificationsControllerMessengerEvents =
-  ControllerStateChangeEvent<
-    typeof controllerName,
-    MetamaskNotificationsControllerState
-  >;
+export type Events =
+  | MetamaskNotificationsControllerNotificationsListUpdatedEvent
+  | MetamaskNotificationsControllerMarkNotificationsAsRead;
 
 // Allowed Events
 export type AllowedEvents =
+  // Keyring Events
   | KeyringControllerStateChangeEvent
-  | PushPlatformNotificationsControllerOnNewNotificationEvent
-  | MetamaskNotificationsControllerNotificationsListUpdatedEvent
-  | MetamaskNotificationsControllerMarkNotificationsAsRead;
+  | KeyringControllerLockEvent
+  | KeyringControllerUnlockEvent
+  // Push Notification Events
+  | PushPlatformNotificationsControllerOnNewNotificationEvent;
 
 // Type for the messenger of MetamaskNotificationsController
 export type MetamaskNotificationsControllerMessenger =
   RestrictedControllerMessenger<
     typeof controllerName,
     Actions | AllowedActions,
-    AllowedEvents,
+    Events | AllowedEvents,
     AllowedActions['type'],
     AllowedEvents['type']
   >;
@@ -241,6 +244,34 @@ export class MetamaskNotificationsController extends BaseController<
   MetamaskNotificationsControllerState,
   MetamaskNotificationsControllerMessenger
 > {
+  // Flag to check is notifications have been setup when the browser/extension is initialized.
+  // We want to re-initialize push notifications when the browser/extension is refreshed
+  // To ensure we subscribe to the most up-to-date notifications
+  #isPushNotificationsSetup = false;
+
+  #isUnlocked = false;
+
+  #keyringController = {
+    setupLockedState: (onUnlock: () => Promise<void>) => {
+      const { isUnlocked } = this.messagingSystem.call(
+        'KeyringController:getState',
+      );
+      this.#isUnlocked = isUnlocked;
+
+      this.messagingSystem.subscribe('KeyringController:unlock', () => {
+        this.#isUnlocked = true;
+        // messaging system cannot await promises
+        // we don't need to wait for a result on this.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        onUnlock();
+      });
+
+      this.messagingSystem.subscribe('KeyringController:lock', () => {
+        this.#isUnlocked = false;
+      });
+    },
+  };
+
   #auth = {
     getBearerToken: async () => {
       return await this.messagingSystem.call(
@@ -319,6 +350,12 @@ export class MetamaskNotificationsController extends BaseController<
       if (!this.state.isMetamaskNotificationsEnabled) {
         return;
       }
+      if (this.#isPushNotificationsSetup) {
+        return;
+      }
+      if (!this.#isUnlocked) {
+        return;
+      }
 
       const storage = await this.#getUserStorage();
       if (!storage) {
@@ -327,6 +364,7 @@ export class MetamaskNotificationsController extends BaseController<
 
       const uuids = MetamaskNotificationsUtils.getAllUUIDs(storage);
       await this.#pushNotifications.enablePushNotifications(uuids);
+      this.#isPushNotificationsSetup = true;
     },
   };
 
@@ -434,6 +472,9 @@ export class MetamaskNotificationsController extends BaseController<
 
     this.#registerMessageHandlers();
     this.#clearLoadingStates();
+    this.#keyringController.setupLockedState(
+      this.#pushNotifications.initializePushNotifications,
+    );
     this.#accounts.initialize();
     this.#pushNotifications.initializePushNotifications();
     this.#accounts.subscribe();

--- a/app/scripts/controllers/metamask-notifications/metamask-notifications.ts
+++ b/app/scripts/controllers/metamask-notifications/metamask-notifications.ts
@@ -252,7 +252,7 @@ export class MetamaskNotificationsController extends BaseController<
   #isUnlocked = false;
 
   #keyringController = {
-    setupLockedState: (onUnlock: () => Promise<void>) => {
+    setupLockedStateSubscriptions: (onUnlock: () => Promise<void>) => {
       const { isUnlocked } = this.messagingSystem.call(
         'KeyringController:getState',
       );
@@ -472,7 +472,7 @@ export class MetamaskNotificationsController extends BaseController<
 
     this.#registerMessageHandlers();
     this.#clearLoadingStates();
-    this.#keyringController.setupLockedState(
+    this.#keyringController.setupLockedStateSubscriptions(
       this.#pushNotifications.initializePushNotifications,
     );
     this.#accounts.initialize();

--- a/app/scripts/controllers/user-storage/user-storage-controller.test.ts
+++ b/app/scripts/controllers/user-storage/user-storage-controller.test.ts
@@ -17,6 +17,7 @@ import {
 } from './mocks/mockStorage';
 import UserStorageController, {
   AllowedActions,
+  AllowedEvents,
 } from './user-storage-controller';
 import {
   mockEndpointGetUserStorage,
@@ -288,10 +289,11 @@ describe('user-storage/user-storage-controller - enableProfileSyncing() tests', 
 function mockUserStorageMessenger() {
   const messenger = new ControllerMessenger<
     AllowedActions,
-    never
+    AllowedEvents
   >().getRestricted({
     name: 'UserStorageController',
     allowedActions: [
+      'KeyringController:getState',
       'SnapController:handleRequest',
       'AuthenticationController:getBearerToken',
       'AuthenticationController:getSessionProfile',
@@ -301,7 +303,7 @@ function mockUserStorageMessenger() {
       'MetamaskNotificationsController:disableMetamaskNotifications',
       'MetamaskNotificationsController:selectIsMetamaskNotificationsEnabled',
     ],
-    allowedEvents: [],
+    allowedEvents: ['KeyringController:lock', 'KeyringController:unlock'],
   });
 
   const mockSnapGetPublicKey = jest.fn().mockResolvedValue('MOCK_PUBLIC_KEY');
@@ -394,6 +396,10 @@ function mockUserStorageMessenger() {
 
     if (actionType === 'AuthenticationController:performSignOut') {
       return mockAuthPerformSignOut();
+    }
+
+    if (actionType === 'KeyringController:getState') {
+      return { isUnlocked: true };
     }
 
     function exhaustedMessengerMocks(action: never) {

--- a/app/scripts/controllers/user-storage/user-storage-controller.ts
+++ b/app/scripts/controllers/user-storage/user-storage-controller.ts
@@ -164,7 +164,7 @@ export default class UserStorageController extends BaseController<
   #isUnlocked = false;
 
   #keyringController = {
-    setupLockedState: () => {
+    setupLockedStateSubscriptions: () => {
       const { isUnlocked } = this.messagingSystem.call(
         'KeyringController:getState',
       );
@@ -195,7 +195,7 @@ export default class UserStorageController extends BaseController<
     });
 
     this.getMetaMetricsState = params.getMetaMetricsState;
-    this.#keyringController.setupLockedState();
+    this.#keyringController.setupLockedStateSubscriptions();
     this.#registerMessageHandlers();
   }
 

--- a/app/scripts/controllers/user-storage/user-storage-controller.ts
+++ b/app/scripts/controllers/user-storage/user-storage-controller.ts
@@ -3,6 +3,11 @@ import {
   RestrictedControllerMessenger,
   StateMetadata,
 } from '@metamask/base-controller';
+import type {
+  KeyringControllerGetStateAction,
+  KeyringControllerLockEvent,
+  KeyringControllerUnlockEvent,
+} from '@metamask/keyring-controller';
 import { HandleSnapRequest } from '@metamask/snaps-controllers';
 import {
   AuthenticationControllerGetBearerToken,
@@ -75,8 +80,9 @@ export type UserStorageControllerEnableProfileSyncing =
 export type UserStorageControllerDisableProfileSyncing =
   ActionsObj['disableProfileSyncing'];
 
-// Allowed Actions
 export type AllowedActions =
+  // Keyring Requests
+  | KeyringControllerGetStateAction
   // Snap Requests
   | HandleSnapRequest
   // Auth Requests
@@ -89,13 +95,17 @@ export type AllowedActions =
   | MetamaskNotificationsControllerDisableMetamaskNotifications
   | MetamaskNotificationsControllerSelectIsMetamaskNotificationsEnabled;
 
+export type AllowedEvents =
+  | KeyringControllerLockEvent
+  | KeyringControllerUnlockEvent;
+
 // Messenger
 export type UserStorageControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   Actions | AllowedActions,
-  never,
+  AllowedEvents,
   AllowedActions['type'],
-  never
+  AllowedEvents['type']
 >;
 
 /**
@@ -151,6 +161,25 @@ export default class UserStorageController extends BaseController<
     },
   };
 
+  #isUnlocked = false;
+
+  #keyringController = {
+    setupLockedState: () => {
+      const { isUnlocked } = this.messagingSystem.call(
+        'KeyringController:getState',
+      );
+      this.#isUnlocked = isUnlocked;
+
+      this.messagingSystem.subscribe('KeyringController:unlock', () => {
+        this.#isUnlocked = true;
+      });
+
+      this.messagingSystem.subscribe('KeyringController:lock', () => {
+        this.#isUnlocked = false;
+      });
+    },
+  };
+
   getMetaMetricsState: () => boolean;
 
   constructor(params: {
@@ -166,6 +195,7 @@ export default class UserStorageController extends BaseController<
     });
 
     this.getMetaMetricsState = params.getMetaMetricsState;
+    this.#keyringController.setupLockedState();
     this.#registerMessageHandlers();
   }
 
@@ -376,6 +406,12 @@ export default class UserStorageController extends BaseController<
   async #snapSignMessage(message: `metamask:${string}`): Promise<string> {
     if (this.#_snapSignMessageCache[message]) {
       return this.#_snapSignMessageCache[message];
+    }
+
+    if (!this.#isUnlocked) {
+      throw new Error(
+        '#snapSignMessage - unable to call snap, wallet is locked',
+      );
     }
 
     const result = (await this.messagingSystem.call(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1417,9 +1417,11 @@ export default class MetamaskController extends EventEmitter {
       messenger: this.controllerMessenger.getRestricted({
         name: 'AuthenticationController',
         allowedActions: [
+          'KeyringController:getState',
           'SnapController:handleRequest',
           'UserStorageController:disableProfileSyncing',
         ],
+        allowedEvents: ['KeyringController:lock', 'KeyringController:unlock'],
       }),
       metametrics: {
         getMetaMetricsId: () => this.metaMetricsController.getMetaMetricsId(),
@@ -1433,6 +1435,7 @@ export default class MetamaskController extends EventEmitter {
       messenger: this.controllerMessenger.getRestricted({
         name: 'UserStorageController',
         allowedActions: [
+          'KeyringController:getState',
           'SnapController:handleRequest',
           'AuthenticationController:getBearerToken',
           'AuthenticationController:getSessionProfile',
@@ -1442,6 +1445,7 @@ export default class MetamaskController extends EventEmitter {
           'MetamaskNotificationsController:disableMetamaskNotifications',
           'MetamaskNotificationsController:selectIsMetamaskNotificationsEnabled',
         ],
+        allowedEvents: ['KeyringController:lock', 'KeyringController:unlock'],
       }),
     });
 
@@ -1491,6 +1495,7 @@ export default class MetamaskController extends EventEmitter {
         name: 'MetamaskNotificationsController',
         allowedActions: [
           'KeyringController:getAccounts',
+          'KeyringController:getState',
           'AuthenticationController:getBearerToken',
           'AuthenticationController:isSignedIn',
           'UserStorageController:enableProfileSyncing',
@@ -1503,6 +1508,8 @@ export default class MetamaskController extends EventEmitter {
         ],
         allowedEvents: [
           'KeyringController:stateChange',
+          'KeyringController:lock',
+          'KeyringController:unlock',
           'PushPlatformNotificationsController:onNewNotifications',
         ],
       }),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ensures that we correctly call the preinstalled snap when the wallet is unlocked. Also prevents unlock confirmations being created due to snap calls when wallet is locked

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26189?quickstart=1)

## **Related issues**

[Ticket](https://consensyssoftware.atlassian.net/browse/NOTIFY-865)

Fixes: https://github.com/MetaMask/metamask-extension/issues/26064

## **Manual testing steps**

1. Install the extension and enable notifications
2. Restart the browser, or reload the extension
3. Should see no auto opening of the wallet, and no unlock confirmations being made.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
