### PR TITLE
fix: flaky test `Test Snap Signature Insights tests Signature Insights functionality (Legacy)`

### DIFF
--- a/test/e2e/snaps/test-snap-siginsights.spec.js
+++ b/test/e2e/snaps/test-snap-siginsights.spec.js
@@ -353,7 +353,12 @@ describe('Test Snap Signature Insights', function () {
           tag: 'p',
         });
 
-        // click checkbox to authorize signing
+        // wait for host to render and click checkbox to authorize signing
+        await driver.waitForSelector({
+          text: '127.0.0.1:8080',
+          tag: 'span',
+        });
+
         await driver.clickElement('.mm-checkbox__input-wrapper');
 
         // click sign button
@@ -391,7 +396,12 @@ describe('Test Snap Signature Insights', function () {
           tag: 'p',
         });
 
-        // click checkbox to authorize signing
+        // wait for host to render and click checkbox to authorize signing
+        await driver.waitForSelector({
+          text: '127.0.0.1:8080',
+          tag: 'span',
+        });
+
         await driver.clickElement('.mm-checkbox__input-wrapper');
 
         // click sign button
@@ -433,7 +443,12 @@ describe('Test Snap Signature Insights', function () {
           tag: 'p',
         });
 
-        // click checkbox to authorize signing
+        // wait for host to render and click checkbox to authorize signing
+        await driver.waitForSelector({
+          text: '127.0.0.1:8080',
+          tag: 'span',
+        });
+
         await driver.clickElement('.mm-checkbox__input-wrapper');
 
         // click sign button
@@ -475,7 +490,12 @@ describe('Test Snap Signature Insights', function () {
           tag: 'p',
         });
 
-        // click checkbox to authorize signing
+        // wait for host to render and click checkbox to authorize signing
+        await driver.waitForSelector({
+          text: '127.0.0.1:8080',
+          tag: 'span',
+        });
+
         await driver.clickElement('.mm-checkbox__input-wrapper');
 
         // click sign button


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
On the snap signature insights test, we trigger a signature and once we try to Sign, a security modal appears, where we need to click the checkbox and then Sign, in order to proceed with the signature.

The problem is that in some occasions, after clicking the checkbox, the Sign button remains disabled, as the checkbox appears unchecked (see artifacts below).
It seems that in these occasions, the component is re-rendered **after** clicking checkbox, leaving it in an unchecked state. We already check for the signature content to be loaded right before clicking, so the other element that can take a bit to load and cause this race condition is the host value, that is displayed in the checkbox text `127.0.0.1:8080`. 
So for preventing this, we wait for the host to be loaded in the component and then proceed with clicking the checkbox.

![Screenshot from 2024-09-10 09-09-18](https://github.com/user-attachments/assets/a81f311f-8133-41a9-82ac-9527d3cc5c0d)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27007?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26762

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
See how, in the logs above, the checkbox was successfully clicked, however, in the picture we can see how the checkbox is unchecked due to a re-render after the click.

![image](https://github.com/user-attachments/assets/ef2d9061-71f6-4b22-b6d4-e1406c7803e9)


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
