### PR TITLE
feat: Add footers to Snap home pages

### DIFF
--- a/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
+++ b/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
@@ -66,12 +66,14 @@ export const SnapHomeRenderer = ({ snapId }) => {
   return (
     <Box height={BlockSize.Full}>
       {error && (
-        <SnapDelineator snapName={snapName} type={DelineatorType.Error}>
-          <Text variant={TextVariant.bodySm} marginBottom={4}>
-            {t('snapsUIError', [<b key="0">{snapName}</b>])}
-          </Text>
-          <Copyable text={error.message} />
-        </SnapDelineator>
+        <Box height={BlockSize.Full} paddingRight={4} paddingLeft={4}>
+          <SnapDelineator snapName={snapName} type={DelineatorType.Error}>
+            <Text variant={TextVariant.bodySm} marginBottom={4}>
+              {t('snapsUIError', [<b key="0">{snapName}</b>])}
+            </Text>
+            <Copyable text={error.message} />
+          </SnapDelineator>
+        </Box>
       )}
       {(interfaceId || loading) && (
         <SnapUIRenderer
@@ -79,6 +81,7 @@ export const SnapHomeRenderer = ({ snapId }) => {
           interfaceId={interfaceId}
           isLoading={loading}
           useDelineator={false}
+          useFooter={true}
         />
       )}
     </Box>

--- a/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
+++ b/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
@@ -66,7 +66,7 @@ export const SnapHomeRenderer = ({ snapId }) => {
   return (
     <Box height={BlockSize.Full}>
       {error && (
-        <Box height={BlockSize.Full} paddingRight={4} paddingLeft={4}>
+        <Box height={BlockSize.Full} padding={4}>
           <SnapDelineator snapName={snapName} type={DelineatorType.Error}>
             <Text variant={TextVariant.bodySm} marginBottom={4}>
               {t('snapsUIError', [<b key="0">{snapName}</b>])}

--- a/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
+++ b/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
@@ -81,7 +81,7 @@ export const SnapHomeRenderer = ({ snapId }) => {
           interfaceId={interfaceId}
           isLoading={loading}
           useDelineator={false}
-          useFooter={true}
+          useFooter
         />
       )}
     </Box>

--- a/ui/components/app/snaps/snap-ui-renderer/components/container.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/container.ts
@@ -52,7 +52,8 @@ export const container: UIComponentFactory<BoxElement> = ({
   }
 
   // Injects the default footer if the dialog uses default footer but none was provided.
-  if (useFooter && !children[1]) {
+  // If onCancel is omitted by the caller we assume that it is safe to not display the default footer.
+  if (useFooter && onCancel && !children[1]) {
     templateChildren.push({
       ...DEFAULT_FOOTER,
       props: {

--- a/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
@@ -32,7 +32,8 @@ const getDefaultButtons = (
 ) => {
   const children = getJsxChildren(footer);
 
-  if (children.length === 1) {
+  // If onCancel is omitted by the caller we assume that it is safe to not display the default footer.
+  if (children.length === 1 && onCancel) {
     return {
       element: 'SnapFooterButton',
       key: 'default-button',

--- a/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
@@ -28,7 +28,7 @@ export const DEFAULT_FOOTER = {
 const getDefaultButtons = (
   footer: FooterElement,
   t: (value: string) => string,
-  onCancel: () => void,
+  onCancel?: () => void,
 ) => {
   const children = getJsxChildren(footer);
 

--- a/ui/components/app/snaps/snap-ui-renderer/components/types.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/types.ts
@@ -5,8 +5,8 @@ export type UIComponentParams<T extends JSXElement> = {
   map: Record<string, number>;
   element: T;
   form?: string;
-  useFooter: boolean;
-  onCancel: () => void;
+  useFooter?: boolean;
+  onCancel?: () => void;
   promptLegacyProps?: {
     onInputChange: (event: ReactChangeEvent<HTMLInputElement>) => void;
     inputValue: string;

--- a/ui/pages/snaps/snap-view/snap-view.js
+++ b/ui/pages/snaps/snap-view/snap-view.js
@@ -108,6 +108,7 @@ function SnapView() {
         <Content
           backgroundColor={BackgroundColor.backgroundDefault}
           className="snap-view__content"
+          marginTop={showSettings ? 4 : 0}
           padding={showSettings ? 4 : 0}
         >
           {showSettings ? (

--- a/ui/pages/snaps/snap-view/snap-view.js
+++ b/ui/pages/snaps/snap-view/snap-view.js
@@ -108,7 +108,6 @@ function SnapView() {
         <Content
           backgroundColor={BackgroundColor.backgroundDefault}
           className="snap-view__content"
-          marginTop={4}
           padding={showSettings ? 4 : 0}
         >
           {showSettings ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Allow `Footer` in Snap home pages, this works in the same way that the new Snap dialogs does, with the exception that default footers are turned off (e.g. a cancel button is not added automatically).

Also fixes a few padding problems with home pages. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26463?quickstart=1)

## **Related issues**

Closes: https://github.com/MetaMask/metamask-extension/issues/25417

## **Manual testing steps**

1. Create a Snap that uses `<Footer>` in `onHomePage`
2. See that the footer now shows up
3. Install any existing Snap that doesn't use `Footer`
4. See that no footer is shown

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/961ffa9e-59b4-452c-8b0f-906ba6e8c4be

![image](https://github.com/user-attachments/assets/0aecc66e-deb5-483b-acd2-504bc8679310)

