### PR TITLE
fix: Fix GitHub release description

### DIFF
--- a/.circleci/scripts/release-create-gh-release.sh
+++ b/.circleci/scripts/release-create-gh-release.sh
@@ -66,7 +66,7 @@ then
     install_github_cli
 
     printf '%s\n' 'Creating GitHub Release'
-    release_body="$(awk -v version="${tag##v}" -f .circleci/scripts/show-changelog.awk CHANGELOG.md)"
+    release_body="$(awk -v version="[${tag##v}]" -f .circleci/scripts/show-changelog.awk CHANGELOG.md)"
     hub release create \
         --attach builds/metamask-chrome-*.zip \
         --attach builds-mv2/metamask-firefox-*.zip \


### PR DESCRIPTION
## **Description**

For years our release scripts have been creating GitHub releases with empty descriptions. GitHub uses the commit message as the description as a default, which is always a merge commit in our case, whcih isn't very decsriptive. The release scripts are supposed to be setting the changelog entries for the current release as the description.

This broke when we last changed our CHANGELOG.md format. Specifically it was the release header change that broke this. We started surrounding the version number in square brackets, which the awk script did not expect.

The script that creates the GitHub release has been updated to pass in a version surrounded by square brackets to the awk script, so it is again able to find the relevant changelog entries.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26247?quickstart=1)

## **Related issues**

Fixes: #18468

## **Manual testing steps**

Start by checking out `master. Then look at the `release-create-gh-release.sh` script, and run the exact same awk command that is shown there. Replace `${tag##v}` with the release version minus the v (e.g. `12.0.0`).

Before this PR it was `awk -v version="12.0.0" -f .circleci/scripts/show-changelog.awk CHANGELOG.md`. This produces no output.

After this PR, its `awk -v version="[12.0.0]" -f .circleci/scripts/show-changelog.awk CHANGELOG.md`. This produces the correct output.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
