### PR TITLE
fix: add migration to delete PPOMController.versionFileETag

### DIFF
--- a/app/scripts/migrations/126.test.ts
+++ b/app/scripts/migrations/126.test.ts
@@ -19,7 +19,8 @@ describe('migration #126', () => {
   it('should remove versionFileETag from PPOMController', async () => {
     const newStorage = await migrate(oldStorage);
 
-    const { versionFileETag } = newStorage.data.PPOMController as PPOMController;
+    const { versionFileETag } = newStorage.data
+      .PPOMController as PPOMController;
 
     expect(versionFileETag).toBeUndefined();
   });

--- a/app/scripts/migrations/126.test.ts
+++ b/app/scripts/migrations/126.test.ts
@@ -1,0 +1,34 @@
+import { migrate, version, PPOMController } from './126';
+
+const oldStorage = {
+  meta: { version },
+  data: {
+    PPOMController: {
+      versionInfo: [
+        {
+          filePath: '/test',
+          hashSignature: 'DUMMY_HASH_SIGNATURE',
+        },
+      ],
+      versionFileETag: 'DUMMY_VERSION_FILE_ETAG',
+    },
+  },
+};
+
+describe('migration #126', () => {
+  it('should remove versionFileETag from PPOMController', async () => {
+    const newStorage = await migrate(oldStorage);
+
+    const { versionFileETag } = newStorage.data.PPOMController as PPOMController;
+
+    expect(versionFileETag).toBeUndefined();
+  });
+
+  it('should not effect other fields in PPOMController', async () => {
+    const newStorage = await migrate(oldStorage);
+
+    const { versionInfo } = newStorage.data.PPOMController as PPOMController;
+
+    expect(versionInfo).toBeDefined();
+  });
+});

--- a/app/scripts/migrations/126.ts
+++ b/app/scripts/migrations/126.ts
@@ -7,6 +7,7 @@ type VersionedData = {
 };
 
 export type PPOMController = {
+  versionInfo?: Record<string, unknown>[];
   versionFileETag?: string;
 };
 

--- a/app/scripts/migrations/126.ts
+++ b/app/scripts/migrations/126.ts
@@ -1,4 +1,3 @@
-import { hasProperty } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
 type VersionedData = {

--- a/app/scripts/migrations/126.ts
+++ b/app/scripts/migrations/126.ts
@@ -1,0 +1,41 @@
+import { hasProperty } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export type PPOMController = {
+  versionFileETag?: string;
+};
+
+export const version = 126;
+
+/**
+ * This migration deletes field versionFileETag from PPOMController.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly
+ * what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by
+ * controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (!state.PPOMController) {
+    return state;
+  }
+  delete (state.PPOMController as PPOMController).versionFileETag;
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -142,6 +142,7 @@ const migrations = [
   require('./123'),
   require('./124'),
   require('./125'),
+  require('./126'),
 ];
 
 export default migrations;

--- a/test/integration/data/integration-init-state.json
+++ b/test/integration/data/integration-init-state.json
@@ -2031,7 +2031,6 @@
     }
   },
   "userOperations": {},
-  "versionFileETag": "W/\"598946a37f16c5b882a0bebbadf4509f\"",
   "versionInfo": [],
   "web3ShimUsageOrigins": {},
   "welcomeScreenSeen": false

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -448,7 +448,6 @@
   "useTransactionSimulations": true,
   "usedNetworks": { "0x1": true, "0x5": true, "0x539": true },
   "userOperations": {},
-  "versionFileETag": "",
   "versionInfo": [],
   "web3ShimUsageOrigins": {},
   "welcomeScreenSeen": false


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add migration to delete field `versionFileETag` from PPOMController state

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26604

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
