### PR TITLE
ci: make git-diff-develop work for PRs from foreign repos 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,11 +118,9 @@ workflows:
       - prep-deps
       - get-changed-files-with-git-diff:
           filters:
-              branches:
-                ignore:
-                  - master
-          requires:
-            - prep-deps
+            branches:
+              ignore:
+                - master
       - test-deps-audit:
           requires:
             - prep-deps
@@ -500,7 +498,6 @@ jobs:
       - run: sudo corepack enable
       - attach_workspace:
           at: .
-      - gh/install
       - run:
           name: Get changed files with git diff
           command: npx tsx .circleci/scripts/git-diff-develop.ts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,11 +360,10 @@ workflows:
         value: << pipeline.git.branch >>
     jobs:
       - prep-deps
-      - get-changed-files-with-git-diff:
-          requires:
-            - prep-deps
+      - get-changed-files-with-git-diff
       - validate-locales-only:
           requires:
+            - prep-deps
             - get-changed-files-with-git-diff
       - test-lint:
           requires:

--- a/.circleci/scripts/git-diff-develop.ts
+++ b/.circleci/scripts/git-diff-develop.ts
@@ -14,16 +14,12 @@ const MAIN_BRANCH = 'develop';
  * @returns The name of the branch targeted by the PR.
  */
 async function getBaseRef(): Promise<string | null> {
-  if (!process.env.CIRCLE_PULL_REQUEST) {
+  if (!process.env.CIRCLE_PR_NUMBER) {
     return null;
   }
 
-  // We're referencing the CIRCLE_PULL_REQUEST environment variable within the script rather than
-  // passing it in because this makes it easier to use Bash parameter expansion to extract the
-  // PR number from the URL.
-  const result = await exec(`gh pr view --json baseRefName "\${CIRCLE_PULL_REQUEST##*/}" --jq '.baseRefName'`);
-  const baseRef = result.stdout.trim();
-  return baseRef;
+  const pull = await (await fetch(`https://api.github.com/repos/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PR_REPONAME}/pulls/${process.env.CIRCLE_PR_NUMBER}`)).json();
+  return pull.base.ref;
 }
 
 /**

--- a/.circleci/scripts/git-diff-develop.ts
+++ b/.circleci/scripts/git-diff-develop.ts
@@ -1,4 +1,3 @@
-import { hasProperty } from '@metamask/utils';
 import { exec as execCallback } from 'child_process';
 import fs from 'fs';
 import path from 'path';
@@ -57,7 +56,8 @@ async function fetchUntilMergeBaseFound() {
     } catch (error: unknown) {
       if (
         error instanceof Error &&
-        hasProperty(error, 'code') &&
+        Object.hasOwnProperty.call(error, 'code') &&
+        // @ts-expect-error
         error.code === 1
       ) {
         console.error(`Error 'no merge base' encountered with depth ${depth}. Incrementing depth...`);

--- a/.circleci/scripts/git-diff-develop.ts
+++ b/.circleci/scripts/git-diff-develop.ts
@@ -18,7 +18,11 @@ async function getBaseRef(): Promise<string | null> {
     return null;
   }
 
-  const pull = await (await fetch(`https://api.github.com/repos/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PR_REPONAME}/pulls/${process.env.CIRCLE_PR_NUMBER}`)).json();
+  const pull = await (
+    await fetch(
+      `https://api.github.com/repos/${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PR_REPONAME}/pulls/${process.env.CIRCLE_PR_NUMBER}`,
+    )
+  ).json();
   return pull.base.ref;
 }
 
@@ -31,7 +35,9 @@ async function getBaseRef(): Promise<string | null> {
 async function fetchWithDepth(depth: number): Promise<boolean> {
   try {
     await exec(`git fetch --depth ${depth} origin ${MAIN_BRANCH}`);
-    await exec(`git fetch --depth ${depth} origin ${SOURCE_BRANCH}:${SOURCE_BRANCH}`);
+    await exec(
+      `git fetch --depth ${depth} origin ${SOURCE_BRANCH}:${SOURCE_BRANCH}`,
+    );
     return true;
   } catch (error: unknown) {
     console.error(`Failed to fetch with depth ${depth}:`, error);
@@ -61,7 +67,9 @@ async function fetchUntilMergeBaseFound() {
         // @ts-expect-error
         error.code === 1
       ) {
-        console.error(`Error 'no merge base' encountered with depth ${depth}. Incrementing depth...`);
+        console.error(
+          `Error 'no merge base' encountered with depth ${depth}. Incrementing depth...`,
+        );
       } else {
         throw error;
       }
@@ -79,9 +87,11 @@ async function fetchUntilMergeBaseFound() {
  */
 async function gitDiff(): Promise<string> {
   await fetchUntilMergeBaseFound();
-  const { stdout: diffResult } = await exec(`git diff --name-only origin/HEAD...${SOURCE_BRANCH}`);
+  const { stdout: diffResult } = await exec(
+    `git diff --name-only origin/HEAD...${SOURCE_BRANCH}`,
+  );
   if (!diffResult) {
-      throw new Error('Unable to get diff after full checkout.');
+    throw new Error('Unable to get diff after full checkout.');
   }
   return diffResult;
 }
@@ -99,22 +109,24 @@ async function storeGitDiffOutput() {
     const outputDir = 'changed-files';
     fs.mkdirSync(outputDir, { recursive: true });
 
-    console.log(`Determining whether this run is for a PR targetting ${MAIN_BRANCH}`)
+    console.log(
+      `Determining whether this run is for a PR targetting ${MAIN_BRANCH}`,
+    );
     if (!process.env.CIRCLE_PULL_REQUEST) {
-      console.log("Not a PR, skipping git diff");
+      console.log('Not a PR, skipping git diff');
       return;
     }
 
     const baseRef = await getBaseRef();
     if (baseRef === null) {
-      console.log("Not a PR, skipping git diff");
+      console.log('Not a PR, skipping git diff');
       return;
     } else if (baseRef !== MAIN_BRANCH) {
       console.log(`This is for a PR targeting '${baseRef}', skipping git diff`);
       return;
     }
 
-    console.log("Attempting to get git diff...");
+    console.log('Attempting to get git diff...');
     const diffOutput = await gitDiff();
     console.log(diffOutput);
 


### PR DESCRIPTION
The `gh` CLI requires authentication, even if the API endpoints do not. We can just fetch the PR URL directly without shelling out.

Fixes [CI error](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/101231/workflows/7b91edba-0c97-4075-934c-5db83a71a2c0/jobs/3769045).

Also removes dependency on `prep-deps` step by removing dependency on external module.