### PR TITLE
fix: "Warning: Invalid argument supplied to oneOfType"

### DIFF
--- a/ui/components/multichain/ramps-card/ramps-card.js
+++ b/ui/components/multichain/ramps-card/ramps-card.js
@@ -147,5 +147,5 @@ export const RampsCard = ({ variant, handleOnClick }) => {
 
 RampsCard.propTypes = {
   variant: PropTypes.oneOf(Object.values(RAMPS_CARD_VARIANT_TYPES)),
-  handleOnClick: PropTypes.oneOfType([PropTypes.func, PropTypes.undefined]),
+  handleOnClick: PropTypes.func,
 };


### PR DESCRIPTION
## **Description**

Fixes this Warning introduced in #26426:

```
ramps-card.js:150 Warning: Invalid argument supplied to oneOfType. Expected an array of check functions, but received undefined at index 1.
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27267?quickstart=1)

## **Related issues**

Fixes: #26426

## **Manual testing steps**
## **Screenshots/Recordings**
### **Before**
### **After**
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
