### PR TITLE
fix: selector getKnownMethodData should return empty object if user has opted out for using 4Byte Resolution

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useFourByte.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFourByte.test.ts
@@ -34,7 +34,7 @@ describe('useFourByte', () => {
     expect(result.current.params).toEqual([]);
   });
 
-  it('returns undefined if resolution is turned off', () => {
+  it('returns empty object if resolution is turned off', () => {
     const currentConfirmation = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
       txData: depositHexData,
@@ -54,7 +54,7 @@ describe('useFourByte', () => {
       },
     );
 
-    expect(result.current).toBeUndefined();
+    expect(result.current).toEqual({});
   });
 
   it("returns undefined if it's not known even if resolution is enabled", () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFourByte.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFourByte.test.ts
@@ -75,6 +75,6 @@ describe('useFourByte', () => {
       },
     );
 
-    expect(result.current).toBeUndefined();
+    expect(result.current).toEqual({});
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useKnownMethodDataInTransaction.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useKnownMethodDataInTransaction.test.ts
@@ -34,7 +34,7 @@ describe('useFourByte', () => {
     expect(result.current.params).toEqual([]);
   });
 
-  it('returns undefined if resolution is turned off', () => {
+  it('returns rmpty object if resolution is turned off', () => {
     const currentConfirmation = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
       txData: depositHexData,
@@ -54,7 +54,7 @@ describe('useFourByte', () => {
       },
     );
 
-    expect(result.current).toBeUndefined();
+    expect(result.current).toEqual({});
   });
 
   it("returns undefined if it's not known even if resolution is enabled", () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useKnownMethodDataInTransaction.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useKnownMethodDataInTransaction.test.ts
@@ -75,6 +75,6 @@ describe('useFourByte', () => {
       },
     );
 
-    expect(result.current).toBeUndefined();
+    expect(result.current).toEqual({});
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useKnownMethodDataInTransaction.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useKnownMethodDataInTransaction.test.ts
@@ -34,7 +34,7 @@ describe('useFourByte', () => {
     expect(result.current.params).toEqual([]);
   });
 
-  it('returns rmpty object if resolution is turned off', () => {
+  it('returns empty object if resolution is turned off', () => {
     const currentConfirmation = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
       txData: depositHexData,

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
@@ -68,7 +68,7 @@ export const MethodDataRow = () => {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const methodData = useFourByte(currentConfirmation);
 
-  if (!methodData) {
+  if (!methodData?.name) {
     return null;
   }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1262,7 +1262,7 @@ export function getKnownMethodData(state, data) {
   const fourBytePrefix = prefixedData.slice(0, 10);
   const { knownMethodData, use4ByteResolution } = state.metamask;
   // If 4byte setting is off, we do not want to return the knownMethodData
-  return use4ByteResolution ? knownMethodData?.[fourBytePrefix] : {};
+  return use4ByteResolution ? knownMethodData?.[fourBytePrefix] ?? {} : {};
 }
 
 export function getFeatureFlags(state) {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1262,7 +1262,7 @@ export function getKnownMethodData(state, data) {
   const fourBytePrefix = prefixedData.slice(0, 10);
   const { knownMethodData, use4ByteResolution } = state.metamask;
   // If 4byte setting is off, we do not want to return the knownMethodData
-  return use4ByteResolution ? knownMethodData?.[fourBytePrefix] : undefined;
+  return use4ByteResolution ? knownMethodData?.[fourBytePrefix] : {};
 }
 
 export function getFeatureFlags(state) {


### PR DESCRIPTION
## **Description**
If user has toggled off **Decode smart contracts** setting he is not able to approve ERC20. This is regression introduced recently.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27188

## **Manual testing steps**

1. Toggle off setting "Decode smart contracts"
2. Try to approve an ERC 20 
3. It should not throw error

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/7f0fd8f9-3d97-4f4b-8e99-c694445ad929


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
