### PR TITLE
feat: [cherry pick][12.1.0] Permit ellipsis fix (1/2) permit display max 15 digits

### DIFF
--- a/ui/components/app/confirm/info/row/text-token-units.test.tsx
+++ b/ui/components/app/confirm/info/row/text-token-units.test.tsx
@@ -10,8 +10,17 @@ describe('ConfirmInfoRowTextTokenUnits', () => {
       <ConfirmInfoRowTextTokenUnits value={value} decimals={decimals} />,
     );
 
-    // Note: using formatAmount loses precision
     expect(getByText('0.0123')).toBeInTheDocument();
+  });
+
+  it('renders the value with the correct formatted number for lengthy decimals', () => {
+    const value = '300012312312123121';
+    const decimals = 18;
+    const { getByText } = render(
+      <ConfirmInfoRowTextTokenUnits value={value} decimals={decimals} />,
+    );
+
+    expect(getByText('0.3')).toBeInTheDocument();
   });
 
   it('renders the value with the correct formatted non-fractional number', () => {
@@ -21,7 +30,26 @@ describe('ConfirmInfoRowTextTokenUnits', () => {
       <ConfirmInfoRowTextTokenUnits value={value} decimals={decimals} />,
     );
 
-    // Note: using formatAmount loses precision
     expect(getByText('12,346')).toBeInTheDocument();
+  });
+
+  it('renders the value with the correct formatted number', () => {
+    const value = '30001231231212312138768';
+    const decimals = 9;
+    const { getByText } = render(
+      <ConfirmInfoRowTextTokenUnits value={value} decimals={decimals} />,
+    );
+
+    expect(getByText('30,001,231,231,212')).toBeInTheDocument();
+  });
+
+  it('renders the value with the correct formatted number and ellipsis', () => {
+    const value = '30001231231212312138768';
+    const decimals = 7;
+    const { getByText } = render(
+      <ConfirmInfoRowTextTokenUnits value={value} decimals={decimals} />,
+    );
+
+    expect(getByText('3,000,123,123,121,23...')).toBeInTheDocument();
   });
 });

--- a/ui/components/app/confirm/info/row/text-token-units.tsx
+++ b/ui/components/app/confirm/info/row/text-token-units.tsx
@@ -3,6 +3,7 @@ import { BigNumber } from 'bignumber.js';
 
 import { calcTokenAmount } from '../../../../../../shared/lib/transactions-controller-utils';
 import {
+  ellipsisAmountText,
   formatAmount,
   formatAmountMaxPrecision,
 } from '../../../../../pages/confirmations/components/simulation-details/formatAmount';
