### PR TITLE
chore: remove opera manifest files as they are not used

### DIFF
--- a/app/manifest/v2/opera.json
+++ b/app/manifest/v2/opera.json
@@ -1,9 +1,0 @@
-{
-  "permissions": [
-    "storage",
-    "tabs",
-    "clipboardWrite",
-    "clipboardRead",
-    "http://localhost:8545/"
-  ]
-}

--- a/app/manifest/v3/opera.json
+++ b/app/manifest/v3/opera.json
@@ -1,9 +1,0 @@
-{
-  "permissions": [
-    "storage",
-    "tabs",
-    "clipboardWrite",
-    "clipboardRead",
-    "http://localhost:8545/"
-  ]
-}


### PR DESCRIPTION
Removes opera's manifest files since we don't actually use it (and it is broken anyway).


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26200?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->