### PR TITLE
fix: limit port stream message size (JSON.stringify)

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -50,6 +50,7 @@ import {
   FakeLedgerBridge,
   FakeTrezorBridge,
 } from '../../test/stub/keyring-bridge';
+import { createFilterStream } from '../../shared/modules/filter-stream';
 import migrations from './migrations';
 import Migrator from './lib/migrator';
 import ExtensionPlatform from './platforms/extension';
@@ -86,6 +87,8 @@ const BADGE_COLOR_APPROVAL = '#0376C9';
 const BADGE_COLOR_NOTIFICATION = '#D73847';
 const BADGE_LABEL_APPROVAL = '\u22EF'; // unicode ellipsis
 const BADGE_MAX_NOTIFICATION_COUNT = 9;
+
+const MAX_MESSAGE_LENGTH = 1000000;
 
 // Setup global hook for improved Sentry state snapshots during initialization
 const inTest = process.env.IN_TEST;
@@ -679,6 +682,26 @@ function trackDappView(remotePort) {
   }
 }
 
+function filterStreamMessageSize(portStream, maxSize = MAX_MESSAGE_LENGTH) {
+  const filterStream = createFilterStream(portStream, {
+    inputFilter: (msg, _encoding) => {
+      const stringifiedMsg = JSON.stringify(msg);
+      if (stringifiedMsg.length < maxSize) {
+        return true;
+      }
+      console.warn(
+        `message exceeded size limit and will be dropped: ${stringifiedMsg.slice(
+          0,
+          1000,
+        )}...`,
+      );
+      return false;
+    },
+  });
+
+  return filterStream;
+}
+
 /**
  * Initializes the MetaMask Controller with any initial state and default language.
  * Configures platform-specific error reporting strategy.
@@ -869,8 +892,9 @@ export function setupController(
     ) {
       const portStream =
         overrides?.getPortStream?.(remotePort) || new PortStream(remotePort);
+      const filteredStream = filterStreamMessageSize(portStream);
       controller.setupPhishingCommunication({
-        connectionStream: portStream,
+        connectionStream: filteredStream,
       });
     } else {
       // this is triggered when a new tab is opened, or origin(url) is changed
@@ -898,8 +922,9 @@ export function setupController(
   connectExternalExtension = (remotePort) => {
     const portStream =
       overrides?.getPortStream?.(remotePort) || new PortStream(remotePort);
+    const filteredStream = filterStreamMessageSize(portStream);
     controller.setupUntrustedCommunicationEip1193({
-      connectionStream: portStream,
+      connectionStream: filteredStream,
       sender: remotePort.sender,
     });
   };
@@ -916,9 +941,10 @@ export function setupController(
 
     const portStream =
       overrides?.getPortStream?.(remotePort) || new PortStream(remotePort);
+    const filteredStream = filterStreamMessageSize(portStream);
 
     controller.setupUntrustedCommunicationCaip({
-      connectionStream: portStream,
+      connectionStream: filteredStream,
       sender: remotePort.sender,
     });
   };

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -685,7 +685,9 @@ function trackDappView(remotePort) {
 function filterStreamMessageSize(portStream, maxSize = MAX_MESSAGE_LENGTH) {
   const filterStream = createFilterStream(portStream, {
     inputFilter: (msg, _encoding) => {
+      const start = new Date()
       const stringifiedMsg = JSON.stringify(msg);
+      console.log('time', (new Date()) - start)
       if (stringifiedMsg.length < maxSize) {
         return true;
       }

--- a/shared/modules/filter-stream.test.ts
+++ b/shared/modules/filter-stream.test.ts
@@ -1,0 +1,152 @@
+import { Duplex, PassThrough } from 'readable-stream';
+import { createDeferredPromise } from '@metamask/utils';
+import { createFilterStream } from './filter-stream';
+
+const writeToStream = async (stream: Duplex, message: unknown) => {
+  const { promise: isWritten, resolve: writeCallback } =
+    createDeferredPromise();
+
+  stream.write(message, () => writeCallback());
+  await isWritten;
+};
+
+const readFromStream = (stream: Duplex): unknown[] => {
+  const chunks: unknown[] = [];
+  stream.on('data', (chunk: unknown) => {
+    chunks.push(chunk);
+  });
+
+  return chunks;
+};
+
+class MockStream extends Duplex {
+  chunks: unknown[] = [];
+
+  constructor() {
+    super({ objectMode: true });
+  }
+
+  _read() {
+    return undefined;
+  }
+
+  _write(
+    value: unknown,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(value);
+    callback();
+  }
+}
+
+describe('Filter Stream', () => {
+  describe('createFilterStream', () => {
+    it('filters messages from source stream to the substream when inputFilter is provided', async () => {
+      const sourceStream = new PassThrough({ objectMode: true });
+      const sourceStreamChunks = readFromStream(sourceStream);
+
+      const inputFilter = jest.fn().mockReturnValueOnce(true);
+
+      const filterStream = createFilterStream(sourceStream, { inputFilter });
+      const filterStreamChunks = readFromStream(filterStream);
+
+      await writeToStream(sourceStream, {
+        message: 1,
+      });
+      await writeToStream(sourceStream, {
+        message: 2,
+      });
+
+      expect(inputFilter).toHaveBeenCalledWith(
+        { message: 1 },
+        expect.any(String),
+      );
+      expect(inputFilter).toHaveBeenCalledWith(
+        { message: 2 },
+        expect.any(String),
+      );
+      expect(sourceStreamChunks).toStrictEqual([
+        { message: 1 },
+        { message: 2 },
+      ]);
+      expect(filterStreamChunks).toStrictEqual([{ message: 1 }]);
+    });
+
+    it('passes through all messages from source stream to the substream when inputFilter is not provided', async () => {
+      const sourceStream = new PassThrough({ objectMode: true });
+      const sourceStreamChunks = readFromStream(sourceStream);
+
+      const filterStream = createFilterStream(sourceStream, {});
+      const filterStreamChunks = readFromStream(filterStream);
+
+      await writeToStream(sourceStream, {
+        message: 1,
+      });
+      await writeToStream(sourceStream, {
+        message: 2,
+      });
+
+      expect(sourceStreamChunks).toStrictEqual([
+        { message: 1 },
+        { message: 2 },
+      ]);
+      expect(filterStreamChunks).toStrictEqual([
+        { message: 1 },
+        { message: 2 },
+      ]);
+    });
+
+    it('filters messages from the substream to the source stream when outputFilter is provided', async () => {
+      // using a fake stream here instead of PassThrough to prevent a loop
+      // when sourceStream gets written back to at the end of the CAIP pipeline
+      const sourceStream = new MockStream();
+
+      const outputFilter = jest.fn().mockReturnValueOnce(true);
+      const filterStream = createFilterStream(sourceStream, {
+        outputFilter,
+      });
+
+      await writeToStream(filterStream, {
+        message: 1,
+      });
+      await writeToStream(filterStream, {
+        message: 2,
+      });
+
+      expect(outputFilter).toHaveBeenCalledWith(
+        { message: 1 },
+        expect.any(String),
+      );
+      expect(outputFilter).toHaveBeenCalledWith(
+        { message: 2 },
+        expect.any(String),
+      );
+      // Note that it's not possible to verify the output side of the internal SplitStream
+      // instantiated inside createFilterStream as only the substream is actually exported
+      expect(sourceStream.chunks).toStrictEqual([{ message: 1 }]);
+    });
+
+    it('passes through all messages from the substream to the source stream when outputFilter is not provided', async () => {
+      // using a fake stream here instead of PassThrough to prevent a loop
+      // when sourceStream gets written back to at the end of the CAIP pipeline
+      const sourceStream = new MockStream();
+
+      const filterStream = createFilterStream(sourceStream, {});
+
+      await writeToStream(filterStream, {
+        message: 1,
+      });
+      await writeToStream(filterStream, {
+        message: 2,
+      });
+
+      // Note that it's not possible to verify the output side of the internal SplitStream
+      // instantiated inside createFilterStream as only the substream is actually exported
+      expect(sourceStream.chunks).toStrictEqual([
+        { message: 1 },
+        { message: 2 },
+      ]);
+    });
+  });
+});

--- a/shared/modules/filter-stream.ts
+++ b/shared/modules/filter-stream.ts
@@ -1,0 +1,98 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error pipeline() isn't defined as part of @types/readable-stream
+import { pipeline, Duplex } from 'readable-stream';
+
+class Substream extends Duplex {
+  parent: Duplex;
+
+  outputFilter: StreamMessageFilter;
+
+  constructor(parent: Duplex, outputFilter?: StreamMessageFilter) {
+    super({ objectMode: true });
+    this.outputFilter = outputFilter;
+    this.parent = parent;
+  }
+
+  _read() {
+    return undefined;
+  }
+
+  _write(
+    value: unknown,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    if (this.outputFilter(value, encoding)) {
+      this.parent.push(value);
+    }
+    callback();
+  }
+}
+
+export type StreamMessageFilter = (
+  value: unknown,
+  encoding: BufferEncoding,
+) => boolean;
+
+export class FilterStream extends Duplex {
+  substream: Duplex;
+
+  inputFilter: StreamMessageFilter;
+
+  constructor(opts: {
+    inputFilter: StreamMessageFilter;
+    outputFilter: StreamMessageFilter;
+  }) {
+    super({ objectMode: true });
+    this.inputFilter = opts.inputFilter;
+    this.substream = new Substream(this, opts.outputFilter);
+  }
+
+  _read() {
+    return undefined;
+  }
+
+  _write(
+    value: unknown,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    if (this.inputFilter(value, encoding)) {
+      this.substream.push(value);
+    }
+    callback();
+  }
+}
+
+/**
+ * Creates a pipeline using a port stream meant to be consumed by the JSON-RPC engine:
+ * - accepts only incoming CAIP messages intended for evm providers from the port stream
+ * - unwraps these incoming messages into a new stream that the JSON-RPC engine should operate off
+ * - wraps the outgoing messages from the new stream back into the CAIP message format
+ * - writes these messages back to the port stream
+ *
+ * @param portStream - The source and sink duplex stream
+ * @param opts - The options object
+ * @param opts.inputFilter - The optional function used to filter incoming messages
+ * @param opts.outputFilter - The optional function used to filter outgoing messages
+ * @returns a new duplex stream that should be operated on instead of the original portStream
+ */
+export const createFilterStream = (
+  portStream: Duplex,
+  opts: {
+    inputFilter?: StreamMessageFilter;
+    outputFilter?: StreamMessageFilter;
+  },
+): Duplex => {
+  const noop = () => true;
+  const filterStream = new FilterStream({
+    inputFilter: opts.inputFilter || noop,
+    outputFilter: opts.outputFilter || noop,
+  });
+
+  pipeline(portStream, filterStream, portStream, (err: Error) =>
+    console.log('MetaMask Filter stream', err),
+  );
+
+  return filterStream.substream;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces a message size filter to PortStreams created in background. Please see attached ticket for more info.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26204?quickstart=1)

## **Related issues**

See: https://github.com/MetaMask/MetaMask-planning/issues/2836

## **Manual testing steps**

See ticket

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
