### PR TITLE
feat: Support CAIP-10 addresses in Snaps

### DIFF
--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -37,6 +37,7 @@ import { SnapUIRadioGroup } from '../snaps/snap-ui-radio-group';
 import { SnapUICheckbox } from '../snaps/snap-ui-checkbox';
 import { SnapUITooltip } from '../snaps/snap-ui-tooltip';
 import { SnapUICard } from '../snaps/snap-ui-card';
+import { SnapUIAddress } from '../snaps/snap-ui-address';
 import { SnapUISelector } from '../snaps/snap-ui-selector';
 import { SnapFooterButton } from '../snaps/snap-footer-button';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
@@ -98,6 +99,7 @@ export const safeComponentList = {
   SnapUITooltip,
   SnapUICard,
   SnapUISelector,
+  SnapUIAddress,
   SnapFooterButton,
   FormTextField,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
+++ b/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
@@ -1,0 +1,445 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SnapUIAddress renders Bitcoin address 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <div
+      style="display: flex;"
+    >
+      <div
+        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 94, 91);"
+      >
+        <svg
+          height="32"
+          width="32"
+          x="0"
+          y="0"
+        >
+          <rect
+            fill="#FA4700"
+            height="32"
+            transform="translate(-8.662444064083436 -0.5511004452514604) rotate(277.5 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#C8146E"
+            height="32"
+            transform="translate(6.57176803029907 -15.152127512910315) rotate(425.9 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#018E79"
+            height="32"
+            transform="translate(20.118327611213395 20.95221350375136) rotate(49.4 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+        </svg>
+      </div>
+    </div>
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      128Lkh3...Mp8p6
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Bitcoin address with blockie 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <img
+      alt=""
+      height="32"
+      src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjA0IDYxJSA0MSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgxODQgNjMlIDUwJSkiIGQ9Ik0xLDBoMXYxaC0xek02LDBoMXYxaC0xek0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0yLDFoMXYxaC0xek01LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0zLDJoMXYxaC0xek00LDJoMXYxaC0xek0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0xLDVoMXYxaC0xek02LDVoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgxODEgNjIlIDUyJSkiIGQ9Ik0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDZoMXYxaC0xek01LDZoMXYxaC0xek0wLDdoMXYxaC0xek03LDdoMXYxaC0xeiIvPjwvc3ZnPg=="
+      style="border-radius: 50%;"
+      width="32"
+    />
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      128Lkh3...Mp8p6
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Cosmos address 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <div
+      style="display: flex;"
+    >
+      <div
+        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 59, 94);"
+      >
+        <svg
+          height="32"
+          width="32"
+          x="0"
+          y="0"
+        >
+          <rect
+            fill="#2339E1"
+            height="32"
+            transform="translate(-10.577095368503558 1.2778853266411496) rotate(258.6 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#FB182B"
+            height="32"
+            transform="translate(5.677337270662435 9.943687420321362) rotate(189.4 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#EDF500"
+            height="32"
+            transform="translate(-25.62998642818306 -17.790405786491355) rotate(296.0 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+        </svg>
+      </div>
+    </div>
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      cosmos1...6hdc0
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Cosmos address with blockie 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <img
+      alt=""
+      height="32"
+      src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjQ3IDQ2JSAzNSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg4NiA3MSUgNTQlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDE4OSA2NSUgMzYlKSIgZD0iTTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6Ii8+PC9zdmc+"
+      style="border-radius: 50%;"
+      width="32"
+    />
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      cosmos1...6hdc0
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Ethereum address 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <div
+      style="display: flex;"
+    >
+      <div
+        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 83);"
+      >
+        <svg
+          height="32"
+          width="32"
+          x="0"
+          y="0"
+        >
+          <rect
+            fill="#F29602"
+            height="32"
+            transform="translate(-2.81750896228304 4.951916544006229) rotate(230.4 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#236CE1"
+            height="32"
+            transform="translate(-13.498650292632812 -9.441918676693094) rotate(245.3 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#018E8E"
+            height="32"
+            transform="translate(18.42469405222943 23.248777206278085) rotate(173.9 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+        </svg>
+      </div>
+    </div>
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      0xab16a...Bfcdb
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Ethereum address with blockie 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <img
+      alt=""
+      height="32"
+      src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woNTIgNzAlIDU4JSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDI2MiA1MiUgNTYlKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTIsM2gxdjFoLTF6TTUsM2gxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTAsNmgxdjFoLTF6TTcsNmgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTEsN2gxdjFoLTF6TTYsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDggNjMlIDUzJSkiIGQ9IiIvPjwvc3ZnPg=="
+      style="border-radius: 50%;"
+      width="32"
+    />
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      0xab16a...Bfcdb
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Hedera address 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <div
+      style="display: flex;"
+    >
+      <div
+        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(251, 24, 81);"
+      >
+        <svg
+          height="32"
+          width="32"
+          x="0"
+          y="0"
+        >
+          <rect
+            fill="#C81441"
+            height="32"
+            transform="translate(7.8929303986963575 3.81505315001625) rotate(81.4 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#F95001"
+            height="32"
+            transform="translate(-15.115532254104156 5.65823114066517) rotate(249.8 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#034A5E"
+            height="32"
+            transform="translate(18.782116410097146 -20.966441380827995) rotate(321.3 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+        </svg>
+      </div>
+    </div>
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      0.0.123...zbhlt
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Hedera address with blockie 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <img
+      alt=""
+      height="32"
+      src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMTkgNzclIDU3JSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDEwMSA1OCUgMzMlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6TTEsN2gxdjFoLTF6TTYsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1NyA5NCUgNDUlKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+"
+      style="border-radius: 50%;"
+      width="32"
+    />
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      0.0.123...zbhlt
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Polkadot address 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <div
+      style="display: flex;"
+    >
+      <div
+        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 198, 242);"
+      >
+        <svg
+          height="32"
+          width="32"
+          x="0"
+          y="0"
+        >
+          <rect
+            fill="#238CE1"
+            height="32"
+            transform="translate(-0.9326359780580042 -0.7760979217397975) rotate(228.7 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#018E77"
+            height="32"
+            transform="translate(14.633859127624504 0.17102681763595054) rotate(175.0 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#F26E02"
+            height="32"
+            transform="translate(22.334011165851894 0.6446527074820322) rotate(17.6 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+        </svg>
+      </div>
+    </div>
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      5hmuyxw...egmfy
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Polkadot address with blockie 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <img
+      alt=""
+      height="32"
+      src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMTMgNjMlIDMzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDEzOCA3NSUgMjglKSIgZD0iTTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6TTEsN2gxdjFoLTF6TTYsN2gxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDczIDc3JSAzMyUpIiBkPSJNMCwwaDF2MWgtMXpNNywwaDF2MWgtMXpNMSwwaDF2MWgtMXpNNiwwaDF2MWgtMXpNMywwaDF2MWgtMXpNNCwwaDF2MWgtMXpNMSwyaDF2MWgtMXpNNiwyaDF2MWgtMXpNMiw1aDF2MWgtMXpNNSw1aDF2MWgtMXpNMyw1aDF2MWgtMXpNNCw1aDF2MWgtMXpNMCw2aDF2MWgtMXpNNyw2aDF2MWgtMXpNMyw2aDF2MWgtMXpNNCw2aDF2MWgtMXpNMiw3aDF2MWgtMXpNNSw3aDF2MWgtMXoiLz48L3N2Zz4="
+      style="border-radius: 50%;"
+      width="32"
+    />
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      5hmuyxw...egmfy
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Starknet address 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <div
+      style="display: flex;"
+    >
+      <div
+        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 110);"
+      >
+        <svg
+          height="32"
+          width="32"
+          x="0"
+          y="0"
+        >
+          <rect
+            fill="#2388E1"
+            height="32"
+            transform="translate(1.8289963783692056 -3.4661888536397423) rotate(409.8 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#F59700"
+            height="32"
+            transform="translate(-16.75527888625542 -8.229921036962272) rotate(352.3 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#18C2F2"
+            height="32"
+            transform="translate(-23.454898584180004 2.8519196153955564) rotate(217.2 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+        </svg>
+      </div>
+    </div>
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      0x02dd1...0ab57
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders Starknet address with blockie 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <img
+      alt=""
+      height="32"
+      src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjM0IDUzJSA2MSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgxODIgNzIlIDMxJSkiIGQ9Ik0xLDBoMXYxaC0xek02LDBoMXYxaC0xek0xLDFoMXYxaC0xek02LDFoMXYxaC0xek0yLDFoMXYxaC0xek01LDFoMXYxaC0xek0wLDJoMXYxaC0xek03LDJoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0zLDJoMXYxaC0xek00LDJoMXYxaC0xek0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0xLDVoMXYxaC0xek02LDVoMXYxaC0xek0yLDVoMXYxaC0xek01LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0yLDZoMXYxaC0xek01LDZoMXYxaC0xek0xLDdoMXYxaC0xek02LDdoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCg2OCA4NiUgNjYlKSIgZD0iTTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsNmgxdjFoLTF6TTcsNmgxdjFoLTF6Ii8+PC9zdmc+"
+      style="border-radius: 50%;"
+      width="32"
+    />
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+    >
+      0x02dd1...0ab57
+    </p>
+  </div>
+</div>
+`;

--- a/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
+++ b/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
       </div>
     </div>
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       128Lkh3...Mp8p6
     </p>
@@ -66,7 +66,7 @@ exports[`SnapUIAddress renders Bitcoin address with blockie 1`] = `
       width="32"
     />
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       128Lkh3...Mp8p6
     </p>
