### PR TITLE
fix: avoid jarring transition between popup-init and popup by fading in the app screen

### DIFF
--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -41,6 +41,16 @@ html {
       }
     }
   }
+
+  &[data-theme] {
+    background: var(--color-background-alternative);
+  }
+
+  @include design-system.screen-sm-max {
+    &[data-theme] {
+      background-color: var(--color-background-default);
+    }
+  }
 }
 
 /*
@@ -62,13 +72,19 @@ html {
   display: flex;
   flex-direction: column;
 
-  html[data-theme] & {
-    background: var(--color-background-alternative);
-  }
+  // fade the app in so that if the app is redirected from popup-init.html to
+  // popup.html the transition between the two is seamless (rather than a blank
+  // background then a sudden loading screen). It still looks nice on
+  // `home.html`, even though there is no redirect. The duration of .3s was
+  // chosen because thats slightly faster than the amount of time it takes for
+  // the app to load on a very fast computer. If we make the app faster, we
+  // should also reduce the animation duration.
+  animation: .3s ease-in forwards app_fadeIn;
+  opacity: 0;
 
-  @include design-system.screen-sm-max {
-    html[data-theme] & {
-      background-color: var(--color-background-default);
+  @keyframes app_fadeIn {
+    to {
+        opacity: 1;
     }
   }
 }


### PR DESCRIPTION
Depends on #26555

See frame-by-frame part of the video in the description of #26555 for an example of what this is trying to "solve".


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26599?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] 

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->