### PR TITLE
fix: Bug in calculating token value when number of decimals in token is large

### DIFF
--- a/shared/lib/swaps-utils.js
+++ b/shared/lib/swaps-utils.js
@@ -182,7 +182,7 @@ export const getBaseApi = function (type, chainId) {
 };
 
 export function calcTokenValue(value, decimals) {
-  const multiplier = Math.pow(10, Number(decimals || 0));
+  const multiplier = new BigNumber(10).pow(new BigNumber(decimals));
   return new BigNumber(String(value)).times(multiplier);
 }
 

--- a/shared/lib/swaps-utils.test.js
+++ b/shared/lib/swaps-utils.test.js
@@ -14,6 +14,7 @@ import {
   fetchTradesInfo,
   shouldEnableDirectWrapping,
   calculateMaxGasLimit,
+  calcTokenValue,
 } from './swaps-utils';
 
 jest.mock('./storage-helpers', () => ({
@@ -268,6 +269,15 @@ describe('Swaps Utils', () => {
         customMaxGas,
       );
       expect(result).toStrictEqual(expectedMaxGas);
+    });
+  });
+
+  describe('calcTokenValue', () => {
+    it('should be possible to calculate very big values', () => {
+      let result = calcTokenValue(1, 20);
+      expect(result.toString()).toStrictEqual('100000000000000000000');
+      result = calcTokenValue(1, 30);
+      expect(result.toString()).toStrictEqual('1e+30');
     });
   });
 });


### PR DESCRIPTION
## **Description**
Approving when token has large number of decimals should not throw error.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26734

## **Manual testing steps**

1. Go to https://holesky.etherscan.io/address/0x0982857bc518873b8a28700fb149d80f08d08f2b#writeContract
2. Aprove some tokens

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/8ed008b9-cd3e-4df5-a541-4c71c61750e6

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
