### PR TITLE
fix: add extra condition to prevent erroneous calls to fetch insight

### DIFF
--- a/ui/hooks/snaps/useSignatureInsights.js
+++ b/ui/hooks/snaps/useSignatureInsights.js
@@ -108,7 +108,7 @@ export function useSignatureInsights({ txData }) {
         }
       }
     }
-    if (Object.keys(txData).length > 0) {
+    if (Object.keys(txData).length > 0 && txData.msgParams !== undefined) {
       fetchInsight();
     }
     return () => {


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? Sentry was showing `undefined` parameters for a signature insight call, it was found that this was reproducible when a signature request was rejected.
2. What is the improvement/solution? Added an extra condition to prevent unnecessary calls to `fetchInsight` in the `useSignatureInsights` hook.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
