### PR TITLE
fix: Fix flakey E2E Request Queue Switch Send Tests

### DIFF
--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -135,6 +135,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         // Wait for switch confirmation to close then tx confirmation to show.
         await driver.waitUntilXWindowHandles(3);
+        await driver.delay(regularDelayMs);
 
         await switchToNotificationWindow(driver, 4);
 
@@ -289,6 +290,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         // Wait for switch confirmation to close then tx confirmation to show.
         await driver.waitUntilXWindowHandles(3);
+        await driver.delay(regularDelayMs);
 
         await switchToNotificationWindow(driver, 4);
 

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -12,7 +12,7 @@ const {
 } = require('../../helpers');
 
 describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
-  it.only('should queue send tx after switch network confirmation and transaction should target the correct network after switch is confirmed', async function () {
+  it('should queue send tx after switch network confirmation and transaction should target the correct network after switch is confirmed', async function () {
     const port = 8546;
     const chainId = 1338;
     await withFixtures(
@@ -167,7 +167,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     );
   });
 
-  it.only('should queue send tx after switch network confirmation and transaction should target the correct network after switch is cancelled.', async function () {
+  it('should queue send tx after switch network confirmation and transaction should target the correct network after switch is cancelled.', async function () {
     const port = 8546;
     const chainId = 1338;
     await withFixtures(

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -12,7 +12,7 @@ const {
 } = require('../../helpers');
 
 describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
-  it('should queue send tx after switch network confirmation and transaction should target the correct network after switch is confirmed', async function () {
+  it.only('should queue send tx after switch network confirmation and transaction should target the correct network after switch is confirmed', async function () {
     const port = 8546;
     const chainId = 1338;
     await withFixtures(
@@ -166,7 +166,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     );
   });
 
-  it('should queue send tx after switch network confirmation and transaction should target the correct network after switch is cancelled.', async function () {
+  it.only('should queue send tx after switch network confirmation and transaction should target the correct network after switch is cancelled.', async function () {
     const port = 8546;
     const chainId = 1338;
     await withFixtures(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes Request Queue Switch then Send tests that have been flakey in CI. Adds a regular delay after the switch confirmation is handled in order to ensure the confirmation popup that follows afterwards is rendered.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/26995?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26472

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
