### PR TITLE
fix: Allow state updates in Snaps interfaces to state values that are falsy

### DIFF
--- a/ui/components/app/snaps/snap-ui-dropdown/snap-ui-dropdown.tsx
+++ b/ui/components/app/snaps/snap-ui-dropdown/snap-ui-dropdown.tsx
@@ -34,7 +34,7 @@ export const SnapUIDropdown: FunctionComponent<SnapUIDropdownProps> = ({
   const [value, setValue] = useState(initialValue ?? '');
 
   useEffect(() => {
-    if (initialValue) {
+    if (initialValue !== undefined && initialValue !== null) {
       setValue(initialValue);
     }
   }, [initialValue]);

--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -22,7 +22,7 @@ export const SnapUIInput: FunctionComponent<
   const [value, setValue] = useState(initialValue ?? '');
 
   useEffect(() => {
-    if (initialValue) {
+    if (initialValue !== undefined && initialValue !== null) {
       setValue(initialValue);
     }
   }, [initialValue]);

--- a/ui/components/app/snaps/snap-ui-selector/snap-ui-selector.tsx
+++ b/ui/components/app/snaps/snap-ui-selector/snap-ui-selector.tsx
@@ -102,7 +102,7 @@ export const SnapUISelector: React.FunctionComponent<SnapUISelectorProps> = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
-    if (initialValue) {
+    if (initialValue !== undefined && initialValue !== null) {
       setSelectedOption(initialValue);
     }
   }, [initialValue]);

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -230,7 +230,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
       ? (initialState[form] as FormState)?.[name]
       : (initialState as FormState)?.[name];
 
-    if (value) {
+    if (value !== undefined && value !== null) {
       return value;
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a problem where state updates to Snaps interfaces would be ignored if the value was falsy, e.g. empty string.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27488?quickstart=1)


## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/e6ea3cee-f8f3-4f0d-9c48-f47ab8456b71

### **After**

https://github.com/user-attachments/assets/6ebf5124-dc16-4f6d-8d6c-bf46ae00c998