### PR TITLE
chore: Adding generic type to useConfirmContext hook

### DIFF
--- a/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.tsx
+++ b/ui/components/institutional/signature-mismatch-banner/signature-mismatch-banner.tsx
@@ -17,9 +17,7 @@ import { BannerAlert } from '../../component-library';
 
 const MMISignatureMismatchBanner: React.FC = memo(() => {
   const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const allAccounts = useSelector(accountsWithSendEtherInfoSelector);
 

--- a/ui/pages/confirmations/components/confirm/info/approve/approve.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/approve.tsx
@@ -41,9 +41,8 @@ import { useIsNFT } from './hooks/use-is-nft';
 const ApproveStaticSimulation = () => {
   const t = useI18nContext();
 
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   const { decimals } = useAssetDetails(
     transactionMeta.txParams.to,
@@ -121,9 +120,8 @@ const SpendingCapGroup = ({
 }) => {
   const t = useI18nContext();
 
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   const { tokenAmount, formattedTokenNum, value } = useApproveTokenSimulation(
     transactionMeta,
@@ -171,9 +169,8 @@ const SpendingCapGroup = ({
 const SpendingCap = () => {
   const t = useI18nContext();
 
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   const { userBalance, tokenSymbol, decimals } = useAssetDetails(
     transactionMeta.txParams.to,
@@ -209,9 +206,8 @@ const SpendingCap = () => {
 };
 
 const ApproveInfo = () => {
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,

--- a/ui/pages/confirmations/components/confirm/info/approve/hooks/use-received-token.ts
+++ b/ui/pages/confirmations/components/confirm/info/approve/hooks/use-received-token.ts
@@ -18,9 +18,8 @@ export type TokenWithBalance = {
 };
 
 export const useReceivedToken = () => {
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   const selectedAccount = useSelector(getSelectedAccount);
 

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.tsx
@@ -11,9 +11,8 @@ import { GasFeesSection } from '../shared/gas-fees-section/gas-fees-section';
 import { TransactionDetails } from '../shared/transaction-details/transaction-details';
 
 const BaseTransactionInfo = () => {
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.ts
@@ -12,9 +12,7 @@ import { useConfirmContext } from '../../../../context/confirm';
 export function useDecodedTransactionData(): AsyncResult<
   DecodedTransactionDataResponse | undefined
 > {
-  const { currentConfirmation } = useConfirmContext() as unknown as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const chainId = currentConfirmation?.chainId as Hex;
   const contractAddress = currentConfirmation?.txParams?.to as Hex;

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
@@ -23,9 +23,7 @@ import { SIWESignInfo } from './siwe-sign';
 
 const PersonalSignInfo: React.FC = () => {
   const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
   const useTransactionSimulations = useSelector(
     selectUseTransactionSimulations,
   );

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/siwe-sign/siwe-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/siwe-sign/siwe-sign.tsx
@@ -15,9 +15,7 @@ import { useConfirmContext } from '../../../../../context/confirm';
 
 const SIWESignInfo: React.FC = () => {
   const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
 
   const siweMessage = currentConfirmation?.msgParams?.siwe?.parsedMessage;
 

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -33,9 +33,8 @@ export const EditGasFeesRow = ({
   const { useNativeCurrencyAsPrimaryCurrency: isNativeCurrencyUsed } =
     useSelector(getPreferences);
 
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   return (
     <ConfirmInfoAlertRow

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
@@ -27,9 +27,8 @@ export const GasFeesDetails = ({
 }) => {
   const t = useI18nContext();
 
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   const { maxFeePerGas, maxPriorityFeePerGas } =
     useEIP1559TxFees(transactionMeta);

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/gas-fees-section.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/gas-fees-section.tsx
@@ -24,9 +24,8 @@ const LegacyTransactionGasModal = ({
 };
 
 export const GasFeesSection = () => {
-  const { currentConfirmation: transactionMeta } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta;
-  };
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
 
   const [showCustomizeGasPopover, setShowCustomizeGasPopover] = useState(false);
   const closeCustomizeGasPopover = useCallback(

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
@@ -29,9 +29,7 @@ import { UniswapPathPool } from '../../../../../../../../app/scripts/lib/transac
 import { useConfirmContext } from '../../../../../context/confirm';
 
 export const TransactionData = () => {
-  const { currentConfirmation } = useConfirmContext() as unknown as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const transactionData = currentConfirmation?.txParams?.data as Hex;
   const decodeResponse = useDecodedTransactionData();

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
@@ -20,9 +20,7 @@ import { useFourByte } from '../../hooks/useFourByte';
 export const OriginRow = () => {
   const t = useI18nContext();
 
-  const { currentConfirmation } = useConfirmContext() as unknown as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const origin = currentConfirmation?.origin;
 
@@ -45,10 +43,7 @@ export const OriginRow = () => {
 
 export const RecipientRow = () => {
   const t = useI18nContext();
-
-  const { currentConfirmation } = useConfirmContext() as unknown as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   if (
     !currentConfirmation?.txParams?.to ||
@@ -70,11 +65,7 @@ export const RecipientRow = () => {
 
 export const MethodDataRow = () => {
   const t = useI18nContext();
-
-  const { currentConfirmation } = useConfirmContext() as unknown as {
-    currentConfirmation: TransactionMeta;
-  };
-
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const methodData = useFourByte(currentConfirmation);
 
   if (!methodData) {
@@ -94,10 +85,7 @@ export const MethodDataRow = () => {
 
 const PaymasterRow = () => {
   const t = useI18nContext();
-
-  const { currentConfirmation } = useConfirmContext() as unknown as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const { id: userOperationId } = currentConfirmation ?? {};
   const isUserOperation = Boolean(currentConfirmation?.isUserOperation);

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/typed-sign-v1.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/typed-sign-v1.tsx
@@ -17,9 +17,7 @@ import { ConfirmInfoSection } from '../../../../../../components/app/confirm/inf
 
 const TypedSignV1Info: React.FC = () => {
   const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
 
   if (!(currentConfirmation as SignatureRequestType)?.msgParams) {
     return null;

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/permit-simulation.tsx
@@ -39,10 +39,7 @@ function extractTokenDetailsByPrimaryType(
 
 const PermitSimulation: React.FC<object> = () => {
   const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
-
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
   const msgData = currentConfirmation.msgParams?.data;
   const {
     domain: { verifyingContract },

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
@@ -26,9 +26,7 @@ import { PermitSimulation } from './permit-simulation';
 
 const TypedSignInfo: React.FC = () => {
   const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
   const useTransactionSimulations = useSelector(
     selectUseTransactionSimulations,
   );

--- a/ui/pages/confirmations/components/confirm/signature-message/signature-message.tsx
+++ b/ui/pages/confirmations/components/confirm/signature-message/signature-message.tsx
@@ -12,9 +12,7 @@ import { useConfirmContext } from '../../../context/confirm';
 
 const SignatureMessage: React.FC = memo(() => {
   const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
 
   if (!currentConfirmation?.msgParams?.data) {
     return null;

--- a/ui/pages/confirmations/context/confirm/index.tsx
+++ b/ui/pages/confirmations/context/confirm/index.tsx
@@ -25,7 +25,7 @@ export const ConfirmContextProvider: React.FC<{
   );
 };
 
-export const useConfirmContext = <T,>() => {
+export const useConfirmContext = <T = Confirmation,>() => {
   const context = useContext(ConfirmContext);
   if (!context) {
     throw new Error(

--- a/ui/pages/confirmations/context/confirm/index.tsx
+++ b/ui/pages/confirmations/context/confirm/index.tsx
@@ -25,12 +25,12 @@ export const ConfirmContextProvider: React.FC<{
   );
 };
 
-export const useConfirmContext = () => {
+export const useConfirmContext = <T,>() => {
   const context = useContext(ConfirmContext);
   if (!context) {
     throw new Error(
       'useConfirmContext must be used within an ConfirmContextProvider',
     );
   }
-  return context;
+  return context as { currentConfirmation: T };
 };

--- a/ui/pages/confirmations/hooks/alerts/signatures/useAccountMismatchAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/signatures/useAccountMismatchAlerts.ts
@@ -15,6 +15,7 @@ import { useConfirmContext } from '../../../context/confirm';
 export default function useAccountMismatchAlerts(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
+
   const { from: fromAddress } = getConfirmationSender(currentConfirmation);
   const isSIWE = isSIWESignatureRequest(currentConfirmation);
   const siweParsedAddress =

--- a/ui/pages/confirmations/hooks/alerts/signatures/useAccountMismatchAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/signatures/useAccountMismatchAlerts.ts
@@ -14,12 +14,8 @@ import { useConfirmContext } from '../../../context/confirm';
  */
 export default function useAccountMismatchAlerts(): Alert[] {
   const t = useI18nContext();
-
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
   const { from: fromAddress } = getConfirmationSender(currentConfirmation);
-
   const isSIWE = isSIWESignatureRequest(currentConfirmation);
   const siweParsedAddress =
     currentConfirmation?.msgParams?.siwe?.parsedMessage?.address;

--- a/ui/pages/confirmations/hooks/alerts/signatures/useDomainMismatchAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/signatures/useDomainMismatchAlerts.ts
@@ -15,12 +15,9 @@ import { useConfirmContext } from '../../../context/confirm';
 
 export default function useDomainMismatchAlerts(): Alert[] {
   const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
 
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
   const { msgParams } = currentConfirmation || {};
-
   const isSIWE = isSIWESignatureRequest(currentConfirmation);
   const isInvalidSIWEDomain =
     isSIWE && !isValidSIWEOrigin(msgParams as WrappedSIWERequest);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useGasEstimateFailedAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useGasEstimateFailedAlerts.ts
@@ -11,10 +11,7 @@ import { useConfirmContext } from '../../../context/confirm';
 
 export function useGasEstimateFailedAlerts(): Alert[] {
   const t = useI18nContext();
-
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const estimationFailed = Boolean(currentConfirmation?.simulationFails);
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useGasTooLowAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useGasTooLowAlerts.ts
@@ -13,10 +13,7 @@ import { useConfirmContext } from '../../../context/confirm';
 
 export function useGasTooLowAlerts(): Alert[] {
   const t = useI18nContext();
-
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const gas = currentConfirmation?.txParams?.gas;
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNetworkBusyAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNetworkBusyAlerts.ts
@@ -10,11 +10,7 @@ import { useConfirmContext } from '../../../context/confirm';
 
 export function useNetworkBusyAlerts(): Alert[] {
   const t = useI18nContext();
-
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
-
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const isNetworkBusy = useSelector((state) =>
     getIsNetworkBusyByChainId(state, currentConfirmation?.chainId),
   );

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNoGasPriceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNoGasPriceAlerts.ts
@@ -19,10 +19,7 @@ import { useConfirmContext } from '../../../context/confirm';
 export function useNoGasPriceAlerts(): Alert[] {
   const t = useI18nContext();
   const isNoGasPriceFetched = useSelector(getNoGasPriceFetched);
-
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: TransactionMeta | undefined;
-  };
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const isNotCustomGasPrice =
     currentConfirmation?.userFeeLevel &&

--- a/ui/pages/confirmations/hooks/useLedgerConnection.ts
+++ b/ui/pages/confirmations/hooks/useLedgerConnection.ts
@@ -22,9 +22,7 @@ import { useConfirmContext } from '../context/confirm';
 
 const useLedgerConnection = () => {
   const dispatch = useDispatch();
-  const { currentConfirmation } = useConfirmContext() as {
-    currentConfirmation: SignatureRequestType;
-  };
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
   const ledgerTransportType = useSelector(getLedgerTransportType);
   const transportStatus = useSelector(getLedgerTransportStatus);
   const webHidConnectedStatus = useSelector(getLedgerWebHidConnectedStatus);


### PR DESCRIPTION
## **Description**

Code cleanup by adding generic type to useConfirmContext hook

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26989

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
