### PR TITLE
fix: correct duplicate notifications event tracking in global menu

### DIFF
--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -149,15 +149,6 @@ export const GlobalMenu = ({ closeMenu, anchorElement, isOpen }) => {
         properties: {
           is_profile_syncing_enabled: isProfileSyncingEnabled,
           is_notifications_enabled: isMetamaskNotificationsEnabled,
-          action_type: 'started',
-        },
-      });
-      trackEvent({
-        category: MetaMetricsEventCategory.NotificationInteraction,
-        event: MetaMetricsEventName.NotificationMenuOpened,
-        properties: {
-          is_profile_syncing_enabled: isProfileSyncingEnabled,
-          is_notifications_enabled: isMetamaskNotificationsEnabled,
         },
       });
       dispatch(showConfirmTurnOnMetamaskNotifications());
@@ -167,6 +158,14 @@ export const GlobalMenu = ({ closeMenu, anchorElement, isOpen }) => {
     }
 
     // Otherwise we can navigate to the notifications page
+    trackEvent({
+      category: MetaMetricsEventCategory.NotificationInteraction,
+      event: MetaMetricsEventName.NotificationMenuOpened,
+      properties: {
+        is_profile_syncing_enabled: isProfileSyncingEnabled,
+        is_notifications_enabled: isMetamaskNotificationsEnabled,
+      },
+    });
     history.push(NOTIFICATIONS_ROUTE);
     closeMenu();
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses an issue where duplicate event tracking calls were made in the `handleNotificationsClick` function within the `GlobalMenu` component. This redundancy could lead to inaccurate event logging and unnecessary data collection. Also, the PR removes an unnecessary property.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26525?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open the global menu
2. Click on the notifications menu item
3. Verify that the event is tracked only once

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
