### PR TITLE
build(chore): switch to `defer` since it guarantees execution order once chunked

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -16,6 +16,6 @@
       <img class="loading-spinner" src="./images/spinner.gif" alt="" loading="lazy" />
     </div>
     <div id="popover-content"></div>
-    <script src="./scripts/load/ui.ts" async></script>
+    <script src="./scripts/load/ui.ts" defer></script>
   </body>
 </html>

--- a/app/popup.html
+++ b/app/popup.html
@@ -12,6 +12,6 @@
       <img class="loading-spinner" src="./images/spinner.gif" alt="" loading="lazy" />
     </div>
     <div id="popover-content"></div>
-    <script src="./scripts/load/ui.ts" async></script>
+    <script src="./scripts/load/ui.ts" defer></script>
   </body>
 </html>


### PR DESCRIPTION
`async` script tags execute as soon as the script is downloaded, whereas `defer` will executes in DOM order. We use `async` in our bundle when chunked (by webpack), and this could result in the JS being executed out of order. I haven't actually seen this race condition occur, but it seems possible.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26425?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->