### PR TITLE
ci: Sentry reporting only on develop branch, with Git message overrides

### DIFF
--- a/app/scripts/lib/manifestFlags.ts
+++ b/app/scripts/lib/manifestFlags.ts
@@ -9,7 +9,10 @@ export type ManifestFlags = {
     nodeIndex?: number;
     prNumber?: number;
   };
-  doNotForceSentryForThisTest?: boolean;
+  sentry?: {
+    tracesSampleRate?: number;
+    doNotForceSentryForThisTest?: boolean;
+  };
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- you can't extend a type, we want this to be an interface

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -115,8 +115,19 @@ function getTracesSampleRate(sentryTarget) {
 
   const flags = getManifestFlags();
 
+  // Grab the tracesSampleRate that may have come in from a git message
+  // 0 is a valid value, so must explicitly check for undefined
+  if (flags.sentry?.tracesSampleRate !== undefined) {
+    return flags.sentry.tracesSampleRate;
+  }
+
   if (flags.circleci) {
-    return 0.003;
+    // Report very frequently on develop branch, and never on other branches
+    // (Unless you do a [flags.sentry.tracesSampleRate: x.xx] override)
+    if (flags.circleci.branch === 'develop') {
+      return 0.03;
+    }
+    return 0;
   }
 
   if (METAMASK_DEBUG) {
@@ -227,7 +238,7 @@ function getSentryEnvironment() {
 
 function getSentryTarget() {
   if (
-    getManifestFlags().doNotForceSentryForThisTest ||
+    getManifestFlags().sentry?.doNotForceSentryForThisTest ||
     (process.env.IN_TEST && !SENTRY_DSN_DEV)
   ) {
     return SENTRY_DSN_FAKE;
@@ -261,7 +272,7 @@ async function getMetaMetricsEnabled() {
 
   if (
     METAMASK_BUILD_TYPE === 'mmi' ||
-    (flags.circleci && !flags.doNotForceSentryForThisTest)
+    (flags.circleci && !flags.sentry?.doNotForceSentryForThisTest)
   ) {
     return true;
   }

--- a/test/e2e/set-manifest-flags.ts
+++ b/test/e2e/set-manifest-flags.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import fs from 'fs';
 import { ManifestFlags } from '../../app/scripts/lib/manifestFlags';
 
@@ -5,6 +6,25 @@ export const folder = `dist/${process.env.SELENIUM_BROWSER}`;
 
 function parseIntOrUndefined(value: string | undefined): number | undefined {
   return value ? parseInt(value, 10) : undefined;
+}
+
+// Grab the tracesSampleRate from the git message if it's set
+function getTracesSampleRateFromGitMessage(): number | undefined {
+  const gitMessage = execSync(
+    `git show --format='%B' --no-patch "HEAD"`,
+  ).toString();
+
+  // Search gitMessage for `[flags.sentry.tracesSampleRate: 0.000 to 1.000]`
+  const tracesSampleRateMatch = gitMessage.match(
+    /\[flags\.sentry\.tracesSampleRate: (0*(\.\d+)?|1(\.0*)?)\]/u,
+  );
+
+  if (tracesSampleRateMatch) {
+    // Return 1st capturing group from regex
+    return parseFloat(tracesSampleRateMatch[1]);
+  }
+
+  return undefined;
 }
 
 // Alter the manifest with CircleCI environment variables and custom flags
@@ -20,6 +40,14 @@ export function setManifestFlags(flags: ManifestFlags = {}) {
         process.env.CIRCLE_PULL_REQUEST?.split('/').pop(), // The CIRCLE_PR_NUMBER variable is only available on forked Pull Requests
       ),
     };
+
+    const tracesSampleRate = getTracesSampleRateFromGitMessage();
+
+    // 0 is a valid value, so must explicitly check for undefined
+    if (tracesSampleRate !== undefined) {
+      // Add tracesSampleRate to flags.sentry (which may or may not already exist)
+      flags.sentry = { ...flags.sentry, tracesSampleRate };
+    }
   }
 
   const manifest = JSON.parse(

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -247,7 +247,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -278,7 +278,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -319,7 +319,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -365,7 +365,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -426,7 +426,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryInvariantMigrationError,
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -475,7 +475,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -521,7 +521,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -585,7 +585,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -621,7 +621,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -656,7 +656,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -702,7 +702,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, ganacheServer, mockedEndpoint }) => {
@@ -766,7 +766,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -810,7 +810,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            doNotForceSentryForThisTest: true,
+            sentry: { doNotForceSentryForThisTest: true },
           },
         },
         async ({ driver, ganacheServer, mockedEndpoint }) => {
@@ -898,7 +898,7 @@ describe('Sentry errors', function () {
         ganacheOptions,
         title: this.test.fullTitle(),
         manifestFlags: {
-          doNotForceSentryForThisTest: true,
+          sentry: { doNotForceSentryForThisTest: true },
         },
       },
       async ({ driver }) => {

--- a/test/e2e/tests/metrics/sessions.spec.ts
+++ b/test/e2e/tests/metrics/sessions.spec.ts
@@ -38,7 +38,7 @@ describe('Sessions', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentrySession,
         manifestFlags: {
-          doNotForceSentryForThisTest: true,
+          sentry: { doNotForceSentryForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -60,7 +60,7 @@ describe('Sessions', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentrySession,
         manifestFlags: {
-          doNotForceSentryForThisTest: true,
+          sentry: { doNotForceSentryForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {

--- a/test/e2e/tests/metrics/traces.spec.ts
+++ b/test/e2e/tests/metrics/traces.spec.ts
@@ -51,7 +51,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryCustomTrace,
         manifestFlags: {
-          doNotForceSentryForThisTest: true,
+          sentry: { doNotForceSentryForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -73,7 +73,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryCustomTrace,
         manifestFlags: {
-          doNotForceSentryForThisTest: true,
+          sentry: { doNotForceSentryForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -95,7 +95,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryAutomatedTrace,
         manifestFlags: {
-          doNotForceSentryForThisTest: true,
+          sentry: { doNotForceSentryForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -117,7 +117,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryAutomatedTrace,
         manifestFlags: {
-          doNotForceSentryForThisTest: true,
+          sentry: { doNotForceSentryForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {


### PR DESCRIPTION
## **Description**

Vaibhav asked for new Sentry reporting rates from CircleCI:
- 10 times as frequent from the `develop` branch
- Never from other branches

I also put in an override, such that if your Git message includes `[flags.sentry.tracesSampleRate: x.xx]` (a decimal number from 0.00 to 1.00), it will set `tracesSampleRate` to that fraction.

Moved what used to be at `_flags.doNotForceSentryForThisTest` to `_flags.sentry.doNotForceSentryForThisTest`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27412?quickstart=1)

## **Related issues**

Improves on: #26588

## **Manual testing steps**

- You shouldn't see any Sentry reporting from this branch
- Try a commit on top of this with a Git message including `[flags.sentry.tracesSampleRate: 1.00]`, and it should report to Sentry

## **Screenshots/Recordings**
### **Before**
### **After**
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
