### PR TITLE
Updated styling of the secondary currency and balance percentage

### DIFF
--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -106,7 +106,6 @@
     color: var(--color-text-alternative);
   }
 
-
   &__button:last-of-type {
     margin-right: 0;
   }

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -106,6 +106,7 @@
     color: var(--color-text-alternative);
   }
 
+
   &__button:last-of-type {
     margin-right: 0;
   }

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -39,6 +39,21 @@
   font-weight: 500;
 }
 
+.coin,
+.eth {
+  &__secondary-balance {
+    @include design-system.Paragraph;
+
+    font-size: 14px;
+  }
+
+  &__cached-secondary-balance {
+    @include design-system.Paragraph;
+
+    font-size: 14px;
+  }
+}
+
 .coin-overview,
 .eth-overview {
   &__balance {

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
@@ -34,8 +34,8 @@ const renderPercentageWithNumber = (
   return (
     <Box display={Display.Flex}>
       <Text
-        fontWeight={FontWeight.Normal}
-        variant={TextVariant.bodyMd}
+        variant={TextVariant.bodySmMedium}
+        fontWeight={FontWeight.Medium}
         color={color}
         data-testid="token-increase-decrease-value"
         style={{ whiteSpace: 'pre' }}
@@ -44,8 +44,8 @@ const renderPercentageWithNumber = (
         {formattedValuePrice}
       </Text>
       <Text
-        fontWeight={FontWeight.Normal}
-        variant={TextVariant.bodyMd}
+        variant={TextVariant.bodySmMedium}
+        fontWeight={FontWeight.Medium}
         color={color}
         data-testid="token-increase-decrease-percentage"
         ellipsis
@@ -107,7 +107,7 @@ export const PercentageAndAmountChange = ({
 
   if (isValidAmount(balanceChange)) {
     if ((balanceChange as number) === 0) {
-      color = TextColor.textDefault;
+      color = TextColor.textAlternative;
     } else if ((balanceChange as number) > 0) {
       color = TextColor.successDefault;
     } else {

--- a/ui/components/ui/currency-display/currency-display.component.js
+++ b/ui/components/ui/currency-display/currency-display.component.js
@@ -8,6 +8,8 @@ import {
   AlignItems,
   Display,
   FlexWrap,
+  FontWeight,
+  TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 
@@ -45,6 +47,8 @@ export default function CurrencyDisplay({
     suffix,
   });
 
+  const secondaryCurrencyColor = className.includes("-overview__primary-balance") && TextColor.textDefault || TextColor.textAlternative;
+
   return (
     <Box
       className={classnames('currency-display-component', className)}
@@ -71,6 +75,8 @@ export default function CurrencyDisplay({
         className="currency-display-component__text"
         ellipsis
         variant={TextVariant.inherit}
+        fontWeight={FontWeight.Medium}
+        color={secondaryCurrencyColor}
         {...textProps}
       >
         {parts.prefix}
@@ -82,6 +88,8 @@ export default function CurrencyDisplay({
           className="currency-display-component__suffix"
           marginInlineStart={1}
           variant={TextVariant.inherit}
+          fontWeight={FontWeight.Medium}
+          color={secondaryCurrencyColor}
           {...suffixProps}
         >
           {parts.suffix}


### PR DESCRIPTION
## **Description**

This pull request addresses and updates the styling of the secondary currency and balance percentage as outlined in https://github.com/MetaMask/metamask-extension/issues/26188

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26188

## **Manual testing steps**

1. Open MetaMask
2. Verify the updates

## **Screenshots/Recordings**

### **Before**

![Screenshot 2024-08-09 at 19 19 35](https://github.com/user-attachments/assets/fe2a58ad-612b-4632-99d8-70dbf37e2207)

### **After**

![Screenshot 2024-08-09 at 19 20 31](https://github.com/user-attachments/assets/e8981a11-1021-4624-8366-86f108e2b814)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
