### PR TITLE
fix: Account for persistence flag when setting initial state in `ComposableObservableStore`

### DIFF
--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -74,7 +74,12 @@ export default class ComposableObservableStore extends ObservableStore {
         );
       }
 
-      initialState[key] = store.state ?? store.getState?.();
+      const initialStoreState = store.state ?? store.getState?.();
+
+      initialState[key] =
+        this.persist && config[key].metadata
+          ? getPersistentState(initialStoreState, config[key].metadata)
+          : initialStoreState;
     }
     this.updateState(initialState);
   }


### PR DESCRIPTION
## **Description**

Fixes a bug where `ComposableObservableStore` would allow non-persistent state properties in its `initialState`. This in turn would cause state properties flagged as non-persistent to be persisted until a controller state change.

This PR addresses this by taking the `persist` flag into account when deriving the initial state for each controller. If the controller does not support `metadata` or persistence is disabled, everything should continue to work as-is.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26280?quickstart=1)
