### PR TITLE
fix: Revert "fix: remove submitRequest from dapp permission"

### DIFF
--- a/app/scripts/lib/snap-keyring/keyring-snaps-permissions.test.ts
+++ b/app/scripts/lib/snap-keyring/keyring-snaps-permissions.test.ts
@@ -102,6 +102,7 @@ describe('keyringSnapPermissionsBuilder', () => {
       KeyringRpcMethod.GetRequest,
       KeyringRpcMethod.ApproveRequest,
       KeyringRpcMethod.RejectRequest,
+      KeyringRpcMethod.SubmitRequest,
     ]);
   });
 

--- a/app/scripts/lib/snap-keyring/keyring-snaps-permissions.ts
+++ b/app/scripts/lib/snap-keyring/keyring-snaps-permissions.ts
@@ -33,7 +33,6 @@ const METAMASK_ALLOWED_METHODS: string[] = [
 
 /**
  * List of keyring methods a dapp can call.
- * !NOTE: DO NOT INCLUDE `KeyringRpcMethod.SubmitRequest` IN THIS LIST.
  */
 const WEBSITE_ALLOWED_METHODS: string[] = [
   KeyringRpcMethod.ListAccounts,
@@ -47,6 +46,7 @@ const WEBSITE_ALLOWED_METHODS: string[] = [
   KeyringRpcMethod.GetRequest,
   KeyringRpcMethod.ApproveRequest,
   KeyringRpcMethod.RejectRequest,
+  KeyringRpcMethod.SubmitRequest,
 ];
 
 /**

--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -20,7 +20,7 @@ export const BUNDLER_URL = 'http://localhost:3000/rpc';
 
 /* URL of the 4337 account snap site. */
 export const ERC_4337_ACCOUNT_SNAP_URL =
-  'https://metamask.github.io/snap-account-abstraction-keyring/0.4.0/';
+  'https://metamask.github.io/snap-account-abstraction-keyring/0.2.2/';
 
 /* Salt used to generate the 4337 account. */
 export const ERC_4337_ACCOUNT_SALT = '0x1';

--- a/test/e2e/flask/user-operations.spec.ts
+++ b/test/e2e/flask/user-operations.spec.ts
@@ -76,38 +76,24 @@ async function setSnapConfig(
     entrypoint,
     simpleAccountFactory,
     paymaster,
-    paymasterSK,
   }: {
     bundlerUrl: string;
     entrypoint: string;
     simpleAccountFactory: string;
     paymaster?: string;
-    paymasterSK?: string;
   },
 ) {
-  await driver.switchToWindowWithTitle('Account Abstraction Snap');
-  await driver.clickElement('[data-testid="chain-select"]');
-  await driver.clickElement('[data-testid="chain-id-1337"]');
-  await driver.fill('[data-testid="bundlerUrl"]', bundlerUrl);
-  await driver.fill('[data-testid="entryPoint"]', entrypoint);
-  await driver.fill(
-    '[data-testid="simpleAccountFactory"]',
+  const data = JSON.stringify({
+    bundlerUrl,
+    entryPoint: entrypoint,
     simpleAccountFactory,
-  );
-  if (paymaster) {
-    await driver.fill(
-      '[data-testid="customVerifyingPaymasterAddress"]',
-      paymaster,
-    );
-  }
-  if (paymasterSK) {
-    await driver.fill(
-      '[data-testid="customVerifyingPaymasterSK"]',
-      paymasterSK,
-    );
-  }
+    customVerifyingPaymasterAddress: paymaster,
+  });
 
-  await driver.clickElement({ text: 'Set Chain Config', tag: 'button' });
+  await driver.switchToWindowWithTitle('Account Abstraction Snap');
+  await driver.clickElement({ text: 'Set Chain Config' });
+  await driver.fill('#set-chain-config-chain-config-object', data);
+  await driver.clickElement({ text: 'Set Chain Configs', tag: 'button' });
 }
 
 async function createSwap(driver: Driver) {


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#26276. This PR was found to cause CI failures on `develop`.

Example: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/94617/workflows/2a0b7600-ce3b-4558-ba16-4eff4e60ff3f/jobs/3524142