### PR TITLE
fix(snaps): Set proper text color for secondary button

### DIFF
--- a/ui/components/app/snaps/snap-ui-footer-button/index.scss
+++ b/ui/components/app/snaps/snap-ui-footer-button/index.scss
@@ -45,6 +45,14 @@
     }
   }
 
+  &.mm-button-secondary {
+    &:hover:not(&--disabled) {
+      & > span {
+        color: var(--color-primary-inverse);
+      }
+    }
+  }
+
   &--disabled {
     cursor: default !important;
   }

--- a/ui/components/app/snaps/snap-ui-footer-button/index.scss
+++ b/ui/components/app/snaps/snap-ui-footer-button/index.scss
@@ -45,6 +45,12 @@
     }
   }
 
+  &:not(&--disabled) {
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
   &.mm-button-secondary {
     &:hover:not(&--disabled) {
       & > span {

--- a/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
@@ -45,6 +45,7 @@ const getDefaultButtons = (
       key: 'default-button',
       props: {
         onCancel,
+        variant: ButtonVariant.Secondary,
         isSnapAction: false,
       },
       children: t('cancel'),
@@ -62,8 +63,9 @@ export const footer: UIComponentFactory<FooterElement> = ({
 }) => {
   const defaultButtons = getDefaultButtons(element, t, onCancel);
 
+  const providedChildren = getJsxChildren(element);
   const footerChildren: UIComponent[] = (
-    getJsxChildren(element) as ButtonElement[]
+    providedChildren as ButtonElement[]
   ).map((children, index) => {
     const buttonMapped = buttonFn({
       ...params,
@@ -74,7 +76,10 @@ export const footer: UIComponentFactory<FooterElement> = ({
       key: `snap-footer-button-${buttonMapped.props?.name ?? index}`,
       props: {
         ...buttonMapped.props,
-        variant: index === 0 ? ButtonVariant.Secondary : ButtonVariant.Primary,
+        variant:
+          providedChildren.length === 2 && index === 0
+            ? ButtonVariant.Secondary
+            : ButtonVariant.Primary,
         isSnapAction: true,
       },
       children: buttonMapped.children,


### PR DESCRIPTION
## **Description**

This PR fixes the button in snaps footer of type `secondary` having the wrong text color on hover.

It also fixes a wrong variant if the interface on had one action provided in the footer.
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27335?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. edit the `getHideSnapBranding` to return `true`
2. go to test snap and use the preinstalled example snap

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
