### PR TITLE
chore: Enable import attributes in Webpack build

### DIFF
--- a/development/webpack/test/loaders.swcLoader.test.ts
+++ b/development/webpack/test/loaders.swcLoader.test.ts
@@ -121,6 +121,7 @@ describe('swcLoader', () => {
         assert.deepStrictEqual(loader.options.jsc.parser, {
           syntax,
           [syntax === 'typescript' ? 'tsx' : 'jsx']: enableJsx,
+          importAttributes: true,
         });
         assert.deepStrictEqual(loader.options.jsc.transform.react, {
           development: isDevelopment,

--- a/development/webpack/utils/loaders/swcLoader.ts
+++ b/development/webpack/utils/loaders/swcLoader.ts
@@ -110,6 +110,12 @@ const schema = {
                   default: false,
                   type: 'boolean',
                 },
+                importAttributes: {
+                  description:
+                    'Enable parsing of import attributes. Defaults to `false`.',
+                  type: 'boolean',
+                  default: false,
+                },
               },
               additionalProperties: false,
               required: ['syntax'],
@@ -122,6 +128,12 @@ const schema = {
                 jsx: {
                   default: false,
                   type: 'boolean',
+                },
+                importAttributes: {
+                  description:
+                    'Enable parsing of import attributes. Defaults to `false`.',
+                  type: 'boolean',
+                  default: false,
                 },
               },
               additionalProperties: false,
@@ -201,6 +213,7 @@ export function getSwcLoader(
         parser: {
           syntax,
           [syntax === 'typescript' ? 'tsx' : 'jsx']: enableJsx,
+          importAttributes: true
         },
       },
     } as const satisfies SwcLoaderOptions,

--- a/development/webpack/utils/loaders/swcLoader.ts
+++ b/development/webpack/utils/loaders/swcLoader.ts
@@ -213,7 +213,7 @@ export function getSwcLoader(
         parser: {
           syntax,
           [syntax === 'typescript' ? 'tsx' : 'jsx']: enableJsx,
-          importAttributes: true
+          importAttributes: true,
         },
       },
     } as const satisfies SwcLoaderOptions,


### PR DESCRIPTION
## **Description**

This updates the settings for the SWC Webpack loader to allow parsing import attributes, which is required for ESM.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27080?quickstart=1)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
