### PR TITLE
fix: [cherry-pick][V12.1.0] Permit ellipsis fixes (4/4) - Permit ellipsis should use max 15 char (#26458)

### DIFF
--- a/ui/components/app/confirm/info/row/text-token-units.test.tsx
+++ b/ui/components/app/confirm/info/row/text-token-units.test.tsx
@@ -40,7 +40,7 @@ describe('ConfirmInfoRowTextTokenUnits', () => {
       <ConfirmInfoRowTextTokenUnits value={value} decimals={decimals} />,
     );
 
-    expect(getByText('30,001,231,231,212')).toBeInTheDocument();
+    expect(getByText('30,001,231,231,...')).toBeInTheDocument();
   });
 
   it('renders the value with the correct formatted number and ellipsis', () => {
@@ -50,6 +50,6 @@ describe('ConfirmInfoRowTextTokenUnits', () => {
       <ConfirmInfoRowTextTokenUnits value={value} decimals={decimals} />,
     );
 
-    expect(getByText('3,000,123,123,121,23...')).toBeInTheDocument();
+    expect(getByText('3,000,123,123,1...')).toBeInTheDocument();
   });
 });

--- a/ui/components/app/confirm/info/row/text-token-units.tsx
+++ b/ui/components/app/confirm/info/row/text-token-units.tsx
@@ -3,10 +3,10 @@ import { BigNumber } from 'bignumber.js';
 
 import { calcTokenAmount } from '../../../../../../shared/lib/transactions-controller-utils';
 import {
-  ellipsisAmountText,
   formatAmount,
   formatAmountMaxPrecision,
 } from '../../../../../pages/confirmations/components/simulation-details/formatAmount';
