### PR TITLE
feat: Enable gas included swaps

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2121,6 +2121,9 @@
     "message": "This gas fee has been suggested by $1. Overriding this may cause a problem with your transaction. Please reach out to $1 if you have questions.",
     "description": "$1 represents the Dapp's origin"
   },
+  "gasFee": {
+    "message": "Gas fee"
+  },
   "gasIsETH": {
     "message": "Gas is $1 "
   },
@@ -2434,6 +2437,9 @@
   },
   "inYourSettings": {
     "message": "in your Settings"
+  },
+  "included": {
+    "message": "included"
   },
   "infuraBlockedNotification": {
     "message": "MetaMask is unable to connect to the blockchain host. Review possible reasons $1.",
@@ -4291,6 +4297,9 @@
   "quoteRate": {
     "message": "Quote rate"
   },
+  "quoteRateWithAsterisk": {
+    "message": "Quote rate*"
+  },
   "rank": {
     "message": "Rank"
   },
@@ -5668,11 +5677,21 @@
     "message": "Gas fees are paid to crypto miners who process transactions on the $1 network. MetaMask does not profit from gas fees.",
     "description": "$1 is the selected network, e.g. Ethereum or BSC"
   },
+  "swapGasIncludedTooltipExplanation": {
+    "message": "This quote incorporates gas fees by adjusting the token amount sent or received. You may receive ETH in a separate transaction on your activity list."
+  },
+  "swapGasIncludedTooltipExplanationLinkText": {
+    "message": "Learn more about gas fees"
+  },
   "swapHighSlippage": {
     "message": "High slippage"
   },
   "swapHighSlippageWarning": {
     "message": "Slippage amount is very high."
+  },
+  "swapIncludesGasAndMetaMaskFee": {
+    "message": "*Includes gas and a $1% MetaMask fee",
+    "description": "Provides information about the fee that metamask takes for swaps. $1 is a decimal number."
   },
   "swapIncludesMMFee": {
     "message": "Includes a $1% MetaMask fee.",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4297,9 +4297,6 @@
   "quoteRate": {
     "message": "Quote rate"
   },
-  "quoteRateWithAsterisk": {
-    "message": "Quote rate*"
-  },
   "rank": {
     "message": "Rank"
   },
@@ -5690,7 +5687,7 @@
     "message": "Slippage amount is very high."
   },
   "swapIncludesGasAndMetaMaskFee": {
-    "message": "*Includes gas and a $1% MetaMask fee",
+    "message": "Includes gas and a $1% MetaMask fee",
     "description": "Provides information about the fee that metamask takes for swaps. $1 is a decimal number."
   },
   "swapIncludesMMFee": {

--- a/app/scripts/controllers/swaps/swaps.test.ts
+++ b/app/scripts/controllers/swaps/swaps.test.ts
@@ -26,6 +26,7 @@ const MOCK_FETCH_PARAMS: FetchTradesInfoParams = {
   fromAddress: '0x7F18BB4Dd92CF2404C54CBa1A9BE4A1153bdb078',
   exchangeList: 'zeroExV1',
   balanceError: false,
+  enableGasIncludedQuotes: false,
 };
 
 const TEST_AGG_ID_1 = 'TEST_AGG_1';
@@ -1164,6 +1165,7 @@ describe('SwapsController', function () {
           fromAddress: '',
           exchangeList: 'zeroExV1',
           balanceError: false,
+          enableGasIncludedQuotes: false,
           metaData: {} as FetchTradesInfoParamsMetadata,
         };
         const swapsFeatureIsLive = false;

--- a/app/scripts/controllers/swaps/swaps.types.ts
+++ b/app/scripts/controllers/swaps/swaps.types.ts
@@ -308,6 +308,7 @@ export type FetchTradesInfoParams = {
   fromAddress: string;
   exchangeList: string;
   balanceError: boolean;
+  enableGasIncludedQuotes: boolean;
 };
 
 export type FetchTradesInfoParamsMetadata = {

--- a/shared/lib/swaps-utils.js
+++ b/shared/lib/swaps-utils.js
@@ -265,6 +265,7 @@ export async function fetchTradesInfo(
     value,
     fromAddress,
     exchangeList,
+    enableGasIncludedQuotes,
   },
   { chainId },
 ) {
@@ -275,6 +276,7 @@ export async function fetchTradesInfo(
     slippage,
     timeout: SECOND * 10,
     walletAddress: fromAddress,
+    enableGasIncludedQuotes,
   };
 
   if (exchangeList) {

--- a/shared/lib/swaps-utils.test.js
+++ b/shared/lib/swaps-utils.test.js
@@ -87,6 +87,7 @@ describe('Swaps Utils', () => {
           sourceDecimals: TOKENS[0].decimals,
           sourceTokenInfo: { ...TOKENS[0] },
           destinationTokenInfo: { ...TOKENS[1] },
+          enableGasIncludedQuotes: false,
         },
         { chainId: CHAIN_IDS.MAINNET },
       );

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -213,18 +213,11 @@ export const createSwapsMockStore = () => {
       currentCurrency: 'usd',
       currencyRates: {
         ETH: {
-          conversionDate: 1708532473.416,
-          conversionRate: 2918.02,
-          usdConversionRate: 2918.02,
+          conversionRate: 1,
         },
       },
       marketData: {
         '0x1': {
-          '0x6B175474E89094C44Da98b954EedeAC495271d0F': {
-            price: 2,
-            contractPercentChange1d: 0.004,
-            priceChange1d: 0.00004,
-          },
           '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
             price: 2,
             contractPercentChange1d: 0.004,

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -210,10 +210,12 @@ export const createSwapsMockStore = () => {
         },
       ],
       useCurrencyRateCheck: true,
-      currentCurrency: 'ETH',
+      currentCurrency: 'usd',
       currencyRates: {
         ETH: {
-          conversionRate: 1,
+          conversionDate: 1708532473.416,
+          conversionRate: 2918.02,
+          usdConversionRate: 2918.02,
         },
       },
       marketData: {
@@ -469,6 +471,23 @@ export const createSwapsMockStore = () => {
               decimals: 18,
             },
             fee: 1,
+            isGasIncludedTrade: false,
+            approvalTxFees: {
+              feeEstimate: 42000000000000,
+              fees: [
+                { maxFeePerGas: 2310003200, maxPriorityFeePerGas: 513154852 },
+              ],
+              gasLimit: 21000,
+              gasUsed: 21000,
+            },
+            tradeTxFees: {
+              feeEstimate: 42000000000000,
+              fees: [
+                { maxFeePerGas: 2310003200, maxPriorityFeePerGas: 513154852 },
+              ],
+              gasLimit: 21000,
+              gasUsed: 21000,
+            },
           },
           TEST_AGG_2: {
             trade: {
@@ -503,6 +522,27 @@ export const createSwapsMockStore = () => {
               decimals: 18,
             },
             fee: 1,
+            isGasIncludedTrade: false,
+            approvalTxFees: {
+              feeEstimate: 42000000000000,
+              fees: [
+                { maxFeePerGas: 2310003200, maxPriorityFeePerGas: 513154852 },
+              ],
+              gasLimit: 21000,
+              gasUsed: 21000,
+            },
+            tradeTxFees: {
+              feeEstimate: 42000000000000,
+              fees: [
+                {
+                  maxFeePerGas: 2310003200,
+                  maxPriorityFeePerGas: 513154852,
+                  tokenFees: [{ balanceNeededToken: '0x426dc933c2e5a' }],
+                },
+              ],
+              gasLimit: 21000,
+              gasUsed: 21000,
+            },
           },
         },
         fetchParams: {

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -220,6 +220,11 @@ export const createSwapsMockStore = () => {
       },
       marketData: {
         '0x1': {
+          '0x6B175474E89094C44Da98b954EedeAC495271d0F': {
+            price: 2,
+            contractPercentChange1d: 0.004,
+            priceChange1d: 0.00004,
+          },
           '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
             price: 2,
             contractPercentChange1d: 0.004,
@@ -537,7 +542,16 @@ export const createSwapsMockStore = () => {
                 {
                   maxFeePerGas: 2310003200,
                   maxPriorityFeePerGas: 513154852,
-                  tokenFees: [{ balanceNeededToken: '0x426dc933c2e5a' }],
+                  tokenFees: [
+                    {
+                      token: {
+                        address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+                        symbol: 'DAI',
+                        decimals: 18,
+                      },
+                      balanceNeededToken: '0x426dc933c2e5a',
+                    },
+                  ],
                 },
               ],
               gasLimit: 21000,

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -435,9 +435,7 @@ export const getPendingSmartTransactions = (state) => {
 };
 
 export const getSmartTransactionFees = (state) => {
-  const selectedQuote = getSelectedQuote(state);
-  const topQuote = getTopQuote(state);
-  const usedQuote = selectedQuote || topQuote;
+  const usedQuote = getUsedQuote(state);
   if (!usedQuote?.isGasIncludedTrade) {
     return state.metamask.smartTransactionsState?.fees;
   }

--- a/ui/ducks/swaps/swaps.test.js
+++ b/ui/ducks/swaps/swaps.test.js
@@ -652,12 +652,35 @@ describe('Ducks - Swaps', () => {
   });
 
   describe('getSmartTransactionFees', () => {
-    it('returns unsigned transactions and estimates', () => {
+    it('returns estimates from the STX controller', () => {
       const state = createSwapsMockStore();
       const smartTransactionFees = swaps.getSmartTransactionFees(state);
       expect(smartTransactionFees).toMatchObject(
         state.metamask.smartTransactionsState.fees,
       );
+    });
+
+    it('returns estimates from a selected quote', () => {
+      const state = createSwapsMockStore();
+      state.metamask.swapsState.quotes.TEST_AGG_2.isGasIncludedTrade = true;
+      const smartTransactionFees = swaps.getSmartTransactionFees(state);
+      expect(smartTransactionFees).toMatchObject({
+        approvalTxFees:
+          state.metamask.swapsState.quotes.TEST_AGG_2.approvalTxFees,
+        tradeTxFees: state.metamask.swapsState.quotes.TEST_AGG_2.tradeTxFees,
+      });
+    });
+
+    it('returns estimates from a top quote if no quote is selected', () => {
+      const state = createSwapsMockStore();
+      state.metamask.swapsState.selectedAggId = null;
+      state.metamask.swapsState.quotes.TEST_AGG_BEST.isGasIncludedTrade = true;
+      const smartTransactionFees = swaps.getSmartTransactionFees(state);
+      expect(smartTransactionFees).toMatchObject({
+        approvalTxFees:
+          state.metamask.swapsState.quotes.TEST_AGG_BEST.approvalTxFees,
+        tradeTxFees: state.metamask.swapsState.quotes.TEST_AGG_BEST.tradeTxFees,
+      });
     });
   });
 

--- a/ui/helpers/constants/zendesk-url.js
+++ b/ui/helpers/constants/zendesk-url.js
@@ -8,6 +8,8 @@ const ZENDESK_URLS = {
   CUSTOMIZE_NONCE:
     'https://support.metamask.io/transactions-and-gas/transactions/how-to-customize-a-transaction-nonce/',
   GAS_FEES: 'https://support.metamask.io/transactions-and-gas/gas-fees/',
+  SWAPS_GAS_FEES:
+    'https://support.metamask.io/token-swaps/user-guide-swaps/#gas-fees',
   HARDWARE_CONNECTION:
     'https://support.metamask.io/privacy-and-security/hardware-wallet-hub/',
   IMPORT_ACCOUNTS:

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -784,7 +784,9 @@ export default function PrepareSwapPage({
 
   const showMaxBalanceLink =
     fromTokenSymbol &&
-    !isSwapsDefaultTokenSymbol(fromTokenSymbol, chainId) &&
+    (isSmartTransaction ||
+      (!isSmartTransaction &&
+        !isSwapsDefaultTokenSymbol(fromTokenSymbol, chainId))) &&
     rawFromTokenBalance > 0;
 
   return (

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -782,12 +782,17 @@ export default function PrepareSwapPage({
     );
   }
 
+  const isNonDefaultToken = !isSwapsDefaultTokenSymbol(
+    fromTokenSymbol,
+    chainId,
+  );
+  const hasPositiveFromTokenBalance = rawFromTokenBalance > 0;
+  const isTokenEligibleForMaxBalance =
+    isSmartTransaction || (!isSmartTransaction && isNonDefaultToken);
   const showMaxBalanceLink =
     fromTokenSymbol &&
-    (isSmartTransaction ||
-      (!isSmartTransaction &&
-        !isSwapsDefaultTokenSymbol(fromTokenSymbol, chainId))) &&
-    rawFromTokenBalance > 0;
+    isTokenEligibleForMaxBalance &&
+    hasPositiveFromTokenBalance;
 
   return (
     <div className="prepare-swap-page">

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -1104,7 +1104,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
       gasTokenAmountDec,
       symbol,
       true,
-      false,
+      true,
     );
   }, [
     isGasIncludedTrade,

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -1195,7 +1195,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
               marginRight={1}
               color={TextColor.textDefault}
             >
-              {t('quoteRateWithAsterisk')}
+              {t('quoteRate')}*
             </Text>
             <ExchangeRateDisplay
               primaryTokenValue={calcTokenValue(
@@ -1425,7 +1425,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
                 variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}
               >
-                {t('swapIncludesGasAndMetaMaskFee', [metaMaskFee])}
+                *{t('swapIncludesGasAndMetaMaskFee', [metaMaskFee])}
               </Text>
               <Text variant={TextVariant.bodySm} color={TextColor.textDefault}>
                 <ViewAllQuotes
@@ -1447,6 +1447,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
                 variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}
               >
+                *
                 {t('swapIncludesMetaMaskFeeViewAllQuotes', [
                   metaMaskFee,
                   <ViewAllQuotes

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -1423,7 +1423,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
                 variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}
               >
-                *{t('swapIncludesGasAndMetaMaskFee', [metaMaskFee])}
+                * {t('swapIncludesGasAndMetaMaskFee', [metaMaskFee])}
               </Text>
               <Text variant={TextVariant.bodySm} color={TextColor.textDefault}>
                 <ViewAllQuotesLink

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -152,30 +152,29 @@ import SlippageNotificationModal from './slippage-notification-modal';
 
 let intervalId;
 
-const ViewAllQuotes = ({
+const ViewAllQuotesLink = React.memo(function ViewAllQuotesLink({
   trackAllAvailableQuotesOpened,
   setSelectQuotePopoverShown,
   t,
-}) => {
+}) {
+  const handleClick = useCallback(() => {
+    trackAllAvailableQuotesOpened();
+    setSelectQuotePopoverShown(true);
+  }, [trackAllAvailableQuotesOpened, setSelectQuotePopoverShown]);
+
   return (
     <ButtonLink
       key="view-all-quotes"
       data-testid="review-quote-view-all-quotes"
-      onClick={
-        /* istanbul ignore next */
-        () => {
-          trackAllAvailableQuotesOpened();
-          setSelectQuotePopoverShown(true);
-        }
-      }
+      onClick={handleClick}
       size={Size.inherit}
     >
       {t('viewAllQuotes')}
     </ButtonLink>
   );
-};
+});
 
-ViewAllQuotes.propTypes = {
+ViewAllQuotesLink.propTypes = {
   trackAllAvailableQuotesOpened: PropTypes.func.isRequired,
   setSelectQuotePopoverShown: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
@@ -1428,7 +1427,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
                 *{t('swapIncludesGasAndMetaMaskFee', [metaMaskFee])}
               </Text>
               <Text variant={TextVariant.bodySm} color={TextColor.textDefault}>
-                <ViewAllQuotes
+                <ViewAllQuotesLink
                   trackAllAvailableQuotesOpened={trackAllAvailableQuotesOpened}
                   setSelectQuotePopoverShown={setSelectQuotePopoverShown}
                   t={t}
@@ -1450,7 +1449,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
                 *
                 {t('swapIncludesMetaMaskFeeViewAllQuotes', [
                   metaMaskFee,
-                  <ViewAllQuotes
+                  <ViewAllQuotesLink
                     key="view-all-quotes"
                     trackAllAvailableQuotesOpened={
                       trackAllAvailableQuotesOpened

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -1078,11 +1078,9 @@ export default function ReviewQuote({ setReceiveToAmount }) {
     }
   };
 
-  let tradeTxTokenFee;
-  if (isGasIncludedTrade) {
-    tradeTxTokenFee =
-      smartTransactionFees?.tradeTxFees?.fees?.[0]?.tokenFees?.[0] || null;
-  }
+  const tradeTxTokenFee = isGasIncludedTrade
+    ? smartTransactionFees?.tradeTxFees?.fees?.[0]?.tokenFees?.[0] ?? null
+    : null;
   const feeTokenBalanceNeededInFiat = useEthFiatAmount(
     Number(hexWEIToDecETH(tradeTxTokenFee?.balanceNeededToken)) || 0,
     { showFiat: true },

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -23,7 +23,6 @@ import { useGasFeeInputs } from '../../confirmations/hooks/useGasFeeInputs';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   getQuotes,
-  getSelectedQuote,
   getApproveTxParams,
   getFetchParams,
   setBalanceError,
@@ -36,6 +35,7 @@ import {
   getDestinationTokenInfo,
   getUsedSwapsGasPrice,
   getTopQuote,
+  getUsedQuote,
   signAndSendTransactions,
   getBackgroundSwapRouteState,
   swapsQuoteSelected,
@@ -238,9 +238,8 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   const balanceError = useSelector(getBalanceError);
   const fetchParams = useSelector(getFetchParams, isEqual);
   const approveTxParams = useSelector(getApproveTxParams, shallowEqual);
-  const selectedQuote = useSelector(getSelectedQuote, isEqual);
   const topQuote = useSelector(getTopQuote, isEqual);
-  const usedQuote = selectedQuote || topQuote;
+  const usedQuote = useSelector(getUsedQuote, isEqual);
   const tradeValue = usedQuote?.trade?.value ?? '0x0';
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);
   const chainId = useSelector(getCurrentChainId);

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -111,10 +111,10 @@ import {
   TextVariant,
   FRACTIONS,
   TEXT_ALIGN,
-  FONT_STYLE,
   Size,
   FlexDirection,
   Severity,
+  FontStyle,
 } from '../../../helpers/constants/design-system';
 import {
   BannerAlert,
@@ -1241,7 +1241,6 @@ export default function ReviewQuote({ setReceiveToAmount }) {
                   as="h6"
                   color={TextColor.textDefault}
                   data-testid="review-quote-gas-fee-in-fiat"
-                  width={FRACTIONS.FOUR_TWELFTHS}
                   textAlign={TEXT_ALIGN.RIGHT}
                   style={{ textDecoration: 'line-through' }}
                   marginRight={1}
@@ -1253,7 +1252,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
                   as="h6"
                   color={TextColor.textDefault}
                   textAlign={TEXT_ALIGN.RIGHT}
-                  fontStyle={FONT_STYLE.ITALIC}
+                  fontStyle={FontStyle.Italic}
                 >
                   {t('included')}
                 </Text>

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -912,6 +912,8 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   ]);
 
   useEffect(() => {
+    // If it's a smart transaction, has sufficient tokens, and gas is not included in the trade,
+    // set up gas fee polling.
     if (isSmartTransaction && !insufficientTokens && !isGasIncludedTrade) {
       const unsignedTx = {
         from: unsignedTransaction.from,

--- a/ui/pages/swaps/prepare-swap-page/review-quote.test.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.test.js
@@ -120,7 +120,7 @@ describe('ReviewQuote', () => {
     ).toBeInTheDocument();
     expect(getByText('view all quotes')).toBeInTheDocument();
     expect(getByText('Gas fee')).toBeInTheDocument();
-    expect(getByText('$3.41')).toBeInTheDocument();
+    expect(getByText('$6.82')).toBeInTheDocument();
     expect(getByText('Swap')).toBeInTheDocument();
   });
 });

--- a/ui/pages/swaps/prepare-swap-page/review-quote.test.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.test.js
@@ -51,7 +51,7 @@ describe('ReviewQuote', () => {
     const props = createProps();
     const { getByText } = renderWithProvider(<ReviewQuote {...props} />, store);
     expect(getByText('New quotes in')).toBeInTheDocument();
-    expect(getByText('Quote rate')).toBeInTheDocument();
+    expect(getByText('Quote rate*')).toBeInTheDocument();
     expect(getByText('Includes a 1% MetaMask fee –')).toBeInTheDocument();
     expect(getByText('view all quotes')).toBeInTheDocument();
     expect(getByText('Estimated gas fee')).toBeInTheDocument();
@@ -73,7 +73,7 @@ describe('ReviewQuote', () => {
     const props = createProps();
     const { getByText } = renderWithProvider(<ReviewQuote {...props} />, store);
     expect(getByText('New quotes in')).toBeInTheDocument();
-    expect(getByText('Quote rate')).toBeInTheDocument();
+    expect(getByText('Quote rate*')).toBeInTheDocument();
     expect(getByText('Includes a 1% MetaMask fee –')).toBeInTheDocument();
     expect(getByText('view all quotes')).toBeInTheDocument();
     expect(getByText('Estimated gas fee')).toBeInTheDocument();
@@ -96,7 +96,7 @@ describe('ReviewQuote', () => {
     const props = createProps();
     const { getByText } = renderWithProvider(<ReviewQuote {...props} />, store);
     expect(getByText('New quotes in')).toBeInTheDocument();
-    expect(getByText('Quote rate')).toBeInTheDocument();
+    expect(getByText('Quote rate*')).toBeInTheDocument();
     expect(getByText('Includes a 1% MetaMask fee –')).toBeInTheDocument();
     expect(getByText('view all quotes')).toBeInTheDocument();
     expect(getByText('Estimated gas fee')).toBeInTheDocument();
@@ -104,6 +104,23 @@ describe('ReviewQuote', () => {
     expect(getByText('Max fee:')).toBeInTheDocument();
     expect(getByText('enable DAI')).toBeInTheDocument();
     expect(getByText('Edit limit')).toBeInTheDocument();
+    expect(getByText('Swap')).toBeInTheDocument();
+  });
+
+  it('renders the component with gas included quotes', () => {
+    const state = createSwapsMockStore();
+    state.metamask.swapsState.quotes.TEST_AGG_2.isGasIncludedTrade = true;
+    const store = configureMockStore(middleware)(state);
+    const props = createProps();
+    const { getByText } = renderWithProvider(<ReviewQuote {...props} />, store);
+    expect(getByText('New quotes in')).toBeInTheDocument();
+    expect(getByText('Quote rate*')).toBeInTheDocument();
+    expect(
+      getByText('*Includes gas and a 1% MetaMask fee'),
+    ).toBeInTheDocument();
+    expect(getByText('view all quotes')).toBeInTheDocument();
+    expect(getByText('Gas fee')).toBeInTheDocument();
+    expect(getByText('$3.41')).toBeInTheDocument();
     expect(getByText('Swap')).toBeInTheDocument();
   });
 });

--- a/ui/pages/swaps/prepare-swap-page/review-quote.test.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.test.js
@@ -9,6 +9,7 @@ import {
   createSwapsMockStore,
   MOCKS,
 } from '../../../../test/jest';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
 import ReviewQuote from './review-quote';
 
 jest.mock(
@@ -110,16 +111,29 @@ describe('ReviewQuote', () => {
   it('renders the component with gas included quotes', () => {
     const state = createSwapsMockStore();
     state.metamask.swapsState.quotes.TEST_AGG_2.isGasIncludedTrade = true;
+    state.metamask.marketData[CHAIN_IDS.MAINNET][
+      '0x6B175474E89094C44Da98b954EedeAC495271d0F' // DAI token contract address.
+    ] = {
+      price: 2,
+      contractPercentChange1d: 0.004,
+      priceChange1d: 0.00004,
+    };
+    state.metamask.currencyRates.ETH = {
+      conversionDate: 1708532473.416,
+      conversionRate: 2918.02,
+      usdConversionRate: 2918.02,
+    };
     const store = configureMockStore(middleware)(state);
     const props = createProps();
     const { getByText } = renderWithProvider(<ReviewQuote {...props} />, store);
     expect(getByText('New quotes in')).toBeInTheDocument();
     expect(getByText('Quote rate*')).toBeInTheDocument();
     expect(
-      getByText('*Includes gas and a 1% MetaMask fee'),
+      getByText('* Includes gas and a 1% MetaMask fee'),
     ).toBeInTheDocument();
     expect(getByText('view all quotes')).toBeInTheDocument();
     expect(getByText('Gas fee')).toBeInTheDocument();
+    // $6.82 gas fee is calculated based on params set in the the beginning of the test.
     expect(getByText('$6.82')).toBeInTheDocument();
     expect(getByText('Swap')).toBeInTheDocument();
   });

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -8,11 +8,10 @@ import {
   getFetchParams,
   prepareToLeaveSwaps,
   getCurrentSmartTransactions,
-  getSelectedQuote,
-  getTopQuote,
   getCurrentSmartTransactionsEnabled,
   getSwapsNetworkConfig,
   cancelSwapsSmartTransaction,
+  getUsedQuote,
 } from '../../../ducks/swaps/swaps';
 import {
   isHardwareWallet,
@@ -74,9 +73,7 @@ export default function SmartTransactionStatusPage() {
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);
   const needsTwoConfirmations = true;
-  const selectedQuote = useSelector(getSelectedQuote, isEqual);
-  const topQuote = useSelector(getTopQuote, isEqual);
-  const usedQuote = selectedQuote || topQuote;
+  const usedQuote = useSelector(getUsedQuote, isEqual);
   const currentSmartTransactions = useSelector(
     getCurrentSmartTransactions,
     isEqual,

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -23,7 +23,6 @@ import { MetaMetricsContext } from '../../../contexts/metametrics';
 import FeeCard from '../fee-card';
 import {
   getQuotes,
-  getSelectedQuote,
   getApproveTxParams,
   getFetchParams,
   setBalanceError,
@@ -36,6 +35,7 @@ import {
   getDestinationTokenInfo,
   getUsedSwapsGasPrice,
   getTopQuote,
+  getUsedQuote,
   signAndSendTransactions,
   getBackgroundSwapRouteState,
   swapsQuoteSelected,
@@ -181,9 +181,8 @@ export default function ViewQuote() {
   const balanceError = useSelector(getBalanceError);
   const fetchParams = useSelector(getFetchParams, isEqual);
   const approveTxParams = useSelector(getApproveTxParams, shallowEqual);
-  const selectedQuote = useSelector(getSelectedQuote, isEqual);
   const topQuote = useSelector(getTopQuote, isEqual);
-  const usedQuote = selectedQuote || topQuote;
+  const usedQuote = useSelector(getUsedQuote, isEqual);
   const tradeValue = usedQuote?.trade?.value ?? '0x0';
   const swapsQuoteRefreshTime = useSelector(getSwapsQuoteRefreshTime);
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4764,7 +4764,8 @@ export function signAndSendSmartTransaction({
         [
           {
             signedTransactions,
-            // Deprecate the "signedCanceledTransactions" param in the STX controller since it's no longer needed.
+            // The "signedCanceledTransactions" parameter is still expected by the STX controller but is no longer used. 
+            // So we are passing an empty array. The parameter may be deprecated in a future update.
             signedCanceledTransactions: [],
             txParams: unsignedTransaction,
           },

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4758,18 +4758,14 @@ export function signAndSendSmartTransaction({
       unsignedTransaction,
       smartTransactionFees.fees,
     );
-    const signedCanceledTransactions = await createSignedTransactions(
-      unsignedTransaction,
-      [],
-      true,
-    );
     try {
       const response = await submitRequestToBackground<{ uuid: string }>(
         'submitSignedTransactions',
         [
           {
             signedTransactions,
-            signedCanceledTransactions,
+            // Deprecate the "signedCanceledTransactions" param in the STX controller since it's no longer needed.
+            signedCanceledTransactions: [],
             txParams: unsignedTransaction,
           },
         ],

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4764,7 +4764,7 @@ export function signAndSendSmartTransaction({
         [
           {
             signedTransactions,
-            // The "signedCanceledTransactions" parameter is still expected by the STX controller but is no longer used. 
+            // The "signedCanceledTransactions" parameter is still expected by the STX controller but is no longer used.
             // So we are passing an empty array. The parameter may be deprecated in a future update.
             signedCanceledTransactions: [],
             txParams: unsignedTransaction,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3664,6 +3664,7 @@ export function fetchAndSetQuotes(
     fromAddress: string;
     balanceError: string;
     sourceDecimals: number;
+    enableGasIncludedQuotes: boolean;
   },
   fetchParamsMetaData: {
     sourceTokenInfo: Token;
@@ -4759,7 +4760,7 @@ export function signAndSendSmartTransaction({
     );
     const signedCanceledTransactions = await createSignedTransactions(
       unsignedTransaction,
-      smartTransactionFees.cancelFees,
+      [],
       true,
     );
     try {


### PR DESCRIPTION
## **Description**
Users who don't have enough ETH to pay for gas fees while swapping will be able to swap now if the gas fee can be taken from one of the tokens they are swapping. Smart transactions must be enabled for this.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27427?quickstart=1)

## **Related issues**


## **Manual testing steps**

Important: updated backend services must be used for this.

1. Enable Smart Transactions in Advanced Settings
2. Have e.g. 0 ETH and 100 USDC
3. Fill in the swap form with USDC -> ETH
4. You will see that the Swap button is enabled now is there is a slightly different UI for it (see the screenshot section)

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/69c7b4e0-770d-4dc4-a922-9645229ca5e9)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
