### PR TITLE
fix: missing deadline in swaps stx status screen (#25779)

### DIFF
--- a/app/scripts/controllers/swaps.constants.ts
+++ b/app/scripts/controllers/swaps.constants.ts
@@ -1,4 +1,5 @@
 import {
+  FALLBACK_SMART_TRANSACTIONS_DEADLINE,
   FALLBACK_SMART_TRANSACTIONS_MAX_FEE_MULTIPLIER,
   FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
 } from '../../../shared/constants/smartTransactions';
@@ -42,6 +43,7 @@ export const swapsControllerInitialState: { swapsState: SwapsControllerState } =
       swapsQuoteRefreshTime: FALLBACK_QUOTE_REFRESH_TIME,
       swapsQuotePrefetchingRefreshTime: FALLBACK_QUOTE_REFRESH_TIME,
       swapsStxBatchStatusRefreshTime: FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
+      swapsStxStatusDeadline: FALLBACK_SMART_TRANSACTIONS_DEADLINE,
       swapsStxGetTransactionsRefreshTime:
         FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
       swapsStxMaxFeeMultiplier: FALLBACK_SMART_TRANSACTIONS_MAX_FEE_MULTIPLIER,

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -120,6 +120,7 @@ const EMPTY_INIT_STATE = {
     swapsStxGetTransactionsRefreshTime:
       FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
     swapsStxMaxFeeMultiplier: FALLBACK_SMART_TRANSACTIONS_MAX_FEE_MULTIPLIER,
+    swapsStxStatusDeadline: 180,
     swapsUserFeeLevel: '',
     saveFetchedQuotes: false,
   },
@@ -1002,6 +1003,7 @@ describe('SwapsController', function () {
         const swapsQuotePrefetchingRefreshTime = 0;
         const swapsStxBatchStatusRefreshTime = 0;
         const swapsStxGetTransactionsRefreshTime = 0;
+        const swapsStxStatusDeadline = 0;
         swapsController.store.updateState({
           swapsState: {
             tokens,
@@ -1012,6 +1014,7 @@ describe('SwapsController', function () {
             swapsQuotePrefetchingRefreshTime,
             swapsStxBatchStatusRefreshTime,
             swapsStxGetTransactionsRefreshTime,
+            swapsStxStatusDeadline,
           },
         });
 

--- a/app/scripts/controllers/swaps.ts
+++ b/app/scripts/controllers/swaps.ts
@@ -24,6 +24,7 @@ import { CHAIN_IDS } from '../../../shared/constants/network';
 import {
   FALLBACK_SMART_TRANSACTIONS_MAX_FEE_MULTIPLIER,
   FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
+  FALLBACK_SMART_TRANSACTIONS_DEADLINE,
 } from '../../../shared/constants/smartTransactions';
 import {
   DEFAULT_ERC20_APPROVE_GAS,
@@ -944,6 +945,9 @@ export default class SwapsController {
         swapsStxMaxFeeMultiplier:
           swapsNetworkConfig?.stxMaxFeeMultiplier ||
           FALLBACK_SMART_TRANSACTIONS_MAX_FEE_MULTIPLIER,
+        swapsStxStatusDeadline:
+          swapsNetworkConfig?.stxStatusDeadline ||
+          FALLBACK_SMART_TRANSACTIONS_DEADLINE,
       },
     });
   }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -335,6 +335,7 @@ export const SENTRY_BACKGROUND_STATE = {
       swapsQuotePrefetchingRefreshTime: true,
       swapsQuoteRefreshTime: true,
       swapsStxBatchStatusRefreshTime: true,
+      swapsStxStatusDeadline: true,
       swapsStxGetTransactionsRefreshTime: true,
       swapsStxMaxFeeMultiplier: true,
       swapsUserFeeLevel: true,

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -271,6 +271,7 @@
       "swapsQuoteRefreshTime": 60000,
       "swapsQuotePrefetchingRefreshTime": 60000,
       "swapsStxBatchStatusRefreshTime": 10000,
+      "swapsStxStatusDeadline": 180,
       "swapsStxGetTransactionsRefreshTime": 10000,
       "swapsStxMaxFeeMultiplier": 2
     }

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -245,6 +245,7 @@
       "swapsQuoteRefreshTime": 60000,
       "swapsQuotePrefetchingRefreshTime": 60000,
       "swapsStxBatchStatusRefreshTime": 10000,
+      "swapsStxStatusDeadline": 180,
       "swapsStxGetTransactionsRefreshTime": 10000,
       "swapsStxMaxFeeMultiplier": 2
     },

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -110,7 +110,6 @@ export default function SmartTransactionStatusPage() {
     cancellationFeeWei =
       latestSmartTransaction?.statusMetadata?.cancellationFeeWei;
   }
-
   const [timeLeftForPendingStxInSec, setTimeLeftForPendingStxInSec] = useState(
     swapsNetworkConfig.stxStatusDeadline,
   );


### PR DESCRIPTION
## **Description**
This PR fixes an issue where the STX status screen for a swap was showing a 0:00 for the timer. It is a cherry-pick of [this PR](https://github.com/MetaMask/metamask-extension/pull/25779).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26544?quickstart=1)

## **Related issues**

Related to: https://github.com/MetaMask/metamask-extension/pull/25063

## **Manual testing steps**

1. Make sure Smart Transactions is on (Settings > Advanced)
2. Do a Swap
3. Observe that timer is not 0:00 and is a reasonable number

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/7388ffe0-c2c3-48e9-a01c-aaf8792cc720

### **After**


https://github.com/user-attachments/assets/302e1fa4-bebf-41d3-8f18-d6ad398d3b3a



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