@@ -119,7 +119,7 @@ exports[`SnapUIAddress renders Cosmos address 1`] = `
       </div>
     </div>
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       cosmos1...6hdc0
     </p>
@@ -140,7 +140,7 @@ exports[`SnapUIAddress renders Cosmos address with blockie 1`] = `
       width="32"
     />
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       cosmos1...6hdc0
     </p>
@@ -193,7 +193,7 @@ exports[`SnapUIAddress renders Ethereum address 1`] = `
       </div>
     </div>
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       0xab16a...Bfcdb
     </p>
@@ -214,7 +214,7 @@ exports[`SnapUIAddress renders Ethereum address with blockie 1`] = `
       width="32"
     />
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       0xab16a...Bfcdb
     </p>
@@ -267,7 +267,7 @@ exports[`SnapUIAddress renders Hedera address 1`] = `
       </div>
     </div>
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       0.0.123...zbhlt
     </p>
@@ -288,7 +288,7 @@ exports[`SnapUIAddress renders Hedera address with blockie 1`] = `
       width="32"
     />
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       0.0.123...zbhlt
     </p>
@@ -341,7 +341,7 @@ exports[`SnapUIAddress renders Polkadot address 1`] = `
       </div>
     </div>
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       5hmuyxw...egmfy
     </p>
@@ -362,7 +362,7 @@ exports[`SnapUIAddress renders Polkadot address with blockie 1`] = `
       width="32"
     />
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       5hmuyxw...egmfy
     </p>
