### PR TITLE
fix: improve warning in add network modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -805,6 +805,10 @@
   "blockExplorerUrlDefinition": {
     "message": "The URL used as the block explorer for this network."
   },
+  "networkUrlErrorWarning": {
+    "message": "Attackers sometimes mimic sites by making small changes to the site address. Make sure you're interacting with the intended site before you continue. Punycode version: $1",
+    "description": "$1 replaced by RPC URL for network"
+  },
   "blockExplorerView": {
     "message": "View account at $1",
     "description": "$1 replaced by URL for custom block explorer"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -805,10 +805,6 @@
   "blockExplorerUrlDefinition": {
     "message": "The URL used as the block explorer for this network."
   },
-  "networkUrlErrorWarning": {
-    "message": "Attackers sometimes mimic sites by making small changes to the site address. Make sure you're interacting with the intended site before you continue. Punycode version: $1",
-    "description": "$1 replaced by RPC URL for network"
-  },
   "blockExplorerView": {
     "message": "View account at $1",
     "description": "$1 replaced by URL for custom block explorer"
@@ -3118,6 +3114,10 @@
   },
   "networkURLDefinition": {
     "message": "The URL used to access this network."
+  },
+  "networkUrlErrorWarning": {
+    "message": "Attackers sometimes mimic sites by making small changes to the site address. Make sure you're interacting with the intended site before you continue. Punycode version: $1",
+    "description": "$1 replaced by RPC URL for network"
   },
   "networks": {
     "message": "Networks"

--- a/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.js
@@ -1,5 +1,7 @@
 import { ethErrors } from 'eth-rpc-errors';
 import React from 'react';
+import punycode from 'punycode/punycode';
+
 import {
   infuraProjectId,
   DEPRECATED_NETWORKS,
@@ -371,6 +373,13 @@ function getValues(pendingApproval, t, actions, history, data) {
             [t('blockExplorerUrl')]: t('blockExplorerUrlDefinition'),
           },
           warnings: {
+            [t('networkURL')]:
+              pendingApproval.requestData.rpcUrl ===
+              punycode.toASCII(pendingApproval.requestData.rpcUrl)
+                ? undefined
+                : t('networkUrlErrorWarning', [
+                    pendingApproval.requestData.rpcUrl,
+                  ]),
             [t('currencySymbol')]: data.currencySymbolWarning,
           },
           dictionary: {

--- a/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.test.js
+++ b/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.test.js
@@ -149,4 +149,31 @@ describe('add-ethereum-chain confirmation', () => {
       expect(getByText('https://rpcurl.test.chain')).toBeInTheDocument();
     });
   });
+
+  it('should show warning if RPC URL has special characters', async () => {
+    const testStore = {
+      metamask: {
+        ...mockBaseStore.metamask,
+        pendingApprovals: {
+          [mockApprovalId]: {
+            ...mockApproval,
+            type: MESSAGE_TYPE.ADD_ETHEREUM_CHAIN,
+            requestData: {
+              ...mockApproval.requestData,
+              rpcUrl: 'https://iոfura.io/gnosis',
+            },
+          },
+        },
+      },
+    };
+    const store = configureMockStore(middleware)(testStore);
+    const { getByText } = renderWithProvider(<Confirmation />, store);
+    await waitFor(() => {
+      expect(
+        getByText(
+          "Attackers sometimes mimic sites by making small changes to the site address. Make sure you're interacting with the intended site before you continue. Punycode version: https://iոfura.io/gnosis",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## **Description**

Improve warning in add network modal.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2365

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
