### PR TITLE
fix: fix percentage change for non standard currencies

### DIFF
--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.test.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.test.tsx
@@ -98,4 +98,14 @@ describe('PercentageChange Component', () => {
     expect(percentageElement).toBeInTheDocument();
     expect(numberElement).toBeInTheDocument();
   });
+
+  it('should not error with non standard currency code', () => {
+    mockGetSelectedAccountCachedBalance.mockReturnValue('0x0');
+    mockGetCurrentCurrency.mockReturnValue('DASH');
+    render(<PercentageAndAmountChange value={-1.234} />);
+    const percentageElement = screen.getByText('(+0.00%)');
+    const numberElement = screen.getByText('+0.00');
+    expect(percentageElement).toBeInTheDocument();
+    expect(numberElement).toBeInTheDocument();
+  });
 });

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
@@ -138,6 +138,7 @@ export const PercentageAndAmountChange = ({
       // Non-standard Currency Codes
       formattedValuePrice += `${Intl.NumberFormat(locale, {
         ...options,
+        minimumFractionDigits: 2,
         style: 'decimal',
       }).format(balanceChange as number)} `;
     }

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
@@ -117,15 +117,31 @@ export const PercentageAndAmountChange = ({
 
   const formattedValue = formatValue(balanceChange === 0 ? 0 : value, true);
 
-  const formattedValuePrice = isValidAmount(balanceChange)
-    ? `${(balanceChange as number) >= 0 ? '+' : ''}${Intl.NumberFormat(locale, {
-        notation: 'compact',
-        compactDisplay: 'short',
+  let formattedValuePrice = '';
+  if (isValidAmount(balanceChange)) {
+    formattedValuePrice = (balanceChange as number) >= 0 ? '+' : '';
+
+    const options = {
+      notation: 'compact',
+      compactDisplay: 'short',
+      maximumFractionDigits: 2,
+    } as const;
+
+    try {
+      // For currencies compliant with ISO 4217 Standard
+      formattedValuePrice += `${Intl.NumberFormat(locale, {
+        ...options,
         style: 'currency',
         currency: fiatCurrency,
-        maximumFractionDigits: 2,
-      }).format(balanceChange as number)} `
-    : '';
+      }).format(balanceChange as number)} `;
+    } catch {
+      // Non-standard Currency Codes
+      formattedValuePrice += `${Intl.NumberFormat(locale, {
+        ...options,
+        style: 'decimal',
+      }).format(balanceChange as number)} `;
+    }
+  }
 
   return renderPercentageWithNumber(formattedValue, formattedValuePrice, color);
 };


### PR DESCRIPTION
## **Description**

PR that fixes error when users choose a currency that is non standard currency code.

```
Reproduction steps:
Open the Settings > General menu
Change the Currency Conversion setting to DASH
Click outside of the extension window to close it, then reopen the extension
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27239?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Settings > General menu
2. Change the Currency Conversion setting to DASH
3. Go back to home page; and you should not see an error

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/431ad277-6d6c-405d-9554-e3769629cca2


<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/248f2da7-be4e-442d-85a6-3ca271009c9e
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
