### PR TITLE
Patch fix for initial connections in preinstalled Snaps

### DIFF
--- a/.yarn/patches/@metamask-snaps-controllers-npm-9.2.0-09a31bab4f.patch
+++ b/.yarn/patches/@metamask-snaps-controllers-npm-9.2.0-09a31bab4f.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/chunk-E52MHHG4.js b/dist/chunk-E52MHHG4.js
+index d34a3ded85472b86d0905ab14c0a69b9bfe4851b..7a7dfcd288bf7888eb29e4533662237a53335e17 100644
+--- a/dist/chunk-E52MHHG4.js
++++ b/dist/chunk-E52MHHG4.js
+@@ -1668,6 +1668,9 @@ handlePreinstalledSnaps_fn = function(preinstalledSnaps) {
+     _chunkEXN2TFDJjs.__privateMethod.call(void 0, this, _validateSnapPermissions, validateSnapPermissions_fn).call(this, processedPermissions);
+     const { newPermissions, unusedPermissions } = _chunkEXN2TFDJjs.__privateMethod.call(void 0, this, _calculatePermissionsChange, calculatePermissionsChange_fn).call(this, snapId, processedPermissions);
+     _chunkEXN2TFDJjs.__privateMethod.call(void 0, this, _updatePermissions, updatePermissions_fn).call(this, { snapId, newPermissions, unusedPermissions });
++    if (manifest.initialConnections) {
++      _chunkEXN2TFDJjs.__privateMethod.call(void 0, this, _handleInitialConnections, handleInitialConnections_fn).call(this, snapId, existingSnap?.initialConnections ?? null, manifest.initialConnections);
++    }
+     this.update((state) => {
+       state.snaps[snapId].status = _snapsutils.SnapStatus.Stopped;
+     });

--- a/package.json
+++ b/package.json
@@ -256,7 +256,8 @@
     "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A19.0.0#~/.yarn/patches/@metamask-network-controller-npm-19.0.0-a5e0d1fe14.patch",
     "@solana/web3.js/rpc-websockets": "^8.0.1",
     "@metamask/network-controller@npm:^19.0.0": "patch:@metamask/network-controller@npm%3A19.0.0#~/.yarn/patches/@metamask-network-controller-npm-19.0.0-a5e0d1fe14.patch",
-    "@metamask/nonce-tracker@npm:^5.0.0": "patch:@metamask/nonce-tracker@npm%3A5.0.0#~/.yarn/patches/@metamask-nonce-tracker-npm-5.0.0-d81478218e.patch"
+    "@metamask/nonce-tracker@npm:^5.0.0": "patch:@metamask/nonce-tracker@npm%3A5.0.0#~/.yarn/patches/@metamask-nonce-tracker-npm-5.0.0-d81478218e.patch",
+    "@metamask/snaps-controllers@npm:^8.1.1": "patch:@metamask/snaps-controllers@npm%3A9.2.0#~/.yarn/patches/@metamask-snaps-controllers-npm-9.2.0-09a31bab4f.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.24.0#~/.yarn/patches/@babel-runtime-npm-7.24.0-7eb1dd11a2.patch",
@@ -339,7 +340,7 @@
     "@metamask/selected-network-controller": "^15.0.2",
     "@metamask/signature-controller": "^16.0.0",
     "@metamask/smart-transactions-controller": "^10.1.6",
-    "@metamask/snaps-controllers": "^9.2.0",
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A9.2.0#~/.yarn/patches/@metamask-snaps-controllers-npm-9.2.0-09a31bab4f.patch",
     "@metamask/snaps-execution-environments": "^6.5.0",
     "@metamask/snaps-rpc-methods": "^9.1.4",
     "@metamask/snaps-sdk": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5943,25 +5943,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^9.0.2":
-  version: 9.1.0
-  resolution: "@metamask/permission-controller@npm:9.1.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^5.0.2"
-    "@metamask/controller-utils": "npm:^9.1.0"
-    "@metamask/json-rpc-engine": "npm:^8.0.2"
-    "@metamask/rpc-errors": "npm:^6.2.1"
-    "@metamask/utils": "npm:^8.3.0"
-    "@types/deep-freeze-strict": "npm:^1.1.0"
-    deep-freeze-strict: "npm:^1.1.1"
-    immer: "npm:^9.0.6"
-    nanoid: "npm:^3.1.31"
-  peerDependencies:
-    "@metamask/approval-controller": ^6.0.0
-  checksum: 10/bfae4c16cbe5b180b00ef029c3fa8d7f770247dfad4c0afc11822f4b0bd36373d6f749ac5507f23cf5dbd848096fa86ad2546be190c665c419cae58fcf0d7f00
-  languageName: node
-  linkType: hard
-
 "@metamask/permission-log-controller@npm:^2.0.1":
   version: 2.0.1
   resolution: "@metamask/permission-log-controller@npm:2.0.1"
@@ -5986,7 +5967,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/phishing-controller@npm:^9.0.1, @metamask/phishing-controller@npm:^9.0.3":
+"@metamask/phishing-controller@npm:^9.0.3":
   version: 9.0.4
   resolution: "@metamask/phishing-controller@npm:9.0.4"
   dependencies:
@@ -6268,44 +6249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^8.1.1":
-  version: 8.4.0
-  resolution: "@metamask/snaps-controllers@npm:8.4.0"
-  dependencies:
-    "@metamask/approval-controller": "npm:^6.0.2"
-    "@metamask/base-controller": "npm:^5.0.2"
-    "@metamask/json-rpc-engine": "npm:^8.0.1"
-    "@metamask/json-rpc-middleware-stream": "npm:^7.0.1"
-    "@metamask/object-multiplex": "npm:^2.0.0"
-    "@metamask/permission-controller": "npm:^9.0.2"
-    "@metamask/phishing-controller": "npm:^9.0.1"
-    "@metamask/post-message-stream": "npm:^8.1.0"
-    "@metamask/rpc-errors": "npm:^6.2.1"
-    "@metamask/snaps-registry": "npm:^3.1.0"
-    "@metamask/snaps-rpc-methods": "npm:^9.1.2"
-    "@metamask/snaps-sdk": "npm:^4.4.2"
-    "@metamask/snaps-utils": "npm:^7.5.0"
-    "@metamask/utils": "npm:^8.3.0"
-    "@xstate/fsm": "npm:^2.0.0"
-    browserify-zlib: "npm:^0.2.0"
-    concat-stream: "npm:^2.0.0"
-    fast-deep-equal: "npm:^3.1.3"
-    get-npm-tarball-url: "npm:^2.0.3"
-    immer: "npm:^9.0.6"
-    nanoid: "npm:^3.1.31"
-    readable-stream: "npm:^3.6.2"
-    readable-web-to-node-stream: "npm:^3.0.2"
-    tar-stream: "npm:^3.1.7"
-  peerDependencies:
-    "@metamask/snaps-execution-environments": ^6.3.0
-  peerDependenciesMeta:
-    "@metamask/snaps-execution-environments":
-      optional: true
-  checksum: 10/12943073dea4c9c6c06294ade19aac6ad5b132f9eb7b39587a974ef5fe62ad58abb8c0b22e018cf49090f5f6435e5204ce01912485da77889170fa9aea3d4267
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-controllers@npm:^9.2.0":
+"@metamask/snaps-controllers@npm:9.2.0":
   version: 9.2.0
   resolution: "@metamask/snaps-controllers@npm:9.2.0"
   dependencies:
@@ -6342,6 +6286,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A9.2.0#~/.yarn/patches/@metamask-snaps-controllers-npm-9.2.0-09a31bab4f.patch":
+  version: 9.2.0
+  resolution: "@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A9.2.0#~/.yarn/patches/@metamask-snaps-controllers-npm-9.2.0-09a31bab4f.patch::version=9.2.0&hash=820ce5"
+  dependencies:
+    "@metamask/approval-controller": "npm:^7.0.0"
+    "@metamask/base-controller": "npm:^6.0.0"
+    "@metamask/json-rpc-engine": "npm:^9.0.0"
+    "@metamask/json-rpc-middleware-stream": "npm:^8.0.0"
+    "@metamask/object-multiplex": "npm:^2.0.0"
+    "@metamask/permission-controller": "npm:^10.0.0"
+    "@metamask/phishing-controller": "npm:^10.0.0"
+    "@metamask/post-message-stream": "npm:^8.1.0"
+    "@metamask/rpc-errors": "npm:^6.2.1"
+    "@metamask/snaps-registry": "npm:^3.1.0"
+    "@metamask/snaps-rpc-methods": "npm:^9.1.4"
+    "@metamask/snaps-sdk": "npm:^6.0.0"
+    "@metamask/snaps-utils": "npm:^7.7.0"
+    "@metamask/utils": "npm:^8.3.0"
+    "@xstate/fsm": "npm:^2.0.0"
+    browserify-zlib: "npm:^0.2.0"
+    concat-stream: "npm:^2.0.0"
+    fast-deep-equal: "npm:^3.1.3"
+    get-npm-tarball-url: "npm:^2.0.3"
+    immer: "npm:^9.0.6"
+    nanoid: "npm:^3.1.31"
+    readable-stream: "npm:^3.6.2"
+    readable-web-to-node-stream: "npm:^3.0.2"
+    tar-stream: "npm:^3.1.7"
+  peerDependencies:
+    "@metamask/snaps-execution-environments": ^6.5.0
+  peerDependenciesMeta:
+    "@metamask/snaps-execution-environments":
+      optional: true
+  checksum: 10/e77ed26022440aec7886dbee4d8b3346433df685399926aebd8572f8007679b3f716e56587ca9f0652acda9c24c1f7c3f763e63066480450f51fa94cbb903541
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-execution-environments@npm:^6.5.0":
   version: 6.5.0
   resolution: "@metamask/snaps-execution-environments@npm:6.5.0"
@@ -6373,7 +6354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^9.1.2, @metamask/snaps-rpc-methods@npm:^9.1.4":
+"@metamask/snaps-rpc-methods@npm:^9.1.4":
   version: 9.1.4
   resolution: "@metamask/snaps-rpc-methods@npm:9.1.4"
   dependencies:
@@ -6402,7 +6383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^7.4.0, @metamask/snaps-utils@npm:^7.5.0, @metamask/snaps-utils@npm:^7.7.0":
+"@metamask/snaps-utils@npm:^7.4.0, @metamask/snaps-utils@npm:^7.7.0":
   version: 7.7.0
   resolution: "@metamask/snaps-utils@npm:7.7.0"
   dependencies:
@@ -25250,7 +25231,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^15.0.2"
     "@metamask/signature-controller": "npm:^16.0.0"
     "@metamask/smart-transactions-controller": "npm:^10.1.6"
-    "@metamask/snaps-controllers": "npm:^9.2.0"
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A9.2.0#~/.yarn/patches/@metamask-snaps-controllers-npm-9.2.0-09a31bab4f.patch"
     "@metamask/snaps-execution-environments": "npm:^6.5.0"
     "@metamask/snaps-rpc-methods": "npm:^9.1.4"
     "@metamask/snaps-sdk": "npm:^6.0.0"


### PR DESCRIPTION
## **Description**

This adds a patch for MetaMask/snaps#2591.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26602?quickstart=1)
