### PR TITLE
Default RPCs: Autofocus Network, RPC, and Block Explorer form fields

### DIFF
--- a/ui/components/multichain/network-list-menu/add-block-explorer-modal/add-block-explorer-modal.tsx
+++ b/ui/components/multichain/network-list-menu/add-block-explorer-modal/add-block-explorer-modal.tsx
@@ -60,6 +60,7 @@ const AddBlockExplorerModal = ({
             variant: TextVariant.bodyMdMedium,
           }}
           onChange={(e) => setUrl(e.target.value)}
+          autoFocus
         />
         {error && (
           <HelpText severity={HelpTextSeverity.Danger}>{error}</HelpText>

--- a/ui/components/multichain/network-list-menu/add-rpc-url-modal/__snapshots__/add-rpc-url-modal.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/add-rpc-url-modal/__snapshots__/add-rpc-url-modal.test.tsx.snap
@@ -18,13 +18,13 @@ exports[`AddRpcUrlModal should render correctly 1`] = `
           rpcUrl
         </label>
         <div
-          class="mm-box mm-text-field mm-text-field--size-lg mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box mm-text-field mm-text-field--size-lg mm-text-field--focused mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
         >
           <input
             autocomplete="off"
             class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
             data-testid="rpc-url-input-test"
-            focused="false"
+            focused="true"
             id="rpcUrl"
             placeholder="enterRpcUrl"
             type="text"

--- a/ui/components/multichain/network-list-menu/add-rpc-url-modal/add-rpc-url-modal.tsx
+++ b/ui/components/multichain/network-list-menu/add-rpc-url-modal/add-rpc-url-modal.tsx
@@ -63,6 +63,7 @@ const AddRpcUrlModal = ({
             'data-testid': 'rpc-url-input-test',
           }}
           onChange={(e) => setUrl(e.target.value)}
+          autoFocus
         />
         {error && (
           <HelpText severity={HelpTextSeverity.Danger}>{error}</HelpText>

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
@@ -331,6 +331,7 @@ export const NetworksForm = ({
           size={FormTextFieldSize.Lg}
           placeholder={t('enterNetworkName')}
           data-testid="network-form-name-input"
+          autoFocus
           helpText={
             ((name && warnings?.name?.msg) || suggestedName) && (
               <>
@@ -339,7 +340,7 @@ export const NetworksForm = ({
                     variant={TextVariant.bodySm}
                     severity={HelpTextSeverity.Warning}
                   >
-                    {warnings?.name?.msg}
+                    {warnings.name.msg}
                   </HelpText>
                 )}
 


### PR DESCRIPTION

## **Description**

To improve UX, we should autofocus the first form field in the Networks form flows .

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27145?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Click the three-dot menu next to any network in the network menu
2. Click "Edit"
3. See the first form field with cursor focus
4. Click to add a RPC or Block Explorer
5. See the first form field with cursor focus

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
