### PR TITLE
fix: flaky test `'Import NFT should continue to display an imported NFT after importing, adding a new account, and switching back`

### DIFF
--- a/test/e2e/tests/tokens/nft/import-nft.spec.js
+++ b/test/e2e/tests/tokens/nft/import-nft.spec.js
@@ -82,7 +82,7 @@ describe('Import NFT', function () {
         // Enter a valid NFT that belongs to user and check success message appears
         await driver.fill('#address', contractAddress);
         await driver.fill('#token-id', '1');
-        await driver.clickElement(
+        await driver.clickElementAndWaitToDisappear(
           '[data-testid="import-nfts-modal-import-button"]',
         );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In this test, we are importing an NFT and right after, we try to switch accounts. Sometimes, when we try to click into the Account, we get an error that another element is obscuring it. 
To fix it, when we click confirm, for importing the NFT, we'll wait until the element disappears, after proceeding to clicking the Account.

`ElementClickInterceptedError: Element <button class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-base--ellipsis multichain-account-picker mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--gap-2 mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"> is not clickable at point (576,112) because another element <div class="mm-box mm-box--display-flex mm-box--justify-content-space-between mm-box--align-items-flex-end"> obscures it`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27006?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27005

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
See how the NFT modal is the element obscuring the Account menu, with the selector `<div class="mm-box mm-box--display-flex mm-box--justify-content-space-between mm-box--align-items-flex-end">`

![Screenshot from 2024-09-10 08-07-07](https://github.com/user-attachments/assets/0595e501-03f0-413b-8622-6a098b934724)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
