### PR TITLE
fix: Contract interactions cannot confirm a contract interaction with `Ledger` with the new redesign

### DIFF
--- a/ui/pages/confirmations/hooks/useLedgerConnection.ts
+++ b/ui/pages/confirmations/hooks/useLedgerConnection.ts
@@ -30,12 +30,8 @@ const useLedgerConnection = () => {
   const transportStatus = useSelector(getLedgerTransportStatus);
   const webHidConnectedStatus = useSelector(getLedgerWebHidConnectedStatus);
 
-  let from: string | undefined;
-  const confirmationParams =
-    currentConfirmation?.msgParams || currentConfirmation?.txParams;
-  if (confirmationParams) {
-    from = confirmationParams.from;
-  }
+  const from =
+    currentConfirmation?.msgParams?.from ?? currentConfirmation?.txParams?.from;
 
   const isLedgerWallet = useSelector(
     (state) => from && isAddressLedger(state, from),

--- a/ui/pages/confirmations/hooks/useLedgerConnection.ts
+++ b/ui/pages/confirmations/hooks/useLedgerConnection.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import {
   HardwareTransportStates,
   LEDGER_USB_VENDOR_ID,
@@ -20,17 +21,22 @@ import { attemptLedgerTransportCreation } from '../../../store/actions';
 import { SignatureRequestType } from '../types/confirm';
 import { useConfirmContext } from '../context/confirm';
 
-const useLedgerConnection = () => {
+const useLedgerConnection = (): {
+  isLedgerWallet: boolean;
+} => {
   const dispatch = useDispatch();
-  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
+  const { currentConfirmation } = useConfirmContext<
+    SignatureRequestType & TransactionMeta
+  >();
   const ledgerTransportType = useSelector(getLedgerTransportType);
   const transportStatus = useSelector(getLedgerTransportStatus);
   const webHidConnectedStatus = useSelector(getLedgerWebHidConnectedStatus);
 
   let from: string | undefined;
-  // todo: extend to other confirmation types
-  if (currentConfirmation?.msgParams) {
-    from = currentConfirmation.msgParams.from;
+  const confirmationParams =
+    currentConfirmation?.msgParams || currentConfirmation?.txParams;
+  if (confirmationParams) {
+    from = confirmationParams.from;
   }
 
   const isLedgerWallet = useSelector(
@@ -112,7 +118,7 @@ const useLedgerConnection = () => {
     };
   }, [dispatch]);
 
-  return { isLedgerWallet };
+  return { isLedgerWallet: !!isLedgerWallet };
 };
 
 export default useLedgerConnection;

--- a/ui/pages/confirmations/hooks/useLedgerConnection.ts
+++ b/ui/pages/confirmations/hooks/useLedgerConnection.ts
@@ -21,9 +21,7 @@ import { attemptLedgerTransportCreation } from '../../../store/actions';
 import { SignatureRequestType } from '../types/confirm';
 import { useConfirmContext } from '../context/confirm';
 
-const useLedgerConnection = (): {
-  isLedgerWallet: boolean;
-} => {
+const useLedgerConnection = () => {
   const dispatch = useDispatch();
   const { currentConfirmation } = useConfirmContext<
     SignatureRequestType & TransactionMeta
@@ -118,7 +116,7 @@ const useLedgerConnection = (): {
     };
   }, [dispatch]);
 
-  return { isLedgerWallet: !!isLedgerWallet };
+  return { isLedgerWallet };
 };
 
 export default useLedgerConnection;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the issue where confirm button is always disabled when contract interactions with Ledger account 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27331?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27240

## **Manual testing steps**

1. Activate Ledger account in MM
2. Go to uniswap
3. Try swapping from Sepolia eth to Weth
4. See confirmation "Confirm" button is not disabled

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/aba4e44c-049e-4d64-b14a-9bdc4c25a9cb



### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
