### PR TITLE
fix: update input raw locator in account watcher e2e to use element ID

### DIFF
--- a/test/e2e/accounts/create-watch-account.spec.ts
+++ b/test/e2e/accounts/create-watch-account.spec.ts
@@ -46,10 +46,7 @@ async function watchEoaAddress(
   address: string = EOA_ADDRESS,
 ): Promise<void> {
   await startCreateWatchAccountFlow(driver, unlockWalletFirst);
-  await driver.fill(
-    '[placeholder="Enter a public address or ENS name"]',
-    address,
-  );
+  await driver.fill('input#address-input[type="text"]', address);
   await driver.clickElement({ text: 'Watch account', tag: 'button' });
   await driver.clickElement('[data-testid="submit-add-account-with-name"]');
 }
@@ -188,10 +185,7 @@ describe('Account-watcher snap', function (this: Suite) {
           async ({ driver }: { driver: Driver }) => {
             await startCreateWatchAccountFlow(driver);
 
-            await driver.fill(
-              '[placeholder="Enter a public address or ENS name"]',
-              input,
-            );
+            await driver.fill('input#address-input[type="text"]', input);
             await driver.clickElement({ text: 'Watch account', tag: 'button' });
 
             // error message should be displayed by the snap


### PR DESCRIPTION
## **Description**
This PR addresses the issue of flaky account watcher tests on develop. I updated the input selector used in these tests to be more reliable, moving away from using the placeholder text as a locator since the placeholder text may vary depending on the network and using `'input#address-input[type="text"]'`. This change should improve the stability of our test suite and reduce the occurrence of false negatives in our CI pipeline.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26950?quickstart=1)

## **Related issues**
Fixes: https://github.com/MetaMask/accounts-planning/issues/584#issue-2508418003

## **Manual testing steps**
1. Build for test `yarn build:test` or `yarn build:test:fask`
2. Run the test suite

- Chrome: `yarn test:e2e:single test/e2e/accounts/create-watch-account.spec.ts --browser=chrome --leave-running`
- Firefox: `yarn test:e2e:single test/e2e/accounts/create-watch-account.spec.ts --browser=firefox --leave-running`

4. Verify that the tests pass consistently across multiple runs
5. Check that the new selector correctly identifies the input field in different browser environments

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**
- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.