### PR TITLE
fix: Remove invalid providerConfig id

### DIFF
--- a/app/scripts/migrations/120.2.test.ts
+++ b/app/scripts/migrations/120.2.test.ts
@@ -291,6 +291,39 @@ describe('migration #120.2', () => {
       );
     });
 
+    it('does nothing if obsolete properties and providerConfig are not set', async () => {
+      const oldState = {
+        NetworkController: {
+          selectedNetworkClientId: 'example',
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual(oldState);
+    });
+
+    it('does nothing if obsolete properties are not set and providerConfig is set to undefined', async () => {
+      const oldState = {
+        NetworkController: {
+          // This should be impossible because `undefined` cannot be returned from persisted state,
+          // it's not valid JSON. But a bug in migration 14 ends up setting this to `undefined`.
+          providerConfig: undefined,
+          selectedNetworkClientId: 'example',
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual(oldState);
+    });
+
     it('does nothing if obsolete properties and providerConfig id are not set', async () => {
       const oldState = {
         NetworkController: {

--- a/app/scripts/migrations/120.2.ts
+++ b/app/scripts/migrations/120.2.ts
@@ -105,7 +105,12 @@ function removeObsoleteNetworkControllerState(
   const networkControllerState = state.NetworkController;
 
   // Check for invalid `providerConfig.id`, and remove if found
-  if (hasProperty(networkControllerState, 'providerConfig')) {
+  if (
+    hasProperty(networkControllerState, 'providerConfig') &&
+    // This should be impossible because `undefined` cannot be returned from persisted state,
+    // it's not valid JSON. But a bug in migration 14 ends up setting this to `undefined`.
+    networkControllerState.providerConfig !== undefined
+  ) {
     if (!isObject(networkControllerState.providerConfig)) {
       global.sentry?.captureException?.(
         new Error(

--- a/app/scripts/migrations/120.2.ts
+++ b/app/scripts/migrations/120.2.ts
@@ -41,7 +41,7 @@ function removeObsoleteSnapControllerState(
   if (!hasProperty(state, 'SnapController')) {
     return;
   } else if (!isObject(state.SnapController)) {
-    global.sentry.captureException(
+    global.sentry?.captureException?.(
       new Error(
         `Migration ${version}: Invalid SnapController state of type '${typeof state.SnapController}'`,
       ),
@@ -94,7 +94,7 @@ function removeObsoleteNetworkControllerState(
   if (!hasProperty(state, 'NetworkController')) {
     return;
   } else if (!isObject(state.NetworkController)) {
-    global.sentry.captureException(
+    global.sentry?.captureException?.(
       new Error(
         `Migration ${version}: Invalid NetworkController state of type '${typeof state.NetworkController}'`,
       ),
@@ -107,7 +107,7 @@ function removeObsoleteNetworkControllerState(
   // Check for invalid `providerConfig.id`, and remove if found
   if (hasProperty(networkControllerState, 'providerConfig')) {
     if (!isObject(networkControllerState.providerConfig)) {
-      global.sentry.captureException(
+      global.sentry?.captureException?.(
         new Error(
           `Migration ${version}: Invalid NetworkController providerConfig state of type '${typeof state
             .NetworkController.providerConfig}'`,
@@ -120,7 +120,7 @@ function removeObsoleteNetworkControllerState(
     const validNetworkConfigurationIds = [];
     if (hasProperty(networkControllerState, 'networkConfigurations')) {
       if (!isObject(networkControllerState.networkConfigurations)) {
-        global.sentry.captureException(
+        global.sentry?.captureException?.(
           new Error(
             `Migration ${version}: Invalid NetworkController networkConfigurations state of type '${typeof networkControllerState.networkConfigurations}'`,
           ),


### PR DESCRIPTION
## **Description**

Remove invalid `providerConfig.id` state. This was one possible explanation for some Sentry errors that we have been encountering in production. The diagnostic state attached to the error was not sufficient to confirm that this was the cause.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26310?quickstart=1)

## **Related issues**

Relates to #26309 and #26320

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
