### PR TITLE
feat(snaps): Map new `center` attribute to `Box` snap custom UI component

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/box.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/box.ts
@@ -2,6 +2,7 @@ import { BoxElement, JSXElement, BoxProps } from '@metamask/snaps-sdk/jsx';
 import { getJsxChildren } from '@metamask/snaps-utils';
 import { NonEmptyArray } from '@metamask/utils';
 import {
+  AlignItems,
   Display,
   FlexDirection,
   JustifyContent,
@@ -45,6 +46,7 @@ export const box: UIComponentFactory<BoxElement> = ({
         ? FlexDirection.Row
         : FlexDirection.Column,
     justifyContent: generateJustifyContent(element.props.alignment),
+    alignItems: element.props.center && AlignItems.center,
     className: 'snap-ui-renderer__panel',
     color: TextColor.textDefault,
   },


### PR DESCRIPTION
## **Description**

This PR adds the new `center` attribute to the `Box` component. It allows to apply `align-items: center` to it.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27106?quickstart=1)

## **Related issues**


## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
