### PR TITLE
fix: flaky test `Increase Token Allowance increases token spending ca..`

### DIFF
--- a/test/e2e/tests/tokens/increase-token-allowance.spec.js
+++ b/test/e2e/tests/tokens/increase-token-allowance.spec.js
@@ -158,10 +158,7 @@ describe('Increase Token Allowance', function () {
     await transferFromRecipientInputEl.clear();
     await transferFromRecipientInputEl.fill(recipientAccount);
 
-    await driver.clickElement({
-      text: 'Transfer From Tokens',
-      tag: 'button',
-    });
+    await driver.clickElement('#transferFromTokens');
     await driver.delay(2000);
   }
 

--- a/test/e2e/tests/tokens/increase-token-allowance.spec.js
+++ b/test/e2e/tests/tokens/increase-token-allowance.spec.js
@@ -296,6 +296,8 @@ describe('Increase Token Allowance', function () {
       css: '.transaction-list__completed-transactions .activity-list-item [data-testid="activity-list-item-action"]',
       text: 'Increase TST spending cap',
     });
+
+    await driver.delay(2000);
   }
 
   async function confirmTransferFromTokensSuccess(driver) {

--- a/test/e2e/tests/tokens/increase-token-allowance.spec.js
+++ b/test/e2e/tests/tokens/increase-token-allowance.spec.js
@@ -280,7 +280,7 @@ describe('Increase Token Allowance', function () {
       text: `${finalSpendingCap} TST`,
       css: '.mm-box > h6',
     });
-    await driver.clickElement({
+    await driver.clickElementAndWaitForWindowToClose({
       tag: 'button',
       text: 'Approve',
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the flaky test 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26640?quickstart=1)

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/26438

## **Manual testing steps**

To execute the test locally or in codespaces
yarn
yarn build:test:webpack
ENABLE_MV3=false yarn test:e2e:single test/e2e/tests/tokens/increase-token-allowance.spec.js --browser=chrome

Validate the test should pass in CI 

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
