### PR TITLE
fix: flaky test `Simulation Details displays generic error message`

### DIFF
--- a/test/e2e/tests/simulation-details/mock-request-error-malformed-transaction.ts
+++ b/test/e2e/tests/simulation-details/mock-request-error-malformed-transaction.ts
@@ -11,7 +11,6 @@ export const MALFORMED_TRANSACTION_MOCK = {
 
 export const MALFORMED_TRANSACTION_REQUEST_MOCK: MockRequestResponse = {
   request: {
-    id: '21',
     jsonrpc: '2.0',
     method: 'infura_simulateTransactions',
     params: [

--- a/test/e2e/tests/simulation-details/simulation-details.spec.ts
+++ b/test/e2e/tests/simulation-details/simulation-details.spec.ts
@@ -261,7 +261,7 @@ describe('Simulation Details', () => {
     );
   });
 
-  it.only('displays generic error message', async function (this: Mocha.Context) {
+  it('displays generic error message', async function (this: Mocha.Context) {
     const mockRequests = async (mockServer: MockttpServer) => {
       await mockRequest(mockServer, MALFORMED_TRANSACTION_REQUEST_MOCK);
     };
@@ -271,7 +271,6 @@ describe('Simulation Details', () => {
         mockRequests,
       },
       async ({ driver }) => {
-        await driver.delay(15000)
         await createDappTransaction(driver, MALFORMED_TRANSACTION_MOCK);
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
@@ -279,8 +278,6 @@ describe('Simulation Details', () => {
           css: '[data-testid="simulation-details-layout"]',
           text: 'There was an error loading your estimation',
         });
-
-        await driver.delay(90000);
       },
     );
   });

--- a/test/e2e/tests/simulation-details/simulation-details.spec.ts
+++ b/test/e2e/tests/simulation-details/simulation-details.spec.ts
@@ -120,7 +120,7 @@ export async function mockRequest(
 ) {
   await server
     .forPost(TX_SENTINEL_URL)
-    .withJsonBody(request)
+    .withJsonBodyIncluding(request)
     .thenJson(200, response);
 }
 
@@ -261,7 +261,7 @@ describe('Simulation Details', () => {
     );
   });
 
-  it('displays generic error message', async function (this: Mocha.Context) {
+  it.only('displays generic error message', async function (this: Mocha.Context) {
     const mockRequests = async (mockServer: MockttpServer) => {
       await mockRequest(mockServer, MALFORMED_TRANSACTION_REQUEST_MOCK);
     };
@@ -271,6 +271,7 @@ describe('Simulation Details', () => {
         mockRequests,
       },
       async ({ driver }) => {
+        await driver.delay(15000)
         await createDappTransaction(driver, MALFORMED_TRANSACTION_MOCK);
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
@@ -278,6 +279,8 @@ describe('Simulation Details', () => {
           css: '[data-testid="simulation-details-layout"]',
           text: 'There was an error loading your estimation',
         });
+
+        await driver.delay(90000);
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This test didn't have the mock correctly implemented, making the request take long, thus sometimes failing the test.
The problem is that in the mock, it sets an `id` of `21`however this value is not always the one used in the request.
Since we cannot know which id is going to use, we can omit this param and just match the rest of the request body.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27156?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27157

## **Manual testing steps**

1. Check ci
2. Run test locally `yarn test:e2e:single test/e2e/tests/simulation-details/simulation-details.spec.ts --browser=chrome --leave-running=true`

## **Screenshots/Recordings**
See how the request has an id of `0` so it won't be mocked

https://github.com/user-attachments/assets/9ed0567f-bc4f-45b6-ba06-ad781202ac74




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
