### PR TITLE
fix: removes showing the token detection modal

### DIFF
--- a/app/scripts/migrations/124.ts
+++ b/app/scripts/migrations/124.ts
@@ -1,0 +1,34 @@
+import { cloneDeep } from 'lodash';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 124;
+
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformState(state: Record<string, any>) {
+  const preferencesControllerState = state?.PreferencesController;
+
+  if (preferencesControllerState?.preferences) {
+    const isBasicFunctionalityToggleEnabled =
+      preferencesControllerState?.useExternalServices;
+    const isTokenDetectionEnabled =
+      preferencesControllerState?.useTokenDetection;
+    if (isBasicFunctionalityToggleEnabled && !isTokenDetectionEnabled) {
+      preferencesControllerState.useTokenDetection = true;
+    }
+  }
+
+  return state;
+}

--- a/app/scripts/migrations/125.test.ts
+++ b/app/scripts/migrations/125.test.ts
@@ -1,0 +1,52 @@
+import { migrate, version } from './125';
+
+const oldVersion = 124;
+
+describe('migration #125', () => {
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('does nothing if no preferences controller state is set', async () => {
+    const oldState = {
+      OtherController: {},
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(oldState);
+  });
+
+  it('turns token detection on if basic functionality is on', async () => {
+    const oldState = {
+      PreferencesController: {
+        useExternalServices: true,
+        useTokenDetection: false,
+      },
+    };
+
+    const expectedState = {
+      PreferencesController: {
+        useExternalServices: true,
+        useTokenDetection: true,
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(expectedState);
+  });
+});

--- a/app/scripts/migrations/125.ts
+++ b/app/scripts/migrations/125.ts
@@ -5,7 +5,7 @@ type VersionedData = {
   data: Record<string, unknown>;
 };
 
-export const version = 124;
+export const version = 125;
 
 export async function migrate(
   originalVersionedData: VersionedData,

--- a/app/scripts/migrations/125.ts
+++ b/app/scripts/migrations/125.ts
@@ -16,11 +16,12 @@ export async function migrate(
   return versionedData;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function transformState(state: Record<string, any>) {
-  const preferencesControllerState = state?.PreferencesController;
+function transformState(state: Record<string, unknown>) {
+  const preferencesControllerState = state?.PreferencesController as
+    | Record<string, unknown>
+    | undefined;
 
-  if (preferencesControllerState?.preferences) {
+  if (preferencesControllerState) {
     const isBasicFunctionalityToggleEnabled =
       preferencesControllerState?.useExternalServices;
     const isTokenDetectionEnabled =

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -135,6 +135,7 @@ const migrations = [
   require('./121'),
   require('./122'),
   require('./123'),
+  require('./124'),
 ];
 
 export default migrations;

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -14,7 +14,6 @@ import RecoveryPhraseReminder from '../../components/app/recovery-phrase-reminde
 import WhatsNewPopup from '../../components/app/whats-new-popup';
 import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 import SmartTransactionsOptInModal from '../../components/app/smart-transactions/smart-transactions-opt-in-modal';
-import AutoDetectTokenModal from '../../components/app/assets/auto-detect-token/auto-detect-token-modal';
 import AutoDetectNftModal from '../../components/app/assets/auto-detect-nft/auto-detect-nft-modal';
 ///: END:ONLY_INCLUDE_IF
 import HomeNotification from '../../components/app/home-notification';
@@ -156,7 +155,6 @@ export default class Home extends PureComponent {
     announcementsToShow: PropTypes.bool.isRequired,
     onboardedInThisUISession: PropTypes.bool,
     isSmartTransactionsOptInModalAvailable: PropTypes.bool.isRequired,
-    isShowTokenAutodetectModal: PropTypes.bool.isRequired,
     isShowNftAutodetectModal: PropTypes.bool.isRequired,
     ///: END:ONLY_INCLUDE_IF
     newNetworkAddedConfigurationId: PropTypes.string,
@@ -996,9 +994,6 @@ export default class Home extends PureComponent {
       firstTimeFlowType,
       newNetworkAddedConfigurationId,
       isSmartTransactionsOptInModalAvailable,
-      isShowTokenAutodetectModal,
-      setTokenAutodetectModal,
-      setShowTokenAutodetectModalOnUpgrade,
       isShowNftAutodetectModal,
       setNftAutodetectModal,
       ///: END:ONLY_INCLUDE_IF
@@ -1027,16 +1022,10 @@ export default class Home extends PureComponent {
       showWhatsNewPopup &&
       !showSmartTransactionsOptInModal;
 
-    const showAutoDetectionModal =
-      canSeeModals &&
-      isShowTokenAutodetectModal &&
-      !showSmartTransactionsOptInModal &&
-      !showWhatsNew;
     // TODO show ths after token autodetect modal is merged
     const showNftAutoDetectionModal =
       canSeeModals &&
       isShowNftAutodetectModal &&
-      !showAutoDetectionModal &&
       !showSmartTransactionsOptInModal &&
       !showWhatsNew;
 
@@ -1063,14 +1052,6 @@ export default class Home extends PureComponent {
           <SmartTransactionsOptInModal
             isOpen={showSmartTransactionsOptInModal}
             hideWhatsNewPopup={hideWhatsNewPopup}
-          />
-
-          <AutoDetectTokenModal
-            isOpen={showAutoDetectionModal}
-            onClose={setTokenAutodetectModal}
-            setShowTokenAutodetectModalOnUpgrade={
-              setShowTokenAutodetectModalOnUpgrade
-            }
           />
 
           <AutoDetectNftModal


### PR DESCRIPTION
## **Description**

This PR(To be cherry picked for v12.3.0)

1- Removes showing the token detection modal
2- Adds new migration to enable token autodetection if user has basic functionality toggle on.

This migration will be reverted for v 12.4.0 in case user toggles the token detection feature OFF again even if we have enabled it by default for this feature.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26220?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create a new user
2. Go to security and privacy and turn off the token detection toggle
3. Go back to home page
4. You should not see the token detection modal

Users who upgrade with token detection toggle OFF and BFT ON, they should see token detection enabled.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
