### PR TITLE
fix: stick add team label version to commit hash

### DIFF
--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - synchronize
 
 jobs:
   add-team-label:

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
 
 jobs:
   add-team-label:

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-team-label:
-    uses: metamask/github-tools/.github/workflows/add-team-label.yml@main
+    uses: metamask/github-tools/.github/workflows/add-team-label.yml@add-team-label
     permissions:
        pull-requests: write
     secrets:

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   add-team-label:
-    uses: metamask/github-tools/.github/workflows/add-team-label.yml@main
-    permissions:
-       pull-requests: write
+    uses: metamask/github-tools/.github/workflows/add-team-label.yml@7c10eb3bafb3f221111a9e4309ae5dcaee171de5
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.RELEASE_LABEL_TOKEN }}

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -8,5 +8,7 @@ on:
 jobs:
   add-team-label:
     uses: metamask/github-tools/.github/workflows/add-team-label.yml@main
+    permissions:
+       pull-requests: write
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.RELEASE_LABEL_TOKEN }}

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -4,11 +4,10 @@ on:
   pull_request:
     types:
       - opened
-      - synchronize
 
 jobs:
   add-team-label:
-    uses: metamask/github-tools/.github/workflows/add-team-label.yml@add-team-label
+    uses: metamask/github-tools/.github/workflows/add-team-label.yml@main
     permissions:
        pull-requests: write
     secrets:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26540?quickstart=1)

This PR is a one-line fix to stick the version of the add-team-label workflow to the commit hash instead of the branch name. This is particularly important due to the breaking change we are introducing to main, as giving write permissions for pull requests is now required as the workflow was reworked in https://github.com/MetaMask/github-tools/pull/27.

## **Related issues**

Fixes: https://github.com/MetaMask/github-tools/issues/24

## **Manual testing steps**

1. Team label should be added automatically when PR is opened

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
