### PR TITLE
fix: cherry pick ledger confirm button fix into `12.3.0`

### DIFF
--- a/ui/pages/confirmations/hooks/useLedgerConnection.ts
+++ b/ui/pages/confirmations/hooks/useLedgerConnection.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import {
   HardwareTransportStates,
   LEDGER_USB_VENDOR_ID,
@@ -24,16 +25,13 @@ const useLedgerConnection = () => {
   const dispatch = useDispatch();
   const currentConfirmation = useSelector(
     currentConfirmationSelector,
-  ) as SignatureRequestType;
+  ) as SignatureRequestType & TransactionMeta;
   const ledgerTransportType = useSelector(getLedgerTransportType);
   const transportStatus = useSelector(getLedgerTransportStatus);
   const webHidConnectedStatus = useSelector(getLedgerWebHidConnectedStatus);
 
-  let from: string | undefined;
-  // todo: extend to other confirmation types
-  if (currentConfirmation?.msgParams) {
-    from = currentConfirmation.msgParams.from;
-  }
+  const from =
+    currentConfirmation?.msgParams?.from ?? currentConfirmation?.txParams?.from;
 
   const isLedgerWallet = useSelector(
     (state) => from && isAddressLedger(state, from),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR cherry-picks https://github.com/MetaMask/metamask-extension/pull/27331

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27342?quickstart=1)

## **Related issues**

https://github.com/MetaMask/metamask-extension/pull/27331

## **Manual testing steps**

Tested and approved by QA in original PR

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
