### PR TITLE
chore: update @metamask/bitcoin-wallet-snap to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "@metamask/approval-controller": "^7.0.0",
     "@metamask/assets-controllers": "^36.0.0",
     "@metamask/base-controller": "^5.0.1",
-    "@metamask/bitcoin-wallet-snap": "^0.4.0",
+    "@metamask/bitcoin-wallet-snap": "^0.5.0",
     "@metamask/browser-passworder": "^4.3.0",
     "@metamask/contract-metadata": "^2.5.0",
     "@metamask/controller-utils": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4923,10 +4923,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bitcoin-wallet-snap@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@metamask/bitcoin-wallet-snap@npm:0.4.0"
-  checksum: 10/2f118e65e8ab2c213218b470dca0d347ea443a2c54635fd2b14b929307d101d7e23f9e16fa18fe60ec8ca2037ee96f62c6d2de7e1976129ed721aafbfc0a7691
+"@metamask/bitcoin-wallet-snap@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@metamask/bitcoin-wallet-snap@npm:0.5.0"
+  checksum: 10/eeb2c11316d58fcd26b73c11b6c8cd6ed0c5d4beb28ae3237bc08c8100fbdde4f8e38ad3efb25c85f8a6722cfec8290bbbfee71718d54735beb86064a9e9435c
   languageName: node
   linkType: hard
 
@@ -26567,7 +26567,7 @@ __metadata:
     "@metamask/assets-controllers": "npm:^36.0.0"
     "@metamask/auto-changelog": "npm:^2.1.0"
     "@metamask/base-controller": "npm:^5.0.1"
-    "@metamask/bitcoin-wallet-snap": "npm:^0.4.0"
+    "@metamask/bitcoin-wallet-snap": "npm:^0.5.0"
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^1.0.0"
     "@metamask/contract-metadata": "npm:^2.5.0"


### PR DESCRIPTION
## **Description**

Bump the BTC Snap to version 0.5.0.

- This new release adds the new `getMaxSpendableBalance` method to fetch the max spendable amount/balance from your account.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26701?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
