### PR TITLE
cherry-pick: Fix migration 120.3 error caused by invalid state (#26485)

### DIFF
--- a/app/scripts/migrations/120.6.test.ts
+++ b/app/scripts/migrations/120.6.test.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import { migrate, version } from './120.3';
+import { migrate, version } from './120.6';
 
 const sentryCaptureExceptionMock = jest.fn();
 
@@ -7,9 +7,9 @@ global.sentry = {
   captureException: sentryCaptureExceptionMock,
 };
 
-const oldVersion = 120.2;
+const oldVersion = 120.5;
 
-describe('migration #120.3', () => {
+describe('migration #120.6', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
@@ -72,7 +72,7 @@ describe('migration #120.3', () => {
     expect(newStorage.data).toStrictEqual(oldStorageDataClone);
   });
 
-  it('reports error and returns state unchanged if transactions property is invalid', async () => {
+  it('removes transactions property if it is invalid', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {
@@ -82,14 +82,13 @@ describe('migration #120.3', () => {
         },
       },
     };
-    const oldStorageDataClone = cloneDeep(oldStorage.data);
 
     const newStorage = await migrate(oldStorage);
 
-    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
-      `Migration ${version}: Invalid TransactionController transactions state of type 'string'`,
-    );
-    expect(newStorage.data).toStrictEqual(oldStorageDataClone);
+    expect(newStorage.data).toStrictEqual({
+      PreferencesController: {},
+      TransactionController: {},
+    });
   });
 
   it('reports error and returns state unchanged if there is an invalid transaction', async () => {

--- a/app/scripts/migrations/120.6.ts
+++ b/app/scripts/migrations/120.6.ts
@@ -7,7 +7,7 @@ type VersionedData = {
   data: Record<string, unknown>;
 };
 
-export const version = 120.3;
+export const version = 120.6;
 
 const MAX_TRANSACTION_HISTORY_LENGTH = 100;
 
@@ -52,9 +52,12 @@ function transformState(state: Record<string, unknown>): void {
     );
     return;
   } else if (!Array.isArray(transactionControllerState.transactions)) {
-    global.sentry?.captureException(
-      `Migration ${version}: Invalid TransactionController transactions state of type '${typeof transactionControllerState.transactions}'`,
+    log.error(
+      new Error(
+        `Migration ${version}: Invalid TransactionController transactions state of type '${typeof transactionControllerState.transactions}'`,
+      ),
     );
+    delete transactionControllerState.transactions;
     return;
   }
 

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -133,9 +133,10 @@ const migrations = [
   require('./120'),
   require('./120.1'),
   require('./120.2'),
-  require('./120.3'),
+  // require('./120.3'), Renamed to 120.6, do not re-use this number
   require('./120.4'),
   require('./120.5'),
+  require('./120.6'),
 ];
 
 export default migrations;


### PR DESCRIPTION
This cherry-picks #26485 into v12.0.6. Original description:

## **Description**

For a small number of users, migration 120.3 is failing due to invalid `TransactionController.transactions` state. We aren't sure yet how this is happening, but we can resolve the problem by updating the migration to delete this invalid state if we detect it. No other state relies on this state, and if it's invalid it won't work properly anyway.

The migration has been renamed from 120.3 to 120.6 so that it will be re-run for any users who encountered this migration on v12.0.1 already.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26517?quickstart=1)

## **Related issues**

Fixes #26423

## **Manual testing steps**

* Create a dev build from v12.0.0
* Install the dev build from the `dist/chrome` directory and proceed through onboarding
* Run this command in the background console: ``` chrome.storage.local.get( null, (state) => { state.data.TransactionController.transactions = {}; chrome.storage.local.set(state, () => chrome.runtime.reload()); } ); ```
* Disable the extension
* Switch to v12.0.1 and create a dev build
* Enable and reload the extension
  * You should see in the console that migration 120.3 has failed
* Disable the extension
* Switch to this branch and create a dev build
* Enable and reload the extension
* You should see in the console that migration 120.6 has run without error
* You can run `chrome.storage.local.get(console.log)` to check that the transactions state has been removed.


## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
