### PR TITLE
Replace fa-lock with new icons in setting tab bar and search options

### DIFF
--- a/ui/components/app/tab-bar/tab-bar.stories.js
+++ b/ui/components/app/tab-bar/tab-bar.stories.js
@@ -34,7 +34,7 @@ export default {
         key: 'snaps',
       },
       {
-        icon: <i className="fa fa-lock" />,
+        icon: <Icon name={IconName.Lock} />,
         content: 'SecurityAndPrivacy',
         key: 'securityAndPrivacy',
       },

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -149,7 +149,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('revealSeedWords'),
     descriptionMessage: (t) => t('revealSeedWords'),
     route: `${SECURITY_ROUTE}#reveal-secretrecovery`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[1]
   {
@@ -157,7 +157,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('showIncomingTransactions'),
     descriptionMessage: (t) => t('showIncomingTransactionsDescription'),
     route: `${SECURITY_ROUTE}#incoming-transaction`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[2]
   {
@@ -165,7 +165,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('usePhishingDetection'),
     descriptionMessage: (t) => t('usePhishingDetectionDescription'),
     route: `${SECURITY_ROUTE}#phishing-detection`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[3]
   {
@@ -173,7 +173,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('use4ByteResolution'),
     descriptionMessage: (t) => t('use4ByteResolutionDescription'),
     route: `${SECURITY_ROUTE}#decode-smart-contracts`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[4]
   {
@@ -181,7 +181,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('participateInMetaMetrics'),
     descriptionMessage: (t) => t('participateInMetaMetricsDescription'),
     route: `${SECURITY_ROUTE}#metametrics`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[5]
   {
@@ -190,7 +190,7 @@ const SETTINGS_CONSTANTS = [
     descriptionMessage: (t) =>
       `${t('chooseYourNetwork')} ${t('chooseYourNetworkDescription')}`,
     route: `${SECURITY_ROUTE}#network-provider`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[6]
   {
@@ -198,7 +198,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('ipfsGateway'),
     descriptionMessage: (t) => t('ipfsGatewayDescription'),
     route: `${SECURITY_ROUTE}#add-custom-ipfs-gateway`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[7]
   {
@@ -206,7 +206,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('autoDetectTokens'),
     descriptionMessage: (t) => t('autoDetectTokensDescription'),
     route: `${SECURITY_ROUTE}#auto-detect-tokens`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[8]
   {
@@ -215,7 +215,7 @@ const SETTINGS_CONSTANTS = [
     descriptionMessage: (t) =>
       t('useMultiAccountBalanceCheckerSettingDescription'),
     route: `${SECURITY_ROUTE}#batch-account-balance-requests`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[9]
   {
@@ -223,7 +223,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('currencyRateCheckToggle'),
     descriptionMessage: (t) => t('currencyRateCheckToggleDescription'),
     route: `${SECURITY_ROUTE}#price-checker`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[10]
   {
@@ -231,7 +231,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('ensDomainsSettingTitle'),
     descriptionMessage: (t) => t('ensDomainsSettingDescriptionIntroduction'),
     route: `${SECURITY_ROUTE}#ens-domains`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[11]
   {
@@ -239,7 +239,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('displayNftMedia'),
     descriptionMessage: (t) => t('displayNftMediaDescription'),
     route: `${SECURITY_ROUTE}#display-nft-media`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[12]
   {
@@ -247,7 +247,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('useNftDetection'),
     descriptionMessage: (t) => t('useNftDetectionDescriptionText'),
     route: `${SECURITY_ROUTE}#autodetect-nfts`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[13]
   {
@@ -255,7 +255,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('useSafeChainsListValidation'),
     descriptionMessage: (t) => t('useSafeChainsListValidationDescription'),
     route: `${SECURITY_ROUTE}#network-details-check`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[14]
   {
@@ -263,7 +263,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('externalNameSourcesSetting'),
     descriptionMessage: (t) => t('externalNameSourcesSettingDescription'),
     route: `${SECURITY_ROUTE}#proposed-nicknames`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[15]
   {
@@ -271,7 +271,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('securityAlerts'),
     descriptionMessage: (t) => t('securityAlertsDescription'),
     route: `${SECURITY_ROUTE}#security-alerts`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[16]
   {
@@ -279,7 +279,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('blockaid'),
     descriptionMessage: (t) => t('blockaidMessage'),
     route: `${SECURITY_ROUTE}#security-alerts-blockaid`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   // securityAndPrivacy settingsRefs[18]
   {
@@ -287,7 +287,7 @@ const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('simulationsSettingSubHeader'),
     descriptionMessage: (t) => t('simulationsSettingDescription'),
     route: `${SECURITY_ROUTE}#transaction-simulations`,
-    icon: 'fa fa-lock',
+    iconName: IconName.Lock,
   },
   {
     tabMessage: (t) => t('alerts'),

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -312,7 +312,7 @@ class SettingsPage extends PureComponent {
       },
       {
         content: t('securityAndPrivacy'),
-        icon: <i className="fa fa-lock" />,
+        icon: <Icon name={IconName.Lock} />,
         key: SECURITY_ROUTE,
       },
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->



## **Description**

- Replace lock icon in following
   - Setting tab bar
   - Setting search option suggestions


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26657?quickstart=1)

## **Related issues**

 #17475

## **Manual testing steps**

1. Login in metamask wallet -> go to home page
2. Click on the menu icon (3 dots) on top right -> Select `Settings` option
3. Please check `Security and Privacy` lock Icon
4. Please also check the lock icon in the setting page search bar suggestion for `security and privacy` page items

Note: for search options/text please refer to the screenshots section

## **Screenshots/Recordings**


<ul>
<li> 
<details><summary>Setting tab navigation bar lock icon</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/8263baf1-3b27-4dea-8b8a-dbf99e4e4df8)


**After Change**

![image](https://github.com/user-attachments/assets/f05ec455-7ed7-4422-babd-073379c6da92)


</p>
</li>
</p>
</li>
<li> 
<details><summary>Setting search: phishing detection </summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/c33dfba1-6539-4cb2-9bd3-ff818b4dce71)

**After Change**

![image](https://github.com/user-attachments/assets/aa100f02-2ecc-4d01-b535-e5084bad0833)


</p>
</li>
<li> 
<details><summary>Setting search: decode smart-contracts </summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/d71fd871-40e4-4a71-82d2-3090c2e6f877)


**After Change**

![image](https://github.com/user-attachments/assets/a997a7c9-df5b-48fe-8c85-4e23a7edcff8)


</p>
</li>
<li> 
<details><summary>Setting search: metametrics</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/539e2f9a-b49a-4baa-9425-19e20fcb5be5)


**After Change**

![image](https://github.com/user-attachments/assets/f4ee6a99-aa12-40eb-bccd-090ac24aeb34)


</p>
</li>
<li> 
<details><summary>Setting search: network-provider </summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/ee95e8fe-7542-4a53-9ced-279fd5d1b39b)
**After Change**

![image](https://github.com/user-attachments/assets/37e999e3-ad10-4ebb-a149-15be3a871013)


</p>
</li>
<li> 
<details><summary>Setting search: ipfs gateway</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/b97c2b16-b167-4ce8-9e57-55e883eff8e1)

**After Change**

![image](https://github.com/user-attachments/assets/77dddd16-173a-4b97-9ed7-1a99d96ba153)


</p>
</li>
<li> 
<details><summary>Setting seacrh: auto-detect-tokens</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/b9fadaa1-a436-4a5c-a6e0-1e3ee2be861a)

**After Change**

![image](https://github.com/user-attachments/assets/e2a6e140-94ea-4793-ad81-ce1ce438365b)


</p>
</li>
<li> 
<details><summary>Setting search: reveal secret</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/e274cec7-11aa-496e-998d-2b7cbabf762f)

**After Change**

![image](https://github.com/user-attachments/assets/bd056062-12ab-440d-a926-8da4113bee50)

</p>
</li>
<li> 
<details><summary>Setting search: incoming transaction</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/e5480693-d9c2-4362-94cf-903ce6e79d97)

**After Change**

![image](https://github.com/user-attachments/assets/d65308a3-4fa5-40ac-91d3-967f13c2bd9b)

</p>
</li>
<li> 
<details><summary>Setting search: batch-account-balance-requests</summary>
<p>
**Before Change**


![image](https://github.com/user-attachments/assets/7be8e902-6744-471f-904d-6103a7f72422)

**After Change**

![image](https://github.com/user-attachments/assets/b7ca7db5-9d2d-4ea5-a625-f54fb7ebca31)

</p>
</li>
<li> 
<details><summary>Setting search: price checker</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/e84911cd-3783-40c7-b84a-a66fc4370a08)

**After Change**

![image](https://github.com/user-attachments/assets/992909f1-ae9b-4723-9422-f93f82736f7c)

</p>
</li>
<li> 
<details><summary>Setting search: ens-domains </summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/816b8dd8-5a19-440a-bf2f-e1e7020a944b)

**After Change**

![image](https://github.com/user-attachments/assets/4a7cd743-194d-46f2-b0ac-825f6e07f31a)


</p>
</li>
<li> 
<details><summary>Setting search: display-nft-media</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/bd32084b-7c1f-4976-a33a-3884f1df5f7c)


**After Change**
![image](https://github.com/user-attachments/assets/daf27b48-7b40-42b5-b24b-746965bee864)

</p>
</li>
<li> 
<details><summary>Setting search: autodetect-nfts</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/9143d000-704d-46fa-b826-507cff702202)

**After Change**

![image](https://github.com/user-attachments/assets/8db7375f-63df-44e6-bbd7-b870088e3fdf)

</p>
</li>
<li> 
<details><summary>Setting search: network-details-check</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/08be1b47-a397-404f-bd02-21df9dd41fad)

**After Change**

![image](https://github.com/user-attachments/assets/b8bb4521-9712-4cae-91b7-1d71bf30cd4a)

</p>
</li>
<li> 
<details><summary>Setting search: proposed-nicknames</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/587c6425-042c-4662-817e-1c6e5dc86a36)

**After Change**

![image](https://github.com/user-attachments/assets/05d0b725-bae1-4734-8053-2b6817745cad)


</p>
</li>
<li> 
<details><summary>Setting Search: security-alerts</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/0ccdb8d6-dd06-4a24-a83d-ff24fb92ff5c)

**After Change**

![image](https://github.com/user-attachments/assets/384b56a0-a197-4fda-9cad-998f1db3828c)

</p>
</li>

<li> 
<details><summary>Setting Search: blockaid</summary>
<p>
**Before Change**

![image](https://github.com/user-attachments/assets/bfef629a-acbe-40dd-98b3-80e1e5b3be4c)

**After Change**

![image](https://github.com/user-attachments/assets/ac3bf6c4-fc07-45fb-bd8e-43e057b73912)

</p>
</li>

</ul>


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