@@ -18,15 +19,12 @@ export const ConfirmInfoRowTextTokenUnits: React.FC<
 > = ({ value, decimals }) => {
   const tokenValue = calcTokenAmount(value, decimals);
 
-  // FIXME - Precision may be lost for large values when using formatAmount
-  /** @see {@link https://github.com/MetaMask/metamask-extension/issues/25755} */
   const tokenText = formatAmount('en-US', tokenValue);
   const tokenTextMaxPrecision = formatAmountMaxPrecision('en-US', tokenValue);
 
   return (
     <ConfirmInfoRowText
-      isEllipsis={true}
-      text={tokenText}
+      text={ellipsisAmountText(tokenText)}
       tooltip={tokenTextMaxPrecision}
     />
   );

--- a/ui/components/app/confirm/info/row/text.tsx
+++ b/ui/components/app/confirm/info/row/text.tsx
@@ -11,18 +11,8 @@ import {
 import { Box, ButtonIcon, IconName, Text } from '../../../../component-library';
 import Tooltip from '../../../../ui/tooltip';
 
-const InfoText = ({
-  isEllipsis,
-  text,
-}: {
-  isEllipsis: boolean;
-  text: string;
-}) => (
-  <Text
-    color={TextColor.inherit}
-    style={isEllipsis ? {} : { whiteSpace: 'pre-wrap' }}
-    ellipsis={isEllipsis}
-  >
+const InfoText = ({ text }: { text: string }) => (
+  <Text color={TextColor.inherit} style={{ whiteSpace: 'pre-wrap' }}>
     {text}
   </Text>
 );
@@ -31,14 +21,12 @@ export type ConfirmInfoRowTextProps = {
   text: string;
   onEditClick?: () => void;
   editIconClassName?: string;
-  isEllipsis?: boolean;
   tooltip?: string;
 };
 
 export const ConfirmInfoRowText: React.FC<ConfirmInfoRowTextProps> = ({
   text,
   onEditClick,
-  isEllipsis = false,
   editIconClassName,
   tooltip,
 }) => {
@@ -61,10 +49,10 @@ export const ConfirmInfoRowText: React.FC<ConfirmInfoRowTextProps> = ({
           wrapperStyle={{ minWidth: 0 }}
           interactive
         >
-          <InfoText isEllipsis={isEllipsis} text={text} />
+          <InfoText text={text} />
         </Tooltip>
       ) : (
-        <InfoText isEllipsis={isEllipsis} text={text} />
+        <InfoText text={text} />
       )}
       {isEditable ? (
         <ButtonIcon

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
@@ -409,7 +409,8 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
                     tabindex="0"
                   >
                     <p
-                      class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-inherit"
+                      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre-wrap;"
                     >
                       3,000
                     </p>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/__snapshots__/permit-simulation.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/__snapshots__/permit-simulation.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`PermitSimulation renders component correctly 1`] = `
                 tabindex="0"
               >
                 <p
-                  class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-2 mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
+                  class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--padding-inline-2 mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
                 >
                   30
                 </p>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
@@ -25,6 +25,7 @@ import { SignatureRequestType } from '../../../../../types/confirm';
 import useTokenExchangeRate from '../../../../../../../components/app/currency-input/hooks/useTokenExchangeRate';
 import { IndividualFiatDisplay } from '../../../../simulation-details/fiat-display';
 import {
+  ellipsisAmountText,
   formatAmount,
   formatAmountMaxPrecision,
 } from '../../../../simulation-details/formatAmount';
@@ -90,9 +91,8 @@ const PermitSimulation: React.FC<{
                   borderRadius={BorderRadius.XL}
                   paddingInline={2}
                   textAlign={TextAlign.Center}
-                  ellipsis
                 >
-                  {tokenValue}
+                  {ellipsisAmountText(tokenValue || '')}
                 </Text>
               </Tooltip>
             </Box>

--- a/ui/pages/confirmations/components/simulation-details/formatAmount.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/formatAmount.test.ts
@@ -1,55 +1,74 @@
 import { BigNumber } from 'bignumber.js';
-import { formatAmount } from './formatAmount';
+import { ellipsisAmountText, formatAmount } from './formatAmount';
 
 describe('formatAmount', () => {
-  const locale = 'en-US';
+  describe('#ellipsisAmountText', () => {
+    const MOCK_MAX_LEFT_DIGITS = 15;
 
-  it('returns "0" for zero amount', () => {
-    expect(formatAmount(locale, new BigNumber(0))).toBe('0');
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      ['1.003', '1.003'],
+      ['1,034', '1,034'],
+      ['1,213,098,292,340,945', '1,213,098,292,340,94...'],
+      ['30,001,231,231,212,312,138,768', '30,001,231,231,212,3...'],
+    ])(
+      'formats amount greater than or equal to 1 with appropriate decimal precision (%s => %s)',
+      (amount: string, expected: string) => {
+        expect(ellipsisAmountText(amount, MOCK_MAX_LEFT_DIGITS)).toBe(expected);
+      },
+    );
   });
 
-  it('returns "<0.000001" for 0 < amount < MIN_AMOUNT', () => {
-    expect(formatAmount(locale, new BigNumber(0.0000009))).toBe('<0.000001');
+  describe('#formatAmount', () => {
+    const locale = 'en-US';
+
+    it('returns "0" for zero amount', () => {
+      expect(formatAmount(locale, new BigNumber(0))).toBe('0');
+    });
+
+    it('returns "<0.000001" for 0 < amount < MIN_AMOUNT', () => {
+      expect(formatAmount(locale, new BigNumber(0.0000009))).toBe('<0.000001');
+    });
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      [0.0000456, '0.000046'],
+      [0.0004567, '0.000457'],
+      [0.003456, '0.00346'],
+      [0.023456, '0.0235'],
+      [0.125456, '0.125'],
+    ])(
+      'formats amount less than 1 with maximum significant digits (%s => %s)',
+      (amount: number, expected: string) => {
+        expect(formatAmount(locale, new BigNumber(amount))).toBe(expected);
+      },
+    );
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      [1.0034, '1.003'],
+      [1.034, '1.034'],
+      [1.3034, '1.303'],
+      [12.0345, '12.03'],
+      [121.456, '121.5'],
+      [1034.123, '1,034'],
+      [47361034.006, '47,361,034'],
+      ['12130982923409.5', '12,130,982,923,410'],
+      ['1213098292340944.5', '1,213,098,292,340,945'],
+      // Precision is lost after the value is greator than Number.MAX_SAFE_INTEGER. The digits after
+      // the 15th digit become 0's.
+      // TODO fix the precision
+      /** @see {@link https://github.com/MetaMask/metamask-extension/issues/25755} */
+      ['30001231231212312138768', '30,001,231,231,212,312,000,000'],
+      [
+        '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+        '115,792,089,237,316,200,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000',
+      ],
+    ])(
+      'formats amount greater than or equal to 1 with appropriate decimal precision (%s => %s)',
+      (amount: number, expected: string) => {
+        expect(formatAmount(locale, new BigNumber(amount))).toBe(expected);
+      },
+    );
   });
-
-  // @ts-expect-error This is missing from the Mocha type definitions
-  it.each([
-    [0.0000456, '0.000046'],
-    [0.0004567, '0.000457'],
-    [0.003456, '0.00346'],
-    [0.023456, '0.0235'],
-    [0.125456, '0.125'],
-  ])(
-    'formats amount less than 1 with maximum significant digits (%s => %s)',
-    (amount: number, expected: string) => {
-      expect(formatAmount(locale, new BigNumber(amount))).toBe(expected);
-    },
-  );
-
-  // @ts-expect-error This is missing from the Mocha type definitions
-  it.each([
-    [1.0034, '1.003'],
-    [1.034, '1.034'],
-    [1.3034, '1.303'],
-    [12.0345, '12.03'],
-    [121.456, '121.5'],
-    [1034.123, '1,034'],
-    [47361034.006, '47,361,034'],
-    ['12130982923409.5', '12,130,982,923,410'],
-    ['1213098292340944.5', '1,213,098,292,340,945'],
-    // Precision is lost after the value is greator than Number.MAX_SAFE_INTEGER. The digits after
-    // the 15th digit become 0's.
-    // TODO fix the precision
-    /** @see {@link https://github.com/MetaMask/metamask-extension/issues/25755} */
-    ['30001231231212312138768', '30,001,231,231,212,312,000,000'],
-    [
-      '115792089237316195423570985008687907853269984665640564039457584007913129639935',
-      '115,792,089,237,316,200,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000',
-    ],
-  ])(
-    'formats amount greater than or equal to 1 with appropriate decimal precision (%s => %s)',
-    (amount: number, expected: string) => {
-      expect(formatAmount(locale, new BigNumber(amount))).toBe(expected);
-    },
-  );
 });

--- a/ui/pages/confirmations/components/simulation-details/formatAmount.ts
+++ b/ui/pages/confirmations/components/simulation-details/formatAmount.ts
@@ -4,10 +4,50 @@ import {
   DEFAULT_PRECISION,
 } from '../../../../hooks/useCurrencyDisplay';
 
+const MAX_ELLIPSIS_LEFT_DIGITS = 15;
+
 // The number of significant decimals places to show for amounts less than 1.
 const MAX_SIGNIFICANT_DECIMAL_PLACES = 3;
 
 const ZERO_DISPLAY = '0';
+
+/**
+ * This function receives an formatted number and will append an ellipsis if the number of digits
+ * is greater than MAX_LEFT_DIGITS. Currently, we're only supporting en-US format. When we support
+ * i18n numbers, we'll need to update this method to support i18n.
+ *
+ * This method has been designed to receive results of formatAmount.
+ *
+ * There is no need to format the decimal portion because formatAmount shaves the portions off
+ * accordingly.
+ *
+ * @param amountText
+ * @param maxLeftDigits
+ */
+export function ellipsisAmountText(
+  amountText: string,
+  maxLeftDigits: number = MAX_ELLIPSIS_LEFT_DIGITS,
+): string {
+  const [integerPart] = amountText.split('.');
+  const cleanIntegerPart = integerPart.replace(/,/gu, '');
+
+  if (cleanIntegerPart.length > maxLeftDigits) {
+    let result = '';
+    let digitCount = 0;
+
+    for (let i = 0; digitCount < maxLeftDigits; i++) {
+      const integerChar = integerPart[i];
+      result += integerChar;
+      if (integerChar !== ',') {
+        digitCount += 1;
+      }
+    }
+
+    return `${result}...`;
+  }
+
+  return amountText;
+}
 
 export function formatAmountMaxPrecision(
   locale: string,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cherry-pick https://github.com/MetaMask/metamask-extension/pull/26227 into v12.1.0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26495?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26226 (Ellipsis fix)
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2730 (older, original issue)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
