### PR TITLE
fix: removed closeMenu for ConnectedAccountsMenu

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -420,7 +420,6 @@ const AccountListItem = ({
           anchorElement={accountListItemMenuElement}
           account={account}
           onClose={() => setAccountOptionsMenuOpen(false)}
-          closeMenu={closeMenu}
           disableAccountSwitcher={isSingleAccount && selected}
           isOpen={accountOptionsMenuOpen}
           onActionClick={onActionClick}

--- a/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.test.tsx
+++ b/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.test.tsx
@@ -19,7 +19,6 @@ const DEFAULT_PROPS = {
   },
   anchorElement: null,
   disableAccountSwitcher: false,
-  closeMenu: jest.fn(),
   onActionClick: jest.fn(),
   activeTabOrigin: 'metamask.github.io',
 };

--- a/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.tsx
+++ b/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.tsx
@@ -34,7 +34,6 @@ export const ConnectedAccountsMenu = ({
   anchorElement,
   disableAccountSwitcher = false,
   onClose,
-  closeMenu,
   onActionClick,
   activeTabOrigin,
 }: {
@@ -43,7 +42,6 @@ export const ConnectedAccountsMenu = ({
   anchorElement: HTMLElement | null;
   disableAccountSwitcher: boolean;
   onClose: () => void;
-  closeMenu: () => void;
   onActionClick: (message: string) => void;
   activeTabOrigin: string;
 }) => {
@@ -123,7 +121,6 @@ export const ConnectedAccountsMenu = ({
                 onClick={() => {
                   dispatch(setSelectedAccount(account.address));
                   onClose();
-                  closeMenu();
                 }}
               >
                 <Text variant={TextVariant.bodyMd}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR is to remove the unused closeMenu prop from ConnectedAccountsMenu
## **Related issues**

Fixes: #27454 

## **Manual testing steps**

1. Go to the connections page
2. click on three dot menu for connected accounts
3. everything should be working as it is

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA
### **After**

NA
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
