### PR TITLE
fix: add secondary sources for from/to network chain id

### DIFF
--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -436,7 +436,7 @@ export default function ConfirmationPage({
 
     const toNetwork =
       pendingConfirmation?.requestData?.toNetworkConfiguration?.chainId ||
-      pendingConfirmations?.[0]?.requestData?.chainId;
+      pendingConfirmation?.requestData?.chainId;
 
     if (fromNetwork && toNetwork) {
       trackEvent({

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -30,6 +30,7 @@ import {
   getApprovalFlows,
   getTotalUnapprovedCount,
   useSafeChainsListValidationSelector,
+  getCurrentNetwork,
   getSnapsMetadata,
 } from '../../../selectors';
 import NetworkDisplay from '../../../components/app/network-display/network-display';
@@ -247,6 +248,8 @@ export default function ConfirmationPage({
 
   const snapsMetadata = useSelector(getSnapsMetadata);
 
+  const { chainId } = useSelector(getCurrentNetwork);
+
   const name = snapsMetadata[pendingConfirmation?.origin]?.name;
 
   const SNAP_DIALOG_TYPE = Object.values(DIALOG_APPROVAL_TYPES);
@@ -427,19 +430,22 @@ export default function ConfirmationPage({
   const handleSubmit = async () => {
     setLoading(true);
 
-    if (
-      pendingConfirmation?.requestData?.fromNetworkConfiguration?.chainId &&
-      pendingConfirmation?.requestData?.toNetworkConfiguration?.chainId
-    ) {
+    const fromNetwork =
+      pendingConfirmation?.requestData?.fromNetworkConfiguration?.chainId ||
+      chainId;
+
+    const toNetwork =
+      pendingConfirmation?.requestData?.toNetworkConfiguration?.chainId ||
+      pendingConfirmations?.[0]?.requestData?.chainId;
+
+    if (fromNetwork && toNetwork) {
       trackEvent({
         category: MetaMetricsEventCategory.Network,
         event: MetaMetricsEventName.NavNetworkSwitched,
         properties: {
           location: 'Switch Modal',
-          from_network:
-            pendingConfirmation.requestData.fromNetworkConfiguration.chainId,
-          to_network:
-            pendingConfirmation.requestData.toNetworkConfiguration.chainId,
+          from_network: fromNetwork,
+          to_network: toNetwork,
           referrer: {
             url: window.location.origin,
           },

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -436,7 +436,8 @@ export default function ConfirmationPage({
 
     const toNetwork =
       pendingConfirmation?.requestData?.toNetworkConfiguration?.chainId ||
-      pendingConfirmation?.requestData?.chainId;
+      pendingConfirmation?.requestData?.chainId ||
+      pendingConfirmation?.chainID;
 
     if (fromNetwork && toNetwork) {
       trackEvent({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes tracking of the confirmation modal. In the case that `pendingConfirmation` does not have the from/to chainID value, then we get the information from a secondary source (getCurrentNetwork for the "for" and pendingConfirmations for the "to")

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26957?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2863

## **Manual testing steps**

1. Go to pancakeswap
2. Trigger a network switch
3. Check that the trackEvent (handleSubmit method) of confirmation.js is being triggered

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
