### PR TITLE
fix: Permit Simulation should include decimals in fiat calculation and show tooltip if shortened

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
@@ -48,7 +48,8 @@ const PermitSimulation: React.FC<{
 
   const fiatValue = useMemo(() => {
     if (exchangeRate && value) {
-      return exchangeRate.times(new Numeric(value, 10)).toNumber();
+      const tokenAmount = calcTokenAmount(value, tokenDecimals);
+      return exchangeRate.times(tokenAmount).toNumber();
     }
     return undefined;
   }, [exchangeRate, value]);

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
@@ -4,7 +4,6 @@ import { NameType } from '@metamask/name-controller';
 
 import { calcTokenAmount } from '../../../../../../../../shared/lib/transactions-controller-utils';
 import { parseTypedDataMessage } from '../../../../../../../../shared/modules/transaction.utils';
-import { Numeric } from '../../../../../../../../shared/modules/Numeric';
 import Name from '../../../../../../../components/app/name/name';
 import {
   ConfirmInfoRow,

--- a/ui/pages/confirmations/components/simulation-details/fiat-display.tsx
+++ b/ui/pages/confirmations/components/simulation-details/fiat-display.tsx
@@ -7,6 +7,7 @@ import {
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { Text } from '../../../../components/component-library';
 import { SizeNumber } from '../../../../components/component-library/box/box.types';
+import Tooltip from '../../../../components/ui/tooltip';
 import { useFiatFormatter } from '../../../../hooks/useFiatFormatter';
 import { useHideFiatForTestnet } from '../../../../hooks/useHideFiatForTestnet';
 import { FIAT_UNAVAILABLE, FiatAmount } from './types';
@@ -51,10 +52,17 @@ export const IndividualFiatDisplay: React.FC<{
     return <FiatNotAvailableDisplay />;
   }
   const absFiat = Math.abs(fiatAmount);
+  const fiatDisplayValue = fiatFormatter(absFiat, { shorten });
 
-  return (
+  return shorten ? (
+    <Tooltip position="bottom" title={fiatDisplayValue} interactive>
+      <Text {...textStyle} data-testid="individual-fiat-display">
+        {fiatDisplayValue}
+      </Text>
+    </Tooltip>
+  ) : (
     <Text {...textStyle} data-testid="individual-fiat-display">
-      {fiatFormatter(absFiat, { shorten })}
+      {fiatDisplayValue}
     </Text>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26523?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26520

## **Manual testing steps**

1. Go to test-dapp
2. Use ethereum mainnet network
3. Test malicious permit 

to test lengthier value: 

1. run `yarn storybook`
2. go to http://localhost:6006/?path=/story/pages-confirmations-confirm-signatures-signedtypeddatav3orv4--permit-story&args=msgParams.data:3.0001231231212312e+22
3. copy and paste the following into data
```
"{\"types\":{\"EIP712Domain\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\"}],\"Permit\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"spender\",\"type\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\"},{\"name\":\"nonce\",\"type\":\"uint256\"},{\"name\":\"deadline\",\"type\":\"uint256\"}]},\"primaryType\":\"Permit\",\"domain\":{\"name\":\"MyToken\",\"version\":\"1\",\"verifyingContract\":\"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC\",\"chainId\":1},\"message\":{\"owner\":\"0x935e73edb9ff52e23bac7f7e043a1ecd06d05477\",\"spender\":\"0x5B38Da6a701c568545dCfcB03FcB875f56beddC4\",\"value\":30001231231212312138768,\"nonce\":0,\"deadline\":50000000000}}"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="320" src="https://github.com/user-attachments/assets/d727cbf5-d729-4d31-b6fd-647692bdef30"> 

### **After**
<img width="320" src="https://github.com/user-attachments/assets/4171d4b9-44ca-418d-8f79-017f59d8edfc"> 

### **After with tooltip showing on lengthy fiat value**
<img width="320" src="https://github.com/user-attachments/assets/9f2dfcbe-3f34-4ce3-9394-667f4fd2dd54"> 


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
