### PR TITLE
chore(2916): refactor stream handler for phishing warning and legacy

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -1,7 +1,7 @@
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
 import PortStream from 'extension-port-stream';
 import ObjectMultiplex from '@metamask/object-multiplex';
-import { pipeline, Transform } from 'readable-stream';
+import { pipeline } from 'readable-stream';
 import browser from 'webextension-polyfill';
 import { EXTENSION_MESSAGES } from '../../shared/constants/app';
 import {
@@ -9,188 +9,34 @@ import {
   getIsBrowserPrerenderBroken,
 } from '../../shared/modules/browser-runtime.utils';
 import shouldInjectProvider from '../../shared/modules/provider-injection';
+import {
+  connectPhishingChannelToWarningSystem,
+  initPhishingStreams,
+  isDetectedPhishingSite,
+} from './streams/phishing-stream';
+import { logStreamDisconnectWarning } from './streams/shared';
+import {
+  destroyLegacyExtensionStreams,
+  notifyInpageOfStreamFailure,
+  setupLegacyExtensionStreams,
+  setupLegacyPageStreams,
+} from './streams/legacy-stream';
 
 // contexts
 const CONTENT_SCRIPT = 'metamask-contentscript';
 const INPAGE = 'metamask-inpage';
-const PHISHING_WARNING_PAGE = 'metamask-phishing-warning-page';
 
 // stream channels
-const PHISHING_SAFELIST = 'metamask-phishing-safelist';
+
 const PROVIDER = 'metamask-provider';
-
-// For more information about these legacy streams, see here:
-// https://github.com/MetaMask/metamask-extension/issues/15491
-// TODO:LegacyProvider: Delete
-const LEGACY_CONTENT_SCRIPT = 'contentscript';
-const LEGACY_INPAGE = 'inpage';
-const LEGACY_PROVIDER = 'provider';
 const LEGACY_PUBLIC_CONFIG = 'publicConfig';
-
-let legacyExtMux,
-  legacyExtChannel,
-  legacyExtPublicConfigChannel,
-  legacyPageMux,
-  legacyPageMuxLegacyProviderChannel,
-  legacyPagePublicConfigChannel,
-  notificationTransformStream;
-
-const phishingPageUrl = new URL(process.env.PHISHING_WARNING_PAGE_URL);
-
-let phishingExtChannel,
-  phishingExtMux,
-  phishingExtPort,
-  phishingExtStream,
-  phishingPageChannel,
-  phishingPageMux;
 
 let extensionMux,
   extensionChannel,
   extensionPort,
-  extensionPhishingStream,
   extensionStream,
   pageMux,
   pageChannel;
-
-/**
- * PHISHING STREAM LOGIC
- */
-
-function setupPhishingPageStreams() {
-  // the transport-specific streams for communication between inpage and background
-  const phishingPageStream = new WindowPostMessageStream({
-    name: CONTENT_SCRIPT,
-    target: PHISHING_WARNING_PAGE,
-  });
-
-  // create and connect channel muxers
-  // so we can handle the channels individually
-  phishingPageMux = new ObjectMultiplex();
-  phishingPageMux.setMaxListeners(25);
-
-  pipeline(phishingPageMux, phishingPageStream, phishingPageMux, (err) =>
-    logStreamDisconnectWarning('MetaMask Inpage Multiplex', err),
-  );
-
-  phishingPageChannel = phishingPageMux.createStream(PHISHING_SAFELIST);
-}
-
-const setupPhishingExtStreams = () => {
-  phishingExtPort = browser.runtime.connect({
-    name: CONTENT_SCRIPT,
-  });
-  phishingExtStream = new PortStream(phishingExtPort);
-
-  // create and connect channel muxers
-  // so we can handle the channels individually
-  phishingExtMux = new ObjectMultiplex();
-  phishingExtMux.setMaxListeners(25);
-
-  pipeline(phishingExtMux, phishingExtStream, phishingExtMux, (err) => {
-    logStreamDisconnectWarning('MetaMask Background Multiplex', err);
-    window.postMessage(
-      {
-        target: PHISHING_WARNING_PAGE, // the post-message-stream "target"
-        data: {
-          // this object gets passed to @metamask/object-multiplex
-          name: PHISHING_SAFELIST, // the @metamask/object-multiplex channel name
-          data: {
-            jsonrpc: '2.0',
-            method: 'METAMASK_STREAM_FAILURE',
-          },
-        },
-      },
-      window.location.origin,
-    );
-  });
-
-  // forward communication across inpage-background for these channels only
-  phishingExtChannel = phishingExtMux.createStream(PHISHING_SAFELIST);
-  pipeline(
-    phishingPageChannel,
-    phishingExtChannel,
-    phishingPageChannel,
-    (error) =>
-      console.debug(
-        `MetaMask: Muxed traffic for channel "${PHISHING_SAFELIST}" failed.`,
-        error,
-      ),
-  );
-
-  // eslint-disable-next-line no-use-before-define
-  phishingExtPort.onDisconnect.addListener(onDisconnectDestroyPhishingStreams);
-};
-
-/** Destroys all of the phishing extension streams */
-const destroyPhishingExtStreams = () => {
-  phishingPageChannel.removeAllListeners();
-
-  phishingExtMux.removeAllListeners();
-  phishingExtMux.destroy();
-
-  phishingExtChannel.removeAllListeners();
-  phishingExtChannel.destroy();
-
-  phishingExtStream = null;
-};
-
-/**
- * This listener destroys the phishing extension streams when the extension port is disconnected,
- * so that streams may be re-established later the phishing extension port is reconnected.
- */
-const onDisconnectDestroyPhishingStreams = () => {
-  const err = checkForLastError();
-
-  phishingExtPort.onDisconnect.removeListener(
-    onDisconnectDestroyPhishingStreams,
-  );
-
-  destroyPhishingExtStreams();
-
-  /**
-   * If an error is found, reset the streams. When running two or more dapps, resetting the service
-   * worker may cause the error, "Error: Could not establish connection. Receiving end does not
-   * exist.", due to a race-condition. The disconnect event may be called by runtime.connect which
-   * may cause issues. We suspect that this is a chromium bug as this event should only be called
-   * once the port and connections are ready. Delay time is arbitrary.
-   */
-  if (err) {
-    console.warn(`${err} Resetting the phishing streams.`);
-    setTimeout(setupPhishingExtStreams, 1000);
-  }
-};
-
-/**
- * When the extension background is loaded it sends the EXTENSION_MESSAGES.READY message to the browser tabs.
- * This listener/callback receives the message to set up the streams after service worker in-activity.
- *
- * @param {object} msg
- * @param {string} msg.name - custom property and name to identify the message received
- * @returns {Promise|undefined}
- */
-const onMessageSetUpPhishingStreams = (msg) => {
-  if (msg.name === EXTENSION_MESSAGES.READY) {
-    if (!phishingExtStream) {
-      setupPhishingExtStreams();
-    }
-    return Promise.resolve(
-      `MetaMask: handled "${EXTENSION_MESSAGES.READY}" for phishing streams`,
-    );
-  }
-  return undefined;
-};
-
-/**
- * Initializes two-way communication streams between the browser extension and
- * the phishing page context. This function also creates an event listener to
- * reset the streams if the service worker resets.
- */
-const initPhishingStreams = () => {
-  setupPhishingPageStreams();
-  setupPhishingExtStreams();
-
-  browser.runtime.onMessage.addListener(onMessageSetUpPhishingStreams);
-};
 
 /**
  * INPAGE - EXTENSION STREAM LOGIC
@@ -245,8 +91,7 @@ const setupExtensionStreams = () => {
   );
 
   // connect "phishing" channel to warning system
-  extensionPhishingStream = extensionMux.createStream('phishing');
-  extensionPhishingStream.once('data', redirectToPhishingWarning);
+  connectPhishingChannelToWarningSystem(extensionMux);
 
   // eslint-disable-next-line no-use-before-define
   extensionPort.onDisconnect.addListener(onDisconnectDestroyStreams);
@@ -266,92 +111,6 @@ const destroyExtensionStreams = () => {
 };
 
 /**
- * LEGACY STREAM LOGIC
- * TODO:LegacyProvider: Delete
- */
-
-// TODO:LegacyProvider: Delete
-const setupLegacyPageStreams = () => {
-  const legacyPageStream = new WindowPostMessageStream({
-    name: LEGACY_CONTENT_SCRIPT,
-    target: LEGACY_INPAGE,
-  });
-
-  legacyPageMux = new ObjectMultiplex();
-  legacyPageMux.setMaxListeners(25);
-
-  pipeline(legacyPageMux, legacyPageStream, legacyPageMux, (err) =>
-    logStreamDisconnectWarning('MetaMask Legacy Inpage Multiplex', err),
-  );
-
-  legacyPageMuxLegacyProviderChannel =
-    legacyPageMux.createStream(LEGACY_PROVIDER);
-  legacyPagePublicConfigChannel =
-    legacyPageMux.createStream(LEGACY_PUBLIC_CONFIG);
-};
-
-// TODO:LegacyProvider: Delete
-const setupLegacyExtensionStreams = () => {
-  legacyExtMux = new ObjectMultiplex();
-  legacyExtMux.setMaxListeners(25);
-
-  notificationTransformStream = getNotificationTransformStream();
-  pipeline(
-    legacyExtMux,
-    extensionStream,
-    notificationTransformStream,
-    legacyExtMux,
-    (err) => {
-      logStreamDisconnectWarning('MetaMask Background Legacy Multiplex', err);
-      notifyInpageOfStreamFailure();
-    },
-  );
-
-  legacyExtChannel = legacyExtMux.createStream(PROVIDER);
-  pipeline(
-    legacyPageMuxLegacyProviderChannel,
-    legacyExtChannel,
-    legacyPageMuxLegacyProviderChannel,
-    (error) =>
-      console.debug(
-        `MetaMask: Muxed traffic between channels "${LEGACY_PROVIDER}" and "${PROVIDER}" failed.`,
-        error,
-      ),
-  );
-
-  legacyExtPublicConfigChannel =
-    legacyExtMux.createStream(LEGACY_PUBLIC_CONFIG);
-  pipeline(
-    legacyPagePublicConfigChannel,
-    legacyExtPublicConfigChannel,
-    legacyPagePublicConfigChannel,
-    (error) =>
-      console.debug(
-        `MetaMask: Muxed traffic for channel "${LEGACY_PUBLIC_CONFIG}" failed.`,
-        error,
-      ),
-  );
-};
-
-/**
- * Destroys all of the legacy extension streams
- * TODO:LegacyProvider: Delete
- */
-const destroyLegacyExtensionStreams = () => {
-  legacyPageMuxLegacyProviderChannel.removeAllListeners();
-  legacyPagePublicConfigChannel.removeAllListeners();
-
-  legacyExtMux.removeAllListeners();
-  legacyExtMux.destroy();
-
-  legacyExtChannel.removeAllListeners();
-  legacyExtChannel.destroy();
-
-  legacyExtPublicConfigChannel.removeAllListeners();
-  legacyExtPublicConfigChannel.destroy();
-};
-
-/**
  * When the extension background is loaded it sends the EXTENSION_MESSAGES.READY message to the browser tabs.
  * This listener/callback receives the message to set up the streams after service worker in-activity.
  *
@@ -363,7 +122,7 @@ const onMessageSetUpExtensionStreams = (msg) => {
   if (msg.name === EXTENSION_MESSAGES.READY) {
     if (!extensionStream) {
       setupExtensionStreams();
-      setupLegacyExtensionStreams();
+      setupLegacyExtensionStreams(extensionStream);
     }
     return Promise.resolve(`MetaMask: handled ${EXTENSION_MESSAGES.READY}`);
   }
@@ -412,38 +171,6 @@ const initStreams = () => {
   browser.runtime.onMessage.addListener(onMessageSetUpExtensionStreams);
 };
 
-// TODO:LegacyProvider: Delete
-function getNotificationTransformStream() {
-  const stream = new Transform({
-    highWaterMark: 16,
-    objectMode: true,
-    transform: (chunk, _, cb) => {
-      if (chunk?.name === PROVIDER) {
-        if (chunk.data?.method === 'metamask_accountsChanged') {
-          chunk.data.method = 'wallet_accountsChanged';
-          chunk.data.result = chunk.data.params;
-          delete chunk.data.params;
-        }
-      }
-      cb(null, chunk);
-    },
-  });
-  return stream;
-}
-
-/**
- * Error handler for page to extension stream disconnections
- *
- * @param {string} remoteLabel - Remote stream name
- * @param {Error} error - Stream connection error
- */
-function logStreamDisconnectWarning(remoteLabel, error) {
-  console.debug(
-    `MetaMask: Content script lost connection to "${remoteLabel}".`,
-    error,
-  );
-}
-
 /**
  * The function notifies inpage when the extension stream connection is ready. When the
  * 'metamask_chainChanged' method is received from the extension, it implies that the
@@ -475,51 +202,7 @@ function extensionStreamMessageListener(msg) {
   }
 }
 
-/**
- * This function must ONLY be called in pipeline destruction/close callbacks.
- * Notifies the inpage context that streams have failed, via window.postMessage.
- * Relies on @metamask/object-multiplex and post-message-stream implementation details.
- */
-function notifyInpageOfStreamFailure() {
-  window.postMessage(
-    {
-      target: INPAGE, // the post-message-stream "target"
-      data: {
-        // this object gets passed to @metamask/object-multiplex
-        name: PROVIDER, // the @metamask/object-multiplex channel name
-        data: {
-          jsonrpc: '2.0',
-          method: 'METAMASK_STREAM_FAILURE',
-        },
-      },
-    },
-    window.location.origin,
-  );
-}
-
-/**
- * Redirects the current page to a phishing information page
- */
-function redirectToPhishingWarning() {
-  console.debug('MetaMask: Routing to Phishing Warning page.');
-  const { hostname, href } = window.location;
-  const baseUrl = process.env.PHISHING_WARNING_PAGE_URL;
-
-  const querystring = new URLSearchParams({ hostname, href });
-  window.location.href = `${baseUrl}#${querystring}`;
-  // eslint-disable-next-line no-constant-condition
-  while (1) {
-    console.log(
-      'MetaMask: Locking js execution, redirection will complete shortly',
-    );
-  }
-}
-
 const start = () => {
-  const isDetectedPhishingSite =
-    window.location.origin === phishingPageUrl.origin &&
-    window.location.pathname === phishingPageUrl.pathname;
-
   if (isDetectedPhishingSite) {
     initPhishingStreams();
     return;

--- a/app/scripts/streams/legacy-stream.js
+++ b/app/scripts/streams/legacy-stream.js
@@ -1,0 +1,147 @@
+import { WindowPostMessageStream } from '@metamask/post-message-stream';
+import ObjectMultiplex from '@metamask/object-multiplex';
+import { pipeline, Transform } from 'readable-stream';
+import { logStreamDisconnectWarning } from './shared';
+
+// For more information about these legacy streams, see here:
+// https://github.com/MetaMask/metamask-extension/issues/15491
+// TODO:LegacyProvider: Delete
+const LEGACY_CONTENT_SCRIPT = 'contentscript';
+const LEGACY_INPAGE = 'inpage';
+const LEGACY_PROVIDER = 'provider';
+const LEGACY_PUBLIC_CONFIG = 'publicConfig';
+const PROVIDER = 'metamask-provider';
+const INPAGE = 'metamask-inpage';
+
+let legacyExtMux,
+  legacyExtChannel,
+  legacyExtPublicConfigChannel,
+  legacyPageMux,
+  legacyPageMuxLegacyProviderChannel,
+  legacyPagePublicConfigChannel,
+  notificationTransformStream;
+
+/**
+ * This function must ONLY be called in pipeline destruction/close callbacks.
+ * Notifies the inpage context that streams have failed, via window.postMessage.
+ * Relies on @metamask/object-multiplex and post-message-stream implementation details.
+ */
+export function notifyInpageOfStreamFailure() {
+  window.postMessage(
+    {
+      target: INPAGE, // the post-message-stream "target"
+      data: {
+        // this object gets passed to @metamask/object-multiplex
+        name: PROVIDER, // the @metamask/object-multiplex channel name
+        data: {
+          jsonrpc: '2.0',
+          method: 'METAMASK_STREAM_FAILURE',
+        },
+      },
+    },
+    window.location.origin,
+  );
+}
+/**
+ * LEGACY STREAM LOGIC
+ * TODO:LegacyProvider: Delete
+ */
+// TODO:LegacyProvider: Delete
+function getNotificationTransformStream() {
+  const stream = new Transform({
+    highWaterMark: 16,
+    objectMode: true,
+    transform: (chunk, _, cb) => {
+      if (chunk?.name === PROVIDER) {
+        if (chunk.data?.method === 'metamask_accountsChanged') {
+          chunk.data.method = 'wallet_accountsChanged';
+          chunk.data.result = chunk.data.params;
+          delete chunk.data.params;
+        }
+      }
+      cb(null, chunk);
+    },
+  });
+  return stream;
+}
+
+// TODO:LegacyProvider: Delete
+export const setupLegacyPageStreams = () => {
+  const legacyPageStream = new WindowPostMessageStream({
+    name: LEGACY_CONTENT_SCRIPT,
+    target: LEGACY_INPAGE,
+  });
+
+  legacyPageMux = new ObjectMultiplex();
+  legacyPageMux.setMaxListeners(25);
+
+  pipeline(legacyPageMux, legacyPageStream, legacyPageMux, (err) =>
+    logStreamDisconnectWarning('MetaMask Legacy Inpage Multiplex', err),
+  );
+
+  legacyPageMuxLegacyProviderChannel =
+    legacyPageMux.createStream(LEGACY_PROVIDER);
+  legacyPagePublicConfigChannel =
+    legacyPageMux.createStream(LEGACY_PUBLIC_CONFIG);
+};
+
+// TODO:LegacyProvider: Delete
+export const setupLegacyExtensionStreams = (extensionStream) => {
+  legacyExtMux = new ObjectMultiplex();
+  legacyExtMux.setMaxListeners(25);
+
+  notificationTransformStream = getNotificationTransformStream();
+  pipeline(
+    legacyExtMux,
+    extensionStream,
+    notificationTransformStream,
+    legacyExtMux,
+    (err) => {
+      logStreamDisconnectWarning('MetaMask Background Legacy Multiplex', err);
+      notifyInpageOfStreamFailure();
+    },
+  );
+
+  legacyExtChannel = legacyExtMux.createStream(PROVIDER);
+  pipeline(
+    legacyPageMuxLegacyProviderChannel,
+    legacyExtChannel,
+    legacyPageMuxLegacyProviderChannel,
+    (error) =>
+      console.debug(
+        `MetaMask: Muxed traffic between channels "${LEGACY_PROVIDER}" and "${PROVIDER}" failed.`,
+        error,
+      ),
+  );
+
+  legacyExtPublicConfigChannel =
+    legacyExtMux.createStream(LEGACY_PUBLIC_CONFIG);
+  pipeline(
+    legacyPagePublicConfigChannel,
+    legacyExtPublicConfigChannel,
+    legacyPagePublicConfigChannel,
+    (error) =>
+      console.debug(
+        `MetaMask: Muxed traffic for channel "${LEGACY_PUBLIC_CONFIG}" failed.`,
+        error,
+      ),
+  );
+};
+
+/**
+ * Destroys all of the legacy extension streams
+ * TODO:LegacyProvider: Delete
+ */
+export const destroyLegacyExtensionStreams = () => {
+  legacyPageMuxLegacyProviderChannel.removeAllListeners();
+  legacyPagePublicConfigChannel.removeAllListeners();
+
+  legacyExtMux.removeAllListeners();
+  legacyExtMux.destroy();
+
+  legacyExtChannel.removeAllListeners();
+  legacyExtChannel.destroy();
+
+  legacyExtPublicConfigChannel.removeAllListeners();
+  legacyExtPublicConfigChannel.destroy();
+};

--- a/app/scripts/streams/phishing-stream.ts
+++ b/app/scripts/streams/phishing-stream.ts
@@ -1,0 +1,203 @@
+import { WindowPostMessageStream } from '@metamask/post-message-stream';
+import ObjectMultiplex from '@metamask/object-multiplex';
+import { Substream } from '@metamask/object-multiplex/dist/Substream';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error types/readable-stream.d.ts does not get picked up by ts-node
+import { pipeline } from 'readable-stream';
+import browser from 'webextension-polyfill';
+import PortStream from 'extension-port-stream';
+import { checkForLastError } from '../../../shared/modules/browser-runtime.utils';
+import { EXTENSION_MESSAGES } from '../../../shared/constants/app';
+import { logStreamDisconnectWarning } from './shared';
+
+const CONTENT_SCRIPT = 'metamask-contentscript';
+const PHISHING_WARNING_PAGE = 'metamask-phishing-warning-page';
+const PHISHING_SAFELIST = 'metamask-phishing-safelist';
+
+const phishingPageUrl = new URL(
+  process.env.PHISHING_WARNING_PAGE_URL as string,
+);
+
+let phishingExtChannel: Substream,
+  phishingExtMux: ObjectMultiplex,
+  phishingExtPort: browser.Runtime.Port,
+  phishingExtStream: PortStream | null,
+  phishingPageChannel: Substream,
+  phishingPageMux: ObjectMultiplex,
+  extensionPhishingStream: Substream;
+
+/**
+ * PHISHING STREAM LOGIC
+ */
+
+function setupPhishingPageStreams(): void {
+  // the transport-specific streams for communication between inpage and background
+  const phishingPageStream = new WindowPostMessageStream({
+    name: CONTENT_SCRIPT,
+    target: PHISHING_WARNING_PAGE,
+  });
+
+  // create and connect channel muxers
+  // so we can handle the channels individually
+  phishingPageMux = new ObjectMultiplex();
+  phishingPageMux.setMaxListeners(25);
+  pipeline(phishingPageMux, phishingPageStream, phishingPageMux, (err: Error) =>
+    logStreamDisconnectWarning('MetaMask Inpage Multiplex', err),
+  );
+
+  phishingPageChannel = phishingPageMux.createStream(PHISHING_SAFELIST);
+}
+
+/** Destroys all of the phishing extension streams */
+const destroyPhishingExtStreams = (): void => {
+  phishingPageChannel.removeAllListeners();
+
+  phishingExtMux.removeAllListeners();
+  phishingExtMux.destroy();
+
+  phishingExtChannel.removeAllListeners();
+  phishingExtChannel.destroy();
+
+  phishingExtStream = null;
+};
+
+export const setupPhishingExtStreams = (): void => {
+  phishingExtPort = browser.runtime.connect({
+    name: CONTENT_SCRIPT,
+  });
+  phishingExtStream = new PortStream(phishingExtPort);
+
+  // create and connect channel muxers so we can handle the channels individually
+  phishingExtMux = new ObjectMultiplex();
+  phishingExtMux.setMaxListeners(25);
+  pipeline(phishingExtMux, phishingExtStream, phishingExtMux, (err: Error) => {
+    logStreamDisconnectWarning('MetaMask Background Multiplex', err);
+    window.postMessage(
+      {
+        target: PHISHING_WARNING_PAGE, // the post-message-stream "target"
+        data: {
+          // this object gets passed to @metamask/object-multiplex
+          name: PHISHING_SAFELIST, // the @metamask/object-multiplex channel name
+          data: {
+            jsonrpc: '2.0',
+            method: 'METAMASK_STREAM_FAILURE',
+          },
+        },
+      },
+      window.location.origin,
+    );
+  });
+
+  // forward communication across inpage-background for these channels only
+  phishingExtChannel = phishingExtMux.createStream(PHISHING_SAFELIST);
+  pipeline(
+    phishingPageChannel,
+    phishingExtChannel,
+    phishingPageChannel,
+    (error: Error) =>
+      console.debug(
+        `MetaMask: Muxed traffic for channel "${PHISHING_SAFELIST}" failed.`,
+        error,
+      ),
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  phishingExtPort.onDisconnect.addListener(onDisconnectDestroyPhishingStreams);
+};
+
+/**
+ * This listener destroys the phishing extension streams when the extension port is disconnected,
+ * so that streams may be re-established later the phishing extension port is reconnected.
+ */
+const onDisconnectDestroyPhishingStreams = (): void => {
+  const err = checkForLastError();
+
+  phishingExtPort.onDisconnect.removeListener(
+    onDisconnectDestroyPhishingStreams,
+  );
+
+  destroyPhishingExtStreams();
+
+  /**
+   * If an error is found, reset the streams. When running two or more dapps, resetting the service
+   * worker may cause the error, "Error: Could not establish connection. Receiving end does not
+   * exist.", due to a race-condition. The disconnect event may be called by runtime.connect which
+   * may cause issues. We suspect that this is a chromium bug as this event should only be called
+   * once the port and connections are ready. Delay time is arbitrary.
+   */
+  if (err) {
+    console.warn(`${err} Resetting the phishing streams.`);
+    setTimeout(setupPhishingExtStreams, 1000);
+  }
+};
+
+/**
+ * When the extension background is loaded it sends the EXTENSION_MESSAGES.READY message to the browser tabs.
+ * This listener/callback receives the message to set up the streams after service worker in-activity.
+ *
+ * @param msg - The message object
+ * @param msg.name - Custom property and name to identify the message received
+ */
+const onMessageSetUpPhishingStreams = (msg: {
+  name: string;
+}): Promise<string | undefined> | undefined => {
+  if (msg.name === EXTENSION_MESSAGES.READY) {
+    if (!phishingExtStream) {
+      setupPhishingExtStreams();
+    }
+    return Promise.resolve(
+      `MetaMask: handled "${EXTENSION_MESSAGES.READY}" for phishing streams`,
+    );
+  }
+  return undefined;
+};
+
+export const isDetectedPhishingSite: boolean =
+  window.location.origin === phishingPageUrl.origin &&
+  window.location.pathname === phishingPageUrl.pathname;
+
+/**
+ * Redirects the current page to a phishing information page
+ */
+export function redirectToPhishingWarning(): void {
+  console.debug('MetaMask: Routing to Phishing Warning page.');
+  const { hostname, href } = window.location;
+  const baseUrl = process.env.PHISHING_WARNING_PAGE_URL;
+
+  const querystring = new URLSearchParams({ hostname, href });
+  window.location.href = `${baseUrl}#${querystring}`;
+  // eslint-disable-next-line no-constant-condition
+  while (1) {
+    console.log(
+      'MetaMask: Locking js execution, redirection will complete shortly',
+    );
+  }
+}
+
+/**
+ * establish a connection between the extension's "phishing" communication channel and a warning system
+ * that triggers when a phishing threat is detected.
+ *
+ * @param extensionMux - The multiplexer used for managing communication channels
+ */
+export function connectPhishingChannelToWarningSystem(
+  extensionMux: ObjectMultiplex,
+): void {
+  // create a stream specifically for handling phishing-related communications
+  extensionPhishingStream = extensionMux.createStream('phishing');
+  // an event listener for the first piece of data received on this "phishing" channel.
+  // Once data is received, it triggers the redirectToPhishingWarning function
+  extensionPhishingStream.once('data', redirectToPhishingWarning);
+}
+
+/**
+ * Initializes two-way communication streams between the browser extension and
+ * the phishing page context. This function also creates an event listener to
+ * reset the streams if the service worker resets.
+ */
+export const initPhishingStreams = (): void => {
+  setupPhishingPageStreams();
+  setupPhishingExtStreams();
+
+  browser.runtime.onMessage.addListener(onMessageSetUpPhishingStreams);
+};

--- a/app/scripts/streams/shared.ts
+++ b/app/scripts/streams/shared.ts
@@ -1,0 +1,15 @@
+/**
+ * Error handler for page to extension stream disconnections.
+ *
+ * @param remoteLabel - The name of the remote stream that was disconnected.
+ * @param error - The stream connection error that occurred.
+ */
+export function logStreamDisconnectWarning(
+  remoteLabel: string,
+  error: Error,
+): void {
+  console.debug(
+    `MetaMask: Content script lost connection to "${remoteLabel}".`,
+    error,
+  );
+}

--- a/test/env.js
+++ b/test/env.js
@@ -16,3 +16,4 @@ process.env.PUSH_NOTIFICATIONS_SERVICE_URL =
 process.env.PORTFOLIO_URL = 'https://portfolio.test';
 process.env.METAMASK_VERSION = 'MOCK_VERSION';
 process.env.ENABLE_CONFIRMATION_REDESIGN = 'true';
+process.env.PHISHING_WARNING_PAGE_URL = 'https://example.com/phishing-warning';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
As part of https://github.com/MetaMask/MetaMask-planning/issues/2916, it is cleaner to extract the stream out of contentscript file and re-use the logic of phishing stream before implement a new stream.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26441?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2916

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
