### PR TITLE
fix(snaps): Fix gaps for custom UI Boxes

### DIFF
--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -33,7 +33,7 @@ export const SnapUIForm: FunctionComponent<SnapUIFormProps> = ({
       id={name}
       display={Display.Flex}
       flexDirection={FlexDirection.Column}
-      gap={4}
+      gap={2}
     >
       {children}
     </Box>

--- a/ui/components/app/snaps/snap-ui-renderer/index.scss
+++ b/ui/components/app/snaps/snap-ui-renderer/index.scss
@@ -5,6 +5,7 @@
 
   &__container {
     & > *:first-child {
+      gap: 16px;
       padding: 16px;
     }
   }
@@ -40,7 +41,7 @@
   }
 
   &__panel {
-    gap: 16px;
+    gap: 8px;
 
     .mm-icon--size-inherit {
       top: 0;


### PR DESCRIPTION
## **Description**

This PR fixes the gap between boxes being always at `16px`.

It's now set to `16px` for the root Box and `8px` for all the children Boxes

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27405?quickstart=1)

## **Related issues**

Fixes: #27399 

## **Manual testing steps**

1. Go to test-snaps
2. Use the send flow example snap
3. The higher box should have a `16px` gap and the other one should have a `8px` gap

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
