### PR TITLE
feat(snaps): Added support for form property in Snap footer buttons

### DIFF
--- a/ui/components/app/snaps/snap-footer-button/snap-footer-button.tsx
+++ b/ui/components/app/snaps/snap-footer-button/snap-footer-button.tsx
@@ -1,6 +1,15 @@
 import React, { FunctionComponent, MouseEvent as ReactMouseEvent } from 'react';
-import { ButtonVariant, UserInputEventType } from '@metamask/snaps-sdk';
-import { Button, ButtonSize, IconSize } from '../../../component-library';
+import {
+  ButtonType,
+  ButtonVariant,
+  UserInputEventType,
+} from '@metamask/snaps-sdk';
+import {
+  Button,
+  ButtonLinkProps,
+  ButtonSize,
+  IconSize,
+} from '../../../component-library';
 import {
   AlignItems,
   Display,
@@ -15,17 +24,23 @@ type SnapFooterButtonProps = {
   onCancel?: () => void;
 };
 
-export const SnapFooterButton: FunctionComponent<SnapFooterButtonProps> = ({
+export const SnapFooterButton: FunctionComponent<
+  SnapFooterButtonProps & ButtonLinkProps<'button'>
+> = ({
   onCancel,
   name,
   children,
   isSnapAction = false,
+  type,
+  form,
   ...props
 }) => {
   const { handleEvent, snapId } = useSnapInterfaceContext();
 
   const handleSnapAction = (event: ReactMouseEvent<HTMLElement>) => {
-    event.preventDefault();
+    if (type === ButtonType.Button) {
+      event.preventDefault();
+    }
 
     handleEvent({
       event: UserInputEventType.ButtonClickEvent,
@@ -38,6 +53,8 @@ export const SnapFooterButton: FunctionComponent<SnapFooterButtonProps> = ({
   return (
     <Button
       className="snap-footer-button"
+      type={type}
+      form={form}
       {...props}
       size={ButtonSize.Lg}
       block

--- a/ui/components/app/snaps/snap-ui-renderer/components/button.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/button.ts
@@ -11,6 +11,7 @@ export const button: UIComponentFactory<ButtonElement> = ({
   element: 'SnapUIButton',
   props: {
     type: element.props.type,
+    form: element.props.form,
     variant: element.props.variant,
     name: element.props.name,
     disabled: element.props.disabled,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds changes required to enable Snaps' footer buttons to submit and reset forms.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27158?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/2691

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
