### PR TITLE
chore: prevent importing between UI and background

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,36 @@ module.exports = {
   plugins: ['@metamask/design-tokens'],
   rules: {
     '@metamask/design-tokens/color-no-hex': 'warn',
+    'import/no-restricted-paths': [
+      'error',
+      {
+        basePath: './',
+        zones: [
+          {
+            target: './app',
+            from: './ui',
+            message:
+              'Should not import from UI in background, use shared directory instead',
+          },
+          {
+            target: './ui',
+            from: './app',
+            message:
+              'Should not import from background in UI, use shared directory instead',
+          },
+          {
+            target: './shared',
+            from: './app',
+            message: 'Should not import from background in shared',
+          },
+          {
+            target: './shared',
+            from: './ui',
+            message: 'Should not import from UI in shared',
+          },
+        ],
+      },
+    ],
   },
   overrides: [
     /**

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -53,6 +53,8 @@ import {
   FakeLedgerBridge,
   FakeTrezorBridge,
 } from '../../test/stub/keyring-bridge';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getCurrentChainId } from '../../ui/selectors';
 import migrations from './migrations';
 import Migrator from './lib/migrator';

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -7,6 +7,8 @@ import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import { MINUTE } from '../../../shared/constants/time';
 import { AUTO_LOCK_TIMEOUT_ALARM } from '../../../shared/constants/alarms';
 import { isManifestV3 } from '../../../shared/modules/mv3.utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { isBeta } from '../../../ui/helpers/utils/build-types';
 import {
   ENVIRONMENT_TYPE_BACKGROUND,

--- a/app/scripts/controllers/bridge/bridge-controller.ts
+++ b/app/scripts/controllers/bridge/bridge-controller.ts
@@ -1,4 +1,6 @@
 import { BaseController, StateMetadata } from '@metamask/base-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { fetchBridgeFeatureFlags } from '../../../../ui/pages/bridge/bridge.util';
 import {
   BRIDGE_CONTROLLER_NAME,

--- a/app/scripts/controllers/mmi-controller.ts
+++ b/app/scripts/controllers/mmi-controller.ts
@@ -28,6 +28,8 @@ import { NetworkController } from '@metamask/network-controller';
 import { InternalAccount } from '@metamask/keyring-api';
 import { toHex } from '@metamask/controller-utils';
 import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { CONNECT_HARDWARE_ROUTE } from '../../../ui/helpers/constants/routes';
 import {
   MMIControllerOptions,
@@ -38,6 +40,8 @@ import {
   ConnectionRequest,
 } from '../../../shared/constants/mmi-controller';
 import AccountTracker from '../lib/account-tracker';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getCurrentChainId } from '../../../ui/selectors';
 import MetaMetricsController from './metametrics';
 import { getPermissionBackgroundApiMethods } from './permissions';

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -21,7 +21,11 @@ import { SIGNING_METHODS } from '../../../shared/constants/transaction';
 import {
   generateSignatureUniqueId,
   getBlockaidMetricsProps,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../ui/helpers/utils/metrics';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { REDESIGN_APPROVAL_TYPES } from '../../../ui/pages/confirmations/utils/confirm';
 import { getSnapAndHardwareInfoForMetrics } from './snap-keyring/metrics';
 

--- a/app/scripts/lib/snap-keyring/bitcoin-wallet-snap.ts
+++ b/app/scripts/lib/snap-keyring/bitcoin-wallet-snap.ts
@@ -5,6 +5,8 @@ import { Json, JsonRpcRequest } from '@metamask/utils';
 // This dependency is still installed as part of the `package.json`, however
 // the Snap is being pre-installed only for Flask build (for the moment).
 import BitcoinWalletSnap from '@metamask/bitcoin-wallet-snap/dist/preinstalled-snap.json';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { handleSnapRequest } from '../../../../ui/store/actions';
 
 export const BITCOIN_WALLET_SNAP_ID: SnapId =

--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -10,6 +10,8 @@ import {
 import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
 import { t } from '../../translate';
 import MetamaskController from '../../metamask-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { IconName } from '../../../../ui/components/component-library/icon';
 import { isBlockedUrl } from './utils/isBlockedUrl';
 import { showError, showSuccess } from './utils/showResult';

--- a/app/scripts/lib/snap-keyring/utils/showResult.ts
+++ b/app/scripts/lib/snap-keyring/utils/showResult.ts
@@ -2,6 +2,8 @@ import type {
   ResultComponent,
   ErrorResult,
 } from '@metamask/approval-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { IconName } from '../../../../../ui/components/component-library/icon';
 import { SnapKeyringBuilderMessenger } from '../types';
 

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -40,10 +40,14 @@ import {
 import {
   getBlockaidMetricsProps,
   getSwapAndSendMetricsProps,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../ui/helpers/utils/metrics';
 import {
   REDESIGN_DEV_TRANSACTION_TYPES,
   REDESIGN_USER_TRANSACTION_TYPES,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../ui/pages/confirmations/utils';
 import {
   getSnapAndHardwareInfoForMetrics,

--- a/app/scripts/lib/tx-verification/tx-verification-middleware.ts
+++ b/app/scripts/lib/tx-verification/tx-verification-middleware.ts
@@ -17,6 +17,8 @@ import {
   TRUSTED_SIGNERS,
 } from '../../../../shared/constants/verification';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getCurrentChainId } from '../../../../ui/selectors';
 
 export type TxParams = {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -228,7 +228,11 @@ import {
   TOKEN_TRANSFER_LOG_TOPIC_HASH,
   TRANSFER_SINFLE_LOG_TOPIC_HASH,
 } from '../../shared/lib/transactions-controller-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getCurrentChainId } from '../../ui/selectors';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getProviderConfig } from '../../ui/ducks/metamask/metamask';
 import { endTrace, trace } from '../../shared/lib/trace';
 import { BalancesController as MultichainBalancesController } from './lib/accounts/BalancesController';

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -5,6 +5,8 @@ import { startCase, toLower } from 'lodash';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { getEnvironmentType } from '../lib/util';
 import { ENVIRONMENT_TYPE_BACKGROUND } from '../../../shared/constants/app';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getURLHostName } from '../../../ui/helpers/utils/util';
 import { t } from '../translate';
 

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -15,6 +15,8 @@ import Eth from '@metamask/ethjs';
 import EthQuery from '@metamask/eth-query';
 import StreamProvider from 'web3-stream-provider';
 import log from 'loglevel';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import launchMetaMaskUi, { updateBackgroundConnection } from '../../ui';
 import {
   ENVIRONMENT_TYPE_FULLSCREEN,

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "lint:changed:fix": "./development/get-changed-file-names.sh | grep -E --regexp='[.](js|ts|tsx)$' | tr '\\n' '\\0' | xargs -0 eslint --fix --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
     "lint:changelog": "auto-changelog validate",
     "lint:changelog:rc": "auto-changelog validate --rc",
+    "lint:debug": "DEBUG=eslint:cli-engine yarn lint",
     "lint:eslint": "eslint . --ext js,ts,tsx,snap --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
     "lint:eslint:fix": "yarn lint:eslint --fix --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
     "lint:lockfile:dedupe": "yarn dedupe --check",

--- a/shared/constants/mmi-controller.ts
+++ b/shared/constants/mmi-controller.ts
@@ -4,9 +4,17 @@ import { TransactionUpdateController } from '@metamask-institutional/transaction
 import { CustodyController } from '@metamask-institutional/custody-controller';
 import { SignatureController } from '@metamask/signature-controller';
 import { NetworkController } from '@metamask/network-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import PreferencesController from '../../app/scripts/controllers/preferences-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { AppStateController } from '../../app/scripts/controllers/app-state';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import AccountTracker from '../../app/scripts/lib/account-tracker';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import MetaMetricsController from '../../app/scripts/controllers/metametrics';
 
 export type MMIControllerOptions = {

--- a/shared/lib/error-utils.js
+++ b/shared/lib/error-utils.js
@@ -1,4 +1,6 @@
 import { memoize } from 'lodash';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import getFirstPreferredLangCode from '../../app/scripts/lib/get-first-preferred-lang-code';
 import { fetchLocale, loadRelativeTimeFormatLocaleData } from '../modules/i18n';
 import switchDirection from './switch-direction';

--- a/shared/lib/multichain.ts
+++ b/shared/lib/multichain.ts
@@ -1,3 +1,5 @@
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { isEthAddress } from '../../app/scripts/lib/multichain/address';
 
 /**

--- a/shared/lib/swaps-utils.js
+++ b/shared/lib/swaps-utils.js
@@ -14,6 +14,8 @@ import {
 import { SECOND } from '../constants/time';
 import { isValidHexAddress } from '../modules/hexstring-utils';
 import { isEqualCaseInsensitive } from '../modules/string-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../app/scripts/lib/util';
 import { decimalToHex } from '../modules/conversion.utils';
 import fetchWithCache from './fetch-with-cache';

--- a/shared/lib/swaps-utils.test.js
+++ b/shared/lib/swaps-utils.test.js
@@ -9,6 +9,8 @@ import {
 import {
   TOKENS,
   MOCK_TRADE_RESPONSE_2,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../ui/pages/swaps/swaps-util-test-constants';
 import {
   fetchTradesInfo,

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -1,6 +1,8 @@
 import * as Sentry from '@sentry/browser';
 import { Primitive, StartSpanOptions } from '@sentry/types';
 import { createModuleLogger } from '@metamask/utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { log as sentryLogger } from '../../app/scripts/lib/setupSentry';
 
 export enum TraceName {

--- a/shared/modules/browser-runtime.utils.js
+++ b/shared/modules/browser-runtime.utils.js
@@ -8,6 +8,8 @@ import log from 'loglevel';
 import {
   BROKEN_PRERENDER_BROWSER_VERSIONS,
   FIXED_PRERENDER_BROWSER_VERSIONS,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../ui/helpers/constants/common';
 
 /**

--- a/shared/modules/metametrics.test.ts
+++ b/shared/modules/metametrics.test.ts
@@ -4,6 +4,8 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { createTestProviderTools } from '../../test/stub/provider';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { TransactionMetricsRequest } from '../../app/scripts/lib/transaction/metrics';
 import { CHAIN_IDS } from '../constants/network';
 import { getSmartTransactionMetricsProperties } from './metametrics';

--- a/shared/modules/metametrics.ts
+++ b/shared/modules/metametrics.ts
@@ -1,4 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { TransactionMetricsRequest } from '../../app/scripts/lib/transaction/metrics';
 
 type SmartTransactionMetricsProperties = {

--- a/shared/modules/selectors/account.ts
+++ b/shared/modules/selectors/account.ts
@@ -1,3 +1,5 @@
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { isHardwareWallet } from '../../../ui/selectors/selectors';
 
 export { isHardwareWallet };

--- a/shared/modules/selectors/feature-flags.ts
+++ b/shared/modules/selectors/feature-flags.ts
@@ -1,3 +1,5 @@
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getCurrentChainId } from '../../../ui/selectors/selectors'; // TODO: Migrate shared selectors to this file.
 import { getNetworkNameByChainId } from '../feature-flags';
 

--- a/shared/modules/selectors/index.ts
+++ b/shared/modules/selectors/index.ts
@@ -1,3 +1,5 @@
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getHardwareWalletType } from '../../../ui/selectors/selectors';
 
 export * from './smart-transactions';

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -7,9 +7,13 @@ import {
   getCurrentNetwork,
   accountSupportsSmartTx,
   getSelectedAccount,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../ui/selectors/selectors'; // TODO: Migrate shared selectors to this file.
 import { isProduction } from '../environment';
 
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { MultichainState } from '../../../ui/selectors/multichain';
 
 type SmartTransactionsMetaMaskState = {

--- a/ui/components/app/account-list-item/account-list-item.js
+++ b/ui/components/app/account-list-item/account-list-item.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Identicon from '../../ui/identicon';
 import AccountMismatchWarning from '../../ui/account-mismatch-warning/account-mismatch-warning.component';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 
 export default function AccountListItem({

--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -69,6 +69,8 @@ import { getShortDateFormatterV2 } from '../../../../../pages/asset/util';
 import { SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../../../shared/constants/swaps';
 import { getConversionRate } from '../../../../../ducks/metamask/metamask';
 import { Numeric } from '../../../../../../shared/modules/Numeric';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addUrlProtocolPrefix } from '../../../../../../app/scripts/lib/util';
 import useGetAssetImageUrl from '../../../../../hooks/useGetAssetImageUrl';
 import NftDetailInformationRow from './nft-detail-information-row';

--- a/ui/components/app/assets/nfts/nfts-items/nfts-items.js
+++ b/ui/components/app/assets/nfts/nfts-items/nfts-items.js
@@ -16,6 +16,8 @@ import {
   FLEX_WRAP,
 } from '../../../../../helpers/constants/design-system';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../../../shared/constants/app';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
 import {
   getCurrentChainId,

--- a/ui/components/app/configure-snap-popup/configure-snap-popup.test.tsx
+++ b/ui/components/app/configure-snap-popup/configure-snap-popup.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../../../app/_locales/en/messages.json';
 import mockState from '../../../../test/data/mock-state.json';
 import ConfigureSnapPopup, {

--- a/ui/components/app/modals/hold-to-reveal-modal/hold-to-reveal-modal.test.js
+++ b/ui/components/app/modals/hold-to-reveal-modal/hold-to-reveal-modal.test.js
@@ -9,6 +9,8 @@ import {
   holdToRevealContent4,
   holdToRevealContent5,
   holdToRevealSRPTitle,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../../app/_locales/en/messages.json';
 import mockState from '../../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers';

--- a/ui/components/app/modals/modal.js
+++ b/ui/components/app/modals/modal.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import { connect } from 'react-redux';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import isMobileView from '../../../helpers/utils/is-mobile-view';

--- a/ui/components/app/modals/new-account-modal/new-account-modal.test.tsx
+++ b/ui/components/app/modals/new-account-modal/new-account-modal.test.tsx
@@ -4,6 +4,8 @@ import { waitFor, fireEvent } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../../test/jest';
 import mockState from '../../../../../test/data/mock-state.json';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../../../../app/_locales/en/messages.json';
 import NewAccountModal from './new-account-modal.container';
 

--- a/ui/components/app/modals/nickname-popovers/nickname-popovers.component.test.tsx
+++ b/ui/components/app/modals/nickname-popovers/nickname-popovers.component.test.tsx
@@ -9,6 +9,8 @@ import {
   MultichainNetworks,
 } from '../../../../../shared/constants/multichain/networks';
 import { createMockInternalAccount } from '../../../../../test/jest/mocks';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../../app/scripts/lib/multichain/address';
 import { mockNetworkState } from '../../../../../test/stub/networks';
 import NicknamePopover from './nickname-popovers.component';

--- a/ui/components/app/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/components/app/modals/qr-scanner/qr-scanner.component.js
@@ -4,6 +4,8 @@ import log from 'loglevel';
 import { BrowserQRCodeReader } from '@zxing/browser';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
 import { getURL } from '../../../../helpers/utils/util';
 import WebcamUtils from '../../../../helpers/utils/webcam-utils';

--- a/ui/components/app/multi-rpc-edit-modal/multi-rpc-edit-modal.tsx
+++ b/ui/components/app/multi-rpc-edit-modal/multi-rpc-edit-modal.tsx
@@ -21,6 +21,8 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { setShowMultiRpcModal } from '../../../store/actions';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { getNetworkConfigurationsByChainId } from '../../../selectors';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';

--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -9,6 +9,8 @@ import { MetaMetricsEventCategory } from '../../../../shared/constants/metametri
 import { PageContainerFooter } from '../../ui/page-container';
 import PermissionsConnectFooter from '../permissions-connect-footer';
 import { RestrictedMethods } from '../../../../shared/constants/permissions';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { PermissionNames } from '../../../../app/scripts/controllers/permissions';
 
 import SnapPrivacyWarning from '../snaps/snap-privacy-warning';

--- a/ui/components/app/qr-hardware-popover/base-reader.js
+++ b/ui/components/app/qr-hardware-popover/base-reader.js
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import log from 'loglevel';
 import { URDecoder } from '@ngraveio/bc-ur';
 import PropTypes from 'prop-types';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
 import WebcamUtils from '../../../helpers/utils/webcam-utils';

--- a/ui/components/app/selected-account/selected-account.component.js
+++ b/ui/components/app/selected-account/selected-account.component.js
@@ -7,6 +7,8 @@ import Tooltip from '../../ui/tooltip';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import { SECOND } from '../../../../shared/constants/time';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { AccountType } from '../../../../shared/constants/custody';

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.test.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.test.tsx
@@ -6,6 +6,8 @@ import userEvent from '@testing-library/user-event';
 import mockStore from '../../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../../test/jest';
 import { toChecksumHexAddress } from '../../../../../shared/modules/hexstring-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../../../../app/_locales/en/messages.json';
 import KeyringSnapRemovalWarning from './keyring-snap-removal-warning';
 

--- a/ui/components/app/srp-input/srp-input.test.js
+++ b/ui/components/app/srp-input/srp-input.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import enLocale from '../../../../app/_locales/en/messages.json';
 import { renderWithLocalization } from '../../../../test/lib/render-helpers';
 import SrpInput from '.';

--- a/ui/components/multichain/account-details/account-details.test.js
+++ b/ui/components/multichain/account-details/account-details.test.js
@@ -2,6 +2,8 @@ import { LavaDomeDebug } from '@lavamoat/lavadome-core';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { showPrivateKey } from '../../../../app/_locales/en/messages.json';
 import mockState from '../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../test/jest';

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -63,6 +63,8 @@ import { ConnectedStatus } from '../connected-status/connected-status';
 import { getCustodianIconForAddress } from '../../../selectors/institutional/selectors';
 import { useTheme } from '../../../hooks/useTheme';
 ///: END:ONLY_INCLUDE_IF
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { AccountListItemMenuTypes } from './account-list-item.types';

--- a/ui/components/multichain/account-list-menu/account-list-menu.test.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.test.tsx
@@ -11,6 +11,8 @@ import { fireEvent, renderWithProvider, waitFor } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../../../app/_locales/en/messages.json';
 import { CONNECT_HARDWARE_ROUTE } from '../../../helpers/constants/routes';
 ///: END:ONLY_INCLUDE_IF

--- a/ui/components/multichain/account-list-menu/account-list-menu.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.tsx
@@ -18,6 +18,8 @@ import {
   BITCOIN_WALLET_NAME,
   BITCOIN_WALLET_SNAP_ID,
   BitcoinWalletSnapSender,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../app/scripts/lib/snap-keyring/bitcoin-wallet-snap';
 ///: END:ONLY_INCLUDE_IF
 import {
@@ -78,6 +80,8 @@ import {
   CUSTODY_ACCOUNT_ROUTE,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../helpers/constants/routes';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { getAccountLabel } from '../../../helpers/utils/accounts';
@@ -96,6 +100,8 @@ import {
 import {
   ACCOUNT_WATCHER_NAME,
   ACCOUNT_WATCHER_SNAP_ID,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../app/scripts/lib/snap-keyring/account-watcher-snap';
 import { HiddenAccountList } from './hidden-account-list';
 

--- a/ui/components/multichain/address-copy-button/address-copy-button.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.js
@@ -25,6 +25,8 @@ import { shortenAddress } from '../../../helpers/utils/util';
 import Tooltip from '../../ui/tooltip/tooltip';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MINUTE } from '../../../../shared/constants/time';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 
 export const AddressCopyButton = ({

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -43,7 +43,11 @@ import {
   getTestNetworkBackgroundColor,
   getOriginOfCurrentTab,
 } from '../../../selectors';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 import { shortenAddress } from '../../../helpers/utils/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -25,6 +25,8 @@ import { Box } from '../../component-library';
 import { getUnapprovedTransactions } from '../../../selectors';
 
 import { toggleNetworkMenu } from '../../../store/actions';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { getIsUnlocked } from '../../../ducks/metamask/metamask';

--- a/ui/components/multichain/app-header/app-header.test.js
+++ b/ui/components/multichain/app-header/app-header.test.js
@@ -4,6 +4,8 @@ import configureStore from '../../../store/store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import mockState from '../../../../test/data/mock-state.json';
 import { SEND_STAGES } from '../../../ducks/send';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { mockNetworkState } from '../../../../test/stub/networks';

--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.test.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { BtcAccountType } from '@metamask/keyring-api';
 import { waitFor } from '@testing-library/react';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../../../app/_locales/en/messages.json';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../test/jest/rendering';
 import { createMockInternalAccount } from '../../../../test/jest/mocks';
 import { shortenAddress } from '../../../helpers/utils/util';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 import { ConnectAccountsModal } from './connect-accounts-modal';
 

--- a/ui/components/multichain/create-named-snap-account/create-named-snap-account.test.tsx
+++ b/ui/components/multichain/create-named-snap-account/create-named-snap-account.test.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { fireEvent, renderWithProvider, waitFor } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../../../app/_locales/en/messages.json';
 import { ETH_EOA_METHODS } from '../../../../shared/constants/eth-methods';
 import {

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -33,6 +33,8 @@ import {
 } from '../../component-library';
 
 import { MenuItem } from '../../ui/menu';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
 import { SUPPORT_LINK } from '../../../../shared/lib/ui-utils';

--- a/ui/components/multichain/import-account/json.test.tsx
+++ b/ui/components/multichain/import-account/json.test.tsx
@@ -3,6 +3,8 @@ import configureMockStore from 'redux-mock-store';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import mockState from '../../../../test/data/mock-state.json';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../../../app/_locales/en/messages.json';
 import Json from './json';
 

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -73,6 +73,8 @@ import {
   isValidHexAddress,
   toChecksumHexAddress,
 } from '../../../../shared/modules/hexstring-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import { STATIC_MAINNET_TOKEN_LIST } from '../../../../shared/constants/tokens';
 import {

--- a/ui/components/multichain/network-list-menu/add-block-explorer-modal/add-block-explorer-modal.tsx
+++ b/ui/components/multichain/network-list-menu/add-block-explorer-modal/add-block-explorer-modal.tsx
@@ -18,6 +18,8 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { isWebUrl } from '../../../../../app/scripts/lib/util';
 
 const AddBlockExplorerModal = ({

--- a/ui/components/multichain/network-list-menu/add-rpc-url-modal/add-rpc-url-modal.tsx
+++ b/ui/components/multichain/network-list-menu/add-rpc-url-modal/add-rpc-url-modal.tsx
@@ -18,6 +18,8 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { isWebUrl } from '../../../../../app/scripts/lib/util';
 
 const AddRpcUrlModal = ({

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -27,6 +27,8 @@ import {
   requestUserApproval,
   toggleNetworkMenu,
 } from '../../../../store/actions';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
 import {
   AlignItems,

--- a/ui/components/multichain/pages/send/components/account-picker.test.tsx
+++ b/ui/components/multichain/pages/send/components/account-picker.test.tsx
@@ -11,6 +11,8 @@ import {
 } from '../../../../../../test/jest/mocks';
 import { CombinedBackgroundAndReduxState } from '../../../../../store/store';
 import { shortenAddress } from '../../../../../helpers/utils/util';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../../../app/scripts/lib/multichain/address';
 import { SendPageAccountPicker } from '.';
 

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
@@ -24,6 +24,8 @@ import {
 import {
   formatValue,
   isValidAmount,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../../../app/scripts/lib/util';
 
 const renderPercentageWithNumber = (

--- a/ui/components/multichain/token-list-item/price/percentage-change/percentage-change.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-change/percentage-change.tsx
@@ -9,6 +9,8 @@ import {
 import {
   formatValue,
   isValidAmount,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../../../app/scripts/lib/util';
 
 export const PercentageChange = ({

--- a/ui/components/ui/qr-code-view/qr-code-view.tsx
+++ b/ui/components/ui/qr-code-view/qr-code-view.tsx
@@ -3,6 +3,8 @@ import React, { useContext } from 'react';
 import qrCode from 'qrcode-generator';
 import { connect } from 'react-redux';
 import { isHexPrefixed } from 'ethereumjs-util';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 import { Box, Icon, IconName, IconSize, Text } from '../../component-library';
 import { MetaMetricsContext } from '../../../contexts/metametrics';

--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -5,6 +5,8 @@ import UnitInput from '../unit-input';
 import CurrencyDisplay from '../currency-display';
 import { getWeiHexFromDecimalValue } from '../../../../shared/modules/conversion.utils';
 
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 import { Numeric } from '../../../../shared/modules/Numeric';

--- a/ui/contexts/metametrics.js
+++ b/ui/contexts/metametrics.js
@@ -15,6 +15,8 @@ import { matchPath, useLocation } from 'react-router-dom';
 import { captureException, captureMessage } from '@sentry/browser';
 
 import { omit } from 'lodash';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../app/scripts/lib/util';
 import { PATH_NAME_MAP } from '../helpers/constants/routes';
 import { MetaMetricsContextProp } from '../../shared/constants/metametrics';

--- a/ui/ducks/bridge/actions.ts
+++ b/ui/ducks/bridge/actions.ts
@@ -1,3 +1,5 @@
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { BridgeBackgroundAction } from '../../../app/scripts/controllers/bridge/types';
 import { forceUpdateMetamaskState } from '../../store/actions';
 import { submitRequestToBackground } from '../../store/background-connection';

--- a/ui/ducks/bridge/bridge.test.ts
+++ b/ui/ducks/bridge/bridge.test.ts
@@ -3,6 +3,8 @@ import thunk from 'redux-thunk';
 import { createBridgeMockStore } from '../../../test/jest/mock-store';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { setBackgroundConnection } from '../../store/background-connection';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { BridgeBackgroundAction } from '../../../app/scripts/controllers/bridge/types';
 import bridgeReducer from './bridge';
 import { setBridgeFeatureFlags, setToChain } from './actions';

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -8,6 +8,8 @@ import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../../shared/constants/bridge';
 import {
   BridgeControllerState,
   BridgeFeatureFlagsKey,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../app/scripts/controllers/bridge/types';
 import { FEATURED_RPCS } from '../../../shared/constants/network';
 import { createDeepEqualSelector } from '../../selectors/util';

--- a/ui/ducks/locale/locale.test.ts
+++ b/ui/ducks/locale/locale.test.ts
@@ -1,3 +1,5 @@
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import locales from '../../../app/_locales/index.json';
 import { getIntlLocale } from './locale';
 

--- a/ui/helpers/utils/accounts.js
+++ b/ui/helpers/utils/accounts.js
@@ -8,6 +8,8 @@ import {
 import { BackgroundColor } from '../constants/design-system';
 import { KeyringType } from '../../../shared/constants/keyring';
 import { HardwareKeyringNames } from '../../../shared/constants/hardware-wallets';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../app/scripts/translate';
 
 export function getAccountNameErrorMessage(

--- a/ui/helpers/utils/build-types.js
+++ b/ui/helpers/utils/build-types.js
@@ -1,7 +1,11 @@
 ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import flaskJson from '../../../app/build-types/flask/images/flask-mascot.json';
 ///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import mmiJson from '../../../app/build-types/mmi/mmi-mascot.json';
 ///: END:ONLY_INCLUDE_IF
 

--- a/ui/helpers/utils/multichain/blockExplorer.ts
+++ b/ui/helpers/utils/multichain/blockExplorer.ts
@@ -1,6 +1,8 @@
 import { getAccountLink } from '@metamask/etherscan-link';
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { MultichainNetwork } from '../../../selectors/multichain';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 
 export const getMultichainBlockExplorerUrl = (

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -26,6 +26,8 @@ import {
   TextColor,
   TextVariant,
 } from '../constants/design-system';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { PermissionNames } from '../../../app/scripts/controllers/permissions';
 import { getURLHost } from './util';
 

--- a/ui/helpers/utils/transactions.util.js
+++ b/ui/helpers/utils/transactions.util.js
@@ -5,6 +5,8 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../../app/scripts/lib/util';
 import { TransactionGroupStatus } from '../../../shared/constants/transaction';
 import { readAddressAsContract } from '../../../shared/modules/contract-utils';

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -30,6 +30,8 @@ import { OUTDATED_BROWSER_VERSIONS } from '../constants/common';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { hexToDecimal } from '../../../shared/modules/conversion.utils';
 import { SNAPS_VIEW_ROUTE } from '../constants/routes';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../app/scripts/lib/multichain/address';
 
 export function formatDate(date, format = "M/d/y 'at' T") {

--- a/ui/helpers/utils/webcam-utils.js
+++ b/ui/helpers/utils/webcam-utils.js
@@ -5,6 +5,8 @@ import {
   PLATFORM_BRAVE,
   PLATFORM_FIREFOX,
 } from '../../../shared/constants/app';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType, getPlatform } from '../../../app/scripts/lib/util';
 
 class WebcamUtils {

--- a/ui/hooks/useEventFragment.js
+++ b/ui/hooks/useEventFragment.js
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../app/scripts/lib/util';
 import { selectMatchingFragment } from '../selectors';
 import {

--- a/ui/hooks/useIsOriginalNativeTokenSymbol.js
+++ b/ui/hooks/useIsOriginalNativeTokenSymbol.js
@@ -11,6 +11,8 @@ import {
   getMultichainIsEvm,
   getMultichainCurrentNetwork,
 } from '../selectors/multichain';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getValidUrl } from '../../app/scripts/lib/util';
 
 export function useIsOriginalNativeTokenSymbol(

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -11,6 +11,8 @@ import {
 import mockState from '../../test/data/mock-state.json';
 import configureStore from '../store/store';
 import transactions from '../../test/data/transaction-data.json';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../app/_locales/en/messages.json';
 import { ASSET_ROUTE, DEFAULT_ROUTE } from '../helpers/constants/routes';
 import { TransactionGroupCategory } from '../../shared/constants/transaction';

--- a/ui/index.js
+++ b/ui/index.js
@@ -6,9 +6,13 @@ import React from 'react';
 import { render } from 'react-dom';
 import browser from 'webextension-polyfill';
 
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../app/scripts/lib/util';
 import { AlertTypes } from '../shared/constants/alerts';
 import { maskObject } from '../shared/modules/object.utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { SENTRY_UI_STATE } from '../app/scripts/constants/sentry-state';
 import { ENVIRONMENT_TYPE_POPUP } from '../shared/constants/app';
 import { COPY_OPTIONS } from '../shared/constants/copy';

--- a/ui/pages/bridge/bridge.util.ts
+++ b/ui/pages/bridge/bridge.util.ts
@@ -2,6 +2,8 @@ import { add0x } from '@metamask/utils';
 import {
   BridgeFeatureFlagsKey,
   BridgeFeatureFlags,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../app/scripts/controllers/bridge/types';
 import {
   BRIDGE_API_BASE_URL,

--- a/ui/pages/confirmations/components/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
+++ b/ui/pages/confirmations/components/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
@@ -5,6 +5,8 @@ import {
   ENVIRONMENT_TYPE_NOTIFICATION,
   ORIGIN_METAMASK,
 } from '../../../../../../shared/constants/app';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
 import NetworkDisplay from '../../../../../components/app/network-display';
 import Identicon from '../../../../../components/ui/identicon';

--- a/ui/pages/confirmations/components/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.test.js
+++ b/ui/pages/confirmations/components/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import { ORIGIN_METAMASK } from '../../../../../../shared/constants/app';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
 import { CHAIN_IDS } from '../../../../../../shared/constants/network';
 import { mockNetworkState } from '../../../../../../test/stub/networks';

--- a/ui/pages/confirmations/components/confirm/info/approve/hooks/use-received-token.ts
+++ b/ui/pages/confirmations/components/confirm/info/approve/hooks/use-received-token.ts
@@ -1,6 +1,8 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../../../../../app/scripts/lib/multichain/address';
 import { useAccountTotalFiatBalance } from '../../../../../../../hooks/useAccountTotalFiatBalance';
 import { getSelectedAccount } from '../../../../../../../selectors';

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
@@ -25,6 +25,8 @@ import {
   DecodedTransactionDataParam,
   DecodedTransactionDataSource,
 } from '../../../../../../../../shared/types/transaction-decode';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { UniswapPathPool } from '../../../../../../../../app/scripts/lib/transaction/decode/uniswap';
 import { useConfirmContext } from '../../../../../context/confirm';
 

--- a/ui/pages/confirmations/components/confirm/ledger-info/ledger-info.tsx
+++ b/ui/pages/confirmations/components/confirm/ledger-info/ledger-info.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../../../shared/constants/app';
 import {

--- a/ui/pages/confirmations/components/ledger-instruction-field/ledger-instruction-field.js
+++ b/ui/pages/confirmations/components/ledger-instruction-field/ledger-instruction-field.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../../shared/constants/app';
 import {

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
@@ -80,6 +80,8 @@ import {
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   getEnvironmentType,
   ///: END:ONLY_INCLUDE_IF
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../app/scripts/lib/util';
 
 import {

--- a/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
@@ -47,6 +47,8 @@ import ConfirmSignatureRequest from '../confirm-signature-request';
 import ConfirmTransactionSwitch from '../confirm-transaction-switch';
 import Confirm from '../confirm/confirm';
 import useCurrentConfirmation from '../hooks/useCurrentConfirmation';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { useAsyncResult } from '../../../hooks/useAsyncResult';
 import { TraceName } from '../../../../shared/lib/trace';

--- a/ui/pages/confirmations/send/send-content/add-recipient/domain-input.component.js
+++ b/ui/pages/confirmations/send/send-content/add-recipient/domain-input.component.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import { isHexString } from '@metamask/utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../../../../../app/scripts/lib/util';
 import { shortenAddress } from '../../../../../helpers/utils/util';
 import {

--- a/ui/pages/confirmations/send/send.utils.js
+++ b/ui/pages/confirmations/send/send.utils.js
@@ -1,5 +1,6 @@
 import { encode } from '@metamask/abi-utils';
-
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import { TokenStandard } from '../../../../shared/constants/transaction';
 import { Numeric } from '../../../../shared/modules/Numeric';

--- a/ui/pages/error/error.component.js
+++ b/ui/pages/error/error.component.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../shared/constants/app';
 import { SUPPORT_REQUEST_LINK } from '../../helpers/constants/common';

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -79,6 +79,8 @@ import {
 import { getWeb3ShimUsageAlertEnabledness } from '../../ducks/metamask/metamask';
 import { getSwapsFeatureIsLive } from '../../ducks/swaps/swaps';
 import { fetchBuyableChains } from '../../ducks/ramps';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import { getIsBrowserDeprecated } from '../../helpers/utils/util';
 import {

--- a/ui/pages/notifications/notification-components/erc1155-sent-received/erc1155-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc1155-sent-received/erc1155-sent-received.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../../../app/scripts/translate';
 
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';

--- a/ui/pages/notifications/notification-components/erc20-sent-received/erc20-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc20-sent-received/erc20-sent-received.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../../../app/scripts/translate';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';

--- a/ui/pages/notifications/notification-components/erc721-sent-received/erc721-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc721-sent-received/erc721-sent-received.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../../../app/scripts/translate';
 
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';

--- a/ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../../../app/scripts/translate';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';

--- a/ui/pages/notifications/notification-components/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
+++ b/ui/pages/notifications/notification-components/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
@@ -11,6 +11,8 @@ import {
   NotificationDetailBlockExplorerButton,
   NotificationDetailAddress,
 } from '../../../../components/multichain';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../../../app/scripts/translate';
 import {
   createTextItems,

--- a/ui/pages/notifications/notification-components/lido-withdrawal-requested/lido-withdrawal-requested.tsx
+++ b/ui/pages/notifications/notification-components/lido-withdrawal-requested/lido-withdrawal-requested.tsx
@@ -20,6 +20,8 @@ import {
   getNetworkDetailsByChainId,
   getUsdAmount,
 } from '../../../../helpers/utils/notification.util';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../../../app/scripts/translate';
 import {
   TextVariant,

--- a/ui/pages/notifications/notification-components/stake/stake.tsx
+++ b/ui/pages/notifications/notification-components/stake/stake.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../../../app/scripts/translate';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';

--- a/ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx
+++ b/ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx
@@ -3,6 +3,8 @@ import { NotificationServicesController } from '@metamask/notification-services-
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import type { NotificationComponent } from '../types/notifications/notifications';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { t } from '../../../../../app/scripts/translate';
 
 import {

--- a/ui/pages/onboarding-flow/metametrics/metametrics.test.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.test.js
@@ -7,6 +7,8 @@ import { ONBOARDING_CREATE_PASSWORD_ROUTE } from '../../../helpers/constants/rou
 import {
   onboardingMetametricsAgree,
   noThanks,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../app/_locales/en/messages.json';
 import {
   setParticipateInMetaMetrics,

--- a/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.js
+++ b/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.js
@@ -4,6 +4,8 @@ import MetaFoxLogo from '../../../components/ui/metafox-logo';
 import Dropdown from '../../../components/ui/dropdown';
 import { getCurrentLocale } from '../../../ducks/locale/locale';
 import { updateCurrentLocale } from '../../../store/actions';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import locales from '../../../../app/_locales/index.json';
 
 export default function OnboardingAppHeader() {

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -2,6 +2,8 @@ import React, { useContext, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { ButtonVariant } from '@metamask/snaps-sdk';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addUrlProtocolPrefix } from '../../../../app/scripts/lib/util';
 import {
   useSetIsProfileSyncingEnabled,

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -3,6 +3,8 @@ import React, { Component } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { ethErrors, serializeError } from 'eth-rpc-errors';
 import { SubjectType } from '@metamask/permission-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { isEthAddress } from '../../../app/scripts/lib/multichain/address';
 import { MILLISECOND } from '../../../shared/constants/time';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
@@ -14,6 +16,8 @@ import {
   CaveatTypes,
   RestrictedMethods,
 } from '../../../shared/constants/permissions';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { PermissionNames } from '../../../app/scripts/controllers/permissions';
 import ChooseAccount from './choose-account';
 import PermissionsRedirect from './redirect';

--- a/ui/pages/permissions-connect/permissions-connect.test.tsx
+++ b/ui/pages/permissions-connect/permissions-connect.test.tsx
@@ -5,6 +5,8 @@ import thunk from 'redux-thunk';
 import { ApprovalType } from '@metamask/controller-utils';
 import { BtcAccountType } from '@metamask/keyring-api';
 import { fireEvent } from '@testing-library/react';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import messages from '../../../app/_locales/en/messages.json';
 import { renderWithProvider } from '../../../test/lib/render-helpers';
 import mockState from '../../../test/data/mock-state.json';

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -99,6 +99,8 @@ import {
   ///: END:ONLY_INCLUDE_IF
 } from '../../../shared/constants/app';
 import { NETWORK_TYPES } from '../../../shared/constants/network';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import ConfirmationPage from '../confirmations/confirmation';
 import OnboardingFlow from '../onboarding-flow/onboarding-flow';

--- a/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings/developer-options-tab/developer-options-tab.tsx
@@ -32,6 +32,8 @@ import {
   setServiceWorkerKeepAlivePreference,
   setRedesignedConfirmationsDeveloperEnabled,
 } from '../../../store/actions';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { getIsRedesignedConfirmationsDeveloperEnabled } from '../../confirmations/selectors/confirm';

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -4,6 +4,8 @@ import React, { PureComponent } from 'react';
 import {
   addUrlProtocolPrefix,
   getEnvironmentType,
+  // TODO: Remove restricted import
+  // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import {

--- a/ui/pages/settings/security-tab/security-tab.test.js
+++ b/ui/pages/settings/security-tab/security-tab.test.js
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import mockState from '../../../../test/data/mock-state.json';

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -12,6 +12,8 @@ import {
 } from '../../../helpers/constants/design-system';
 import Dropdown from '../../../components/ui/dropdown';
 import ToggleButton from '../../../components/ui/toggle-button';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import locales from '../../../../app/_locales/index.json';
 import Jazzicon from '../../../components/ui/jazzicon';
 import BlockieIdenticon from '../../../components/ui/identicon/blockieIdenticon';

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -40,6 +40,8 @@ import {
   TextVariant,
 } from '../../helpers/constants/design-system';
 import MetafoxLogo from '../../components/ui/metafox-logo';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../shared/constants/app';
 import SettingsTab from './settings-tab';

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { getAddressBookEntryOrAccountName } from '../../selectors';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../shared/constants/app';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import {

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -133,6 +133,8 @@ import {
   calcTokenAmount,
   toPrecisionWithoutTrailingZeros,
 } from '../../../../shared/lib/transactions-controller-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import {
   calcTokenValue,

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -107,6 +107,8 @@ import {
   calcTokenAmount,
   toPrecisionWithoutTrailingZeros,
 } from '../../../../shared/lib/transactions-controller-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import {
   calcTokenValue,

--- a/ui/pages/unlock-page/unlock-page.container.js
+++ b/ui/pages/unlock-page/unlock-page.container.js
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../shared/constants/app';
 import {

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -1,3 +1,5 @@
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix } from '../../app/scripts/lib/util';
 import { decEthToConvertedCurrency } from '../../shared/modules/conversion.utils';
 import { formatCurrency } from '../helpers/utils/confirm-tx.util';

--- a/ui/selectors/institutional/selectors.ts
+++ b/ui/selectors/institutional/selectors.ts
@@ -2,6 +2,8 @@ import { toChecksumAddress } from 'ethereumjs-util';
 import { getAccountType, getSelectedInternalAccount } from '../selectors';
 import { getProviderConfig } from '../../ducks/metamask/metamask';
 import { hexToDecimal } from '../../../shared/modules/conversion.utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../app/scripts/lib/multichain/address';
 import { AccountType } from '../../../shared/constants/custody';
 

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -16,6 +16,8 @@ import {
   getNativeCurrency,
   getProviderConfig,
 } from '../ducks/metamask/metamask';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { BalancesControllerState } from '../../app/scripts/lib/accounts/BalancesController';
 import { MultichainNativeAssets } from '../../shared/constants/multichain/assets';
 import {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -12,6 +12,8 @@ import { NameType } from '@metamask/name-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { RpcEndpointType } from '@metamask/network-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix, getEnvironmentType } from '../../app/scripts/lib/util';
 import {
   TEST_CHAINS,
@@ -102,6 +104,8 @@ import {
 import { PRIVACY_POLICY_DATE } from '../helpers/constants/privacy-policy';
 import { ENVIRONMENT_TYPE_POPUP } from '../../shared/constants/app';
 import { MultichainNativeAssets } from '../../shared/constants/multichain/assets';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { BridgeFeatureFlagsKey } from '../../app/scripts/controllers/bridge/types';
 import {
   getAllUnapprovedTransactions,

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -4,7 +4,11 @@ import thunk from 'redux-thunk';
 import { EthAccountType } from '@metamask/keyring-api';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import enLocale from '../../app/_locales/en/messages.json';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import MetaMaskController from '../../app/scripts/metamask-controller';
 import { HardwareDeviceNames } from '../../shared/constants/hardware-wallets';
 import { GAS_LIMITS } from '../../shared/constants/gas';

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -46,6 +46,8 @@ import {
   ORIGIN_METAMASK,
   POLLING_TOKEN_ENVIRONMENT_TYPES,
 } from '../../shared/constants/app';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType, addHexPrefix } from '../../app/scripts/lib/util';
 import {
   getMetaMaskAccounts,

--- a/ui/store/institutional/institution-actions.test.js
+++ b/ui/store/institutional/institution-actions.test.js
@@ -1,6 +1,8 @@
 import sinon from 'sinon';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import MetaMaskController from '../../../app/scripts/metamask-controller';
 import { setBackgroundConnection } from '../background-connection';
 import { mockNetworkState } from '../../../test/stub/networks';


### PR DESCRIPTION
## **Description**

The architecture of our browser extension requires the following layers:

- The background page / server / service worker to process requests from the dApps and from the UI.
- Frontend pages to render the state and allow users to interact with the wallet, including the popup, notification and full-screen variations.

These are executed in alternate processes, and so data is transferred between them using a JSON-RPC API and a custom stream.

Historically, the associated code for these layers was also kept separate in order to:

- Organise the code to simplify maintenance and extensibility.
- Avoid technical limitations if code in one layer cannot function in another.
- Encourage decoupling and modularisation.

An additional `shared` layer exists to define common code that can be used in both layers, naturally this should not depend on any code in the background or UI layers.

Unfortunately, instances where we have imported across the layers have increased over time, such as:

- Using background utility functions in the UI.
- Referencing UI types in the shared layer.
- Relying on Redux selectors from the UI in the `MetamaskController`.

This PR applies the `import/no-restricted-paths` ESLint rule to detect this and generate a linting error.

To minimise the scope of this PR, all existing instances (138) of this problem have been ignored with an inline comment and `TODO`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27329?quickstart=1)

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
