### PR TITLE
fix: track `swapAndSend` transaction type (#26535)

### DIFF
--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -36,7 +36,10 @@ import {
   getSwapsTokensReceivedFromTxMeta,
   TRANSACTION_ENVELOPE_TYPE_NAMES,
 } from '../../../../shared/lib/transactions-controller-utils';
-import { getBlockaidMetricsProps } from '../../../../ui/helpers/utils/metrics';
+import {
+  getBlockaidMetricsProps,
+  getSwapAndSendMetricsProps,
+} from '../../../../ui/helpers/utils/metrics';
 import { getSmartTransactionMetricsProperties } from '../../../../shared/modules/metametrics';
 import {
   getSnapAndHardwareInfoForMetrics,
@@ -895,7 +898,9 @@ async function buildEventFragmentProperties({
   let transactionApprovalAmountVsProposedRatio;
   let transactionApprovalAmountVsBalanceRatio;
   let transactionType = TransactionType.simpleSend;
-  if (type === TransactionType.cancel) {
+  if (type === TransactionType.swapAndSend) {
+    transactionType = TransactionType.swapAndSend;
+  } else if (type === TransactionType.cancel) {
     transactionType = TransactionType.cancel;
   } else if (type === TransactionType.retry && originalType) {
     transactionType = originalType;
@@ -984,6 +989,9 @@ async function buildEventFragmentProperties({
       transactionMeta,
     );
 
+  const swapAndSendMetricsProperties =
+    getSwapAndSendMetricsProps(transactionMeta);
+
   /** The transaction status property is not considered sensitive and is now included in the non-anonymous event */
   let properties = {
     chain_id: chainId,
@@ -1009,6 +1017,7 @@ async function buildEventFragmentProperties({
     // ui_customizations must come after ...blockaidProperties
     ui_customizations: uiCustomizations.length > 0 ? uiCustomizations : null,
     ...smartTransactionMetricsProperties,
+    ...swapAndSendMetricsProperties,
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as Record<string, any>;

--- a/ui/helpers/utils/metrics.js
+++ b/ui/helpers/utils/metrics.js
@@ -1,8 +1,10 @@
+import { TransactionType } from '@metamask/transaction-controller';
 import {
   BlockaidReason,
   BlockaidResultType,
 } from '../../../shared/constants/security-provider';
 import { MetaMetricsEventUiCustomization } from '../../../shared/constants/metametrics';
+import { calcTokenAmount } from '../../../shared/lib/transactions-controller-utils';
 
 export function getMethodName(camelCase) {
   if (!camelCase || typeof camelCase !== 'string') {
@@ -83,6 +85,45 @@ export const getBlockaidMetricsProps = ({ securityAlertResponse }) => {
       params[metricKey] = providerRequestsCount[key];
     });
   }
+
+  return params;
+};
+
+export const getSwapAndSendMetricsProps = (transactionMeta) => {
+  if (transactionMeta.type !== TransactionType.swapAndSend) {
+    return {};
+  }
+
+  const {
+    chainId,
+    sourceTokenAmount,
+    sourceTokenDecimals,
+    destinationTokenAmount,
+    destinationTokenDecimals,
+    sourceTokenSymbol,
+    destinationTokenAddress,
+    destinationTokenSymbol,
+    sourceTokenAddress,
+  } = transactionMeta;
+
+  const params = {
+    chain_id: chainId,
+    token_amount_source:
+      sourceTokenAmount && sourceTokenDecimals
+        ? calcTokenAmount(sourceTokenAmount, sourceTokenDecimals).toString()
+        : undefined,
+    token_amount_dest_estimate:
+      destinationTokenAmount && destinationTokenDecimals
+        ? calcTokenAmount(
+            destinationTokenAmount,
+            destinationTokenDecimals,
+          ).toString()
+        : undefined,
+    token_symbol_source: sourceTokenSymbol,
+    token_symbol_destination: destinationTokenSymbol,
+    token_address_source: sourceTokenAddress,
+    token_address_destination: destinationTokenAddress,
+  };
 
   return params;
 };

--- a/ui/helpers/utils/metrics.test.js
+++ b/ui/helpers/utils/metrics.test.js
@@ -2,7 +2,11 @@ import {
   BlockaidReason,
   BlockaidResultType,
 } from '../../../shared/constants/security-provider';
-import { getBlockaidMetricsProps, getMethodName } from './metrics';
+import {
+  getBlockaidMetricsProps,
+  getMethodName,
+  getSwapAndSendMetricsProps,
+} from './metrics';
 
 describe('getMethodName', () => {
   it('gets correct method names', () => {
@@ -175,5 +179,41 @@ describe('getBlockaidMetricsProps', () => {
       security_alert_response: BlockaidResultType.Malicious,
       security_alert_reason: BlockaidReason.setApprovalForAll,
     });
+  });
+});
+
+describe('getSwapAndSendMetricsProps', () => {
+  it('returns an empty object when transaction type is not swapAndSend', () => {
+    const transactionMeta = {
+      type: 'other',
+    };
+    const result = getSwapAndSendMetricsProps(transactionMeta);
+    expect(result).toStrictEqual({});
+  });
+
+  it('returns the expected metrics props when transaction type is swapAndSend', () => {
+    const transactionMeta = {
+      type: 'swapAndSend',
+      chainId: 1,
+      sourceTokenAmount: '1000000000000',
+      sourceTokenDecimals: 12,
+      destinationTokenAmount: '200',
+      destinationTokenDecimals: 2,
+      sourceTokenSymbol: 'ETH',
+      destinationTokenAddress: '0x123',
+      destinationTokenSymbol: 'ABC',
+      sourceTokenAddress: '0x456',
+    };
+    const expectedMetricsProps = {
+      chain_id: 1,
+      token_amount_source: '1',
+      token_amount_dest_estimate: '2',
+      token_symbol_source: 'ETH',
+      token_symbol_destination: 'ABC',
+      token_address_source: '0x456',
+      token_address_destination: '0x123',
+    };
+    const result = getSwapAndSendMetricsProps(transactionMeta);
+    expect(result).toStrictEqual(expectedMetricsProps);
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cherry picks #26535

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26594?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
