### PR TITLE
fix: flaky test "Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Acc..." 

### DIFF
--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.js
@@ -67,8 +67,8 @@ describe('Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Accounts Tx', functio
         assert.deepStrictEqual(accountsBeforeConnect, '');
 
         // Reject the pending confirmation from the first dapp
-        await switchToNotificationWindow(driver, 4);
-        await driver.clickElement({ text: 'Reject', tag: 'button' });
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.clickElementAndWaitForWindowToClose({ text: 'Reject', tag: 'button' });
 
         // Wait for switch confirmation to close then request accounts confirmation to show for the second dapp
         await driver.delay(regularDelayMs);

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.js
@@ -10,7 +10,6 @@ const {
   regularDelayMs,
   WINDOW_TITLES,
   defaultGanacheOptions,
-  switchToNotificationWindow,
 } = require('../../helpers');
 
 describe('Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Accounts Tx', function () {
@@ -68,7 +67,10 @@ describe('Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Accounts Tx', functio
 
         // Reject the pending confirmation from the first dapp
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await driver.clickElementAndWaitForWindowToClose({ text: 'Reject', tag: 'button' });
+        await driver.clickElementAndWaitForWindowToClose({
+          text: 'Reject',
+          tag: 'button',
+        });
 
         // Wait for switch confirmation to close then request accounts confirmation to show for the second dapp
         await driver.delay(regularDelayMs);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR resolves flaky test for the dialog to be clicked before its been close by using the fix from PR #26449 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26872?quickstart=1)

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/26860

## **Manual testing steps**

Use the below commands to execute the test locally or in codespaces
yarn 
yarn build:test:webpack
ENABLE_MV3=false yarn test:e2e:single test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.js --browser=chrome

CI for the webpack has passed
https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/98563/workflows/66616cec-d428-4a58-b7b1-1399d92bd028/jobs/3668268/steps

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
