### PR TITLE
fix(snaps): Keep focus on input if interface re-renders

### DIFF
--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -2,6 +2,7 @@ import React, {
   ChangeEvent,
   FunctionComponent,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
@@ -15,9 +16,13 @@ export type SnapUIInputProps = {
 export const SnapUIInput: FunctionComponent<
   SnapUIInputProps & FormTextFieldProps<'div'>
 > = ({ name, form, ...props }) => {
-  const { handleInputChange, getValue } = useSnapInterfaceContext();
+  const { handleInputChange, getValue, focusedInput, setCurrentFocusedInput } =
+    useSnapInterfaceContext();
+
+  const inputRef = useRef<HTMLDivElement>(null);
 
   const initialValue = getValue(name, form) as string;
+  console.log(name);
 
   const [value, setValue] = useState(initialValue ?? '');
 
@@ -27,14 +32,29 @@ export const SnapUIInput: FunctionComponent<
     }
   }, [initialValue]);
 
+  /*
+   * Focus input if the last focused input was this input
+   * This avoids loosing the focus when the UI is re-rendered
+   */
+  useEffect(() => {
+    if (inputRef.current && name === focusedInput) {
+      (inputRef.current.children[0] as HTMLInputElement).focus();
+    }
+  }, [inputRef]);
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
     handleInputChange(name, event.target.value ?? null, form);
   };
 
+  const handleFocus = () => setCurrentFocusedInput(name);
+  const handleBlur = () => setCurrentFocusedInput(null);
+
   return (
     <FormTextField
-      autoFocus
+      ref={inputRef}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       className="snap-ui-renderer__input"
       id={name}
       value={value}

--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -22,7 +22,6 @@ export const SnapUIInput: FunctionComponent<
   const inputRef = useRef<HTMLDivElement>(null);
 
   const initialValue = getValue(name, form) as string;
-  console.log(name);
 
   const [value, setValue] = useState(initialValue ?? '');
 

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -42,11 +42,15 @@ export type HandleFileChange = (
   form?: string,
 ) => void;
 
+export type SetCurrentInputFocus = (name: string | null) => void;
+
 export type SnapInterfaceContextType = {
   handleEvent: HandleEvent;
   getValue: GetValue;
   handleInputChange: HandleInputChange;
   handleFileChange: HandleFileChange;
+  setCurrentFocusedInput: SetCurrentInputFocus;
+  focusedInput: string | null;
   snapId: string;
 };
 
@@ -80,6 +84,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   // UI. It's kept in a ref to avoid useless re-rendering of the entire tree of
   // components.
   const internalState = useRef<InterfaceState>(initialState ?? {});
+  const focusedInput = useRef<string | null>(null);
 
   // Since the internal state is kept in a reference, it won't update when the
   // interface is updated. We have to manually update it.
@@ -237,6 +242,9 @@ export const SnapInterfaceContextProvider: FunctionComponent<
     return undefined;
   };
 
+  const setCurrentFocusedInput: SetCurrentInputFocus = (name) =>
+    (focusedInput.current = name);
+
   return (
     <SnapInterfaceContext.Provider
       value={{
@@ -244,6 +252,8 @@ export const SnapInterfaceContextProvider: FunctionComponent<
         getValue,
         handleInputChange,
         handleFileChange,
+        setCurrentFocusedInput,
+        focusedInput: focusedInput.current,
         snapId,
       }}
     >


### PR DESCRIPTION
## **Description**

This PR adds a reference to the currently focused input in a snap interface and set the focus back to the last focused input if the interface re-renders.

This fixes a problem where it will loose input focus and set it to the last input of the interface if an interface was re-rendered.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27429?quickstart=1)

## **Related issues**

Fixes: #27424 

## **Manual testing steps**

1. Go to test-snaps
2. Use the send flow example snap
3. Try typing something in the "To address" field
4. The focus should stay on your input.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/4a15acda-f41b-4e32-bc71-dfceaa1920c9

### **After**


https://github.com/user-attachments/assets/80745da0-edbb-4ab1-8a32-d2b465a31aee



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
