### PR TITLE
fix: Permit DataTree token decimals

### DIFF
--- a/shared/lib/transactions-controller-utils.js
+++ b/shared/lib/transactions-controller-utils.js
@@ -36,7 +36,7 @@ export function toPrecisionWithoutTrailingZeros(n, precision) {
 
 /**
  * @param {number|string|BigNumber} value
- * @param {number} decimals
+ * @param {number=} decimals
  * @returns {BigNumber}
  */
 export function calcTokenAmount(value, decimals) {

--- a/shared/lib/transactions-controller-utils.js
+++ b/shared/lib/transactions-controller-utils.js
@@ -39,8 +39,8 @@ export function toPrecisionWithoutTrailingZeros(n, precision) {
  * @param {number} decimals
  * @returns {BigNumber}
  */
-export function calcTokenAmount(value, decimals = 0) {
-  const divisor = new BigNumber(10).pow(decimals);
+export function calcTokenAmount(value, decimals) {
+  const divisor = new BigNumber(10).pow(decimals ?? 0);
   return new BigNumber(String(value)).div(divisor);
 }
 

--- a/test/e2e/tests/confirmations/signatures/permit.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/permit.spec.ts
@@ -123,7 +123,7 @@ async function assertInfoValues(driver: Driver) {
     css: '.name__value',
     text: '0x5B38D...eddC4',
   });
-  const value = driver.findElement({ text: '3,000' });
+  const value = driver.findElement({ text: '<0.000001' });
   const nonce = driver.findElement({ text: '0' });
   const deadline = driver.findElement({ text: '09 June 3554, 16:53' });
 

--- a/ui/components/app/confirm/info/row/text-token-units.tsx
+++ b/ui/components/app/confirm/info/row/text-token-units.tsx
@@ -11,7 +11,7 @@ import { ConfirmInfoRowText } from './text';
 
 type ConfirmInfoRowTextTokenUnitsProps = {
   value: number | string | BigNumber;
-  decimals: number;
+  decimals?: number;
 };
 
 export const ConfirmInfoRowTextTokenUnits: React.FC<

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
@@ -12,12 +12,12 @@ import {
   ConfirmInfoRowUrl,
 } from '../../../../../../components/app/confirm/info/row';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
-import { getTokenStandardAndDetails } from '../../../../../../store/actions';
 import { SignatureRequestType } from '../../../../types/confirm';
 import {
   isOrderSignatureRequest,
   isPermitSignatureRequest,
 } from '../../../../utils';
+import { fetchErc20Decimals } from '../../../../utils/token';
 import { useConfirmContext } from '../../../../context/confirm';
 import { selectUseTransactionSimulations } from '../../../../selectors/preferences';
 import { ConfirmInfoRowTypedSignData } from '../../row/typed-sign-data/typedSignData';
@@ -49,10 +49,8 @@ const TypedSignInfo: React.FC = () => {
       if (!isPermit && !isOrder) {
         return;
       }
-      const tokenDetails = await getTokenStandardAndDetails(verifyingContract);
-      const tokenDecimals = tokenDetails?.decimals;
-
-      setDecimals(parseInt(tokenDecimals ?? '0', 10));
+      const tokenDecimals = await fetchErc20Decimals(verifyingContract);
+      setDecimals(tokenDecimals);
     })();
   }, [verifyingContract]);
 

