### PR TITLE
chore: Fix link in change entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [12.3.1]
 ### Fixed
 - Fix duplicate network validation ([#27463](https://github.com/MetaMask/metamask-extension/pull/27463))
-- Fix notification metrics ([#26807](https://github.com/MetaMask/metamask-extension/pull/26807))
+- Fix notification metrics ([#27435](https://github.com/MetaMask/metamask-extension/pull/27435))
 - Fix transaction metrics ([#27457](https://github.com/MetaMask/metamask-extension/pull/27457))
 
 ## [12.3.0]


### PR DESCRIPTION
## **Description**

The "Fix notification metrics" change entry linked a PR where some of these metrics were originally introduced, but it should have linked the PR where they were fixed. The link has been updated.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27508?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
