### PR TITLE
test: [Snaps E2E] Add changes to fix flakiness in Snaps UI Images test

### DIFF
--- a/test/e2e/snaps/test-snap-ui-imgs.spec.js
+++ b/test/e2e/snaps/test-snap-ui-imgs.spec.js
@@ -52,7 +52,7 @@ describe('Test Snap Images', function () {
 
         // deal with OK button
         await driver.waitForSelector({ text: 'OK' });
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'OK',
           tag: 'button',
         });
@@ -70,13 +70,15 @@ describe('Test Snap Images', function () {
         await driver.clickElement('#showSVGImage');
 
         // switch to notification window
-        await switchToNotificationWindow(driver, 2);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // check snaps ui image using waitForSelector
         await driver.waitForSelector('[data-testid="snaps-ui-image"]');
 
         // click ok to close window
-        await driver.clickElement('[data-testid="confirmation-submit-button"]');
+        await driver.clickElementAndWaitForWindowToClose(
+          '[data-testid="confirmation-submit-button"]',
+        );
 
         // switch back to test-snaps window
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
@@ -85,7 +87,7 @@ describe('Test Snap Images', function () {
         await driver.clickElement('#showPNGImage');
 
         // switch to notification window
-        await switchToNotificationWindow(driver, 2);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // check snaps ui image using waitForSelector
         await driver.waitForSelector('[data-testid="snaps-ui-image"]');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Made changes to remove deprecated method for switching to dialog window, as well as changing some click elements to clickElementAndWaitForWindowToClose

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26725?quickstart=1)

## **Related issues**

Fixes: #26574 

## **Manual testing steps**

1. Run test individually multiple times and check that CI passes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