--- a/ui/pages/confirmations/components/confirm/row/dataTree.tsx
+++ b/ui/pages/confirmations/components/confirm/row/dataTree.tsx
@@ -72,6 +72,12 @@ const FIELD_DATE_PRIMARY_TYPES: Record<string, string[]> = {
  */
 const NONE_DATE_VALUE = -1;
 
+/**
+ * If a token contract is found within the dataTree, fetch the token decimal of this contract
+ * to be utilized for displaying token amounts of the dataTree.
+ *
+ * @param dataTreeData
+ */
 const getTokenDecimalsOfDataTree = async (
   dataTreeData: Record<string, TreeData> | TreeData[],
 ): Promise<void | number> => {
@@ -91,7 +97,7 @@ const getTokenDecimalsOfDataTree = async (
 export const DataTree = ({
   data,
   primaryType,
-  tokenDecimals = 0,
+  tokenDecimals: tokenDecimalsProp,
 }: {
   data: Record<string, TreeData> | TreeData[];
   primaryType?: PrimaryType;
@@ -102,8 +108,8 @@ export const DataTree = ({
     [data],
   );
 
-  const tokenContractDecimals =
-    typeof decimalsResponse === 'number' ? decimalsResponse : undefined;
+  const tokenDecimals =
+    typeof decimalsResponse === 'number' ? decimalsResponse : tokenDecimalsProp;
 
   return (
     <Box width={BlockSize.Full}>
@@ -122,7 +128,7 @@ export const DataTree = ({
               primaryType={primaryType}
               value={value}
               type={type}
-              tokenDecimals={tokenContractDecimals ?? tokenDecimals}
+              tokenDecimals={tokenDecimals}
             />
           }
         </ConfirmInfoRow>
@@ -153,7 +159,7 @@ const DataField = memo(
     primaryType?: PrimaryType;
     type: string;
     value: ValueType;
-    tokenDecimals: number;
+    tokenDecimals?: number;
   }) => {
     const t = useI18nContext();
 

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -289,7 +289,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
           >
             <div>
               <div
-                aria-describedby="tippy-tooltip-18"
+                aria-describedby="tippy-tooltip-1"
                 class=""
                 data-original-title="Account details"
                 data-tooltipped=""
@@ -348,7 +348,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                 </p>
                 <div>
                   <div
-                    aria-describedby="tippy-tooltip-19"
+                    aria-describedby="tippy-tooltip-2"
                     class=""
                     data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
                     data-tooltipped=""
@@ -407,7 +407,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                           style="min-width: 0;"
                         >
                           <div
-                            aria-describedby="tippy-tooltip-20"
+                            aria-describedby="tippy-tooltip-3"
                             class=""
                             data-original-title="14,615,016,373,309,029,182,036,848,327,162,830,196,559,325,429.75"
                             data-tooltipped=""
@@ -457,7 +457,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                           style="min-width: 0;"
                         >
                           <div
-                            aria-describedby="tippy-tooltip-21"
+                            aria-describedby="tippy-tooltip-4"
                             class=""
                             data-original-title="24,615,016,373,309,029,182,036,848,327,162,830,196,559,325,429.75"
                             data-tooltipped=""
@@ -591,7 +591,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                 </p>
                 <div>
                   <div
-                    aria-describedby="tippy-tooltip-22"
+                    aria-describedby="tippy-tooltip-5"
                     class=""
                     data-original-title="This is the site asking for your signature."
                     data-tooltipped=""
@@ -867,7 +867,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                                   style="min-width: 0;"
                                 >
                                   <div
-                                    aria-describedby="tippy-tooltip-23"
+                                    aria-describedby="tippy-tooltip-6"
                                     class=""
                                     data-original-title="14,615,016,373,309,029,182,036,848,327,162,830,196,559,325,429.75"
                                     data-tooltipped=""
@@ -1046,7 +1046,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                                   style="min-width: 0;"
                                 >
                                   <div
-                                    aria-describedby="tippy-tooltip-24"
+                                    aria-describedby="tippy-tooltip-7"
                                     class=""
                                     data-original-title="24,615,016,373,309,029,182,036,848,327,162,830,196,559,325,429.75"
                                     data-tooltipped=""

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -289,7 +289,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
           >
             <div>
               <div
-                aria-describedby="tippy-tooltip-1"
+                aria-describedby="tippy-tooltip-18"
                 class=""
                 data-original-title="Account details"
                 data-tooltipped=""
@@ -348,7 +348,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                 </p>
                 <div>
                   <div
-                    aria-describedby="tippy-tooltip-2"
+                    aria-describedby="tippy-tooltip-19"
                     class=""
                     data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
                     data-tooltipped=""
@@ -407,7 +407,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                           style="min-width: 0;"
                         >
                           <div
-                            aria-describedby="tippy-tooltip-3"
+                            aria-describedby="tippy-tooltip-20"
                             class=""
                             data-original-title="14,615,016,373,309,029,182,036,848,327,162,830,196,559,325,429.75"
                             data-tooltipped=""
@@ -457,7 +457,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                           style="min-width: 0;"
                         >
                           <div
-                            aria-describedby="tippy-tooltip-4"
+                            aria-describedby="tippy-tooltip-21"
                             class=""
                             data-original-title="24,615,016,373,309,029,182,036,848,327,162,830,196,559,325,429.75"
                             data-tooltipped=""
@@ -591,7 +591,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                 </p>
                 <div>
                   <div
-                    aria-describedby="tippy-tooltip-5"
+                    aria-describedby="tippy-tooltip-22"
                     class=""
                     data-original-title="This is the site asking for your signature."
                     data-tooltipped=""
@@ -867,7 +867,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                                   style="min-width: 0;"
                                 >
                                   <div
-                                    aria-describedby="tippy-tooltip-6"
+                                    aria-describedby="tippy-tooltip-23"
                                     class=""
                                     data-original-title="14,615,016,373,309,029,182,036,848,327,162,830,196,559,325,429.75"
                                     data-tooltipped=""
@@ -1046,7 +1046,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                                   style="min-width: 0;"
                                 >
                                   <div
-                                    aria-describedby="tippy-tooltip-7"
+                                    aria-describedby="tippy-tooltip-24"
                                     class=""
                                     data-original-title="24,615,016,373,309,029,182,036,848,327,162,830,196,559,325,429.75"
                                     data-tooltipped=""

--- a/ui/pages/confirmations/confirm/confirm.test.tsx
+++ b/ui/pages/confirmations/confirm/confirm.test.tsx
@@ -147,12 +147,10 @@ describe('Confirm', () => {
     });
 
     await act(async () => {
-      const { container, findByText } = await renderWithConfirmContextProvider(
-        <Confirm />,
-        mockStore,
-      );
+      const { container, findAllByText } =
+        await renderWithConfirmContextProvider(<Confirm />, mockStore);
 
-      expect(await findByText('1,461,501,637,3...')).toBeInTheDocument();
+      expect(await findAllByText('14,615,016,373,...')).toHaveLength(2);
       expect(container).toMatchSnapshot();
     });
   });
@@ -172,12 +170,10 @@ describe('Confirm', () => {
     });
 
     await act(async () => {
-      const { container, findByText } = await renderWithConfirmContextProvider(
-        <Confirm />,
-        mockStore,
-      );
+      const { container, findAllByText } =
+        await renderWithConfirmContextProvider(<Confirm />, mockStore);
 
-      expect(await findByText('1,461,501,637,3...')).toBeInTheDocument();
+      expect(await findAllByText('14,615,016,373,...')).toHaveLength(2);
       expect(container).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When no token detail decimals are found in the DataTree showing an amount, we should use the verifiedContract token details passed from TypedSignInfo component. This PR applies this and adds an "Incomplete Asset Displayed" when getTokenStandardAndDetails fails to return details of a token. 

also adds support for passing null decimals to fetchErc20Decimals

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27328?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27243

## **Manual testing steps**

1. Go to test-dapp
2. Test Permit

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="320" src="https://github.com/user-attachments/assets/b31f0964-9602-4284-bcf0-3fe1a49c7703">

### **After**

<img width="320" src="https://github.com/user-attachments/assets/c07eef49-ee77-4bb6-9da4-0dd45177f7ca"> 


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
