### PR TITLE
CherryPick: "fix: issue where `wallet_addEtherumChain` was incorrectly enforcing inclusion of a blockExplorerUrls property which is not required (#26938)"

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
@@ -120,6 +120,35 @@ describe('addEthereumChainHandler', () => {
       expect(mocks.setActiveNetwork).toHaveBeenCalledWith(123);
     });
 
+    it('creates a new networkConfiguration when called without "blockExplorerUrls" property', async () => {
+      const mocks = makeMocks({
+        permissionsFeatureFlagIsActive: false,
+      });
+      await addEthereumChainHandler(
+        {
+          origin: 'example.com',
+          params: [
+            {
+              chainId: CHAIN_IDS.OPTIMISM,
+              chainName: 'Optimism Mainnet',
+              rpcUrls: ['https://optimism.llamarpc.com'],
+              nativeCurrency: {
+                symbol: 'ETH',
+                decimals: 18,
+              },
+              iconUrls: ['https://optimism.icon.com'],
+            },
+          ],
+        },
+        {},
+        jest.fn(),
+        jest.fn(),
+        mocks,
+      );
+      expect(mocks.upsertNetworkConfiguration).toHaveBeenCalledTimes(1);
+      expect(mocks.setActiveNetwork).toHaveBeenCalledTimes(1);
+    });
+
     describe('if a networkConfiguration for the given chainId already exists', () => {
       it('creates a new network configuration for the given chainid and switches to it if proposed networkConfiguration has a different rpcUrl from all existing networkConfigurations', async () => {
         const mocks = makeMocks({

--- a/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js
@@ -119,22 +119,15 @@ export function validateAddEthereumChainParams(params, end) {
   };
 
   const firstValidRPCUrl = rpcUrls.find((rpcUrl) => isLocalhostOrHttps(rpcUrl));
-  const firstValidBlockExplorerUrl =
-    blockExplorerUrls !== null && Array.isArray(blockExplorerUrls)
-      ? blockExplorerUrls.find((blockExplorerUrl) =>
-          isLocalhostOrHttps(blockExplorerUrl),
-        )
-      : null;
+  const firstValidBlockExplorerUrl = Array.isArray(blockExplorerUrls)
+    ? blockExplorerUrls.find((blockExplorerUrl) =>
+        isLocalhostOrHttps(blockExplorerUrl),
+      )
+    : null;
 
   if (!firstValidRPCUrl) {
     throw ethErrors.rpc.invalidParams({
       message: `Expected an array with at least one valid string HTTPS url 'rpcUrls', Received:\n${rpcUrls}`,
-    });
-  }
-
-  if (blockExplorerUrls !== null && !firstValidBlockExplorerUrl) {
-    throw ethErrors.rpc.invalidParams({
-      message: `Expected null or array with at least one valid string HTTPS URL 'blockExplorerUrl'. Received: ${blockExplorerUrls}`,
     });
   }
 


### PR DESCRIPTION
Fix issue where `wallet_addEtherumChain` was incorrectly enforcing inclusion of a blockExplorerUrls property which is not required

## **Description**

[![Open in GitHub
Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26938?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26844

## **Manual testing steps**

1. Go to https://protect.flashbots.net/summary?fast=true
2. Click "Add to Metamask"
3. You should see the add network confirmation and be able to add the network configuration successfully to the wallet

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/5c5718b5-f5e7-4499-9393-307bbe5c4eaa


### **After**


https://github.com/user-attachments/assets/14d1b1aa-f2d8-4133-9056-064d7875379a


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26944?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
