### PR TITLE
fix: Override fetch global for snaps-controllers

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2637,7 +2637,7 @@
         "URL": true,
         "clearTimeout": true,
         "document.getElementById": true,
-        "fetch.bind": true,
+        "fetch": true,
         "setTimeout": true
       },
       "packages": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2637,7 +2637,7 @@
         "URL": true,
         "clearTimeout": true,
         "document.getElementById": true,
-        "fetch.bind": true,
+        "fetch": true,
         "setTimeout": true
       },
       "packages": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2637,7 +2637,7 @@
         "URL": true,
         "clearTimeout": true,
         "document.getElementById": true,
-        "fetch.bind": true,
+        "fetch": true,
         "setTimeout": true
       },
       "packages": {

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2729,7 +2729,7 @@
         "URL": true,
         "clearTimeout": true,
         "document.getElementById": true,
-        "fetch.bind": true,
+        "fetch": true,
         "setTimeout": true
       },
       "packages": {

--- a/lavamoat/browserify/policy-override.json
+++ b/lavamoat/browserify/policy-override.json
@@ -1,5 +1,10 @@
 {
   "resources": {
+    "@metamask/snaps-controllers": {
+      "globals": {
+        "fetch": true
+      }
+    },
     "@metamask/snaps-execution-environments": {
       "packages": {
         "@metamask/post-message-stream": true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a problem with `fetch` being illegally invoked when building without Sentry. The fix is to override the LavaMoat policy for `snaps-controllers` to specify `fetch` as an endowment instead of `fetch.bind`, since this makes the binding work.

My assumption is that this wasn't necessary when Sentry is enabled as modifies the `fetch` global in some way. 

This needs a sanity check.

Can be tested by building with `yarn dist --build-type=flask` and attempting any install of Snap. You must build without `SENTRY_DSN_DEV` defined.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26431?quickstart=1)


