### PR TITLE
fix: flaky test `Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx should queue send tx after switch network confirmation and transaction should target the correct network after switch is confirmed`

### DIFF
--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -5,7 +5,6 @@ const {
   defaultGanacheOptions,
   openDapp,
   unlockWallet,
-  veryLargeDelayMs,
   WINDOW_TITLES,
   withFixtures,
 } = require('../../helpers');
@@ -134,7 +133,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         // There is an extra window appearing and disappearing
         // so we leave this delay until the issue is fixed (#27360)
-        await driver.delay(veryLargeDelayMs);
+        await driver.delay(3000);
 
         const newDialog = await driver.getNewOrLastWindowHandle({
           driver,
@@ -294,6 +293,9 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
 
         // Wait for switch confirmation to close then tx confirmation to show.
+        // There is an extra window appearing and disappearing
+        // so we leave this delay until the issue is fixed (#27360)
+        await driver.delay(3000);
         const newDialog = await driver.getNewOrLastWindowHandle({
           driver,
           windowsBefore,

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -113,6 +113,12 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           `window.ethereum.request(${switchEthereumChainRequest})`,
         );
 
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.findElement({
+          text: 'Allow this site to switch the network?',
+          tag: 'h3',
+        });
+
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
 
         await driver.clickElement('#sendButton');
@@ -120,7 +126,6 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         const windowsBefore = await driver.getAllWindowHandles();
-
         await driver.clickElement({ text: 'Switch network', tag: 'button' });
 
         // Wait for switch confirmation to close then tx confirmation to show.
@@ -129,9 +134,11 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           windowsBefore,
         });
 
-        // For Firefox and Chrome Webpack, there is an extra window appearing and disapearing
+        // In Firefox, there is an extra window appearing and disappearing
         // so we leave this delay until the issue is fixed (#27360)
-        await driver.delay(veryLargeDelayMs);
+        if (process.env.SELENIUM_BROWSER === 'firefox') {
+          await driver.delay(veryLargeDelayMs);
+        }
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
@@ -267,6 +274,12 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.executeScript(
           `window.ethereum.request(${switchEthereumChainRequest})`,
         );
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.findElement({
+          text: 'Allow this site to switch the network?',
+          tag: 'h3',
+        });
 
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
 

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -3,7 +3,6 @@ const {
   DAPP_ONE_URL,
   DAPP_URL,
   defaultGanacheOptions,
-  largeDelayMs,
   openDapp,
   unlockWallet,
   WINDOW_TITLES,
@@ -119,20 +118,18 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
+        const windowsBefore = await driver.getAllWindowHandles();
+
         await driver.clickElement({ text: 'Switch network', tag: 'button' });
 
         // Wait for switch confirmation to close then tx confirmation to show.
-        await driver.waitUntilXWindowHandles(3);
-        await driver.delay(largeDelayMs);
+        const newDialogWindow =
+          await driver.getNewNotificationHandleAfterOldOneCloses({
+            driver,
+            windowsBefore,
+          });
 
-        // Wait for tx confirmation to show.
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-
-        // Check correct network on the send confirmation.
-        await driver.findElement({
-          css: '[data-testid="network-display"]',
-          text: 'Localhost 8546',
-        });
+        await driver.switchToWindow(newDialogWindow);
 
         await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
@@ -267,13 +264,18 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
+        const windowsBefore = await driver.getAllWindowHandles();
+
         await driver.clickElement({ text: 'Cancel', tag: 'button' });
 
         // Wait for switch confirmation to close then tx confirmation to show.
-        await driver.waitUntilXWindowHandles(3);
-        await driver.delay(largeDelayMs);
+        const newDialogWindow =
+          await driver.getNewNotificationHandleAfterOldOneCloses({
+            driver,
+            windowsBefore,
+          });
 
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.switchToWindow(newDialogWindow);
 
         // Check correct network on the send confirmation.
         await driver.findElement({

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -125,7 +125,12 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         });
 
         // Switch network and wait for confirmation to close
-        await driver.clickElementAndWaitForWindowToClose({
+        await driver.clickElement({
+          text: 'Switch network',
+          tag: 'button',
+        });
+
+        await driver.assertElementNotPresent({
           text: 'Switch network',
           tag: 'button',
         });

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -124,23 +124,16 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        const windowsBefore = await driver.getAllWindowHandles();
         await driver.clickElement({ text: 'Switch network', tag: 'button' });
 
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
 
         // Wait for switch confirmation to close then tx confirmation to show.
-
         // There is an extra window appearing and disappearing
         // so we leave this delay until the issue is fixed (#27360)
-        await driver.delay(3000);
+        await driver.delay(5000);
 
-        const newDialog = await driver.getNewOrLastWindowHandle({
-          driver,
-          windowsBefore,
-        });
-
-        await driver.switchToWindow(newDialog);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // Check correct network on the send confirmation.
         await driver.findElement({
@@ -287,21 +280,14 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        const windowsBefore = await driver.getAllWindowHandles();
-
         await driver.clickElement({ text: 'Cancel', tag: 'button' });
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
 
         // Wait for switch confirmation to close then tx confirmation to show.
         // There is an extra window appearing and disappearing
         // so we leave this delay until the issue is fixed (#27360)
-        await driver.delay(3000);
-        const newDialog = await driver.getNewOrLastWindowHandle({
-          driver,
-          windowsBefore,
-        });
-
-        await driver.switchToWindow(newDialog);
+        await driver.delay(5000);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // Check correct network on the send confirmation.
         await driver.findElement({

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -128,19 +128,20 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         const windowsBefore = await driver.getAllWindowHandles();
         await driver.clickElement({ text: 'Switch network', tag: 'button' });
 
+        await driver.switchToWindowWithUrl(DAPP_ONE_URL);
+
         // Wait for switch confirmation to close then tx confirmation to show.
-        await driver.waitForNotificationToCloseAndOpen({
+
+        // There is an extra window appearing and disappearing
+        // so we leave this delay until the issue is fixed (#27360)
+        await driver.delay(veryLargeDelayMs);
+
+        const newDialog = await driver.getNewOrLastWindowHandle({
           driver,
           windowsBefore,
         });
 
-        // In Firefox, there is an extra window appearing and disappearing
-        // so we leave this delay until the issue is fixed (#27360)
-        if (process.env.SELENIUM_BROWSER === 'firefox') {
-          await driver.delay(veryLargeDelayMs);
-        }
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.switchToWindow(newDialog);
 
         // Check correct network on the send confirmation.
         await driver.findElement({
@@ -290,14 +291,15 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         const windowsBefore = await driver.getAllWindowHandles();
 
         await driver.clickElement({ text: 'Cancel', tag: 'button' });
+        await driver.switchToWindowWithUrl(DAPP_ONE_URL);
 
         // Wait for switch confirmation to close then tx confirmation to show.
-        await driver.waitForNotificationToCloseAndOpen({
+        const newDialog = await driver.getNewOrLastWindowHandle({
           driver,
           windowsBefore,
         });
 
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.switchToWindow(newDialog);
 
         // Check correct network on the send confirmation.
         await driver.findElement({

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -10,7 +10,7 @@ const {
 } = require('../../helpers');
 
 describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
-  it('should queue send tx after switch network confirmation and transaction should target the correct network after switch is confirmed', async function () {
+  it.only('should queue send tx after switch network confirmation and transaction should target the correct network after switch is confirmed', async function () {
     const port = 8546;
     const chainId = 1338;
     await withFixtures(
@@ -119,6 +119,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         const windowsBefore = await driver.getAllWindowHandles();
+        console.log("WINDOW HANDLES WITH SWITCH NETWORK MM DIALOG", windowsBefore);
 
         await driver.clickElement({ text: 'Switch network', tag: 'button' });
 
@@ -129,6 +130,8 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
             windowsBefore,
           });
 
+        const windowAfter = await driver.getAllWindowHandles();
+        console.log("WINDOW HANDLES WITH SEND MM DIALOG", windowAfter);
         await driver.switchToWindow(newDialogWindow);
 
         // Check correct network on the send confirmation.

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -1,14 +1,13 @@
 const FixtureBuilder = require('../../fixture-builder');
 const {
-  withFixtures,
+  DAPP_ONE_URL,
+  DAPP_URL,
+  defaultGanacheOptions,
+  largeDelayMs,
   openDapp,
   unlockWallet,
-  DAPP_URL,
-  DAPP_ONE_URL,
-  regularDelayMs,
   WINDOW_TITLES,
-  defaultGanacheOptions,
-  switchToNotificationWindow,
+  withFixtures,
 } = require('../../helpers');
 
 describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
@@ -119,21 +118,12 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.clickElement('#sendButton');
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await driver.findClickableElements({
-          text: 'Switch network',
-          tag: 'button',
-        });
 
-        // Switch network and wait for confirmation to close
-        await driver.clickElement({
-          text: 'Switch network',
-          tag: 'button',
-        });
+        await driver.clickElement({ text: 'Switch network', tag: 'button' });
 
-        await driver.assertElementNotPresent({
-          text: 'Switch network',
-          tag: 'button',
-        });
+        // Wait for switch confirmation to close then tx confirmation to show.
+        await driver.waitUntilXWindowHandles(3);
+        await driver.delay(largeDelayMs);
 
         // Wait for tx confirmation to show.
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
@@ -208,9 +198,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.findClickableElement({ text: 'Connect', tag: 'button' });
         await driver.clickElement('#connectButton');
 
-        await driver.delay(regularDelayMs);
-
-        await switchToNotificationWindow(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         await driver.clickElement({
           text: 'Next',
@@ -218,7 +206,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           css: '[data-testid="page-container-footer-next"]',
         });
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
           tag: 'button',
           css: '[data-testid="page-container-footer-next"]',
@@ -237,9 +225,6 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           css: 'p',
         });
 
-        // Wait for the first dapp's connect confirmation to disappear
-        await driver.waitUntilXWindowHandles(2);
-
         // TODO: Request Queuing bug when opening both dapps at the same time will have them stuck on the same network, with will be incorrect for one of them.
         // Open Dapp Two
         await openDapp(driver, undefined, DAPP_ONE_URL);
@@ -248,9 +233,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.findClickableElement({ text: 'Connect', tag: 'button' });
         await driver.clickElement('#connectButton');
 
-        await driver.delay(regularDelayMs);
-
-        await switchToNotificationWindow(driver, 4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         await driver.clickElement({
           text: 'Next',
@@ -258,7 +241,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           css: '[data-testid="page-container-footer-next"]',
         });
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
           tag: 'button',
           css: '[data-testid="page-container-footer-next"]',
@@ -282,19 +265,15 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.clickElement('#sendButton');
 
-        await switchToNotificationWindow(driver, 4);
-        await driver.findClickableElements({
-          text: 'Cancel',
-          tag: 'button',
-        });
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         await driver.clickElement({ text: 'Cancel', tag: 'button' });
 
         // Wait for switch confirmation to close then tx confirmation to show.
         await driver.waitUntilXWindowHandles(3);
-        await driver.delay(regularDelayMs);
+        await driver.delay(largeDelayMs);
 
-        await switchToNotificationWindow(driver, 4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // Check correct network on the send confirmation.
         await driver.findElement({
@@ -302,7 +281,10 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           text: 'Localhost 8546',
         });
 
-        await driver.clickElement({ text: 'Confirm', tag: 'button' });
+        await driver.clickElementAndWaitForWindowToClose({
+          text: 'Confirm',
+          tag: 'button',
+        });
 
         // Switch back to the extension
         await driver.switchToWindowWithTitle(

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -51,9 +51,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.findClickableElement({ text: 'Connect', tag: 'button' });
         await driver.clickElement('#connectButton');
 
-        await driver.delay(regularDelayMs);
-
-        await switchToNotificationWindow(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         await driver.clickElement({
           text: 'Next',
@@ -61,7 +59,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           css: '[data-testid="page-container-footer-next"]',
         });
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
           tag: 'button',
           css: '[data-testid="page-container-footer-next"]',
@@ -80,9 +78,6 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           css: 'p',
         });
 
-        // Wait for the first dapp's connect confirmation to disappear
-        await driver.waitUntilXWindowHandles(2);
-
         // TODO: Request Queuing bug when opening both dapps at the same time will have them stuck on the same network, with will be incorrect for one of them.
         // Open Dapp Two
         await openDapp(driver, undefined, DAPP_ONE_URL);
@@ -91,9 +86,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.findClickableElement({ text: 'Connect', tag: 'button' });
         await driver.clickElement('#connectButton');
 
-        await driver.delay(regularDelayMs);
-
-        await switchToNotificationWindow(driver, 4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         await driver.clickElement({
           text: 'Next',
@@ -101,7 +94,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           css: '[data-testid="page-container-footer-next"]',
         });
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
           tag: 'button',
           css: '[data-testid="page-container-footer-next"]',
@@ -125,19 +118,20 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.clickElement('#sendButton');
 
-        await switchToNotificationWindow(driver, 4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
         await driver.findClickableElements({
           text: 'Switch network',
           tag: 'button',
         });
 
-        await driver.clickElement({ text: 'Switch network', tag: 'button' });
+        // Switch network and wait for confirmation to close
+        await driver.clickElementAndWaitForWindowToClose({
+          text: 'Switch network',
+          tag: 'button',
+        });
 
-        // Wait for switch confirmation to close then tx confirmation to show.
-        await driver.waitUntilXWindowHandles(3);
-        await driver.delay(regularDelayMs);
-
-        await switchToNotificationWindow(driver, 4);
+        // Wait for tx confirmation to show.
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // Check correct network on the send confirmation.
         await driver.findElement({
@@ -145,7 +139,10 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           text: 'Localhost 8546',
         });
 
-        await driver.clickElement({ text: 'Confirm', tag: 'button' });
+        await driver.clickElementAndWaitForWindowToClose({
+          text: 'Confirm',
+          tag: 'button',
+        });
 
         // Switch back to the extension
         await driver.switchToWindowWithTitle(

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -131,6 +131,12 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         await driver.switchToWindow(newDialogWindow);
 
+        // Check correct network on the send confirmation.
+        await driver.findElement({
+          css: '[data-testid="network-display"]',
+          text: 'Localhost 8546',
+        });
+
         await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
           tag: 'button',

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js
@@ -129,11 +129,9 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           windowsBefore,
         });
 
-        // For Firefox/Webpack, there is an extra window appearing and disapearing
+        // For Firefox and Chrome Webpack, there is an extra window appearing and disapearing
         // so we leave this delay until the issue is fixed (#27360)
-        if (process.env.SELENIUM_BROWSER !== 'chrome') {
-          await driver.delay(veryLargeDelayMs);
-        }
+        await driver.delay(veryLargeDelayMs);
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1091,17 +1091,17 @@ class Driver {
   }
 
   /**
-   * Waits for a notification to close and a new one to open, handling race conditions.
+   * Waits for a notification to close and a new one to open, handling potential race conditions.
    *
    * @param {object} params - The parameters for the function.
    * @param {WebDriver} params.driver - The WebDriver instance used to interact with the browser.
-   * @param {Array<string>} params.windowsBefore - The list of window handles before the action to close the notification.
+   * @param {Array<string>} params.windowsBefore - The list of window handles before the action.
    * @param {number} [params.maxAttempts] - The maximum number of attempts to find the new window handle.
    * @param {number} [params.retryDelayMs] - The delay in milliseconds between retry attempts.
    * @returns {Promise<string>} A promise that resolves to the new window handle.
    * @throws {Error} If the new window handle is not found after the maximum number of attempts.
    */
-  async getNewNotificationHandleAfterOldOneCloses({
+  async waitForNotificationToCloseAndOpen({
     driver,
     maxAttempts = 5,
     retryDelayMs = 1500,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1111,7 +1111,7 @@ class Driver {
     let newWindowHandle;
     let windowsAfter;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      windowsAfter = await driver.getAllWindowHandles();
+      windowsAfter = await this.getAllWindowHandles();
       const foundNewWindow = windowsAfter.find(
         (handle) => !windowsBefore.includes(handle),
       );

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1100,7 +1100,7 @@ class Driver {
    * @param {Array<string>} params.windowsBefore - The list of window handles before the action.
    * @param {number} [params.maxAttempts] - The maximum number of attempts to find the new window handle.
    * @param {number} [params.retryDelayMs] - The delay in milliseconds between retry attempts.
-   * @returns {string} The new window handle if found, or the last window handle from the array if not found.
+   * @returns {Promise<string>} A promise that resolves to the new window handle if found, or the last window handle from the array if not found.
    */
   async getNewOrLastWindowHandle({
     driver,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1098,7 +1098,6 @@ class Driver {
    * @param {Array<string>} params.windowsBefore - The list of window handles before the action.
    * @param {number} [params.maxAttempts] - The maximum number of attempts to find the new window handle.
    * @param {number} [params.retryDelayMs] - The delay in milliseconds between retry attempts.
-   * @returns {Promise<string>} A promise that resolves to the new window handle.
    * @throws {Error} If the new window handle is not found after the maximum number of attempts.
    */
   async waitForNotificationToCloseAndOpen({
@@ -1133,8 +1132,6 @@ class Driver {
         'Failed to identify the new window handle after multiple attempts',
       );
     }
-
-    return newWindowHandle;
   }
 
   // Error handling

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1103,33 +1103,37 @@ class Driver {
   async waitForNotificationToCloseAndOpen({
     driver,
     maxAttempts = 5,
-    retryDelayMs = 1500,
+    retryDelayMs = 2000,
     windowsBefore,
   }) {
-    let newWindowHandle;
+    let newWindowHandles = [];
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const windowsAfter = await driver.getAllWindowHandles();
-      newWindowHandle = windowsAfter.find(
-        (handle) => !windowsBefore.includes(handle),
+      const foundNewWindows = windowsAfter.filter(
+        (handle) =>!windowsBefore.includes(handle) && !newWindowHandles.includes(handle),
       );
 
-      if (newWindowHandle) {
-        console.log(`New window handle found: ${newWindowHandle}`);
-        break;
+      if (foundNewWindows.length > 0) {
+        newWindowHandles = [...newWindowHandles, ...foundNewWindows];
+        console.log(`New window handles found: ${foundNewWindows.join(', ')}`);
       }
 
       if (attempt < maxAttempts) {
         console.log(
-          `New window handle not found, retrying in ${retryDelayMs}ms...`,
+          `Checking for additional new windows in ${retryDelayMs}ms...`,
         );
         await driver.delay(retryDelayMs);
       }
     }
 
-    if (!newWindowHandle) {
-      throw new Error(
-        'Failed to identify the new window handle after multiple attempts',
+    if (newWindowHandles.length === 0) {
+      console.log(
+        'Failed to identify any new window handles after multiple attempts',
+      );
+    } else {
+      console.log(
+        `Total new window handles found: ${newWindowHandles.join(', ')}`,
       );
     }
   }

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1090,54 +1090,6 @@ class Driver {
     }
   }
 
-  /**
-   * Gets a new window handle if one is found, or returns the last window handle if no new one is found
-   * after several retrials.
-   * This function is specially suitable when there are multiple popups queued, and context is invalidated.
-   *
-   * @param {object} params - The parameters for the function.
-   * @param {WebDriver} params.driver - The WebDriver instance used to interact with the browser.
-   * @param {Array<string>} params.windowsBefore - The list of window handles before the action.
-   * @param {number} [params.maxAttempts] - The maximum number of attempts to find the new window handle.
-   * @param {number} [params.retryDelayMs] - The delay in milliseconds between retry attempts.
-   * @returns {Promise<string>} A promise that resolves to the new window handle if found, or the last window handle from the array if not found.
-   */
-  async getNewOrLastWindowHandle({
-    driver,
-    maxAttempts = 5,
-    retryDelayMs = 2000,
-    windowsBefore,
-  }) {
-    let newWindowHandle;
-    let windowsAfter;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      windowsAfter = await this.getAllWindowHandles();
-      const foundNewWindow = windowsAfter.find(
-        (handle) => !windowsBefore.includes(handle),
-      );
-
-      if (foundNewWindow) {
-        newWindowHandle = foundNewWindow;
-        console.log(`New window handle found: ${foundNewWindow}`);
-      }
-
-      if (attempt < maxAttempts) {
-        console.log(
-          `Checking for additional new windows in ${retryDelayMs}ms...`,
-        );
-        await driver.delay(retryDelayMs);
-      }
-    }
-
-    if (!newWindowHandle) {
-      console.log(
-        'Failed to identify a new window handle after multiple attempts',
-      );
-      newWindowHandle = windowsAfter.slice(-1)[0];
-    }
-    return newWindowHandle;
-  }
-
   // Error handling
 
   async verboseReportOnFailure(title, error) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a race condition with window management that makes this test fail quite often. The test performs these actions and there are different behaviors happening, depending on the build:

1. Action: trigger a network switch -> this opens a new dialog window (we have 4)
2. Action: trigger a send -> we are still with the network switch window open
3. Action: we click switch network -> this closes the dialog (now we have 3 windows for a brief moment - if this is fast, like in webpack, it fails with the error `Error: waitUntilXWindowHandles timed out polling window handles. Expected: 3, Actual: 4`)
4. A new dialog is open automatically -> now we have 4 windows again, but the dialog handle ids are different
5. Sometimes this dialog is closed and then a new one is open
6. We switch to the dialog, but often the context is invalidated as we are switching to either 1 or 4 or 5

Extra Notes:
This PR fixes the flakiness of waiting for 3 windows by adding a delay. This won't fix the root cause of the 2 new identified issues, but after re-runs has proven to stabilize the test

- In Webpack, sometimes the dialog for the transaction never appears, and the wallet get's in  a frozen state. The issue is on the wallet level, see https://github.com/MetaMask/metamask-extension/issues/27414
- see issue https://github.com/MetaMask/metamask-extension/issues/27360
Since there is only a brief moment for having 3 windows, waiting for 3 windows and then proceeding also makes the test flaky, so it's not effective.



![Screenshot from 2024-09-26 11-26-34](https://github.com/user-attachments/assets/d4f7684f-6fc6-481f-9d47-a65656c8989a)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27352?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27387

## **Manual testing steps**

1. Check ci
2. Run test locally `yarn test:e2e:single test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.js --browser=chrome`

## **Screenshots/Recordings**

Problem in FF and Webpack, see how popup is open and closed, and then a new popup is open with the transaction.


https://github.com/user-attachments/assets/c17ff7bd-6b1d-4517-b33f-95f7ac6d3120


Problem in Webpack, where tx does not open after the change networks

https://github.com/user-attachments/assets/2b626159-ec37-4b3c-9c91-80ab4011f751





Problem Webpack, see how popup is open and closed, and then a new popup is open with the transaction.


https://github.com/user-attachments/assets/8165b3e7-2ed4-4704-91dc-82776edb0bd8




<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
