### PR TITLE
fix: skip over preinstalled ENS snap when custom RPC is used for mainnet

### DIFF
--- a/ui/ducks/domains.test.ts
+++ b/ui/ducks/domains.test.ts
@@ -1,0 +1,238 @@
+import { fetchResolutions, shouldSkipEnsResolutionSnap } from './domains';
+// eslint-disable-next-line import/order
+import * as storeActions from '../store/actions';
+
+jest.mock('../store/actions', () => ({
+  ...jest.requireActual('../store/actions'),
+  handleSnapRequest: jest.fn(() => Promise.resolve({ resolvedAddresses: [] })),
+}));
+const mockedStoreActions = jest.mocked(storeActions);
+
+const preinstalledSnapState = {
+  snaps: {
+    'npm:@metamask/ens-resolver-snap': {
+      blocked: false,
+      enabled: true,
+      id: 'npm:@metamask/ens-resolver-snap',
+      initialPermissions: {
+        'endowment:ethereum-provider': {},
+        'endowment:name-lookup': {},
+        'endowment:network-access': {},
+      },
+      localizationFiles: [],
+      manifest: {
+        description: 'A Snap used for ENS name resolution',
+        initialPermissions: {
+          'endowment:ethereum-provider': {},
+          'endowment:name-lookup': {},
+          'endowment:network-access': {},
+        },
+        manifestVersion: '0.1',
+        proposedName: 'Ethereum Name Service resolver',
+        repository: {
+          type: 'git',
+          url: 'https://github.com/MetaMask/ens-resolver-snap.git',
+        },
+        source: {
+          location: {
+            npm: {
+              filePath: 'dist/bundle.js',
+              iconPath: 'images/icon.svg',
+              packageName: '@metamask/ens-resolver-snap',
+              registry: 'https://registry.npmjs.org/',
+            },
+          },
+          shasum: 'BizRmzfV+oKEIlvph12McsIqzzDECIw/Td7Lx+/cios=',
+        },
+        version: '0.1.2',
+      },
+      preinstalled: true,
+      removable: false,
+      status: 'crashed',
+      version: '0.1.2',
+      versionHistory: [
+        { date: 1726481055390, origin: 'metamask', version: '0.1.2' },
+      ],
+    },
+  },
+  subjects: {
+    'npm:@metamask/ens-resolver-snap': {
+      origin: 'npm:@metamask/ens-resolver-snap',
+      permissions: {
+        'endowment:ethereum-provider': {
+          caveats: null,
+          date: 1726481055390,
+          id: '5BFL-61JzLdm9GD-fxBy2',
+          invoker: 'npm:@metamask/ens-resolver-snap',
+          parentCapability: 'endowment:ethereum-provider',
+        },
+        'endowment:name-lookup': {
+          caveats: null,
+          date: 1726481055390,
+          id: 'b0q0p5kbA95LB1pRB9lsm',
+          invoker: 'npm:@metamask/ens-resolver-snap',
+          parentCapability: 'endowment:name-lookup',
+        },
+        'endowment:network-access': {
+          caveats: null,
+          date: 1726481055390,
+          id: 'XMk2mHrkgrRgXC8kjwtzV',
+          invoker: 'npm:@metamask/ens-resolver-snap',
+          parentCapability: 'endowment:network-access',
+        },
+      },
+    },
+  },
+};
+
+describe('domain resolution using preinstalled snap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not skip snap for mainnet', async () => {
+    const state = {
+      metamask: {
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            name: 'Ethereum Mainnet',
+            nativeCurrency: 'ETH',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+          },
+        },
+        ...preinstalledSnapState,
+      },
+    };
+
+    await fetchResolutions({
+      domain: 'luc.eth',
+      chainId: 'eip155:1',
+      state,
+    });
+
+    expect(mockedStoreActions.handleSnapRequest).toHaveBeenCalledWith({
+      snapId: 'npm:@metamask/ens-resolver-snap',
+      origin: '',
+      handler: 'onNameLookup',
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {
+          chainId: 'eip155:1',
+          domain: 'luc.eth',
+        },
+      },
+    });
+  });
+
+  it('should not skip other snaps', async () => {
+    const skip = shouldSkipEnsResolutionSnap(
+      'eip155:100',
+      'npm:@metamask/other-snap',
+      {},
+    );
+
+    expect(skip).toBe(false);
+  });
+
+  it('should not skip snap when non-mainnet and using infura', async () => {
+    const state = {
+      metamask: {
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            name: 'Ethereum Mainnet',
+            nativeCurrency: 'ETH',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+          },
+        },
+        ...preinstalledSnapState,
+      },
+    };
+
+    await fetchResolutions({
+      domain: 'luc.eth',
+      chainId: 'eip155:100',
+      state,
+    });
+
+    expect(mockedStoreActions.handleSnapRequest).toHaveBeenCalledWith({
+      snapId: 'npm:@metamask/ens-resolver-snap',
+      origin: '',
+      handler: 'onNameLookup',
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {
+          chainId: 'eip155:100',
+          domain: 'luc.eth',
+        },
+      },
+    });
+  });
+
+  it('should skip snap when non-mainnet and using custom RPC', async () => {
+    const state = {
+      metamask: {
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            name: 'Ethereum Mainnet',
+            nativeCurrency: 'ETH',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+              {
+                url: 'https://eth.llamarpc.com',
+                name: 'llama',
+                type: 'custom',
+                networkClientId: '39f2289a-1876-4a9d-ae85-3bb84fb013cf',
+              },
+            ],
+            defaultRpcEndpointIndex: 1,
+          },
+        },
+        ...preinstalledSnapState,
+      },
+    };
+    const resolutions = await fetchResolutions({
+      domain: 'luc.eth',
+      chainId: 'eip155:100',
+      state,
+    });
+    expect(resolutions).toEqual([]);
+    expect(mockedStoreActions.handleSnapRequest).not.toHaveBeenCalled();
+  });
+
+  it('should skip snap when non-mainnet and no RPC for mainnet', async () => {
+    const skip = shouldSkipEnsResolutionSnap(
+      'eip155:100',
+      'npm:@metamask/ens-resolver-snap',
+      {
+        metamask: {
+          networkConfigurationsByChainId: {},
+        },
+      },
+    );
+
+    expect(skip).toBe(true);
+  });
+});

