### PR TITLE
fix: Apply padding to Snaps UI root element no matter the type

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/index.scss
+++ b/ui/components/app/snaps/snap-ui-renderer/index.scss
@@ -4,7 +4,7 @@
   }
 
   &__container {
-    & > div:first-child {
+    & > *:first-child {
       padding: 16px;
     }
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a problem where padding would not be applied correctly to the first child of the Snaps UI container. We were expecting all root elements to be `div`. But many different types of components are allowed at the root. Quick fix by applying the padding no matter what type the root element is.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26850?quickstart=1)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/4a6680cc-137b-419d-8265-52345d4414cc)


### **After**

![image](https://github.com/user-attachments/assets/8655005b-f37b-44eb-8624-3f6e75250051)
