### PR TITLE
fix: Update Swaps symbol from matic to pol

### DIFF
--- a/shared/constants/swaps.ts
+++ b/shared/constants/swaps.ts
@@ -70,8 +70,8 @@ export const BNB_SWAPS_TOKEN_OBJECT: SwapsTokenObject = {
 } as const;
 
 export const MATIC_SWAPS_TOKEN_OBJECT: SwapsTokenObject = {
-  symbol: CURRENCY_SYMBOLS.MATIC,
-  name: 'Matic',
+  symbol: CURRENCY_SYMBOLS.POL,
+  name: 'Polygon',
   address: DEFAULT_TOKEN_ADDRESS,
   decimals: 18,
   iconUrl: POL_TOKEN_IMAGE_URL,


### PR DESCRIPTION
## **Description**

Updates MATIC to POL in swaps UI

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page

Go to swaps screen for POL token, token should be POL not MATIC

## **Screenshots/Recordings**

<img width="318" alt="Screenshot 2024-08-30 at 12 28 52 PM" src="https://github.com/user-attachments/assets/040385ef-de53-42a9-b589-138c3b9c6bb2">

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
