### PR TITLE
feat(snaps): Removed Snaps name-lookup permission code fences

### DIFF
--- a/shared/constants/snaps/permissions.ts
+++ b/shared/constants/snaps/permissions.ts
@@ -8,9 +8,7 @@ export const EndowmentPermissions = Object.freeze({
   'endowment:lifecycle-hooks': 'endowment:lifecycle-hooks',
   'endowment:page-home': 'endowment:page-home',
   'endowment:signature-insight': 'endowment:signature-insight',
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   'endowment:name-lookup': 'endowment:name-lookup',
-  ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   'endowment:keyring': 'endowment:keyring',
   ///: END:ONLY_INCLUDE_IF
@@ -22,11 +20,6 @@ export const ExcludedSnapPermissions = Object.freeze({
     'eth_accounts is disabled. For more information please see https://github.com/MetaMask/snaps/issues/990.',
 });
 
-export const ExcludedSnapEndowments = Object.freeze({
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main)
-  'endowment:name-lookup':
-    'This endowment is experimental and therefore not available.',
-  ///: END:ONLY_INCLUDE_IF
-});
+export const ExcludedSnapEndowments = Object.freeze({});
 
 export const DynamicSnapPermissions = Object.freeze(['eth_accounts']);

--- a/ui/components/multichain/pages/send/components/domain-input-resolution-cell.tsx
+++ b/ui/components/multichain/pages/send/components/domain-input-resolution-cell.tsx
@@ -1,35 +1,22 @@
-import React, {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
-  useContext,
-  ///: END:ONLY_INCLUDE_IF
-  useRef,
-  useEffect,
-  useState,
-} from 'react';
+import React, { useContext, useRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 import { I18nContext } from '../../../../../contexts/i18n';
-///: END:ONLY_INCLUDE_IF
 import Confusable from '../../../../ui/confusable';
 import {
   AvatarAccount,
   Box,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   AvatarIcon,
   AvatarIconSize,
   BadgeWrapper,
   IconName,
-  ///: END:ONLY_INCLUDE_IF
   Text,
 } from '../../../../component-library';
 import {
   AlignItems,
   Display,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   BackgroundColor,
   BorderColor,
   IconColor,
-  ///: END:ONLY_INCLUDE_IF
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
@@ -49,15 +36,11 @@ export const DomainInputResolutionCell = ({
   domainType,
   address,
   domainName,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   resolvingSnap = '',
-  ///: END:ONLY_INCLUDE_IF
   onClick,
   protocol,
 }: DomainInputResolutionCellArgs) => {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   const t: (key: string, params: unknown[]) => string = useContext(I18nContext);
-  ///: END:ONLY_INCLUDE_IF
   const titleRef = useRef<null | HTMLDivElement>(null);
   const breakpointRef = useRef<null | number>(null);
   const [isTitleOverflowing, setIsTitleOverflowing] = useState(false);
@@ -106,7 +89,6 @@ export const DomainInputResolutionCell = ({
     </Tooltip>
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   if (domainType === 'Other') {
     // Snap provided resolution.
     return (
@@ -180,7 +162,6 @@ export const DomainInputResolutionCell = ({
       </Box>
     );
   }
-  ///: END:ONLY_INCLUDE_IF
   const getTitle = () => {
     if (domainName && isTitleOverflowing) {
       return <OverflowingTitle />;
@@ -242,9 +223,7 @@ DomainInputResolutionCell.propTypes = {
   domainType: PropTypes.string.isRequired,
   address: PropTypes.string.isRequired,
   domainName: PropTypes.string.isRequired,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   resolvingSnap: PropTypes.string.isRequired,
-  ///: END:ONLY_INCLUDE_IF
   onClick: PropTypes.func,
   protocol: PropTypes.string,
 };

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -496,14 +496,12 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     weight: 3,
   }),
   ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   [EndowmentPermissions['endowment:name-lookup']]: ({ t }) => ({
     label: t('permission_nameLookup'),
     description: t('permission_nameLookupDescription'),
     leftIcon: IconName.Search,
     weight: 4,
   }),
-  ///: END:ONLY_INCLUDE_IF
   [EndowmentPermissions['endowment:signature-insight']]: ({
     t,
     permissionValue,


### PR DESCRIPTION


## **Description**

This removes code fences for `endowment:name-lookup` Snap permission, bringing this permission into main build out of Flask.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26392?quickstart=1)

## **Related issues**

Fixes https://github.com/MetaMask/snaps/issues/2621