@@ -415,7 +415,7 @@ exports[`SnapUIAddress renders Starknet address 1`] = `
       </div>
     </div>
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       0x02dd1...0ab57
     </p>
@@ -436,9 +436,62 @@ exports[`SnapUIAddress renders Starknet address with blockie 1`] = `
       width="32"
     />
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
       0x02dd1...0ab57
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SnapUIAddress renders legacy Ethereum address 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+  >
+    <div
+      style="display: flex;"
+    >
+      <div
+        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 83);"
+      >
+        <svg
+          height="32"
+          width="32"
+          x="0"
+          y="0"
+        >
+          <rect
+            fill="#F29602"
+            height="32"
+            transform="translate(-2.81750896228304 4.951916544006229) rotate(230.4 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#236CE1"
+            height="32"
+            transform="translate(-13.498650292632812 -9.441918676693094) rotate(245.3 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+          <rect
+            fill="#018E8E"
+            height="32"
+            transform="translate(18.42469405222943 23.248777206278085) rotate(173.9 16 16)"
+            width="32"
+            x="0"
+            y="0"
+          />
+        </svg>
+      </div>
+    </div>
+    <p
+      class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+    >
+      0xab16a...Bfcdb
     </p>
   </div>
 </div>

--- a/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
+++ b/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
       style="display: flex;"
     >
       <div
