### PR TITLE
fix: remove cancel swap smart transaction button

### DIFF
--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -263,8 +263,9 @@ export default function SmartTransactionStatusPage() {
     );
   }
 
-  const showCancelSwapLink =
-    latestSmartTransaction.cancellable && !cancelSwapLinkClicked;
+  // Keeping this code in here since swaps will be cancel-able, but hardcoding to false since they currently are not
+  const showCancelSwapLink = false;
+  // latestSmartTransaction.cancellable && !cancelSwapLinkClicked;
 
   const CancelSwap = () => {
     return (

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.test.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.test.js
@@ -147,20 +147,34 @@ describe('SmartTransactionStatusLabel', () => {
     expect(getByText('Close')).toBeInTheDocument();
   });
 
-  it('cancels a transaction', () => {
+  // Commenting this out; cancels are currently not working so the button is being temporarily removed
+  // it('cancels a transaction', () => {
+  //   const store = configureMockStore(middleware)(createSwapsMockStore());
+  //   const { getByText } = renderWithProvider(
+  //     <SmartTransactionStatusLabel />,
+  //     store,
+  //   );
+  //   expect(getByText('Publicly submitting your Swap...')).toBeInTheDocument();
+  //   const cancelLink = getByText('Attempt to cancel swap for free');
+  //   expect(cancelLink).toBeInTheDocument();
+  //   fireEvent.click(cancelLink);
+  //   expect(
+  //     getByText('Trying to cancel your transaction...'),
+  //   ).toBeInTheDocument();
+  //   expect(cancelLink).not.toBeInTheDocument();
+  // });
+
+  // When cancels are re-introduced, we can delete this test
+  it('does not show the user a button to cancel their transaction', () => {
     const store = configureMockStore(middleware)(createSwapsMockStore());
-    const { getByText } = renderWithProvider(
+    const { getByText, queryByText } = renderWithProvider(
       <SmartTransactionStatusLabel />,
       store,
     );
     expect(getByText('Publicly submitting your Swap...')).toBeInTheDocument();
-    const cancelLink = getByText('Attempt to cancel swap for free');
-    expect(cancelLink).toBeInTheDocument();
-    fireEvent.click(cancelLink);
     expect(
-      getByText('Trying to cancel your transaction...'),
-    ).toBeInTheDocument();
-    expect(cancelLink).not.toBeInTheDocument();
+      queryByText('Attempt to cancel swap for free'),
+    ).not.toBeInTheDocument();
   });
 
   it('clicks on the Close button', () => {


### PR DESCRIPTION
## **Description**

Removes the smart swaps "Cancel" button because the endpoint to cancel is consistently responding with a 500. Keeps the cancel-related code, however, because the cancel functionality is expected to be fixed at some point.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27148?quickstart=1)


## **Manual testing steps**
1. Enable smart transactions
2. Go to mainnet
3. Do a swap
4. Observe that the link to cancel the transaction no longer apepars

## **Screenshots/Recordings**

### **Before**

<img width="311" alt="Screenshot 2024-09-13 at 1 44 19 PM" src="https://github.com/user-attachments/assets/cc6c455e-bd5f-4b53-9700-0d8b702df857">


### **After**

<img width="345" alt="Screenshot 2024-09-13 at 1 45 24 PM" src="https://github.com/user-attachments/assets/a7d0c15e-44be-4cd1-b894-6966e1d7e307">


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
