### PR TITLE
fix: timeout and "Rerun failed tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,8 +389,7 @@ jobs:
           steps:
             - run:
                 name: Build beta prod
-                command: |
-                  .circleci/scripts/trigger-beta-build.sh
+                command: .circleci/scripts/trigger-beta-build.sh
             - run:
                 name: Move beta build to 'dist-beta' to avoid conflict with production build
                 command: mv ./dist ./dist-beta
@@ -463,8 +462,7 @@ jobs:
       - run: sudo corepack enable
       - run:
           name: Save Yarn version
-          command: |
-            yarn --version > /tmp/YARN_VERSION
+          command: yarn --version > /tmp/YARN_VERSION
       - restore_cache:
           keys:
             # First try to get the specific cache for the checksum of the yarn.lock file.
@@ -1086,7 +1084,7 @@ jobs:
           command: mv ./dist-test-webpack ./dist
       - run:
           name: test:e2e:chrome:webpack
-          command: timeout 20m yarn test:e2e:chrome:webpack --retries 1
+          command: .circleci/scripts/test-run-e2e.sh yarn test:e2e:chrome:webpack
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1110,8 +1108,7 @@ jobs:
       - gh/install
       - run:
           name: test:api-specs
-          command: |
-            timeout 20m yarn test:api-specs --retries 2
+          command: .circleci/scripts/test-run-e2e.sh yarn test:api-specs
           no_output_timeout: 5m
       - run:
           name: Comment on PR
@@ -1142,11 +1139,7 @@ jobs:
           command: mv ./builds-test ./builds
       - run:
           name: test:e2e:chrome
-          command: |
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:chrome --retries 1
-            fi
+          command: .circleci/scripts/test-run-e2e.sh yarn test:e2e:chrome
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1170,11 +1163,7 @@ jobs:
           command: mv ./builds-test ./builds
       - run:
           name: test:e2e:chrome:rpc
-          command: |
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:chrome:rpc --retries 1
-            fi
+          command: .circleci/scripts/test-run-e2e.sh yarn test:e2e:chrome:rpc
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1198,11 +1187,7 @@ jobs:
           command: mv ./builds-test ./builds
       - run:
           name: test:e2e:chrome:multi-provider
-          command: |
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              yarn test:e2e:chrome:multi-provider --retries 1
-            fi
+          command: .circleci/scripts/test-run-e2e.sh yarn test:e2e:chrome:multi-provider
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1225,11 +1210,7 @@ jobs:
           command: mv ./builds-test-mmi ./builds
       - run:
           name: test:e2e:chrome:rpc
-          command: |
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:chrome:rpc --retries 1 --build-type=mmi
-            fi
+          command: .circleci/scripts/test-run-e2e.sh yarn test:e2e:chrome:rpc --build-type=mmi
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1245,12 +1226,8 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: test:e2e:chrome:vault
-          command: |
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.js --browser chrome --retries 1
-            fi
+          name: test:e2e:single
+          command: .circleci/scripts/test-run-e2e.sh yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.js --browser chrome
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1274,12 +1251,7 @@ jobs:
           command: mv ./builds-test-flask-mv2 ./builds
       - run:
           name: test:e2e:firefox:flask
-          command: |
-            export ENABLE_MV3=false
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:firefox:flask --retries 1
-            fi
+          command: ENABLE_MV3=false .circleci/scripts/test-run-e2e.sh yarn test:e2e:firefox:flask
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1303,11 +1275,7 @@ jobs:
           command: mv ./builds-test-flask ./builds
       - run:
           name: test:e2e:chrome:flask
-          command: |
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:chrome:flask --retries 1
-            fi
+          command: .circleci/scripts/test-run-e2e.sh yarn test:e2e:chrome:flask
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1331,11 +1299,7 @@ jobs:
           command: mv ./builds-test-mmi ./builds
       - run:
           name: test:e2e:chrome:mmi
-          command: |
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:chrome:mmi --retries 1 --build-type=mmi
-            fi
+          command: .circleci/scripts/test-run-e2e.sh yarn test:e2e:chrome:mmi --build-type=mmi
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1357,8 +1321,7 @@ jobs:
           command: mv ./dist-test-mmi-playwright ./dist
       - run:
           name: Install chromium
-          command: |
-            yarn playwright install chromium
+          command: yarn playwright install chromium
       - run:
           name: test:e2e:chrome:mmi
           command: |
@@ -1395,8 +1358,7 @@ jobs:
           at: .
       - run:
           name: Install chromium
-          command: |
-            yarn playwright install chromium
+          command: yarn playwright install chromium
       - run:
           name: test:e2e:chrome:swap
           command: |
@@ -1432,12 +1394,7 @@ jobs:
           command: mv ./builds-test-mv2 ./builds
       - run:
           name: test:e2e:firefox
-          command: |
-            export ENABLE_MV3=false
-            if .circleci/scripts/test-run-e2e.sh
-            then
-              timeout 20m yarn test:e2e:firefox --retries 1
-            fi
+          command: ENABLE_MV3=false .circleci/scripts/test-run-e2e.sh yarn test:e2e:firefox
           no_output_timeout: 5m
       - store_artifacts:
           path: test-artifacts
@@ -1615,8 +1572,7 @@ jobs:
           command: yarn sentry:publish --build-type mmi
       - run:
           name: Create GitHub release
-          command: |
-            .circleci/scripts/release-create-gh-release.sh
+          command: .circleci/scripts/release-create-gh-release.sh
 
   job-publish-storybook:
     executor: node-browsers-small
@@ -1672,8 +1628,7 @@ jobs:
           at: .
       - run:
           name: Validate source maps
-          command: |
-            .circleci/scripts/validate-source-maps-beta.sh
+          command: .circleci/scripts/validate-source-maps-beta.sh
 
   validate-source-maps-mmi:
     executor: node-browsers-small

--- a/.circleci/scripts/test-run-e2e.sh
+++ b/.circleci/scripts/test-run-e2e.sh
@@ -11,4 +11,16 @@ then
     exit 1
 fi
 
+# Run the actual test command from the parameters
+timeout 20m "$@" --retries 1
+
+# Error code 124 means the command timed out
+if [ $? -eq 124 ]; then
+  # Once deleted, if someone tries to "Rerun failed tests" the result will be
+  # "Error: can not rerun failed tests: no failed tests could be found"
+  echo 'Timeout error, deleting the test results'
+  rm -rf test/test-results/e2e
+  exit 124
+fi
+
 exit 0


### PR DESCRIPTION
## **Description**

### The problem from Mark Stacey

> Today I learned that the "Rerun failed tests" button in CircleCI can result in some tests being skipped completely, never having been run for that commit at all.
"Rerun failed tests" will only rerun tests that had failed. It will skip tests that haven't been run at all. This is problematic when the test process exits before all tests are run, like if a test hits the 20 minute timeout we have set.

I rewrote .circleci/scripts/test-run-e2e.sh to allow `config.yml` to be simpler, and 45 lines shorter.  Now if it timeouts and someone tries to "Rerun failed tests" the result will be
`Error: can not rerun failed tests: no failed tests could be found`

So it doesn't stop you from trying, but it fails once you try.

I also removed some unnecessary `|` for line continuations.

This might not catch `no_output_timeout` failures.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26239?quickstart=1)

## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
### **Before**
### **After**
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
