### PR TITLE
fix: Flaky contract interaction test

### DIFF
--- a/test/e2e/tests/confirmations/transactions/shared.ts
+++ b/test/e2e/tests/confirmations/transactions/shared.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { MockedEndpoint } from 'mockttp';
+import { veryLargeDelayMs } from '../../../helpers';
+import { Ganache } from '../../../seeder/ganache';
 import GanacheContractAddressRegistry from '../../../seeder/ganache-contract-address-registry';
 import { Driver } from '../../../webdriver/driver';
-import { Ganache } from '../../../seeder/ganache';
 
 const {
   logInWithBalanceValidation,
@@ -109,6 +110,7 @@ export async function confirmDepositTransactionWithCustomNonce(
     text: 'Save',
     tag: 'button',
   });
+  await driver.delay(veryLargeDelayMs);
   await scrollAndConfirmAndAssertConfirm(driver);
 
   // Confirm tx was submitted with the higher nonce


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On https://github.com/MetaMask/metamask-extension/pull/26234, `scrollAndConfirmAndAssertConfirm` was modified to use `clickElementSafe` instead of `clickElement`.

Even though this was probably useful for the test in `snap-account-contract-interaction.spec.ts` that the PR introduced, it broke `Sends a contract interaction type 2 transaction with custom nonce editing (EIP1559)` inside `contract-interaction-redesign.spec.ts`. This is because `clickElementSafe` doesn't attempt to find a clickable element multiple times like `clickElement`. Without that retry, the scroll button was not pressed. Without that, the confirm button in the footer was not enabled and the test fails.

Adding a delay before the particular usage of `scrollAndConfirmAndAssertConfirm` that was failing fixes the test execution.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26420?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26417

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
