### PR TITLE
fix: Remove double padding on Snap home page

### DIFF
--- a/ui/pages/snaps/snap-view/index.scss
+++ b/ui/pages/snaps/snap-view/index.scss
@@ -27,7 +27,7 @@
 
   &__content {
     @include design-system.screen-sm-max {
-      padding: 0 16px 16px 16px;
+      padding-top: 0;
     }
 
     &__permissions {

--- a/ui/pages/snaps/snap-view/snap-view.js
+++ b/ui/pages/snaps/snap-view/snap-view.js
@@ -109,6 +109,7 @@ function SnapView() {
           backgroundColor={BackgroundColor.backgroundDefault}
           className="snap-view__content"
           marginTop={4}
+          padding={showSettings ? 4 : 0}
         >
           {showSettings ? (
             <SnapSettings


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a newly introduced issue where the Snap home page would have double padding since all Snap UI's are wrapped in `<Container>` as of https://github.com/MetaMask/metamask-extension/commit/f461e37b46ebcf27b070469d2d8cfd0a4ac7c2ff, the container component adds 16px of padding by itself.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26462?quickstart=1)
