### PR TITLE
fix: Delete obsolete properties from phishingController and networkControl…

### DIFF
--- a/app/scripts/migrations/120.4.test.ts
+++ b/app/scripts/migrations/120.4.test.ts
@@ -198,8 +198,7 @@ describe('migration #120.4', () => {
     it('deletes obsolete properties from the NetworkController state', async () => {
       const oldState = {
         NetworkController: {
-          phishing: 'test',
-          lastFetched: 'test',
+          network: 'test',
         },
       };
 

--- a/app/scripts/migrations/120.4.test.ts
+++ b/app/scripts/migrations/120.4.test.ts
@@ -164,7 +164,7 @@ describe('migration #120.4', () => {
   });
 
   describe('NetworkController', () => {
-    it('does nothing if CurrencyController state is not set', async () => {
+    it('does nothing if NetworkController state is not set', async () => {
       const oldState = {
         OtherController: {},
       };

--- a/app/scripts/migrations/120.4.test.ts
+++ b/app/scripts/migrations/120.4.test.ts
@@ -97,7 +97,7 @@ describe('migration #120.4', () => {
   });
 
   describe('PhishingController', () => {
-    it('does nothing if CurrencyController state is not set', async () => {
+    it('does nothing if PhishingController state is not set', async () => {
       const oldState = {
         OtherController: {},
       };

--- a/app/scripts/migrations/120.4.test.ts
+++ b/app/scripts/migrations/120.4.test.ts
@@ -95,4 +95,138 @@ describe('migration #120.4', () => {
       });
     });
   });
+
+  describe('PhishingController', () => {
+    it('does nothing if CurrencyController state is not set', async () => {
+      const oldState = {
+        OtherController: {},
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual(oldState);
+    });
+
+    it('captures an error and leaves state unchanged if PhishingController state is corrupted', async () => {
+      const oldState = {
+        PhishingController: 'invalid',
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual(oldState);
+      expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+        new Error(
+          `Migration ${version}: Invalid PhishingController state of type 'string'`,
+        ),
+      );
+    });
+
+    it('deletes obsolete properties from the PhishingController state', async () => {
+      const oldState = {
+        PhishingController: {
+          phishing: 'test',
+          lastFetched: 'test',
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual({ PhishingController: {} });
+    });
+
+    it('does not delete non-obsolete properties from the PhishingController state', async () => {
+      const oldState = {
+        PhishingController: {
+          phishing: 'test',
+          phishingLists: 'test',
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual({
+        PhishingController: { phishingLists: 'test' },
+      });
+    });
+  });
+
+  describe('NetworkController', () => {
+    it('does nothing if CurrencyController state is not set', async () => {
+      const oldState = {
+        OtherController: {},
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual(oldState);
+    });
+
+    it('captures an error and leaves state unchanged if NetworkController state is corrupted', async () => {
+      const oldState = {
+        NetworkController: 'invalid',
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual(oldState);
+      expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+        new Error(
+          `Migration ${version}: Invalid NetworkController state of type 'string'`,
+        ),
+      );
+    });
+
+    it('deletes obsolete properties from the NetworkController state', async () => {
+      const oldState = {
+        NetworkController: {
+          phishing: 'test',
+          lastFetched: 'test',
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual({ NetworkController: {} });
+    });
+
+    it('does not delete non-obsolete properties from the NetworkController state', async () => {
+      const oldState = {
+        NetworkController: {
+          network: 'test',
+          selectedNetworkClientId: 'test',
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: cloneDeep(oldState),
+      });
+
+      expect(transformedState.data).toEqual({
+        NetworkController: { selectedNetworkClientId: 'test' },
+      });
+    });
+  });
 });

--- a/app/scripts/migrations/120.4.ts
+++ b/app/scripts/migrations/120.4.ts
@@ -63,10 +63,57 @@ function removeObsoleteCurrencyControllerState(
 }
 
 /**
+ * Remove obsolete PhishingController state
+ *
+ * @param state - The persisted MetaMask state, keyed by controller.
+ */
+function removeObsoletePhishingControllerState(
+  state: Record<string, unknown>,
+): void {
+  if (!hasProperty(state, 'PhishingController')) {
+    return;
+  } else if (!isObject(state.PhishingController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `Migration ${version}: Invalid PhishingController state of type '${typeof state.PhishingController}'`,
+      ),
+    );
+    return;
+  }
+
+  delete state.PhishingController.phishing;
+  delete state.PhishingController.lastFetched;
+}
+
+/**
+ * Remove obsolete NetworkController state
+ *
+ * @param state - The persisted MetaMask state, keyed by controller.
+ */
+function removeObsoleteNetworkControllerState(
+  state: Record<string, unknown>,
+): void {
+  if (!hasProperty(state, 'NetworkController')) {
+    return;
+  } else if (!isObject(state.NetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `Migration ${version}: Invalid NetworkController state of type '${typeof state.NetworkController}'`,
+      ),
+    );
+    return;
+  }
+
+  delete state.NetworkController.network;
+}
+
+/**
  * Remove obsolete controller state.
  *
  * @param state - The persisted MetaMask state, keyed by controller.
  */
 function transformState(state: Record<string, unknown>): void {
   removeObsoleteCurrencyControllerState(state);
+  removeObsoletePhishingControllerState(state);
+  removeObsoleteNetworkControllerState(state);
 }


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Expands on https://github.com/MetaMask/metamask-extension/pull/26383 to delete more obsolete state from the Network and Phishing controllers, to eliminate other sentry errors.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26396?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
