### PR TITLE
fix: `wallet_addEthereumChain` does not attach a `result` under certain conditions

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -139,6 +139,7 @@ async function addEthereumChainHandler(
       currentChainIdForDomain === chainId &&
       currentRpcUrl === firstValidRPCUrl
     ) {
+      res.result = null;
       return end();
     }
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -134,7 +134,6 @@ async function addEthereumChainHandler(
   } else {
     networkClientId = existingNetwork.id ?? existingNetwork.type;
     const currentRpcUrl = getCurrentRpcUrl();
-
     if (
       currentChainIdForDomain === chainId &&
       currentRpcUrl === firstValidRPCUrl

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
@@ -3,7 +3,6 @@ import {
   CHAIN_IDS,
   NETWORK_TYPES,
 } from '../../../../../shared/constants/network';
-import * as chainUtils from './ethereum-chain-utils';
 import addEthereumChain from './add-ethereum-chain';
 
 const NON_INFURA_CHAIN_ID = '0x123456789';
@@ -543,33 +542,36 @@ describe('addEthereumChainHandler', () => {
     );
   });
 
-  it('should add result set to null to response object if the requested rpcUrl (and chainId) is currently selected', async () => {
-    jest.spyOn(chainUtils, 'findExistingNetwork').mockReturnValue({
-      chainId: '0x1',
-      rpcUrl: 'https://mainnet.infura.io/v3/',
-      ticker: 'ETH',
-    });
+  it.only('should add result set to null to response object if the requested rpcUrl (and chainId) is currently selected', async () => {
+    const CURRENT_RPC_CONFIG = createMockNonInfuraConfiguration();
 
     const mocks = makeMocks({
       permissionsFeatureFlagIsActive: false,
       overrides: {
-        getCurrentChainIdForDomain: jest.fn().mockReturnValue('0x1'),
+        getCurrentChainIdForDomain: jest
+          .fn()
+          .mockReturnValue(CURRENT_RPC_CONFIG.chainId),
+        findNetworkConfigurationBy: jest
+          .fn()
+          .mockReturnValue(CURRENT_RPC_CONFIG),
+        getCurrentRpcUrl: jest.fn().mockReturnValue(CURRENT_RPC_CONFIG.rpcUrl),
       },
     });
     const res = {};
+
     await addEthereumChainHandler(
       {
         origin: 'example.com',
         params: [
           {
-            chainId: CHAIN_IDS.MAINNET,
-            chainName: 'Ethereum Mainnet',
-            rpcUrls: ['https://mainnet.infura.io/v3/'],
+            chainId: CURRENT_RPC_CONFIG.chainId,
+            chainName: 'Custom Network',
+            rpcUrls: [CURRENT_RPC_CONFIG.rpcUrl],
             nativeCurrency: {
-              symbol: 'ETH',
+              symbol: CURRENT_RPC_CONFIG.ticker,
               decimals: 18,
             },
-            blockExplorerUrls: ['https://etherscan.io'],
+            blockExplorerUrls: ['https://custom.blockexplorer'],
           },
         ],
       },

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
@@ -542,7 +542,7 @@ describe('addEthereumChainHandler', () => {
     );
   });
 
-  it.only('should add result set to null to response object if the requested rpcUrl (and chainId) is currently selected', async () => {
+  it('should add result set to null to response object if the requested rpcUrl (and chainId) is currently selected', async () => {
     const CURRENT_RPC_CONFIG = createMockNonInfuraConfiguration();
 
     const mocks = makeMocks({

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
@@ -3,6 +3,7 @@ import {
   CHAIN_IDS,
   NETWORK_TYPES,
 } from '../../../../../shared/constants/network';
+import * as chainUtils from './ethereum-chain-utils';
 import addEthereumChain from './add-ethereum-chain';
 
 const NON_INFURA_CHAIN_ID = '0x123456789';
@@ -540,5 +541,43 @@ describe('addEthereumChainHandler', () => {
         message: `nativeCurrency.symbol does not match currency symbol for a network the user already has added with the same chainId. Received:\nWRONG`,
       }),
     );
+  });
+
+  it('should add result set to null to response object if the requested rpcUrl (and chainId) is currently selected', async () => {
+    jest.spyOn(chainUtils, 'findExistingNetwork').mockReturnValue({
+      chainId: '0x1',
+      rpcUrl: 'https://mainnet.infura.io/v3/',
+      ticker: 'ETH',
+    });
+
+    const mocks = makeMocks({
+      permissionsFeatureFlagIsActive: false,
+      overrides: {
+        getCurrentChainIdForDomain: jest.fn().mockReturnValue('0x1'),
+      },
+    });
+    const res = {};
+    await addEthereumChainHandler(
+      {
+        origin: 'example.com',
+        params: [
+          {
+            chainId: CHAIN_IDS.MAINNET,
+            chainName: 'Ethereum Mainnet',
+            rpcUrls: ['https://mainnet.infura.io/v3/'],
+            nativeCurrency: {
+              symbol: 'ETH',
+              decimals: 18,
+            },
+            blockExplorerUrls: ['https://etherscan.io'],
+          },
+        ],
+      },
+      res,
+      jest.fn(),
+      jest.fn(),
+      mocks,
+    );
+    expect(res.result).toBeNull();
   });
 });


### PR DESCRIPTION
## **Description**

Fix issue where `wallet_addEthereumChain` does not attach a result to the response object when the currently selected rpcUrl matches the request.

This would cause the request to get "stuck" in the `QueuedRequestController` queue, preventing the queue from progressing and causing confusing behavior.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26726?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26706

## **Manual testing steps**

1. Go to https://chainlist.org/?chain=56&search=blast
2. Connect the wallet and add Blast Mainnet 
(For other chains it appears Chainlist cycles to the next rpcUrl you don't have which avoids this bug, so use Blast)
3. After successfully adding the network, attempt to add Blast again. Nothing should happen.
4. Then go to https://faucet.quicknode.com/blast/sepolia (or any dapp where your wallet isn't already connected) and attempt to connect
5. You should be able to connect as usual

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/b997027f-1c62-4279-87c6-0fe70989abb3


### **After**

https://github.com/user-attachments/assets/08307a88-8f6f-44cd-9b75-877aadb1805a


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
