### PR TITLE
fix: flaky test `Vault Decryptor Page is able to decrypt the vault us..` due to empty file load

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,11 +239,6 @@ workflows:
             - prep-build-test-mmi
             - get-changed-files-with-git-diff
       - test-e2e-chrome-vault-decryption:
-          filters:
-            branches:
-              only:
-                - develop
-                - /^Version-v(\d+)[.](\d+)[.](\d+)/
           requires:
             - prep-build
       - test-storybook:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,11 @@ workflows:
             - prep-build-test-mmi
             - get-changed-files-with-git-diff
       - test-e2e-chrome-vault-decryption:
+          filters:
+            branches:
+              only:
+                - develop
+                - /^Version-v(\d+)[.](\d+)[.](\d+)/
           requires:
             - prep-build
       - test-storybook:

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -38,7 +38,6 @@ async function getExtensionStorageFilePath(driver) {
   const logFiles = fs
     .readdirSync(extensionStoragePath)
     .filter((filename) => filename.endsWith('.log'));
-
   // Use the first of the `.log` files found
   return path.resolve(extensionStoragePath, logFiles[0]);
 }
@@ -121,6 +120,8 @@ describe('Vault Decryptor Page', function () {
         // fill the input field with storage recovered from filesystem
         await driver.clickElement('[name="vault-source"]');
         const inputField = await driver.findElement('#fileinput');
+
+        await driver.delay(5000);
         inputField.press(await getExtensionStorageFilePath(driver));
         // fill in the password
         await driver.fill('#passwordinput', WALLET_PASSWORD);

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -143,7 +143,7 @@ describe('Vault Decryptor Page', function () {
         await logFileSize(filePath);
         await inputField.press(filePath);
 
-        const fileLoaded = await driver.isElementPresent({
+        const isFileLoadedError = await driver.isElementPresent({
           tag: 'span',
           text: '❌ Can not read vault from file',
         });

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -39,7 +39,7 @@ async function getExtensionStorageFilePath(driver) {
     .readdirSync(extensionStoragePath)
     .filter((filename) => filename.endsWith('.log'));
 
-    // Use the first of the `.log` files found
+  // Use the first of the `.log` files found
   return path.resolve(extensionStoragePath, logFiles[0]);
 }
 

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -149,7 +149,7 @@ describe('Vault Decryptor Page', function () {
         });
 
         // Retry-logic if file upload fails
-        if (!fileLoaded) {
+        if (isFileLoadedError) {
           await inputField.press(filePath);
         }
 

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -39,6 +39,7 @@ async function getExtensionStorageFilePath(driver) {
     .readdirSync(extensionStoragePath)
     .filter((filename) => filename.endsWith('.log'));
 
+    // Use the first of the `.log` files found
   return path.resolve(extensionStoragePath, logFiles[0]);
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The vault decrypt test is flaky, at the point where we upload the vault file into the browser. 
I added logs for checking the file size, and I saw that when the file failed to upload, the file size was really small.

The problem seemed to start appearing [after this PR](https://github.com/MetaMask/metamask-extension/pull/26402/files) was merged. The changes doesn't seem related, but it updated a lot of dependencies, some of them related to cryptography/addres derivation packages (see screenshot below) - which could somehow affect somehow the timings.

Fix:
- Added a function to get the file size
- Added a retry logic to check the file size before uploading it, making sure it's bigger than a conservatory size

See logic in action:

![image](https://github.com/user-attachments/assets/4445c42a-5f83-45bc-83c0-3c28c3e34371)

Notes and future work:
- there isn't an easy way to determine when Chrome has finished writing into the file, since this can depend on numerous factors ( Data Changes, Internal Buffering, Extension Activity, Browser Events..)
- currently we are testing the log file, instead of the ldb file, as described in the Vault Decryptor [instructions](https://support.metamask.io/managing-my-wallet/secret-recovery-phrase-and-private-keys/how-to-recover-your-secret-recovery-phrase/). I haven't find the ldb file, after waiting ~30seconds and closing/repoening the browser, however, that file might also exibit flakiness as Chrome would also need to write to it. For this reason, in this PR the test is kept as it was, and it only focuses on fixing the spec with the retry logic.
- there is another test proposed by @davidmurdoch , for reading the vault value from the file and then using the function "Paste into the field" for testing that. I've decided to do this on a separate PR and keep this PR focused on the current issue only, to unblock ci faster

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26612?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26572

## **Manual testing steps**

1. Check ci https://app.circleci.com/jobs/github/MetaMask/metamask-extension/3612121

## **Screenshots/Recordings**
When the error appears, we can see how the file size is really small `19 bytes`.

![Screenshot from 2024-08-22 15-44-24](https://github.com/user-attachments/assets/3a427a81-2731-4aa8-8d47-eac53ea5058c)

whereas when the test is successful, the file size is bigger `7358117 bytes`.

![Screenshot from 2024-08-22 16-02-18](https://github.com/user-attachments/assets/1c390f32-48fa-42ea-85d2-9d8819305d9f)


See changes mentioned, after flakiness started appearing:

![Screenshot from 2024-08-22 16-30-16](https://github.com/user-attachments/assets/57b65530-5734-49a1-a4ba-da31230befa5)


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
