### PR TITLE
fix: Fix `create_release_pull_request` OOM error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
                   - builds-beta
 
   create_release_pull_request:
-    executor: node-browsers-small
+    executor: node-browsers-medium
     steps:
       - checkout
       - run: sudo corepack enable


### PR DESCRIPTION
## **Description**

The `create_release_pull_request` job is failing due to a lack of memory during the `yarn version` step. The `yarn version` command appears to install Yarn dependencies over again. The job where we install Yarn dependencies uses a "medium" size execution environment because we encountered similar memory issues there, but the `create_release_pull_request` job is still using small.

It has been updated to use a medium execution environment, which should be enough memory given that it's what `prep-deps` uses.

Example failure: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/94391/workflows/4fce2a9e-2762-4c07-8617-317b0781dd27/jobs/3513290

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26249?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

We should be able to reproduce this by running the job in a Docker image. But I have not tried this. Probably easier to merge it and see if it works in this case.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
