### PR TITLE
test: Fix flaky permit test

### DIFF
--- a/test/e2e/tests/confirmations/signatures/permit.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/permit.spec.ts
@@ -46,11 +46,6 @@ describe('Confirmation Signature - Permit @no-mmi', function (this: Suite) {
 
         await clickHeaderInfoBtn(driver);
         await assertHeaderInfoBalance(driver);
-        await assertAccountDetailsMetrics(
-          driver,
-          mockedEndpoints as MockedEndpoint[],
-          'eth_signTypedData_v4',
-        );
 
         await copyAddressAndPasteWalletAddress(driver);
         await assertPastedAddress(driver);
@@ -59,6 +54,12 @@ describe('Confirmation Signature - Permit @no-mmi', function (this: Suite) {
         await assertInfoValues(driver);
         await scrollAndConfirmAndAssertConfirm(driver);
         await driver.delay(1000);
+
+        await assertAccountDetailsMetrics(
+          driver,
+          mockedEndpoints as MockedEndpoint[],
+          'eth_signTypedData_v4',
+        );
 
         await assertSignatureConfirmedMetrics({
           driver,

--- a/test/e2e/tests/confirmations/signatures/signature-helpers.ts
+++ b/test/e2e/tests/confirmations/signatures/signature-helpers.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import { MockedEndpoint } from 'mockttp';
+import { Key } from 'selenium-webdriver/lib/input';
 import {
   WINDOW_TITLES,
   getEventPayloads,
@@ -209,9 +210,11 @@ function assertEventPropertiesMatch(
 
 export async function clickHeaderInfoBtn(driver: Driver) {
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-  await driver.clickElement(
-    'button[data-testid="header-info__account-details-button"]',
+
+  const accountDetailsButton = await driver.findElement(
+    '[data-testid="header-info__account-details-button"]',
   );
+  await accountDetailsButton.sendKeys(Key.RETURN);
 }
 
 export async function assertHeaderInfoBalance(driver: Driver) {


### PR DESCRIPTION
## **Description**

This PR fixes: `test/e2e/tests/confirmations/signatures/permit.spec.ts`

Issue was that e2e were passing in CI, but failing locally. The changes here provide a few helpers to prevent this flakey behavior.

The issue was first flagged here: https://github.com/MetaMask/metamask-extension/pull/27184#discussion_r1765883386

Follow up slack thread here: https://consensys.slack.com/archives/C03ETQA9EPK/p1727373903173259

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27450?quickstart=1)

## **Related issues**

Fixes: `test/e2e/tests/confirmations/signatures/permit.spec.ts` when running chrome e2e locally

## **Manual testing steps**

1. Running `permit.spec.ts` should pass e2e chrome locally and in CI

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
