### PR TITLE
fix: flaky test `Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx should queue signTypedData tx after eth_sendTransaction confirmation and signTypedData confirmation should target the correct network after eth_sendTransaction is confirmed @no-mmi`

### DIFF
--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js
@@ -119,6 +119,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         // eth_sendTransaction request
         await driver.clickElement('#sendButton');
+        await driver.waitUntilXWindowHandles(3);
 
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a race condition which happens when we trigger a Send from Dapp 1 (Localhost 7777) and quickly switch to Dapp 0 (Localhost 8545) and trigger a Sign there.

What happens is that the network for the first Send, is taken for the one on Dapp 0 (localhost 8545), so when we try to find the correct network (7777) in the Send screen fails (see artifacts below).

```
// Check correct network on the send confirmation.
        await driver.findElement({
          css: '[data-testid="network-display"]',
          text: 'Localhost 7777',
        });
```
To mitigate this race condition, after we trigger the Send from Dapp 1 (Localhost 7777) we wait until the popup is open and then switch to Dapp 0 and proceed with the Sign action (Localhost 8545).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26794?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26795

## **Manual testing steps**

1. Check ci
2. Run test locally in webpack build `yarn test:e2e:single test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.js --browser=chrome --retries=10 --stop-after-one-failure=true`

## **Screenshots/Recordings**
Notice the Send has Localhost 8545, but it should be Localhost 7777

![image](https://github.com/user-attachments/assets/cc7c0758-9587-451c-a8fc-2e9f0caaefef)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