+import { shortenString } from '../../../../../helpers/utils/util';
 import { ConfirmInfoRowText } from './text';
 
 type ConfirmInfoRowTextTokenUnitsProps = {
@@ -24,7 +24,12 @@ export const ConfirmInfoRowTextTokenUnits: React.FC<
 
   return (
     <ConfirmInfoRowText
-      text={ellipsisAmountText(tokenText)}
+      text={shortenString(tokenText, {
+        truncatedCharLimit: 15,
+        truncatedStartChars: 15,
+        truncatedEndChars: 0,
+        skipCharacterInEnd: true,
+      })}
       tooltip={tokenTextMaxPrecision}
     />
   );

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -222,24 +222,30 @@ export function getRandomFileName() {
  * @param {number} options.truncatedCharLimit - The maximum length of the string.
  * @param {number} options.truncatedStartChars - The number of characters to preserve at the beginning.
  * @param {number} options.truncatedEndChars - The number of characters to preserve at the end.
+ * @param {boolean} options.skipCharacterInEnd - Skip the character at the end.
  * @returns {string} The shortened string.
  */
 export function shortenString(
   stringToShorten = '',
-  { truncatedCharLimit, truncatedStartChars, truncatedEndChars } = {
+  {
+    truncatedCharLimit,
+    truncatedStartChars,
+    truncatedEndChars,
+    skipCharacterInEnd,
+  } = {
     truncatedCharLimit: TRUNCATED_NAME_CHAR_LIMIT,
     truncatedStartChars: TRUNCATED_ADDRESS_START_CHARS,
     truncatedEndChars: TRUNCATED_ADDRESS_END_CHARS,
+    skipCharacterInEnd: false,
   },
 ) {
   if (stringToShorten.length < truncatedCharLimit) {
     return stringToShorten;
   }
 
-  return `${stringToShorten.slice(
-    0,
-    truncatedStartChars,
-  )}...${stringToShorten.slice(-truncatedEndChars)}`;
+  return `${stringToShorten.slice(0, truncatedStartChars)}...${
+    skipCharacterInEnd ? '' : stringToShorten.slice(-truncatedEndChars)
+  }`;
 }
 
 /**
@@ -258,6 +264,7 @@ export function shortenAddress(address = '') {
     truncatedCharLimit: TRUNCATED_NAME_CHAR_LIMIT,
     truncatedStartChars: TRUNCATED_ADDRESS_START_CHARS,
     truncatedEndChars: TRUNCATED_ADDRESS_END_CHARS,
+    skipCharacterInEnd: false,
   });
 }
 

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -1081,5 +1081,16 @@ describe('util', () => {
         }),
       ).toStrictEqual('0x12...7890');
     });
+
+    it('should shorten the string and remove all characters from the end if skipCharacterInEnd is true', () => {
+      expect(
+        util.shortenString('0x1234567890123456789012345678901234567890', {
+          truncatedCharLimit: 10,
+          truncatedStartChars: 4,
+          truncatedEndChars: 4,
+          skipCharacterInEnd: true,
+        }),
+      ).toStrictEqual('0x12...');
+    });
   });
 });

--- a/ui/hooks/useFiatFormatter.test.ts
+++ b/ui/hooks/useFiatFormatter.test.ts
@@ -35,6 +35,44 @@ describe('useFiatFormatter', () => {
     expect(formatFiat(0)).toBe('$0.00');
   });
 
+  describe('shorten the fiat', () => {
+    it('when currency symbol on the left for given locale', () => {
+      mockGetIntlLocale.mockReturnValue('en-US');
+      mockGetCurrentCurrency.mockReturnValue('USD');
+
+      const { result } = renderHook(() => useFiatFormatter());
+      const formatFiat = result.current;
+
+      expect(formatFiat(100000000000000000, { shorten: true })).toBe(
+        '$100,000,000,...',
+      );
+    });
+
+    it('when currency symbol on the right for given locale', () => {
+      mockGetIntlLocale.mockReturnValue('es-ES');
+      mockGetCurrentCurrency.mockReturnValue('EUR');
+
+      const { result } = renderHook(() => useFiatFormatter());
+      const formatFiat = result.current;
+
+      expect(formatFiat(100000000000000000, { shorten: true })).toBe(
+        '100.000.000....€',
+      );
+    });
+
+    it('handle unknown currencies by returning amount followed by currency code', () => {
+      mockGetCurrentCurrency.mockReturnValue('storj');
+      mockGetIntlLocale.mockReturnValue('en-US');
+
+      const { result } = renderHook(() => useFiatFormatter());
+      const formatFiat = result.current;
+
+      expect(formatFiat(100000, { shorten: true })).toBe('100,000 storj');
+      expect(formatFiat(500.5, { shorten: true })).toBe('500.5 storj');
+      expect(formatFiat(0, { shorten: true })).toBe('0 storj');
+    });
+  });
+
   it('should use the current locale and currency from the mocked functions', () => {
     mockGetIntlLocale.mockReturnValue('fr-FR');
     mockGetCurrentCurrency.mockReturnValue('EUR');
@@ -47,12 +85,13 @@ describe('useFiatFormatter', () => {
 
   it('should gracefully handle unknown currencies by returning amount followed by currency code', () => {
     mockGetCurrentCurrency.mockReturnValue('storj');
+    mockGetIntlLocale.mockReturnValue('en-US');
 
     const { result } = renderHook(() => useFiatFormatter());
     const formatFiat = result.current;
 
     // Testing the fallback formatting for an unknown currency
-    expect(formatFiat(1000)).toBe('1000 storj');
+    expect(formatFiat(100000)).toBe('100,000 storj');
     expect(formatFiat(500.5)).toBe('500.5 storj');
     expect(formatFiat(0)).toBe('0 storj');
   });

--- a/ui/hooks/useFiatFormatter.ts
+++ b/ui/hooks/useFiatFormatter.ts
@@ -1,35 +1,98 @@
 import { useSelector } from 'react-redux';
 import { getIntlLocale } from '../ducks/locale/locale';
 import { getCurrentCurrency } from '../selectors';
+import { shortenString } from '../helpers/utils/util';
 
 /**
  * Returns a function that formats a fiat amount as a localized string.
+ * The hook takes an optional options object to configure the formatting.
  *
  * Example usage:
  *
  * ```
  * const formatFiat = useFiatFormatter();
  * const formattedAmount = formatFiat(1000);
+ *
+ * const shorteningFiatFormatter = useFiatFormatter();
+ * const shortenedAmount = shorteningFiatFormatter(100000000000000000, { shorten: true });
  * ```
  *
  * @returns A function that takes a fiat amount as a number and returns a formatted string.
  */
 
-type FiatFormatter = (fiatAmount: number) => string;
+const TRUNCATED_CHAR_LIMIT_FOR_SHORTENED_FIAT = 15;
+const TRUNCATED_START_CHARS_FOR_SHORTENED_FIAT = 12;
+
+type FiatFormatterOptions = {
+  shorten?: boolean;
+};
+
+type FiatFormatter = (
+  fiatAmount: number,
+  options?: FiatFormatterOptions,
+) => string;
 
 export const useFiatFormatter = (): FiatFormatter => {
   const locale = useSelector(getIntlLocale);
   const fiatCurrency = useSelector(getCurrentCurrency);
 
-  return (fiatAmount: number) => {
+  return (fiatAmount: number, options: FiatFormatterOptions = {}) => {
+    const { shorten } = options;
+
     try {
-      return new Intl.NumberFormat(locale, {
+      const formatter = new Intl.NumberFormat(locale, {
         style: 'currency',
         currency: fiatCurrency,
-      }).format(fiatAmount);
+      });
+
+      if (!shorten) {
+        return formatter.format(fiatAmount);
+      }
+
+      const parts = formatter.formatToParts(fiatAmount);
+
+      let currencySymbol = '';
+      let numberString = '';
+
+      parts.forEach((part) => {
+        if (part.type === 'currency') {
+          currencySymbol += part.value;
+        } else {
+          numberString += part.value;
+        }
+      });
+
+      // Shorten the number part while preserving commas
+      const shortenedNumberString = shortenString(numberString, {
+        truncatedCharLimit: TRUNCATED_CHAR_LIMIT_FOR_SHORTENED_FIAT,
+        truncatedStartChars: TRUNCATED_START_CHARS_FOR_SHORTENED_FIAT,
+        truncatedEndChars: 0,
+        skipCharacterInEnd: true,
+      });
+
+      // Determine the position of the currency symbol
+      const currencyBeforeNumber =
+        parts.findIndex((part) => part.type === 'currency') <
+        parts.findIndex((part) => part.type === 'integer');
+
+      // Reassemble the formatted string
+      return currencyBeforeNumber
+        ? `${currencySymbol}${shortenedNumberString}`
+        : `${shortenedNumberString}${currencySymbol}`;
     } catch (error) {
       // Fallback for unknown or unsupported currencies
-      return `${fiatAmount} ${fiatCurrency}`;
+      const formattedNumber = new Intl.NumberFormat(locale).format(fiatAmount);
+      const shortenedNumberString = shortenString(formattedNumber, {
+        truncatedCharLimit: TRUNCATED_CHAR_LIMIT_FOR_SHORTENED_FIAT,
+        truncatedStartChars: TRUNCATED_START_CHARS_FOR_SHORTENED_FIAT,
+        truncatedEndChars: 0,
+        skipCharacterInEnd: true,
+      });
+
+      if (shorten) {
+        return `${shortenedNumberString} ${fiatCurrency}`;
+      }
+      return `${formattedNumber} ${fiatCurrency}`;
     }
   };
 };

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
@@ -97,7 +97,9 @@ const PermitSimulation: React.FC<{
             <Name value={verifyingContract} type={NameType.ETHEREUM_ADDRESS} />
           </Box>
           <Box>
-            {fiatValue && <IndividualFiatDisplay fiatAmount={fiatValue} />}
+            {fiatValue && (
+              <IndividualFiatDisplay fiatAmount={fiatValue} shorten />
+            )}
           </Box>
         </Box>
       </ConfirmInfoRow>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
@@ -10,6 +10,7 @@ import {
   ConfirmInfoRow,
   ConfirmInfoRowText,
 } from '../../../../../../../components/app/confirm/info/row';
+import { shortenString } from '../../../../../../../helpers/utils/util';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { currentConfirmationSelector } from '../../../../../../../selectors';
 import { Box, Text } from '../../../../../../../components/component-library';
@@ -25,7 +26,6 @@ import { SignatureRequestType } from '../../../../../types/confirm';
 import useTokenExchangeRate from '../../../../../../../components/app/currency-input/hooks/useTokenExchangeRate';
 import { IndividualFiatDisplay } from '../../../../simulation-details/fiat-display';
 import {
-  ellipsisAmountText,
   formatAmount,
   formatAmountMaxPrecision,
 } from '../../../../simulation-details/formatAmount';
@@ -90,7 +90,12 @@ const PermitSimulation: React.FC<{
                   paddingInline={2}
                   textAlign={TextAlign.Center}
                 >
-                  {ellipsisAmountText(tokenValue || '')}
+                  {shortenString(tokenValue || '', {
+                    truncatedCharLimit: 15,
+                    truncatedStartChars: 15,
+                    truncatedEndChars: 0,
+                    skipCharacterInEnd: true,
+                  })}
                 </Text>
               </Tooltip>
             </Box>

--- a/ui/pages/confirmations/components/simulation-details/amount-pill.tsx
+++ b/ui/pages/confirmations/components/simulation-details/amount-pill.tsx
@@ -59,6 +59,7 @@ export const AmountPill: React.FC<{
       truncatedCharLimit: 11,
       truncatedStartChars: 4,
       truncatedEndChars: 4,
+      skipCharacterInEnd: false,
     });
 
     const shortenedTokenIdPart = `#${shortenedDecimalTokenId}`;

--- a/ui/pages/confirmations/components/simulation-details/fiat-display.tsx
+++ b/ui/pages/confirmations/components/simulation-details/fiat-display.tsx
@@ -32,12 +32,14 @@ export function calculateTotalFiat(fiatAmounts: FiatAmount[]): number {
 /**
  * Displays the fiat value of a single balance change.
  *
- * @param props
- * @param props.fiatAmount
+ * @param props - The props object.
+ * @param props.fiatAmount - The fiat amount to display.
+ * @param props.shorten - Whether to shorten the fiat amount.
  */
-export const IndividualFiatDisplay: React.FC<{ fiatAmount: FiatAmount }> = ({
-  fiatAmount,
-}) => {
+export const IndividualFiatDisplay: React.FC<{
+  fiatAmount: FiatAmount;
+  shorten?: boolean;
+}> = ({ fiatAmount, shorten = false }) => {
   const hideFiatForTestnet = useHideFiatForTestnet();
   const fiatFormatter = useFiatFormatter();
 
@@ -50,7 +52,7 @@ export const IndividualFiatDisplay: React.FC<{ fiatAmount: FiatAmount }> = ({
   }
   const absFiat = Math.abs(fiatAmount);
 
-  return <Text {...textStyle}>{fiatFormatter(absFiat)}</Text>;
+  return <Text {...textStyle}>{fiatFormatter(absFiat, { shorten })}</Text>;
 };
 
 /**

--- a/ui/pages/confirmations/components/simulation-details/formatAmount.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/formatAmount.test.ts
@@ -1,24 +1,7 @@
 import { BigNumber } from 'bignumber.js';
-import { ellipsisAmountText, formatAmount } from './formatAmount';
+import { formatAmount } from './formatAmount';
 
 describe('formatAmount', () => {
-  describe('#ellipsisAmountText', () => {
-    const MOCK_MAX_LEFT_DIGITS = 15;
-
-    // @ts-expect-error This is missing from the Mocha type definitions
-    it.each([
-      ['1.003', '1.003'],
-      ['1,034', '1,034'],
-      ['1,213,098,292,340,945', '1,213,098,292,340,94...'],
-      ['30,001,231,231,212,312,138,768', '30,001,231,231,212,3...'],
-    ])(
-      'formats amount greater than or equal to 1 with appropriate decimal precision (%s => %s)',
-      (amount: string, expected: string) => {
-        expect(ellipsisAmountText(amount, MOCK_MAX_LEFT_DIGITS)).toBe(expected);
-      },
-    );
-  });
-
   describe('#formatAmount', () => {
     const locale = 'en-US';
 

--- a/ui/pages/confirmations/components/simulation-details/formatAmount.ts
+++ b/ui/pages/confirmations/components/simulation-details/formatAmount.ts
@@ -4,50 +4,10 @@ import {
   DEFAULT_PRECISION,
 } from '../../../../hooks/useCurrencyDisplay';
 
-const MAX_ELLIPSIS_LEFT_DIGITS = 15;
-
 // The number of significant decimals places to show for amounts less than 1.
 const MAX_SIGNIFICANT_DECIMAL_PLACES = 3;
 
 const ZERO_DISPLAY = '0';
-
-/**
- * This function receives an formatted number and will append an ellipsis if the number of digits
- * is greater than MAX_LEFT_DIGITS. Currently, we're only supporting en-US format. When we support
- * i18n numbers, we'll need to update this method to support i18n.
- *
- * This method has been designed to receive results of formatAmount.
- *
- * There is no need to format the decimal portion because formatAmount shaves the portions off
- * accordingly.
- *
- * @param amountText
- * @param maxLeftDigits
- */
-export function ellipsisAmountText(
-  amountText: string,
-  maxLeftDigits: number = MAX_ELLIPSIS_LEFT_DIGITS,
-): string {
-  const [integerPart] = amountText.split('.');
-  const cleanIntegerPart = integerPart.replace(/,/gu, '');
-
-  if (cleanIntegerPart.length > maxLeftDigits) {
-    let result = '';
-    let digitCount = 0;
-
-    for (let i = 0; digitCount < maxLeftDigits; i++) {
-      const integerChar = integerPart[i];
-      result += integerChar;
-      if (integerChar !== ',') {
-        digitCount += 1;
-      }
-    }
-
-    return `${result}...`;
-  }
-
-  return amountText;
-}
 
 export function formatAmountMaxPrecision(
   locale: string,


### PR DESCRIPTION
## **Description**

Cherry-pick fix: Permit ellipsis should use max 15 char (#26458) into v12.1.0

> Display max 15 characters, not max 15 digits, before ellipsis for amounts shown in Permit pages. Updated to use `shortenString` here.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26516?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2845

## **Manual testing steps**

1. Go to test-dapp
2. Trigger Malicious Permit request
3. Observe ellipsis values in  a. spending cap in simulation b. value in the message

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

There is a decimal issue that will be merged with another cherry-pick
<img width="320" src="https://github.com/user-attachments/assets/e9c75347-b6e4-410b-b235-682c925313a3"> 

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

