### PR TITLE
fix: handle send transaction API errors

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
@@ -41,6 +41,7 @@ type AssetPickerAmountProps = OverridingUnion<
     asset: Asset;
     amount: Amount;
     isAmountLoading?: boolean;
+    error?: string;
     /**
      * Callback for when the amount changes; disables the input when undefined
      */
@@ -57,6 +58,7 @@ export const AssetPickerAmount = ({
   amount,
   onAmountChange,
   isAmountLoading,
+  error: passedError,
   ...assetPickerProps
 }: AssetPickerAmountProps) => {
   const selectedAccount = useSelector(getSelectedInternalAccount);
@@ -170,7 +172,9 @@ export const AssetPickerAmount = ({
       </Box>
       <Box display={Display.Flex}>
         {/* Only show balance if mutable */}
-        {onAmountChange && <AssetBalance asset={asset} error={error} />}
+        {onAmountChange && (
+          <AssetBalance asset={asset} error={passedError || error} />
+        )}
         {isSwapsErrorShown && (
           <Text variant={TextVariant.bodySm} color={TextColor.errorDefault}>
             {t(swapQuotesError)}

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -238,11 +238,6 @@ export const SendPage = () => {
     try {
       await dispatch(signTransaction(history));
 
-      // prevents state update on unmounted component error
-      if (isSubmitting) {
-        setIsSubmitting(false);
-      }
-
       trackEvent({
         category: MetaMetricsEventCategory.Transactions,
         event: 'Complete',
@@ -253,9 +248,12 @@ export const SendPage = () => {
         },
       });
     } catch {
-      setIsSubmitting(false);
       setError(TRANSACTION_ERRORED_EVENT);
-      // throw error;
+    } finally {
+      // prevents state update on unmounted component error
+      if (isSubmitting) {
+        setIsSubmitting(false);
+      }
     }
   };
 

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -105,14 +105,6 @@ jest.mock('lodash', () => ({
   debounce: (fn) => fn,
 }));
 
-setBackgroundConnection({
-  addPollingTokenToAppState: jest.fn(),
-  addTransaction: jest.fn((_u, _v, cb) => {
-    cb(null, { transactionMeta: null });
-  }),
-  updateTransactionSendFlowHistory: jest.fn((_x, _y, _z, cb) => cb(null)),
-});
-
 const getTestUUIDTx = (state) => state.draftTransactions['test-uuid'];
 
 describe('Send Slice', () => {
@@ -124,6 +116,14 @@ describe('Send Slice', () => {
   let setDefaultHomeActiveTabNameStub;
 
   beforeEach(() => {
+    setBackgroundConnection({
+      addPollingTokenToAppState: jest.fn(),
+      addTransaction: jest.fn((_u, _v, cb) => {
+        cb(null, { transactionMeta: null });
+      }),
+      updateTransactionSendFlowHistory: jest.fn((_x, _y, _z, cb) => cb(null)),
+    });
+
     jest.useFakeTimers();
     getTokenStandardAndDetailsStub = jest
       .spyOn(Actions, 'getTokenStandardAndDetails')
@@ -3019,6 +3019,74 @@ describe('Send Slice', () => {
           expect(
             addTransactionAndRouteToConfirmationPageStub.mock.calls[0][0].to,
           ).toStrictEqual('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
+        });
+        it('should rethrow addTransactionAndRouteToConfirmationPage errors', async () => {
+          const tokenTransferTxState = {
+            metamask: {
+              providerConfig: {
+                chainId: CHAIN_IDS.GOERLI,
+              },
+              transactions: [
+                {
+                  id: 1,
+                  chainId: CHAIN_IDS.GOERLI,
+                  status: 'unapproved',
+                  txParams: {
+                    value: 'oldTxValue',
+                  },
+                },
+              ],
+            },
+            send: {
+              ...getInitialSendStateWithExistingTxState({
+                id: 1,
+                sendAsset: {
+                  details: {
+                    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+                  },
+                  type: 'TOKEN',
+                },
+                receiveAsset: {
+                  details: {
+                    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+                  },
+                  type: 'TOKEN',
+                },
+                recipient: {
+                  address: '4F90e18605Fd46F9F9Fab0e225D88e1ACf5F5324',
+                },
+                amount: {
+                  value: '0x1',
+                },
+              }),
+              stage: SEND_STAGES.DRAFT,
+              selectedAccount: {
+                address: '0x6784e8507A1A46443f7bDc8f8cA39bdA92A675A6',
+              },
+            },
+          };
+
+          jest.mock('../../store/actions.ts');
+
+          const store = mockStore(tokenTransferTxState);
+
+          const ERROR = new Error('rejected');
+
+          const history = { push: jest.fn() };
+
+          setBackgroundConnection({
+            addPollingTokenToAppState: jest.fn(),
+            addTransaction: jest.fn((_u, _v) => {
+              throw new Error(ERROR);
+            }),
+            updateTransactionSendFlowHistory: jest.fn((_x, _y, _z, cb) =>
+              cb(null),
+            ),
+          });
+
+          await expect(
+            store.dispatch(signTransaction(history)),
+          ).rejects.toThrow('rejected');
         });
       });
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1011,6 +1011,7 @@ export function addTransactionAndRouteToConfirmationPage(
     } catch (error) {
       dispatch(hideLoadingIndication());
       dispatch(displayWarning(error));
+      throw error;
     }
     return null;
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We are seeing a pair of sentry errors for a failing deconstruction error, `Cannot destructure property 'id' of '(intermediate value)' as it is null`:

- https://metamask.sentry.io/issues/5093909594/?project=273505&query=is%3Aunresolved+Cannot+destructure+property+%27id%27+of&referrer=issue-stream&statsPeriod=14d&stream_index=0
- https://metamask.sentry.io/issues/5093909594/?project=273505&query=is%3Aunresolved+Cannot+destructure+property+%27id%27+of&referrer=issue-stream&statsPeriod=14d&stream_index=0

This is because instead of returning an error when a transaction fails, we return `null` for the metadata.

This PR addresses the underlying issue by rethrowing the error for a failed transaction request, then adding UI treatments for the failed transaction.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26253?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Add an `Error` right before the `sendTransaction` background method in `addTransactionAndRouteToConfirmationPage`
2. Go to the send flow
3. Attempt a basic send
4. Ensure that the page does not crash and the `transactionErrored` copy is shown
## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/0342e322-4348-47bd-8bfc-3f92db8f1001


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/32ba3e75-f266-48c0-abfa-3816c4d3abd5


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
