### PR TITLE
fix: Remove dangling `snapErrors` state property

### DIFF
--- a/app/scripts/migrations/120.2.test.ts
+++ b/app/scripts/migrations/120.2.test.ts
@@ -94,4 +94,41 @@ describe('migration #120.2', () => {
 
     expect(transformedState.data).toEqual(oldState);
   });
+
+  it('strips SnapController.snapErrors if it exists', async () => {
+    const oldState = {
+      SnapController: {
+        snapErrors: {},
+        snapStates: {},
+        unencryptedSnapStates: {},
+        snaps: {},
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual({
+      SnapController: { snapStates: {}, unencryptedSnapStates: {}, snaps: {} },
+    });
+  });
+
+  it('does nothing if SnapController.snapErrors doesnt exist', async () => {
+    const oldState = {
+      SnapController: {
+        snapStates: {},
+        unencryptedSnapStates: {},
+        snaps: {},
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(oldState);
+  });
 });

--- a/app/scripts/migrations/120.2.ts
+++ b/app/scripts/migrations/120.2.ts
@@ -26,9 +26,8 @@ export async function migrate(
   return versionedData;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function transformState(state: Record<string, any>) {
-  if (hasProperty(state, 'SnapController')) {
+function transformState(state: Record<string, unknown>) {
+  if (hasProperty(state, 'SnapController') && isObject(state.SnapController)) {
     delete state.SnapController.snapErrors;
   }
 

--- a/app/scripts/migrations/120.2.ts
+++ b/app/scripts/migrations/120.2.ts
@@ -9,7 +9,7 @@ type VersionedData = {
 export const version = 120.2;
 
 /**
- * This migration removes any dangling instances of SelectedNetworkController.perDomainNetwork
+ * This migration removes any dangling instances of SelectedNetworkController.perDomainNetwork and SnapController.snapErrors
  *
  * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
  * @param originalVersionedData.meta - State metadata.
@@ -26,7 +26,12 @@ export async function migrate(
   return versionedData;
 }
 
-function transformState(state: Record<string, unknown>) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformState(state: Record<string, any>) {
+  if (hasProperty(state, 'SnapController')) {
+    delete state.SnapController.snapErrors;
+  }
+
   if (!hasProperty(state, 'SelectedNetworkController')) {
     return state;
   }


### PR DESCRIPTION
## **Description**

Adds a line to the `120.2` migration to also remove a dangling state property in the `SnapController`, that is causing sentry errors.

This property is likely dangling due to https://github.com/MetaMask/metamask-extension/pull/26280

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26282?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26281
