### PR TITLE
chore: MMI Fixes passing the state to route using history.push

### DIFF
--- a/test/e2e/playwright/mmi/specs/navigation.spec.ts
+++ b/test/e2e/playwright/mmi/specs/navigation.spec.ts
@@ -7,11 +7,10 @@ import {
   getPageAndCloseRepeated,
 } from '../helpers/utils';
 import { MMIMainMenuPage } from '../pageObjects/mmi-mainMenu-page';
-import { Auth0Page } from '../pageObjects/mmi-auth0-page';
 import { MMIMainPage } from '../pageObjects/mmi-main-page';
 
-const portfolio = `${process.env.MMI_E2E_MMI_DASHBOARD_URL}/portfolio`;
-const stake = `${process.env.MMI_E2E_MMI_DASHBOARD_URL}/stake`;
+const portfolio = `${process.env.MMI_E2E_MMI_DASHBOARD_URL}`;
+const stake = `${process.env.MMI_E2E_MMI_DASHBOARD_URL}`;
 const support = 'https://mmi-support.metamask.io/hc/en-us';
 const supportContactUs =
   'https://mmi-support.metamask.io/hc/en-us/requests/new';
@@ -50,12 +49,6 @@ test.describe('MMI Navigation', () => {
     await mainMenuPage.switchTestNetwork();
     // await mainMenuPage.showIncomingTransactionsOff()
     await mainMenuPage.closeSettings();
-
-    // This is removed to improve test performance
-    // Signin auth0
-    const auth0 = new Auth0Page(await context.newPage());
-    await auth0.signIn();
-    await auth0.page.close();
 
     // // Close pages not used to remove data from logs
     await closePages(context, ['metamask-institutional.io']);

--- a/ui/pages/institutional/interactive-replacement-token-page/interactive-replacement-token-page.test.tsx
+++ b/ui/pages/institutional/interactive-replacement-token-page/interactive-replacement-token-page.test.tsx
@@ -202,6 +202,10 @@ describe('Interactive Replacement Token Page', function () {
       imgSrc: 'iconUrl',
       title: 'Your custodian token has been refreshed',
     };
+    const fullData = {
+      pathname: mostRecentOverviewPage,
+      state: mostRecentOverviewPageState,
+    };
 
     await act(async () => {
       const { getByText } = await render();
@@ -216,10 +220,7 @@ describe('Interactive Replacement Token Page', function () {
       token: connectRequests[0].token,
     });
     expect(history.push).toHaveBeenCalled();
-    expect(history.push).toHaveBeenCalledWith(
-      mostRecentOverviewPage,
-      mostRecentOverviewPageState,
-    );
+    expect(history.push).toHaveBeenCalledWith(fullData);
   });
 
   it('should reject if there are errors', async () => {

--- a/ui/pages/institutional/interactive-replacement-token-page/interactive-replacement-token-page.tsx
+++ b/ui/pages/institutional/interactive-replacement-token-page/interactive-replacement-token-page.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { Location as HistoryLocation } from 'history';
 import {
   Box,
   Button,
@@ -246,11 +247,17 @@ const InteractiveReplacementTokenPage: React.FC = () => {
 
       onRemoveAddTokenConnectRequest(connectRequest);
 
-      history.push(INSTITUTIONAL_FEATURES_DONE_ROUTE, {
+      const state = {
         imgSrc: custodian?.iconUrl,
         title: t('custodianReplaceRefreshTokenChangedTitle'),
         description: t('custodianReplaceRefreshTokenChangedSubtitle'),
-      });
+      };
+      const newLocation: Partial<HistoryLocation> = {
+        pathname: INSTITUTIONAL_FEATURES_DONE_ROUTE,
+        state,
+      };
+
+      history.push(newLocation);
 
       if (isMountedRef.current) {
         setIsLoading(false);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Passing the state to route using history.push in order to get these values in the final view.
They were not arriving before.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
