### PR TITLE
fix: isPermitSignatureRequest logic. Do not display as Permit if spender is not present

### DIFF
--- a/test/data/confirmations/typed_sign.ts
+++ b/test/data/confirmations/typed_sign.ts
@@ -163,6 +163,65 @@ export const orderSignatureMsg = {
   },
 };
 
+export const permitMessageDataJson = {
+  types: {
+    EIP712Domain: [
+      {
+        name: 'name',
+        type: 'string',
+      },
+      {
+        name: 'version',
+        type: 'string',
+      },
+      {
+        name: 'chainId',
+        type: 'uint256',
+      },
+      {
+        name: 'verifyingContract',
+        type: 'address',
+      },
+    ],
+    Permit: [
+      {
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        name: 'nonce',
+        type: 'uint256',
+      },
+      {
+        name: 'deadline',
+        type: 'uint256',
+      },
+    ],
+  },
+  primaryType: 'Permit',
+  domain: {
+    name: 'MyToken',
+    version: '1',
+    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    chainId: 1,
+  },
+  message: {
+    owner: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+    spender: '0x5B38Da6a701c568545dCfcB03FcB875f56beddC4',
+    value: 3000,
+    nonce: 0,
+    deadline: 50000000000,
+  },
+};
+
 export const permitSignatureMsg = {
   id: '0b1787a0-1c44-11ef-b70d-e7064bd7b659',
   securityAlertResponse: {
@@ -174,7 +233,7 @@ export const permitSignatureMsg = {
   time: 1716826404122,
   type: TransactionType.signTypedData,
   msgParams: {
-    data: '{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"primaryType":"Permit","domain":{"name":"MyToken","version":"1","verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC","chainId":1},"message":{"owner":"0x935e73edb9ff52e23bac7f7e043a1ecd06d05477","spender":"0x5B38Da6a701c568545dCfcB03FcB875f56beddC4","value":3000,"nonce":0,"deadline":50000000000}}',
+    data: JSON.stringify(permitMessageDataJson),
     from: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
     version: 'V4',
     requestId: 14,

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
@@ -60,6 +60,10 @@ const TypedSignInfo: React.FC = () => {
     <>
       {isPermit && useTransactionSimulations && <PermitSimulation />}
       <ConfirmInfoSection>
+        {/*
+          It's possible the primaryType matches our Permit primaryType list,
+          but it may not be, so check spender exists before displaying.
+        */}
         {isPermit && spender && (
           <>
             <ConfirmInfoRow label={t('spender')}>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
@@ -60,7 +60,7 @@ const TypedSignInfo: React.FC = () => {
     <>
       {isPermit && useTransactionSimulations && <PermitSimulation />}
       <ConfirmInfoSection>
-        {isPermit && (
+        {isPermit && spender && (
           <>
             <ConfirmInfoRow label={t('spender')}>
               <ConfirmInfoRowAddress address={spender} />

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
@@ -60,11 +60,7 @@ const TypedSignInfo: React.FC = () => {
     <>
       {isPermit && useTransactionSimulations && <PermitSimulation />}
       <ConfirmInfoSection>
-        {/*
-          It's possible the primaryType matches our Permit primaryType list,
-          but it may not be, so check spender exists before displaying.
-        */}
-        {isPermit && spender && (
+        {isPermit && (
           <>
             <ConfirmInfoRow label={t('spender')}>
               <ConfirmInfoRowAddress address={spender} />

--- a/ui/pages/confirmations/utils/confirm.test.ts
+++ b/ui/pages/confirmations/utils/confirm.test.ts
@@ -79,50 +79,6 @@ describe('confirm util', () => {
       expect(result).toStrictEqual(true);
     });
 
-    it('returns true for permit signature requests including when value is 0', () => {
-      const data = cloneDeep(permitMessageDataJson);
-      data.message.value = 0;
-
-      const mockMessage = {
-        ...permitSignatureMsg,
-        msgParams: {
-          data: JSON.stringify(data),
-        },
-      } as SignatureRequestType;
-
-      const result = isPermitSignatureRequest(mockMessage);
-      expect(result).toStrictEqual(true);
-    });
-
-    it('returns false if it is missing a value', () => {
-      const data = cloneDeep(permitMessageDataJson);
-      data.message.value = NaN;
-
-      const mockMessage = {
-        ...permitSignatureMsg,
-        msgParams: {
-          data: JSON.stringify(data),
-        },
-      } as SignatureRequestType;
-
-      const result = isPermitSignatureRequest(mockMessage);
-      expect(result).toStrictEqual(false);
-    });
-
-    it('returns false if it is missing a valid owner address', () => {
-      const data = cloneDeep(permitMessageDataJson);
-      data.message.owner = '0x';
-      const mockMessage = {
-        ...permitSignatureMsg,
-        msgParams: {
-          data: JSON.stringify(data),
-        },
-      } as SignatureRequestType;
-
-      const result = isPermitSignatureRequest(mockMessage);
-      expect(result).toStrictEqual(false);
-    });
-
     it('returns false if it is missing a valid spender address', () => {
       const data = cloneDeep(permitMessageDataJson);
       data.message.spender = '';

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -95,14 +95,13 @@ export const isPermitSignatureRequest = (request?: Confirmation) => {
   ) {
     return false;
   }
-  const parsedData = parseTypedDataMessage(
-    (request as SignatureRequestType).msgParams?.data as string,
-  );
 
   const {
     message: { spender },
     primaryType,
-  } = parsedData;
+  } = parseTypedDataMessage(
+    (request as SignatureRequestType).msgParams?.data as string,
+  );
 
   if (!isHexString(spender)) {
     return false;

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -77,11 +77,11 @@ export const isOrderSignatureRequest = (request: SignatureRequestType) => {
 };
 
 /**
- * Returns true if the request appears to be a Permit or Permit2 Typed Sign signature request
- * Caution: This is a limited check. It may exclude valid types if the primaryType does not
- * match our list.
+ * Returns true if the request appears to be an EIP-2612 Permit or Permit2 signTypedData signature request.
+ * Caution: This is a limited check. It may include other Permits which are not the specific types mentioned
+ * if they match the primaryType check and have a spender field.
  *
- * TODO: Improve detection of fields and remove explicit primaryType check.
+ * TODO: Improve detection of fields.
  *
  * @param request - The confirmation request to check
  */

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -1,7 +1,7 @@
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 import { TransactionType } from '@metamask/transaction-controller';
-import { isValidHexAddress, Json } from '@metamask/utils';
+import { isHexString, Json } from '@metamask/utils';
 import {
   PRIMARY_TYPES_ORDER,
   PRIMARY_TYPES_PERMIT,
@@ -77,10 +77,11 @@ export const isOrderSignatureRequest = (request: SignatureRequestType) => {
 };
 
 /**
- * Returns true if the request appears to be a Permit Typed Sign signature request
- * based on EIP-2612 spec and the primaryType. This may exclude EIP-2612 types if
- * the primaryType does not match our list. Ideally, we will remove the strict
- * primaryType specification.
+ * Returns true if the request appears to be a Permit or Permit2 Typed Sign signature request
+ * Caution: This is a limited check. It may exclude valid types if the primaryType does not
+ * match our list.
+ *
+ * TODO: Improve detection of fields and remove explicit primaryType check.
  *
  * @param request - The confirmation request to check
  */
@@ -99,17 +100,11 @@ export const isPermitSignatureRequest = (request?: Confirmation) => {
   );
 
   const {
-    message: { owner, spender, value },
+    message: { spender },
     primaryType,
   } = parsedData;
 
-  const hasPermitFields =
-    isValidHexAddress(owner) &&
-    isValidHexAddress(spender) &&
-    value !== undefined &&
-    value !== null;
-
-  if (!hasPermitFields) {
+  if (!isHexString(spender)) {
     return false;
   }
 

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -77,7 +77,9 @@ export const isOrderSignatureRequest = (request: SignatureRequestType) => {
 };
 
 /**
- * Returns true if the request is a Permit Typed Sign signature request
+ * Returns true if the request appears to be a Permit Typed Sign signature request
+ * based on the primaryType. This *does not* do an in-depth check to verify the message matches
+ * the EIP-2612 standard.
  *
  * @param request - The confirmation request to check
  */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

If primaryType either:
- Permit 
- PermitBatch
- PermitBatchTransferFrom
- PermitSingle
-  PermitTransferFrom

and it does not have a "spender" hex address, do not render the signature as a Permit. Without a spender, we will fallback to an EIP-712 signature.

Note: The check for isPermitSignatureRequest is not sophisticated. This will be revisited with the upcoming Signatures API work. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27384?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27385

## **Manual testing steps**

```
await window.ethereum.request({ "method": "eth_signTypedData_v4", "params": [
  "0xE56E7847Fd3661A9B7c86aAF1DaEa08D9DA5750e", 
    {
            domain: {
              name: 'Test Domain',
              version: '1',
              chainId: 11155111,
              verifyingContract: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
            },
                    types: {
          Person: [
            { name: "name", type: "string" },
            { name: "wallet", type: "address" },
          ],
          Permit: [
            { name: "from", type: "Person" },
            { name: "to", type: "Person" },
            { name: "contents", type: "string" },
          ],
        },
        primaryType: "Permit",
        message: {
          from: {
            name: "Cow",
            wallet: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
          },
          to: {
            name: "Bob",
            wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
          },
          contents: "Hello, Bob!",
        },
  }
], });
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="320" src="https://github.com/user-attachments/assets/2605809c-0e50-452e-9ee5-d8f954969285"> 

### **After**

<!-- [screenshots/recordings] -->
<img width="320" src="https://github.com/user-attachments/assets/b6ed0e7a-bdfe-4869-8a4b-dce37c0acdfa">

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
