### PR TITLE
refactor: add performance tracing infrastructure (#26044) [cherry-pick]

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1515,6 +1515,24 @@
   "developerOptionsResetStatesOnboarding": {
     "message": "Resets various states related to onboarding and redirects to the \"Secure Your Wallet\" onboarding page."
   },
+  "developerOptionsSentryButtonGenerateBackgroundError": {
+    "message": "Generate Background Error"
+  },
+  "developerOptionsSentryButtonGenerateTrace": {
+    "message": "Generate Trace"
+  },
+  "developerOptionsSentryButtonGenerateUIError": {
+    "message": "Generate UI Error"
+  },
+  "developerOptionsSentryDescriptionGenerateBackgroundError": {
+    "message": "Generate an unhandled $1 in the service worker."
+  },
+  "developerOptionsSentryDescriptionGenerateTrace": {
+    "message": " Generate a $1 Sentry trace."
+  },
+  "developerOptionsSentryDescriptionGenerateUIError": {
+    "message": "Generate an unhandled $1 in this window."
+  },
   "developerOptionsServiceWorkerKeepAlive": {
     "message": "Results in a timestamp being continuously saved to session.storage"
   },

--- a/development/README.md
+++ b/development/README.md
@@ -55,39 +55,22 @@ You can inspect the requests in the `Network` tab of your browser's Developer To
 by filtering for `POST` requests to `/v1/batch`. The full url will be `http://localhost:9090/v1/batch`
 or `https://api.segment.io/v1/batch` respectively.
 
-## Sentry
+## Debugging Sentry
 
-### Debugging in Sentry
+1. Set `SENTRY_DSN_DEV`, or `SENTRY_DSN` if using a production build, in `.metamaskrc` to a suitable Sentry URL.
+  - The example value specified in `.metamaskrc.dist` uses the `test-metamask` project in the MetaMask account.
+  - Alternatively, create a free Sentry account with a new organization and project.
+  - The DSN is specified in: `Settings > Projects > [Project Name] > Client Keys (DSN)`.
 
-To debug in a production Sentry environment:
+2. To display Sentry logs, include `DEBUG=metamask:sentry:*` in `.metamaskrc`.
 
-- If you have not already got a Sentry account, you can create a free account on [Sentry](https://sentry.io/)
-- Create a New Sentry Organization
-    - If you already have an existing Sentry account and workspace, open the sidebar drop down menu, then click `Switch organization` followed by `Create a new organization`
-- Create a New Project
-- Copy the `Public Key` and `Project ID` from the Client Keys section under your projects Settings
-    - Select `Settings` in the sidebar menu, then select `Projects` in the secondary menu. Click your project then select `Client Keys (DSN)` from the secondary menu. Click the `Configure` button on the `Client Keys` page and copy your `Project Id` and `Public Key`
--   Add/replace the `SENTRY_DSN` and `SENTRY_DSN_DEV` variables in `.metamaskrc`
-    ```
-    SENTRY_DSN_DEV=https://{SENTRY_PUBLIC_KEY}@sentry.io/{SENTRY_PROJECT_ID}
-    SENTRY_DSN=https://{SENTRY_PUBLIC_KEY}@sentry.io/{SENTRY_PROJECT_ID}
-    ```
--   Build the project to the `./dist/` folder with `yarn dist`
+3. To display more verbose logs if not in a developer build, include `METAMASK_DEBUG=true` in `.metamaskrc`.
 
-Errors reported whilst using the extension will be displayed in Sentry's `Issues` page.
+4. Ensure metrics are enabled during onboarding or via `Settings > Security & privacy > Participate in MetaMetrics`.
 
-To debug in test build we need to comment out the below:- <br>
-- `setupSentry` function comment the return statement in the `app/scripts/lib
-/setupSentry.js`  https://github.com/MetaMask/metamask-extension/blob/e3c76ca699e94bacfc43793d28291fa5ddf06752/app/scripts/lib/setupSentry.js#L496
-- `setupStateHooks` function set the if condition to true in the `ui
-/index.js` https://github.com/MetaMask/metamask-extension/blob/e3c76ca699e94bacfc43793d28291fa5ddf06752/ui/index.js#L242
+5. To test Sentry via the developer options in the UI, include `ENABLE_SETTINGS_PAGE_DEV_OPTIONS=true` in `.metamaskrc`.
 
-How to trigger Sentry error:-
-1. Open the background console.
-2. Load the extension app and open the developer console.
-3. Toggle the `Participate in MetaMetrics` menu option to the `ON` position.
-4. Enter `window.stateHooks.throwTestBackgroundError()` into the developer console.
-5. There should now be requests sent to sentry in the background network tab.
+6. Alternatively, call `window.stateHooks.throwTestError()` or `window.stateHooks.throwTestBackgroundError()` via the UI console.
 
 ## Source Maps
 

--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -1,0 +1,112 @@
+import { Span, startSpan, withIsolationScope } from '@sentry/browser';
+import { trace } from './trace';
+
+jest.mock('@sentry/browser', () => ({
+  withIsolationScope: jest.fn(),
+  startSpan: jest.fn(),
+}));
+
+const NAME_MOCK = 'testTransaction';
+const PARENT_CONTEXT_MOCK = {} as Span;
+
+const TAGS_MOCK = {
+  tag1: 'value1',
+  tag2: true,
+  tag3: 123,
+};
+
+const DATA_MOCK = {
+  data1: 'value1',
+  data2: true,
+  data3: 123,
+};
+
+function mockGetMetaMetricsEnabled(enabled: boolean) {
+  global.sentry = {
+    getMetaMetricsEnabled: () => Promise.resolve(enabled),
+  };
+}
+
+describe('Trace', () => {
+  const startSpanMock = jest.mocked(startSpan);
+  const withIsolationScopeMock = jest.mocked(withIsolationScope);
+  const setTagsMock = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    startSpanMock.mockImplementation((_, fn) => fn({} as Span));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    withIsolationScopeMock.mockImplementation((fn: any) =>
+      fn({ setTags: setTagsMock }),
+    );
+  });
+
+  describe('trace', () => {
+    // @ts-expect-error This function is missing from the Mocha type definitions
+    it.each([
+      ['enabled', true],
+      ['disabled', false],
+    ])(
+      'executes callback if Sentry is %s',
+      async (_: string, sentryEnabled: boolean) => {
+        let callbackExecuted = false;
+
+        mockGetMetaMetricsEnabled(sentryEnabled);
+
+        await trace({ name: NAME_MOCK }, async () => {
+          callbackExecuted = true;
+        });
+
+        expect(callbackExecuted).toBe(true);
+      },
+    );
+
+    // @ts-expect-error This function is missing from the Mocha type definitions
+    it.each([
+      ['enabled', true],
+      ['disabled', false],
+    ])(
+      'returns value from callback if Sentry is %s',
+      async (_: string, sentryEnabled: boolean) => {
+        mockGetMetaMetricsEnabled(sentryEnabled);
+
+        const result = await trace({ name: NAME_MOCK }, async () => {
+          return true;
+        });
+
+        expect(result).toBe(true);
+      },
+    );
+
+    it('invokes Sentry if enabled', async () => {
+      mockGetMetaMetricsEnabled(true);
+
+      await trace(
+        {
+          name: NAME_MOCK,
+          tags: TAGS_MOCK,
+          data: DATA_MOCK,
+          parentContext: PARENT_CONTEXT_MOCK,
+        },
+        async () => Promise.resolve(),
+      );
+
+      expect(withIsolationScopeMock).toHaveBeenCalledTimes(1);
+
+      expect(startSpanMock).toHaveBeenCalledTimes(1);
+      expect(startSpanMock).toHaveBeenCalledWith(
+        {
+          name: NAME_MOCK,
+          parentSpan: PARENT_CONTEXT_MOCK,
+          attributes: DATA_MOCK,
+        },
+        expect.any(Function),
+      );
+
+      expect(setTagsMock).toHaveBeenCalledTimes(1);
+      expect(setTagsMock).toHaveBeenCalledWith(TAGS_MOCK);
+    });
+  });
+});

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -1,0 +1,54 @@
+import * as Sentry from '@sentry/browser';
+import { Primitive } from '@sentry/types';
+import { createModuleLogger } from '@metamask/utils';
+import { log as sentryLogger } from '../../app/scripts/lib/setupSentry';
+
+const log = createModuleLogger(sentryLogger, 'trace');
+
+export type TraceRequest = {
+  data?: Record<string, number | string | boolean>;
+  name: string;
+  parentContext?: unknown;
+  tags?: Record<string, number | string | boolean>;
+};
+
+export async function trace<T>(
+  request: TraceRequest,
+  fn: (context?: unknown) => Promise<T>,
+): Promise<T> {
+  const { data: attributes, name, parentContext, tags } = request;
+  const parentSpan = (parentContext ?? null) as Sentry.Span | null;
+
+  const isSentryEnabled =
+    (await globalThis.sentry.getMetaMetricsEnabled()) as boolean;
+
+  const callback = async (span: Sentry.Span | null) => {
+    log('Starting trace', name, request);
+
+    const start = Date.now();
+    let error;
+
+    try {
+      return await fn(span);
+    } catch (currentError) {
+      error = currentError;
+      throw currentError;
+    } finally {
+      const end = Date.now();
+      const duration = end - start;
+
+      log('Finished trace', name, duration, { error, request });
+    }
+  };
+
+  if (!isSentryEnabled) {
+    log('Skipping Sentry trace as metrics disabled', name, request);
+    return callback(null);
+  }
+
+  return await Sentry.withIsolationScope(async (scope) => {
+    scope.setTags(tags as Record<string, Primitive>);
+
+    return await Sentry.startSpan({ name, parentSpan, attributes }, callback);
+  });
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,6 +1,10 @@
+// Many of the state hooks return untyped raw state.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 // In order for variables to be considered on the global scope they must be
 // declared using var and not const or let, which is why this rule is disabled
 /* eslint-disable no-var */
+
 import * as Sentry from '@sentry/browser';
 import {
   Success,
@@ -224,7 +228,26 @@ declare class Chrome {
   runtime: Runtime;
 }
 
-type SentryObject = Sentry;
+type SentryObject = Sentry & {
+  getMetaMetricsEnabled: () => Promise<boolean>;
+};
+
+type StateHooks = {
+  getCleanAppState?: () => Promise<any>;
+  getLogs?: () => any[];
+  getMostRecentPersistedState?: () => any;
+  getPersistedState: () => Promise<any>;
+  getSentryAppState?: () => any;
+  getSentryState: () => {
+    browser: string;
+    version: string;
+    state?: any;
+    persistedState?: any;
+  };
+  metamaskGetState?: () => Promise<any>;
+  throwTestBackgroundError?: (msg?: string) => Promise<void>;
+  throwTestError?: (msg?: string) => void;
+};
 
 export declare global {
   var platform: Platform;
@@ -232,6 +255,8 @@ export declare global {
   var sentry: SentryObject | undefined;
 
   var chrome: Chrome;
+
+  var stateHooks: StateHooks;
 
   namespace jest {
     // The interface is being used for declaration merging, which is an acceptable exception to this rule.

--- a/ui/index.js
+++ b/ui/index.js
@@ -219,7 +219,11 @@ async function startApp(metamaskState, backgroundConnection, opts) {
  * @param {object} store - The Redux store.
  */
 function setupStateHooks(store) {
-  if (process.env.METAMASK_DEBUG || process.env.IN_TEST) {
+  if (
+    process.env.METAMASK_DEBUG ||
+    process.env.IN_TEST ||
+    process.env.ENABLE_SETTINGS_PAGE_DEV_OPTIONS
+  ) {
     /**
      * The following stateHook is a method intended to throw an error, used in
      * our E2E test to ensure that errors are attempted to be sent to sentry.
@@ -241,7 +245,7 @@ function setupStateHooks(store) {
     window.stateHooks.throwTestBackgroundError = async function (
       msg = 'Test Error',
     ) {
-      store.dispatch(actions.throwTestBackgroundError(msg));
+      await actions.throwTestBackgroundError(msg);
     };
   }
 

--- a/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
+++ b/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
@@ -238,6 +238,147 @@ exports[`Develop options tab should match snapshot 1`] = `
         </div>
       </div>
     </div>
+    <p
+      class="mm-box mm-text settings-page__security-tab-sub-header__bold mm-text--body-md mm-box--color-text-default"
+    >
+      Sentry
+    </p>
+    <div
+      class="settings-page__content-padded"
+    >
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <div
+            class="settings-page__content-description"
+          >
+            <span>
+               
+              Generate an unhandled 
+              <b>
+                TestError
+              </b>
+               in this window.
+               
+            </span>
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
+          >
+            Generate UI Error
+          </button>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <div
+            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
+            style="height: 40px; width: 40px;"
+          >
+            <span
+              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
+              hidden=""
+              style="mask-image: url('./images/icons/check.svg');"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <div
+            class="settings-page__content-description"
+          >
+            <span>
+               
+              Generate an unhandled 
+              <b>
+                TestError
+              </b>
+               in the service worker.
+               
+            </span>
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
+          >
+            Generate Background Error
+          </button>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <div
+            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
+            style="height: 40px; width: 40px;"
+          >
+            <span
+              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
+              hidden=""
+              style="mask-image: url('./images/icons/check.svg');"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <div
+            class="settings-page__content-description"
+          >
+            <span>
+               
+               Generate a 
+              <b>
+                Developer Test
+              </b>
+               Sentry trace.
+               
+            </span>
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
+          >
+            Generate Trace
+          </button>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <div
+            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
+            style="height: 40px; width: 40px;"
+          >
+            <span
+              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
+              hidden=""
+              style="mask-image: url('./images/icons/check.svg');"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
@@ -34,6 +34,7 @@ import {
 } from '../../../store/actions';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
+import { SentryTest } from './sentry-test';
 
 const DeveloperOptionsTab = () => {
   const t = useI18nContext();
@@ -275,6 +276,7 @@ const DeveloperOptionsTab = () => {
         {renderServiceWorkerKeepAliveToggle()}
         {renderNetworkMenuRedesign()}
       </div>
+      <SentryTest />
     </div>
   );
 };

--- a/ui/pages/settings/developer-options-tab/sentry-test.tsx
+++ b/ui/pages/settings/developer-options-tab/sentry-test.tsx
@@ -1,0 +1,187 @@
+import React, { useState, useCallback, ReactElement } from 'react';
+import { ButtonVariant } from '@metamask/snaps-sdk';
+import {
+  Box,
+  Button,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+} from '../../../components/component-library';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+  IconColor,
+  JustifyContent,
+} from '../../../helpers/constants/design-system';
+import { trace } from '../../../../shared/lib/trace';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+export function SentryTest() {
+  return (
+    <>
+      <Text className="settings-page__security-tab-sub-header__bold">
+        Sentry
+      </Text>
+      <div className="settings-page__content-padded">
+        <GenerateUIError />
+        <GenerateBackgroundError />
+        <GenerateTrace />
+      </div>
+    </>
+  );
+}
+
+function GenerateUIError() {
+  const t = useI18nContext();
+
+  const handleClick = useCallback(async () => {
+    await window.stateHooks.throwTestError?.('Developer Options');
+  }, []);
+
+  return (
+    <TestButton
+      name={t('developerOptionsSentryButtonGenerateUIError')}
+      description={t('developerOptionsSentryDescriptionGenerateUIError', [
+        <b>TestError</b>,
+      ])}
+      onClick={handleClick}
+      expectError
+    />
+  );
+}
+
+function GenerateBackgroundError() {
+  const t = useI18nContext();
+
+  const handleClick = useCallback(async () => {
+    await window.stateHooks.throwTestBackgroundError?.('Developer Options');
+  }, []);
+
+  return (
+    <TestButton
+      name={t('developerOptionsSentryButtonGenerateBackgroundError')}
+      description={t(
+        'developerOptionsSentryDescriptionGenerateBackgroundError',
+        [<b>TestError</b>],
+      )}
+      onClick={handleClick}
+      expectError
+    />
+  );
+}
+
+function GenerateTrace() {
+  const t = useI18nContext();
+
+  const handleClick = useCallback(async () => {
+    await trace(
+      {
+        name: 'Developer Test',
+        data: { 'test.data.number': 123 },
+        tags: { 'test.tag.number': 123 },
+      },
+      async (context) => {
+        await trace(
+          {
+            name: 'Nested Test 1',
+            data: { 'test.data.boolean': true },
+            tags: { 'test.tag.boolean': true },
+            parentContext: context,
+          },
+          () => sleep(1000),
+        );
+
+        await trace(
+          {
+            name: 'Nested Test 2',
+            data: { 'test.data.string': 'test' },
+            tags: { 'test.tag.string': 'test' },
+            parentContext: context,
+          },
+          () => sleep(500),
+        );
+      },
+    );
+  }, []);
+
+  return (
+    <TestButton
+      name={t('developerOptionsSentryButtonGenerateTrace')}
+      description={t('developerOptionsSentryDescriptionGenerateTrace', [
+        <b>Developer Test</b>,
+      ])}
+      onClick={handleClick}
+    />
+  );
+}
+
+function TestButton({
+  name,
+  description,
+  onClick,
+  expectError,
+}: {
+  name: string;
+  description: ReactElement;
+  onClick: () => Promise<void>;
+  expectError?: boolean;
+}) {
+  const [isComplete, setIsComplete] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    let hasError = false;
+
+    try {
+      await onClick();
+    } catch (error) {
+      hasError = true;
+      throw error;
+    } finally {
+      if (expectError || !hasError) {
+        setIsComplete(true);
+      }
+    }
+  }, [onClick]);
+
+  return (
+    <Box
+      className="settings-page__content-row"
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      justifyContent={JustifyContent.spaceBetween}
+      gap={4}
+    >
+      <div className="settings-page__content-item">
+        <div className="settings-page__content-description">{description}</div>
+      </div>
+      <div className="settings-page__content-item-col">
+        <Button variant={ButtonVariant.Primary} onClick={handleClick}>
+          {name}
+        </Button>
+      </div>
+      <div className="settings-page__content-item-col">
+        <Box
+          display={Display.Flex}
+          alignItems={AlignItems.center}
+          paddingLeft={2}
+          paddingRight={2}
+          style={{ height: '40px', width: '40px' }}
+        >
+          <Icon
+            className="settings-page-developer-options__icon-check"
+            name={IconName.Check}
+            color={IconColor.successDefault}
+            size={IconSize.Lg}
+            hidden={!isComplete}
+          />
+        </Box>
+      </div>
+    </Box>
+  );
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -5122,7 +5122,7 @@ export function setName(
  * Throw an error in the background for testing purposes.
  *
  * @param message - The error message.
- * @deprecated This is only mean to facilitiate E2E testing. We should not use
+ * @deprecated This is only meant to facilitiate E2E testing. We should not use
  * this for handling errors.
  */
 export async function throwTestBackgroundError(message: string): Promise<void> {


### PR DESCRIPTION
Cherry-pick of (#26044) for v12.1.0. original description: 

## **Description**

Add initial tracing and performance metrics infrastructure.

Specifically:

- Add the `trace` method, to be used anywhere in the client to generate a Sentry trace to monitor and analyse performance metrics.
- Add buttons to the developer settings as an easy mechanism to generate Sentry errors (in the UI or background) and traces.
- Add the `Sentry.browserTracingIntegration` to automatically generate traces for each page navigation, including nested spans for any HTTP requests.
- Update the Sentry debugging documentation in the `README`.

Note that the previously used `browserProfilingIntegration` does not generate transactions or traces itself, but rather attempts to add profiling data to any generated transactions. This does not appear to be compatible given it requires the Self-Profiling API object which is only available in Chrome and in our case, the UI. In addition, it requires the `js-profiling` document policy which also appears to currently not be supported in browser extensions.

Sentry also provides React specific automated instrumentation via `@sentry/react` and the `Sentry.reactRouterV5BrowserTracingInstrumentation` integration, but this should be pursued in a separate ticket if needed given the required further refactor.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26044?quickstart=1)

## **Related issues**

Fixes: [#2711](https://github.com/MetaMask/MetaMask-planning/issues/2711)

## **Manual testing steps**

1. Enable metrics in the settings.
2. Login to Sentry account.
3. Go to `Traces` or `Performance` section.
4. Note new transactions or traces named `popup.html` with nested spans including HTTP requests.

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="250" alt="Sentry Developer Options" src="https://github.com/user-attachments/assets/620cbfb8-ab4d-4ed0-b5f6-ba04ef975ddc">

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
