### PR TITLE
fix: Allow to re-submit a cancelled swap if cancelled via a HW wallet

### DIFF
--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -1029,6 +1029,7 @@ export const signAndSendSwapsSmartTransaction = ({
       dispatch(setSwapsSTXSubmitLoading(false));
     } catch (e) {
       console.log('signAndSendSwapsSmartTransaction error', e);
+      dispatch(setSwapsSTXSubmitLoading(false));
       const {
         swaps: { isFeatureFlagLoaded },
       } = getState();

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -973,7 +973,6 @@ export const signAndSendSwapsSmartTransaction = ({
       );
       if (!fees) {
         log.error('"fetchSwapsSmartTransactionFees" failed');
-        dispatch(setSwapsSTXSubmitLoading(false));
         dispatch(setCurrentSmartTransactionsError(StxErrorTypes.unavailable));
         return;
       }
@@ -1026,10 +1025,8 @@ export const signAndSendSwapsSmartTransaction = ({
         );
       }
       history.push(SMART_TRANSACTION_STATUS_ROUTE);
-      dispatch(setSwapsSTXSubmitLoading(false));
     } catch (e) {
       console.log('signAndSendSwapsSmartTransaction error', e);
-      dispatch(setSwapsSTXSubmitLoading(false));
       const {
         swaps: { isFeatureFlagLoaded },
       } = getState();
@@ -1037,6 +1034,8 @@ export const signAndSendSwapsSmartTransaction = ({
         const errorObj = parseSmartTransactionsError(e.message);
         dispatch(setCurrentSmartTransactionsError(errorObj?.error));
       }
+    } finally {
+      dispatch(setSwapsSTXSubmitLoading(false));
     }
   };
 };

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -963,17 +963,19 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   }, [dispatch, trackViewQuotePageLoadedEvent, reviewSwapClickedTimestamp]);
 
   useEffect(() => {
-    // if smart transaction error is turned off, reset submit clicked boolean
     if (
-      !currentSmartTransactionsEnabled &&
-      currentSmartTransactionsError &&
-      submitClicked
+      (!currentSmartTransactionsEnabled &&
+        currentSmartTransactionsError &&
+        submitClicked) ||
+      (isSmartTransaction && !swapsSTXLoading && submitClicked)
     ) {
       setSubmitClicked(false);
     }
   }, [
     currentSmartTransactionsEnabled,
     currentSmartTransactionsError,
+    isSmartTransaction,
+    swapsSTXLoading,
     submitClicked,
   ]);
 


### PR DESCRIPTION
## **Description**
This PR is a partial cherry pick of [this one](https://github.com/MetaMask/metamask-extension/pull/26251) and fixes an edge case for [this PR](https://github.com/MetaMask/metamask-extension/pull/25742), where when a swap was cancelled on a HW device, the submit button for swaps was disabled. Now a user can resubmit cancelled swaps repeatedly. 

It was already fixed [here](https://github.com/MetaMask/metamask-extension/pull/26251) about a month ago, but it's not in the v12.3.0 release. That's why this partial cherry-pick is needed.

## **Manual testing steps**

1. Go to Swaps with a HW wallet on Ethereum Mainnet and Smart Transactions enabled in Advanced Settings
2. Submit a swap, but cancel it on a HW device
3. You should see the quote overview page again and the `Swap` button should be enabled

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
