### PR TITLE
fix: Fix CircleCI `create_release_pull_request` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ jobs:
   create_release_pull_request:
     executor: node-browsers-small
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run: sudo corepack enable
       - attach_workspace:
           at: .


### PR DESCRIPTION
## **Description**

The `create_release_pull_request` job has been failing since we switched to using a shallow checkout by default. It's failing because the first step of this job uses the `yarn version` command, which expects a full repository history for some reason. The script works again with a full checkout.

Example failure: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/94314/workflows/e2b01944-7607-4714-9cac-01489cce3d2e/jobs/3510394

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26246?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

I was able to reproduce the failure by running the shallow checkout steps locally, then running the `release-bump-manifest-version.sh` script. I tested that this worked by doing the same thing with a full checkout. Note that you need to set the `CI, `CIRCLECI`, and `CIRCLECI_BRANCH` environment variables for the script to work.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
