### PR TITLE
test: [Snaps E2E] Update snaps dialog test to include Custom dialog type

### DIFF
--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -2,14 +2,13 @@ const {
   defaultGanacheOptions,
   withFixtures,
   unlockWallet,
-  switchToNotificationWindow,
   WINDOW_TITLES,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
 describe('Test Snap Dialog', function () {
-  it('test all three snap_dialog types', async function () {
+  it('test all four snap_dialog types', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),
@@ -34,7 +33,7 @@ describe('Test Snap Dialog', function () {
         await driver.clickElement('#connectdialogs');
 
         // switch to metamask extension and click connect
-        await switchToNotificationWindow(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
         await driver.clickElement({
           text: 'Connect',
           tag: 'button',
@@ -63,11 +62,12 @@ describe('Test Snap Dialog', function () {
           text: 'Reconnect to Dialogs Snap',
         });
 
+        // test 1 - alert dialog
         // click on alert dialog
         await driver.clickElement('#sendAlertButton');
 
         // switch to dialog popup
-        await switchToNotificationWindow(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // check dialog contents
         const result = await driver.findElement('.snap-ui-renderer__panel');
@@ -92,11 +92,12 @@ describe('Test Snap Dialog', function () {
           text: 'null',
         });
 
+        // test 2 - confirmation dialog
         // click conf button
         await driver.clickElement('#sendConfirmationButton');
 
         // switch to dialog popup
-        await switchToNotificationWindow(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // click reject
         await driver.clickElement({
@@ -117,7 +118,7 @@ describe('Test Snap Dialog', function () {
         await driver.clickElement('#sendConfirmationButton');
 
         // switch to dialog popup
-        await switchToNotificationWindow(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // click accept
         await driver.clickElement({
@@ -134,11 +135,12 @@ describe('Test Snap Dialog', function () {
           text: 'true',
         });
 
+        // test 3 - prompt dialog
         // click prompt button
         await driver.clickElement('#sendPromptButton');
 
         // switch to dialog popup
-        await switchToNotificationWindow(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // click cancel button
         await driver.clickElement({
@@ -159,7 +161,7 @@ describe('Test Snap Dialog', function () {
         await driver.clickElement('#sendPromptButton');
 
         // switch to dialog popup
-        await switchToNotificationWindow(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // fill '2323' in form field
         await driver.pasteIntoField('.mm-input', '2323');
@@ -168,6 +170,52 @@ describe('Test Snap Dialog', function () {
         await driver.clickElement({
           text: 'Submit',
           tag: 'button',
+        });
+
+        // switch back to test snaps tab
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
+
+        // check result is equal to '2323'
+        await driver.waitForSelector({
+          css: '#dialogResult',
+          text: '"2323"',
+        });
+
+        // test 4 - custom dialog
+        // click custom button
+        await driver.clickElement('#sendCustomButton');
+
+        // switch to dialog popup
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        // click cancel button
+        await driver.clickElement({
+          text: 'Cancel',
+          tag: 'span',
+        });
+
+        // switch back to test snaps tab
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
+
+        // check result is equal to 'null'
+        await driver.waitForSelector({
+          css: '#dialogResult',
+          text: 'null',
+        });
+
+        // click prompt button
+        await driver.clickElement('#sendCustomButton');
+
+        // switch to dialog popup
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        // fill '2323' in form field
+        await driver.pasteIntoField('#custom-input', '2323');
+
+        // click confirm button
+        await driver.clickElement({
+          text: 'Confirm',
+          tag: 'span',
         });
 
         // switch back to test snaps tab

--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -48,7 +48,7 @@ describe('Test Snap Dialog', function () {
 
         await driver.waitForSelector({ text: 'OK' });
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'OK',
           tag: 'button',
         });
@@ -78,7 +78,7 @@ describe('Test Snap Dialog', function () {
         });
 
         // click ok button
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'OK',
           tag: 'button',
         });
@@ -100,7 +100,7 @@ describe('Test Snap Dialog', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // click reject
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Reject',
           tag: 'button',
         });
@@ -121,7 +121,7 @@ describe('Test Snap Dialog', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // click accept
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Approve',
           tag: 'button',
         });
@@ -143,7 +143,7 @@ describe('Test Snap Dialog', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // click cancel button
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Cancel',
           tag: 'button',
         });
@@ -167,7 +167,7 @@ describe('Test Snap Dialog', function () {
         await driver.pasteIntoField('.mm-input', '2323');
 
         // click submit button
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Submit',
           tag: 'button',
         });
@@ -189,7 +189,7 @@ describe('Test Snap Dialog', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // click cancel button
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Cancel',
           tag: 'span',
         });
@@ -213,7 +213,7 @@ describe('Test Snap Dialog', function () {
         await driver.pasteIntoField('#custom-input', '2323');
 
         // click confirm button
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
           tag: 'span',
         });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This updates snaps dialog test to include Custom dialog type
This also changes some clickElement to be clickElementAndWaitForWindowToClose, and replaces deprecated switchToNotificationWindow.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26598?quickstart=1)

## **Related issues**

Fixes: #26566 

## **Manual testing steps**

1. Test works if CI passes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