-        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 94, 91);"
+        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(35, 83, 225);"
       >
         <svg
           height="32"
@@ -18,25 +18,25 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
           y="0"
         >
           <rect
-            fill="#FA4700"
+            fill="#03475E"
             height="32"
-            transform="translate(-8.662444064083436 -0.5511004452514604) rotate(277.5 16 16)"
+            transform="translate(2.9305136451897345 1.2261469525972557) rotate(127.9 16 16)"
             width="32"
             x="0"
             y="0"
           />
           <rect
-            fill="#C8146E"
+            fill="#F95801"
             height="32"
-            transform="translate(6.57176803029907 -15.152127512910315) rotate(425.9 16 16)"
+            transform="translate(7.1718321011849575 11.079805523008025) rotate(153.0 16 16)"
             width="32"
             x="0"
             y="0"
           />
           <rect
-            fill="#018E79"
+            fill="#017B8E"
             height="32"
-            transform="translate(20.118327611213395 20.95221350375136) rotate(49.4 16 16)"
+            transform="translate(8.451434427080768 22.468601749359266) rotate(146.6 16 16)"
             width="32"
             x="0"
             y="0"

--- a/ui/components/app/snaps/snap-ui-address/index.ts
+++ b/ui/components/app/snaps/snap-ui-address/index.ts
@@ -1,0 +1,1 @@
+export * from './snap-ui-address';

--- a/ui/components/app/snaps/snap-ui-address/snap-ui-address.stories.tsx
+++ b/ui/components/app/snaps/snap-ui-address/snap-ui-address.stories.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { SnapUIAddress } from './snap-ui-address';
+
+export default {
+  title: 'Components/App/Snaps/SnapUIAddress',
+  component: SnapUIAddress,
+  argTypes: {},
+};
+
+export const EthereumStory = (args) => <SnapUIAddress {...args} />;
+
+EthereumStory.storyName = 'Ethereum';
+
+EthereumStory.args = {
+  address: 'eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb',
+};
+
+export const BitcoinStory = (args) => <SnapUIAddress {...args} />;
+
+BitcoinStory.storyName = 'Bitcoin';
+
+BitcoinStory.args = {
+  address:
+    'bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6',
+};
+
+export const CosmosStory = (args) => <SnapUIAddress {...args} />;
+
+CosmosStory.storyName = 'Cosmos';
+
+CosmosStory.args = {
+  address: 'cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0',
+};
+
+export const PolkadotStory = (args) => <SnapUIAddress {...args} />;
+
+PolkadotStory.storyName = 'Polkadot';
+
+PolkadotStory.args = {
+  address:
+    'polkadot:b0a8d493285c2df73290dfb7e61f870f:5hmuyxw9xdgbpptgypokw4thfyoe3ryenebr381z9iaegmfy',
+};
+
+export const StarknetStory = (args) => <SnapUIAddress {...args} />;
+
+StarknetStory.storyName = 'Starknet';
+
+StarknetStory.args = {
+  address:
+    'starknet:SN_GOERLI:0x02dd1b492765c064eac4039e3841aa5f382773b598097a40073bd8b48170ab57',
+};
+
+export const HederaStory = (args) => <SnapUIAddress {...args} />;
+
+HederaStory.storyName = 'Hedera';
+
+HederaStory.args = {
+  address: 'hedera:mainnet:0.0.1234567890-zbhlt',
+};
+
+export const All = () => (
+  <>
+    <SnapUIAddress address="eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb" />
+    <SnapUIAddress address="bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6" />
+    <SnapUIAddress address="cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0" />
+    <SnapUIAddress address="polkadot:b0a8d493285c2df73290dfb7e61f870f:5hmuyxw9xdgbpptgypokw4thfyoe3ryenebr381z9iaegmfy" />
+    <SnapUIAddress address="starknet:SN_GOERLI:0x02dd1b492765c064eac4039e3841aa5f382773b598097a40073bd8b48170ab57" />
+    <SnapUIAddress address="hedera:mainnet:0.0.1234567890-zbhlt" />
+  </>
+);

