### PR TITLE
fix: Fix snaps permission connection for `CHAIN_PERMISSIONS` feature flag

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1535,7 +1535,7 @@ export default class MetamaskController extends EventEmitter {
         },
       },
       env: {
-        isAccountSyncingEnabled: false,
+        isAccountSyncingEnabled: isManifestV3,
       },
       messenger: this.controllerMessenger.getRestricted({
         name: 'UserStorageController',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1535,7 +1535,7 @@ export default class MetamaskController extends EventEmitter {
         },
       },
       env: {
-        isAccountSyncingEnabled: isManifestV3,
+        isAccountSyncingEnabled: false,
       },
       messenger: this.controllerMessenger.getRestricted({
         name: 'UserStorageController',

--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -147,7 +147,7 @@ export default class PermissionPageContainer extends Component {
     );
 
     const permittedChainsPermission =
-      _request.permissions[PermissionNames.permittedChains];
+      _request.permissions?.[PermissionNames.permittedChains];
     const approvedChainIds = permittedChainsPermission?.caveats.find(
       (caveat) => caveat.type === CaveatTypes.restrictNetworkSwitching,
     )?.value;
@@ -155,8 +155,8 @@ export default class PermissionPageContainer extends Component {
     const request = {
       ..._request,
       permissions: { ..._request.permissions },
-      ...(_request.permissions.eth_accounts && { approvedAccounts }),
-      ...(_request.permissions[PermissionNames.permittedChains] && {
+      ...(_request.permissions?.eth_accounts && { approvedAccounts }),
+      ...(_request.permissions?.[PermissionNames.permittedChains] && {
         approvedChainIds,
       }),
     };

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -14,7 +14,6 @@ import SnapAuthorshipHeader from '../../components/app/snaps/snap-authorship-hea
 import PermissionConnectHeader from '../../components/app/permission-connect-header';
 import {
   CaveatTypes,
-  EndowmentTypes,
   RestrictedMethods,
 } from '../../../shared/constants/permissions';
 // TODO: Remove restricted import
@@ -339,7 +338,7 @@ export default class PermissionConnect extends Component {
             <Route
               path={connectPath}
               exact
-              render={() => (
+              render={() =>
                 process.env.CHAIN_PERMISSIONS ? (
                   <ConnectPage
                     rejectPermissionsRequest={(requestId) =>
@@ -354,7 +353,9 @@ export default class PermissionConnect extends Component {
                   <ChooseAccount
                     accounts={accounts}
                     nativeCurrency={nativeCurrency}
-                    selectAccounts={(addresses) => this.selectAccounts(addresses)}
+                    selectAccounts={(addresses) =>
+                      this.selectAccounts(addresses)
+                    }
                     selectNewAccountViaModal={(handleAccountClick) => {
                       showNewAccountModal({
                         onCreateNewAccount: (address) =>
@@ -371,35 +372,35 @@ export default class PermissionConnect extends Component {
                     targetSubjectMetadata={targetSubjectMetadata}
                   />
                 )
-              )}
+              }
             />
             <Route
               path={confirmPermissionPath}
               exact
-              render={() =>
-                  <PermissionPageContainer
-                    request={permissionsRequest || {}}
-                    approvePermissionsRequest={(...args) => {
-                      approvePermissionsRequest(...args);
-                      this.redirect(true);
-                    }}
-                    rejectPermissionsRequest={(requestId) =>
-                      this.cancelPermissionsRequest(requestId)
-                    }
-                    selectedAccounts={accounts.filter((account) =>
-                      selectedAccountAddresses.has(account.address),
-                    )}
-                    targetSubjectMetadata={targetSubjectMetadata}
-                    history={this.props.history}
-                    connectPath={connectPath}
-                    snapsInstallPrivacyWarningShown={
-                      snapsInstallPrivacyWarningShown
-                    }
-                    setSnapsInstallPrivacyWarningShownStatus={
-                      setSnapsInstallPrivacyWarningShownStatus
-                    }
-                  />
-              }
+              render={() => (
+                <PermissionPageContainer
+                  request={permissionsRequest || {}}
+                  approvePermissionsRequest={(...args) => {
+                    approvePermissionsRequest(...args);
+                    this.redirect(true);
+                  }}
+                  rejectPermissionsRequest={(requestId) =>
+                    this.cancelPermissionsRequest(requestId)
+                  }
+                  selectedAccounts={accounts.filter((account) =>
+                    selectedAccountAddresses.has(account.address),
+                  )}
+                  targetSubjectMetadata={targetSubjectMetadata}
+                  history={this.props.history}
+                  connectPath={connectPath}
+                  snapsInstallPrivacyWarningShown={
+                    snapsInstallPrivacyWarningShown
+                  }
+                  setSnapsInstallPrivacyWarningShownStatus={
+                    setSnapsInstallPrivacyWarningShownStatus
+                  }
+                />
+              )}
             />
             <Route
               path={snapsConnectPath}

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -14,6 +14,7 @@ import SnapAuthorshipHeader from '../../components/app/snaps/snap-authorship-hea
 import PermissionConnectHeader from '../../components/app/permission-connect-header';
 import {
   CaveatTypes,
+  EndowmentTypes,
   RestrictedMethods,
 } from '../../../shared/constants/permissions';
 // TODO: Remove restricted import
@@ -147,9 +148,6 @@ export default class PermissionConnect extends Component {
     if (!permissionsRequest) {
       history.replace(DEFAULT_ROUTE);
       return;
-    }
-    if (process.env.CHAIN_PERMISSIONS) {
-      history.replace(confirmPermissionPath);
     }
     // if this is an incremental permission request for permitted chains, skip the account selection
     if (
@@ -342,32 +340,7 @@ export default class PermissionConnect extends Component {
               path={connectPath}
               exact
               render={() => (
-                <ChooseAccount
-                  accounts={accounts}
-                  nativeCurrency={nativeCurrency}
-                  selectAccounts={(addresses) => this.selectAccounts(addresses)}
-                  selectNewAccountViaModal={(handleAccountClick) => {
-                    showNewAccountModal({
-                      onCreateNewAccount: (address) =>
-                        handleAccountClick(address),
-                      newAccountNumber,
-                    });
-                  }}
-                  addressLastConnectedMap={addressLastConnectedMap}
-                  cancelPermissionsRequest={(requestId) =>
-                    this.cancelPermissionsRequest(requestId)
-                  }
-                  permissionsRequestId={permissionsRequestId}
-                  selectedAccountAddresses={selectedAccountAddresses}
-                  targetSubjectMetadata={targetSubjectMetadata}
-                />
-              )}
-            />
-            <Route
-              path={confirmPermissionPath}
-              exact
-              render={() =>
-                process.env.CHAIN_PERMISSIONS && !permissionsRequest?.diff ? (
+                process.env.CHAIN_PERMISSIONS ? (
                   <ConnectPage
                     rejectPermissionsRequest={(requestId) =>
                       this.cancelPermissionsRequest(requestId)
@@ -378,6 +351,32 @@ export default class PermissionConnect extends Component {
                     approveConnection={this.approveConnection}
                   />
                 ) : (
+                  <ChooseAccount
+                    accounts={accounts}
+                    nativeCurrency={nativeCurrency}
+                    selectAccounts={(addresses) => this.selectAccounts(addresses)}
+                    selectNewAccountViaModal={(handleAccountClick) => {
+                      showNewAccountModal({
+                        onCreateNewAccount: (address) =>
+                          handleAccountClick(address),
+                        newAccountNumber,
+                      });
+                    }}
+                    addressLastConnectedMap={addressLastConnectedMap}
+                    cancelPermissionsRequest={(requestId) =>
+                      this.cancelPermissionsRequest(requestId)
+                    }
+                    permissionsRequestId={permissionsRequestId}
+                    selectedAccountAddresses={selectedAccountAddresses}
+                    targetSubjectMetadata={targetSubjectMetadata}
+                  />
+                )
+              )}
+            />
+            <Route
+              path={confirmPermissionPath}
+              exact
+              render={() =>
                   <PermissionPageContainer
                     request={permissionsRequest || {}}
                     approvePermissionsRequest={(...args) => {
@@ -400,7 +399,6 @@ export default class PermissionConnect extends Component {
                       setSnapsInstallPrivacyWarningShownStatus
                     }
                   />
-                )
               }
             />
             <Route


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Recent permission flow changes introduced behind the `CHAIN_PERMISSIONS` feature flag have broken permission connection for Snaps. This PR fixes it by removing an incorrect forced route direct in the permission connection component.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27459?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/26635

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
