### PR TITLE
Cherry-Pick: "fix: issue where `setNetworkClientIdForDomain` was called without checking whether the origin was eligible for setting its own network (#26323)"

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -28,6 +28,7 @@ import {
   getShowNetworkBanner,
   getOriginOfCurrentTab,
   getUseRequestQueue,
+  getAllDomains,
 } from '../../../selectors';
 import ToggleButton from '../../ui/toggle-button';
 import {
@@ -76,6 +77,7 @@ export const NetworkListMenu = ({ onClose }) => {
 
   const selectedTabOrigin = useSelector(getOriginOfCurrentTab);
   const useRequestQueue = useSelector(getUseRequestQueue);
+  const domains = useSelector(getAllDomains);
 
   const dispatch = useDispatch();
   const history = useHistory();
@@ -193,10 +195,14 @@ export const NetworkListMenu = ({ onClose }) => {
             dispatch(setActiveNetwork(network.id));
           }
 
-          // If presently on a dapp, communicate a change to
-          // the dapp via silent switchEthereumChain that the
-          // network has changed due to user action
-          if (useRequestQueue && selectedTabOrigin) {
+          // If presently on and connected to a dapp, communicate a change to
+          // the dapp via silent switchEthereumChain that the network has
+          // changed due to user action
+          if (
+            useRequestQueue &&
+            selectedTabOrigin &&
+            domains[selectedTabOrigin]
+          ) {
             setNetworkClientIdForDomain(selectedTabOrigin, network.id);
           }
 


### PR DESCRIPTION
CherryPicks https://github.com/MetaMask/metamask-extension/commit/80f538eeef8200221fb18773ff5b9c67533b0008 onto v12.0.1:

> This PR fixes a issue where `setNetworkClientIdForDomain` was frequently called with origins that had no account permissions yet (which is the threshhold we currently set for giving site's their own network) resulting in [a large number of silent errors in the background that are clogging up
> sentry](https://metamask.sentry.io/issues/5659582204/?environment=production&project=273505&qu%5B%E2%80%A6%5Derrer=issue-stream&sort=freq&statsPeriod=90d&stream_index=1).
> 
> [![Open in GitHub
> Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26323?quickstart=1)
> 
> Fixes:
> https://metamask.sentry.io/issues/5659582204/?environment=production&project=273505&qu%5B%E2%80%A6%5Derrer=issue-stream&sort=freq&statsPeriod=90d&stream_index=1