### PR TITLE
fix (cherry-pick for v12.0.1): improve error handling for swap and send

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
@@ -41,6 +41,7 @@ type AssetPickerAmountProps = OverridingUnion<
     asset: Asset;
     amount: Amount;
     isAmountLoading?: boolean;
+    error?: string;
     /**
      * Callback for when the amount changes; disables the input when undefined
      */
@@ -57,6 +58,7 @@ export const AssetPickerAmount = ({
   amount,
   onAmountChange,
   isAmountLoading,
+  error: passedError,
   ...assetPickerProps
 }: AssetPickerAmountProps) => {
   const selectedAccount = useSelector(getSelectedInternalAccount);
@@ -170,7 +172,9 @@ export const AssetPickerAmount = ({
       </Box>
       <Box display={Display.Flex}>
         {/* Only show balance if mutable */}
-        {onAmountChange && <AssetBalance asset={asset} error={error} />}
+        {onAmountChange && (
+          <AssetBalance asset={asset} error={passedError || error} />
+        )}
         {isSwapsErrorShown && (
           <Text variant={TextVariant.bodySm} color={TextColor.errorDefault}>
             {t(swapQuotesError)}

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -989,6 +989,10 @@ const slice = createSlice({
       const draftTransaction =
         state.draftTransactions[state.currentTransactionUUID];
 
+      if (!draftTransaction) {
+        return;
+      }
+
       // use maxFeePerGas as the multiplier if working with a FEE_MARKET transaction
       // otherwise use gasPrice
       if (
@@ -1080,7 +1084,7 @@ const slice = createSlice({
       const draftTransaction =
         state.draftTransactions[state.currentTransactionUUID];
       let amount = '0x0';
-      if (draftTransaction.sendAsset.type === AssetType.token) {
+      if (draftTransaction?.sendAsset.type === AssetType.token) {
         const decimals = draftTransaction.sendAsset.details?.decimals ?? 0;
 
         const multiplier = Math.pow(10, Number(decimals));
@@ -1292,7 +1296,7 @@ const slice = createSlice({
       state.gasTotalForLayer1 = action.payload;
       if (
         state.amountMode === AMOUNT_MODES.MAX &&
-        draftTransaction.sendAsset.type === AssetType.native
+        draftTransaction?.sendAsset.type === AssetType.native
       ) {
         slice.caseReducers.updateAmountToMax(state);
       }
@@ -1456,6 +1460,10 @@ const slice = createSlice({
       const draftTransaction =
         state.draftTransactions[state.currentTransactionUUID];
 
+      if (!draftTransaction) {
+        return;
+      }
+
       const amountValue = new Numeric(draftTransaction.amount.value, 16);
 
       switch (true) {
@@ -1557,6 +1565,11 @@ const slice = createSlice({
     validateGasField: (state) => {
       const draftTransaction =
         state.draftTransactions[state.currentTransactionUUID];
+
+      if (!draftTransaction) {
+        return;
+      }
+
       const insufficientFunds = !isBalanceSufficient({
         amount:
           draftTransaction.sendAsset.type === AssetType.native

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -105,14 +105,6 @@ jest.mock('lodash', () => ({
   debounce: (fn) => fn,
 }));
 
-setBackgroundConnection({
-  addPollingTokenToAppState: jest.fn(),
-  addTransaction: jest.fn((_u, _v, cb) => {
-    cb(null, { transactionMeta: null });
-  }),
-  updateTransactionSendFlowHistory: jest.fn((_x, _y, _z, cb) => cb(null)),
-});
-
 const getTestUUIDTx = (state) => state.draftTransactions['test-uuid'];
 
 describe('Send Slice', () => {
@@ -124,6 +116,14 @@ describe('Send Slice', () => {
   let setDefaultHomeActiveTabNameStub;
 
   beforeEach(() => {
+    setBackgroundConnection({
+      addPollingTokenToAppState: jest.fn(),
+      addTransaction: jest.fn((_u, _v, cb) => {
+        cb(null, { transactionMeta: null });
+      }),
+      updateTransactionSendFlowHistory: jest.fn((_x, _y, _z, cb) => cb(null)),
+    });
+
     jest.useFakeTimers();
     getTokenStandardAndDetailsStub = jest
       .spyOn(Actions, 'getTokenStandardAndDetails')
@@ -3025,6 +3025,74 @@ describe('Send Slice', () => {
           expect(
             addTransactionAndRouteToConfirmationPageStub.mock.calls[0][0].to,
           ).toStrictEqual('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
+        });
+        it('should rethrow addTransactionAndRouteToConfirmationPage errors', async () => {
+          const tokenTransferTxState = {
+            metamask: {
+              providerConfig: {
+                chainId: CHAIN_IDS.GOERLI,
+              },
+              transactions: [
+                {
+                  id: 1,
+                  chainId: CHAIN_IDS.GOERLI,
+                  status: 'unapproved',
+                  txParams: {
+                    value: 'oldTxValue',
+                  },
+                },
+              ],
+            },
+            send: {
+              ...getInitialSendStateWithExistingTxState({
+                id: 1,
+                sendAsset: {
+                  details: {
+                    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+                  },
+                  type: 'TOKEN',
+                },
+                receiveAsset: {
+                  details: {
+                    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+                  },
+                  type: 'TOKEN',
+                },
+                recipient: {
+                  address: '4F90e18605Fd46F9F9Fab0e225D88e1ACf5F5324',
+                },
+                amount: {
+                  value: '0x1',
+                },
+              }),
+              stage: SEND_STAGES.DRAFT,
+              selectedAccount: {
+                address: '0x6784e8507A1A46443f7bDc8f8cA39bdA92A675A6',
+              },
+            },
+          };
+
+          jest.mock('../../store/actions.ts');
+
+          const store = mockStore(tokenTransferTxState);
+
+          const ERROR = new Error('rejected');
+
+          const history = { push: jest.fn() };
+
+          setBackgroundConnection({
+            addPollingTokenToAppState: jest.fn(),
+            addTransaction: jest.fn((_u, _v) => {
+              throw new Error(ERROR);
+            }),
+            updateTransactionSendFlowHistory: jest.fn((_x, _y, _z, cb) =>
+              cb(null),
+            ),
+          });
+
+          await expect(
+            store.dispatch(signTransaction(history)),
+          ).rejects.toThrow('rejected');
         });
       });
 

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -283,7 +283,28 @@ describe('Send Slice', () => {
         expect(draft.amount.value).toStrictEqual('0xadf7');
         expect(draft.status).toStrictEqual(SEND_STATUSES.VALID);
       });
+
+      it('should not error when draft transaction is not defined', () => {
+        const state = getInitialSendStateWithExistingTxState({
+          gas: {
+            gasPrice: '0x1',
+            maxFeePerGas: '0x2',
+            gasLimit: GAS_LIMITS.SIMPLE,
+          },
+        });
+
+        delete state.draftTransactions['test-uuid'];
+
+        const action = {
+          type: 'send/calculateGasTotal',
+        };
+
+        const runAction = () => sendReducer(state, action);
+
+        expect(runAction).not.toThrow();
+      });
     });
+
     describe('resetSendState', () => {
       it('should set the state back to a blank slate matching the initialState object', () => {
         const action = {
@@ -1076,6 +1097,29 @@ describe('Send Slice', () => {
         );
         expect(draftTransaction.status).toBe(SEND_STATUSES.INVALID);
       });
+
+      it('should not throw error when draft transaction does not exist', () => {
+        const tokenAssetState = getInitialSendStateWithExistingTxState({
+          amount: {
+            value: '0x77359400', // 2000000000
+          },
+          sendAsset: {
+            type: AssetType.token,
+            balance: '0x6fc23ac0', // 1875000000
+            details: {
+              decimals: 0,
+            },
+          },
+        });
+
+        const action = {
+          type: 'send/validateAmountField',
+        };
+
+        delete tokenAssetState.draftTransactions['test-uuid'];
+
+        expect(() => sendReducer(tokenAssetState, action)).not.toThrow();
+      });
     });
 
     describe('validateGasField', () => {
@@ -1100,6 +1144,24 @@ describe('Send Slice', () => {
         expect(draftTransaction.gas.error).toStrictEqual(
           INSUFFICIENT_FUNDS_ERROR,
         );
+      });
+      it('should not throw error when draft transaction does not exist', () => {
+        const gasFieldState = getInitialSendStateWithExistingTxState({
+          account: {
+            balance: '0x0',
+          },
+          gas: {
+            gasTotal: '0x1319718a5000', // 21000000000000
+          },
+        });
+
+        delete gasFieldState.draftTransactions['test-uuid'];
+
+        const action = {
+          type: 'send/validateGasField',
+        };
+
+        expect(() => sendReducer(gasFieldState, action)).not.toThrow();
       });
     });
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1019,6 +1019,7 @@ export function addTransactionAndRouteToConfirmationPage(
     } catch (error) {
       dispatch(hideLoadingIndication());
       dispatch(displayWarning(error));
+      throw error;
     }
     return null;
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cherry picks #26253, #26295
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26315?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
