### PR TITLE
test: fix flaky test Import flow @no-mmi Import wallet using Secret Recovery Phrase

### DIFF
--- a/test/e2e/tests/account/import-flow.spec.js
+++ b/test/e2e/tests/account/import-flow.spec.js
@@ -46,7 +46,7 @@ describe('Import flow @no-mmi', function () {
         ganacheOptions,
         title: this.test.fullTitle(),
       },
-      async ({ driver }) => {
+      async ({ driver, ganacheServer }) => {
         await driver.navigate();
 
         await completeImportSRPOnboardingFlow(
@@ -128,6 +128,7 @@ describe('Import flow @no-mmi', function () {
 
         // Send ETH from inside MetaMask
         // starts a send transaction
+        await locateAccountBalanceDOM(driver, ganacheServer);
         await openActionMenuAndStartSendFlow(driver);
         await driver.fill(
           'input[placeholder="Enter public address (0x) or ENS name"]',


### PR DESCRIPTION
## **Description**

This pull request addresses the flaky test: Import flow @no-mmi Import wallet using Secret Recovery Phrase 
CI failure: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/94292/workflows/550cb2c0-09db-40ef-9478-c951793146b4/jobs/3509303/parallel-runs/4

Reason of flakiness is a race condition happens after switching from account 2 to account 1 and immediately starts send flow.

Changes made is to include a step to wait and verify the account balance is loaded before starting the send flow.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26275?quickstart=1)

## **Related issues**

Fixes: #26274 

## **Manual testing steps**

Check ci (test is re-run 5 times)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
