### PR TITLE
STX Timer bug cherrypick 12.3

### DIFF
--- a/app/scripts/controllers/swaps/index.ts
+++ b/app/scripts/controllers/swaps/index.ts
@@ -937,6 +937,7 @@ export default class SwapsController extends BaseController<
       stxBatchStatus: refreshRates.stxBatchStatus * 1000,
       stxStatusDeadline: refreshRates.stxStatusDeadline,
       stxMaxFeeMultiplier: parameters.stxMaxFeeMultiplier,
+      swapsStxStatusDeadline: parameters.stxStatusDeadline,
     };
   }
 
@@ -1063,6 +1064,7 @@ export default class SwapsController extends BaseController<
       stxBatchStatus: number;
       stxStatusDeadline: number;
       stxMaxFeeMultiplier: number;
+      swapsStxStatusDeadline: number;
     } | null = null;
 
     try {
@@ -1085,7 +1087,7 @@ export default class SwapsController extends BaseController<
         swapsNetworkConfig?.stxMaxFeeMultiplier ||
         FALLBACK_SMART_TRANSACTIONS_MAX_FEE_MULTIPLIER;
       _state.swapsState.swapsStxStatusDeadline =
-        swapsNetworkConfig?.stxStatusDeadline ||
+        swapsNetworkConfig?.swapsStxStatusDeadline ||
         FALLBACK_SMART_TRANSACTIONS_DEADLINE;
     });
   }

--- a/app/scripts/controllers/swaps/swaps.test.ts
+++ b/app/scripts/controllers/swaps/swaps.test.ts
@@ -1171,6 +1171,7 @@ describe('SwapsController', function () {
         const swapsQuotePrefetchingRefreshTime = 0;
         const swapsStxBatchStatusRefreshTime = 0;
         const swapsStxGetTransactionsRefreshTime = 0;
+        const swapsStxStatusDeadline = 0;
         swapsController.__test__updateState({
           swapsState: {
             ...swapsController.state.swapsState,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue where the STX status screen for a swap was showing a 0:00 for the timer. It is a cherrypick of https://github.com/MetaMask/metamask-extension/pull/25779 into v12.3.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/25779?quickstart=1)

## **Related issues**

Related to: https://github.com/MetaMask/metamask-extension/pull/25063/

## **Manual testing steps**

1. Make sure Smart Transactions is on (Settings > Advanced)
2. Do a Swap
3. Observe that timer is not 0:00 and is a reasonable number

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/MetaMask/metamask-extension/assets/139582705/26fe6167-614f-4771-b35b-10803bc23fc0



### **After**

<!-- [screenshots/recordings] -->

https://github.com/MetaMask/metamask-extension/assets/139582705/d92b933d-1011-48b4-bf04-344f275d35db



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
