### PR TITLE
fix: genUnapprovedApproveConfirmation import path

### DIFF
--- a/ui/pages/confirmations/hooks/useLedgerConnection.test.ts
+++ b/ui/pages/confirmations/hooks/useLedgerConnection.test.ts
@@ -1,18 +1,18 @@
-import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { KeyringObject } from '@metamask/keyring-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
-import { KeyringType } from '../../../../shared/constants/keyring';
-import { renderHookWithConfirmContextProvider } from '../../../../test/lib/confirmations/render-helpers';
-import { getMockConfirmStateForTransaction } from '../../../../test/data/confirmations/helper';
-import { genUnapprovedApproveConfirmation } from '../../../../test/data/confirmations/contract-interaction';
-import { flushPromises } from '../../../../test/lib/timer-helpers';
 import {
+  HardwareTransportStates,
+  LEDGER_USB_VENDOR_ID,
   LedgerTransportTypes,
   WebHIDConnectedStatuses,
-  LEDGER_USB_VENDOR_ID,
-  HardwareTransportStates,
 } from '../../../../shared/constants/hardware-wallets';
+import { KeyringType } from '../../../../shared/constants/keyring';
+import { getMockConfirmStateForTransaction } from '../../../../test/data/confirmations/helper';
+import { genUnapprovedApproveConfirmation } from '../../../../test/data/confirmations/token-approve';
+import { renderHookWithConfirmContextProvider } from '../../../../test/lib/confirmations/render-helpers';
+import { flushPromises } from '../../../../test/lib/timer-helpers';
 import * as appActions from '../../../ducks/app/app';
 import { attemptLedgerTransportCreation } from '../../../store/actions';
 import useLedgerConnection from './useLedgerConnection';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Merging https://github.com/MetaMask/metamask-extension/pull/27358 and then https://github.com/MetaMask/metamask-extension/pull/27391 without rebasing caused an erroneous import path in unit tests. This caused failing test and import linting.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27530?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