--- a/ui/ducks/domains.test.ts
+++ b/ui/ducks/domains.test.ts
@@ -90,7 +90,7 @@ describe('domain resolution using preinstalled snap', () => {
     jest.clearAllMocks();
   });
 
-  it('should not skip snap for mainnet', async () => {
+  it('does not skip ENS snap for mainnet', async () => {
     const state = {
       metamask: {
         networkConfigurationsByChainId: {
@@ -113,7 +113,7 @@ describe('domain resolution using preinstalled snap', () => {
     };
 
     await fetchResolutions({
-      domain: 'luc.eth',
+      domain: 'test.eth',
       chainId: 'eip155:1',
       state,
     });
@@ -127,13 +127,13 @@ describe('domain resolution using preinstalled snap', () => {
         method: ' ',
         params: {
           chainId: 'eip155:1',
-          domain: 'luc.eth',
+          domain: 'test.eth',
         },
       },
     });
   });
 
-  it('should not skip other snaps', async () => {
+  it('does not skip other snaps', async () => {
     const skip = shouldSkipEnsResolutionSnap(
       'eip155:100',
       'npm:@metamask/other-snap',
@@ -143,7 +143,7 @@ describe('domain resolution using preinstalled snap', () => {
     expect(skip).toBe(false);
   });
 
-  it('should not skip snap when non-mainnet and using infura', async () => {
+  it('does not skip ENS snap when non-mainnet and using infura', async () => {
     const state = {
       metamask: {
         networkConfigurationsByChainId: {
@@ -166,7 +166,7 @@ describe('domain resolution using preinstalled snap', () => {
     };
 
     await fetchResolutions({
-      domain: 'luc.eth',
+      domain: 'test.eth',
       chainId: 'eip155:100',
       state,
     });
@@ -180,13 +180,13 @@ describe('domain resolution using preinstalled snap', () => {
         method: ' ',
         params: {
           chainId: 'eip155:100',
-          domain: 'luc.eth',
+          domain: 'test.eth',
         },
       },
     });
   });
 
-  it('should skip snap when non-mainnet and using custom RPC', async () => {
+  it('skips ENS snap when non-mainnet and using custom RPC', async () => {
     const state = {
       metamask: {
         networkConfigurationsByChainId: {
@@ -214,7 +214,7 @@ describe('domain resolution using preinstalled snap', () => {
       },
     };
     const resolutions = await fetchResolutions({
-      domain: 'luc.eth',
+      domain: 'test.eth',
       chainId: 'eip155:100',
       state,
     });
@@ -222,7 +222,7 @@ describe('domain resolution using preinstalled snap', () => {
     expect(mockedStoreActions.handleSnapRequest).not.toHaveBeenCalled();
   });
 
-  it('should skip snap when non-mainnet and no RPC for mainnet', async () => {
+  it('skips ENS snap when non-mainnet and no RPC defined for mainnet', async () => {
     const skip = shouldSkipEnsResolutionSnap(
       'eip155:100',
       'npm:@metamask/ens-resolver-snap',


### PR DESCRIPTION
## **Description**

We now have a preinstalled snap that does the [ENS forward resolution in the Metamask-extension](https://github.com/MetaMask/metamask-extension/pull/26242)

However, because ENS requires a mainnet connection and there is no way for a snap to request a particular provider configuration from the wallet, the snap is forced to use a direct connection to Infura in certain corner cases.

This is a temporary situation, as there is a plan to [enhance the provider API for snaps](https://github.com/MetaMask/MetaMask-planning/issues/2915).

Until we have that better API we should respect the user's choice to not use Infura, so the compromise solution that was proposed is to disable the snap in those corner cases when the user is using a custom RPC for mainnet.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27367?quickstart=1)

## **Related issues**

fixes https://github.com/MetaMask/MetaMask-planning/issues/3339

## **Manual testing steps**

### Direct test
1. Configure a custom RPC URL for mainnet (e.g. https://eth.llamarpc.com)
2. Select that custom RPC URL
3. Switch networks to some other network (e.g. Linea)
4. Initiate a send flow and try to resolve an ENS name (e.g. `vitalik.eth`)
5. Observe the error `No resolution for domain provided.`
### Other cases are not affected
6.Switch networks to mainnet (keeping custom RPC selected)
7. Observe `vitalik.eth` resolving to an address
8. Select infura RPC for mainnet and select mainnet as a network
9. Observe `vitalik.eth` resolving to an address
10. While infura RPC is selected for mainnet, switch to a different network
11. Observe `vitalik.eth` resolving to an address from mainnet (with a warning :warning:)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/3d3881cf-a127-431d-9f48-89702ca57d0e

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
