### PR TITLE
fix: Remove obsolete NetworkController state

### DIFF
--- a/app/scripts/migrations/120.2.ts
+++ b/app/scripts/migrations/120.2.ts
@@ -80,6 +80,37 @@ function removeObsoleteSelectedNetworkControllerState(
 }
 
 /**
+ * Remove obsolete NetworkController state.
+ *
+ * We don't know exactly why yet, but we see from Sentry that some users have these properties
+ * in state. They should have been removed by migrations long ago. They are no longer used.
+ *
+ * @param state - The persisted MetaMask state, keyed by controller.
+ */
+function removeObsoleteNetworkControllerState(
+  state: Record<string, unknown>,
+): void {
+  if (!hasProperty(state, 'NetworkController')) {
+    return;
+  } else if (!isObject(state.NetworkController)) {
+    global.sentry.captureException(
+      new Error(
+        `Migration ${version}: Invalid NetworkController state of type '${typeof state.NetworkController}'`,
+      ),
+    );
+    return;
+  }
+
+  const networkControllerState = state.NetworkController;
+
+  delete networkControllerState.networkDetails;
+  delete networkControllerState.networkId;
+  delete networkControllerState.networkStatus;
+  delete networkControllerState.previousProviderStore;
+  delete networkControllerState.provider;
+}
+
+/**
  * Remove obsolete controller state.
  *
  * @param state - The persisted MetaMask state, keyed by controller.
@@ -87,4 +118,5 @@ function removeObsoleteSelectedNetworkControllerState(
 function transformState(state: Record<string, unknown>): void {
   removeObsoleteSnapControllerState(state);
   removeObsoleteSelectedNetworkControllerState(state);
+  removeObsoleteNetworkControllerState(state);
 }


### PR DESCRIPTION
## **Description**

Migration 120.2 has been updated to remove obsolete NetworkController state as well.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26302?quickstart=1)

## **Related issues**

Fixes #26297

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
