### PR TITLE
chore: Rename `permittedChains` permission to `endowment:permitted-chains`

### DIFF
--- a/app/scripts/controllers/permissions/specifications.js
+++ b/app/scripts/controllers/permissions/specifications.js
@@ -25,7 +25,7 @@ import {
  */
 export const PermissionNames = Object.freeze({
   ...RestrictedMethods,
-  permittedChains: 'permittedChains',
+  permittedChains: 'endowment:permitted-chains',
 });
 
 /**

--- a/app/scripts/controllers/permissions/specifications.test.js
+++ b/app/scripts/controllers/permissions/specifications.test.js
@@ -9,6 +9,7 @@ import {
   CaveatFactories,
   getCaveatSpecifications,
   getPermissionSpecifications,
+  PermissionNames,
   unrestrictedMethods,
 } from './specifications';
 
@@ -239,9 +240,9 @@ describe('PermissionController specifications', () => {
       expect(
         permissionSpecifications[RestrictedMethods.eth_accounts].targetName,
       ).toStrictEqual(RestrictedMethods.eth_accounts);
-      expect(permissionSpecifications.permittedChains.targetName).toStrictEqual(
-        'permittedChains',
-      );
+      expect(
+        permissionSpecifications[PermissionNames.permittedChains].targetName,
+      ).toStrictEqual('endowment:permitted-chains');
     });
 
     describe('eth_accounts', () => {

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
@@ -73,7 +73,7 @@ describe('addEthereumChainHandler', () => {
     jest.clearAllMocks();
   });
 
-  describe('with permittedChains permissioning inactive', () => {
+  describe('with `endowment:permitted-chains` permissioning inactive', () => {
     it('creates a new network configuration for the given chainid and switches to it if none exists', async () => {
       const mocks = makeMocks({
         permissionsFeatureFlagIsActive: false,
@@ -253,8 +253,8 @@ describe('addEthereumChainHandler', () => {
     });
   });
 
-  describe('with permittedChains permissioning active', () => {
-    it('creates a new network configuration for the given chainid, requests permittedChains permission and switches to it if no networkConfigurations with the same chainId exist', async () => {
+  describe('with `endowment:permitted-chains` permissioning active', () => {
+    it('creates a new network configuration for the given chainid, requests `endowment:permitted-chains` permission and switches to it if no networkConfigurations with the same chainId exist', async () => {
       const mocks = makeMocks({
         permissionedChainIds: [],
         permissionsFeatureFlagIsActive: true,
@@ -297,7 +297,7 @@ describe('addEthereumChainHandler', () => {
 
     describe('if a networkConfiguration for the given chainId already exists', () => {
       describe('if the proposed networkConfiguration has a different rpcUrl from the one already in state', () => {
-        it('create a new networkConfiguration and switches to it without requesting permissions, if the requested chainId has permittedChains permission granted for requesting origin', async () => {
+        it('create a new networkConfiguration and switches to it without requesting permissions, if the requested chainId has `endowment:permitted-chains` permission granted for requesting origin', async () => {
           const mocks = makeMocks({
             permissionedChainIds: [CHAIN_IDS.MAINNET],
             permissionsFeatureFlagIsActive: true,

--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.test.js
@@ -167,7 +167,7 @@ describe('switchEthereumChainHandler', () => {
   describe('with permittedChains permissioning active', () => {
     const permissionsFeatureFlagIsActive = true;
 
-    it('should call requestPermittedChainsPermission and setActiveNetwork when chainId is not in permittedChains', async () => {
+    it('should call requestPermittedChainsPermission and setActiveNetwork when chainId is not in `endowment:permitted-chains`', async () => {
       const mockrequestPermittedChainsPermission = jest
         .fn()
         .mockResolvedValue();
@@ -200,7 +200,7 @@ describe('switchEthereumChainHandler', () => {
       );
     });
 
-    it('should call setActiveNetwork without calling requestPermittedChainsPermission when requested chainId is in permittedChains', async () => {
+    it('should call setActiveNetwork without calling requestPermittedChainsPermission when requested chainId is in `endowment:permitted-chains`', async () => {
       const mocks = makeMocks({
         permissionsFeatureFlagIsActive,
         permissionedChainIds: [CHAIN_IDS.MAINNET],

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4683,10 +4683,11 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Stops exposing the specified chain ID to all third parties.
-   * Exposed chain IDs are stored in caveats of the permittedChains permission. This
-   * method uses `PermissionController.updatePermissionsByCaveat` to
-   * remove the specified chain ID from every permittedChains permission. If a
-   * permission only included this chain ID, the permission is revoked entirely.
+   * Exposed chain IDs are stored in caveats of the `endowment:permitted-chains`
+   * permission. This method uses `PermissionController.updatePermissionsByCaveat`
+   * to remove the specified chain ID from every `endowment:permitted-chains`
+   * permission. If a permission only included this chain ID, the permission is
+   * revoked entirely.
    *
    * @param {string} targetChainId - The chain ID to stop exposing
    * to third parties.

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -14,6 +14,7 @@ import {
   CaveatTypes,
   RestrictedMethods,
 } from '../../../shared/constants/permissions';
+import { PermissionNames } from '../../../app/scripts/controllers/permissions';
 import ChooseAccount from './choose-account';
 import PermissionsRedirect from './redirect';
 import SnapsConnect from './snaps/snaps-connect';
@@ -143,7 +144,11 @@ export default class PermissionConnect extends Component {
       return;
     }
     // if this is an incremental permission request for permitted chains, skip the account selection
-    if (permissionsRequest?.diff?.permissionDiffMap?.permittedChains) {
+    if (
+      permissionsRequest?.diff?.permissionDiffMap?.[
+        PermissionNames.permittedChains
+      ]
+    ) {
       history.replace(confirmPermissionPath);
     }
 


### PR DESCRIPTION
## **Description**

This renames the `permittedChains` permission to `endowment:permitted-chains` for consistency with other endowment permissions.

This permission is not used in production yet, so it does not require a migration.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26534?quickstart=1)