### PR TITLE
chore(snaps): Remove debouncing/throttling of interfaces actions

### DIFF
--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -34,6 +34,7 @@ export const SnapUIInput: FunctionComponent<
 
   return (
     <FormTextField
+      autoFocus
       className="snap-ui-renderer__input"
       id={name}
       value={value}

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -125,15 +125,13 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
   // The submission of user input events is debounced or throttled to avoid
   // crashing the snap if there's too many events sent at the same time.
-  const snapRequestDebounced = debounce(rawSnapRequestFunction, 200);
-  const snapRequestThrottled = throttle(rawSnapRequestFunction, 200);
+  const snapRequestDebounced = rawSnapRequestFunction;
+  const snapRequestThrottled = rawSnapRequestFunction;
 
   // The update of the state is debounced to avoid crashes due to too many
   // updates in a short amount of time.
-  const updateStateDebounced = debounce(
-    (state) => dispatch(updateInterfaceState(interfaceId, state)),
-    200,
-  );
+  const updateStateDebounced = (state) =>
+    dispatch(updateInterfaceState(interfaceId, state));
 
   /**
    * Handle the submission of an user input event to the Snap.
@@ -152,7 +150,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
     flush = false,
   }) => {
     // We always flush the debounced request for updating the state.
-    updateStateDebounced.flush();
+    // updateStateDebounced.flush();
 
     const fn = THROTTLED_EVENTS.includes(event)
       ? snapRequestThrottled
@@ -163,20 +161,17 @@ export const SnapInterfaceContextProvider: FunctionComponent<
     // Certain events have their own debounce or throttling logic
     // and therefore may want to flush
     if (flush) {
-      fn.flush();
+      // fn.flush();
     }
   };
 
-  const handleInputChangeDebounced = debounce(
-    (name, value) =>
-      handleEvent({
-        event: UserInputEventType.InputChangeEvent,
-        name,
-        value,
-        flush: true,
-      }),
-    300,
-  );
+  const handleInputChangeDebounced = (name, value) =>
+    handleEvent({
+      event: UserInputEventType.InputChangeEvent,
+      name,
+      value,
+      flush: true,
+    });
 
   /**
    * Handle the value change of an input.
@@ -245,7 +240,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
           internalState.current = state;
           updateStateDebounced(state);
-          updateStateDebounced.flush();
+          //updateStateDebounced.flush();
           uploadFile(name, fileObject);
         });
 
@@ -256,7 +251,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
     internalState.current = state;
     updateStateDebounced(state);
-    updateStateDebounced.flush();
+    //updateStateDebounced.flush();
     uploadFile(name, null);
   };
 

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -30,7 +30,7 @@ export type HandleEvent = <Type extends State>(args: {
 
 export type HandleInputChange = <Type extends State>(
   name: string,
-  value: Type | null,
+  value: Type | undefined,
   form?: string,
 ) => void;
 
@@ -113,7 +113,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
     }).then(() => forceUpdateMetamaskState(dispatch));
   };
 
-  const updateState = (state) =>
+  const updateState = (state: InterfaceState) =>
     dispatch(updateInterfaceState(interfaceId, state));
 
   /**
@@ -130,7 +130,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
     value = name ? internalState.current[name] : undefined,
   }) => handleSnapRequest(event, name, value);
 
-  const submitInputChange = (name, value) =>
+  const submitInputChange = (name: string, value: State | undefined) =>
     handleEvent({
       event: UserInputEventType.InputChangeEvent,
       name,
@@ -210,7 +210,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
       return;
     }
 
-    const state = mergeValue(internalState.current, name, null, form);
+    const state = mergeValue(internalState.current, name, undefined, form);
 
     internalState.current = state;
     updateState(state);

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -25,12 +25,12 @@ import { mergeValue } from './utils';
 export type HandleEvent = <Type extends State>(args: {
   event: UserInputEventType;
   name?: string;
-  value?: Type;
+  value?: Type | null;
 }) => void;
 
 export type HandleInputChange = <Type extends State>(
   name: string,
-  value: Type | undefined,
+  value: Type | null,
   form?: string,
 ) => void;
 
@@ -130,7 +130,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
     value = name ? internalState.current[name] : undefined,
   }) => handleSnapRequest(event, name, value);
 
-  const submitInputChange = (name: string, value: State | undefined) =>
+  const submitInputChange = (name: string, value: State | null) =>
     handleEvent({
       event: UserInputEventType.InputChangeEvent,
       name,
@@ -210,7 +210,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
       return;
     }
 
-    const state = mergeValue(internalState.current, name, undefined, form);
+    const state = mergeValue(internalState.current, name, null, form);
 
     internalState.current = state;
     updateState(state);

--- a/ui/contexts/snaps/utils.ts
+++ b/ui/contexts/snaps/utils.ts
@@ -13,7 +13,7 @@ import { FormState, InterfaceState, State } from '@metamask/snaps-sdk';
 export const mergeValue = <Type extends State>(
   state: InterfaceState,
   name: string,
-  value: Type | null,
+  value: Type | undefined,
   form?: string,
 ): InterfaceState => {
   if (form) {
@@ -21,9 +21,9 @@ export const mergeValue = <Type extends State>(
       ...state,
       [form]: {
         ...(state[form] as FormState),
-        [name]: value,
+        [name]: value ?? null,
       },
     };
   }
-  return { ...state, [name]: value };
+  return { ...state, [name]: value ?? null };
 };

--- a/ui/contexts/snaps/utils.ts
+++ b/ui/contexts/snaps/utils.ts
@@ -13,7 +13,7 @@ import { FormState, InterfaceState, State } from '@metamask/snaps-sdk';
 export const mergeValue = <Type extends State>(
   state: InterfaceState,
   name: string,
-  value: Type | undefined,
+  value: Type | null,
   form?: string,
 ): InterfaceState => {
   if (form) {
@@ -21,9 +21,9 @@ export const mergeValue = <Type extends State>(
       ...state,
       [form]: {
         ...(state[form] as FormState),
-        [name]: value ?? null,
+        [name]: value,
       },
     };
   }
-  return { ...state, [name]: value ?? null };
+  return { ...state, [name]: value };
 };


### PR DESCRIPTION
## **Description**

This PR removes the `throttle` and `debounce` in the `SnapInterfaceContext`. The snaps seems to handle well having the calls directly sent to it.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27273?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go test-snaps
2. Try the interactive interface example snap
3. Try to break anything by going fast 

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
