### PR TITLE
chore: Remove Snaps from LavaMoat policy CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 *                                    @MetaMask/extension-devs
 development/                         @MetaMask/extension-devs @kumavis
-lavamoat/                            @MetaMask/extension-devs @MetaMask/supply-chain @MetaMask/snaps-devs
+lavamoat/                            @MetaMask/extension-devs @MetaMask/supply-chain
 
 # The offscreen.ts script file that is included in the offscreen document html
 # file is responsible, at present, for loading the snaps execution environment


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

Removes Snaps from teams that have code ownership of `lavamoat/`. This was required at one point, but is not required anymore and is causing more confusion than necessary. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26962?quickstart=1)

