### PR TITLE
cherry-pick: Add signature insights hotfix to RC

### DIFF
--- a/ui/hooks/snaps/useSignatureInsights.js
+++ b/ui/hooks/snaps/useSignatureInsights.js
@@ -108,7 +108,7 @@ export function useSignatureInsights({ txData }) {
         }
       }
     }
-    if (Object.keys(txData).length > 0) {
+    if (Object.keys(txData).length > 0 && txData.msgParams !== undefined) {
       fetchInsight();
     }
     return () => {


### PR DESCRIPTION
## **Description**

Cherry-picks https://github.com/MetaMask/metamask-extension/commit/ee8009f7cba59012e3bcad346da2e2d3f5c91371 to the 12.0.6 RC to fix a Sentry error triggered by `msgParams` being undefined.