### PR TITLE
feat: Make footers and headers sticky in confirmation popups

### DIFF
--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -466,10 +466,22 @@ export default function ConfirmationPage({
       ? handleSubmit
       : null);
 
+  let contentMargin = 0;
+  if (pendingConfirmations.length > 1) {
+    contentMargin += 32;
+  }
+  if (isSnapCustomUIDialog) {
+    contentMargin += 80;
+  }
+
   return (
     <div className="confirmation-page">
       {pendingConfirmations.length > 1 && (
-        <div className="confirmation-page__navigation">
+        <Box
+          className="confirmation-page__navigation"
+          style={{ position: 'fixed', zIndex: 1 }}
+          width={BlockSize.Screen}
+        >
           <p>
             {t('xOfYPending', [
               currentPendingConfirmation + 1,
@@ -497,20 +509,31 @@ export default function ConfirmationPage({
           >
             <Icon name={IconName.ArrowRight} />
           </button>
-        </div>
+        </Box>
+      )}
+      {isSnapCustomUIDialog && (
+        <Box
+          width={BlockSize.Screen}
+          style={{
+            position: 'fixed',
+            zIndex: 1,
+            marginTop: pendingConfirmations.length > 1 ? '32px' : 'initial',
+          }}
+        >
+          <SnapAuthorshipHeader
+            snapId={pendingConfirmation?.origin}
+            onCancel={handleSnapDialogCancel}
+          />
+        </Box>
       )}
       <Box
         className="confirmation-page__content"
         paddingTop={process.env.CHAIN_PERMISSIONS ? 4 : 0}
+        style={{
+          marginTop: `${contentMargin}px`,
+          overflowY: 'auto',
+        }}
       >
-        {isSnapCustomUIDialog && (
-          <Box width={BlockSize.Screen}>
-            <SnapAuthorshipHeader
-              snapId={pendingConfirmation?.origin}
-              onCancel={handleSnapDialogCancel}
-            />
-          </Box>
-        )}
         {templatedValues.networkDisplay && !process.env.CHAIN_PERMISSIONS ? (
           <Box justifyContent="center" marginTop={2} display={Display.Flex}>
             <NetworkDisplay />

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
@@ -7,6 +7,7 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <div
         class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--justify-content-center"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-named-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-named-snap-account.test.js.snap
@@ -7,6 +7,7 @@ exports[`create-named-snap-account confirmation matches snapshot 1`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <div
         class="mm-box name-snap-account-page mm-box--padding-4"
@@ -105,6 +106,7 @@ exports[`create-named-snap-account confirmation matches snapshot 2`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <div
         class="mm-box name-snap-account-page mm-box--padding-4"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
@@ -7,6 +7,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <div
         class="mm-box create-snap-account-page mm-box--margin-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/error.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/error.test.js.snap
@@ -7,6 +7,7 @@ exports[`error template matches the snapshot 1`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <h2
         class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h2 typography--weight-normal typography--style-normal typography--color-text-default"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -7,6 +7,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <div
         class="mm-box remove-snap-account-page mm-box--margin-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
@@ -7,6 +7,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <div
         class="mm-box create-snap-account-page mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/success.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/success.test.js.snap
@@ -7,6 +7,7 @@ exports[`success template matches the snapshot 1`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <h2
         class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h2 typography--weight-normal typography--style-normal typography--color-text-default"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
@@ -7,6 +7,7 @@ exports[`switch-ethereum-chain confirmation should match snapshot 1`] = `
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <div
         class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--justify-content-center"
@@ -123,6 +124,7 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
   >
     <div
       class="mm-box confirmation-page__content mm-box--padding-top-0"
+      style="margin-top: 0px; overflow-y: auto;"
     >
       <div
         class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--justify-content-center"


### PR DESCRIPTION
## **Description**
New Snaps custom UI pages require UI/UX improvements that also require having sticky headers and footer within the confirmation popup. This PR makes sticky headers and footer, while content in the middle is now scrollable.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26853?quickstart=1)

## **Related issues**
Fixes:

## **Manual testing steps**
1. Do some actions that will trigger the confirmation popup to appear (Snap alert, Snap custom UI dialog, Account Snaps, Add network confirmation, etc.).
2. Make sure content is visible and headers + footers are sticky/fixed.
3. Make sure that there are no edge cases with UI glitches, etc.

## **Screenshots/Recordings**
### **Before**
![Screenshot 2024-09-03 at 13 05 03](https://github.com/user-attachments/assets/2d402fb1-f7ef-4df9-a067-939bcdcd97b9)
![Screenshot 2024-09-03 at 13 05 15](https://github.com/user-attachments/assets/cc01ae50-86dc-4d66-8c75-c28ab818aa95)
![Screenshot 2024-09-03 at 13 05 24](https://github.com/user-attachments/assets/26a9f459-def5-48db-b518-dbaafdb44c10)
![Screenshot 2024-09-03 at 13 05 34](https://github.com/user-attachments/assets/b5d4f237-abc4-461b-af64-ad71197a3eb1)

### **After**
![Screenshot 2024-09-03 at 12 45 29](https://github.com/user-attachments/assets/0aba0078-0b26-4d75-a64e-7aee8a3ca05d)
![Screenshot 2024-09-03 at 12 45 19](https://github.com/user-attachments/assets/e6bd2a8a-0bd7-42d3-98df-11ba6c98b8a9)
![Screenshot 2024-09-03 at 12 45 08](https://github.com/user-attachments/assets/36bd98c4-08a0-4141-b036-1482e887073c)
![Screenshot 2024-09-03 at 12 44 55](https://github.com/user-attachments/assets/ccf6dc9a-fdf1-497c-b563-c7c171f01275)
![Screenshot 2024-09-03 at 12 45 40](https://github.com/user-attachments/assets/d9d5ab1b-4287-496e-a9ed-db8bfd99ca03)
![Screenshot 2024-09-03 at 12 47 04](https://github.com/user-attachments/assets/2aed03d7-d0ff-4c5e-898d-182f69c52e38)
![Screenshot 2024-09-03 at 12 47 30](https://github.com/user-attachments/assets/482760b9-cda9-4932-8041-200de630d4df)
![Screenshot 2024-09-03 at 12 49 14](https://github.com/user-attachments/assets/95215267-89ef-46be-b793-201a37282ac3)

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
