### PR TITLE
fix: Cherrypick f3383ac to Version v12.1

### DIFF
--- a/test/e2e/tests/settings/account-token-list.spec.js
+++ b/test/e2e/tests/settings/account-token-list.spec.js
@@ -57,6 +57,16 @@ describe('Settings', function () {
           tag: 'div',
         });
         await driver.clickElement({ text: 'Fiat', tag: 'label' });
+        // We now need to enable "Show fiat on testnet" if we are using testnets (and since our custom
+        // network during test is using a testnet chain ID, it will be considered as a test network)
+        await driver.clickElement({
+          text: 'Advanced',
+          tag: 'div',
+        });
+        await driver.clickElement('.show-fiat-on-testnets-toggle');
+        // Looks like when enabling the "Show fiat on testnet" it takes some time to re-update the
+        // overview screen, so just wait a bit here:
+        await driver.delay(1000);
 
         await driver.clickElement(
           '.settings-page__header__title-container__close-button',
@@ -68,7 +78,7 @@ describe('Settings', function () {
         const tokenListAmount = await driver.findElement(
           '.eth-overview__primary-container',
         );
-        assert.equal(await tokenListAmount.getText(), '25\nETH');
+        assert.equal(await tokenListAmount.getText(), '$42,500.00\nUSD');
         await driver.clickElement('[data-testid="account-menu-icon"]');
         const accountTokenValue = await driver.waitForSelector(
           '.multichain-account-list-item .multichain-account-list-item__asset',

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -534,17 +534,17 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
             <div
               class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
               data-testid="first-currency-display"
-              title="$880.18 USD"
+              title="0.006 ETH"
             >
               <span
                 class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
               >
-                $880.18
+                0.006
               </span>
               <span
                 class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
               >
-                USD
+                ETH
               </span>
             </div>
           </div>

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -51,12 +51,13 @@ import {
   getUseBlockie,
 } from '../../../selectors';
 import {
+  getMultichainIsTestnet,
   getMultichainNativeCurrency,
   getMultichainNativeCurrencyImage,
   getMultichainNetwork,
+  getMultichainShouldShowFiat,
 } from '../../../selectors/multichain';
 import { useMultichainAccountTotalFiatBalance } from '../../../hooks/useMultichainAccountTotalFiatBalance';
-import { TEST_NETWORKS } from '../../../../shared/constants/network';
 import { ConnectedStatus } from '../connected-status/connected-status';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 import { getCustodianIconForAddress } from '../../../selectors/institutional/selectors';
@@ -90,17 +91,19 @@ export const AccountListItem = ({
     useState();
 
   const useBlockie = useSelector(getUseBlockie);
-  const { network: currentNetwork, isEvmNetwork } = useMultichainSelector(
-    getMultichainNetwork,
-    account,
-  );
+  const { isEvmNetwork } = useMultichainSelector(getMultichainNetwork, account);
   const setAccountListItemMenuRef = (ref) => {
     setAccountListItemMenuElement(ref);
   };
+  const isTestnet = useMultichainSelector(getMultichainIsTestnet, account);
+  const isMainnet = !isTestnet;
+  const shouldShowFiat = useMultichainSelector(
+    getMultichainShouldShowFiat,
+    account,
+  );
   const showFiatInTestnets = useSelector(getShowFiatInTestnets);
   const showFiat =
-    !isEvmNetwork ||
-    (TEST_NETWORKS.includes(currentNetwork?.nickname) && !showFiatInTestnets);
+    shouldShowFiat && (isMainnet || (isTestnet && showFiatInTestnets));
   const accountTotalFiatBalances =
     useMultichainAccountTotalFiatBalance(account);
   const mappedOrderedTokenList = accountTotalFiatBalances.orderedTokenList.map(
@@ -108,12 +111,9 @@ export const AccountListItem = ({
       avatarValue: item.iconUrl,
     }),
   );
-  let balanceToTranslate = isEvmNetwork
-    ? accountTotalFiatBalances.totalWeiBalance
+  const balanceToTranslate = isEvmNetwork
+    ? account.balance
     : accountTotalFiatBalances.totalBalance;
-  if (showFiat && isEvmNetwork) {
-    balanceToTranslate = account.balance;
-  }
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   const custodianIcon = useSelector((state) =>
@@ -307,9 +307,7 @@ export const AccountListItem = ({
                 ethNumberOfDecimals={MAXIMUM_CURRENCY_DECIMALS}
                 value={balanceToTranslate}
                 type={PRIMARY}
-                showFiat={
-                  !showFiat || !TEST_NETWORKS.includes(currentNetwork?.nickname)
-                }
+                showFiat={showFiat}
                 data-testid="first-currency-display"
               />
             </Text>

--- a/ui/components/multichain/account-list-item/account-list-item.test.js
+++ b/ui/components/multichain/account-list-item/account-list-item.test.js
@@ -210,6 +210,9 @@ describe('AccountListItem', () => {
                 chainId: CHAIN_IDS.SEPOLIA,
                 nickname: SEPOLIA_DISPLAY_NAME,
               },
+              preferences: {
+                showFiatInTestnets: false,
+              },
             },
           },
         );
@@ -263,7 +266,7 @@ describe('AccountListItem', () => {
           '[data-testid="avatar-group"]',
         );
 
-        const expectedBalance = '$0.00';
+        const expectedBalance = '$3.31';
 
         expect(firstCurrencyDisplay).toBeInTheDocument();
         expect(firstCurrencyDisplay.firstChild.textContent).toContain(
@@ -275,9 +278,18 @@ describe('AccountListItem', () => {
       });
 
       it('renders fiat for non-EVM account', () => {
-        const { container } = render({
-          account: mockNonEvmAccount,
-        });
+        const { container } = render(
+          {
+            account: mockNonEvmAccount,
+          },
+          {
+            metamask: {
+              preferences: {
+                showFiatInTestnets: true,
+              },
+            },
+          },
+        );
 
         const firstCurrencyDisplay = container.querySelector(
           '[data-testid="first-currency-display"]',

--- a/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
+++ b/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
@@ -293,17 +293,17 @@ exports[`Connections Content should render correctly 1`] = `
                     <div
                       class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                       data-testid="first-currency-display"
-                      title="$880.18 USD"
+                      title="966.988 ETH"
                     >
                       <span
                         class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
                       >
-                        $880.18
+                        966.988
                       </span>
                       <span
                         class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                       >
-                        USD
+                        ETH
                       </span>
                     </div>
                   </div>

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -467,11 +467,13 @@ exports[`SendPage render and initialization should render correctly even when a 
                             <div
                               class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                               data-testid="first-currency-display"
-                              title="null USD"
+                              title="$0.00 USD"
                             >
                               <span
                                 class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
-                              />
+                              >
+                                $0.00
+                              </span>
                               <span
                                 class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                               >
@@ -500,7 +502,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                           <div
                             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
                           >
-                            ?
+                            E
                           </div>
                           <div
                             class="mm-box mm-text mm-text--body-sm mm-text--text-align-end mm-box--color-text-alternative"

--- a/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
@@ -241,17 +241,17 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               <div
                 class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                 data-testid="first-currency-display"
-                title="$880.18 USD"
+                title="966.988 ETH"
               >
                 <span
                   class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
                 >
-                  $880.18
+                  966.988
                 </span>
                 <span
                   class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                 >
-                  USD
+                  ETH
                 </span>
               </div>
             </div>
@@ -538,17 +538,17 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               <div
                 class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                 data-testid="first-currency-display"
-                title="$0.00 USD"
+                title="0 ETH"
               >
                 <span
                   class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
                 >
-                  $0.00
+                  0
                 </span>
                 <span
                   class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                 >
-                  USD
+                  ETH
                 </span>
               </div>
             </div>
@@ -835,17 +835,17 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               <div
                 class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                 data-testid="first-currency-display"
-                title="$0.00 USD"
+                title="0 ETH"
               >
                 <span
                   class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
                 >
-                  $0.00
+                  0
                 </span>
                 <span
                   class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                 >
-                  USD
+                  ETH
                 </span>
               </div>
             </div>
@@ -1141,17 +1141,17 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               <div
                 class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                 data-testid="first-currency-display"
-                title="$0.00 USD"
+                title="0 ETH"
               >
                 <span
                   class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
                 >
-                  $0.00
+                  0
                 </span>
                 <span
                   class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                 >
-                  USD
+                  ETH
                 </span>
               </div>
             </div>
@@ -1438,17 +1438,17 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               <div
                 class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                 data-testid="first-currency-display"
-                title="$0.00 USD"
+                title="0 ETH"
               >
                 <span
                   class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
                 >
-                  $0.00
+                  0
                 </span>
                 <span
                   class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                 >
-                  USD
+                  ETH
                 </span>
               </div>
             </div>
@@ -1748,17 +1748,17 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               <div
                 class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                 data-testid="first-currency-display"
-                title="$0.00 USD"
+                title="0 ETH"
               >
                 <span
                   class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
                 >
-                  $0.00
+                  0
                 </span>
                 <span
                   class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                 >
-                  USD
+                  ETH
                 </span>
               </div>
             </div>

--- a/ui/components/multichain/pages/send/send.test.js
+++ b/ui/components/multichain/pages/send/send.test.js
@@ -181,6 +181,7 @@ const baseStore = {
     providerConfig: {
       chainId: CHAIN_IDS.GOERLI,
       nickname: GOERLI_DISPLAY_NAME,
+      ticker: 'ETH',
     },
     nativeCurrency: 'ETH',
     featureFlags: {
@@ -215,6 +216,8 @@ const baseStore = {
       },
     },
     completedOnboarding: true,
+    useCurrencyRateCheck: true,
+    ticker: 'ETH',
   },
   activeTab: {
     origin: 'https://uniswap.org/',
@@ -379,6 +382,7 @@ describe('SendPage', () => {
             chainId: CHAIN_IDS.GOERLI,
             nickname: GOERLI_DISPLAY_NAME,
             type: NETWORK_TYPES.GOERLI,
+            ticker: 'ETH',
           },
         },
       };

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -339,15 +339,17 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                           <div
                             class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
                             data-testid="first-currency-display"
-                            title="null USD"
+                            title="966.988 ETH"
                           >
                             <span
                               class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
-                            />
+                            >
+                              966.988
+                            </span>
                             <span
                               class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
                             >
-                              USD
+                              ETH
                             </span>
                           </div>
                         </div>
@@ -372,7 +374,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
                         >
-                          ?
+                          E
                         </div>
                         <div
                           class="mm-box mm-text mm-text--body-sm mm-text--text-align-end mm-box--color-text-alternative"

--- a/ui/pages/confirmations/confirmation/templates/remove-snap-account.test.js
+++ b/ui/pages/confirmations/confirmation/templates/remove-snap-account.test.js
@@ -17,6 +17,7 @@ const mockPublicAddress = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 const providerConfig = {
   chainId: '0x5',
   nickname: '',
+  ticker: 'ETH',
 };
 const mockApproval = {
   id: mockApprovalId,

--- a/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
+++ b/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
@@ -231,7 +231,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
         class="settings-page__content-item-col"
       >
         <label
-          class="toggle-button toggle-button--off"
+          class="toggle-button toggle-button--off show-fiat-on-testnets-toggle"
           tabindex="0"
         >
           <div

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -360,6 +360,7 @@ export default class AdvancedTab extends PureComponent {
             }
             offLabel={t('off')}
             onLabel={t('on')}
+            className="show-fiat-on-testnets-toggle"
           />
         </div>
       </Box>

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -8,12 +8,15 @@ import AdvancedTab from '.';
 
 const mockSetAutoLockTimeLimit = jest.fn().mockReturnValue({ type: 'TYPE' });
 const mockSetShowTestNetworks = jest.fn();
+const mockSetShowFiatConversionOnTestnetsPreference = jest.fn();
 const mockSetStxOptIn = jest.fn();
 
 jest.mock('../../../store/actions.ts', () => {
   return {
     setAutoLockTimeLimit: (...args) => mockSetAutoLockTimeLimit(...args),
     setShowTestNetworks: () => mockSetShowTestNetworks,
+    setShowFiatConversionOnTestnetsPreference: () =>
+      mockSetShowFiatConversionOnTestnetsPreference,
     setSmartTransactionsOptInStatus: () => mockSetStxOptIn,
   };
 });
@@ -72,6 +75,16 @@ describe('AdvancedTab Component', () => {
     fireEvent.click(autoLockoutButton);
 
     expect(mockSetAutoLockTimeLimit).toHaveBeenCalledWith(0);
+  });
+
+  it('should toggle show fiat on test networks', () => {
+    const { queryAllByRole } = renderWithProvider(<AdvancedTab />, mockStore);
+
+    const testShowFiatOnTestnets = queryAllByRole('checkbox')[2];
+
+    fireEvent.click(testShowFiatOnTestnets);
+
+    expect(mockSetShowFiatConversionOnTestnetsPreference).toHaveBeenCalled();
   });
 
   it('should toggle show test networks', () => {

--- a/ui/selectors/multichain.test.ts
+++ b/ui/selectors/multichain.test.ts
@@ -12,7 +12,7 @@ import {
   MOCK_ACCOUNT_BIP122_P2WPKH,
   MOCK_ACCOUNT_BIP122_P2WPKH_TESTNET,
 } from '../../test/data/mock-accounts';
-import { CHAIN_IDS } from '../../shared/constants/network';
+import { CHAIN_IDS, TEST_NETWORK_IDS } from '../../shared/constants/network';
 import { MultichainNativeAssets } from '../../shared/constants/multichain/assets';
 import { AccountsState } from './accounts';
 import {
@@ -28,6 +28,7 @@ import {
   getMultichainProviderConfig,
   getMultichainSelectedAccountCachedBalance,
   getMultichainShouldShowFiat,
+  getMultichainIsTestnet,
 } from './multichain';
 import {
   getCurrentCurrency,
@@ -326,6 +327,44 @@ describe('Multichain Selectors', () => {
         const state = getNonEvmState(account);
 
         expect(getMultichainIsMainnet(state)).toBe(isMainnet);
+      },
+    );
+  });
+
+  describe('getMultichainIsTestnet', () => {
+    it('returns false if account is EVM (mainnet)', () => {
+      const state = getEvmState();
+
+      expect(getMultichainIsTestnet(state)).toBe(false);
+    });
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(TEST_NETWORK_IDS)(
+      'returns true if account is EVM (testnet): %s',
+      (chainId: string) => {
+        const state = getEvmState();
+
+        state.metamask.providerConfig.chainId = chainId;
+        expect(getMultichainIsTestnet(state)).toBe(true);
+      },
+    );
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      { isTestnet: false, account: MOCK_ACCOUNT_BIP122_P2WPKH },
+      { isTestnet: true, account: MOCK_ACCOUNT_BIP122_P2WPKH_TESTNET },
+    ])(
+      'returns $isTestnet if non-EVM account address "$account.address" is compatible with mainnet',
+      ({
+        isTestnet,
+        account,
+      }: {
+        isTestnet: boolean;
+        account: InternalAccount;
+      }) => {
+        const state = getNonEvmState(account);
+
+        expect(getMultichainIsTestnet(state)).toBe(isTestnet);
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pr cherry picks f3383ac to RC 12.1

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26285?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
