### PR TITLE
fix: fix flaky nft dapp interaction

### DIFF
--- a/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
+++ b/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
@@ -51,7 +51,7 @@ describe('ERC721 NFTs testdapp interaction', function () {
         await driver.clickElement(
           '[data-testid="account-overview__activity-tab"]',
         );
-        await driver.delay(500);
+        await driver.delay(1000);
         const transactionItem = await driver.waitForSelector({
           css: '[data-testid="activity-list-item-action"]',
           text: 'Deposit',

--- a/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
+++ b/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
@@ -51,6 +51,7 @@ describe('ERC721 NFTs testdapp interaction', function () {
         await driver.clickElement(
           '[data-testid="account-overview__activity-tab"]',
         );
+        await driver.delay(500);
         const transactionItem = await driver.waitForSelector({
           css: '[data-testid="activity-list-item-action"]',
           text: 'Deposit',

--- a/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
+++ b/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
@@ -126,6 +126,7 @@ describe('ERC721 NFTs testdapp interaction', function () {
         assert.equal(await transactionItem.isDisplayed(), true);
 
         // verify the mint transaction has finished
+        await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         const nftsMintStatus = await driver.findElement({
           css: '#nftsStatus',

--- a/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
+++ b/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
@@ -125,6 +125,7 @@ describe('ERC721 NFTs testdapp interaction', function () {
         assert.equal(await transactionItem.isDisplayed(), true);
 
         // verify the mint transaction has finished
+        await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         const nftsMintStatus = await driver.findElement({
           css: '#nftsStatus',

--- a/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
+++ b/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
@@ -58,6 +58,7 @@ describe('ERC721 NFTs testdapp interaction', function () {
         assert.equal(await transactionItem.isDisplayed(), true);
 
         // verify the mint transaction has finished
+        await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         const nftsMintStatus = await driver.findElement({
           css: '#nftsStatus',
@@ -65,6 +66,7 @@ describe('ERC721 NFTs testdapp interaction', function () {
         });
         assert.equal(await nftsMintStatus.isDisplayed(), true);
 
+        await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,
         );

--- a/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
+++ b/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
@@ -126,7 +126,6 @@ describe('ERC721 NFTs testdapp interaction', function () {
         assert.equal(await transactionItem.isDisplayed(), true);
 
         // verify the mint transaction has finished
-        await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         const nftsMintStatus = await driver.findElement({
           css: '#nftsStatus',

--- a/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
+++ b/test/e2e/tests/tokens/nft/erc721-interaction.spec.js
@@ -243,6 +243,7 @@ describe('ERC721 NFTs testdapp interaction', function () {
         await driver.clickElement(
           '[data-testid="account-overview__activity-tab"]',
         );
+        await driver.delay(1000);
         const transactionItem = await driver.waitForSelector({
           css: '[data-testid="activity-list-item-action"]',
           text: 'Deposit',


### PR DESCRIPTION
## **Description**

This test was reported that its flaky [ERC721 NFTs testdapp interaction should add NFTs to state by parsing tx logs without having to click on watch NFT](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/97720/workflows/1a1a28d2-9df6-4d5d-b0fb-e8914146cb70/jobs/3637068/tests#failed-test-0)

I added `waitUntilXWindowHandles` before `switchToWindowWithTitle`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26735?quickstart=1)

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/26759

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
