### PR TITLE
fix: flaky test `Sentry errors before initialization, after opting into metrics @no-mmi should send error events in background`

### DIFF
--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -315,7 +315,6 @@ describe('Sentry errors', function () {
           }, 3000);
 
           const [mockedRequest] = await mockedEndpoint.getSeenRequests();
-
           const mockTextBody = (await mockedRequest.body.getText()).split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
 

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -173,7 +173,7 @@ function getMissingProperties(complete, object) {
 describe('Sentry errors', function () {
   const migrationError =
     process.env.SELENIUM_BROWSER === Browser.CHROME
-      ? `Cannot read properties of undefined (reading 'version')`
+      ? `"type":"TypeError","value":"Cannot read properties of undefined (reading 'version')`
       : 'meta is undefined';
   async function mockSentryMigratorError(mockServer) {
     return await mockServer
@@ -313,20 +313,6 @@ describe('Sentry errors', function () {
             const isPending = await mockedEndpoint.isPending();
             return isPending === false;
           }, 3000);
-
-          const [mockedRequest] = await mockedEndpoint.getSeenRequests();
-          const mockTextBody = (await mockedRequest.body.getText()).split('\n');
-          const mockJsonBody = JSON.parse(mockTextBody[2]);
-          const { level } = mockJsonBody;
-          const [{ type, value }] = mockJsonBody.exception.values;
-
-          // Left for debugging purposes
-          console.log(mockJsonBody.exception.values);
-
-          // Verify request
-          assert.equal(type, 'TypeError');
-          assert(value.includes(migrationError));
-          assert.equal(level, 'error');
         },
       );
     });

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -318,9 +318,14 @@ describe('Sentry errors', function () {
           const mockTextBody = (await mockedRequest.body.getText()).split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
           // Verify request
+          const escapedMigrationError = migrationError.replace(
+            /[.*+?^${}()|[\]\\]/gu,
+            '\\$&',
+          );
+          const migrationErrorRegex = new RegExp(escapedMigrationError, 'u');
           assert.match(
             JSON.stringify(mockJsonBody.exception),
-            /"type":"TypeError","value":"Cannot read properties of undefined \(reading 'version'\)"/u,
+            migrationErrorRegex,
           );
         },
       );

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -319,6 +319,10 @@ describe('Sentry errors', function () {
           const mockJsonBody = JSON.parse(mockTextBody[2]);
           const { level } = mockJsonBody;
           const [{ type, value }] = mockJsonBody.exception.values;
+
+          // Left for debugging purposes
+          console.log(mockJsonBody.exception.values);
+
           // Verify request
           assert.equal(type, 'TypeError');
           assert(value.includes(migrationError));

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -313,6 +313,16 @@ describe('Sentry errors', function () {
             const isPending = await mockedEndpoint.isPending();
             return isPending === false;
           }, 3000);
+
+          const [mockedRequest] = await mockedEndpoint.getSeenRequests();
+
+          const mockTextBody = (await mockedRequest.body.getText()).split('\n');
+          const mockJsonBody = JSON.parse(mockTextBody[2]);
+
+          // Verify request
+          assert(
+            JSON.stringify(mockJsonBody.exception).includes(migrationError),
+          );
         },
       );
     });

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -320,7 +320,7 @@ describe('Sentry errors', function () {
           // Verify request
           assert.match(
             JSON.stringify(mockJsonBody.exception),
-            RegExp(migrationError).
+            /"type":"TypeError","value":"Cannot read properties of undefined \(reading 'version'\)"/u,
           );
         },
       );

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -317,7 +317,6 @@ describe('Sentry errors', function () {
           const [mockedRequest] = await mockedEndpoint.getSeenRequests();
           const mockTextBody = (await mockedRequest.body.getText()).split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
-
           // Verify request
           assert(
             JSON.stringify(mockJsonBody.exception).includes(migrationError),

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -318,8 +318,9 @@ describe('Sentry errors', function () {
           const mockTextBody = (await mockedRequest.body.getText()).split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
           // Verify request
-          assert(
-            JSON.stringify(mockJsonBody.exception).includes(migrationError),
+          assert.match(
+            JSON.stringify(mockJsonBody.exception),
+            RegExp(migrationError).
           );
         },
       );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
[The test is flaky](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/94004/workflows/25f428d4-8fcb-4aca-8ddb-49edb51b57cf/jobs/3499122/tests) as sometimes we get a different error in the mocked endpoint, `Error: Could not establish connection. Receiving end does not exist`, instead of the expected one. This is because the condition for entering into the mock is not strict enough, and both errors include `value":"Cannot read properties of undefined (reading 'version')` in their body.

The solution here is:
- make the condition mock more strict, to make sure we capture the error we want (not the `receiving end` one)
- verify that this specific request is mocked - no need to assert on the json body as we already have this in the mock condition, however we leave it for debugging purposes. The change that has been made, is to assert the complete error all in once, so we get a more meaningful assertion and failure (if that's the case)


![Screenshot from 2024-07-30 08-32-30](https://github.com/user-attachments/assets/95e56014-6147-4a98-8449-43be44ad7380)

Case 1: the same mock, enters in the condition, with the error `Error","value":"Could not establish connection`, this will make the test fail.

```
{"exception":{"values":[{"type":"Error","value":"Could not establish connection. Receiving end does not exist.","stacktrace":{"frames":[{"filename":"/metamask/common-8.js","function":"wrappedSendMessageCallback","in_app":true,"lineno":15202,"colno":20}]},"mechanism":{"type":"onunhandledrejection","handled":false}}]},"level":"error","platform":"javascript","request":{"url":"/metamask/scripts/app-init.js","headers":{"User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"}},"event_id":"350b00b955444903ae0e4572268eba8b","timestamp":1722323826.34,"environment":"development","release":"11.16.15","sdk":{"integrations":["InboundFilters","FunctionToString","BrowserApiErrors","Breadcrumbs","GlobalHandlers","LinkedErrors","Dedupe","HttpContext","FilterEvents","ExtraErrorData","BrowserProfiling"],"name":"sentry.javascript.browser","version":"8.19.0","packages":[{"name":"npm:@sentry/browser","version":"8.19.0"}]},"breadcrumbs":[{"timestamp":1722323826.33,"category":"sentry.event","event_id":"f84aa75ba52f450fa08c535372648a46","level":"error","message":"TypeError: Cannot read properties of undefined (reading 'version')"}],"contexts":{"trace":{"trace_id":"9dc46f6dfa2f42918276344dd54426f7","span_id":"b72b97bd6b5a7d97"},"Error":{}},"extra":{"appState":{"browser":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36","version":"11.16.15","persistedState":{"data":{"AuthenticationController":{"isSignedIn":"boolean"},"UserStorageController":{"isProfileSyncingEnabled":true},"MetamaskNotificationsController":{"subscriptionAccountsSeen":"object","isFeatureAnnouncementsEnabled":"boolean","isMetamaskNotificationsEnabled":"boolean","isMetamaskNotificationsFeatureSeen":"boolean","metamaskNotificationsList":"object","metamaskNotificationsReadList":"object"},"AccountsController":{"internalAccounts":{"selectedAccount":"string","accounts":"object"}},"AlertController":{"alertEnabledness":{"unconnectedAccount":true,"web3ShimUsage":true},"unconnectedAccountAlertShownOrigins":"object","web3ShimUsageOrigins":"object"},"AnnouncementController":{"announcements":"object"},"NetworkOrderController":{"orderedNetworkList":{"0":"object","1":"object","2":"object"}},"AccountOrderController":{"pinnedAccountList":{},"hiddenAccountList":{}},"AppStateController":{"browserEnvironment":{},"nftsDropdownState":{},"connectedStatusPopoverHasBeenShown":true,"termsOfUseLastAgreed":1722323821698,"defaultHomeActiveTabName":null,"fullScreenGasPollTokens":[],"notificationGasPollTokens":[],"popupGasPollTokens":[],"qrHardware":{},"recoveryPhraseReminderHasBeenShown":true,"recoveryPhraseReminderLastShown":1722323821698,"showTestnetMessageInDropdown":true,"trezorModel":null,"newPrivacyPolicyToastClickedOrClosed":"boolean","newPrivacyPolicyToastShownDate":"number","usedNetworks":{"0x1":true,"0xe708":true,"0x5":true,"0x539":true},"snapsInstallPrivacyWarningShown":true},"CurrencyController":{"currentCurrency":"usd","currencyRates":{"ETH":{"conversionDate":1665507600,"conversionRate":1700,"usdConversionRate":1700}}},"GasFeeController":{"estimatedGasFeeTimeBounds":{},"gasEstimateType":"none","gasFeeEstimates":{}},"KeyringController":{"vault":"string"},"MetaMetricsController":{"eventsBeforeMetricsOptIn":"object","fragments":"object","metaMetricsId":"fake-metrics-id","participateInMetaMetrics":true,"dataCollectionForMarketing":"boolean","traits":"object"},"NetworkController":{"selectedNetworkClientId":"string","networksMetadata":{"networkConfigurationId":{"EIPS":{},"status":"available"}},"providerConfig":{"chainId":"0x539","nickname":"Localhost 8545","rpcPrefs":"object","rpcUrl":"string","ticker":"ETH","type":"rpc","id":"networkConfigurationId"},"networkConfigurations":"object"},"OnboardingController":{"completedOnboarding":true,"firstTimeFlowType":"import","onboardingTabs":"object","seedPhraseBackedUp":true},"PermissionController":{"subjects":"object"},"PreferencesController":{"advancedGasFee":null,"currentLocale":"en","useExternalServices":"boolean","dismissSeedBackUpReminder":true,"featureFlags":{},"forgottenPassword":false,"identities":"object","ipfsGateway":"string","knownMethodData":"object","ledgerTransportType":"webhid","lostIdentities":"object","openSeaEnabled":false,"preferences":{"hideZeroBalanceTokens":false,"showExtensionInFullSizeView":false,"showFiatInTestnets":false,"showTestNetworks":false,"smartTransactionsOptInStatus":false,"useNativeCurrencyAsPrimaryCurrency":true,"petnamesEnabled":true,"showTokenAutodetectModal":"boolean","isRedesignedConfirmationsDeveloperEnabled":"boolean","showConfirmationAdvancedDetails":false},"selectedAddress":"string","theme":"light","useBlockie":false,"useNftDetection":false,"useNonceField":false,"usePhishDetect":true,"useTokenDetection":false,"useCurrencyRateCheck":true,"useMultiAccountBalanceChecker":true,"useRequestQueue":true},"QueuedRequestController":{"queuedRequestCount":0},"SelectedNetworkController":{"domains":"object"},"SmartTransactionsController":{"smartTransactionsState":{"fees":{},"liveness":true,"smartTransactions":"object"}},"SubjectMetadataController":{"subjectMetadata":"object"},"TokensController":{"allDetectedTokens":{},"allIgnoredTokens":{},"allTokens":{},"detectedTokens":"object","ignoredTokens":"object","tokens":"object"},"TransactionController":{"transactions":"object"},"config":"object","firstTimeInfo":"object"}}}}}
```

Case 2: the same mock, enters in the condition, with the error `"TypeError","value":"Cannot read properties of undefined (reading 'version')","stacktrace":`, this will make the test pass.

```
{"exception":{"values":[{"type":"TypeError","value":"Cannot read properties of undefined (reading 'version')","stacktrace":{"frames":[{"filename":"/metamask/background-5.js","function":"async initBackground","in_app":true,"lineno":36184,"colno":5},{"filename":"/metamask/background-5.js","function":"async initialize","in_app":true,"lineno":35538,"colno":22},{"filename":"/metamask/background-5.js","function":"loadStateFromPersistence","in_app":true,"lineno":35696,"colno":34},{"filename":"/metamask/background-0.js","function":"Migrator.migrateData","in_app":true,"lineno":12867,"colno":47},{"filename":"<anonymous>","function":"Array.filter","in_app":true},{"filename":"/metamask/background-0.js","function":"migrationIsPending","in_app":true,"lineno":12908,"colno":53}]},"mechanism":{"type":"onunhandledrejection","handled":false}}]},"level":"error","platform":"javascript","request":{"url":"/metamask/scripts/app-init.js","headers":{"User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"}},"event_id":"82038055aaf44c82b48b4b8c46fed6f8","timestamp":1722323813.849,"environment":"development","release":"11.16.15","sdk":{"integrations":["InboundFilters","FunctionToString","BrowserApiErrors","Breadcrumbs","GlobalHandlers","LinkedErrors","Dedupe","HttpContext","FilterEvents","ExtraErrorData","BrowserProfiling"],"name":"sentry.javascript.browser","version":"8.19.0","packages":[{"name":"npm:@sentry/browser","version":"8.19.0"}]},"contexts":{"trace":{"trace_id":"c0a2d394093b4f578d140afe81cbb141","span_id":"9ce7001290457fcc"},"TypeError":{}},"extra":{"appState":{"browser":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36","version":"11.16.15","persistedState":{"data":{"AuthenticationController":{"isSignedIn":"boolean"},"UserStorageController":{"isProfileSyncingEnabled":true},"MetamaskNotificationsController":{"subscriptionAccountsSeen":"object","isFeatureAnnouncementsEnabled":"boolean","isMetamaskNotificationsEnabled":"boolean","isMetamaskNotificationsFeatureSeen":"boolean","metamaskNotificationsList":"object","metamaskNotificationsReadList":"object"},"AccountsController":{"internalAccounts":{"selectedAccount":"string","accounts":"object"}},"AlertController":{"alertEnabledness":{"unconnectedAccount":true,"web3ShimUsage":true},"unconnectedAccountAlertShownOrigins":"object","web3ShimUsageOrigins":"object"},"AnnouncementController":{"announcements":"object"},"NetworkOrderController":{"orderedNetworkList":{"0":"object","1":"object","2":"object"}},"AccountOrderController":{"pinnedAccountList":{},"hiddenAccountList":{}},"AppStateController":{"browserEnvironment":{},"nftsDropdownState":{},"connectedStatusPopoverHasBeenShown":true,"termsOfUseLastAgreed":1722323809392,"defaultHomeActiveTabName":null,"fullScreenGasPollTokens":[],"notificationGasPollTokens":[],"popupGasPollTokens":[],"qrHardware":{},"recoveryPhraseReminderHasBeenShown":true,"recoveryPhraseReminderLastShown":1722323809392,"showTestnetMessageInDropdown":true,"trezorModel":null,"newPrivacyPolicyToastClickedOrClosed":"boolean","newPrivacyPolicyToastShownDate":"number","usedNetworks":{"0x1":true,"0xe708":true,"0x5":true,"0x539":true},"snapsInstallPrivacyWarningShown":true},"CurrencyController":{"currentCurrency":"usd","currencyRates":{"ETH":{"conversionDate":1665507600,"conversionRate":1700,"usdConversionRate":1700}}},"GasFeeController":{"estimatedGasFeeTimeBounds":{},"gasEstimateType":"none","gasFeeEstimates":{}},"KeyringController":{"vault":"string"},"MetaMetricsController":{"eventsBeforeMetricsOptIn":"object","fragments":"object","metaMetricsId":"fake-metrics-id","participateInMetaMetrics":true,"dataCollectionForMarketing":"boolean","traits":"object"},"NetworkController":{"selectedNetworkClientId":"string","networksMetadata":{"networkConfigurationId":{"EIPS":{},"status":"available"}},"providerConfig":{"chainId":"0x539","nickname":"Localhost 8545","rpcPrefs":"object","rpcUrl":"string","ticker":"ETH","type":"rpc","id":"networkConfigurationId"},"networkConfigurations":"object"},"OnboardingController":{"completedOnboarding":true,"firstTimeFlowType":"import","onboardingTabs":"object","seedPhraseBackedUp":true},"PermissionController":{"subjects":"object"},"PreferencesController":{"advancedGasFee":null,"currentLocale":"en","useExternalServices":"boolean","dismissSeedBackUpReminder":true,"featureFlags":{},"forgottenPassword":false,"identities":"object","ipfsGateway":"string","knownMethodData":"object","ledgerTransportType":"webhid","lostIdentities":"object","openSeaEnabled":false,"preferences":{"hideZeroBalanceTokens":false,"showExtensionInFullSizeView":false,"showFiatInTestnets":false,"showTestNetworks":false,"smartTransactionsOptInStatus":false,"useNativeCurrencyAsPrimaryCurrency":true,"petnamesEnabled":true,"showTokenAutodetectModal":"boolean","isRedesignedConfirmationsDeveloperEnabled":"boolean","showConfirmationAdvancedDetails":false},"selectedAddress":"string","theme":"light","useBlockie":false,"useNftDetection":false,"useNonceField":false,"usePhishDetect":true,"useTokenDetection":false,"useCurrencyRateCheck":true,"useMultiAccountBalanceChecker":true,"useRequestQueue":true},"QueuedRequestController":{"queuedRequestCount":0},"SelectedNetworkController":{"domains":"object"},"SmartTransactionsController":{"smartTransactionsState":{"fees":{},"liveness":true,"smartTransactions":"object"}},"SubjectMetadataController":{"subjectMetadata":"object"},"TokensController":{"allDetectedTokens":{},"allIgnoredTokens":{},"allTokens":{},"detectedTokens":"object","ignoredTokens":"object","tokens":"object"},"TransactionController":{"transactions":"object"},"config":"object","firstTimeInfo":"object"}}}}}
```



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26216?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26217

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
