### PR TITLE
fix: flaky test `Change assets changes to native currency when switching accounts during a NFT send`

### DIFF
--- a/test/e2e/tests/transaction/change-assets.spec.js
+++ b/test/e2e/tests/transaction/change-assets.spec.js
@@ -1,9 +1,8 @@
 const { strict: assert } = require('assert');
 const {
   defaultGanacheOptions,
-  logInWithBalanceValidation,
-  veryLargeDelayMs,
   withFixtures,
+  logInWithBalanceValidation,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 const { SMART_CONTRACTS } = require('../../seeder/smart-contracts');
@@ -344,10 +343,10 @@ describe('Change assets', function () {
         // Make sure gas is updated by resetting amount and hex data
         // Note: this is needed until the race condition is fixed on the wallet level (issue #25243)
         await driver.fill('[data-testid="currency-input"]', '2');
-        await driver.delay(veryLargeDelayMs);
+        await driver.delay(1000);
         await hexDataLocator.fill('0x');
         await hexDataLocator.fill('');
-        await driver.delay(veryLargeDelayMs);
+        await driver.delay(1000);
 
         // Go to the last confirmation screen
         await driver.clickElement({ text: 'Continue', css: 'button' });

--- a/test/e2e/tests/transaction/change-assets.spec.js
+++ b/test/e2e/tests/transaction/change-assets.spec.js
@@ -343,6 +343,7 @@ describe('Change assets', function () {
         // Make sure gas is updated by resetting amount and hex data
         // Note: this is needed until the race condition is fixed on the wallet level (issue #25243)
         await driver.fill('[data-testid="currency-input"]', '2');
+        await driver.delay(3000);
         await hexDataLocator.fill('0x');
         await hexDataLocator.fill('');
 

--- a/test/e2e/tests/transaction/change-assets.spec.js
+++ b/test/e2e/tests/transaction/change-assets.spec.js
@@ -1,8 +1,9 @@
 const { strict: assert } = require('assert');
 const {
   defaultGanacheOptions,
-  withFixtures,
   logInWithBalanceValidation,
+  veryLargeDelayMs,
+  withFixtures,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 const { SMART_CONTRACTS } = require('../../seeder/smart-contracts');
@@ -343,9 +344,10 @@ describe('Change assets', function () {
         // Make sure gas is updated by resetting amount and hex data
         // Note: this is needed until the race condition is fixed on the wallet level (issue #25243)
         await driver.fill('[data-testid="currency-input"]', '2');
-        await driver.delay(3000);
+        await driver.delay(veryLargeDelayMs);
         await hexDataLocator.fill('0x');
         await hexDataLocator.fill('');
+        await driver.delay(veryLargeDelayMs);
 
         // Go to the last confirmation screen
         await driver.clickElement({ text: 'Continue', css: 'button' });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27014?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
