### PR TITLE
refactor: extract Send-specific functionality out of AssetPicker

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-balance/asset-balance-text.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-balance/asset-balance-text.tsx
@@ -20,7 +20,7 @@ import { useTokenFiatAmount } from '../../../../hooks/useTokenFiatAmount';
 import { getIsFiatPrimary } from '../utils';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { hexToDecimal } from '../../../../../shared/modules/conversion.utils';
-import { Token } from '../asset-picker-modal/types';
+import { TokenWithBalance } from '../asset-picker-modal/types';
 
 export type AssetBalanceTextProps = {
   asset: Asset;
@@ -38,7 +38,7 @@ export function AssetBalanceText({
 
   const isFiatPrimary = useSelector(getIsFiatPrimary);
 
-  const { tokensWithBalances }: { tokensWithBalances: Token[] } =
+  const { tokensWithBalances }: { tokensWithBalances: TokenWithBalance[] } =
     useTokenTracker({
       tokens:
         asset.details?.address && !asset.balance

--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.test.tsx
@@ -39,6 +39,7 @@ describe('AssetPickerAmount', () => {
   const onAmountChangeMock = jest.fn();
 
   const defaultProps = {
+    header: 'testHeader',
     asset: {
       type: AssetType.token,
       details: { address: '0xToken', symbol: 'TOKEN', decimals: 18 },

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.test.tsx
@@ -5,6 +5,7 @@ import { getTokenList } from '../../../../selectors';
 import { useTokenFiatAmount } from '../../../../hooks/useTokenFiatAmount';
 import { getIntlLocale } from '../../../../ducks/locale/locale';
 import { TokenListItem } from '../../token-list-item';
+import { AssetType } from '../../../../../shared/constants/transaction';
 import Asset from './Asset';
 
 jest.mock('react-redux', () => ({
@@ -60,9 +61,13 @@ describe('Asset', () => {
   it('should render TokenListItem with correct props when address is provided', () => {
     const { getByText } = render(
       <Asset
+        type={AssetType.token}
+        image="token-icon-url"
         address="0x123"
         symbol="WETH"
-        decimalTokenAmount="10"
+        string="10"
+        balance="10000000000000000000"
+        decimals={18}
         tooltipText="tooltip"
       />,
     );
@@ -75,25 +80,6 @@ describe('Asset', () => {
         primary: '10',
         secondary: '$10.10',
         title: 'Token',
-        tooltipText: 'tooltip',
-      }),
-      {},
-    );
-  });
-
-  it('should render TokenListItem with correct props when address is not provided', () => {
-    const { getByText } = render(
-      <Asset symbol="WETH" decimalTokenAmount="10" tooltipText="tooltip" />,
-    );
-
-    expect(getByText('TokenListItem')).toBeInTheDocument();
-    expect(TokenListItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tokenSymbol: 'WETH',
-        tokenImage: undefined,
-        primary: '10',
-        secondary: '$10.10',
-        title: 'WETH',
         tooltipText: 'tooltip',
       }),
       {},

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.tsx
@@ -7,12 +7,9 @@ import { TokenListItem } from '../../token-list-item';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
 import { formatAmount } from '../../../../pages/confirmations/components/simulation-details/formatAmount';
 import { getIntlLocale } from '../../../../ducks/locale/locale';
+import { AssetWithDisplayData, ERC20Asset } from './types';
 
-type AssetProps = {
-  address?: string | null;
-  image?: string;
-  symbol: string;
-  decimalTokenAmount?: string;
+type AssetProps = AssetWithDisplayData<ERC20Asset> & {
   tooltipText?: string;
 };
 
@@ -20,7 +17,7 @@ export default function Asset({
   address,
   image,
   symbol,
-  decimalTokenAmount,
+  string: decimalTokenAmount,
   tooltipText,
 }: AssetProps) {
   const locale = useSelector(getIntlLocale);

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.test.tsx
@@ -108,7 +108,7 @@ describe('AssetList', () => {
     render(
       <AssetList
         handleAssetChange={handleAssetChangeMock}
-        asset={{ balance: '1', type: AssetType.native }}
+        asset={{ type: AssetType.native }}
         tokenList={tokenList}
       />,
     );
@@ -121,7 +121,7 @@ describe('AssetList', () => {
     render(
       <AssetList
         handleAssetChange={handleAssetChangeMock}
-        asset={{ balance: '1', type: AssetType.native }}
+        asset={{ type: AssetType.native }}
         tokenList={tokenList}
       />,
     );
@@ -149,7 +149,7 @@ describe('AssetList', () => {
     render(
       <AssetList
         handleAssetChange={handleAssetChangeMock}
-        asset={{ balance: '1', type: AssetType.native }}
+        asset={{ type: AssetType.native }}
         tokenList={tokenList}
         isTokenDisabled={(token) => token.address === '0xToken1'}
       />,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.test.tsx
@@ -110,7 +110,6 @@ describe('AssetList', () => {
         handleAssetChange={handleAssetChangeMock}
         asset={{ balance: '1', type: AssetType.native }}
         tokenList={tokenList}
-        memoizedSwapsBlockedTokens={new Set([])}
       />,
     );
 
@@ -124,7 +123,6 @@ describe('AssetList', () => {
         handleAssetChange={handleAssetChangeMock}
         asset={{ balance: '1', type: AssetType.native }}
         tokenList={tokenList}
-        memoizedSwapsBlockedTokens={new Set([])}
       />,
     );
 
@@ -153,8 +151,7 @@ describe('AssetList', () => {
         handleAssetChange={handleAssetChangeMock}
         asset={{ balance: '1', type: AssetType.native }}
         tokenList={tokenList}
-        sendingAssetSymbol="IRRELEVANT"
-        memoizedSwapsBlockedTokens={new Set(['0xtoken1'])}
+        isTokenDisabled={(token) => token.address === '0xToken1'}
       />,
     );
 

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.test.tsx
@@ -9,7 +9,9 @@ import { getNativeCurrency } from '../../../../ducks/metamask/metamask';
 import { useUserPreferencedCurrency } from '../../../../hooks/useUserPreferencedCurrency';
 import { useCurrencyDisplay } from '../../../../hooks/useCurrencyDisplay';
 import { AssetType } from '../../../../../shared/constants/transaction';
+import { CHAIN_ID_TOKEN_IMAGE_MAP } from '../../../../../shared/constants/network';
 import AssetList from './AssetList';
+import { AssetWithDisplayData, ERC20Asset, NativeAsset } from './types';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -40,8 +42,11 @@ jest.mock('./Asset', () => jest.fn(() => <div>AssetComponent</div>));
 describe('AssetList', () => {
   const handleAssetChangeMock = jest.fn();
   const nativeCurrency = 'ETH';
-  const balanceValue = '1000000000000000000';
-  const tokenList = [
+  const balanceValue = '0x121';
+  const tokenList: (
+    | AssetWithDisplayData<ERC20Asset>
+    | AssetWithDisplayData<NativeAsset>
+  )[] = [
     {
       address: '0xToken1',
       symbol: 'TOKEN1',
@@ -61,13 +66,13 @@ describe('AssetList', () => {
       balance: '10',
     },
     {
-      address: '0xToken3',
-      symbol: 'TOKEN3',
+      address: null,
+      symbol: 'ETH',
       type: AssetType.native,
-      image: 'image3.png',
+      image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
       string: '30',
       decimals: 18,
-      balance: '20',
+      balance: '0x121',
     },
   ];
   const primaryCurrency = 'USD';
@@ -108,7 +113,11 @@ describe('AssetList', () => {
     render(
       <AssetList
         handleAssetChange={handleAssetChangeMock}
-        asset={{ type: AssetType.native }}
+        asset={{
+          type: AssetType.native,
+          image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
+          symbol: 'ETH',
+        }}
         tokenList={tokenList}
       />,
     );
@@ -121,7 +130,11 @@ describe('AssetList', () => {
     render(
       <AssetList
         handleAssetChange={handleAssetChangeMock}
-        asset={{ type: AssetType.native }}
+        asset={{
+          type: AssetType.native,
+          image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
+          symbol: 'ETH',
+        }}
         tokenList={tokenList}
       />,
     );
@@ -149,7 +162,11 @@ describe('AssetList', () => {
     render(
       <AssetList
         handleAssetChange={handleAssetChangeMock}
-        asset={{ type: AssetType.native }}
+        asset={{
+          type: AssetType.native,
+          image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
+          symbol: 'ETH',
+        }}
         tokenList={tokenList}
         isTokenDisabled={(token) => token.address === '0xToken1'}
       />,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
@@ -19,7 +19,6 @@ import {
   FlexWrap,
 } from '../../../../helpers/constants/design-system';
 import { TokenListItem } from '../..';
-import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
 import { Asset, Token } from './types';
 import AssetComponent from './Asset';
 
@@ -27,16 +26,14 @@ type AssetListProps = {
   handleAssetChange: (token: Token) => void;
   asset: Asset;
   tokenList: Token[];
-  sendingAssetSymbol?: string;
-  memoizedSwapsBlockedTokens: Set<string>;
+  isTokenDisabled?: (token: Token) => boolean;
 };
 
 export default function AssetList({
   handleAssetChange,
   asset,
   tokenList,
-  sendingAssetSymbol,
-  memoizedSwapsBlockedTokens,
+  isTokenDisabled,
 }: AssetListProps) {
   const selectedToken = asset.details?.address;
 
@@ -71,10 +68,7 @@ export default function AssetList({
       {tokenList.map((token) => {
         const tokenAddress = token.address?.toLowerCase();
         const isSelected = tokenAddress === selectedToken?.toLowerCase();
-        const isDisabled = sendingAssetSymbol
-          ? !isEqualCaseInsensitive(sendingAssetSymbol, token.symbol) &&
-            memoizedSwapsBlockedTokens.has(tokenAddress as string)
-          : false;
+        const isDisabled = isTokenDisabled?.(token) ?? false;
         return (
           <Box
             padding={0}

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
@@ -19,12 +19,18 @@ import {
   FlexWrap,
 } from '../../../../helpers/constants/design-system';
 import { TokenListItem } from '../..';
-import { Asset, Token } from './types';
+import { Token } from './types';
 import AssetComponent from './Asset';
 
 type AssetListProps = {
   handleAssetChange: (token: Token) => void;
-  asset: Asset;
+  asset?: {
+    type: AssetType;
+    image?: string;
+    address?: string; // native token if undefined or null
+    symbol?: string;
+    tokenId?: number;
+  };
   tokenList: Token[];
   isTokenDisabled?: (token: Token) => boolean;
 };
@@ -35,7 +41,7 @@ export default function AssetList({
   tokenList,
   isTokenDisabled,
 }: AssetListProps) {
-  const selectedToken = asset.details?.address;
+  const selectedToken = asset?.address;
 
   const nativeCurrency = useSelector(getNativeCurrency);
   const balanceValue = useSelector(getSelectedAccountCachedBalance);

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
@@ -19,20 +19,21 @@ import {
   FlexWrap,
 } from '../../../../helpers/constants/design-system';
 import { TokenListItem } from '../..';
-import { Token } from './types';
 import AssetComponent from './Asset';
+import { AssetWithDisplayData, ERC20Asset, NativeAsset } from './types';
 
 type AssetListProps = {
-  handleAssetChange: (token: Token) => void;
-  asset?: {
-    type: AssetType;
-    image?: string;
-    address?: string; // native token if undefined or null
-    symbol?: string;
-    tokenId?: number;
-  };
-  tokenList: Token[];
-  isTokenDisabled?: (token: Token) => boolean;
+  handleAssetChange: (
+    token: AssetWithDisplayData<ERC20Asset> | AssetWithDisplayData<NativeAsset>,
+  ) => void;
+  asset?: ERC20Asset | NativeAsset;
+  tokenList: (
+    | AssetWithDisplayData<ERC20Asset>
+    | AssetWithDisplayData<NativeAsset>
+  )[];
+  isTokenDisabled?: (
+    token: AssetWithDisplayData<ERC20Asset> | AssetWithDisplayData<NativeAsset>,
+  ) => boolean;
 };
 
 export default function AssetList({
@@ -133,7 +134,6 @@ export default function AssetList({
                   <AssetComponent
                     key={token.address}
                     {...token}
-                    decimalTokenAmount={token.string}
                     tooltipText={
                       isDisabled ? 'swapTokenNotAvailable' : undefined
                     }

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.tsx
@@ -17,7 +17,6 @@ import {
   FlexDirection,
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { TokenStandard } from '../../../../../shared/constants/transaction';
 import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
 import Spinner from '../../../ui/spinner';
 import {
@@ -26,24 +25,8 @@ import {
   getUseNftDetection,
 } from '../../../../selectors';
 import NFTsDetectionNoticeNFTsTab from '../../../app/assets/nfts/nfts-detection-notice-nfts-tab/nfts-detection-notice-nfts-tab';
-
-type NFT = {
-  address: string;
-  description: string | null;
-  favorite: boolean;
-  image: string | null;
-  isCurrentlyOwned: boolean;
-  name: string | null;
-  standard: TokenStandard;
-  tokenId: string;
-  tokenURI?: string;
-};
-
-type Collection = {
-  collectionName: string;
-  collectionImage: string | null;
-  nfts: NFT[];
-};
+import { useNftsCollections } from '../../../../hooks/useNftsCollections';
+import { Collection, NFT } from './types';
 
 type PreviouslyOwnedCollections = {
   collectionName: string;
@@ -51,19 +34,48 @@ type PreviouslyOwnedCollections = {
 };
 
 type AssetPickerModalNftTabProps = {
-  collectionDataFiltered: Collection[];
-  previouslyOwnedCollection: PreviouslyOwnedCollections;
+  searchQuery: string;
   onClose: () => void;
   renderSearch: () => void;
 };
 
 export function AssetPickerModalNftTab({
-  collectionDataFiltered,
-  previouslyOwnedCollection,
+  searchQuery,
   onClose,
   renderSearch,
 }: AssetPickerModalNftTabProps) {
   const t = useI18nContext();
+
+  const {
+    collections,
+    previouslyOwnedCollection,
+  }: {
+    collections: Record<string, Collection>;
+    previouslyOwnedCollection: PreviouslyOwnedCollections;
+  } = useNftsCollections();
+
+  const collectionsKeys = Object.keys(collections);
+
+  const collectionsData = collectionsKeys.reduce((acc: unknown[], key) => {
+    // TODO: Replace `any` with type
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const collection = (collections as any)[key];
+
+    const isMatchingQuery = collection.collectionName
+      ?.toLowerCase()
+      .includes(searchQuery.toLowerCase());
+
+    if (isMatchingQuery) {
+      acc.push(collection);
+      return acc;
+    }
+    return acc;
+  }, []);
+
+  // filter and exclude ERC1155
+  const collectionDataFiltered = (collectionsData as Collection[]).filter(
+    (collection) => collection.nfts.length > 0,
+  );
 
   const hasAnyNfts = Object.keys(collectionDataFiltered).length > 0;
   const useNftDetection = useSelector(getUseNftDetection);

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-search.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-search.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import {
+  Box,
+  ButtonIconSize,
+  TextFieldSearch,
+  TextFieldSearchSize,
+} from '../../../component-library';
+import {
+  BlockSize,
+  BorderRadius,
+} from '../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+
+/**
+ * Renders a search component for the asset picker modal.
+ *
+ * @param props
+ * @param props.searchQuery - The current search query.
+ * @param props.onChange - The function to handle search query changes.
+ * @param props.isNFTSearch - Indicates if the search is for NFTs.
+ * @param props.props - Additional props for the containing Box component.
+ * @returns The rendered search component.
+ */
+export const Search = ({
+  searchQuery,
+  onChange,
+  isNFTSearch = false,
+  props,
+}: {
+  searchQuery: string;
+  onChange: (value: string) => void;
+  isNFTSearch?: boolean;
+  props?: React.ComponentProps<typeof Box>;
+}) => {
+  const t = useI18nContext();
+
+  return (
+    <Box padding={4} {...props}>
+      <TextFieldSearch
+        borderRadius={BorderRadius.LG}
+        placeholder={t(isNFTSearch ? 'searchNfts' : 'searchTokens')}
+        value={searchQuery}
+        onChange={(e) => onChange(e.target.value)}
+        error={false}
+        autoFocus
+        autoComplete={false}
+        width={BlockSize.Full}
+        clearButtonOnClick={() => onChange('')}
+        clearButtonProps={{
+          size: ButtonIconSize.Sm,
+        }}
+        showClearButton
+        className="asset-picker-modal__search-list"
+        inputProps={{
+          'data-testid': 'asset-picker-modal-search-input',
+        }}
+        endAccessory={null}
+        size={TextFieldSearchSize.Lg}
+      />
+    </Box>
+  );
+};

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-tabs.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-tabs.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from 'react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { Tab, Tabs } from '../../../ui/tabs';
+
+export enum TabName {
+  TOKENS = 'tokens',
+  NFTS = 'nfts',
+}
+
+/**
+ * AssetPickerModalTabs component.
+ *
+ * @param props
+ * @param props.defaultActiveTabKey - The key of the default active tab.
+ * @param props.children - The child components to be displayed within tabs.
+ * @param props.visibleTabs - A list of visible tabs.
+ * @returns A Tabs instance with the provided visible children.
+ */
+export const AssetPickerModalTabs = ({
+  defaultActiveTabKey = TabName.TOKENS,
+  children,
+  visibleTabs = [TabName.TOKENS, TabName.NFTS],
+}: {
+  defaultActiveTabKey?: TabName;
+  children: ReactElement[];
+  visibleTabs?: TabName[];
+}) => {
+  const t = useI18nContext();
+
+  if (visibleTabs.length > 1) {
+    return (
+      <Tabs
+        defaultActiveTabKey={defaultActiveTabKey}
+        tabsClassName="modal-tab__tabs"
+      >
+        {visibleTabs.map((tabName) => {
+          return (
+            <Tab
+              key={tabName}
+              activeClassName="modal-tab__tab--active"
+              className="modal-tab__tab"
+              name={t(tabName)}
+              tabKey={tabName}
+            >
+              {children.find(({ key }) => key === tabName)}
+            </Tab>
+          );
+        })}
+      </Tabs>
+    );
+  }
+
+  return (
+    <>
+      {visibleTabs.map((tabName) =>
+        children.find(({ key }) => key === tabName),
+      )}
+    </>
+  );
+};

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.stories.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.stories.tsx
@@ -6,6 +6,7 @@ import mockState from '../../../../../test/data/mock-state.json';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import { AssetPickerModal } from './asset-picker-modal';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { ERC20Asset } from './types';
 
 const storybook = {
   title: 'Components/Multichain/AssetPickerModal',
@@ -16,11 +17,11 @@ const props = {
   isOpen: true,
   onClose: () => ({}),
   asset: {
-    balance: null,
-    details: null,
-    error: null,
+    address: '0xAddress',
+    symbol: 'TOKEN',
+    image: 'image.png',
     type: AssetType.token,
-  } as unknown as Asset,
+  } as ERC20Asset,
 };
 export const DefaultStory = () => {
   const t = useI18nContext();

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.stories.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.stories.tsx
@@ -5,6 +5,7 @@ import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import { AssetPickerModal } from './asset-picker-modal';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 const storybook = {
   title: 'Components/Multichain/AssetPickerModal',
@@ -21,15 +22,29 @@ const props = {
     type: AssetType.token,
   } as unknown as Asset,
 };
-export const DefaultStory = () => (
-  <AssetPickerModal onAssetChange={() => ({})} {...props} />
-);
+export const DefaultStory = () => {
+  const t = useI18nContext();
+  return (
+    <AssetPickerModal
+      header={t('sendSelectSendAsset')}
+      onAssetChange={() => ({})}
+      {...props}
+    />
+  );
+};
 
 DefaultStory.storyName = 'Default';
 
-export const TokenStory = () => (
-  <AssetPickerModal onAssetChange={() => ({})} {...props} />
-);
+export const TokenStory = () => {
+  const t = useI18nContext();
+  return (
+    <AssetPickerModal
+      header={t('sendSelectSendAsset')}
+      onAssetChange={() => ({})}
+      {...props}
+    />
+  );
+};
 
 TokenStory.storyName = 'Modal With Balance';
 

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -69,6 +69,7 @@ describe('AssetPickerModal', () => {
   const onCloseMock = jest.fn();
 
   const defaultProps = {
+    header: 'sendSelectReceiveAsset',
     isOpen: true,
     onClose: onCloseMock,
     asset: {

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -29,6 +29,7 @@ import {
 import { getTopAssets } from '../../../../ducks/swaps/swaps';
 import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';
 import * as actions from '../../../../store/actions';
+import { getSwapsBlockedTokens } from '../../../../ducks/send';
 import { AssetPickerModal } from './asset-picker-modal';
 import { Asset } from './types';
 import AssetList from './AssetList';
@@ -105,7 +106,18 @@ describe('AssetPickerModal', () => {
         return {};
       }
       if (selector === getTokenList) {
-        return { '0xAddress': { ...defaultProps.asset, symbol: 'TOKEN' } };
+        return {
+          '0xAddress': { ...defaultProps.asset, symbol: 'TOKEN' },
+          '0xtoken1': {
+            address: '0xToken1',
+            symbol: 'TOKEN1',
+            type: AssetType.token,
+            image: 'image1.png',
+            string: '10',
+            decimals: 18,
+            balance: '0',
+          },
+        };
       }
       if (selector === getConversionRate) {
         return 1;
@@ -121,6 +133,9 @@ describe('AssetPickerModal', () => {
       }
       if (selector === getPreferences) {
         return { useNativeCurrencyAsPrimaryCurrency: false };
+      }
+      if (selector === getSwapsBlockedTokens) {
+        return new Set(['0xtoken1']);
       }
       return undefined;
     });
@@ -184,7 +199,7 @@ describe('AssetPickerModal', () => {
 
     expect(
       (AssetList as jest.Mock).mock.calls.slice(-1)[0][0].tokenList.length,
-    ).toBe(1);
+    ).toBe(2);
 
     fireEvent.change(screen.getByPlaceholderText('searchTokens'), {
       target: { value: 'UNAVAILABLE TOKEN' },
@@ -232,5 +247,45 @@ describe('AssetPickerModal', () => {
 
     expect(modalTitle).toBeInTheDocument();
     expect(searchPlaceholder).toBeInTheDocument();
+  });
+
+  it('should disable the token if it is in the blocked tokens list', () => {
+    renderWithProvider(
+      <AssetPickerModal {...defaultProps} sendingAssetSymbol="IRRELEVANT" />,
+      store,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('searchTokens'), {
+      target: { value: 'TO' },
+    });
+
+    expect(
+      (AssetList as jest.Mock).mock.calls.slice(-1)[0][0].tokenList.length,
+    ).toBe(2);
+
+    fireEvent.change(screen.getByPlaceholderText('searchTokens'), {
+      target: { value: 'TOKEN1' },
+    });
+
+    expect((AssetList as jest.Mock).mock.calls[1][0]).not.toEqual(
+      expect.objectContaining({
+        asset: {
+          balance: '0x0',
+          details: { address: '0xAddress', decimals: 18, symbol: 'TOKEN' },
+          error: null,
+          type: 'NATIVE',
+        },
+      }),
+    );
+
+    expect(
+      (AssetList as jest.Mock).mock.calls.slice(-1)[0][0].tokenList.length,
+    ).toBe(1);
+
+    expect(
+      (AssetList as jest.Mock).mock.calls[2][0].isTokenDisabled({
+        address: '0xtoken1',
+      }),
+    ).toBe(true);
   });
 });

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -179,7 +179,6 @@ describe('AssetPickerModal', () => {
       <AssetPickerModal
         {...defaultProps}
         asset={{
-          balance: '0x0',
           type: AssetType.NFT,
         }}
         sendingAsset={undefined}

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -31,8 +31,8 @@ import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';
 import * as actions from '../../../../store/actions';
 import { getSwapsBlockedTokens } from '../../../../ducks/send';
 import { AssetPickerModal } from './asset-picker-modal';
-import { Asset } from './types';
 import AssetList from './AssetList';
+import { ERC20Asset } from './types';
 
 jest.mock('./AssetList', () => jest.fn(() => <div>AssetList</div>));
 
@@ -73,11 +73,11 @@ describe('AssetPickerModal', () => {
     isOpen: true,
     onClose: onCloseMock,
     asset: {
-      balance: '0x0',
-      details: { address: '0xAddress', decimals: 18, symbol: 'TOKEN' },
-      error: null,
-      type: 'TOKEN',
-    } as unknown as Asset,
+      address: '0xAddress',
+      symbol: 'TOKEN',
+      image: 'image.png',
+      type: AssetType.token,
+    } as ERC20Asset,
     onAssetChange: onAssetChangeMock,
     sendingAsset: {
       image: 'image.png',
@@ -180,6 +180,8 @@ describe('AssetPickerModal', () => {
         {...defaultProps}
         asset={{
           type: AssetType.NFT,
+          tokenId: 5,
+          image: 'nft image',
         }}
         sendingAsset={undefined}
       />,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -79,8 +79,10 @@ describe('AssetPickerModal', () => {
       type: 'TOKEN',
     } as unknown as Asset,
     onAssetChange: onAssetChangeMock,
-    sendingAssetImage: 'image.png',
-    sendingAssetSymbol: 'SYMB',
+    sendingAsset: {
+      image: 'image.png',
+      symbol: 'SYMB',
+    },
   };
 
   beforeEach(() => {
@@ -180,8 +182,7 @@ describe('AssetPickerModal', () => {
           balance: '0x0',
           type: AssetType.NFT,
         }}
-        sendingAssetImage={undefined}
-        sendingAssetSymbol={undefined}
+        sendingAsset={undefined}
       />,
       store,
     );
@@ -252,7 +253,10 @@ describe('AssetPickerModal', () => {
 
   it('should disable the token if it is in the blocked tokens list', () => {
     renderWithProvider(
-      <AssetPickerModal {...defaultProps} sendingAssetSymbol="IRRELEVANT" />,
+      <AssetPickerModal
+        {...defaultProps}
+        sendingAsset={{ image: '', symbol: 'IRRELEVANT' }}
+      />,
       store,
     );
 

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -44,17 +44,16 @@ import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';
 import { useEqualityCheck } from '../../../../hooks/useEqualityCheck';
 import { getSwapsBlockedTokens } from '../../../../ducks/send';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
-import { Asset, Token } from './types';
+import { Token } from './types';
+import { AssetPickerModalTabs, TabName } from './asset-picker-modal-tabs';
 import { AssetPickerModalNftTab } from './asset-picker-modal-nft-tab';
 import AssetList from './AssetList';
 import { Search } from './asset-picker-modal-search';
-import { AssetPickerModalTabs, TabName } from './asset-picker-modal-tabs';
 
 type AssetPickerModalProps = {
   header: JSX.Element | string | null;
   isOpen: boolean;
   onClose: () => void;
-  asset: Asset;
   onAssetChange: (asset: Token) => void;
   /**
    * Sending asset for UI treatments; only for dest component
@@ -63,7 +62,8 @@ type AssetPickerModalProps = {
 } & Pick<
   React.ComponentProps<typeof AssetPickerModalTabs>,
   'visibleTabs' | 'defaultActiveTabKey'
->;
+> &
+  Pick<React.ComponentProps<typeof AssetList>, 'asset'>;
 
 const MAX_UNOWNED_TOKENS_RENDERED = 30;
 

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useMemo } from 'react';
 
 import { useSelector } from 'react-redux';
 import { isEqual, uniqBy } from 'lodash';
-import { Tab, Tabs } from '../../../ui/tabs';
 import {
   Modal,
   ModalContent,
@@ -50,6 +49,7 @@ import { Asset, Collection, Token } from './types';
 import { AssetPickerModalNftTab } from './asset-picker-modal-nft-tab';
 import AssetList from './AssetList';
 import { Search } from './asset-picker-modal-search';
+import { AssetPickerModalTabs, TabName } from './asset-picker-modal-tabs';
 
 type AssetPickerModalProps = {
   header: JSX.Element | string | null;
@@ -59,7 +59,10 @@ type AssetPickerModalProps = {
   onAssetChange: (asset: Token) => void;
   sendingAssetImage?: string;
   sendingAssetSymbol?: string;
-};
+} & Pick<
+  React.ComponentProps<typeof AssetPickerModalTabs>,
+  'visibleTabs' | 'defaultActiveTabKey'
+>;
 
 const MAX_UNOWNED_TOKENS_RENDERED = 30;
 
@@ -71,6 +74,7 @@ export function AssetPickerModal({
   onAssetChange,
   sendingAssetImage,
   sendingAssetSymbol,
+  ...tabProps
 }: AssetPickerModalProps) {
   const t = useI18nContext();
 
@@ -109,8 +113,6 @@ export function AssetPickerModal({
   const isDest = sendingAssetImage && sendingAssetSymbol;
 
   const handleAssetChange = useCallback(onAssetChange, [onAssetChange]);
-
-  const defaultActiveTabKey = asset?.type === AssetType.NFT ? 'nfts' : 'tokens';
 
   const chainId = useSelector(getCurrentChainId);
 
@@ -279,8 +281,8 @@ export function AssetPickerModal({
           </Box>
         )}
         <Box className="modal-tab__wrapper">
-          {isDest ? (
-            <>
+          <AssetPickerModalTabs {...tabProps}>
+            <React.Fragment key={TabName.TOKENS}>
               <Search
                 searchQuery={searchQuery}
                 onChange={(value) => setSearchQuery(value)}
@@ -291,51 +293,21 @@ export function AssetPickerModal({
                 tokenList={filteredTokenList}
                 isTokenDisabled={getIsDisabled}
               />
-            </>
-          ) : (
-            <Tabs
-              defaultActiveTabKey={defaultActiveTabKey}
-              tabsClassName="modal-tab__tabs"
-            >
-              <Tab
-                activeClassName="modal-tab__tab--active"
-                className="modal-tab__tab"
-                name={t('tokens')}
-                tabKey="tokens"
-              >
+            </React.Fragment>
+            <AssetPickerModalNftTab
+              key={TabName.NFTS}
+              collectionDataFiltered={collectionDataFiltered}
+              previouslyOwnedCollection={previouslyOwnedCollection}
+              onClose={onClose}
+              renderSearch={() => (
                 <Search
+                  isNFTSearch
                   searchQuery={searchQuery}
                   onChange={(value) => setSearchQuery(value)}
                 />
-                <AssetList
-                  handleAssetChange={handleAssetChange}
-                  asset={asset}
-                  tokenList={filteredTokenList}
-                  isTokenDisabled={getIsDisabled}
-                />
-              </Tab>
-
-              <Tab
-                activeClassName="modal-tab__tab--active"
-                className="modal-tab__tab"
-                name={t('nfts')}
-                tabKey="nfts"
-              >
-                <AssetPickerModalNftTab
-                  collectionDataFiltered={collectionDataFiltered}
-                  previouslyOwnedCollection={previouslyOwnedCollection}
-                  onClose={onClose}
-                  renderSearch={() => (
-                    <Search
-                      isNFTSearch
-                      searchQuery={searchQuery}
-                      onChange={(value) => setSearchQuery(value)}
-                    />
-                  )}
-                />
-              </Tab>
-            </Tabs>
-          )}
+              )}
+            />
+          </AssetPickerModalTabs>
         </Box>
       </ModalContent>
     </Modal>

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -8,16 +8,12 @@ import {
   ModalContent,
   ModalOverlay,
   ModalHeader,
-  TextFieldSearch,
   Box,
-  ButtonIconSize,
-  TextFieldSearchSize,
   AvatarTokenSize,
   AvatarToken,
   Text,
 } from '../../../component-library';
 import {
-  BlockSize,
   BorderRadius,
   TextVariant,
   TextAlign,
@@ -61,6 +57,7 @@ import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-uti
 import { Asset, Collection, Token } from './types';
 import { AssetPickerModalNftTab } from './asset-picker-modal-nft-tab';
 import AssetList from './AssetList';
+import { Search } from './asset-picker-modal-search';
 
 type AssetPickerModalProps = {
   isOpen: boolean;
@@ -280,41 +277,6 @@ export function AssetPickerModal({
     sendingAssetSymbol,
   ]);
 
-  const Search = useCallback(
-    ({
-      isNFTSearch = false,
-      props,
-    }: {
-      isNFTSearch?: boolean;
-      props?: React.ComponentProps<typeof Box>;
-    }) => (
-      <Box padding={4} {...props}>
-        <TextFieldSearch
-          borderRadius={BorderRadius.LG}
-          placeholder={t(isNFTSearch ? 'searchNfts' : 'searchTokens')}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          error={false}
-          autoFocus
-          autoComplete={false}
-          width={BlockSize.Full}
-          clearButtonOnClick={() => setSearchQuery('')}
-          clearButtonProps={{
-            size: ButtonIconSize.Sm,
-          }}
-          showClearButton
-          className="asset-picker-modal__search-list"
-          inputProps={{
-            'data-testid': 'asset-picker-modal-search-input',
-          }}
-          endAccessory={null}
-          size={TextFieldSearchSize.Lg}
-        />
-      </Box>
-    ),
-    [searchQuery],
-  );
-
   return (
     <Modal
       className="asset-picker-modal"
@@ -350,7 +312,11 @@ export function AssetPickerModal({
         <Box className="modal-tab__wrapper">
           {isDest ? (
             <>
-              <Search props={{ paddingTop: 1 }} />
+              <Search
+                props={{ paddingTop: 1 }}
+                searchQuery={searchQuery}
+                onChange={(value) => setSearchQuery(value)}
+              />
               <AssetList
                 handleAssetChange={handleAssetChange}
                 asset={asset}
@@ -369,7 +335,10 @@ export function AssetPickerModal({
                 name={t('tokens')}
                 tabKey="tokens"
               >
-                <Search />
+                <Search
+                  searchQuery={searchQuery}
+                  onChange={(value) => setSearchQuery(value)}
+                />
                 <AssetList
                   handleAssetChange={handleAssetChange}
                   asset={asset}
@@ -388,7 +357,13 @@ export function AssetPickerModal({
                   collectionDataFiltered={collectionDataFiltered}
                   previouslyOwnedCollection={previouslyOwnedCollection}
                   onClose={onClose}
-                  renderSearch={() => Search({ isNFTSearch: true })}
+                  renderSearch={() => (
+                    <Search
+                      isNFTSearch
+                      searchQuery={searchQuery}
+                      onChange={(value) => setSearchQuery(value)}
+                    />
+                  )}
                 />
               </Tab>
             </Tabs>

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -177,6 +177,18 @@ export function AssetPickerModal({
 
   const memoizedUsersTokens = useEqualityCheck(usersTokens);
 
+  const getIsDisabled = useCallback(
+    ({ address, symbol }: Token) => {
+      const isDisabled = sendingAssetSymbol
+        ? !isEqualCaseInsensitive(sendingAssetSymbol, symbol) &&
+          memoizedSwapsBlockedTokens.has(address || '')
+        : false;
+
+      return isDisabled;
+    },
+    [sendingAssetSymbol, memoizedSwapsBlockedTokens],
+  );
+
   const filteredTokenList = useMemo(() => {
     const nativeToken = {
       address: null,
@@ -190,15 +202,6 @@ export function AssetPickerModal({
     const filteredTokens: Token[] = [];
     // undefined would be the native token address
     const filteredTokensAddresses = new Set<string | undefined>();
-
-    const getIsDisabled = ({ address, symbol }: Token) => {
-      const isDisabled = sendingAssetSymbol
-        ? !isEqualCaseInsensitive(sendingAssetSymbol, symbol) &&
-          memoizedSwapsBlockedTokens.has(address || '')
-        : false;
-
-      return isDisabled;
-    };
 
     function* tokenGenerator() {
       yield nativeToken;
@@ -299,7 +302,7 @@ export function AssetPickerModal({
           clearButtonProps={{
             size: ButtonIconSize.Sm,
           }}
-          showClearButton={true}
+          showClearButton
           className="asset-picker-modal__search-list"
           inputProps={{
             'data-testid': 'asset-picker-modal-search-input',
@@ -352,8 +355,7 @@ export function AssetPickerModal({
                 handleAssetChange={handleAssetChange}
                 asset={asset}
                 tokenList={filteredTokenList}
-                sendingAssetSymbol={sendingAssetSymbol}
-                memoizedSwapsBlockedTokens={memoizedSwapsBlockedTokens}
+                isTokenDisabled={getIsDisabled}
               />
             </>
           ) : (
@@ -361,38 +363,34 @@ export function AssetPickerModal({
               defaultActiveTabKey={defaultActiveTabKey}
               tabsClassName="modal-tab__tabs"
             >
-              {
-                <Tab
-                  activeClassName="modal-tab__tab--active"
-                  className="modal-tab__tab"
-                  name={t('tokens')}
-                  tabKey="tokens"
-                >
-                  <Search />
-                  <AssetList
-                    handleAssetChange={handleAssetChange}
-                    asset={asset}
-                    tokenList={filteredTokenList}
-                    memoizedSwapsBlockedTokens={memoizedSwapsBlockedTokens}
-                  />
-                </Tab>
-              }
+              <Tab
+                activeClassName="modal-tab__tab--active"
+                className="modal-tab__tab"
+                name={t('tokens')}
+                tabKey="tokens"
+              >
+                <Search />
+                <AssetList
+                  handleAssetChange={handleAssetChange}
+                  asset={asset}
+                  tokenList={filteredTokenList}
+                  isTokenDisabled={getIsDisabled}
+                />
+              </Tab>
 
-              {
-                <Tab
-                  activeClassName="modal-tab__tab--active"
-                  className="modal-tab__tab"
-                  name={t('nfts')}
-                  tabKey="nfts"
-                >
-                  <AssetPickerModalNftTab
-                    collectionDataFiltered={collectionDataFiltered}
-                    previouslyOwnedCollection={previouslyOwnedCollection}
-                    onClose={onClose}
-                    renderSearch={() => Search({ isNFTSearch: true })}
-                  />
-                </Tab>
-              }
+              <Tab
+                activeClassName="modal-tab__tab--active"
+                className="modal-tab__tab"
+                name={t('nfts')}
+                tabKey="nfts"
+              >
+                <AssetPickerModalNftTab
+                  collectionDataFiltered={collectionDataFiltered}
+                  previouslyOwnedCollection={previouslyOwnedCollection}
+                  onClose={onClose}
+                  renderSearch={() => Search({ isNFTSearch: true })}
+                />
+              </Tab>
             </Tabs>
           )}
         </Box>

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useContext } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 
 import { useSelector } from 'react-redux';
 import { isEqual, uniqBy } from 'lodash';
@@ -44,15 +44,7 @@ import { useTokenTracker } from '../../../../hooks/useTokenTracker';
 import { getTopAssets } from '../../../../ducks/swaps/swaps';
 import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';
 import { useEqualityCheck } from '../../../../hooks/useEqualityCheck';
-import {
-  MetaMetricsEventName,
-  MetaMetricsEventCategory,
-} from '../../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../../contexts/metametrics';
-import {
-  getSendAnalyticProperties,
-  getSwapsBlockedTokens,
-} from '../../../../ducks/send';
+import { getSwapsBlockedTokens } from '../../../../ducks/send';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
 import { Asset, Collection, Token } from './types';
 import { AssetPickerModalNftTab } from './asset-picker-modal-nft-tab';
@@ -63,7 +55,7 @@ type AssetPickerModalProps = {
   isOpen: boolean;
   onClose: () => void;
   asset: Asset;
-  onAssetChange: (asset: Asset) => void;
+  onAssetChange: (asset: Token) => void;
   sendingAssetImage?: string;
   sendingAssetSymbol?: string;
 };
@@ -79,8 +71,6 @@ export function AssetPickerModal({
   sendingAssetSymbol,
 }: AssetPickerModalProps) {
   const t = useI18nContext();
-  const trackEvent = useContext(MetaMetricsContext);
-  const sendAnalytics = useSelector(getSendAnalyticProperties);
 
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -116,29 +106,7 @@ export function AssetPickerModal({
 
   const isDest = sendingAssetImage && sendingAssetSymbol;
 
-  const handleAssetChange = useCallback(
-    (token: Token) => {
-      onAssetChange(token);
-      trackEvent(
-        {
-          event: MetaMetricsEventName.sendAssetSelected,
-          category: MetaMetricsEventCategory.Send,
-          properties: {
-            is_destination_asset_picker_modal: Boolean(isDest),
-            is_nft: false,
-          },
-          sensitiveProperties: {
-            ...sendAnalytics,
-            new_asset_symbol: token.symbol,
-            new_asset_address: token.address,
-          },
-        },
-        { excludeMetaMetricsId: false },
-      );
-      onClose();
-    },
-    [onAssetChange],
-  );
+  const handleAssetChange = useCallback(onAssetChange, [onAssetChange]);
 
   const defaultActiveTabKey = asset?.type === AssetType.NFT ? 'nfts' : 'tokens';
 

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -23,7 +23,6 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { AssetType } from '../../../../../shared/constants/transaction';
 
-import { useNftsCollections } from '../../../../hooks/useNftsCollections';
 import {
   getAllTokens,
   getCurrentChainId,
@@ -45,7 +44,7 @@ import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';
 import { useEqualityCheck } from '../../../../hooks/useEqualityCheck';
 import { getSwapsBlockedTokens } from '../../../../ducks/send';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
-import { Asset, Collection, Token } from './types';
+import { Asset, Token } from './types';
 import { AssetPickerModalNftTab } from './asset-picker-modal-nft-tab';
 import AssetList from './AssetList';
 import { Search } from './asset-picker-modal-search';
@@ -79,31 +78,6 @@ export function AssetPickerModal({
   const t = useI18nContext();
 
   const [searchQuery, setSearchQuery] = useState('');
-
-  const { collections, previouslyOwnedCollection } = useNftsCollections();
-
-  const collectionsKeys = Object.keys(collections);
-
-  const collectionsData = collectionsKeys.reduce((acc: unknown[], key) => {
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const collection = (collections as any)[key];
-
-    const isMatchingQuery = collection.collectionName
-      ?.toLowerCase()
-      .includes(searchQuery.toLowerCase());
-
-    if (isMatchingQuery) {
-      acc.push(collection);
-      return acc;
-    }
-    return acc;
-  }, []);
-
-  // filter and exclude ERC1155
-  const collectionDataFiltered = (collectionsData as Collection[]).filter(
-    (collection) => collection.nfts.length > 0,
-  );
 
   const swapsBlockedTokens = useSelector(getSwapsBlockedTokens);
   const memoizedSwapsBlockedTokens = useMemo(() => {
@@ -296,8 +270,7 @@ export function AssetPickerModal({
             </React.Fragment>
             <AssetPickerModalNftTab
               key={TabName.NFTS}
-              collectionDataFiltered={collectionDataFiltered}
-              previouslyOwnedCollection={previouslyOwnedCollection}
+              searchQuery={searchQuery}
               onClose={onClose}
               renderSearch={() => (
                 <Search

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -254,7 +254,7 @@ export function AssetPickerModal({
     >
       <ModalOverlay />
       <ModalContent modalDialogProps={{ padding: 0 }}>
-        <ModalHeader paddingBottom={2} onClose={onClose}>
+        <ModalHeader onClose={onClose}>
           <Text variant={TextVariant.headingSm} textAlign={TextAlign.Center}>
             {t(isDest ? 'sendSelectReceiveAsset' : 'sendSelectSendAsset')}
           </Text>
@@ -265,7 +265,6 @@ export function AssetPickerModal({
             gap={1}
             alignItems={AlignItems.center}
             marginInline="auto"
-            marginBottom={3}
           >
             <AvatarToken
               borderRadius={BorderRadius.full}
@@ -281,7 +280,6 @@ export function AssetPickerModal({
           {isDest ? (
             <>
               <Search
-                props={{ paddingTop: 1 }}
                 searchQuery={searchQuery}
                 onChange={(value) => setSearchQuery(value)}
               />

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -56,8 +56,10 @@ type AssetPickerModalProps = {
   onClose: () => void;
   asset: Asset;
   onAssetChange: (asset: Token) => void;
-  sendingAssetImage?: string;
-  sendingAssetSymbol?: string;
+  /**
+   * Sending asset for UI treatments; only for dest component
+   */
+  sendingAsset?: { image: string; symbol: string } | undefined;
 } & Pick<
   React.ComponentProps<typeof AssetPickerModalTabs>,
   'visibleTabs' | 'defaultActiveTabKey'
@@ -71,8 +73,7 @@ export function AssetPickerModal({
   onClose,
   asset,
   onAssetChange,
-  sendingAssetImage,
-  sendingAssetSymbol,
+  sendingAsset,
   ...tabProps
 }: AssetPickerModalProps) {
   const t = useI18nContext();
@@ -83,8 +84,6 @@ export function AssetPickerModal({
   const memoizedSwapsBlockedTokens = useMemo(() => {
     return new Set<string>(swapsBlockedTokens);
   }, [swapsBlockedTokens]);
-
-  const isDest = sendingAssetImage && sendingAssetSymbol;
 
   const handleAssetChange = useCallback(onAssetChange, [onAssetChange]);
 
@@ -122,14 +121,14 @@ export function AssetPickerModal({
 
   const getIsDisabled = useCallback(
     ({ address, symbol }: Token) => {
-      const isDisabled = sendingAssetSymbol
-        ? !isEqualCaseInsensitive(sendingAssetSymbol, symbol) &&
+      const isDisabled = sendingAsset?.symbol
+        ? !isEqualCaseInsensitive(sendingAsset.symbol, symbol) &&
           memoizedSwapsBlockedTokens.has(address || '')
         : false;
 
       return isDisabled;
     },
-    [sendingAssetSymbol, memoizedSwapsBlockedTokens],
+    [sendingAsset?.symbol, memoizedSwapsBlockedTokens],
   );
 
   const filteredTokenList = useMemo(() => {
@@ -159,7 +158,7 @@ export function AssetPickerModal({
       for (const address of Object.keys(topTokens)) {
         const token = tokenList?.[address];
         if (token) {
-          if (isDest && getIsDisabled(token)) {
+          if (getIsDisabled(token)) {
             blockedTokens.push(token);
             continue;
           } else {
@@ -215,12 +214,16 @@ export function AssetPickerModal({
     nativeCurrency,
     nativeCurrencyImage,
     balanceValue,
+    memoizedUsersTokens,
+    topTokens,
+    tokenList,
+    getIsDisabled,
+    searchQuery,
     tokenConversionRates,
     conversionRate,
     currentCurrency,
     chainId,
     tokenList,
-    sendingAssetSymbol,
   ]);
 
   return (
@@ -237,7 +240,7 @@ export function AssetPickerModal({
             {header}
           </Text>
         </ModalHeader>
-        {isDest && (
+        {sendingAsset?.image && sendingAsset?.symbol && (
           <Box
             display={Display.Flex}
             gap={1}
@@ -246,11 +249,11 @@ export function AssetPickerModal({
           >
             <AvatarToken
               borderRadius={BorderRadius.full}
-              src={sendingAssetImage}
+              src={sendingAsset.image}
               size={AvatarTokenSize.Xs}
             />
             <Text variant={TextVariant.bodySm}>
-              {t('sendingAsset', [sendingAssetSymbol])}
+              {t('sendingAsset', [sendingAsset.symbol])}
             </Text>
           </Box>
         )}

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -52,6 +52,7 @@ import AssetList from './AssetList';
 import { Search } from './asset-picker-modal-search';
 
 type AssetPickerModalProps = {
+  header: JSX.Element | string | null;
   isOpen: boolean;
   onClose: () => void;
   asset: Asset;
@@ -63,6 +64,7 @@ type AssetPickerModalProps = {
 const MAX_UNOWNED_TOKENS_RENDERED = 30;
 
 export function AssetPickerModal({
+  header,
   isOpen,
   onClose,
   asset,
@@ -256,7 +258,7 @@ export function AssetPickerModal({
       <ModalContent modalDialogProps={{ padding: 0 }}>
         <ModalHeader onClose={onClose}>
           <Text variant={TextVariant.headingSm} textAlign={TextAlign.Center}>
-            {t(isDest ? 'sendSelectReceiveAsset' : 'sendSelectSendAsset')}
+            {header}
           </Text>
         </ModalHeader>
         {isDest && (

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/types.ts
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/types.ts
@@ -1,8 +1,14 @@
+import { Token, TokenListToken } from '@metamask/assets-controllers';
+import { Hex } from '@metamask/utils';
 import type {
   AssetType,
   TokenStandard,
 } from '../../../../../shared/constants/transaction';
 import type { Asset } from '../../../../ducks/send';
+import {
+  CHAIN_ID_TO_CURRENCY_SYMBOL_MAP,
+  CHAIN_ID_TOKEN_IMAGE_MAP,
+} from '../../../../../shared/constants/network';
 
 export type NFT = {
   address: string;
@@ -12,24 +18,49 @@ export type NFT = {
   isCurrentlyOwned: boolean;
   name: string | null;
   standard: TokenStandard;
-  tokenId: string;
+  tokenId: number;
   tokenURI?: string;
+  type: AssetType.NFT;
+  symbol?: string;
 };
 
-export type Token = {
-  address: string | null;
-  symbol: string;
-  decimals: number;
+/**
+ * Passed in to AssetPicker, AssetPickerModal and AssetList as a prop
+ * Since token interfaces can vary between experiences (i.e. send vs bridge,
+ * these fields need to be set before passing an asset to the AssetPicker
+ */
+export type ERC20Asset = Pick<TokenListToken, 'address' | 'symbol'> & {
+  type: AssetType.token;
   image: string;
-  balance: string;
-  string: string;
-  type: AssetType;
 };
+export type NativeAsset = {
+  type: AssetType.native;
+  address?: null; // TODO add zero address
+  image: typeof CHAIN_ID_TOKEN_IMAGE_MAP extends Record<string, infer V>
+    ? V
+    : never; // only allow wallet's hardcoded images
+  symbol: typeof CHAIN_ID_TO_CURRENCY_SYMBOL_MAP extends Record<string, infer V>
+    ? V
+    : never; // only allow wallet's hardcoded symbols
+};
+
+/**
+ * ERC20Asset or NativeAsset, plus additional fields for display purposes in the Asset component
+ */
+export type AssetWithDisplayData<T extends ERC20Asset | NativeAsset> = T & {
+  balance: T['type'] extends AssetType.token ? string : Hex; // raw balance
+  string: string | undefined; // normalized balance as a stringified number
+} & Pick<TokenListToken, 'decimals'>;
 
 export type Collection = {
   collectionName: string;
   collectionImage: string | null;
   nfts: NFT[];
 };
+
+/**
+ * Type of useTokenTracker's tokensWithBalances result
+ */
+export type TokenWithBalance = Token & { balance?: string; string?: string };
 
 export { Asset };

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/types.ts
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/types.ts
@@ -35,7 +35,7 @@ export type ERC20Asset = Pick<TokenListToken, 'address' | 'symbol'> & {
 };
 export type NativeAsset = {
   type: AssetType.native;
-  address?: null; // TODO add zero address
+  address?: null;
   image: typeof CHAIN_ID_TOKEN_IMAGE_MAP extends Record<string, infer V>
     ? V
     : never; // only allow wallet's hardcoded images

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.stories.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.stories.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from '../../../../store/store';
+import mockState from '../../../../../test/data/mock-state.json';
+import { AssetType } from '../../../../../shared/constants/transaction';
+import { AssetPicker } from './asset-picker';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { CHAIN_ID_TOKEN_IMAGE_MAP } from '../../../../../shared/constants/network';
+import { ERC20Asset } from '../asset-picker-modal/types';
+
+const storybook = {
+  title: 'Components/Multichain/AssetPicker',
+  component: AssetPicker,
+};
+
+const props = {
+  asset: {
+    symbol: 'ETH',
+    address: '0xaddress1',
+    image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
+    type: AssetType.token,
+  } as ERC20Asset,
+};
+export const DefaultStory = () => {
+  const t = useI18nContext();
+  return (
+    <AssetPicker
+      header={t('sendSelectReceiveAsset')}
+      onAssetChange={() => ({})}
+      {...props}
+    />
+  );
+};
+
+DefaultStory.storyName = 'Default';
+
+export const DisabledStory = () => {
+  const t = useI18nContext();
+  return (
+    <AssetPicker
+      header={t('sendSelectReceiveAsset')}
+      onAssetChange={() => ({})}
+      {...props}
+      isDisabled
+    />
+  );
+};
+
+DisabledStory.storyName = 'Disabled';
+
+export const SendDestStory = () => {
+  const t = useI18nContext();
+  return (
+    <AssetPicker
+      header={t('sendSelectReceiveAsset')}
+      onAssetChange={() => ({})}
+      {...props}
+      asset={{
+        symbol: 'ETH',
+        image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
+        type: AssetType.native,
+      }}
+      sendingAsset={{
+        image: 'token image',
+        symbol: 'ETH',
+      }}
+    />
+  );
+};
+
+function store() {
+  const defaultMockState = { ...mockState };
+  defaultMockState.metamask = {
+    ...defaultMockState.metamask,
+    providerConfig: {
+      ...defaultMockState.metamask.providerConfig,
+      chainId: '0x1',
+      ticker: 'ETH',
+      nickname: 'Ethereum Mainnet',
+    },
+  };
+  return configureStore(defaultMockState);
+}
+
+SendDestStory.decorators = [
+  (story) => <Provider store={store()}>{story()}</Provider>,
+];
+
+SendDestStory.storyName = 'With Sending Asset';
+
+export default storybook;

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
@@ -8,8 +8,11 @@ import configureStore from '../../../../store/store';
 import {
   CHAIN_IDS,
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
+  CHAIN_ID_TOKEN_IMAGE_MAP,
 } from '../../../../../shared/constants/network';
 import { mockNetworkState } from '../../../../../test/stub/networks';
+
+import { ERC20Asset, NativeAsset, NFT } from '../asset-picker-modal/types';
 import { AssetPicker } from './asset-picker';
 
 const unknownChainId = '0x2489078';
@@ -52,7 +55,7 @@ describe('AssetPicker', () => {
       type: AssetType.native,
       image: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP['0x1'],
       symbol: NATIVE_TICKER,
-    };
+    } as NativeAsset;
     const mockAssetChange = jest.fn();
 
     const { asFragment } = render(
@@ -70,8 +73,9 @@ describe('AssetPicker', () => {
   it('calls onClick handler', () => {
     const asset = {
       type: AssetType.native,
-      symbol: NATIVE_TICKER,
-    };
+      image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
+      symbol: 'NATIVE',
+    } as NativeAsset;
     const mockAssetChange = jest.fn();
     const mockOnClick = jest.fn();
     const { getByTestId } = render(
@@ -91,9 +95,9 @@ describe('AssetPicker', () => {
   it('native: renders symbol and image', () => {
     const asset = {
       type: AssetType.native,
-      image: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP['0x1'],
+      image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
       symbol: 'NATIVE',
-    };
+    } as NativeAsset;
     const mockAssetChange = jest.fn();
 
     const { getByText, getByAltText } = render(
@@ -114,9 +118,9 @@ describe('AssetPicker', () => {
   it('native: renders overflowing symbol and image', () => {
     const asset = {
       type: AssetType.native,
-      image: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP['0x1'],
+      image: CHAIN_ID_TOKEN_IMAGE_MAP['0x1'],
       symbol: NATIVE_TICKER,
-    };
+    } as NativeAsset;
     const mockAssetChange = jest.fn();
 
     const { getByText, getByAltText } = render(
@@ -140,7 +144,7 @@ describe('AssetPicker', () => {
       address: 'token address',
       image: 'token icon url',
       symbol: 'symbol',
-    };
+    } as ERC20Asset;
     const mockAssetChange = jest.fn();
 
     const { getByText, getByAltText } = render(
@@ -164,7 +168,7 @@ describe('AssetPicker', () => {
       address: 'token address',
       image: 'token icon url',
       symbol: 'symbol overflow',
-    };
+    } as ERC20Asset;
     const mockAssetChange = jest.fn();
 
     const { getByText, getByAltText } = render(
@@ -191,7 +195,7 @@ describe('AssetPicker', () => {
       type: AssetType.token,
       address: 'token address',
       symbol: 'symbol',
-    };
+    } as ERC20Asset;
     const mockAssetChange = jest.fn();
 
     const { getByText } = render(
@@ -218,7 +222,7 @@ describe('AssetPicker', () => {
       type: AssetType.NFT,
       address: 'token address',
       tokenId: 1234567890,
-    };
+    } as NFT;
     const mockAssetChange = jest.fn();
 
     const { getByText } = render(
@@ -238,7 +242,7 @@ describe('AssetPicker', () => {
       type: AssetType.NFT,
       address: 'token address',
       tokenId: 1234567890123456,
-    };
+    } as NFT;
     const mockAssetChange = jest.fn();
 
     const { getByText } = render(
@@ -258,7 +262,7 @@ describe('AssetPicker', () => {
       type: AssetType.token,
       address: 'token address',
       symbol: 'symbol',
-    };
+    } as ERC20Asset;
     const mockAssetChange = jest.fn();
 
     const { container } = render(

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
@@ -10,6 +10,12 @@ import { mockNetworkState } from '../../../../../test/stub/networks';
 import { AssetPicker } from './asset-picker';
 
 const unknownChainId = '0x2489078';
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+}));
 
 const store = (
   nativeTicker = 'NATIVE TICKER',
@@ -50,6 +56,27 @@ describe('AssetPicker', () => {
       </Provider>,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('calls onClick handler', () => {
+    const asset = {
+      type: AssetType.native,
+      balance: '1000000',
+    };
+    const mockAssetChange = jest.fn();
+    const mockOnClick = jest.fn();
+    const { getByTestId } = render(
+      <Provider store={store('NATIVE')}>
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+          onClick={mockOnClick}
+        />
+      </Provider>,
+    );
+    getByTestId('asset-picker-button').click();
+    expect(mockOnClick).toHaveBeenCalled();
   });
 
   it('native: renders symbol and image', () => {

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
@@ -5,7 +5,10 @@ import { Hex } from '@metamask/utils';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import mockSendState from '../../../../../test/data/mock-send-state.json';
 import configureStore from '../../../../store/store';
-import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import {
+  CHAIN_IDS,
+  CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
+} from '../../../../../shared/constants/network';
 import { mockNetworkState } from '../../../../../test/stub/networks';
 import { AssetPicker } from './asset-picker';
 
@@ -17,8 +20,9 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
+const NATIVE_TICKER = 'NATIVE TICKER';
 const store = (
-  nativeTicker = 'NATIVE TICKER',
+  nativeTicker = NATIVE_TICKER,
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tokenList = {} as any,
@@ -46,7 +50,8 @@ describe('AssetPicker', () => {
   it('matches snapshot', () => {
     const asset = {
       type: AssetType.native,
-      balance: '1000000',
+      image: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP['0x1'],
+      symbol: NATIVE_TICKER,
     };
     const mockAssetChange = jest.fn();
 
@@ -65,7 +70,7 @@ describe('AssetPicker', () => {
   it('calls onClick handler', () => {
     const asset = {
       type: AssetType.native,
-      balance: '1000000',
+      symbol: NATIVE_TICKER,
     };
     const mockAssetChange = jest.fn();
     const mockOnClick = jest.fn();
@@ -86,7 +91,8 @@ describe('AssetPicker', () => {
   it('native: renders symbol and image', () => {
     const asset = {
       type: AssetType.native,
-      balance: '1000000',
+      image: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP['0x1'],
+      symbol: 'NATIVE',
     };
     const mockAssetChange = jest.fn();
 
@@ -108,12 +114,13 @@ describe('AssetPicker', () => {
   it('native: renders overflowing symbol and image', () => {
     const asset = {
       type: AssetType.native,
-      balance: '1000000',
+      image: CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP['0x1'],
+      symbol: NATIVE_TICKER,
     };
     const mockAssetChange = jest.fn();
 
     const { getByText, getByAltText } = render(
-      <Provider store={store('NATIVE TOKEN')}>
+      <Provider store={store(NATIVE_TICKER)}>
         <AssetPicker
           header={'testHeader'}
           asset={asset}
@@ -130,21 +137,14 @@ describe('AssetPicker', () => {
   it('token: renders symbol and image', () => {
     const asset = {
       type: AssetType.token,
-      details: {
-        address: 'token address',
-        decimals: 2,
-        symbol: 'symbol',
-      },
-      balance: '100',
+      address: 'token address',
+      image: 'token icon url',
+      symbol: 'symbol',
     };
     const mockAssetChange = jest.fn();
 
     const { getByText, getByAltText } = render(
-      <Provider
-        store={store("SHOULDN'T MATTER", {
-          'token address': { iconUrl: 'token icon url' },
-        })}
-      >
+      <Provider store={store("SHOULDN'T MATTER")}>
         <AssetPicker
           header={'testHeader'}
           asset={asset}
@@ -161,12 +161,9 @@ describe('AssetPicker', () => {
   it('token: renders symbol and image overflowing', () => {
     const asset = {
       type: AssetType.token,
-      details: {
-        address: 'token address',
-        decimals: 2,
-        symbol: 'symbol overflow',
-      },
-      balance: '100',
+      address: 'token address',
+      image: 'token icon url',
+      symbol: 'symbol overflow',
     };
     const mockAssetChange = jest.fn();
 
@@ -192,12 +189,8 @@ describe('AssetPicker', () => {
   it('token: renders symbol and image falls back', () => {
     const asset = {
       type: AssetType.token,
-      details: {
-        address: 'token address',
-        decimals: 2,
-        symbol: 'symbol',
-      },
-      balance: '100',
+      address: 'token address',
+      symbol: 'symbol',
     };
     const mockAssetChange = jest.fn();
 
@@ -223,12 +216,8 @@ describe('AssetPicker', () => {
   it('nft: does not truncates if token ID is under length 13', () => {
     const asset = {
       type: AssetType.NFT,
-      details: {
-        address: 'token address',
-        decimals: 2,
-        tokenId: 1234567890,
-      },
-      balance: '100',
+      address: 'token address',
+      tokenId: 1234567890,
     };
     const mockAssetChange = jest.fn();
 
@@ -247,12 +236,8 @@ describe('AssetPicker', () => {
   it('nft: truncates if token ID is too long', () => {
     const asset = {
       type: AssetType.NFT,
-      details: {
-        address: 'token address',
-        decimals: 2,
-        tokenId: 1234567890123456,
-      },
-      balance: '100',
+      address: 'token address',
+      tokenId: 1234567890123456,
     };
     const mockAssetChange = jest.fn();
 
@@ -271,12 +256,8 @@ describe('AssetPicker', () => {
   it('render if disabled', () => {
     const asset = {
       type: AssetType.token,
-      details: {
-        address: 'token address',
-        decimals: 2,
-        symbol: 'symbol',
-      },
-      balance: '100',
+      address: 'token address',
+      symbol: 'symbol',
     };
     const mockAssetChange = jest.fn();
 

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
@@ -52,7 +52,11 @@ describe('AssetPicker', () => {
 
     const { asFragment } = render(
       <Provider store={store()}>
-        <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+        />
       </Provider>,
     );
     expect(asFragment()).toMatchSnapshot();
@@ -88,7 +92,11 @@ describe('AssetPicker', () => {
 
     const { getByText, getByAltText } = render(
       <Provider store={store('NATIVE')}>
-        <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+        />
       </Provider>,
     );
     expect(getByText('NATIVE')).toBeInTheDocument();
@@ -106,7 +114,11 @@ describe('AssetPicker', () => {
 
     const { getByText, getByAltText } = render(
       <Provider store={store('NATIVE TOKEN')}>
-        <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+        />
       </Provider>,
     );
     expect(getByText('NATIVE...')).toBeInTheDocument();
@@ -133,7 +145,11 @@ describe('AssetPicker', () => {
           'token address': { iconUrl: 'token icon url' },
         })}
       >
-        <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+        />
       </Provider>,
     );
     expect(getByText('symbol')).toBeInTheDocument();
@@ -160,7 +176,11 @@ describe('AssetPicker', () => {
           'token address': { iconUrl: 'token icon url' },
         })}
       >
-        <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+        />
       </Provider>,
     );
     expect(getByText('symbol...')).toBeInTheDocument();
@@ -189,7 +209,11 @@ describe('AssetPicker', () => {
           unknownChainId,
         )}
       >
-        <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+        />
       </Provider>,
     );
     expect(getByText('symbol')).toBeInTheDocument();
@@ -210,7 +234,11 @@ describe('AssetPicker', () => {
 
     const { getByText } = render(
       <Provider store={store()}>
-        <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+        />
       </Provider>,
     );
     expect(getByText('#1234567890')).toBeInTheDocument();
@@ -230,7 +258,11 @@ describe('AssetPicker', () => {
 
     const { getByText } = render(
       <Provider store={store()}>
-        <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
+        <AssetPicker
+          header={'testHeader'}
+          asset={asset}
+          onAssetChange={() => mockAssetChange()}
+        />
       </Provider>,
     );
     expect(getByText('#123456...3456')).toBeInTheDocument();
@@ -257,6 +289,7 @@ describe('AssetPicker', () => {
         )}
       >
         <AssetPicker
+          header={'testHeader'}
           asset={asset}
           onAssetChange={() => mockAssetChange()}
           isDisabled

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -41,6 +41,7 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 ///: END:ONLY_INCLUDE_IF
 import { ellipsify } from '../../../../pages/confirmations/send/send.utils';
 import { Token } from '../asset-picker-modal/types';
+import { TabName } from '../asset-picker-modal/asset-picker-modal-tabs';
 
 const ELLIPSIFY_LENGTH = 13; // 6 (start) + 4 (end) + 3 (...)
 
@@ -56,7 +57,10 @@ export type AssetPickerProps = {
   sendingAsset?: Asset;
   onClick?: () => void;
   isDisabled?: boolean;
-} & Pick<React.ComponentProps<typeof AssetPickerModal>, 'header'>;
+} & Pick<
+  React.ComponentProps<typeof AssetPickerModal>,
+  'visibleTabs' | 'header'
+>;
 
 // A component that lets the user pick from a list of assets.
 export function AssetPicker({
@@ -66,6 +70,7 @@ export function AssetPicker({
   sendingAsset,
   onClick,
   isDisabled = false,
+  visibleTabs,
 }: AssetPickerProps) {
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   const t = useI18nContext();
@@ -134,6 +139,7 @@ export function AssetPicker({
     <>
       {/* This is the Modal that ask to choose token to send */}
       <AssetPickerModal
+        visibleTabs={visibleTabs}
         header={header}
         isOpen={showAssetPickerModal}
         onClose={() => setShowAssetPickerModal(false)}
@@ -145,6 +151,9 @@ export function AssetPicker({
         sendingAssetImage={sendingTokenImage}
         sendingAssetSymbol={
           sendingAsset?.details?.symbol || nativeCurrencySymbol
+        }
+        defaultActiveTabKey={
+          asset?.type === AssetType.NFT ? TabName.NFTS : TabName.TOKENS
         }
       />
 

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -56,10 +56,11 @@ export type AssetPickerProps = {
   sendingAsset?: Asset;
   onClick?: () => void;
   isDisabled?: boolean;
-};
+} & Pick<React.ComponentProps<typeof AssetPickerModal>, 'header'>;
 
 // A component that lets the user pick from a list of assets.
 export function AssetPicker({
+  header,
   asset,
   onAssetChange,
   sendingAsset,
@@ -133,6 +134,7 @@ export function AssetPicker({
     <>
       {/* This is the Modal that ask to choose token to send */}
       <AssetPickerModal
+        header={header}
         isOpen={showAssetPickerModal}
         onClose={() => setShowAssetPickerModal(false)}
         asset={asset}

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   AvatarTokenSize,
@@ -11,7 +11,7 @@ import {
   BadgeWrapper,
   AvatarNetwork,
 } from '../../../component-library';
-import { Asset, getSendAnalyticProperties } from '../../../../ducks/send';
+import { Asset } from '../../../../ducks/send';
 import {
   AlignItems,
   BackgroundColor,
@@ -39,11 +39,6 @@ import { getAssetImageURL } from '../../../../helpers/utils/util';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 ///: END:ONLY_INCLUDE_IF
-import { MetaMetricsContext } from '../../../../contexts/metametrics';
-import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../../../shared/constants/metametrics';
 import { ellipsify } from '../../../../pages/confirmations/send/send.utils';
 import { Token } from '../asset-picker-modal/types';
 
@@ -59,6 +54,7 @@ export type AssetPickerProps = {
    * Sending asset for UI treatments; only for dest component
    */
   sendingAsset?: Asset;
+  onClick?: () => void;
   isDisabled?: boolean;
 };
 
@@ -67,13 +63,12 @@ export function AssetPicker({
   asset,
   onAssetChange,
   sendingAsset,
+  onClick,
   isDisabled = false,
 }: AssetPickerProps) {
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   const t = useI18nContext();
   ///: END:ONLY_INCLUDE_IF
-  const trackEvent = useContext(MetaMetricsContext);
-  const sendAnalytics = useSelector(getSendAnalyticProperties);
 
   const nativeCurrencySymbol = useSelector(getNativeCurrency);
   const nativeCurrencyImageUrl = useSelector(getNativeCurrencyImage);
@@ -165,19 +160,7 @@ export function AssetPicker({
         backgroundColor={BackgroundColor.transparent}
         onClick={() => {
           setShowAssetPickerModal(true);
-          trackEvent(
-            {
-              event: MetaMetricsEventName.sendTokenModalOpened,
-              category: MetaMetricsEventCategory.Send,
-              properties: {
-                is_destination_asset_picker_modal: Boolean(sendingAsset),
-              },
-              sensitiveProperties: {
-                ...sendAnalytics,
-              },
-            },
-            { excludeMetaMetricsId: false },
-          );
+          onClick?.();
         }}
         endIconName={IconName.ArrowDown}
         endIconProps={{

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -25,28 +25,23 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import { AssetPickerModal } from '../asset-picker-modal/asset-picker-modal';
-import { getNativeCurrency } from '../../../../ducks/metamask/metamask';
 import {
   getCurrentNetwork,
-  getIpfsGateway,
-  getNativeCurrencyImage,
   getTestNetworkBackgroundColor,
-  getTokenList,
 } from '../../../../selectors';
 import Tooltip from '../../../ui/tooltip';
 import { LARGE_SYMBOL_LENGTH } from '../constants';
-import { getAssetImageURL } from '../../../../helpers/utils/util';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 ///: END:ONLY_INCLUDE_IF
 import { ellipsify } from '../../../../pages/confirmations/send/send.utils';
 import { Token } from '../asset-picker-modal/types';
 import { TabName } from '../asset-picker-modal/asset-picker-modal-tabs';
+import AssetList from '../asset-picker-modal/AssetList';
 
 const ELLIPSIFY_LENGTH = 13; // 6 (start) + 4 (end) + 3 (...)
 
 export type AssetPickerProps = {
-  asset: Asset;
   /**
    * Needs to be wrapped in a callback
    */
@@ -56,7 +51,8 @@ export type AssetPickerProps = {
 } & Pick<
   React.ComponentProps<typeof AssetPickerModal>,
   'visibleTabs' | 'header' | 'sendingAsset'
->;
+> &
+  Pick<React.ComponentProps<typeof AssetList>, 'asset'>;
 
 // A component that lets the user pick from a list of assets.
 export function AssetPicker({
@@ -72,33 +68,14 @@ export function AssetPicker({
   const t = useI18nContext();
   ///: END:ONLY_INCLUDE_IF
 
-  const nativeCurrencySymbol = useSelector(getNativeCurrency);
-  const nativeCurrencyImageUrl = useSelector(getNativeCurrencyImage);
-  // TODO: Replace `any` with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const tokenList: Record<string, any> = useSelector(getTokenList);
-
-  const ipfsGateway = useSelector(getIpfsGateway);
-
   const [showAssetPickerModal, setShowAssetPickerModal] = useState(false);
 
-  let primaryTokenImage: string | undefined;
+  // selected asset details
+  const primaryTokenImage = asset?.image;
+  const symbol = asset?.symbol;
 
-  if (asset.type === AssetType.native) {
-    primaryTokenImage = nativeCurrencyImageUrl;
-  } else if (tokenList && asset.details) {
-    primaryTokenImage =
-      getAssetImageURL(asset.details?.image, ipfsGateway) ||
-      tokenList[asset.details.address?.toLowerCase()]?.iconUrl;
-  }
-
-  const symbol =
-    asset.type === AssetType.native
-      ? nativeCurrencySymbol
-      : asset.details?.symbol;
-
-  const isSymbolLong = symbol?.length > LARGE_SYMBOL_LENGTH;
-  const isNFT = asset.type === AssetType.NFT;
+  const isSymbolLong = symbol && symbol.length > LARGE_SYMBOL_LENGTH;
+  const isNFT = asset?.type === AssetType.NFT;
 
   const formattedSymbol =
     isSymbolLong && !isNFT
@@ -193,15 +170,15 @@ export function AssetPicker({
             <Text className="asset-picker__symbol" variant={TextVariant.bodyMd}>
               {formattedSymbol}
             </Text>
-            {asset.details?.tokenId && (
+            {asset?.tokenId && (
               <Text
                 variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}
               >
                 #
-                {String(asset.details.tokenId).length < ELLIPSIFY_LENGTH
-                  ? asset.details.tokenId
-                  : ellipsify(String(asset.details.tokenId), 6, 4)}
+                {String(asset.tokenId).length < ELLIPSIFY_LENGTH
+                  ? asset.tokenId
+                  : ellipsify(String(asset.tokenId), 6, 4)}
               </Text>
             )}
           </Tooltip>

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -51,15 +51,11 @@ export type AssetPickerProps = {
    * Needs to be wrapped in a callback
    */
   onAssetChange: (newAsset: Asset) => void;
-  /**
-   * Sending asset for UI treatments; only for dest component
-   */
-  sendingAsset?: Asset;
   onClick?: () => void;
   isDisabled?: boolean;
 } & Pick<
   React.ComponentProps<typeof AssetPickerModal>,
-  'visibleTabs' | 'header'
+  'visibleTabs' | 'header' | 'sendingAsset'
 >;
 
 // A component that lets the user pick from a list of assets.
@@ -94,18 +90,6 @@ export function AssetPicker({
     primaryTokenImage =
       getAssetImageURL(asset.details?.image, ipfsGateway) ||
       tokenList[asset.details.address?.toLowerCase()]?.iconUrl;
-  }
-
-  let sendingTokenImage: string | undefined;
-
-  if (sendingAsset) {
-    if (sendingAsset.type === AssetType.native) {
-      sendingTokenImage = nativeCurrencyImageUrl;
-    } else if (tokenList && sendingAsset.details) {
-      sendingTokenImage =
-        getAssetImageURL(sendingAsset.details?.image, ipfsGateway) ||
-        tokenList[sendingAsset.details.address?.toLowerCase()]?.iconUrl;
-    }
   }
 
   const symbol =
@@ -148,10 +132,7 @@ export function AssetPicker({
           onAssetChange(token);
           setShowAssetPickerModal(false);
         }}
-        sendingAssetImage={sendingTokenImage}
-        sendingAssetSymbol={
-          sendingAsset?.details?.symbol || nativeCurrencySymbol
-        }
+        sendingAsset={sendingAsset}
         defaultActiveTabKey={
           asset?.type === AssetType.NFT ? TabName.NFTS : TabName.TOKENS
         }

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -11,7 +11,6 @@ import {
   BadgeWrapper,
   AvatarNetwork,
 } from '../../../component-library';
-import { Asset } from '../../../../ducks/send';
 import {
   AlignItems,
   BackgroundColor,
@@ -35,24 +34,36 @@ import { LARGE_SYMBOL_LENGTH } from '../constants';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 ///: END:ONLY_INCLUDE_IF
 import { ellipsify } from '../../../../pages/confirmations/send/send.utils';
-import { Token } from '../asset-picker-modal/types';
+import {
+  AssetWithDisplayData,
+  ERC20Asset,
+  NativeAsset,
+  NFT,
+} from '../asset-picker-modal/types';
 import { TabName } from '../asset-picker-modal/asset-picker-modal-tabs';
-import AssetList from '../asset-picker-modal/AssetList';
 
 const ELLIPSIFY_LENGTH = 13; // 6 (start) + 4 (end) + 3 (...)
 
 export type AssetPickerProps = {
+  asset?:
+    | ERC20Asset
+    | NativeAsset
+    | Pick<NFT, 'type' | 'tokenId' | 'image' | 'symbol'>
+    | undefined;
   /**
    * Needs to be wrapped in a callback
    */
-  onAssetChange: (newAsset: Asset) => void;
+  onAssetChange: (
+    newAsset:
+      | AssetWithDisplayData<NativeAsset>
+      | AssetWithDisplayData<ERC20Asset>,
+  ) => void;
   onClick?: () => void;
   isDisabled?: boolean;
 } & Pick<
   React.ComponentProps<typeof AssetPickerModal>,
   'visibleTabs' | 'header' | 'sendingAsset'
-> &
-  Pick<React.ComponentProps<typeof AssetList>, 'asset'>;
+>;
 
 // A component that lets the user pick from a list of assets.
 export function AssetPicker({
@@ -70,13 +81,13 @@ export function AssetPicker({
 
   const [showAssetPickerModal, setShowAssetPickerModal] = useState(false);
 
+  const isNFT = asset?.type === AssetType.NFT;
+
   // selected asset details
   const primaryTokenImage = asset?.image;
   const symbol = asset?.symbol;
 
   const isSymbolLong = symbol && symbol.length > LARGE_SYMBOL_LENGTH;
-  const isNFT = asset?.type === AssetType.NFT;
-
   const formattedSymbol =
     isSymbolLong && !isNFT
       ? `${symbol.substring(0, LARGE_SYMBOL_LENGTH - 1)}...`
@@ -105,7 +116,11 @@ export function AssetPicker({
         isOpen={showAssetPickerModal}
         onClose={() => setShowAssetPickerModal(false)}
         asset={asset}
-        onAssetChange={(token: Token) => {
+        onAssetChange={(
+          token:
+            | AssetWithDisplayData<ERC20Asset>
+            | AssetWithDisplayData<NativeAsset>,
+        ) => {
           onAssetChange(token);
           setShowAssetPickerModal(false);
         }}
@@ -158,7 +173,7 @@ export function AssetPicker({
             >
               <AvatarToken
                 borderRadius={isNFT ? BorderRadius.LG : BorderRadius.full}
-                src={primaryTokenImage}
+                src={primaryTokenImage ?? undefined}
                 size={AvatarTokenSize.Md}
                 name={symbol}
                 {...(isNFT && { backgroundColor: BackgroundColor.transparent })}
@@ -170,7 +185,7 @@ export function AssetPicker({
             <Text className="asset-picker__symbol" variant={TextVariant.bodyMd}>
               {formattedSymbol}
             </Text>
-            {asset?.tokenId && (
+            {isNFT && asset?.tokenId && (
               <Text
                 variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -45,6 +45,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../../shared/constants/metametrics';
 import { ellipsify } from '../../../../pages/confirmations/send/send.utils';
+import { Token } from '../asset-picker-modal/types';
 
 const ELLIPSIFY_LENGTH = 13; // 6 (start) + 4 (end) + 3 (...)
 
@@ -140,7 +141,10 @@ export function AssetPicker({
         isOpen={showAssetPickerModal}
         onClose={() => setShowAssetPickerModal(false)}
         asset={asset}
-        onAssetChange={onAssetChange}
+        onAssetChange={(token: Token) => {
+          onAssetChange(token);
+          setShowAssetPickerModal(false);
+        }}
         sendingAssetImage={sendingTokenImage}
         sendingAssetSymbol={
           sendingAsset?.details?.symbol || nativeCurrencySymbol

--- a/ui/components/multichain/pages/send/components/recipient-content.test.tsx
+++ b/ui/components/multichain/pages/send/components/recipient-content.test.tsx
@@ -17,6 +17,14 @@ import { AssetType } from '../../../../../../shared/constants/transaction';
 import { getSendHexDataFeatureFlagState } from '../../../../../ducks/metamask/metamask';
 import { SendPageRecipientContent } from './recipient-content';
 
+jest.mock('reselect', () => ({
+  createSelector: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/util', () => ({
+  createDeepEqualSelector: jest.fn(),
+}));
+
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
   useDispatch: jest.fn(),
@@ -65,6 +73,7 @@ describe('SendPageRecipientContent', () => {
   const defaultProps = {
     requireContractAddressAcknowledgement: false,
     onAssetChange: onAssetChangeMock,
+    onClick: jest.fn(),
   };
 
   beforeEach(() => {

--- a/ui/components/multichain/pages/send/components/recipient-content.tsx
+++ b/ui/components/multichain/pages/send/components/recipient-content.tsx
@@ -38,14 +38,17 @@ import {
 
 import type { Quote } from '../../../../../ducks/send/swap-and-send-utils';
 import { isEqualCaseInsensitive } from '../../../../../../shared/modules/string-utils';
+import { AssetPicker } from '../../../asset-picker-amount/asset-picker';
 import { SendHexData, SendPageRow, QuoteCard } from '.';
 
 export const SendPageRecipientContent = ({
   requireContractAddressAcknowledgement,
   onAssetChange,
+  onClick,
 }: {
   requireContractAddressAcknowledgement: boolean;
   onAssetChange: (newAsset: Asset, isReceived: boolean) => void;
+  onClick: () => React.ComponentProps<typeof AssetPicker>['onClick'];
 }) => {
   const t = useI18nContext();
 
@@ -147,6 +150,7 @@ export const SendPageRecipientContent = ({
           isAmountLoading={isLoadingInitialQuotes}
           amount={amount}
           isDisabled={!isSwapAllowed}
+          onClick={onClick}
         />
       </SendPageRow>
       <QuoteCard scrollRef={scrollRef} />

--- a/ui/components/multichain/pages/send/components/recipient-content.tsx
+++ b/ui/components/multichain/pages/send/components/recipient-content.tsx
@@ -141,6 +141,7 @@ export const SendPageRecipientContent = ({
       ) : null}
       <SendPageRow>
         <AssetPickerAmount
+          header={t('sendSelectReceiveAsset')}
           asset={isSwapAllowed ? receiveAsset : sendAsset}
           sendingAsset={isSwapAllowed ? sendAsset : undefined}
           onAssetChange={useCallback(

--- a/ui/components/multichain/pages/send/components/recipient-content.tsx
+++ b/ui/components/multichain/pages/send/components/recipient-content.tsx
@@ -39,6 +39,7 @@ import {
 import type { Quote } from '../../../../../ducks/send/swap-and-send-utils';
 import { isEqualCaseInsensitive } from '../../../../../../shared/modules/string-utils';
 import { AssetPicker } from '../../../asset-picker-amount/asset-picker';
+import { TabName } from '../../../asset-picker-amount/asset-picker-modal/asset-picker-modal-tabs';
 import { SendHexData, SendPageRow, QuoteCard } from '.';
 
 export const SendPageRecipientContent = ({
@@ -152,6 +153,7 @@ export const SendPageRecipientContent = ({
           amount={amount}
           isDisabled={!isSwapAllowed}
           onClick={onClick}
+          visibleTabs={[TabName.TOKENS]}
         />
       </SendPageRow>
       <QuoteCard scrollRef={scrollRef} />

--- a/ui/components/multichain/pages/send/components/recipient-content.tsx
+++ b/ui/components/multichain/pages/send/components/recipient-content.tsx
@@ -6,12 +6,20 @@ import React, {
   useRef,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
+import { TokenListMap } from '@metamask/assets-controllers';
+///: END:ONLY_INCLUDE_IF
 import {
   BannerAlert,
   BannerAlertSeverity,
   Box,
 } from '../../../../component-library';
-import { getSendHexDataFeatureFlagState } from '../../../../../ducks/metamask/metamask';
+import {
+  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
+  getNativeCurrency,
+  ///: END:ONLY_INCLUDE_IF
+  getSendHexDataFeatureFlagState,
+} from '../../../../../ducks/metamask/metamask';
 import {
   Asset,
   acknowledgeRecipientWarning,
@@ -31,7 +39,10 @@ import { AssetPickerAmount } from '../../..';
 import { decimalToHex } from '../../../../../../shared/modules/conversion.utils';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import {
+  getIpfsGateway,
   getIsSwapsChain,
+  getNativeCurrencyImage,
+  getTokenList,
   getUseExternalServices,
 } from '../../../../../selectors';
 ///: END:ONLY_INCLUDE_IF
@@ -40,6 +51,7 @@ import type { Quote } from '../../../../../ducks/send/swap-and-send-utils';
 import { isEqualCaseInsensitive } from '../../../../../../shared/modules/string-utils';
 import { AssetPicker } from '../../../asset-picker-amount/asset-picker';
 import { TabName } from '../../../asset-picker-amount/asset-picker-modal/asset-picker-modal-tabs';
+import { getAssetImageURL } from '../../../../../helpers/utils/util';
 import { SendHexData, SendPageRow, QuoteCard } from '.';
 
 export const SendPageRecipientContent = ({
@@ -76,6 +88,11 @@ export const SendPageRecipientContent = ({
   const memoizedSwapsBlockedTokens = useMemo(() => {
     return new Set(swapsBlockedTokens);
   }, [swapsBlockedTokens]);
+
+  const nativeCurrencySymbol = useSelector(getNativeCurrency);
+  const nativeCurrencyImageUrl = useSelector(getNativeCurrencyImage);
+  const tokenList = useSelector(getTokenList) as TokenListMap;
+  const ipfsGateway = useSelector(getIpfsGateway);
 
   isSwapAllowed =
     isSwapsChain &&
@@ -144,7 +161,20 @@ export const SendPageRecipientContent = ({
         <AssetPickerAmount
           header={t('sendSelectReceiveAsset')}
           asset={isSwapAllowed ? receiveAsset : sendAsset}
-          sendingAsset={isSwapAllowed ? sendAsset : undefined}
+          sendingAsset={
+            isSwapAllowed &&
+            sendAsset && {
+              image:
+                sendAsset.type === AssetType.native
+                  ? nativeCurrencyImageUrl
+                  : tokenList &&
+                    sendAsset.details &&
+                    (getAssetImageURL(sendAsset.details?.image, ipfsGateway) ||
+                      tokenList[sendAsset.details.address?.toLowerCase()]
+                        ?.iconUrl),
+              symbol: sendAsset?.details?.symbol || nativeCurrencySymbol,
+            }
+          }
           onAssetChange={useCallback(
             (newAsset) => onAssetChange(newAsset, isSwapAllowed),
             [onAssetChange, isSwapAllowed],

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -376,6 +376,7 @@ export const SendPage = () => {
         {isSendFormShown && (
           <AssetPickerAmount
             error={error}
+            header={t('sendSelectSendAsset')}
             asset={transactionAsset}
             amount={amount}
             onAssetChange={handleSelectSendToken}

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -146,9 +146,26 @@ export const SendPage = () => {
           }),
         );
       }
+
+      trackEvent(
+        {
+          event: MetaMetricsEventName.sendAssetSelected,
+          category: MetaMetricsEventCategory.Send,
+          properties: {
+            is_destination_asset_picker_modal: Boolean(isReceived),
+            is_nft: false,
+          },
+          sensitiveProperties: {
+            ...sendAnalytics,
+            new_asset_symbol: token.symbol,
+            new_asset_address: token.address,
+          },
+        },
+        { excludeMetaMetricsId: false },
+      );
       history.push(SEND_ROUTE);
     },
-    [dispatch, history],
+    [dispatch, history, sendAnalytics, trackEvent],
   );
 
   const cleanup = useCallback(() => {

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -168,6 +168,25 @@ export const SendPage = () => {
     [dispatch, history, sendAnalytics, trackEvent],
   );
 
+  const handleAssetPickerClick = useCallback(
+    (isDest) => {
+      trackEvent(
+        {
+          event: MetaMetricsEventName.sendTokenModalOpened,
+          category: MetaMetricsEventCategory.Send,
+          properties: {
+            is_destination_asset_picker_modal: Boolean(isDest),
+          },
+          sensitiveProperties: {
+            ...sendAnalytics,
+          },
+        },
+        { excludeMetaMetricsId: false },
+      );
+    },
+    [sendAnalytics, trackEvent],
+  );
+
   const cleanup = useCallback(() => {
     dispatch(resetSendState());
     setIsSubmitting(false);
@@ -361,6 +380,7 @@ export const SendPage = () => {
             amount={amount}
             onAssetChange={handleSelectSendToken}
             onAmountChange={onAmountChange}
+            onClick={() => handleAssetPickerClick(false)}
           />
         )}
         <Box marginTop={6}>
@@ -371,6 +391,7 @@ export const SendPage = () => {
                 requireContractAddressAcknowledgement
               }
               onAssetChange={handleSelectToken}
+              onClick={() => handleAssetPickerClick(true)}
             />
           ) : (
             <SendPageRecipient />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The goal of this PR is to make the AssetPicker component experience-agnostic so that it can be reused within other experiences.

Since the AssetPicker was initially built for the Swap+Send experience, most changes here are for moving send-specific logic out of the component, including:
* move Send event tracking callbacks to send page
* add new AssetPicker props for setting custom modal header and visible tabs
* define an experience-agnostic `asset` prop, which contains the minimal required information about the selected asset
* use accurate type definitions for assets and props

<!--This also includes a style change to make spacing consistent between the AssetPicker modal header and contents.-->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26349?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/METABRIDGE-890

## **Manual testing steps**

1. Swap+Send asset selection experience should not change

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before -> After**


![Screenshot 2024-08-20 at 6 50 34 PM](https://github.com/user-attachments/assets/1b907e17-c204-478f-8590-b286166893e1) ![Screenshot 2024-08-20 at 6 52 10 PM](https://github.com/user-attachments/assets/363e994b-9a7a-44b6-ad41-2effa3f79d2d)

![Screenshot 2024-08-20 at 6 50 44 PM](https://github.com/user-attachments/assets/4fb081f4-d404-4eca-9034-64facf95ee5c) ![Screenshot 2024-08-20 at 6 52 18 PM](https://github.com/user-attachments/assets/a5c8f693-867d-427b-aac8-bfa8f1343706)





<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
