### PR TITLE
fix: flaky test `Phishing Detection should navigate the user to PhishFort to dispute a Phishfort Block`

### DIFF
--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -274,14 +274,9 @@ describe('Phishing Detection', function () {
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
         await driver.clickElement({ text: 'report a detection problem.' });
 
-        // wait for page to load before checking URL.
-        await driver.findElement({
-          text: `Empty page by ${BlockProvider.PhishFort}`,
+        await driver.waitForUrl({
+          url: `https://github.com/phishfort/phishfort-lists/issues/new?title=[Legitimate%20Site%20Blocked]%20127.0.0.1&body=http%3A%2F%2F127.0.0.1%2F`,
         });
-        assert.equal(
-          await driver.getCurrentUrl(),
-          `https://github.com/phishfort/phishfort-lists/issues/new?title=[Legitimate%20Site%20Blocked]%20127.0.0.1&body=http%3A%2F%2F127.0.0.1%2F`,
-        );
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a race condition where we assert the currentUrl is the desired one. This can create a race condition, where the current Url is not yet the expected one.


```
assert.equal(
   await driver.getCurrentUrl(),
    `https://github.com/phishfort/phishfort-lists/issues/new?title=[Legitimate%20Site%20Blocked]%20127.0.0.1&body=http%3A%2F%2F127.0.0.1%2F`,
);
```

Instead, we need to **wait** for the correct url to be the current url.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26651?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26650

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

![Screenshot from 2024-08-26 13-36-02](https://github.com/user-attachments/assets/4b161425-bdfa-486d-9464-1730caa2d762)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
