### PR TITLE
fix: Allowlist Snap UI card component

### DIFF
--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -35,6 +35,7 @@ import { SnapUIDropdown } from '../snaps/snap-ui-dropdown';
 import { SnapUIRadioGroup } from '../snaps/snap-ui-radio-group';
 import { SnapUICheckbox } from '../snaps/snap-ui-checkbox';
 import { SnapUITooltip } from '../snaps/snap-ui-tooltip';
+import { SnapUICard } from '../snaps/snap-ui-card';
 import { SnapFooterButton } from '../snaps/snap-footer-button';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { SnapAccountSuccessMessage } from '../../../pages/confirmations/components/snap-account-success-message';
@@ -92,6 +93,7 @@ export const safeComponentList = {
   SnapUIRadioGroup,
   SnapUICheckbox,
   SnapUITooltip,
+  SnapUICard,
   SnapFooterButton,
   FormTextField,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
+++ b/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
@@ -6,6 +6,7 @@ import {
   TextAlign,
   TextColor,
   TextVariant,
+  AlignItems,
 } from '../../../../helpers/constants/design-system';
 import { Box, Text } from '../../../component-library';
 import { SnapUIImage } from '../snap-ui-image';
@@ -30,8 +31,9 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
       className="snap-ui-renderer__card"
       display={Display.Flex}
       justifyContent={JustifyContent.spaceBetween}
+      alignItems={AlignItems.center}
     >
-      <Box display={Display.Flex} gap={4}>
+      <Box display={Display.Flex} gap={4} alignItems={AlignItems.center}>
         {image && (
           <SnapUIImage
             width="32px"
@@ -40,18 +42,35 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
             style={{ borderRadius: '999px' }}
           />
         )}
-        <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
-          <Text variant={TextVariant.bodyMdMedium}>{title}</Text>
-          <Text color={TextColor.textAlternative}>{description}</Text>
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          style={{ overflow: 'hidden' }}
+        >
+          <Text variant={TextVariant.bodyMdMedium} ellipsis>
+            {title}
+          </Text>
+          {description && (
+            <Text color={TextColor.textAlternative} ellipsis>
+              {description}
+            </Text>
+          )}
         </Box>
       </Box>
       <Box
         display={Display.Flex}
         flexDirection={FlexDirection.Column}
         textAlign={TextAlign.Right}
+        style={{ overflow: 'hidden' }}
       >
-        <Text variant={TextVariant.bodyMdMedium}>{value}</Text>
-        <Text color={TextColor.textAlternative}>{extra}</Text>
+        <Text variant={TextVariant.bodyMdMedium} ellipsis>
+          {value}
+        </Text>
+        {extra && (
+          <Text color={TextColor.textAlternative} ellipsis>
+            {extra}
+          </Text>
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a problem where the `Card` component was not allowlisted for use in Snaps UI, the UI would crash when attempting to use this specific component.

Also tweaks the design of the Card component, aligning the image and handling cases where text could previously overflow.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26565?quickstart=1)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Crash

### **After**

![image](https://github.com/user-attachments/assets/8bd24898-f7cb-450a-ae7d-6ba4d964cf84)
