### PR TITLE
fix(multichain): fix eth send flow (from dapp) when a btc account is selected

### DIFF
--- a/test/jest/mocks.ts
+++ b/test/jest/mocks.ts
@@ -180,12 +180,14 @@ export function createMockInternalAccount({
   address = MOCK_DEFAULT_ADDRESS,
   type = EthAccountType.Eoa,
   keyringType = KeyringTypes.hd,
+  lastSelected = 0,
   snapOptions = undefined,
 }: {
   name?: string;
   address?: string;
   type?: string;
   keyringType?: string;
+  lastSelected?: number;
   snapOptions?: {
     enabled: boolean;
     name: string;
@@ -228,6 +230,7 @@ export function createMockInternalAccount({
         type: keyringType,
       },
       snap: snapOptions,
+      lastSelected,
     },
     options: {},
     methods,

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.d.ts
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.d.ts
@@ -1,10 +1,12 @@
 import type { CurrencyDisplayProps } from '../../ui/currency-display/currency-display.component';
 import type { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
+import { InternalAccount } from '@metamask/keyring-api';
 
 export type UserPrefrencedCurrencyDisplayProps = OverridingUnion<
   CurrencyDisplayProps,
   {
     type?: PRIMARY | SECONDARY;
+    account?: InternalAccount;
     currency?: string;
     showEthLogo?: boolean;
     ethNumberOfDecimals?: string | number;

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.d.ts
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.d.ts
@@ -1,6 +1,6 @@
+import { InternalAccount } from '@metamask/keyring-api';
 import type { CurrencyDisplayProps } from '../../ui/currency-display/currency-display.component';
 import type { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
-import { InternalAccount } from '@metamask/keyring-api';
 
 export type UserPrefrencedCurrencyDisplayProps = OverridingUnion<
   CurrencyDisplayProps,

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
@@ -10,13 +10,15 @@ import {
   getMultichainCurrentNetwork,
 } from '../../../selectors/multichain';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
+import { useSelector } from 'react-redux';
+import { getSelectedEvmInternalAccount } from '../../../selectors';
 
 /* eslint-disable jsdoc/require-param-name */
 // eslint-disable-next-line jsdoc/require-param
 /** @param {PropTypes.InferProps<typeof UserPreferencedCurrencyDisplayPropTypes>>} */
 export default function UserPreferencedCurrencyDisplay({
   'data-testid': dataTestId,
-  account,
+  account: account_,
   ethNumberOfDecimals,
   fiatNumberOfDecimals,
   numberOfDecimals: propsNumberOfDecimals,
@@ -28,6 +30,15 @@ export default function UserPreferencedCurrencyDisplay({
   shouldCheckShowNativeToken,
   ...restProps
 }) {
+  // NOTE: When displaying currencies, we need the actual account to detect whether we're in a
+  // multichain world or EVM-only world.
+  // To preserve the original behavior of this component, we default to the lastly selected
+  // EVM accounts (when used in an EVM-only context).
+  // The caller has to pass the account in a multichain context to properly display the currency
+  // here (e.g for Bitcoin).
+  const evmAccount = useSelector(getSelectedEvmInternalAccount);
+  const account = account_ ?? evmAccount;
+
   const currentNetwork = useMultichainSelector(
     getMultichainCurrentNetwork,
     account,

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
@@ -18,7 +18,7 @@ import { getSelectedEvmInternalAccount } from '../../../selectors';
 /** @param {PropTypes.InferProps<typeof UserPreferencedCurrencyDisplayPropTypes>>} */
 export default function UserPreferencedCurrencyDisplay({
   'data-testid': dataTestId,
-  account: account_,
+  account: multichainAccount,
   ethNumberOfDecimals,
   fiatNumberOfDecimals,
   numberOfDecimals: propsNumberOfDecimals,
@@ -37,7 +37,7 @@ export default function UserPreferencedCurrencyDisplay({
   // The caller has to pass the account in a multichain context to properly display the currency
   // here (e.g for Bitcoin).
   const evmAccount = useSelector(getSelectedEvmInternalAccount);
-  const account = account_ ?? evmAccount;
+  const account = multichainAccount ?? evmAccount;
 
   const currentNetwork = useMultichainSelector(
     getMultichainCurrentNetwork,

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { EtherDenomination } from '../../../../shared/constants/common';
 import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
 import CurrencyDisplay from '../../ui/currency-display';
@@ -10,7 +11,6 @@ import {
   getMultichainCurrentNetwork,
 } from '../../../selectors/multichain';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
-import { useSelector } from 'react-redux';
 import { getSelectedEvmInternalAccount } from '../../../selectors';
 
 /* eslint-disable jsdoc/require-param-name */

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -54,7 +54,6 @@ import {
   getMetaMetricsId,
   getParticipateInMetaMetrics,
   SwapsEthToken,
-  getSelectedAccount,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
 import Spinner from '../../ui/spinner';

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -54,6 +54,7 @@ import {
   getMetaMetricsId,
   getParticipateInMetaMetrics,
   SwapsEthToken,
+  getSelectedAccount,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
 import Spinner from '../../ui/spinner';
@@ -117,6 +118,7 @@ export const CoinOverview = ({
 
   ///: END:ONLY_INCLUDE_IF
 
+  const account = useSelector(getSelectedAccount);
   const showNativeTokenAsMainBalanceRoute = getSpecificSettingsRoute(
     t,
     t('general'),
@@ -254,6 +256,7 @@ export const CoinOverview = ({
               {balanceToDisplay ? (
                 <UserPreferencedCurrencyDisplay
                   style={{ display: 'contents' }}
+                  account={account}
                   className={classnames(
                     `${classPrefix}-overview__primary-balance`,
                     {

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -306,7 +306,7 @@ export function getAccountByAddress(accounts = [], targetAddress) {
 /**
  * Sort the given list of account their selecting order (descending). Meaning the
  * first account of the sorted list will be the last selected account.
-
+ *
  * @param {import('@metamask/keyring-api').InternalAccount[]} accounts - The internal accounts list.
  * @returns {import('@metamask/keyring-api').InternalAccount[]} The sorted internal account list.
  */

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -304,6 +304,25 @@ export function getAccountByAddress(accounts = [], targetAddress) {
 }
 
 /**
+ * Sort the given list of account their selecting order (descending). Meaning the
+ * first account of the sorted list will be the last selected account.
+
+ * @param {import('@metamask/keyring-api').InternalAccount[]} accounts - The internal accounts list.
+ * @returns {import('@metamask/keyring-api').InternalAccount[]} The sorted internal account list.
+ */
+export function sortSelectedInternalAccounts(accounts) {
+  // This logic comes from the `AccountsController`:
+  // TODO: Expose a free function from this controller and use it here
+  return accounts.sort((accountA, accountB) => {
+    // Sort by `.lastSelected` in descending order
+    return (
+      (accountB.metadata.lastSelected ?? 0) -
+      (accountA.metadata.lastSelected ?? 0)
+    );
+  });
+}
+
+/**
  * Strips the following schemes from URL strings:
  * - http
  * - https

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -4,8 +4,8 @@ import { CHAIN_IDS } from '../../../shared/constants/network';
 import { addHexPrefixToObjectValues } from '../../../shared/lib/swaps-utils';
 import { toPrecisionWithoutTrailingZeros } from '../../../shared/lib/transactions-controller-utils';
 import { MinPermissionAbstractionDisplayCount } from '../../../shared/constants/permissions';
-import * as util from './util';
 import { createMockInternalAccount } from '../../../test/jest/mocks';
+import * as util from './util';
 
 describe('util', () => {
   let ethInWei = '1';
@@ -1266,9 +1266,13 @@ describe('util', () => {
     const account2 = createMockInternalAccount({ lastSelected: 2 });
     const account3 = createMockInternalAccount({ lastSelected: 3 });
     // We use a big "gap" here to make sure we're not only sorting with sequential indexes
-    const accountWithBigSelectedIndexGap = createMockInternalAccount({ lastSelected: 108912379837 });
+    const accountWithBigSelectedIndexGap = createMockInternalAccount({
+      lastSelected: 108912379837,
+    });
     // We wanna make sure that negative indexes are also being considered properly
-    const accountWithNegativeSelectedIndex = createMockInternalAccount({ lastSelected: -1 });
+    const accountWithNegativeSelectedIndex = createMockInternalAccount({
+      lastSelected: -1,
+    });
 
     const orderedAccounts = [account3, account2, account1];
 
@@ -1278,28 +1282,30 @@ describe('util', () => {
       { accounts: [account3, account2, account1] },
     ])('sorts accounts by descending order: $accounts', ({ accounts }) => {
       const sortedAccount = util.sortSelectedInternalAccounts(accounts);
-      expect(sortedAccount).toEqual(orderedAccounts);
+      expect(sortedAccount).toStrictEqual(orderedAccounts);
     });
 
     it('sorts accounts with bigger gap', () => {
       const accounts = [account1, accountWithBigSelectedIndexGap, account3];
       const sortedAccount = util.sortSelectedInternalAccounts(accounts);
       expect(sortedAccount.length).toBeGreaterThan(0);
-      expect(sortedAccount.length).toBe(accounts.length);
-      expect(sortedAccount[0]).toEqual(accountWithBigSelectedIndexGap);
+      expect(sortedAccount).toHaveLength(accounts.length);
+      expect(sortedAccount[0]).toStrictEqual(accountWithBigSelectedIndexGap);
     });
 
     it('sorts accounts with negative `lastSelected` index', () => {
       const accounts = [account1, accountWithNegativeSelectedIndex, account3];
       const sortedAccount = util.sortSelectedInternalAccounts(accounts);
       expect(sortedAccount.length).toBeGreaterThan(0); // Required since we using `length - 1`
-      expect(sortedAccount.length).toBe(accounts.length);
-      expect(sortedAccount[sortedAccount.length - 1]).toEqual(accountWithNegativeSelectedIndex);
+      expect(sortedAccount).toHaveLength(accounts.length);
+      expect(sortedAccount[sortedAccount.length - 1]).toStrictEqual(
+        accountWithNegativeSelectedIndex,
+      );
     });
 
     it('succeed with no accounts', () => {
       const sortedAccount = util.sortSelectedInternalAccounts([]);
-      expect(sortedAccount).toEqual([]);
+      expect(sortedAccount).toStrictEqual([]);
     });
   });
 });

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -5,6 +5,7 @@ import { addHexPrefixToObjectValues } from '../../../shared/lib/swaps-utils';
 import { toPrecisionWithoutTrailingZeros } from '../../../shared/lib/transactions-controller-utils';
 import { MinPermissionAbstractionDisplayCount } from '../../../shared/constants/permissions';
 import * as util from './util';
+import { createMockInternalAccount } from '../../../test/jest/mocks';
 
 describe('util', () => {
   let ethInWei = '1';
@@ -1257,6 +1258,48 @@ describe('util', () => {
         mockTokenPercent1dAgo,
       );
       expect(result).toBe(0);
+    });
+  });
+
+  describe('sortSelectedInternalAccounts', () => {
+    const account1 = createMockInternalAccount({ lastSelected: 1 });
+    const account2 = createMockInternalAccount({ lastSelected: 2 });
+    const account3 = createMockInternalAccount({ lastSelected: 3 });
+    // We use a big "gap" here to make sure we're not only sorting with sequential indexes
+    const accountWithBigSelectedIndexGap = createMockInternalAccount({ lastSelected: 108912379837 });
+    // We wanna make sure that negative indexes are also being considered properly
+    const accountWithNegativeSelectedIndex = createMockInternalAccount({ lastSelected: -1 });
+
+    const orderedAccounts = [account3, account2, account1];
+
+    it.each([
+      { accounts: [account1, account2, account3] },
+      { accounts: [account2, account3, account1] },
+      { accounts: [account3, account2, account1] },
+    ])('sorts accounts by descending order: $accounts', ({ accounts }) => {
+      const sortedAccount = util.sortSelectedInternalAccounts(accounts);
+      expect(sortedAccount).toEqual(orderedAccounts);
+    });
+
+    it('sorts accounts with bigger gap', () => {
+      const accounts = [account1, accountWithBigSelectedIndexGap, account3];
+      const sortedAccount = util.sortSelectedInternalAccounts(accounts);
+      expect(sortedAccount.length).toBeGreaterThan(0);
+      expect(sortedAccount.length).toBe(accounts.length);
+      expect(sortedAccount[0]).toEqual(accountWithBigSelectedIndexGap);
+    });
+
+    it('sorts accounts with negative `lastSelected` index', () => {
+      const accounts = [account1, accountWithNegativeSelectedIndex, account3];
+      const sortedAccount = util.sortSelectedInternalAccounts(accounts);
+      expect(sortedAccount.length).toBeGreaterThan(0); // Required since we using `length - 1`
+      expect(sortedAccount.length).toBe(accounts.length);
+      expect(sortedAccount[sortedAccount.length - 1]).toEqual(accountWithNegativeSelectedIndex);
+    });
+
+    it('succeed with no accounts', () => {
+      const sortedAccount = util.sortSelectedInternalAccounts([]);
+      expect(sortedAccount).toEqual([]);
     });
   });
 });

--- a/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
+++ b/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import {
   getIsMainnet,
+  getSelectedEvmInternalAccount,
   getUnapprovedTransactions,
   getUseCurrencyRateCheck,
   transactionFeeSelector,
@@ -29,6 +30,12 @@ const renderHeartBeatIfNotInTest = () =>
 
 const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
   const t = useI18nContext();
+
+  // NOTE: When display currencies, we need the actual account to detect whether we're in a
+  // multichain world or EVM-only world. Here, we expect to be EVM-only, thus, we keep the
+  // original behavior before the introduction of other non-EVM currencies and defaults to
+  // the currently select EVM account:
+  const evmAccount = useSelector(getSelectedEvmInternalAccount);
 
   // state selectors
   const isMainnet = useSelector(getIsMainnet);
@@ -104,6 +111,7 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
           <div>
             {renderHeartBeatIfNotInTest()}
             <UserPreferencedCurrencyDisplay
+              account={evmAccount}
               type={SECONDARY}
               value={estimatedHexMinFeeTotal}
               hideLabel
@@ -115,6 +123,7 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
         <div>
           {renderHeartBeatIfNotInTest()}
           <UserPreferencedCurrencyDisplay
+            account={evmAccount}
             type={PRIMARY}
             value={estimatedHexMinFeeTotal}
             suffixProps={{
@@ -137,6 +146,7 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
           <div key="editGasSubTextFeeValue">
             {renderHeartBeatIfNotInTest()}
             <UserPreferencedCurrencyDisplay
+              account={evmAccount}
               key="editGasSubTextFeeAmount"
               type={PRIMARY}
               value={estimatedHexMaxFeeTotal}

--- a/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
+++ b/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
@@ -31,12 +31,6 @@ const renderHeartBeatIfNotInTest = () =>
 const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
   const t = useI18nContext();
 
-  // NOTE: When display currencies, we need the actual account to detect whether we're in a
-  // multichain world or EVM-only world. Here, we expect to be EVM-only, thus, we keep the
-  // original behavior before the introduction of other non-EVM currencies and defaults to
-  // the currently select EVM account:
-  const evmAccount = useSelector(getSelectedEvmInternalAccount);
-
   // state selectors
   const isMainnet = useSelector(getIsMainnet);
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
@@ -111,7 +105,6 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
           <div>
             {renderHeartBeatIfNotInTest()}
             <UserPreferencedCurrencyDisplay
-              account={evmAccount}
               type={SECONDARY}
               value={estimatedHexMinFeeTotal}
               hideLabel
@@ -123,7 +116,6 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
         <div>
           {renderHeartBeatIfNotInTest()}
           <UserPreferencedCurrencyDisplay
-            account={evmAccount}
             type={PRIMARY}
             value={estimatedHexMinFeeTotal}
             suffixProps={{
@@ -146,7 +138,6 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
           <div key="editGasSubTextFeeValue">
             {renderHeartBeatIfNotInTest()}
             <UserPreferencedCurrencyDisplay
-              account={evmAccount}
               key="editGasSubTextFeeAmount"
               type={PRIMARY}
               value={estimatedHexMaxFeeTotal}

--- a/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
+++ b/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
@@ -5,7 +5,6 @@ import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import {
   getIsMainnet,
-  getSelectedEvmInternalAccount,
   getUnapprovedTransactions,
   getUseCurrencyRateCheck,
   transactionFeeSelector,

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -231,7 +231,10 @@ export function getMultichainProviderConfig(
   return getMultichainNetwork(state, account).network;
 }
 
-export function getMultichainCurrentNetwork(state: MultichainState, account?: InternalAccount) {
+export function getMultichainCurrentNetwork(
+  state: MultichainState,
+  account?: InternalAccount,
+) {
   return getMultichainProviderConfig(state, account);
 }
 

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -231,8 +231,8 @@ export function getMultichainProviderConfig(
   return getMultichainNetwork(state, account).network;
 }
 
-export function getMultichainCurrentNetwork(state: MultichainState) {
-  return getMultichainProviderConfig(state);
+export function getMultichainCurrentNetwork(state: MultichainState, account?: InternalAccount) {
+  return getMultichainProviderConfig(state, account);
 }
 
 export function getMultichainNativeCurrency(

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -364,13 +364,6 @@ export function getSelectedInternalAccount(state) {
   return state.metamask.internalAccounts.accounts[accountId];
 }
 
-export function getSelectedEvmInternalAccount(state) {
-  const [evmAccountSelected] = sortSelectedInternalAccounts(
-    getEvmInternalAccounts(state),
-  );
-  return evmAccountSelected;
-}
-
 export function checkIfMethodIsEnabled(state, methodName) {
   const internalAccount = getSelectedInternalAccount(state);
   return Boolean(internalAccount.methods.includes(methodName));
@@ -392,14 +385,26 @@ export function getInternalAccounts(state) {
   return Object.values(state.metamask.internalAccounts.accounts);
 }
 
-export function getEvmInternalAccounts(state) {
-  const accounts = Object.values(state.metamask.internalAccounts.accounts);
-  return accounts.filter((account) => isEvmAccountType(account.type));
-}
-
 export function getInternalAccount(state, accountId) {
   return state.metamask.internalAccounts.accounts[accountId];
 }
+
+export const getEvmInternalAccounts = createSelector(
+  getInternalAccounts,
+  (accounts) => {
+    return accounts.filter((account) => isEvmAccountType(account.type));
+  },
+);
+
+export const getSelectedEvmInternalAccount = createSelector(
+  getEvmInternalAccounts,
+  (accounts) => {
+    // We should always have 1 EVM account (if not, it would be `undefined`, same
+    // as `getSelectedInternalAccount` selector.
+    const [evmAccountSelected] = sortSelectedInternalAccounts(accounts);
+    return evmAccountSelected;
+  },
+);
 
 /**
  * Returns an array of internal accounts sorted by keyring.

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -67,6 +67,7 @@ import {
   shortenAddress,
   getAccountByAddress,
   getURLHostName,
+  sortSelectedInternalAccounts,
 } from '../helpers/utils/util';
 
 import {
@@ -363,6 +364,13 @@ export function getSelectedInternalAccount(state) {
   return state.metamask.internalAccounts.accounts[accountId];
 }
 
+export function getSelectedEvmInternalAccount(state) {
+  const [evmAccountSelected] = sortSelectedInternalAccounts(
+    getEvmInternalAccounts(state),
+  );
+  return evmAccountSelected;
+}
+
 export function checkIfMethodIsEnabled(state, methodName) {
   const internalAccount = getSelectedInternalAccount(state);
   return Boolean(internalAccount.methods.includes(methodName));
@@ -382,6 +390,11 @@ export function getSelectedInternalAccountWithBalance(state) {
 
 export function getInternalAccounts(state) {
   return Object.values(state.metamask.internalAccounts.accounts);
+}
+
+export function getEvmInternalAccounts(state) {
+  const accounts = Object.values(state.metamask.internalAccounts.accounts);
+  return accounts.filter((account) => isEvmAccountType(account.type));
 }
 
 export function getInternalAccount(state, accountId) {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -1,6 +1,10 @@
 import { deepClone } from '@metamask/snaps-utils';
 import { ApprovalType } from '@metamask/controller-utils';
-import { EthAccountType, EthMethod } from '@metamask/keyring-api';
+import {
+  BtcAccountType,
+  EthAccountType,
+  EthMethod,
+} from '@metamask/keyring-api';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import mockState from '../../test/data/mock-state.json';
 import { KeyringType } from '../../shared/constants/keyring';
@@ -34,6 +38,21 @@ const modifyStateWithHWKeyring = (keyring) => {
   ].metadata.keyring.type = keyring;
 
   return modifiedState;
+};
+
+const mockAccountsState = (accounts) => {
+  const accountsMap = accounts.reduce((accountsMap, account) => {
+    accountsMap[account.id] = account;
+    return accountsMap;
+  }, {});
+
+  return {
+    metamask: {
+      internalAccounts: {
+        accounts: accountsMap,
+      },
+    },
+  };
 };
 
 describe('Selectors', () => {
@@ -2078,6 +2097,87 @@ describe('#getConnectedSitesList', () => {
           },
         }),
       ).toStrictEqual('INITIALIZED');
+    });
+  });
+
+  describe('getEvmInternalAccounts', () => {
+    const account1 = createMockInternalAccount({
+      keyringType: KeyringType.hd,
+    });
+    const account2 = createMockInternalAccount({
+      type: EthAccountType.Erc4337,
+      keyringType: KeyringType.snap,
+    });
+    const account3 = createMockInternalAccount({
+      keyringType: KeyringType.imported,
+    });
+    const account4 = createMockInternalAccount({
+      keyringType: KeyringType.ledger,
+    });
+    const account5 = createMockInternalAccount({
+      keyringType: KeyringType.trezor,
+    });
+    const nonEvmAccount1 = createMockInternalAccount({
+      type: BtcAccountType.P2wpkh,
+      keyringType: KeyringType.snap,
+    });
+    const nonEvmAccount2 = createMockInternalAccount({
+      type: BtcAccountType.P2wpkh,
+      keyringType: KeyringType.snap,
+    });
+
+    const evmAccounts = [account1, account2, account3, account4, account5];
+
+    it('only returns EVM accounts with only EVM accounts', () => {
+      const state = mockAccountsState(evmAccounts);
+      expect(selectors.getEvmInternalAccounts(state)).toEqual(evmAccounts);
+    });
+
+    it('only returns EVM accounts when there is non-EVM accounts', () => {
+      const state = mockAccountsState([...evmAccounts, nonEvmAccount1, nonEvmAccount2]);
+      expect(selectors.getEvmInternalAccounts(state)).toEqual(evmAccounts);
+    });
+
+    it('returns an empty array when there is no EVM accounts', () => {
+      const state = mockAccountsState([nonEvmAccount1, nonEvmAccount2]);
+      expect(selectors.getEvmInternalAccounts(state)).toEqual([]);
+    });
+  });
+
+  describe('getSelectedEvmInternalAccount', () => {
+    const account1 = createMockInternalAccount({
+      lastSelected: 1,
+    });
+    const account2 = createMockInternalAccount({
+      lastSelected: 2,
+    });
+    const account3 = createMockInternalAccount({
+      lastSelected: 3,
+    });
+    const nonEvmAccount1 = createMockInternalAccount({
+      type: BtcAccountType.P2wpkh,
+      keyringType: KeyringType.snap,
+      lastSelected: 4,
+    });
+    const nonEvmAccount2 = createMockInternalAccount({
+      type: BtcAccountType.P2wpkh,
+      keyringType: KeyringType.snap,
+      lastSelected: 5,
+    });
+
+    it('returns the last selected EVM account', () => {
+      const state = mockAccountsState([account1, account2, account3]);
+      expect(selectors.getSelectedEvmInternalAccount(state)).toBe(account3);
+    });
+
+    it('returns the last selected EVM account even with non-EVM accounts', () => {
+      const state = mockAccountsState([account1, account2, account3, nonEvmAccount1, nonEvmAccount2]);
+      expect(selectors.getSelectedEvmInternalAccount(state)).toBe(account3);
+    });
+
+    it('returns `undefined` if there is no EVM accounts', () => {
+      const state = mockAccountsState([nonEvmAccount1, nonEvmAccount2]);
+      expect(selectors.getSelectedEvmInternalAccount(state)).toBe(undefined);
     });
   });
 });

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -41,9 +41,9 @@ const modifyStateWithHWKeyring = (keyring) => {
 };
 
 const mockAccountsState = (accounts) => {
-  const accountsMap = accounts.reduce((accountsMap, account) => {
-    accountsMap[account.id] = account;
-    return accountsMap;
+  const accountsMap = accounts.reduce((map, account) => {
+    map[account.id] = account;
+    return map;
   }, {});
 
   return {
@@ -2130,17 +2130,25 @@ describe('#getConnectedSitesList', () => {
 
     it('only returns EVM accounts with only EVM accounts', () => {
       const state = mockAccountsState(evmAccounts);
-      expect(selectors.getEvmInternalAccounts(state)).toEqual(evmAccounts);
+      expect(selectors.getEvmInternalAccounts(state)).toStrictEqual(
+        evmAccounts,
+      );
     });
 
     it('only returns EVM accounts when there is non-EVM accounts', () => {
-      const state = mockAccountsState([...evmAccounts, nonEvmAccount1, nonEvmAccount2]);
-      expect(selectors.getEvmInternalAccounts(state)).toEqual(evmAccounts);
+      const state = mockAccountsState([
+        ...evmAccounts,
+        nonEvmAccount1,
+        nonEvmAccount2,
+      ]);
+      expect(selectors.getEvmInternalAccounts(state)).toStrictEqual(
+        evmAccounts,
+      );
     });
 
     it('returns an empty array when there is no EVM accounts', () => {
       const state = mockAccountsState([nonEvmAccount1, nonEvmAccount2]);
-      expect(selectors.getEvmInternalAccounts(state)).toEqual([]);
+      expect(selectors.getEvmInternalAccounts(state)).toStrictEqual([]);
     });
   });
 
@@ -2171,7 +2179,13 @@ describe('#getConnectedSitesList', () => {
     });
 
     it('returns the last selected EVM account even with non-EVM accounts', () => {
-      const state = mockAccountsState([account1, account2, account3, nonEvmAccount1, nonEvmAccount2]);
+      const state = mockAccountsState([
+        account1,
+        account2,
+        account3,
+        nonEvmAccount1,
+        nonEvmAccount2,
+      ]);
       expect(selectors.getSelectedEvmInternalAccount(state)).toBe(account3);
     });
 

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -2128,14 +2128,14 @@ describe('#getConnectedSitesList', () => {
 
     const evmAccounts = [account1, account2, account3, account4, account5];
 
-    it('only returns EVM accounts with only EVM accounts', () => {
+    it('returns all EVM accounts when only EVM accounts are present', () => {
       const state = mockAccountsState(evmAccounts);
       expect(selectors.getEvmInternalAccounts(state)).toStrictEqual(
         evmAccounts,
       );
     });
 
-    it('only returns EVM accounts when there is non-EVM accounts', () => {
+    it('only returns EVM accounts when there are non-EVM accounts', () => {
       const state = mockAccountsState([
         ...evmAccounts,
         nonEvmAccount1,
@@ -2146,7 +2146,7 @@ describe('#getConnectedSitesList', () => {
       );
     });
 
-    it('returns an empty array when there is no EVM accounts', () => {
+    it('returns an empty array when there are no EVM accounts', () => {
       const state = mockAccountsState([nonEvmAccount1, nonEvmAccount2]);
       expect(selectors.getEvmInternalAccounts(state)).toStrictEqual([]);
     });
@@ -2178,7 +2178,7 @@ describe('#getConnectedSitesList', () => {
       expect(selectors.getSelectedEvmInternalAccount(state)).toBe(account3);
     });
 
-    it('returns the last selected EVM account even with non-EVM accounts', () => {
+    it('returns the last selected EVM account when there are non-EVM accounts', () => {
       const state = mockAccountsState([
         account1,
         account2,
@@ -2189,7 +2189,7 @@ describe('#getConnectedSitesList', () => {
       expect(selectors.getSelectedEvmInternalAccount(state)).toBe(account3);
     });
 
-    it('returns `undefined` if there is no EVM accounts', () => {
+    it('returns `undefined` if there are no EVM accounts', () => {
       const state = mockAccountsState([nonEvmAccount1, nonEvmAccount2]);
       expect(selectors.getSelectedEvmInternalAccount(state)).toBe(undefined);
     });


### PR DESCRIPTION
## **Description**

The extension displays an error (with a stacktrace) whenever a user tries to start a "Send ETH" flow from a dapp while having a Bitcoin account being selected in the wallet.

Some UI components rely on the currently selected account to display currencies/network logos, and since Eth is using hex-format when formatting amounts (while Bitcoin is using standard decimal numbers), then the "Send ETH" amount's could not be properly displayed since we were expecting a "Bitcoin number format" but the dapp is sending an hex-formatted number.

To avoid having similar issues elsewhere, the `UserPreferencedCurrencyDisplay` component will now fallback to the original EVM behavior if the `account` property is omitted. Meaning that, in a multichain context, you will HAVE TO pass the `account` property to be able to display the correct currency for that account.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27566?quickstart=1)

## **Related issues**

Fixes:
- https://github.com/MetaMask/accounts-planning/issues/616

## **Manual testing steps**

1. `yarn start:flask`
2. Settings > Experimental > Enable bitcoin support
3. Create a bitcoin account
4. Make sure to have the Bitcoin account being selected in your wallet
5. Go to: https://metamask.github.io/test-dapp/
6. Connect 1 EVM account
7. Then use "Send" button from the "Send Eth" section
8. You should be able to display a Eth send confirmation on MM

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2024-10-01 at 11 08 24](https://github.com/user-attachments/assets/a71aa68b-f0b7-4151-b1eb-0b83fe599032)

### **After**

![Screenshot 2024-10-02 at 15 29 52](https://github.com/user-attachments/assets/70c0eb70-6423-43e6-a06e-0e1b6afb841f)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
