### PR TITLE
fix: flaky test `BTC Account - Overview has portfolio button enabled for BTC accounts`

### DIFF
--- a/test/e2e/flask/btc/btc-account-overview.spec.ts
+++ b/test/e2e/flask/btc/btc-account-overview.spec.ts
@@ -30,15 +30,15 @@ describe('BTC Account - Overview', function (this: Suite) {
           css: '[disabled]',
         });
 
-        const buySellButton = await driver.waitForSelector(
+        // buy sell button
+        await driver.findClickableElement(
           '[data-testid="coin-overview-buy"]',
         );
-        assert.equal(await buySellButton.isEnabled(), true);
 
-        const portfolioButton = await driver.waitForSelector(
+        // portfolio button
+        await driver.findClickableElement(
           '[data-testid="coin-overview-receive"]',
         );
-        assert.equal(await portfolioButton.isEnabled(), true);
       },
     );
   });

--- a/test/e2e/flask/btc/btc-account-overview.spec.ts
+++ b/test/e2e/flask/btc/btc-account-overview.spec.ts
@@ -1,4 +1,3 @@
-import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
 import { withBtcAccountSnap } from './common-btc';
 
@@ -31,9 +30,7 @@ describe('BTC Account - Overview', function (this: Suite) {
         });
 
         // buy sell button
-        await driver.findClickableElement(
-          '[data-testid="coin-overview-buy"]',
-        );
+        await driver.findClickableElement('[data-testid="coin-overview-buy"]');
 
         // portfolio button
         await driver.findClickableElement(

--- a/test/e2e/flask/btc/btc-account-overview.spec.ts
+++ b/test/e2e/flask/btc/btc-account-overview.spec.ts
@@ -32,7 +32,7 @@ describe('BTC Account - Overview', function (this: Suite) {
         // buy sell button
         await driver.findClickableElement('[data-testid="coin-overview-buy"]');
 
-        // portfolio button
+        // receive button
         await driver.findClickableElement(
           '[data-testid="coin-overview-receive"]',
         );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The way the last 2 assertions are constructed are an anti-pattern, that give place to a race condition, where we wait for the selector to appear, but we don't wait for it to be enabled, so it can happen that when we do the assertion, the button is not yet enabled.

```
const buySellButton = await driver.waitForSelector(
  '[data-testid="coin-overview-buy"]',
);
assert.equal(await buySellButton.isEnabled(), true);

const portfolioButton = await driver.waitForSelector(
  '[data-testid="coin-overview-receive"]',
);
assert.equal(await portfolioButton.isEnabled(), true);
```
![Screenshot from 2024-09-10 11-48-09](https://github.com/user-attachments/assets/70672d6c-5f05-47ea-aaf9-5561131ebf25)


To fix this, we need to directly wait for the element to be enabled (`findClickableElement`).


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27017?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27018

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
See how the element Buy is present and it's already enabled but when the assertion took place, the button was still disabled.

![image](https://github.com/user-attachments/assets/5c97c1a6-2fcf-4697-bdec-6e3dadb9cf24)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
