### PR TITLE
fix: Apply flex to Snaps buttons only when containing images and icons

### DIFF
--- a/ui/components/app/snaps/snap-ui-button/index.scss
+++ b/ui/components/app/snaps/snap-ui-button/index.scss
@@ -1,8 +1,11 @@
 .snap-ui-renderer__button {
   background: none;
   text-align: center;
-  display: flex;
-  padding-inline: 0;
+
+  &:has(.snap-ui-renderer__icon, .snap-ui-renderer__image) {
+    display: flex;
+    padding-inline: 0;
+  }
 
   &:not(&--disabled) {
     &:hover {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an alignment problem introduced recently when trying to correctly align images and icons nested in Snaps buttons.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27564?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/2780

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/aac8a932-19d6-48b3-afa4-82cd64fe9125)


### **After**

![image](https://github.com/user-attachments/assets/1d049309-b28f-45c8-b4a1-3fcc9d350cf1)

![image](https://github.com/user-attachments/assets/040ec79e-5723-44ec-88ed-8d37e7e64f9f)

