### PR TITLE
chore: normalize separator in `content` on the `viewport` `meta` tag

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -2,7 +2,7 @@
 <html dir="ltr">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <% if (it.isMMI && !it.isTest) { %>
     <title>MetaMask Institutional</title>
     <% } else { %>

--- a/app/popup.html
+++ b/app/popup.html
@@ -2,7 +2,7 @@
 <html style="width:357px; height:600px;" dir="ltr">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>MetaMask</title>
     <link rel="stylesheet" href="./index.css">
   </head>

--- a/development/ts-migration-dashboard/app/public/index.html
+++ b/development/ts-migration-dashboard/app/public/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>Extension TypeScript Migration Status</title>
     <link rel="stylesheet" href="index.css">
   </head>


### PR DESCRIPTION
The functionality is the same as before, but it this change works around a bug in https://github.com/terser/html-minifier-terser which causes the space to be removed, and the tag to become invalid (this only affects the webpack build).

Upstream issues:

https://github.com/webdiscus/html-bundler-webpack-plugin/issues/106
https://github.com/terser/html-minifier-terser/issues/178

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**
t is the improvement/solution?


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26268?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->