### PR TITLE
fix: limit port stream message size (object-sizeOf)

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -686,13 +686,10 @@ function trackDappView(remotePort) {
 function filterStreamMessageSize(portStream, maxSize = MAX_MESSAGE_LENGTH) {
   const filterStream = createFilterStream(portStream, {
     inputFilter: (msg, _encoding) => {
-      const start = new Date()
       try {
         assertObjectMaxSize(msg, maxSize)
-        console.log('time', (new Date()) - start)
         return true
       } catch (err) {
-        console.log('time', (new Date()) - start)
         console.warn(
           'message exceeded size limit and will be dropped', err
         );

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -80,6 +80,7 @@ import { createOffscreen } from './offscreen';
 /* eslint-enable import/first */
 
 import { TRIGGER_TYPES } from './controllers/metamask-notifications/constants/notification-schema';
+import { assertObjectMaxSize } from '../../shared/modules/sizeof';
 
 // eslint-disable-next-line @metamask/design-tokens/color-no-hex
 const BADGE_COLOR_APPROVAL = '#0376C9';
@@ -685,16 +686,17 @@ function trackDappView(remotePort) {
 function filterStreamMessageSize(portStream, maxSize = MAX_MESSAGE_LENGTH) {
   const filterStream = createFilterStream(portStream, {
     inputFilter: (msg, _encoding) => {
-      const stringifiedMsg = JSON.stringify(msg);
-      if (stringifiedMsg.length < maxSize) {
-        return true;
+      const start = new Date()
+      try {
+        assertObjectMaxSize(msg, maxSize)
+        console.log('time', (new Date()) - start)
+        return true
+      } catch (err) {
+        console.warn(
+          'message exceeded size limit and will be dropped', err
+        );
+        console.log('time', (new Date()) - start)
       }
-      console.warn(
-        `message exceeded size limit and will be dropped: ${stringifiedMsg.slice(
-          0,
-          1000,
-        )}...`,
-      );
       return false;
     },
   });

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -686,10 +686,13 @@ function trackDappView(remotePort) {
 function filterStreamMessageSize(portStream, maxSize = MAX_MESSAGE_LENGTH) {
   const filterStream = createFilterStream(portStream, {
     inputFilter: (msg, _encoding) => {
+      const start = new Date();
       try {
         assertObjectMaxSize(msg, maxSize)
+        console.log('time', start, (new Date()) - start)
         return true
       } catch (err) {
+        console.log('time', start, (new Date()) - start)
         console.warn(
           'message exceeded size limit and will be dropped', err
         );

--- a/shared/modules/sizeof.js
+++ b/shared/modules/sizeof.js
@@ -1,102 +1,108 @@
-/ Copyright 2014 Andrei Karpushonak
+// Copyright 2014 Andrei Karpushonak
 
-'use strict'
+'use strict';
 
-const ECMA_SIZES = require('./byte_size')
-const Buffer = require('buffer/').Buffer
+const ECMA_SIZES = {
+  STRING: 2,
+  BOOLEAN: 4,
+  BYTES: 4,
+  NUMBER: 8,
+  Int8Array: 1,
+  Uint8Array: 1,
+  Uint8ClampedArray: 1,
+  Int16Array: 2,
+  Uint16Array: 2,
+  Int32Array: 4,
+  Uint32Array: 4,
+  Float32Array: 4,
+  Float64Array: 8,
+};
 
 const isNodePlatform =
-  typeof process === 'object' && typeof require === 'function'
+  typeof process === 'object' && typeof require === 'function';
 
-function allProperties (obj) {
-  const stringProperties = []
+function allProperties(obj) {
+  const stringProperties = [];
   for (const prop in obj) {
-    stringProperties.push(prop)
+    if (Object.hasOwn(obj, prop)) {
+      stringProperties.push(prop);
+    }
   }
   if (Object.getOwnPropertySymbols) {
-    const symbolProperties = Object.getOwnPropertySymbols(obj)
-    Array.prototype.push.apply(stringProperties, symbolProperties)
+    const symbolProperties = Object.getOwnPropertySymbols(obj);
+    Array.prototype.push.apply(stringProperties, symbolProperties);
   }
-  return stringProperties
+  return stringProperties;
 }
 
-function sizeOfObject (seen, object) {
-  if (object == null) {
-    return 0
+function sizeOfObject(state, object) {
+  if (object === null) {
+    return;
   }
 
-  let bytes = 0
-  const properties = allProperties(object)
+  const properties = allProperties(object);
+  const calc = getCalculator(state);
   for (let i = 0; i < properties.length; i++) {
-    const key = properties[i]
-    // Do not recalculate circular references
-    if (typeof object[key] === 'object' && object[key] !== null) {
-      if (seen.has(object[key])) {
-        continue
-      }
-      seen.add(object[key])
-    }
-
-    bytes += getCalculator(seen)(key)
-    try {
-      bytes += getCalculator(seen)(object[key])
-    } catch (ex) {
-      if (ex instanceof RangeError) {
-        // circular reference detected, final result might be incorrect
-        // let's be nice and not throw an exception
-        bytes = 0
-      }
-    }
+    const key = properties[i];
+    calc(key);
+    calc(object[key]);
   }
-
-  return bytes
 }
 
-function getCalculator (seen) {
-  return function calculator (object) {
+function getCalculator(state) {
+  return function calculator(object) {
+    if (state.size > state.maxSize) {
+      throw new Error('object exceeded max size');
+    }
     if (Buffer.isBuffer(object)) {
-      return object.length
+      state.size += object.length;
     }
 
-    const objectType = typeof object
+    const objectType = typeof object;
     switch (objectType) {
       case 'string':
         // https://stackoverflow.com/questions/68789144/how-much-memory-do-v8-take-to-store-a-string/68791382#68791382
-        return isNodePlatform
+        state.size += isNodePlatform
           ? 12 + 4 * Math.ceil(object.length / 4)
-          : object.length * ECMA_SIZES.STRING
+          : object.length * ECMA_SIZES.STRING;
+        return;
       case 'boolean':
-        return ECMA_SIZES.BOOLEAN
+        state.size += ECMA_SIZES.BOOLEAN;
+        return;
       case 'number':
-        return ECMA_SIZES.NUMBER
+        state.size += ECMA_SIZES.NUMBER;
+        return;
       case 'symbol': {
-        const isGlobalSymbol = Symbol.keyFor && Symbol.keyFor(object)
-        return isGlobalSymbol
+        const isGlobalSymbol = Symbol.keyFor && Symbol.keyFor(object);
+        state.size += isGlobalSymbol
           ? Symbol.keyFor(object).length * ECMA_SIZES.STRING
-          : (object.toString().length - 8) * ECMA_SIZES.STRING
+          : (object.toString().length - 8) * ECMA_SIZES.STRING;
+        return;
       }
       case 'object':
         if (Array.isArray(object)) {
-          return object.map(getCalculator(seen)).reduce(function (acc, curr) {
-            return acc + curr
-          }, 0)
+          const calc = getCalculator(state);
+          object.forEach((value) => {
+            calc(value);
+          });
         } else {
-          return sizeOfObject(seen, object)
+          sizeOfObject(state, object);
         }
+        return
       default:
-        return 0
+        return
     }
-  }
+  };
 }
 
 /**
  * Main module's entry point
  * Calculates Bytes for the provided parameter
+ *
  * @param object - handles object/string/boolean/buffer
+ * @param maxSize
  * @returns {*}
  */
-function sizeof (object) {
-  return getCalculator(new WeakSet())(object)
+export function assertObjectMaxSize(object, maxSize = 0) {
+  getCalculator({ size: 0, maxSize })(object);
 }
-
-module.exports = sizeof

--- a/shared/modules/sizeof.js
+++ b/shared/modules/sizeof.js
@@ -1,0 +1,102 @@
+/ Copyright 2014 Andrei Karpushonak
+
+'use strict'
+
+const ECMA_SIZES = require('./byte_size')
+const Buffer = require('buffer/').Buffer
+
+const isNodePlatform =
+  typeof process === 'object' && typeof require === 'function'
+
+function allProperties (obj) {
+  const stringProperties = []
+  for (const prop in obj) {
+    stringProperties.push(prop)
+  }
+  if (Object.getOwnPropertySymbols) {
+    const symbolProperties = Object.getOwnPropertySymbols(obj)
+    Array.prototype.push.apply(stringProperties, symbolProperties)
+  }
+  return stringProperties
+}
+
+function sizeOfObject (seen, object) {
+  if (object == null) {
+    return 0
+  }
+
+  let bytes = 0
+  const properties = allProperties(object)
+  for (let i = 0; i < properties.length; i++) {
+    const key = properties[i]
+    // Do not recalculate circular references
+    if (typeof object[key] === 'object' && object[key] !== null) {
+      if (seen.has(object[key])) {
+        continue
+      }
+      seen.add(object[key])
+    }
+
+    bytes += getCalculator(seen)(key)
+    try {
+      bytes += getCalculator(seen)(object[key])
+    } catch (ex) {
+      if (ex instanceof RangeError) {
+        // circular reference detected, final result might be incorrect
+        // let's be nice and not throw an exception
+        bytes = 0
+      }
+    }
+  }
+
+  return bytes
+}
+
+function getCalculator (seen) {
+  return function calculator (object) {
+    if (Buffer.isBuffer(object)) {
+      return object.length
+    }
+
+    const objectType = typeof object
+    switch (objectType) {
+      case 'string':
+        // https://stackoverflow.com/questions/68789144/how-much-memory-do-v8-take-to-store-a-string/68791382#68791382
+        return isNodePlatform
+          ? 12 + 4 * Math.ceil(object.length / 4)
+          : object.length * ECMA_SIZES.STRING
+      case 'boolean':
+        return ECMA_SIZES.BOOLEAN
+      case 'number':
+        return ECMA_SIZES.NUMBER
+      case 'symbol': {
+        const isGlobalSymbol = Symbol.keyFor && Symbol.keyFor(object)
+        return isGlobalSymbol
+          ? Symbol.keyFor(object).length * ECMA_SIZES.STRING
+          : (object.toString().length - 8) * ECMA_SIZES.STRING
+      }
+      case 'object':
+        if (Array.isArray(object)) {
+          return object.map(getCalculator(seen)).reduce(function (acc, curr) {
+            return acc + curr
+          }, 0)
+        } else {
+          return sizeOfObject(seen, object)
+        }
+      default:
+        return 0
+    }
+  }
+}
+
+/**
+ * Main module's entry point
+ * Calculates Bytes for the provided parameter
+ * @param object - handles object/string/boolean/buffer
+ * @returns {*}
+ */
+function sizeof (object) {
+  return getCalculator(new WeakSet())(object)
+}
+
+module.exports = sizeof


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. 
-->

## **Description**

Attempt at using analysis of the actual message object to determine if the request is too large or not. Uses the [object-sizeOf](https://github.com/miktam/sizeof) package as a base. Seems to be about 3x faster than the JSON.stringify approach

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26208?quickstart=1)

## **Related issues**

See: https://github.com/MetaMask/metamask-extension/pull/26204

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
