### PR TITLE
feat: Improve account list menu rendering performance

### DIFF
--- a/ui/components/app/account-list-item/account-list-item.tsx
+++ b/ui/components/app/account-list-item/account-list-item.tsx
@@ -25,6 +25,7 @@ type AccountListItemProps = {
    * Pass icon component to be displayed. Currently not used
    */
   icon?: React.ReactNode;
+
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   /**
    * MMI Prop, will hide the default AccountMismatchWarning when needed
@@ -38,11 +39,11 @@ const AccountListItem = ({
   className,
   displayAddress = false,
   handleClick,
-  icon = null,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   hideDefaultMismatchWarning = false,
-}: ///: END:ONLY_INCLUDE_IF
-AccountListItemProps) => {
+  ///: END:ONLY_INCLUDE_IF
+  icon = null,
+}: AccountListItemProps) => {
   const {
     metadata: { name },
     address,

--- a/ui/components/app/account-list-item/account-list-item.tsx
+++ b/ui/components/app/account-list-item/account-list-item.tsx
@@ -1,10 +1,39 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { InternalAccount } from '@metamask/keyring-api';
 import Identicon from '../../ui/identicon';
 import AccountMismatchWarning from '../../ui/account-mismatch-warning/account-mismatch-warning.component';
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 
-export default function AccountListItem({
+type AccountListItemProps = {
+  /**
+   * An account object that has name, address, and balance data
+   */
+  account: InternalAccount;
+  /**
+   * Additional className to add to the root div element of AccountListItem
+   */
+  className?: string;
+  /**
+   * Display the address of the account object
+   */
+  displayAddress?: boolean;
+  /**
+   * The onClick handler of the AccountListItem
+   */
+  handleClick?: (account: InternalAccount | null) => void;
+  /**
+   * Pass icon component to be displayed. Currently not used
+   */
+  icon?: React.ReactNode;
+  ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+  /**
+   * MMI Prop, will hide the default AccountMismatchWarning when needed
+   */
+  hideDefaultMismatchWarning?: boolean;
+  ///: END:ONLY_INCLUDE_IF
+};
+
+const AccountListItem = ({
   account,
   className,
   displayAddress = false,
@@ -12,8 +41,8 @@ export default function AccountListItem({
   icon = null,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   hideDefaultMismatchWarning = false,
-  ///: END:ONLY_INCLUDE_IF
-}) {
+}: ///: END:ONLY_INCLUDE_IF
+AccountListItemProps) => {
   const {
     metadata: { name },
     address,
@@ -58,48 +87,6 @@ export default function AccountListItem({
       )}
     </div>
   );
-}
-
-AccountListItem.propTypes = {
-  /**
-   * An account object that has name, address, and balance data
-   */
-  account: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    address: PropTypes.string.isRequired,
-    balance: PropTypes.string.isRequired,
-    metadata: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      snap: PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        name: PropTypes.string,
-        enabled: PropTypes.bool,
-      }),
-      keyring: PropTypes.shape({
-        type: PropTypes.string.isRequired,
-      }).isRequired,
-    }).isRequired,
-  }).isRequired,
-  /**
-   * Additional className to add to the root div element of AccountListItem
-   */
-  className: PropTypes.string,
-  /**
-   * Display the address of the account object
-   */
-  displayAddress: PropTypes.bool,
-  /**
-   * The onClick handler of the AccountListItem
-   */
-  handleClick: PropTypes.func,
-  /**
-   * Pass icon component to be displayed. Currently not used
-   */
-  icon: PropTypes.node,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
-  /**
-   * MMI Prop, will hide the default AccountMismatchWarning when needed
-   */
-  hideDefaultMismatchWarning: PropTypes.bool,
-  ///: END:ONLY_INCLUDE_IF
 };
+
+export default React.memo(AccountListItem);

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -12,9 +12,11 @@ import {
 import {
   getOriginOfCurrentTab,
   getOrderedConnectedAccountsForActiveTab,
+} from '../../../../selectors';
+import {
   getSelectedInternalAccount,
   getInternalAccounts,
-} from '../../../../selectors';
+} from '../../../../selectors/accounts';
 import { isExtensionUrl, getURLHost } from '../../../../helpers/utils/util';
 import Popover from '../../../ui/popover';
 import Button from '../../../ui/button';

--- a/ui/components/app/assets/nfts/nfts-items/nfts-items.js
+++ b/ui/components/app/assets/nfts/nfts-items/nfts-items.js
@@ -20,10 +20,10 @@ import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
 import {
   getCurrentChainId,
   getIpfsGateway,
-  getSelectedInternalAccount,
   getCurrentNetwork,
   getOpenSeaEnabled,
 } from '../../../../../selectors';
