### PR TITLE
ci: followup to CircleCI Sentry reporting

### DIFF
--- a/.circleci/scripts/git-diff-develop.ts
+++ b/.circleci/scripts/git-diff-develop.ts
@@ -104,12 +104,18 @@ async function gitDiff(): Promise<string> {
   return diffResult;
 }
 
+function writePrBodyToFile(prBody: string) {
+  const prBodyPath = path.resolve(CHANGED_FILES_DIR, 'pr-body.txt');
+  fs.writeFileSync(prBodyPath, prBody.trim());
+  console.log(`PR body saved to ${prBodyPath}`);
+}
+
 /**
  * Stores the output of git diff to a file.
  *
  * @returns Returns a promise that resolves when the git diff output is successfully stored.
  */
-async function storeGitDiffOutput() {
+async function storeGitDiffOutputAndPrBody() {
   try {
     // Create the directory
     // This is done first because our CirleCI config requires that this directory is present,
@@ -132,6 +138,7 @@ async function storeGitDiffOutput() {
       return;
     } else if (baseRef !== MAIN_BRANCH) {
       console.log(`This is for a PR targeting '${baseRef}', skipping git diff`);
+      writePrBodyToFile(prInfo.body);
       return;
     }
 
@@ -142,8 +149,10 @@ async function storeGitDiffOutput() {
     // Store the output of git diff
     const outputPath = path.resolve(CHANGED_FILES_DIR, 'changed-files.txt');
     fs.writeFileSync(outputPath, diffOutput.trim());
-
     console.log(`Git diff results saved to ${outputPath}`);
+
+    writePrBodyToFile(prInfo.body);
+
     process.exit(0);
   } catch (error: any) {
     console.error('An error occurred:', error.message);
@@ -151,4 +160,4 @@ async function storeGitDiffOutput() {
   }
 }
 
-storeGitDiffOutput();
+storeGitDiffOutputAndPrBody();

--- a/.circleci/scripts/git-diff-develop.ts
+++ b/.circleci/scripts/git-diff-develop.ts
@@ -111,9 +111,9 @@ function writePrBodyToFile(prBody: string) {
 }
 
 /**
- * Stores the output of git diff to a file.
+ * Main run function, stores the output of git diff and the body of the matching PR to a file.
  *
- * @returns Returns a promise that resolves when the git diff output is successfully stored.
+ * @returns Returns a promise that resolves when the git diff output and PR body is successfully stored.
  */
 async function storeGitDiffOutputAndPrBody() {
   try {

--- a/app/scripts/lib/manifestFlags.ts
+++ b/app/scripts/lib/manifestFlags.ts
@@ -11,7 +11,7 @@ export type ManifestFlags = {
   };
   sentry?: {
     tracesSampleRate?: number;
-    doNotForceSentryForThisTest?: boolean;
+    doNotForceForThisTest?: boolean;
   };
 };
 

--- a/app/scripts/lib/manifestFlags.ts
+++ b/app/scripts/lib/manifestFlags.ts
@@ -11,7 +11,7 @@ export type ManifestFlags = {
   };
   sentry?: {
     tracesSampleRate?: number;
-    doNotForceForThisTest?: boolean;
+    forceEnable?: boolean;
   };
 };
 

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -238,7 +238,7 @@ function getSentryEnvironment() {
 
 function getSentryTarget() {
   if (
-    getManifestFlags().sentry?.doNotForceForThisTest ||
+    !getManifestFlags().sentry?.forceEnable ||
     (process.env.IN_TEST && !SENTRY_DSN_DEV)
   ) {
     return SENTRY_DSN_FAKE;
@@ -272,7 +272,7 @@ async function getMetaMetricsEnabled() {
 
   if (
     METAMASK_BUILD_TYPE === 'mmi' ||
-    (flags.circleci && !flags.sentry?.doNotForceForThisTest)
+    (flags.circleci && flags.sentry.forceEnable)
   ) {
     return true;
   }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -123,7 +123,7 @@ function getTracesSampleRate(sentryTarget) {
 
   if (flags.circleci) {
     // Report very frequently on develop branch, and never on other branches
-    // (Unless you use a `flags = {"sentry": {"tracesSampleRate": 0.1}}` override)
+    // (Unless you use a `flags = {"sentry": {"tracesSampleRate": x.xx}}` override)
     if (flags.circleci.branch === 'develop') {
       return 0.03;
     }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -123,7 +123,7 @@ function getTracesSampleRate(sentryTarget) {
 
   if (flags.circleci) {
     // Report very frequently on develop branch, and never on other branches
-    // (Unless you do a [flags.sentry.tracesSampleRate: x.xx] override)
+    // (Unless you use a `flags = {"sentry": {"tracesSampleRate": 0.1}}` override)
     if (flags.circleci.branch === 'develop') {
       return 0.03;
     }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -238,7 +238,7 @@ function getSentryEnvironment() {
 
 function getSentryTarget() {
   if (
-    getManifestFlags().sentry?.doNotForceSentryForThisTest ||
+    getManifestFlags().sentry?.doNotForceForThisTest ||
     (process.env.IN_TEST && !SENTRY_DSN_DEV)
   ) {
     return SENTRY_DSN_FAKE;
@@ -272,7 +272,7 @@ async function getMetaMetricsEnabled() {
 
   if (
     METAMASK_BUILD_TYPE === 'mmi' ||
-    (flags.circleci && !flags.sentry?.doNotForceSentryForThisTest)
+    (flags.circleci && !flags.sentry?.doNotForceForThisTest)
   ) {
     return true;
   }

--- a/test/e2e/set-manifest-flags.ts
+++ b/test/e2e/set-manifest-flags.ts
@@ -103,6 +103,14 @@ export function setManifestFlags(flags: ManifestFlags = {}) {
 
     addFlagsFromPrBody(flags);
     addFlagsFromGitMessage(flags);
+
+    // Set `flags.sentry.forceEnable` to true by default
+    if (flags.sentry === undefined) {
+      flags.sentry = {};
+    }
+    if (flags.sentry.forceEnable === undefined) {
+      flags.sentry.forceEnable = true;
+    }
   }
 
   const manifest = JSON.parse(

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -247,7 +247,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -278,7 +278,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -319,7 +319,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -365,7 +365,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -426,7 +426,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryInvariantMigrationError,
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -475,7 +475,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -521,7 +521,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -585,7 +585,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -621,7 +621,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -656,7 +656,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -702,7 +702,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, ganacheServer, mockedEndpoint }) => {
@@ -766,7 +766,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -810,7 +810,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceForThisTest: true },
+            sentry: { forceEnable: false },
           },
         },
         async ({ driver, ganacheServer, mockedEndpoint }) => {
@@ -898,7 +898,7 @@ describe('Sentry errors', function () {
         ganacheOptions,
         title: this.test.fullTitle(),
         manifestFlags: {
-          sentry: { doNotForceForThisTest: true },
+          sentry: { forceEnable: false },
         },
       },
       async ({ driver }) => {

--- a/test/e2e/tests/metrics/errors.spec.js
+++ b/test/e2e/tests/metrics/errors.spec.js
@@ -247,7 +247,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -278,7 +278,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -319,7 +319,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -365,7 +365,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryMigratorError,
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -426,7 +426,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryInvariantMigrationError,
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -475,7 +475,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -521,7 +521,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -585,7 +585,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -621,7 +621,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -656,7 +656,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -702,7 +702,7 @@ describe('Sentry errors', function () {
           title: this.test.fullTitle(),
           testSpecificMock: mockSentryTestError,
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, ganacheServer, mockedEndpoint }) => {
@@ -766,7 +766,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, mockedEndpoint }) => {
@@ -810,7 +810,7 @@ describe('Sentry errors', function () {
           testSpecificMock: mockSentryTestError,
           ignoredConsoleErrors: ['TestError'],
           manifestFlags: {
-            sentry: { doNotForceSentryForThisTest: true },
+            sentry: { doNotForceForThisTest: true },
           },
         },
         async ({ driver, ganacheServer, mockedEndpoint }) => {
@@ -898,7 +898,7 @@ describe('Sentry errors', function () {
         ganacheOptions,
         title: this.test.fullTitle(),
         manifestFlags: {
-          sentry: { doNotForceSentryForThisTest: true },
+          sentry: { doNotForceForThisTest: true },
         },
       },
       async ({ driver }) => {

--- a/test/e2e/tests/metrics/sessions.spec.ts
+++ b/test/e2e/tests/metrics/sessions.spec.ts
@@ -38,7 +38,7 @@ describe('Sessions', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentrySession,
         manifestFlags: {
-          sentry: { doNotForceSentryForThisTest: true },
+          sentry: { doNotForceForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -60,7 +60,7 @@ describe('Sessions', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentrySession,
         manifestFlags: {
-          sentry: { doNotForceSentryForThisTest: true },
+          sentry: { doNotForceForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {

--- a/test/e2e/tests/metrics/sessions.spec.ts
+++ b/test/e2e/tests/metrics/sessions.spec.ts
@@ -38,7 +38,7 @@ describe('Sessions', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentrySession,
         manifestFlags: {
-          sentry: { doNotForceForThisTest: true },
+          sentry: { forceEnable: false },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -60,7 +60,7 @@ describe('Sessions', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentrySession,
         manifestFlags: {
-          sentry: { doNotForceForThisTest: true },
+          sentry: { forceEnable: false },
         },
       },
       async ({ driver, mockedEndpoint }) => {

--- a/test/e2e/tests/metrics/traces.spec.ts
+++ b/test/e2e/tests/metrics/traces.spec.ts
@@ -51,7 +51,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryCustomTrace,
         manifestFlags: {
-          sentry: { doNotForceSentryForThisTest: true },
+          sentry: { doNotForceForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -73,7 +73,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryCustomTrace,
         manifestFlags: {
-          sentry: { doNotForceSentryForThisTest: true },
+          sentry: { doNotForceForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -95,7 +95,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryAutomatedTrace,
         manifestFlags: {
-          sentry: { doNotForceSentryForThisTest: true },
+          sentry: { doNotForceForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -117,7 +117,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryAutomatedTrace,
         manifestFlags: {
-          sentry: { doNotForceSentryForThisTest: true },
+          sentry: { doNotForceForThisTest: true },
         },
       },
       async ({ driver, mockedEndpoint }) => {

--- a/test/e2e/tests/metrics/traces.spec.ts
+++ b/test/e2e/tests/metrics/traces.spec.ts
@@ -51,7 +51,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryCustomTrace,
         manifestFlags: {
-          sentry: { doNotForceForThisTest: true },
+          sentry: { forceEnable: false },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -73,7 +73,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryCustomTrace,
         manifestFlags: {
-          sentry: { doNotForceForThisTest: true },
+          sentry: { forceEnable: false },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -95,7 +95,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryAutomatedTrace,
         manifestFlags: {
-          sentry: { doNotForceForThisTest: true },
+          sentry: { forceEnable: false },
         },
       },
       async ({ driver, mockedEndpoint }) => {
@@ -117,7 +117,7 @@ describe('Traces', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryAutomatedTrace,
         manifestFlags: {
-          sentry: { doNotForceForThisTest: true },
+          sentry: { forceEnable: false },
         },
       },
       async ({ driver, mockedEndpoint }) => {


### PR DESCRIPTION
## **Description**

Implementing some suggestions from @matthewwalsh0 from #27412

~Also incorporates changes from @legobeat's #27268~

- Renamed `doNotForceSentryForThisTest` to `doNotForceForThisTest` because the `Sentry` is now implied by the parent property
- Abstracted to `addFlagsFromPrBody()` and `addFlagsFromGitMessage()` functions
  - Only supports one flag right now (`tracesSampleRate`) but it's built to be easily extendable for anything
  - It's now an incredibly powerful general way to pass runtime flags into the Extension in CircleCI, either through the PR body or through the Git commit message
  - In either the PR body or the Git commit message, add a line like
  `flags = {"sentry": {"tracesSampleRate": x.xx}}`
  If you do both, Git commit message takes precedence
  - This changes the format from
  `[flags.sentry.tracesSampleRate: x.xx]` to
  `flags = {"sentry": {"tracesSampleRate": x.xx}}`

Note: This PR, as is, will hit the following error because it's trying to actually parse the sample code above with `x.xx`.  The good news is it fails gracefully.
```
Error parsing flags from PR body, ignoring flags
 SyntaxError: Unexpected token 'x', ..."pleRate": x.xx}}" is not valid JSON
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27548?quickstart=1)

## **Related issues**

Followup to: #27412

## **Manual testing steps**

## **Screenshots/Recordings**
### **Before**
### **After**
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
