### PR TITLE
fix: confirmation screen with in expanded extension view

### DIFF
--- a/ui/pages/confirmations/confirm/index.scss
+++ b/ui/pages/confirmations/confirm/index.scss
@@ -4,6 +4,6 @@
   box-shadow: var(--shadow-size-lg) var(--color-shadow-default);
 
   @media screen and (min-width: design-system.$break-small) {
-    max-width: 62%;
+    max-width: 360px;
   }
 }


### PR DESCRIPTION
## **Description**

Fix width of confirmation pages in expanded view.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26937

## **Manual testing steps**

1. Go to test dapp
2. Submit signature
3. Open signature in expanded view - it should have small page width

## **Screenshots/Recordings**
<img width="1018" alt="Screenshot 2024-09-06 at 5 03 29 PM" src="https://github.com/user-attachments/assets/9e0b605f-55e2-41e7-9a22-bbd99f975416">

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
