### PR TITLE
fix: flaky test `Navigation Signature - Different signature types initiates and queues multiple signatures and confirms`

### DIFF
--- a/test/e2e/tests/confirmations/navigation.spec.ts
+++ b/test/e2e/tests/confirmations/navigation.spec.ts
@@ -151,24 +151,22 @@ async function verifySignedTypeV4Confirmation(driver: Driver) {
 }
 
 async function queueSignatures(driver: Driver) {
+  // There is a race condition which changes the order in which signatures are displayed (#25251)
+  // We fix it deterministically by waiting for an element in the screen for each signature
   await driver.clickElement('#signTypedData');
   await driver.waitUntilXWindowHandles(3);
+  await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+  await driver.findElement({ text: 'Hi, Alice!' });
   await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-  await driver.delay(2000); // Delay needed due to a race condition
-  // To be fixed in https://github.com/MetaMask/metamask-extension/issues/25251
-
   await driver.clickElement('#signTypedDataV3');
   await driver.waitUntilXWindowHandles(3);
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-  await driver.delay(2000);
+  await driver.findElement({ text: 'Reject all' });
 
-  await driver.waitUntilXWindowHandles(3);
   await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-
   await driver.clickElement('#signTypedDataV4');
   await driver.waitUntilXWindowHandles(3);
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-  await driver.delay(2000);
 }
 
 async function queueSignaturesAndTransactions(driver: Driver) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a known race-condition that can display the signature queue in unexpected order, so the test had a delay to address that, but this doesn't fix the issue in all occasions. In this PR we add a deterministic condition, to ensure this doesn't happen: we wait until we find an element for the given signature, before triggering a new one, making sure signatures are ordered.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26707?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26507

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
The artifacts and local run show how sometimes we start with the signature page 2, instead of the1, making the subsequent steps to fail.

![image](https://github.com/user-attachments/assets/08cab78b-8805-4b69-b2ff-eb703d68e0a6)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