--- a/ui/components/app/snaps/snap-ui-address/snap-ui-address.test.tsx
+++ b/ui/components/app/snaps/snap-ui-address/snap-ui-address.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+
+import mockState from '../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import { SnapUIAddress } from './snap-ui-address';
+
+const mockStore = configureMockStore([])(mockState);
+const mockStoreWithBlockies = configureMockStore([])({
+  ...mockState,
+  metamask: {
+    ...mockState.metamask,
+    useBlockie: true,
+  },
+});
+
+describe('SnapUIAddress', () => {
+  it('renders Ethereum address', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb" />,
+      mockStore,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Ethereum address with blockie', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb" />,
+      mockStoreWithBlockies,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Bitcoin address', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6" />,
+      mockStore,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Bitcoin address with blockie', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6" />,
+      mockStoreWithBlockies,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Cosmos address', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0" />,
+      mockStore,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Cosmos address with blockie', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0" />,
+      mockStoreWithBlockies,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Polkadot address', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="polkadot:b0a8d493285c2df73290dfb7e61f870f:5hmuyxw9xdgbpptgypokw4thfyoe3ryenebr381z9iaegmfy" />,
+      mockStore,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Polkadot address with blockie', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="polkadot:b0a8d493285c2df73290dfb7e61f870f:5hmuyxw9xdgbpptgypokw4thfyoe3ryenebr381z9iaegmfy" />,
+      mockStoreWithBlockies,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Starknet address', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="starknet:SN_GOERLI:0x02dd1b492765c064eac4039e3841aa5f382773b598097a40073bd8b48170ab57" />,
+      mockStore,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Starknet address with blockie', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="starknet:SN_GOERLI:0x02dd1b492765c064eac4039e3841aa5f382773b598097a40073bd8b48170ab57" />,
+      mockStoreWithBlockies,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders Hedera address', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="hedera:mainnet:0.0.1234567890-zbhlt" />,
+      mockStore,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+
+  it('renders Hedera address with blockie', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="hedera:mainnet:0.0.1234567890-zbhlt" />,
+      mockStoreWithBlockies,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/ui/components/app/snaps/snap-ui-address/snap-ui-address.test.tsx
+++ b/ui/components/app/snaps/snap-ui-address/snap-ui-address.test.tsx
@@ -15,6 +15,15 @@ const mockStoreWithBlockies = configureMockStore([])({
 });
 
 describe('SnapUIAddress', () => {
+  it('renders legacy Ethereum address', () => {
+    const { container } = renderWithProvider(
+      <SnapUIAddress address="0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb" />,
+      mockStore,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
   it('renders Ethereum address', () => {
     const { container } = renderWithProvider(
       <SnapUIAddress address="eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb" />,
@@ -113,7 +122,6 @@ describe('SnapUIAddress', () => {
 
     expect(container).toMatchSnapshot();
   });
-
 
   it('renders Hedera address with blockie', () => {
     const { container } = renderWithProvider(

--- a/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
+++ b/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { parseCaipAccountId } from '@metamask/utils';
+import { CaipAccountId, parseCaipAccountId } from '@metamask/utils';
 import { Box, Text } from '../../../component-library';
 import {
   AlignItems,
@@ -9,6 +9,7 @@ import {
 import BlockieIdenticon from '../../../ui/identicon/blockieIdenticon';
 import Jazzicon from '../../../ui/jazzicon';
 import { getUseBlockie } from '../../../../selectors';
+import { shortenAddress } from '../../../../helpers/utils/util';
 
 export type SnapUIAddressProps = {
   // The address must be a CAIP-10 string.
@@ -16,8 +17,8 @@ export type SnapUIAddressProps = {
   diameter?: number;
 };
 
-export const SnapUIAddress = ({ address, diameter = 32 }) => {
-  const parsed = useMemo(() => parseCaipAccountId(address), [address]);
+export const SnapUIAddress: React.FunctionComponent<SnapUIAddressProps> = ({ address, diameter = 32 }) => {
+  const parsed = useMemo(() => parseCaipAccountId(address as CaipAccountId), [address]);
   const useBlockie = useSelector(getUseBlockie);
 
   return (
@@ -36,7 +37,7 @@ export const SnapUIAddress = ({ address, diameter = 32 }) => {
           style={{ display: 'flex' }}
         />
       )}
-      <Text>{parsed.address}</Text>
+      <Text>{shortenAddress(parsed.address)}</Text>
     </Box>
   );
 };

--- a/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
+++ b/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
@@ -1,0 +1,42 @@
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { parseCaipAccountId } from '@metamask/utils';
+import { Box, Text } from '../../../component-library';
+import {
+  AlignItems,
+  Display,
+} from '../../../../helpers/constants/design-system';
+import BlockieIdenticon from '../../../ui/identicon/blockieIdenticon';
+import Jazzicon from '../../../ui/jazzicon';
+import { getUseBlockie } from '../../../../selectors';
+
+export type SnapUIAddressProps = {
+  // The address must be a CAIP-10 string.
+  address: string;
+  diameter?: number;
+};
+
+export const SnapUIAddress = ({ address, diameter = 32 }) => {
+  const parsed = useMemo(() => parseCaipAccountId(address), [address]);
+  const useBlockie = useSelector(getUseBlockie);
+
+  return (
+    <Box display={Display.Flex} alignItems={AlignItems.center} gap={2}>
+      {useBlockie ? (
+        <BlockieIdenticon
+          address={parsed.address}
+          diameter={diameter}
+          borderRadius="50%"
+        />
+      ) : (
+        <Jazzicon
+          namespace={parsed.chain.namespace}
+          address={parsed.address}
+          diameter={diameter}
+          style={{ display: 'flex' }}
+        />
+      )}
+      <Text>{parsed.address}</Text>
+    </Box>
+  );
+};

--- a/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
+++ b/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
@@ -1,15 +1,21 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { CaipAccountId, parseCaipAccountId } from '@metamask/utils';
+import {
+  CaipAccountId,
+  isHexString,
+  parseCaipAccountId,
+} from '@metamask/utils';
 import { Box, Text } from '../../../component-library';
 import {
   AlignItems,
   Display,
+  TextColor,
 } from '../../../../helpers/constants/design-system';
 import BlockieIdenticon from '../../../ui/identicon/blockieIdenticon';
 import Jazzicon from '../../../ui/jazzicon';
 import { getUseBlockie } from '../../../../selectors';
 import { shortenAddress } from '../../../../helpers/utils/util';
+import { toChecksumHexAddress } from '../../../../../shared/modules/hexstring-utils';
 
 export type SnapUIAddressProps = {
   // The address must be a CAIP-10 string.
@@ -17,9 +23,27 @@ export type SnapUIAddressProps = {
   diameter?: number;
 };
 
-export const SnapUIAddress: React.FunctionComponent<SnapUIAddressProps> = ({ address, diameter = 32 }) => {
-  const parsed = useMemo(() => parseCaipAccountId(address as CaipAccountId), [address]);
+export const SnapUIAddress: React.FunctionComponent<SnapUIAddressProps> = ({
+  address,
+  diameter = 32,
+}) => {
+  const parsed = useMemo(() => {
+    if (isHexString(address)) {
+      // For legacy address inputs we assume them to be Ethereum addresses.
+      // NOTE: This means the chain ID is not gonna be reliable.
+      return parseCaipAccountId(`eip155:1:${address}`);
+    }
+
+    return parseCaipAccountId(address as CaipAccountId);
+  }, [address]);
   const useBlockie = useSelector(getUseBlockie);
+
+  // For EVM addresses, we make sure they are checksummed.
+  const transformedAddress =
+    parsed.chain.namespace === 'eip155'
+      ? toChecksumHexAddress(parsed.address)
+      : parsed.address;
+  const shortenedAddress = shortenAddress(transformedAddress);
 
   return (
     <Box display={Display.Flex} alignItems={AlignItems.center} gap={2}>
@@ -37,7 +61,7 @@ export const SnapUIAddress: React.FunctionComponent<SnapUIAddressProps> = ({ add
           style={{ display: 'flex' }}
         />
       )}
-      <Text>{shortenAddress(parsed.address)}</Text>
+      <Text color={TextColor.inherit}>{shortenedAddress}</Text>
     </Box>
   );
 };

--- a/ui/components/app/snaps/snap-ui-renderer/components/address.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/address.ts
@@ -2,9 +2,9 @@ import { AddressElement } from '@metamask/snaps-sdk/jsx';
 import { UIComponentFactory } from './types';
 
 export const address: UIComponentFactory<AddressElement> = ({ element }) => ({
-  element: 'ConfirmInfoRowAddress',
+  element: 'SnapUIAddress',
   props: {
     address: element.props.address,
-    isSnapUsingThis: true,
+    diameter: 16,
   },
 });

--- a/ui/components/ui/jazzicon/jazzicon.component.js
+++ b/ui/components/ui/jazzicon/jazzicon.component.js
@@ -1,9 +1,21 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import jazzicon from '@metamask/jazzicon';
-import iconFactoryGenerator from '../../../helpers/utils/icon-factory';
+import { stringToBytes } from '@metamask/utils';
+import iconFactoryGenerator, {
+  IconFactory,
+} from '../../../helpers/utils/icon-factory';
 
-const iconFactory = iconFactoryGenerator(jazzicon);
+// Our existing seed generation for Ethereum addresses does not work with arbitrary string inputs.
+// Since it assumes the address can be parsed as hexadecimal, however that assumption does not hold for all multichain addresses.
+// Therefore we choose to use a byte array as the seed for multichain addresses.
+// This works since the underlying Mersenne Twister PRNG can be seeded with an array as well.
+function generateSeed(address) {
+  return Array.from(stringToBytes(address));
+}
+
+const ethereumIconFactory = iconFactoryGenerator(jazzicon);
+const multichainIconFactory = new IconFactory(jazzicon, generateSeed);
 
 /**
  * Wrapper around the jazzicon library to return a React component, as the library returns an
@@ -16,11 +28,15 @@ function Jazzicon({
   diameter = 46,
   style,
   tokenList = {},
+  namespace = 'eip155',
 }) {
   const container = useRef();
 
   useEffect(() => {
     const _container = container.current;
+
+    const iconFactory =
+      namespace === 'eip155' ? ethereumIconFactory : multichainIconFactory;
 
     // add icon
     const imageNode = iconFactory.iconForAddress(
@@ -64,6 +80,10 @@ Jazzicon.propTypes = {
    * Add list of token in object
    */
   tokenList: PropTypes.object,
+  /**
+   * Must be a CAIP-10 namespace, defaults to eip155 (EVM).
+   */
+  namespace: PropTypes.string,
 };
 
 export default Jazzicon;

--- a/ui/components/ui/jazzicon/jazzicon.component.js
+++ b/ui/components/ui/jazzicon/jazzicon.component.js
@@ -11,7 +11,7 @@ import iconFactoryGenerator, {
 // Therefore we choose to use a byte array as the seed for multichain addresses.
 // This works since the underlying Mersenne Twister PRNG can be seeded with an array as well.
 function generateSeed(address) {
-  return Array.from(stringToBytes(address));
+  return Array.from(stringToBytes(address.normalize('NFKC')));
 }
 
 const ethereumIconFactory = iconFactoryGenerator(jazzicon);

--- a/ui/components/ui/jazzicon/jazzicon.component.js
+++ b/ui/components/ui/jazzicon/jazzicon.component.js
@@ -11,7 +11,7 @@ import iconFactoryGenerator, {
 // Therefore we choose to use a byte array as the seed for multichain addresses.
 // This works since the underlying Mersenne Twister PRNG can be seeded with an array as well.
 function generateSeed(address) {
-  return Array.from(stringToBytes(address.normalize('NFKC')));
+  return Array.from(stringToBytes(address.normalize('NFKC').toLowerCase()));
 }
 
 const ethereumIconFactory = iconFactoryGenerator(jazzicon);

--- a/ui/helpers/utils/icon-factory.ts
+++ b/ui/helpers/utils/icon-factory.ts
@@ -10,11 +10,16 @@ type TokenMetadata = {
 /**
  * A factory for generating icons for cryptocurrency addresses using Jazzicon or predefined token metadata.
  */
-class IconFactory {
+export class IconFactory {
   /**
    * Function to generate a Jazzicon SVG element.
    */
-  jazzicon: (diameter: number, seed: number) => SVGSVGElement;
+  jazzicon: (diameter: number, seed: number | number[]) => SVGSVGElement;
+
+  /**
+   * Function to generate seed before passing to jazzicon implementation.
+   */
+  generateSeed: (address: string) => number | number[];
 
   /**
    * Cache for storing generated SVG elements to avoid re-rendering.
@@ -25,9 +30,14 @@ class IconFactory {
    * Constructs an IconFactory instance with a given Jazzicon function.
    *
    * @param jazzicon - A function that returns a Jazzicon SVG given a diameter and seed.
+   * @param generateSeed - An optional function that generates a seed based on an address.
    */
-  constructor(jazzicon: (diameter: number, seed: number) => SVGSVGElement) {
+  constructor(
+    jazzicon: (diameter: number, seed: number | number[]) => SVGSVGElement,
+    generateSeed = jsNumberForAddress,
+  ) {
     this.jazzicon = jazzicon;
+    this.generateSeed = generateSeed;
     this.cache = {};
   }
 
@@ -75,7 +85,7 @@ class IconFactory {
    * @returns A new Jazzicon SVG element.
    */
   generateNewIdenticon(address: string, diameter: number): SVGSVGElement {
-    const numericRepresentation = jsNumberForAddress(address);
+    const numericRepresentation = this.generateSeed(address);
     const identicon = this.jazzicon(diameter, numericRepresentation);
     return identicon;
   }
@@ -90,7 +100,7 @@ let iconFactory: IconFactory | undefined;
  * @returns An IconFactory instance.
  */
 export default function iconFactoryGenerator(
-  jazzicon: (diameter: number, seed: number) => SVGSVGElement,
+  jazzicon: (diameter: number, seed: number | number[]) => SVGSVGElement,
 ): IconFactory {
   if (!iconFactory) {
     iconFactory = new IconFactory(jazzicon);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add support for showing CAIP-10 addresses in Snaps by introducing `SnapUIAddress`. This component mimics the original implementation of `ConfirmInfoRowAddress` but also adds parsing logic for CAIP-10 addresses. 

CAIP-10 addresses are parsed in the component and the address part is passed to the jazzicon or blockie implementation to render an avatar. The blockie implementation supports arbitrary strings and did not need to be altered. For jazzicons, this PR implements seed generation that is compatible with any address string by seeding the PRNG used for jazzicons with the normalized byte array of the address. Plain Ethereum addresses are still supported and will use the regular jazzicon seed generation logic.

This PR will also need a release of the Snaps packages to update the JSX validation to allow passing CAIP-10 addresses.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26799?quickstart=1)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="385" alt="Screenshot 2024-09-02 at 14 35 33" src="https://github.com/user-attachments/assets/344d849b-9121-4bcb-bf58-8cb0b1286112">

### **After**

<img width="384" alt="Screenshot 2024-09-02 at 14 45 30" src="https://github.com/user-attachments/assets/158e3421-4f9f-46e1-a4cf-93daec45db66">