### PR TITLE
docs: edit reviewer checklist

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -44,6 +44,8 @@ Fixes:
 - [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
 - [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
 
+_Each reviewer should include the following checklist in review feedbacks:_
+
 ## **Pre-merge reviewer checklist**
 
 - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Each PR includes the "Pre-merge reviewer checklist", but it almost never gets used by reviewers. Also, it carries some intrinsic problems:
- The template doesn't _support_ multiple reviewers explicitly
- Checkmarks left by a reviewer tend to become stale when the author pushes new commits, which would give a false indication since the reviewer would have to go through another review cycle. This is probably worse than leaving the checklist unchecked
- The PR author implicitly loses ownership of the main PR comment, since reviewers are supposed to edit it

With this PR I would like to propose an alternative solution, with reviewers including the Pre-merge reviewer checklist in the review feedback comment ([See example](https://github.com/MetaMask/metamask-extension/pull/26880#pullrequestreview-2299908008)). This would have these advantages:
- Multiple reviewers _supported out of the box_, because each reviewer writes its own checklist
- Gives the opportunity to reviewers to leave multiple feedbacks along the review cycle, with potentially different test outcomes: this makes even more sense if the checklist should also detail what exactly has been tested
- It makes easy to see the last commit tested by the reviewer and infer whether the checklist may still be valid after additional commits
- It leaves the ownership of the main PR comment to the author
- If a reviewer includes a checklist, chances are that other reviewers will do that as well

I believe this should translate in an additional explicit instruction in the PR template, but I'm not sure how to phrase it. I'd love to hear your thoughts!

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27217?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
