### PR TITLE
fix: Add a second id to ignore for the GHSA-9wv6-86v2-598j

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -52,6 +52,7 @@ npmAuditIgnoreAdvisories:
   # by an external / malicious actor. Meanwhile, once we update to v6+,
   # path-to-regexp will no longer be used.
   - 1099499
+  - 1099514
 
   # Temp fix for https://github.com/MetaMask/metamask-extension/pull/16920 for the sake of 11.7.1 hotfix
   # This will be removed in this ticket https://github.com/MetaMask/metamask-extension/issues/22299


### PR DESCRIPTION
## **Description**

Follow up to https://github.com/MetaMask/metamask-extension/pull/27024. Since that was merged, an update was made to https://github.com/MetaMask/metamask-extension/pull/27024, and so the yarn audit warning now has a new id, which we need to include in the `npmAuditIgnoreAdvisories` config.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27041?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
