### PR TITLE
fix: problem with origins in the Snaps permission UI

### DIFF
--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -71,7 +71,11 @@ export default function SnapPermissionsList({
   };
 
   return (
-    <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+      width={BlockSize.Full}
+    >
       <Box className="snap-permissions-list" width={BlockSize.Full}>
         <SnapPermissionAdapter
           permissions={showAll ? weightedPermissions : filteredPermissions}

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -8,6 +8,7 @@ import {
   getSnapsMetadata,
 } from '../../../../selectors';
 import {
+  BlockSize,
   Display,
   FlexDirection,
   JustifyContent,
@@ -71,7 +72,7 @@ export default function SnapPermissionsList({
 
   return (
     <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
-      <Box className="snap-permissions-list">
+      <Box className="snap-permissions-list" width={BlockSize.Full}>
         <SnapPermissionAdapter
           permissions={showAll ? weightedPermissions : filteredPermissions}
           snapId={snapId}

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -41,6 +41,7 @@ function getSnapNameComponent(snapName) {
       fontWeight={FontWeight.Medium}
       variant={TextVariant.inherit}
       color={TextColor.inherit}
+      style={{ lineBreak: 'anywhere' }}
     >
       {snapName}
     </Text>
@@ -270,6 +271,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
               variant={TextVariant.inherit}
               fontWeight={FontWeight.Medium}
               key={snapId}
+              style={{ lineBreak: 'anywhere' }}
             >
               {snapName}
             </Text>,
@@ -566,6 +568,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
             fontWeight={FontWeight.Medium}
             variant={TextVariant.inherit}
             color={TextColor.inherit}
+            style={{ lineBreak: 'anywhere' }}
           >
             {connectionName}
           </Text>,

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -410,6 +410,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
             color={TextColor.inherit}
             variant={TextVariant.inherit}
             fontWeight={FontWeight.Medium}
+            style={{ lineBreak: 'anywhere' }}
           >
             {allowedOrigins[0]}
           </Text>
@@ -423,6 +424,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
               color={TextColor.inherit}
               variant={TextVariant.inherit}
               fontWeight={FontWeight.Medium}
+              style={{ lineBreak: 'anywhere' }}
             >
               {origin}
             </Text>
@@ -437,6 +439,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
             variant={TextVariant.inherit}
             fontWeight={FontWeight.Medium}
             key="2"
+            style={{ lineBreak: 'anywhere' }}
           >
             {lastOrigin}
           </Text>,

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -41,7 +41,6 @@ function getSnapNameComponent(snapName) {
       fontWeight={FontWeight.Medium}
       variant={TextVariant.inherit}
       color={TextColor.inherit}
-      style={{ lineBreak: 'anywhere' }}
     >
       {snapName}
     </Text>
@@ -271,7 +270,6 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
               variant={TextVariant.inherit}
               fontWeight={FontWeight.Medium}
               key={snapId}
-              style={{ lineBreak: 'anywhere' }}
             >
               {snapName}
             </Text>,


### PR DESCRIPTION
## **Description**
Displaying website URLs for origins in Snaps permissions UI is problematic and can cause UI to break. 
This PR introduces usage of `line-break: anywhere` for the origins.
Full width is also added to the permissions list, to stretch the box that is holding permission cells, this helps in cases with less content that doesn't push all elements to the full width (e.g. info icon).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26422?quickstart=1)

## **Related issues**
Fixes: https://github.com/MetaMask/metamask-extension/issues/26421

## **Manual testing steps**
1. Try installing https://snaps.metamask.io/snap/npm/silencelaboratories/silent-shard-snap/ or https://snaps.metamask.io/snap/npm/safeheron/mpcsnap/
2. Check that UI is not broken like before

## **Screenshots/Recordings**
### **Before**
![image](https://github.com/user-attachments/assets/e60eca86-9ad1-4c7b-8d30-13561fdabec1)
![image](https://github.com/user-attachments/assets/b5e46dd9-5816-4e2e-aaca-53ea2ac8beca)

### **After**
![Screenshot 2024-08-14 at 16 17 59](https://github.com/user-attachments/assets/2d27500b-5495-4b60-83d8-ceabd6641529)
![Screenshot 2024-08-14 at 16 18 21](https://github.com/user-attachments/assets/b61fd831-c0c8-4956-afcc-6b6796985f02)

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