+import { getSelectedInternalAccount } from '../../../../../selectors/accounts';
 import {
   ASSET_ROUTE,
   SEND_ROUTE,

--- a/ui/components/app/confirm/info/row/hook.ts
+++ b/ui/components/app/confirm/info/row/hook.ts
@@ -3,12 +3,14 @@ import { useSelector } from 'react-redux';
 import { toChecksumHexAddress } from '../../../../../../shared/modules/hexstring-utils';
 import { shortenAddress } from '../../../../../helpers/utils/util';
 import {
-  getAccountName,
   getAddressBookEntry,
   getEnsResolutionByAddress,
-  getInternalAccounts,
   getMetadataContractName,
 } from '../../../../../selectors';
+import {
+  getInternalAccounts,
+  getAccountName,
+} from '../../../../../selectors/accounts';
 import { ConfirmInfoRowContext } from './row';
 
 export const useRowContext = () => useContext(ConfirmInfoRowContext);

--- a/ui/components/app/connected-status-indicator/connected-status-indicator.js
+++ b/ui/components/app/connected-status-indicator/connected-status-indicator.js
@@ -15,9 +15,9 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getPermissionsForActiveTab,
-  getSelectedInternalAccount,
   getPermittedAccountsForCurrentTab,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { ConnectedSiteMenu } from '../../multichain';
 
 export default function ConnectedStatusIndicator({ onClick, disabled }) {

--- a/ui/components/app/modals/edit-approval-permission/edit-approval-permission.container.js
+++ b/ui/components/app/modals/edit-approval-permission/edit-approval-permission.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props';
-import { getSelectedInternalAccount } from '../../../../selectors';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
 import EditApprovalPermission from './edit-approval-permission.component';
 
 const mapStateToProps = (state) => {

--- a/ui/components/app/modals/nickname-popovers/nickname-popovers.component.js
+++ b/ui/components/app/modals/nickname-popovers/nickname-popovers.component.js
@@ -4,10 +4,8 @@ import PropTypes from 'prop-types';
 
 import { getMultichainAccountUrl } from '../../../../helpers/utils/multichain/blockExplorer';
 import { addToAddressBook } from '../../../../store/actions';
-import {
-  getAddressBook,
-  getInternalAccountByAddress,
-} from '../../../../selectors';
+import { getAddressBook } from '../../../../selectors';
+import { getInternalAccountByAddress } from '../../../../selectors/accounts';
 import NicknamePopover from '../../../ui/nickname-popover';
 import UpdateNicknamePopover from '../../../ui/update-nickname-popover/update-nickname-popover';
 import { getMultichainNetwork } from '../../../../selectors/multichain';

--- a/ui/components/app/permission-page-container/permission-page-container.container.js
+++ b/ui/components/app/permission-page-container/permission-page-container.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
-import { getInternalAccounts, getPermissions } from '../../../selectors';
+import { getInternalAccounts } from '../../../selectors/accounts';
+import { getPermissions } from '../../../selectors';
 import PermissionPageContainer from './permission-page-container.component';
 
 const mapStateToProps = (state, ownProps) => {

--- a/ui/components/app/selected-account/selected-account.container.js
+++ b/ui/components/app/selected-account/selected-account.container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
-  getSelectedInternalAccount,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   getAccountType,
   ///: END:ONLY_INCLUDE_IF

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -11,14 +11,18 @@ import {
   getIsCustomNetwork,
   getRpcPrefsForCurrentProvider,
   getEnsResolutionByAddress,
-  getAccountName,
   getMetadataContractName,
-  getInternalAccounts,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   getKnownMethodData,
-  getSelectedInternalAccount,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
+import {
+  getAccountName,
+  getInternalAccounts,
+  ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+  getSelectedInternalAccount,
+  ///: END:ONLY_INCLUDE_IF
+} from '../../../selectors/accounts';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import TransactionListItemDetails from './transaction-list-item-details.component';
 

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -7,13 +7,13 @@ import {
   isBalanceCached,
   getIsSwapsChain,
   getCurrentChainId,
-  getSelectedInternalAccount,
   getSelectedAccountCachedBalance,
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   getSwapsDefaultToken,
   getIsBridgeChain,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { getIsNativeTokenBuyable } from '../../../ducks/ramps';
 ///: END:ONLY_INCLUDE_IF

--- a/ui/components/institutional/custody-confirm-link-modal/custody-confirm-link-modal.tsx
+++ b/ui/components/institutional/custody-confirm-link-modal/custody-confirm-link-modal.tsx
@@ -11,7 +11,7 @@ import withModalProps from '../../../helpers/higher-order-components/with-modal-
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import { mmiActionsFactory } from '../../../store/institutional/institution-background';
 import { setSelectedInternalAccount } from '../../../store/actions';
-import { getInternalAccounts } from '../../../selectors';
+import { getInternalAccounts } from '../../../selectors/accounts';
 import {
   getMMIAddressFromModalOrAddress,
   getCustodyAccountDetails,

--- a/ui/components/institutional/interactive-replacement-token-modal/interactive-replacement-token-modal.tsx
+++ b/ui/components/institutional/interactive-replacement-token-modal/interactive-replacement-token-modal.tsx
@@ -4,7 +4,7 @@ import { ICustodianType } from '@metamask-institutional/types';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { hideModal } from '../../../store/actions';
-import { getSelectedInternalAccount } from '../../../selectors/selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import {
   Box,

--- a/ui/components/institutional/interactive-replacement-token-notification/interactive-replacement-token-notification.tsx
+++ b/ui/components/institutional/interactive-replacement-token-notification/interactive-replacement-token-notification.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  getCurrentKeyring,
-  getSelectedInternalAccount,
-} from '../../../selectors';
+import { getCurrentKeyring } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { getInteractiveReplacementToken } from '../../../selectors/institutional/selectors';
 import { getIsUnlocked } from '../../../ducks/metamask/metamask';
 import { useI18nContext } from '../../../hooks/useI18nContext';

--- a/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.tsx
+++ b/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.tsx
@@ -5,8 +5,8 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   accountsWithSendEtherInfoSelector,
   currentConfirmationSelector,
-  getSelectedInternalAccount,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   getAccountByAddress,
   shortenAddress,

--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -6,11 +6,8 @@ import QrCodeView from '../../ui/qr-code-view';
 import EditableLabel from '../../ui/editable-label/editable-label';
 
 import { setAccountLabel } from '../../../store/actions';
-import {
-  getCurrentChainId,
-  getHardwareWalletType,
-  getInternalAccountByAddress,
-} from '../../../selectors';
+import { getCurrentChainId, getHardwareWalletType } from '../../../selectors';
+import { getInternalAccountByAddress } from '../../../selectors/accounts';
 import { isAbleToExportAccount } from '../../../helpers/utils/util';
 import {
   Box,

--- a/ui/components/multichain/account-details/account-details.js
+++ b/ui/components/multichain/account-details/account-details.js
@@ -14,11 +14,8 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import {
-  getInternalAccountByAddress,
-  getMetaMaskAccountsOrdered,
-  getUseBlockie,
-} from '../../../selectors';
+import { getMetaMaskAccountsOrdered, getUseBlockie } from '../../../selectors';
+import { getInternalAccountByAddress } from '../../../selectors/accounts';
 import {
   clearAccountDetails,
   hideWarning,

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -147,14 +147,6 @@ const AccountListItem = ({
     currentTabOrigin && currentTabIsConnectedToSelectedAddress;
   const isSingleAccount = accountsCount === 1;
 
-  const renderCount = useRef(0);
-  useEffect(() => {
-    renderCount.current += 1;
-    console.log(
-      `AccountListItem Component has re-rendered ${renderCount.current} times`,
-    );
-  });
-
   return (
     <Box
       display={Display.Flex}

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -49,7 +49,6 @@ import {
   isAccountConnectedToCurrentTab,
   getShowFiatInTestnets,
   getUseBlockie,
-  getSelectedInternalAccount,
 } from '../../../selectors';
 import {
   getMultichainIsTestnet,
@@ -73,7 +72,7 @@ const MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP = 17;
 
 export const AccountListItem = ({
   account,
-  selected = false,
+  selected,
   onClick,
   closeMenu,
   accountsCount,
@@ -147,7 +146,6 @@ export const AccountListItem = ({
   const isConnected =
     currentTabOrigin && currentTabIsConnectedToSelectedAddress;
   const isSingleAccount = accountsCount === 1;
-  const selectedAccount = useSelector(getSelectedInternalAccount);
 
   const renderCount = useRef(0);
   useEffect(() => {
@@ -428,9 +426,7 @@ export const AccountListItem = ({
           account={account}
           onClose={() => setAccountOptionsMenuOpen(false)}
           closeMenu={closeMenu}
-          disableAccountSwitcher={
-            isSingleAccount && selectedAccount.address === account.address
-          }
+          disableAccountSwitcher={isSingleAccount && selected}
           isOpen={accountOptionsMenuOpen}
           onActionClick={onActionClick}
           activeTabOrigin={currentTabOrigin}
@@ -467,7 +463,7 @@ AccountListItem.propTypes = {
   /**
    * Represents if this account is currently selected
    */
-  selected: PropTypes.bool,
+  selected: PropTypes.bool.isRequired,
   /**
    * Function to execute when the item is clicked
    */

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -70,7 +70,7 @@ import { AccountListItemMenuTypes } from './account-list-item.types';
 const MAXIMUM_CURRENCY_DECIMALS = 3;
 const MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP = 17;
 
-export const AccountListItem = ({
+const AccountListItem = ({
   account,
   selected,
   onClick,
@@ -511,3 +511,5 @@ AccountListItem.propTypes = {
 };
 
 AccountListItem.displayName = 'AccountListItem';
+
+export default React.memo(AccountListItem);

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -149,6 +149,14 @@ export const AccountListItem = ({
   const isSingleAccount = accountsCount === 1;
   const selectedAccount = useSelector(getSelectedInternalAccount);
 
+  const renderCount = useRef(0);
+  useEffect(() => {
+    renderCount.current += 1;
+    console.log(
+      `AccountListItem Component has re-rendered ${renderCount.current} times`,
+    );
+  });
+
   return (
     <Box
       display={Display.Flex}

--- a/ui/components/multichain/account-list-item/account-list-item.test.js
+++ b/ui/components/multichain/account-list-item/account-list-item.test.js
@@ -32,6 +32,7 @@ const mockNonEvmAccount = {
 
 const DEFAULT_PROPS = {
   account: mockAccount,
+  selected: false,
   onClick: jest.fn(),
 };
 

--- a/ui/components/multichain/account-list-item/index.js
+++ b/ui/components/multichain/account-list-item/index.js
@@ -1,2 +1,2 @@
-export { AccountListItem } from './account-list-item';
+export { default as AccountListItem } from './account-list-item';
 export { AccountListItemMenuTypes } from './account-list-item.types';

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import Fuse from 'fuse.js';
@@ -193,6 +193,14 @@ export const AccountListMenu = ({
 
   const [searchQuery, setSearchQuery] = useState('');
   const [actionMode, setActionMode] = useState(ACTION_MODES.LIST);
+
+  const renderCount = useRef(0);
+  useEffect(() => {
+    renderCount.current += 1;
+    console.log(
+      `AccountListMenu Component has re-rendered ${renderCount.current} times`,
+    );
+  });
 
   let searchResults = updatedAccountsList;
   if (searchQuery) {

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -53,7 +53,6 @@ import {
   ///: END:ONLY_INCLUDE_IF
   getMetaMaskAccountsOrdered,
   getOriginOfCurrentTab,
-  getSelectedInternalAccount,
   getUpdatedAndSortedAccounts,
 } from '../../../selectors';
 import { setSelectedAccount } from '../../../store/actions';
@@ -71,11 +70,14 @@ import {
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { getAccountLabel } from '../../../helpers/utils/accounts';
-///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 import {
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   hasCreatedBtcMainnetAccount,
   hasCreatedBtcTestnetAccount,
+  ///: END:ONLY_INCLUDE_IF
+  getSelectedInternalAccount,
 } from '../../../selectors/accounts';
+///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 ///: END:ONLY_INCLUDE_IF
 import { HiddenAccountList } from './hidden-account-list';

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -1,11 +1,4 @@
-import React, {
-  useContext,
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  useMemo,
-} from 'react';
+import React, { useContext, useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import Fuse from 'fuse.js';
@@ -202,14 +195,6 @@ export const AccountListMenu = ({
 
   const [searchQuery, setSearchQuery] = useState('');
   const [actionMode, setActionMode] = useState(ACTION_MODES.LIST);
-
-  const renderCount = useRef(0);
-  useEffect(() => {
-    renderCount.current += 1;
-    console.log(
-      `AccountListMenu Component has re-rendered ${renderCount.current} times`,
-    );
-  });
 
   let searchResults = updatedAccountsList;
   if (searchQuery) {

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -1,4 +1,11 @@
-import React, { useContext, useState, useEffect, useRef } from 'react';
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import Fuse from 'fuse.js';
@@ -219,7 +226,7 @@ export const AccountListMenu = ({
   }
   searchResults = mergeAccounts(searchResults, accounts);
 
-  const title = getActionTitle(t, actionMode);
+  const title = useMemo(() => getActionTitle(t, actionMode), [actionMode, t]);
 
   let onBack = null;
   if (actionMode !== ACTION_MODES.LIST) {
@@ -229,6 +236,21 @@ export const AccountListMenu = ({
       onBack = () => setActionMode(ACTION_MODES.MENU);
     }
   }
+
+  const onAccountListItemItemClicked = useCallback(
+    (account) => {
+      onClose();
+      trackEvent({
+        category: MetaMetricsEventCategory.Navigation,
+        event: MetaMetricsEventName.NavAccountSwitched,
+        properties: {
+          location: 'Main Menu',
+        },
+      });
+      dispatch(setSelectedAccount(account.address));
+    },
+    [dispatch, onClose, trackEvent],
+  );
 
   return (
     <Modal isOpen onClose={onClose}>
@@ -518,17 +540,7 @@ export const AccountListMenu = ({
                     key={account.address}
                   >
                     <AccountListItem
-                      onClick={() => {
-                        onClose();
-                        trackEvent({
-                          category: MetaMetricsEventCategory.Navigation,
-                          event: MetaMetricsEventName.NavAccountSwitched,
-                          properties: {
-                            location: 'Main Menu',
-                          },
-                        });
-                        dispatch(setSelectedAccount(account.address));
-                      }}
+                      onClick={() => onAccountListItemItemClicked(account)}
                       account={account}
                       key={account.address}
                       selected={selectedAccount.address === account.address}

--- a/ui/components/multichain/account-list-menu/hidden-account-list.js
+++ b/ui/components/multichain/account-list-menu/hidden-account-list.js
@@ -19,11 +19,11 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getConnectedSubjectsForAllAddresses,
   getHiddenAccountsList,
-  getInternalAccounts,
   getMetaMaskAccountsOrdered,
   getOriginOfCurrentTab,
   getSelectedAccount,
 } from '../../../selectors';
+import { getInternalAccounts } from '../../../selectors/accounts';
 import { setSelectedAccount } from '../../../store/actions';
 import {
   AvatarIcon,

--- a/ui/components/multichain/account-overview/account-overview.tsx
+++ b/ui/components/multichain/account-overview/account-overview.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { BtcAccountType, EthAccountType } from '@metamask/keyring-api';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { BannerAlert, BannerAlertSeverity } from '../../component-library';
-import { getSelectedInternalAccount } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { AccountOverviewEth } from './account-overview-eth';
 import { AccountOverviewBtc } from './account-overview-btc';
 import { AccountOverviewUnknown } from './account-overview-unknown';

--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -21,12 +21,10 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import {
-  getUseBlockie,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
-  getSelectedAddress,
-  ///: END:ONLY_INCLUDE_IF
-} from '../../../selectors';
+import { getUseBlockie } from '../../../selectors';
+///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+import { getSelectedAddress } from '../../../selectors/accounts';
+///: END:ONLY_INCLUDE_IF
 import { shortenAddress } from '../../../helpers/utils/util';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 import { getCustodianIconForAddress } from '../../../selectors/institutional/selectors';

--- a/ui/components/multichain/address-copy-button/address-copy-button.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 import { useSelector } from 'react-redux';
-import { getSelectedInternalAccount } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   getIsCustodianSupportedChain,
   getCustodianIconForAddress,

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -39,10 +39,10 @@ import ConnectedStatusIndicator from '../../app/connected-status-indicator';
 import { AccountPicker } from '../account-picker';
 import { GlobalMenu } from '../global-menu';
 import {
-  getSelectedInternalAccount,
   getTestNetworkBackgroundColor,
   getOriginOfCurrentTab,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 import { shortenAddress } from '../../../helpers/utils/util';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { getSelectedInternalAccount } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   getCurrentDraftTransaction,
   getIsNativeSendPossible,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
@@ -12,7 +12,7 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { getSelectedInternalAccount } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 
 import {
   AssetType,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -16,11 +16,11 @@ import {
   getNativeCurrencyImage,
   getPreferences,
   getSelectedAccountCachedBalance,
-  getSelectedInternalAccount,
   getShouldHideZeroBalanceTokens,
   getTokenExchangeRates,
   getTokenList,
 } from '../../../../selectors';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
 import {
   getConversionRate,
   getNativeCurrency,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -35,11 +35,11 @@ import {
   getCurrentCurrency,
   getNativeCurrencyImage,
   getSelectedAccountCachedBalance,
-  getSelectedInternalAccount,
   getShouldHideZeroBalanceTokens,
   getTokenExchangeRates,
   getTokenList,
 } from '../../../../selectors';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
 import {
   getConversionRate,
   getNativeCurrency,

--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
@@ -93,6 +93,7 @@ export const ConnectAccountsModalList: React.FC<ConnectAccountsListProps> = ({
             return (
               <AccountListItem
                 onClick={() => handleAccountClick(account.address)}
+                selected={isSelectedAccount}
                 account={account}
                 key={account.address}
                 closeMenu={onClose}

--- a/ui/components/multichain/connected-site-menu/connected-site-menu.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.js
@@ -25,11 +25,8 @@ import {
   IconName,
   IconSize,
 } from '../../component-library';
-import {
-  getOriginOfCurrentTab,
-  getSelectedInternalAccount,
-  getSubjectMetadata,
-} from '../../../selectors';
+import { getOriginOfCurrentTab, getSubjectMetadata } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import Tooltip from '../../ui/tooltip';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -53,12 +53,12 @@ import {
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   getMetaMetricsId,
   ///: END:ONLY_INCLUDE_IF(build-mmi)
-  getSelectedInternalAccount,
   getUnapprovedTransactions,
   getAnySnapUpdateAvailable,
   getNotifySnaps,
   getUseExternalServices,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   AlignItems,
   BlockSize,

--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
@@ -24,9 +24,9 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getCurrentChainId,
   getIsMainnet,
-  getSelectedInternalAccount,
   getOpenSeaEnabled,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   addNftVerifyOwnership,
   getTokenStandardAndDetails,

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -13,14 +13,12 @@ import { Tab, Tabs } from '../../ui/tabs';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getCurrentChainId,
-  getInternalAccounts,
   getIsDynamicTokenListAvailable,
   getIsMainnet,
   getIsTokenDetectionInactiveOnMainnet,
   getIsTokenDetectionSupported,
   getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
   getRpcPrefsForCurrentProvider,
-  getSelectedInternalAccount,
   getSelectedNetworkClientId,
   getTokenDetectionSupportNetworkByChainId,
   getTokenList,
@@ -28,6 +26,10 @@ import {
   getTestNetworkBackgroundColor,
   contractExchangeRateSelector,
 } from '../../../selectors';
+import {
+  getInternalAccounts,
+  getSelectedInternalAccount,
+} from '../../../selectors/accounts';
 import {
   addImportedTokens,
   clearPendingTokens,

--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -18,15 +18,15 @@ import { getURLHost } from '../../../../helpers/utils/util';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   getConnectedSitesList,
-  getInternalAccounts,
   getOrderedConnectedAccountsForConnectedDapp,
   getPermissionSubjects,
   getPermittedAccountsByOrigin,
   getPermittedAccountsForSelectedTab,
-  getSelectedAccount,
   getSubjectMetadata,
   getUnconnectedAccounts,
+  getSelectedAccount,
 } from '../../../../selectors';
+import { getInternalAccounts } from '../../../../selectors/accounts';
 import {
   AvatarFavicon,
   AvatarFaviconSize,

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -232,8 +232,11 @@ exports[`SendPage render and initialization should render correctly even when a 
                   class="mm-box mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column"
                 >
                   <div
-                    class="mm-box multichain-account-list-item multichain-account-list-item--clickable mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+                    class="mm-box multichain-account-list-item multichain-account-list-item--selected multichain-account-list-item--clickable mm-box--padding-4 mm-box--display-flex mm-box--background-color-primary-muted"
                   >
+                    <div
+                      class="mm-box multichain-account-list-item__selected-indicator mm-box--background-color-primary-default mm-box--rounded-pill"
+                    />
                     <div
                       class="mm-box mm-box--display-flex mm-box--sm:display-none"
                       data-testid="account-list-item-badge"

--- a/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
@@ -6,8 +6,11 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
     class="mm-box mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column"
   >
     <div
-      class="mm-box multichain-account-list-item multichain-account-list-item--clickable mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+      class="mm-box multichain-account-list-item multichain-account-list-item--selected multichain-account-list-item--clickable mm-box--padding-4 mm-box--display-flex mm-box--background-color-primary-muted"
     >
+      <div
+        class="mm-box multichain-account-list-item__selected-indicator mm-box--background-color-primary-default mm-box--rounded-pill"
+      />
       <div
         class="mm-box mm-box--display-flex mm-box--sm:display-none"
         data-testid="account-list-item-badge"

--- a/ui/components/multichain/pages/send/components/account-picker.tsx
+++ b/ui/components/multichain/pages/send/components/account-picker.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { getSelectedInternalAccount } from '../../../../../selectors/accounts';
 import { Label } from '../../../../component-library';
@@ -23,6 +23,10 @@ export const SendPageAccountPicker = () => {
 
   const sendStage = useSelector(getSendStage);
   const disabled = SEND_STAGES.EDIT === sendStage;
+  const accountListItemProps = { showOptions: false };
+  const onAccountListMenuClose = useCallback(() => {
+    setShowAccountPicker(false);
+  }, []);
 
   return (
     <SendPageRow>
@@ -59,9 +63,9 @@ export const SendPageAccountPicker = () => {
       />
       {showAccountPicker ? (
         <AccountListMenu
-          accountListItemProps={{ showOptions: false }}
+          accountListItemProps={accountListItemProps}
           showAccountCreation={false}
-          onClose={() => setShowAccountPicker(false)}
+          onClose={onAccountListMenuClose}
         />
       ) : null}
     </SendPageRow>

--- a/ui/components/multichain/pages/send/components/account-picker.tsx
+++ b/ui/components/multichain/pages/send/components/account-picker.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { getSelectedInternalAccount } from '../../../../../selectors';
+import { getSelectedInternalAccount } from '../../../../../selectors/accounts';
 import { Label } from '../../../../component-library';
 import { AccountPicker } from '../../../account-picker';
 import {

--- a/ui/components/multichain/pages/send/components/your-accounts.tsx
+++ b/ui/components/multichain/pages/send/components/your-accounts.tsx
@@ -1,8 +1,10 @@
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { InternalAccountTypes } from '@metamask/keyring-api';
 import {
   getUpdatedAndSortedAccounts,
   getInternalAccounts,
+  getSelectedInternalAccount,
 } from '../../../../../selectors';
 import { AccountListItem } from '../../..';
 import {
@@ -24,8 +26,10 @@ export const SendPageYourAccounts = () => {
 
   // Your Accounts
   const accounts = useSelector(getUpdatedAndSortedAccounts);
-  const internalAccounts = useSelector(getInternalAccounts);
+  const internalAccounts: InternalAccountTypes[] =
+    useSelector(getInternalAccounts);
   const mergedAccounts = mergeAccounts(accounts, internalAccounts);
+  const selectedAccount = useSelector(getSelectedInternalAccount);
 
   return (
     <SendPageRow>
@@ -34,6 +38,7 @@ export const SendPageYourAccounts = () => {
       {mergedAccounts.map((account: any) => (
         <AccountListItem
           account={account}
+          selected={selectedAccount.address === account.address}
           key={account.address}
           isPinned={Boolean(account.pinned)}
           onClick={() => {

--- a/ui/components/multichain/pages/send/components/your-accounts.tsx
+++ b/ui/components/multichain/pages/send/components/your-accounts.tsx
@@ -1,11 +1,10 @@
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { InternalAccountTypes } from '@metamask/keyring-api';
+import { getUpdatedAndSortedAccounts } from '../../../../../selectors';
 import {
-  getUpdatedAndSortedAccounts,
   getInternalAccounts,
   getSelectedInternalAccount,
-} from '../../../../../selectors';
+} from '../../../../../selectors/accounts';
 import { AccountListItem } from '../../..';
 import {
   addHistoryEntry,
@@ -26,8 +25,7 @@ export const SendPageYourAccounts = () => {
 
   // Your Accounts
   const accounts = useSelector(getUpdatedAndSortedAccounts);
-  const internalAccounts: InternalAccountTypes[] =
-    useSelector(getInternalAccounts);
+  const internalAccounts = useSelector(getInternalAccounts);
   const mergedAccounts = mergeAccounts(accounts, internalAccounts);
   const selectedAccount = useSelector(getSelectedInternalAccount);
 

--- a/ui/components/multichain/receive-modal/receive-modal.js
+++ b/ui/components/multichain/receive-modal/receive-modal.js
@@ -14,7 +14,8 @@ import {
 } from '../../component-library';
 import QrCodeView from '../../ui/qr-code-view';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { getInternalAccountByAddress, getUseBlockie } from '../../../selectors';
+import { getUseBlockie } from '../../../selectors';
+import { getInternalAccountByAddress } from '../../../selectors/accounts';
 import {
   AlignItems,
   BlockSize,

--- a/ui/ducks/alerts/unconnected-account.js
+++ b/ui/ducks/alerts/unconnected-account.js
@@ -9,11 +9,11 @@ import {
   setSelectedAccount,
   setSelectedInternalAccount,
 } from '../../store/actions';
+import { getOriginOfCurrentTab } from '../../selectors';
 import {
   getInternalAccount,
-  getOriginOfCurrentTab,
   getSelectedInternalAccount,
-} from '../../selectors';
+} from '../../selectors/accounts';
 import { ALERT_STATE } from './enums';
 
 // Constants

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -16,8 +16,8 @@ import {
   checkNetworkAndAccountSupports1559,
   getAddressBook,
   getSelectedNetworkClientId,
-  getSelectedInternalAccount,
 } from '../../selectors';
+import { getSelectedInternalAccount } from '../../selectors/accounts';
 import * as actionConstants from '../../store/actionConstants';
 import { updateTransactionGasFees } from '../../store/actions';
 import { setCustomGasLimit, setCustomGasPrice } from '../gas/gas.duck';

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -50,13 +50,13 @@ import {
   getAddressBookEntryOrAccountName,
   getEnsResolutionByAddress,
   getSelectedAccount,
-  getSelectedInternalAccount,
   getSelectedInternalAccountWithBalance,
   getUnapprovedTransactions,
   getSelectedNetworkClientId,
   getIsSwapsChain,
   getUseExternalServices,
 } from '../../selectors';
+import { getSelectedInternalAccount } from '../../selectors/accounts';
 import {
   displayWarning,
   hideLoadingIndication,

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -63,8 +63,8 @@ import {
   getHardwareWalletType,
   checkNetworkAndAccountSupports1559,
   getSelectedNetworkClientId,
-  getSelectedInternalAccount,
 } from '../../selectors';
+import { getSelectedInternalAccount } from '../../selectors/accounts';
 import {
   getSmartTransactionsOptInStatus,
   getSmartTransactionsEnabled,

--- a/ui/hooks/useAddressDetails.js
+++ b/ui/hooks/useAddressDetails.js
@@ -1,11 +1,8 @@
 import { useSelector } from 'react-redux';
 
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
-import {
-  getAddressBook,
-  getInternalAccounts,
-  getTokenList,
-} from '../selectors';
+import { getAddressBook, getTokenList } from '../selectors';
+import { getInternalAccounts } from '../selectors/accounts';
 import { shortenAddress } from '../helpers/utils/util';
 
 const useAddressDetails = (toAddress) => {

--- a/ui/hooks/useMultichainSelector.ts
+++ b/ui/hooks/useMultichainSelector.ts
@@ -1,6 +1,9 @@
 import { useSelector, DefaultRootState } from 'react-redux';
 import { InternalAccount } from '@metamask/keyring-api';
-import { getSelectedInternalAccount } from '../selectors';
+import {
+  AccountsState,
+  getSelectedInternalAccount,
+} from '../selectors/accounts';
 
 export function useMultichainSelector<
   TState = DefaultRootState,
@@ -11,6 +14,9 @@ export function useMultichainSelector<
 ) {
   return useSelector((state: TState) => {
     // We either pass an account or fallback to the currently selected one
-    return selector(state, account || getSelectedInternalAccount(state));
+    return selector(
+      state,
+      account || getSelectedInternalAccount(state as AccountsState),
+    );
   });
 }

--- a/ui/hooks/useNftsCollections.js
+++ b/ui/hooks/useNftsCollections.js
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isEqual } from 'lodash';
 import { getNfts, getNftContracts } from '../ducks/metamask/metamask';
-import { getCurrentChainId, getSelectedInternalAccount } from '../selectors';
+import { getCurrentChainId } from '../selectors';
+import { getSelectedInternalAccount } from '../selectors/accounts';
 import { usePrevious } from './usePrevious';
 import { useI18nContext } from './useI18nContext';
 

--- a/ui/hooks/useTokenTracker.js
+++ b/ui/hooks/useTokenTracker.js
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import TokenTracker from '@metamask/eth-token-tracker';
 import { shallowEqual, useSelector } from 'react-redux';
-import { getCurrentChainId, getSelectedInternalAccount } from '../selectors';
+import { getCurrentChainId } from '../selectors';
+import { getSelectedInternalAccount } from '../selectors/accounts';
 import { SECOND } from '../../shared/constants/time';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 import { useEqualityCheck } from './useEqualityCheck';

--- a/ui/hooks/useUserPreferencedCurrency.js
+++ b/ui/hooks/useUserPreferencedCurrency.js
@@ -1,5 +1,6 @@
 import { shallowEqual, useSelector } from 'react-redux';
-import { getPreferences, getSelectedInternalAccount } from '../selectors';
+import { getPreferences } from '../selectors';
+import { getSelectedInternalAccount } from '../selectors/accounts';
 import {
   getMultichainNativeCurrency,
   getMultichainCurrentCurrency,

--- a/ui/index.js
+++ b/ui/index.js
@@ -18,12 +18,12 @@ import configureStore from './store/store';
 import {
   getOriginOfCurrentTab,
   getPermittedAccountsForCurrentTab,
-  getSelectedInternalAccount,
   getUnapprovedTransactions,
   getNetworkToAutomaticallySwitchTo,
   getSwitchedNetworkDetails,
   getUseRequestQueue,
 } from './selectors';
+import { getSelectedInternalAccount } from './selectors/accounts';
 import { ALERT_STATE } from './ducks/alerts';
 import {
   getUnconnectedAccountAlertEnabledness,

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -8,10 +8,10 @@ import {
   getCurrentCurrency,
   getIsBridgeChain,
   getIsSwapsChain,
-  getSelectedInternalAccount,
   getSwapsDefaultToken,
   getTokensMarketData,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   Display,
   FlexDirection,

--- a/ui/pages/asset/components/native-asset.tsx
+++ b/ui/pages/asset/components/native-asset.tsx
@@ -6,9 +6,9 @@ import {
   getNativeCurrencyImage,
   getRpcPrefsForCurrentProvider,
   getSelectedAccountCachedBalance,
-  getSelectedInternalAccount,
   getShouldShowFiat,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay';
 import {
   getNativeCurrency,

--- a/ui/pages/asset/components/token-asset.tsx
+++ b/ui/pages/asset/components/token-asset.tsx
@@ -6,9 +6,9 @@ import { useHistory } from 'react-router-dom';
 import {
   getCurrentChainId,
   getRpcPrefsForCurrentProvider,
-  getSelectedInternalAccount,
   getTokenList,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { AssetType } from '../../../../shared/constants/transaction';

--- a/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.js
+++ b/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.js
@@ -33,10 +33,10 @@ import {
   getSuggestedNfts,
   getIpfsGateway,
   getNetworkIdentifier,
-  getSelectedInternalAccount,
   getSelectedAccountCachedBalance,
   getAddressBookEntryOrAccountName,
 } from '../../selectors';
+import { getSelectedInternalAccount } from '../../selectors/accounts';
 import NftDefaultImage from '../../components/app/assets/nfts/nft-default-image/nft-default-image';
 import { getAssetImageURL, shortenAddress } from '../../helpers/utils/util';
 import {

--- a/ui/pages/confirmations/components/confirm-page-container/confirm-page-container.component.js
+++ b/ui/pages/confirmations/components/confirm-page-container/confirm-page-container.component.js
@@ -40,13 +40,15 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import useTransactionInsights from '../../../../hooks/useTransactionInsights';
 import InsightWarnings from '../../../../components/app/snaps/insight-warnings';
 import {
-  getAccountName,
   getAddressBookEntry,
-  getInternalAccounts,
   getMetadataContractName,
   getNetworkIdentifier,
   getSwapsDefaultToken,
 } from '../../../../selectors';
+import {
+  getAccountName,
+  getInternalAccounts,
+} from '../../../../selectors/accounts';
 import useRamps from '../../../../hooks/ramps/useRamps/useRamps';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { MetaMetricsContext } from '../../../../contexts/metametrics';

--- a/ui/pages/confirmations/components/confirm-page-container/confirm-page-container.container.js
+++ b/ui/pages/confirmations/components/confirm-page-container/confirm-page-container.container.js
@@ -4,9 +4,11 @@ import {
   getNetworkIdentifier,
   getSwapsDefaultToken,
   getMetadataContractName,
+} from '../../../../selectors';
+import {
   getAccountName,
   getInternalAccounts,
-} from '../../../../selectors';
+} from '../../../../selectors/accounts';
 import ConfirmPageContainer from './confirm-page-container.component';
 
 function mapStateToProps(state, ownProps) {

--- a/ui/pages/confirmations/components/signature-request-original/signature-request-original.container.js
+++ b/ui/pages/confirmations/components/signature-request-original/signature-request-original.container.js
@@ -25,9 +25,11 @@ import {
   getTotalUnapprovedMessagesCount,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   getAccountType,
-  getSelectedInternalAccount,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../../selectors';
+///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+///: END:ONLY_INCLUDE_IF
 import { getAccountByAddress, valuesFor } from '../../../../helpers/utils/util';
 import { clearConfirmTransaction } from '../../../../ducks/confirm-transaction/confirm-transaction.duck';
 import { getMostRecentOverviewPage } from '../../../../ducks/history/history';

--- a/ui/pages/confirmations/components/signature-request/signature-request-data/signature-request-data.js
+++ b/ui/pages/confirmations/components/signature-request/signature-request-data/signature-request-data.js
@@ -4,7 +4,7 @@ import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import { NameType } from '@metamask/name-controller';
 import {
-  getMemoizedMetaMaskInternalAccounts,
+  getInternalAccounts,
   getAccountName,
 } from '../../../../../selectors/accounts';
 import Address from '../../transaction-decoding/components/decoding/address';
@@ -24,7 +24,7 @@ import { usePetnamesEnabled } from '../../../../../hooks/usePetnamesEnabled';
 import Name from '../../../../../components/app/name/name';
 
 function SignatureRequestData({ data }) {
-  const internalAccounts = useSelector(getMemoizedMetaMaskInternalAccounts);
+  const internalAccounts = useSelector(getInternalAccounts);
   const petnamesEnabled = usePetnamesEnabled();
 
   return (

--- a/ui/pages/confirmations/components/signature-request/signature-request-data/signature-request-data.js
+++ b/ui/pages/confirmations/components/signature-request/signature-request-data/signature-request-data.js
@@ -6,7 +6,7 @@ import { NameType } from '@metamask/name-controller';
 import {
   getMemoizedMetaMaskInternalAccounts,
   getAccountName,
-} from '../../../../../selectors';
+} from '../../../../../selectors/accounts';
 import Address from '../../transaction-decoding/components/decoding/address';
 import {
   isValidHexAddress,

--- a/ui/pages/confirmations/components/signature-request/signature-request.test.js
+++ b/ui/pages/confirmations/components/signature-request/signature-request.test.js
@@ -24,7 +24,6 @@ import {
 } from '../../../../selectors';
 import {
   getInternalAccounts,
-  getMemoizedMetaMaskInternalAccounts,
   getSelectedInternalAccount,
 } from '../../../../selectors/accounts';
 import { ETH_EOA_METHODS } from '../../../../../shared/constants/eth-methods';
@@ -138,8 +137,6 @@ const generateUseSelectorRouter = (opts) => (selector) => {
     case getSelectedAccount:
       return mockSelectedInternalAccount;
     case getInternalAccounts:
-      return Object.values(opts.metamask.internalAccounts.accounts);
-    case getMemoizedMetaMaskInternalAccounts:
       return Object.values(opts.metamask.internalAccounts.accounts);
     case getMemoizedAddressBook:
       return [];

--- a/ui/pages/confirmations/components/signature-request/signature-request.test.js
+++ b/ui/pages/confirmations/components/signature-request/signature-request.test.js
@@ -18,13 +18,15 @@ import {
   getPreferences,
   getSelectedAccount,
   getTotalUnapprovedMessagesCount,
-  getInternalAccounts,
   unconfirmedTransactionsHashSelector,
   getAccountType,
-  getMemoizedMetaMaskInternalAccounts,
-  getSelectedInternalAccount,
   pendingApprovalsSortedSelector,
 } from '../../../../selectors';
+import {
+  getInternalAccounts,
+  getMemoizedMetaMaskInternalAccounts,
+  getSelectedInternalAccount,
+} from '../../../../selectors/accounts';
 import { ETH_EOA_METHODS } from '../../../../../shared/constants/eth-methods';
 import SignatureRequest from './signature-request';
 

--- a/ui/pages/confirmations/confirm-signature-request/index.js
+++ b/ui/pages/confirmations/confirm-signature-request/index.js
@@ -21,12 +21,12 @@ import {
   getTargetSubjectMetadata,
   getCurrentNetworkTransactions,
   getUnapprovedTransactions,
-  getInternalAccounts,
   getMemoizedUnapprovedPersonalMessages,
   getMemoizedUnapprovedTypedMessages,
   getMemoizedCurrentChainId,
   getMemoizedTxId,
 } from '../../../selectors';
+import { getInternalAccounts } from '../../../selectors/accounts';
 import { useSignatureInsights } from '../../../hooks/snaps/useSignatureInsights';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { getSendTo } from '../../../ducks/send';

--- a/ui/pages/confirmations/confirm-token-transaction-base/confirm-token-transaction-base.js
+++ b/ui/pages/confirmations/confirm-token-transaction-base/confirm-token-transaction-base.js
@@ -18,8 +18,8 @@ import {
   getCurrentChainId,
   getCurrentCurrency,
   getRpcPrefsForCurrentProvider,
-  getSelectedInternalAccount,
 } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   getConversionRate,
   getNativeCurrency,

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
@@ -52,11 +52,11 @@ import {
   getFullTxData,
   getUseCurrencyRateCheck,
   getUnapprovedTransactions,
-  getInternalAccountByAddress,
   getApprovedAndSignedTransactions,
   getSelectedNetworkClientId,
   getPrioritizedUnapprovedTemplatedConfirmations,
 } from '../../../selectors';
+import { getInternalAccountByAddress } from '../../../selectors/accounts';
 import {
   getCurrentChainSupportsSmartTransactions,
   getSmartTransactionsOptInStatus,

--- a/ui/pages/confirmations/hooks/useBalance.js
+++ b/ui/pages/confirmations/hooks/useBalance.js
@@ -1,11 +1,11 @@
 import { useSelector } from 'react-redux';
 import {
   getCurrentNetwork,
-  getInternalAccountByAddress,
   getSelectedAccountCachedBalance,
   getShouldHideZeroBalanceTokens,
   getShowFiatInTestnets,
 } from '../../../selectors';
+import { getInternalAccountByAddress } from '../../../selectors/accounts';
 import { TEST_NETWORKS } from '../../../../shared/constants/network';
 import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBalance';
 

--- a/ui/pages/confirmations/hooks/useConfirmationRecipientInfo.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationRecipientInfo.test.ts
@@ -1,6 +1,6 @@
 import mockState from '../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers';
-import { getInternalAccountByAddress } from '../../../selectors';
+import { getInternalAccountByAddress } from '../../../selectors/accounts';
 import useConfirmationRecipientInfo from './useConfirmationRecipientInfo';
 
 const SenderAddress = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';

--- a/ui/pages/confirmations/hooks/useTransactionInfo.js
+++ b/ui/pages/confirmations/hooks/useTransactionInfo.js
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 import { getProviderConfig } from '../../../ducks/metamask/metamask';
 
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
-import { getSelectedInternalAccount } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 
 export const useTransactionInfo = (txData = {}) => {
   const { allNftContracts } = useSelector((state) => state.metamask);

--- a/ui/pages/connected-accounts/connected-accounts.component.js
+++ b/ui/pages/connected-accounts/connected-accounts.component.js
@@ -10,7 +10,7 @@ import { useI18nContext } from '../../hooks/useI18nContext';
 import ConnectedSnaps from '../../components/app/connected-sites-list/connected-snaps';
 import { TextColor, TextVariant } from '../../helpers/constants/design-system';
 import { Box, Text } from '../../components/component-library';
-import { getInternalAccounts } from '../../selectors';
+import { getInternalAccounts } from '../../selectors/accounts';
 
 export default function ConnectedAccounts({
   accountToConnect = null,

--- a/ui/pages/connected-accounts/connected-accounts.container.js
+++ b/ui/pages/connected-accounts/connected-accounts.container.js
@@ -4,11 +4,13 @@ import {
   getOrderedConnectedAccountsForActiveTab,
   getOriginOfCurrentTab,
   getPermissionsForActiveTab,
-  getSelectedInternalAccount,
   getPermissionSubjects,
   getSubjectMetadata,
-  getInternalAccounts,
 } from '../../selectors';
+import {
+  getSelectedInternalAccount,
+  getInternalAccounts,
+} from '../../selectors/accounts';
 import { isExtensionUrl } from '../../helpers/utils/util';
 import {
   addPermittedAccount,

--- a/ui/pages/connected-sites/connected-sites.container.js
+++ b/ui/pages/connected-sites/connected-sites.container.js
@@ -10,8 +10,8 @@ import {
   getOriginOfCurrentTab,
   getPermissionSubjects,
   getPermittedAccountsByOrigin,
-  getSelectedInternalAccount,
 } from '../../selectors';
+import { getSelectedInternalAccount } from '../../selectors/accounts';
 import { CONNECT_ROUTE } from '../../helpers/constants/routes';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import ConnectedSites from './connected-sites.component';

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -43,7 +43,6 @@ import {
   getApprovalFlows,
   getNewTokensImportedError,
   hasPendingApprovals,
-  getSelectedInternalAccount,
   getQueuedRequestCount,
   getEditedNetwork,
   getPrioritizedUnapprovedTemplatedConfirmations,
@@ -51,6 +50,7 @@ import {
   getAccountType,
   ///: END:ONLY_INCLUDE_IF
 } from '../../selectors';
+import { getSelectedInternalAccount } from '../../selectors/accounts';
 import {
   getIsShowTokenAutodetectModal,
   getIsSmartTransactionsOptInModalAvailable,

--- a/ui/pages/institutional/custody/custody.tsx
+++ b/ui/pages/institutional/custody/custody.tsx
@@ -40,10 +40,8 @@ import {
   CUSTODY_ACCOUNT_ROUTE,
   DEFAULT_ROUTE,
 } from '../../../helpers/constants/routes';
-import {
-  getCurrentChainId,
-  getSelectedInternalAccount,
-} from '../../../selectors';
+import { getCurrentChainId } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { getMMIConfiguration } from '../../../selectors/institutional/selectors';
 import { getInstitutionalConnectRequests } from '../../../ducks/institutional/institutional';
 import CustodyAccountList from '../account-list';

--- a/ui/pages/institutional/interactive-replacement-token-page/interactive-replacement-token-page.tsx
+++ b/ui/pages/institutional/interactive-replacement-token-page/interactive-replacement-token-page.tsx
@@ -26,7 +26,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { getMetaMaskAccounts } from '../../../selectors';
 import { getInstitutionalConnectRequests } from '../../../ducks/institutional/institutional';
-import { getSelectedInternalAccount } from '../../../selectors/selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import { SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../shared/constants/swaps';
 import { CHAIN_IDS } from '../../../../shared/constants/network';

--- a/ui/pages/notifications-settings/notifications-settings.tsx
+++ b/ui/pages/notifications-settings/notifications-settings.tsx
@@ -27,23 +27,11 @@ import {
   selectIsMetamaskNotificationsEnabled,
   getIsUpdatingMetamaskNotifications,
 } from '../../selectors/metamask-notifications/metamask-notifications';
-import { getInternalAccounts } from '../../selectors';
+import { getInternalAccounts } from '../../selectors/accounts';
 import { useAccountSettingsProps } from '../../hooks/metamask-notifications/useSwitchNotifications';
 import { NotificationsSettingsAllowNotifications } from './notifications-settings-allow-notifications';
 import { NotificationsSettingsTypes } from './notifications-settings-types';
 import { NotificationsSettingsPerAccount } from './notifications-settings-per-account';
-
-// Define KeyringType interface
-type KeyringType = {
-  type: string;
-};
-
-// Define AccountType interface
-type AccountType = InternalAccount & {
-  balance: string;
-  keyring: KeyringType;
-  label: string;
-};
 
 export default function NotificationsSettings() {
   const history = useHistory();
@@ -56,14 +44,14 @@ export default function NotificationsSettings() {
   const isUpdatingMetamaskNotifications = useSelector(
     getIsUpdatingMetamaskNotifications,
   );
-  const accounts: AccountType[] = useSelector(getInternalAccounts);
+  const accounts = useSelector(getInternalAccounts);
 
   // States
   const [loadingAllowNotifications, setLoadingAllowNotifications] =
     useState<boolean>(isUpdatingMetamaskNotifications);
 
   const accountAddresses = useMemo(
-    () => accounts.map((a) => a.address),
+    () => accounts.map((a: InternalAccount) => a.address),
     [accounts],
   );
 
@@ -142,7 +130,7 @@ export default function NotificationsSettings() {
                 paddingRight={8}
                 paddingBottom={4}
               >
-                {accounts.map((account) => (
+                {accounts.map((account: InternalAccount) => (
                   <NotificationsSettingsPerAccount
                     key={account.id}
                     address={account.address}

--- a/ui/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/pages/permissions-connect/permissions-connect.container.js
@@ -7,13 +7,13 @@ import {
   getAccountsWithLabels,
   getLastConnectedInfo,
   getPermissionsRequests,
-  getSelectedInternalAccount,
   getSnapInstallOrUpdateRequests,
   getRequestState,
   getSnapsInstallPrivacyWarningShown,
   getRequestType,
   getTargetSubjectMetadata,
 } from '../../selectors';
+import { getSelectedInternalAccount } from '../../selectors/accounts';
 import { getNativeCurrency } from '../../ducks/metamask/metamask';
 
 import { formatDate, getURLHostName } from '../../helpers/utils/util';

--- a/ui/pages/remove-snap-account/snap-account-card.tsx
+++ b/ui/pages/remove-snap-account/snap-account-card.tsx
@@ -37,7 +37,7 @@ export const SnapAccountCard = ({
         boxShadow: 'var(--shadow-size-lg) var(--color-shadow-default)',
       }}
     >
-      <AccountListItem account={account} selected={remove} />
+      <AccountListItem account={account} selected={remove || false} />
     </Box>
   );
 };

--- a/ui/pages/remove-snap-account/snap-account-card.tsx
+++ b/ui/pages/remove-snap-account/snap-account-card.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import {
-  getInternalAccounts,
-  getMetaMaskAccountsOrdered,
-} from '../../selectors';
+import { getMetaMaskAccountsOrdered } from '../../selectors';
+import { getInternalAccounts } from '../../selectors/accounts';
 import { BlockSize, BorderRadius } from '../../helpers/constants/design-system';
 import { Box } from '../../components/component-library';
 import { AccountListItem } from '../../components/multichain';

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -906,7 +906,7 @@ export default class Routes extends Component {
           ///: END:ONLY_INCLUDE_IF
         }
         {isAccountMenuOpen ? (
-          <AccountListMenu onClose={() => toggleAccountMenu()} />
+          <AccountListMenu onClose={toggleAccountMenu} />
         ) : null}
         {isNetworkMenuOpen ? (
           <NetworkListMenu

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
@@ -1,10 +1,8 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import {
-  getAddressBookEntry,
-  getInternalAccountByAddress,
-} from '../../../../selectors';
+import { getAddressBookEntry } from '../../../../selectors';
+import { getInternalAccountByAddress } from '../../../../selectors/accounts';
 import { getProviderConfig } from '../../../../ducks/metamask/metamask';
 import {
   CONTACT_VIEW_ROUTE,

--- a/ui/pages/settings/contact-list-tab/view-contact/view-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/view-contact/view-contact.container.js
@@ -1,10 +1,8 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import {
-  getAddressBookEntry,
-  getInternalAccountByAddress,
-} from '../../../../selectors';
+import { getAddressBookEntry } from '../../../../selectors';
+import { getInternalAccountByAddress } from '../../../../selectors/accounts';
 import {
   CONTACT_EDIT_ROUTE,
   CONTACT_LIST_ROUTE,

--- a/ui/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/pages/settings/settings-tab/settings-tab.container.js
@@ -8,12 +8,8 @@ import {
   setParticipateInMetaMetrics,
   setTheme,
 } from '../../../store/actions';
-import {
-  getTokenList,
-  getPreferences,
-  getTheme,
-  getSelectedInternalAccount,
-} from '../../../selectors';
+import { getTokenList, getPreferences, getTheme } from '../../../selectors';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import SettingsTab from './settings-tab.component';
 
 const mapStateToProps = (state, ownProps) => {

--- a/ui/pages/snaps/snap-view/snap-settings.js
+++ b/ui/pages/snaps/snap-view/snap-settings.js
@@ -36,7 +36,7 @@ import {
   getSnapMetadata,
 } from '../../../selectors';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-import { getMemoizedMetaMaskInternalAccounts } from '../../../selectors/accounts';
+import { getInternalAccounts } from '../../../selectors/accounts';
 ///: END:ONLY_INCLUDE_IF
 import {
   Box,
@@ -72,7 +72,7 @@ function SnapSettings({ snapId, initRemove, resetInitRemove }) {
   // eslint-disable-next-line no-unused-vars -- Main build does not use setKeyringAccounts
   const [keyringAccounts, setKeyringAccounts] = useState([]);
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  const internalAccounts = useSelector(getMemoizedMetaMaskInternalAccounts);
+  const internalAccounts = useSelector(getInternalAccounts);
   ///: END:ONLY_INCLUDE_IF
 
   const connectedSubjects = useSelector((state) =>

--- a/ui/pages/snaps/snap-view/snap-settings.js
+++ b/ui/pages/snaps/snap-view/snap-settings.js
@@ -34,10 +34,10 @@ import {
   getPermissions,
   getSnapLatestVersion,
   getSnapMetadata,
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  getMemoizedMetaMaskInternalAccounts,
-  ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
+///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+import { getMemoizedMetaMaskInternalAccounts } from '../../../selectors/accounts';
+///: END:ONLY_INCLUDE_IF
 import {
   Box,
   Button,

--- a/ui/selectors/accounts.ts
+++ b/ui/selectors/accounts.ts
@@ -8,7 +8,8 @@ import {
   isBtcMainnetAddress,
   isBtcTestnetAddress,
 } from '../../shared/lib/multichain';
-import { getSelectedInternalAccount, getInternalAccounts } from './selectors';
+import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
+import { createDeepEqualSelector } from './util';
 
 export type AccountsState = {
   metamask: AccountsControllerState;
@@ -18,6 +19,67 @@ function isBtcAccount(account: InternalAccount) {
   const { P2wpkh } = BtcAccountType;
 
   return Boolean(account && account.type === P2wpkh);
+}
+
+export const getInternalAccounts = createDeepEqualSelector(
+  (state: AccountsState) => state.metamask.internalAccounts.accounts,
+  (accounts) => Object.values(accounts),
+);
+
+export const getSelectedInternalAccount = createDeepEqualSelector(
+  (state: AccountsState) => state.metamask.internalAccounts,
+  (internalAccounts) => {
+    const accountId = internalAccounts.selectedAccount;
+    return internalAccounts.accounts[accountId];
+  },
+);
+
+/**
+ * Returns a memoized selector that gets the internal accounts from the Redux store.
+ *
+ * @param state - The Redux store state.
+ * @returns {Array} An array of internal accounts.
+ */
+export const getMemoizedMetaMaskInternalAccounts = createDeepEqualSelector(
+  getInternalAccounts,
+  (internalAccounts) => internalAccounts,
+);
+
+export const getMaybeSelectedInternalAccount = createDeepEqualSelector(
+  (state: AccountsState) => state.metamask.internalAccounts,
+  (internalAccounts) => {
+    // Same as `getSelectedInternalAccount`, but might potentially be `undefined`:
+    // - This might happen during the onboarding
+    const accountId = internalAccounts?.selectedAccount;
+    return accountId ? internalAccounts?.accounts[accountId] : undefined;
+  },
+);
+
+export function getInternalAccountByAddress(
+  state: AccountsState,
+  address: string,
+) {
+  return Object.values(state.metamask.internalAccounts.accounts).find(
+    (account) => isEqualCaseInsensitive(account.address, address),
+  );
+}
+
+export function getSelectedAddress(state: AccountsState) {
+  return getSelectedInternalAccount(state)?.address;
+}
+
+export function getInternalAccount(state: AccountsState, accountId: string) {
+  return state.metamask.internalAccounts.accounts[accountId];
+}
+
+export function getAccountName(
+  accounts: InternalAccount[],
+  accountAddress: string,
+) {
+  const account = accounts.find((internalAccount: InternalAccount) =>
+    isEqualCaseInsensitive(internalAccount.address, accountAddress),
+  );
+  return account && account.metadata.name !== '' ? account.metadata.name : '';
 }
 
 export function isSelectedInternalAccountEth(state: AccountsState) {
@@ -36,7 +98,7 @@ function hasCreatedBtcAccount(
   isAddressCallback: (address: string) => boolean,
 ) {
   const accounts = getInternalAccounts(state);
-  return accounts.some((account) => {
+  return accounts.some((account: InternalAccount) => {
     return isBtcAccount(account) && isAddressCallback(account.address);
   });
 }

--- a/ui/selectors/accounts.ts
+++ b/ui/selectors/accounts.ts
@@ -34,17 +34,6 @@ export const getSelectedInternalAccount = createDeepEqualSelector(
   },
 );
 
-/**
- * Returns a memoized selector that gets the internal accounts from the Redux store.
- *
- * @param state - The Redux store state.
- * @returns {Array} An array of internal accounts.
- */
-export const getMemoizedMetaMaskInternalAccounts = createDeepEqualSelector(
-  getInternalAccounts,
-  (internalAccounts) => internalAccounts,
-);
-
 export const getMaybeSelectedInternalAccount = createDeepEqualSelector(
   (state: AccountsState) => state.metamask.internalAccounts,
   (internalAccounts) => {

--- a/ui/selectors/institutional/selectors.js
+++ b/ui/selectors/institutional/selectors.js
@@ -1,5 +1,6 @@
 import { toChecksumAddress } from 'ethereumjs-util';
-import { getAccountType, getSelectedInternalAccount } from '../selectors';
+import { getAccountType } from '../selectors';
+import { getSelectedInternalAccount } from '../accounts';
 import { getProviderConfig } from '../../ducks/metamask/metamask';
 import { hexToDecimal } from '../../../shared/modules/conversion.utils';
 import { normalizeSafeAddress } from '../../../app/scripts/lib/multichain/address';

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -27,16 +27,18 @@ import {
   NETWORK_TYPES,
   TEST_NETWORK_IDS,
 } from '../../shared/constants/network';
-import { AccountsState } from './accounts';
+import {
+  getSelectedInternalAccount,
+  getMaybeSelectedInternalAccount,
+  AccountsState,
+} from './accounts';
 import {
   getCurrentChainId,
   getCurrentCurrency,
   getIsMainnet,
-  getMaybeSelectedInternalAccount,
   getNativeCurrencyImage,
   getNetworkConfigurations,
   getSelectedAccountCachedBalance,
-  getSelectedInternalAccount,
   getShouldShowFiat,
   getShowFiatInTestnets,
 } from '.';

--- a/ui/selectors/permissions.js
+++ b/ui/selectors/permissions.js
@@ -4,11 +4,10 @@ import { isEvmAccountType } from '@metamask/keyring-api';
 import { CaveatTypes } from '../../shared/constants/permissions';
 import { getApprovalRequestsByType } from './approvals';
 import { createDeepEqualSelector } from './util';
+import { getInternalAccount, getSelectedInternalAccount } from './accounts';
 import {
-  getInternalAccount,
   getMetaMaskAccountsOrdered,
   getOriginOfCurrentTab,
-  getSelectedInternalAccount,
   getTargetSubjectMetadata,
 } from '.';
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -119,6 +119,11 @@ import {
   getOrderedConnectedAccountsForConnectedDapp,
   getSubjectMetadata,
 } from './permissions';
+import {
+  getSelectedInternalAccount,
+  getInternalAccounts,
+  getInternalAccountByAddress,
+} from './accounts';
 import { createDeepEqualSelector } from './util';
 import { getMultichainBalances, getMultichainNetwork } from './multichain';
 
@@ -173,14 +178,6 @@ export function getCurrentQRHardwareState(state) {
 export function getIsSigningQRHardwareTransaction(state) {
   return state.metamask.qrHardware?.sign?.request !== undefined;
 }
-
-export const getSelectedInternalAccount = createDeepEqualSelector(
-  (state) => state.metamask.internalAccounts,
-  (internalAccounts) => {
-    const accountId = internalAccounts.selectedAccount;
-    return internalAccounts.accounts[accountId];
-  },
-);
 
 export function getCurrentKeyring(state) {
   const internalAccount = getSelectedInternalAccount(state);
@@ -283,11 +280,6 @@ export function getAccountTypeForKeyring(keyring) {
   }
 }
 
-export const getInternalAccounts = createDeepEqualSelector(
-  (state) => state.metamask.internalAccounts.accounts,
-  (accounts) => accounts,
-);
-
 /**
  * Get MetaMask accounts, including account name and balance.
  */
@@ -344,32 +336,6 @@ export const getMetaMaskAccounts = createDeepEqualSelector(
     }, {}),
 );
 
-export function getInternalAccountByAddress(state, address) {
-  return Object.values(state.metamask.internalAccounts.accounts).find(
-    (account) => isEqualCaseInsensitive(account.address, address),
-  );
-}
-
-export const getMaybeSelectedInternalAccount = createDeepEqualSelector(
-  (state) => state.metamask.internalAccounts,
-  (internalAccounts) => {
-    // Same as `getSelectedInternalAccount`, but might potentially be `undefined`:
-    // - This might happen during the onboarding
-    const accountId = internalAccounts?.selectedAccount;
-    return accountId ? internalAccounts?.accounts[accountId] : undefined;
-  },
-);
-
-/**
- * Returns the address of the selected InternalAccount from the Metamask state.
- *
- * @param state - The Metamask state object.
- * @returns {string} The selected address.
- */
-export function getSelectedAddress(state) {
-  return getSelectedInternalAccount(state)?.address;
-}
-
 export function checkIfMethodIsEnabled(state, methodName) {
   const internalAccount = getSelectedInternalAccount(state);
   return Boolean(internalAccount.methods.includes(methodName));
@@ -385,10 +351,6 @@ export function getSelectedInternalAccountWithBalance(state) {
   };
 
   return selectedAccountWithBalance;
-}
-
-export function getInternalAccount(state, accountId) {
-  return state.metamask.internalAccounts.accounts[accountId];
 }
 
 /**
@@ -579,13 +541,6 @@ export function getAddressBookEntryOrAccountName(state, address) {
   );
 
   return internalAccount?.metadata.name || address;
-}
-
-export function getAccountName(accounts, accountAddress) {
-  const account = accounts.find((internalAccount) =>
-    isEqualCaseInsensitive(internalAccount.address, accountAddress),
-  );
-  return account && account.metadata.name !== '' ? account.metadata.name : '';
 }
 
 export function accountsWithSendEtherInfoSelector(state) {
@@ -1357,17 +1312,6 @@ export function getNextSuggestedNonce(state) {
 export function getShowWhatsNewPopup(state) {
   return state.appState.showWhatsNewPopup;
 }
-
-/**
- * Returns a memoized selector that gets the internal accounts from the Redux store.
- *
- * @param state - The Redux store state.
- * @returns {Array} An array of internal accounts.
- */
-export const getMemoizedMetaMaskInternalAccounts = createDeepEqualSelector(
-  getInternalAccounts,
-  (internalAccounts) => internalAccounts,
-);
 
 export const getMemoizedAddressBook = createDeepEqualSelector(
   getAddressBook,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -278,7 +278,7 @@ export function getAccountTypeForKeyring(keyring) {
 /**
  * Get MetaMask accounts, including account name and balance.
  */
-export const getMetaMaskAccounts = createSelector(
+export const getMetaMaskAccounts = createDeepEqualSelector(
   getInternalAccounts,
   getMetaMaskAccountBalances,
   getMetaMaskCachedBalances,
@@ -392,7 +392,7 @@ export function getInternalAccount(state, accountId) {
  * @param accounts - The object containing the accounts.
  * @returns The array of internal accounts sorted by keyring.
  */
-export const getInternalAccountsSortedByKeyring = createSelector(
+export const getInternalAccountsSortedByKeyring = createDeepEqualSelector(
   getMetaMaskKeyrings,
   getMetaMaskAccounts,
   (keyrings, accounts) => {
@@ -445,7 +445,7 @@ export function getMetaMaskCachedBalances(state) {
 /**
  * Get ordered (by keyrings) accounts with InternalAccount and balance
  */
-export const getMetaMaskAccountsOrdered = createSelector(
+export const getMetaMaskAccountsOrdered = createDeepEqualSelector(
   getInternalAccountsSortedByKeyring,
   getMetaMaskAccounts,
   (internalAccounts, accounts) => {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -174,6 +174,14 @@ export function getIsSigningQRHardwareTransaction(state) {
   return state.metamask.qrHardware?.sign?.request !== undefined;
 }
 
+export const getSelectedInternalAccount = createDeepEqualSelector(
+  (state) => state.metamask.internalAccounts,
+  (internalAccounts) => {
+    const accountId = internalAccounts.selectedAccount;
+    return internalAccounts.accounts[accountId];
+  },
+);
+
 export function getCurrentKeyring(state) {
   const internalAccount = getSelectedInternalAccount(state);
 
@@ -275,6 +283,11 @@ export function getAccountTypeForKeyring(keyring) {
   }
 }
 
+export const getInternalAccounts = createDeepEqualSelector(
+  (state) => state.metamask.internalAccounts.accounts,
+  (accounts) => accounts,
+);
+
 /**
  * Get MetaMask accounts, including account name and balance.
  */
@@ -330,6 +343,23 @@ export const getMetaMaskAccounts = createDeepEqualSelector(
       };
     }, {}),
 );
+
+export function getInternalAccountByAddress(state, address) {
+  return Object.values(state.metamask.internalAccounts.accounts).find(
+    (account) => isEqualCaseInsensitive(account.address, address),
+  );
+}
+
+export const getMaybeSelectedInternalAccount = createDeepEqualSelector(
+  (state) => state.metamask.internalAccounts,
+  (internalAccounts) => {
+    // Same as `getSelectedInternalAccount`, but might potentially be `undefined`:
+    // - This might happen during the onboarding
+    const accountId = internalAccounts?.selectedAccount;
+    return accountId ? internalAccounts?.accounts[accountId] : undefined;
+  },
+);
+
 /**
  * Returns the address of the selected InternalAccount from the Metamask state.
  *
@@ -338,26 +368,6 @@ export const getMetaMaskAccounts = createDeepEqualSelector(
  */
 export function getSelectedAddress(state) {
   return getSelectedInternalAccount(state)?.address;
-}
-
-export function getInternalAccountByAddress(state, address) {
-  return Object.values(state.metamask.internalAccounts.accounts).find(
-    (account) => isEqualCaseInsensitive(account.address, address),
-  );
-}
-
-export function getMaybeSelectedInternalAccount(state) {
-  // Same as `getSelectedInternalAccount`, but might potentially be `undefined`:
-  // - This might happen during the onboarding
-  const accountId = state.metamask.internalAccounts?.selectedAccount;
-  return accountId
-    ? state.metamask.internalAccounts?.accounts[accountId]
-    : undefined;
-}
-
-export function getSelectedInternalAccount(state) {
-  const accountId = state.metamask.internalAccounts.selectedAccount;
-  return state.metamask.internalAccounts.accounts[accountId];
 }
 
 export function checkIfMethodIsEnabled(state, methodName) {
@@ -375,10 +385,6 @@ export function getSelectedInternalAccountWithBalance(state) {
   };
 
   return selectedAccountWithBalance;
-}
-
-export function getInternalAccounts(state) {
-  return Object.values(state.metamask.internalAccounts.accounts);
 }
 
 export function getInternalAccount(state, accountId) {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -1,6 +1,6 @@
 import { deepClone } from '@metamask/snaps-utils';
 import { ApprovalType, NetworkType } from '@metamask/controller-utils';
-import { EthAccountType, EthMethod } from '@metamask/keyring-api';
+import { EthMethod } from '@metamask/keyring-api';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import mockState from '../../test/data/mock-state.json';
 import { KeyringType } from '../../shared/constants/keyring';
@@ -13,7 +13,6 @@ import {
 import { SURVEY_DATE, SURVEY_GMT } from '../helpers/constants/survey';
 import { PRIVACY_POLICY_DATE } from '../helpers/constants/privacy-policy';
 import { createMockInternalAccount } from '../../test/jest/mocks';
-import { ETH_EOA_METHODS } from '../../shared/constants/eth-methods';
 import * as selectors from './selectors';
 
 jest.mock('../../app/scripts/lib/util', () => ({
@@ -39,73 +38,6 @@ const modifyStateWithHWKeyring = (keyring) => {
 };
 
 describe('Selectors', () => {
-  describe('#getSelectedAddress', () => {
-    it('returns undefined if selectedAddress is undefined', () => {
-      expect(
-        selectors.getSelectedAddress({
-          metamask: { internalAccounts: { accounts: {}, selectedAccount: '' } },
-        }),
-      ).toBeUndefined();
-    });
-
-    it('returns selectedAddress', () => {
-      const mockInternalAccount = createMockInternalAccount();
-      const internalAccounts = {
-        accounts: {
-          [mockInternalAccount.id]: mockInternalAccount,
-        },
-        selectedAccount: mockInternalAccount.id,
-      };
-
-      expect(
-        selectors.getSelectedAddress({ metamask: { internalAccounts } }),
-      ).toStrictEqual(mockInternalAccount.address);
-    });
-  });
-
-  describe('#getSelectedInternalAccount', () => {
-    it('returns undefined if selectedAccount is undefined', () => {
-      expect(
-        selectors.getSelectedInternalAccount({
-          metamask: {
-            internalAccounts: {
-              accounts: {},
-              selectedAccount: '',
-            },
-          },
-        }),
-      ).toBeUndefined();
-    });
-
-    it('returns selectedAccount', () => {
-      const mockInternalAccount = {
-        address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-        id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
-        metadata: {
-          name: 'Test Account',
-          keyring: {
-            type: 'HD Key Tree',
-          },
-        },
-        options: {},
-        methods: ETH_EOA_METHODS,
-        type: EthAccountType.Eoa,
-      };
-      expect(
-        selectors.getSelectedInternalAccount({
-          metamask: {
-            internalAccounts: {
-              accounts: {
-                [mockInternalAccount.id]: mockInternalAccount,
-              },
-              selectedAccount: mockInternalAccount.id,
-            },
-          },
-        }),
-      ).toStrictEqual(mockInternalAccount);
-    });
-  });
-
   describe('#checkIfMethodIsEnabled', () => {
     it('returns true if the method is enabled', () => {
       expect(
@@ -138,35 +70,6 @@ describe('Selectors', () => {
           EthMethod.SignTransaction,
         ),
       ).toBe(false);
-    });
-  });
-
-  describe('#getInternalAccounts', () => {
-    it('returns a list of internal accounts', () => {
-      expect(selectors.getInternalAccounts(mockState)).toStrictEqual(
-        Object.values(mockState.metamask.internalAccounts.accounts),
-      );
-    });
-  });
-
-  describe('#getInternalAccount', () => {
-    it("returns undefined if the account doesn't exist", () => {
-      expect(
-        selectors.getInternalAccount(mockState, 'unknown'),
-      ).toBeUndefined();
-    });
-
-    it('returns the account', () => {
-      expect(
-        selectors.getInternalAccount(
-          mockState,
-          'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
-        ),
-      ).toStrictEqual(
-        mockState.metamask.internalAccounts.accounts[
-          'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3'
-        ],
-      );
     });
   });
 
@@ -926,28 +829,6 @@ describe('Selectors', () => {
       expect(selectors.getHardwareWalletType(mockStateWithTrezor)).toBe(
         KeyringType.trezor,
       );
-    });
-  });
-
-  it('returns selected internalAccount', () => {
-    expect(selectors.getSelectedInternalAccount(mockState)).toStrictEqual({
-      address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-      id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
-      metadata: {
-        name: 'Test Account',
-        keyring: {
-          type: 'HD Key Tree',
-        },
-      },
-      options: {},
-      methods: [
-        'personal_sign',
-        'eth_signTransaction',
-        'eth_signTypedData_v1',
-        'eth_signTypedData_v3',
-        'eth_signTypedData_v4',
-      ],
-      type: 'eip155:eoa',
     });
   });
 

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -13,7 +13,8 @@ import txHelper from '../helpers/utils/tx-helper';
 import { SmartTransactionStatus } from '../../shared/constants/transaction';
 import { hexToDecimal } from '../../shared/modules/conversion.utils';
 import { getProviderConfig } from '../ducks/metamask/metamask';
-import { getCurrentChainId, getSelectedInternalAccount } from './selectors';
+import { getCurrentChainId } from './selectors';
+import { getSelectedInternalAccount } from './accounts';
 import { hasPendingApprovals, getApprovalRequestsByType } from './approvals';
 import {
   createDeepEqualSelector,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -56,11 +56,13 @@ import {
   getPermissionSubjects,
   getFirstSnapInstallOrUpdateRequest,
   ///: END:ONLY_INCLUDE_IF
+  getSelectedNetworkClientId,
+} from '../selectors';
+import {
   getInternalAccountByAddress,
   getSelectedInternalAccount,
   getInternalAccounts,
-  getSelectedNetworkClientId,
-} from '../selectors';
+} from '../selectors/accounts';
 import {
   computeEstimatedGasLimit,
   initializeSendState,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26205?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/512

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
