### PR TITLE
fix: add isUnlocked Check for Metamask Notifications

### DIFF
--- a/ui/contexts/metamask-notifications/metamask-notifications.tsx
+++ b/ui/contexts/metamask-notifications/metamask-notifications.tsx
@@ -5,6 +5,7 @@ import { useListNotifications } from '../../hooks/metamask-notifications/useNoti
 import { selectIsProfileSyncingEnabled } from '../../selectors/metamask-notifications/profile-syncing';
 import { selectIsMetamaskNotificationsEnabled } from '../../selectors/metamask-notifications/metamask-notifications';
 import { getUseExternalServices } from '../../selectors';
+import { getIsUnlocked } from '../../ducks/metamask/metamask';
 
 type Notification = NotificationServicesController.Types.INotification;
 
@@ -35,7 +36,7 @@ export const MetamaskNotificationsProvider: React.FC = ({ children }) => {
     selectIsMetamaskNotificationsEnabled,
   );
   const basicFunctionality = useSelector(getUseExternalServices);
-
+  const isUnlocked = useSelector(getIsUnlocked);
   const { listNotifications, notificationsData, isLoading, error } =
     useListNotifications();
 
@@ -45,10 +46,15 @@ export const MetamaskNotificationsProvider: React.FC = ({ children }) => {
   );
 
   useEffect(() => {
-    if (basicFunctionality && shouldFetchNotifications) {
+    if (basicFunctionality && shouldFetchNotifications && isUnlocked) {
       listNotifications();
     }
-  }, [shouldFetchNotifications, listNotifications, basicFunctionality]);
+  }, [
+    shouldFetchNotifications,
+    listNotifications,
+    basicFunctionality,
+    isUnlocked,
+  ]);
 
   return (
     <MetamaskNotificationsContext.Provider


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces an additional check to verify if Metamask is unlocked before attempting to fetch notifications. This change enhances the security and reliability of the notification system.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26960?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

- Verify that notifications are fetched only when Metamask is unlocked

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
