### PR TITLE
chore: Use "gas_included" event prop

### DIFF
--- a/shared/modules/metametrics.test.ts
+++ b/shared/modules/metametrics.test.ts
@@ -72,6 +72,9 @@ const createTransactionMeta = () => {
     },
     hash: txHash,
     error: null,
+    swapMetaData: {
+      gas_included: true,
+    },
   };
 };
 
@@ -107,6 +110,7 @@ describe('getSmartTransactionMetricsProperties', () => {
     );
 
     expect(result).toStrictEqual({
+      gas_included: true,
       is_smart_transaction: true,
       smart_transaction_duplicated: true,
       smart_transaction_proxied: true,
@@ -132,7 +136,7 @@ describe('getSmartTransactionMetricsProperties', () => {
     });
   });
 
-  it('returns "is_smart_transaction: true" only if it is a smart transaction, but does not have statusMetadata', () => {
+  it('returns "is_smart_transaction" and "gas_included" params only if it is a smart transaction, but does not have statusMetadata', () => {
     const transactionMetricsRequest = createTransactionMetricsRequest({
       getIsSmartTransaction: () => true,
       getSmartTransactionByMinedTxHash: () => {
@@ -152,6 +156,7 @@ describe('getSmartTransactionMetricsProperties', () => {
 
     expect(result).toStrictEqual({
       is_smart_transaction: true,
+      gas_included: true,
     });
   });
 });

--- a/shared/modules/metametrics.ts
+++ b/shared/modules/metametrics.ts
@@ -5,6 +5,7 @@ import { TransactionMetricsRequest } from '../../app/scripts/lib/transaction/met
 
 type SmartTransactionMetricsProperties = {
   is_smart_transaction: boolean;
+  gas_included: boolean;
   smart_transaction_duplicated?: boolean;
   smart_transaction_timed_out?: boolean;
   smart_transaction_proxied?: boolean;
@@ -21,6 +22,7 @@ export const getSmartTransactionMetricsProperties = (
   if (!isSmartTransaction) {
     return properties;
   }
+  properties.gas_included = transactionMeta.swapMetaData?.gas_included;
   const smartTransaction =
     transactionMetricsRequest.getSmartTransactionByMinedTxHash(
       transactionMeta.hash,

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -942,7 +942,7 @@ export const signAndSendSwapsSmartTransaction = ({
       stx_enabled: smartTransactionsEnabled,
       current_stx_enabled: currentSmartTransactionsEnabled,
       stx_user_opt_in: smartTransactionsOptInStatus,
-      is_gas_included_trade: usedQuote.isGasIncludedTrade,
+      gas_included: usedQuote.isGasIncludedTrade,
       ...additionalTrackingParams,
     };
     trackEvent({


### PR DESCRIPTION
## **Description**
It's an event prop that indicates if gas was included. It can only happen if Smart Transactions are enabled.

## **Related issues**

Fixes:

## **Manual testing steps**
1. Follow testing steps from the feature PR: https://github.com/MetaMask/metamask-extension/pull/27427
2. Check the following events for the "gas_included" prop: "STX Swap Started", "Swap Completed" and "Transaction Finalized Anon"

## **Screenshots/Recordings**


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
