### PR TITLE
chore: anonymize send analytic properties

### DIFF
--- a/ui/components/app/nfts-items/nfts-items.js
+++ b/ui/components/app/nfts-items/nfts-items.js
@@ -169,11 +169,13 @@ export default function NftsItems({
         event: MetaMetricsEventName.sendAssetSelected,
         category: MetaMetricsEventCategory.Send,
         properties: {
-          ...sendAnalytics,
           is_destination_asset_picker_modal: false,
           new_asset_symbol: nft.name,
           new_asset_address: nft.address,
           is_nft: true,
+        },
+        sensitiveProperties: {
+          ...sendAnalytics,
         },
       },
       { excludeMetaMetricsId: false },

--- a/ui/components/app/nfts-items/nfts-items.js
+++ b/ui/components/app/nfts-items/nfts-items.js
@@ -170,12 +170,12 @@ export default function NftsItems({
         category: MetaMetricsEventCategory.Send,
         properties: {
           is_destination_asset_picker_modal: false,
-          new_asset_symbol: nft.name,
-          new_asset_address: nft.address,
           is_nft: true,
         },
         sensitiveProperties: {
           ...sendAnalytics,
+          new_asset_symbol: nft.name,
+          new_asset_address: nft.address,
         },
       },
       { excludeMetaMetricsId: false },

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -128,11 +128,13 @@ export function AssetPickerModal({
           event: MetaMetricsEventName.sendAssetSelected,
           category: MetaMetricsEventCategory.Send,
           properties: {
-            ...sendAnalytics,
             is_destination_asset_picker_modal: Boolean(isDest),
             new_asset_symbol: token.symbol,
             new_asset_address: token.address,
             is_nft: false,
+          },
+          sensitiveProperties: {
+            ...sendAnalytics,
           },
         },
         { excludeMetaMetricsId: false },

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -129,12 +129,12 @@ export function AssetPickerModal({
           category: MetaMetricsEventCategory.Send,
           properties: {
             is_destination_asset_picker_modal: Boolean(isDest),
-            new_asset_symbol: token.symbol,
-            new_asset_address: token.address,
             is_nft: false,
           },
           sensitiveProperties: {
             ...sendAnalytics,
+            new_asset_symbol: token.symbol,
+            new_asset_address: token.address,
           },
         },
         { excludeMetaMetricsId: false },

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -167,8 +167,10 @@ export function AssetPicker({
               event: MetaMetricsEventName.sendTokenModalOpened,
               category: MetaMetricsEventCategory.Send,
               properties: {
-                ...sendAnalytics,
                 is_destination_asset_picker_modal: Boolean(sendingAsset),
+              },
+              sensitiveProperties: {
+                ...sendAnalytics,
               },
             },
             { excludeMetaMetricsId: false },

--- a/ui/components/multichain/pages/send/components/quote-card/index.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/index.tsx
@@ -90,8 +90,10 @@ export function QuoteCard({ scrollRef }: QuoteCardProps) {
           event: MetaMetricsEventName.sendSwapQuoteFetched,
           category: MetaMetricsEventCategory.Send,
           properties: {
-            ...sendAnalytics,
             is_first_fetch: isQuoteJustLoaded,
+          },
+          sensitiveProperties: {
+            ...sendAnalytics,
           },
         },
         { excludeMetaMetricsId: false },

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -205,7 +205,7 @@ export const SendPage = () => {
       {
         event: MetaMetricsEventName.sendFlowExited,
         category: MetaMetricsEventCategory.Send,
-        properties: {
+        sensitiveProperties: {
           ...sendAnalytics,
         },
       },
@@ -223,7 +223,7 @@ export const SendPage = () => {
         {
           event: MetaMetricsEventName.sendSwapQuoteError,
           category: MetaMetricsEventCategory.Send,
-          properties: {
+          sensitiveProperties: {
             ...sendAnalytics,
           },
         },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Certain send analytics can be used to correlated metric IDs with analytics data; this PR marks these as sensitive.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26627?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
