### PR TITLE
perf: preload `_locales/en/messages.json` so we don't have to wait as long for our JS to dynamically load it

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -8,6 +8,7 @@
     <% } else { %>
     <title>MetaMask</title>
     <% } %>
+    <link rel="preload" href="/_locales/en/messages.json" as="fetch" crossorigin="anonymous" />
     <link rel="stylesheet" href="../ui/css/index.scss">
   </head>
   <body>

--- a/app/notification.html
+++ b/app/notification.html
@@ -32,6 +32,7 @@
         margin-top: 1rem;
       }
     </style>
+    <link rel="preload" href="/_locales/en/messages.json" as="fetch" crossorigin="anonymous" />
     <link rel="stylesheet" href="../ui/css/index.scss" />
   </head>
   <body class="notification">

--- a/app/popup.html
+++ b/app/popup.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>MetaMask</title>
+    <link rel="preload" href="/_locales/en/messages.json" as="fetch" crossorigin="anonymous" />
     <link rel="stylesheet" href="../ui/css/index.scss" />
   </head>
   <body style="width:357px; height:600px;">


### PR DESCRIPTION
We always load the English version of `messages.json`. This PR makes use of link `rel=preload` so that the browser will get the file ready for use immediately -- well before our JavaScript file that will eventually need it asks for it. This reduces the amount of waiting due to Network Waterfall (even if the network is the local file system).

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26556?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->