### PR TITLE
fix: flaky test `Navigate transactions should reject and remove all unapproved transactions`

### DIFF
--- a/test/e2e/tests/transaction/navigate-transactions.spec.js
+++ b/test/e2e/tests/transaction/navigate-transactions.spec.js
@@ -239,11 +239,12 @@ describe('Navigate transactions', function () {
       async ({ driver, ganacheServer }) => {
         await unlockWallet(driver);
 
-        // Wait until total amount is loaded to mitigate flakiness on reject
+        // Wait until total amount and gas timing is loaded to mitigate flakiness on reject
         await driver.findElement({
           tag: 'span',
           text: '3.0000315',
         });
+        await driver.findElement('[data-testid="gas-timing-time"]');
 
         // reject transactions
         await driver.clickElement({ text: 'Reject 4', tag: 'a' });

--- a/test/e2e/tests/transaction/navigate-transactions.spec.js
+++ b/test/e2e/tests/transaction/navigate-transactions.spec.js
@@ -239,12 +239,19 @@ describe('Navigate transactions', function () {
       async ({ driver, ganacheServer }) => {
         await unlockWallet(driver);
 
-        // Wait until total amount and gas timing is loaded to mitigate flakiness on reject
+        // Wait until the confirmation screen is stabilized to mitigate flakiness on reject:
+        // 1. Total amount is loaded
         await driver.findElement({
           tag: 'span',
           text: '3.0000315',
         });
+        // 2. Gas timing is loaded
         await driver.findElement('[data-testid="gas-timing-time"]');
+        // 3. Insufficient funds warning is not present
+        await driver.assertElementNotPresent({
+          text: 'You do not have enough ETH',
+          tag: 'p',
+        });
 
         // reject transactions
         await driver.clickElement({ text: 'Reject 4', tag: 'a' });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In the Navigate transactions test, we inject 4 transactions using fixtures, and then try to Reject them all.
The problem is that the confirmation screen takes some time to fully load. If there is a case where we click the Reject 4 button, before the page is loaded, it could be that there is a re-render, and the click doesn't take effect. See logs, how the Reject 4 click happened, but then it cannot find the Reject all, since the modal doesn't appear:

![Screenshot from 2024-09-10 16-15-27](https://github.com/user-attachments/assets/d41c0e7f-278a-43de-ab87-4bf7d8c9aead)


Specifically there are 3 items that require a couple of seconds:
- Total amount
- Gas
- Load balance so the lack of funds warning disappears

In this [PR](https://github.com/MetaMask/metamask-extension/pull/25312) the first case was fixed and mitigated most of the flakiness, but there's still a small chance to happen the last 2 cases.

In this PR, we add guards for the last 2 components, in order to wait for the confirmation page to be fully loaded before clicking Reject.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27028?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27031

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
![image](https://github.com/user-attachments/assets/6f1d6841-7087-47f5-80ab-279e4c658da0)


https://github.com/user-attachments/assets/46934e9a-8159-4062-9ec2-274ad0e9ad7d



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
