### PR TITLE
fix: Handle null return value from getMethodData to prevent destructuring error (#27457)

### DIFF
--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -810,10 +810,10 @@ async function buildEventFragmentProperties({
 
   let contractMethodName;
   if (transactionMeta.txParams.data) {
-    const { name } = await transactionMetricsRequest.getMethodData(
+    const methodData = await transactionMetricsRequest.getMethodData(
       transactionMeta.txParams.data,
     );
-    contractMethodName = name;
+    contractMethodName = methodData?.name;
   }
 
   // TODO: Replace `any` with type


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The original code assumes that getMethodData will always return an object with a name property. However, in certain instances, getMethodData can return null. When this happens, destructuring the name property from null causes a runtime error.

To address this issue, the code has been updated to use optional chaining. This ensures that if getMethodData returns null, the destructuring will not occur, and contractMethodName will be set to undefined instead of causing an error.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27457?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27436

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
