### PR TITLE
fix: flaky test `Import flow allows importing multiple tokens from search`

### DIFF
--- a/test/e2e/tests/tokens/import-tokens.spec.js
+++ b/test/e2e/tests/tokens/import-tokens.spec.js
@@ -37,7 +37,9 @@ describe('Import flow', function () {
   it('allows importing multiple tokens from search', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerOnMainnet()
+          .build(),
         ganacheOptions: defaultGanacheOptions,
         title: this.test.fullTitle(),
         testSpecificMock: mockPriceFetch,
@@ -45,21 +47,7 @@ describe('Import flow', function () {
       async ({ driver }) => {
         await unlockWallet(driver);
 
-        // Token list is only on mainnet
-        await driver.clickElement('[data-testid="network-display"]');
-        const networkSelectionModal = await driver.findVisibleElement(
-          '.mm-modal',
-        );
         await driver.assertElementNotPresent('.loading-overlay');
-
-        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'p' });
-
-        // Wait for network to change and token list to load from state
-        await networkSelectionModal.waitForElementState('hidden');
-        await driver.findElement({
-          css: '[data-testid="network-display"]',
-          text: 'Ethereum Mainnet',
-        });
 
         await driver.clickElement('[data-testid="import-token-button"]');
 

--- a/test/e2e/tests/tokens/import-tokens.spec.js
+++ b/test/e2e/tests/tokens/import-tokens.spec.js
@@ -37,9 +37,7 @@ describe('Import flow', function () {
   it('allows importing multiple tokens from search', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder()
-          .withNetworkControllerOnMainnet()
-          .build(),
+        fixtures: new FixtureBuilder().withNetworkControllerOnMainnet().build(),
         ganacheOptions: defaultGanacheOptions,
         title: this.test.fullTitle(),
         testSpecificMock: mockPriceFetch,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In this test, we look for some tokens and then add them into the wallet. The issue seems to arise after switching to Mainnet and right after clicking into the Import Token button.
We can see how in the next step it tries to search for some token, but it cannot locate the search element.

![Screenshot from 2024-10-02 16-41-25](https://github.com/user-attachments/assets/3955ba69-de76-4724-bdf5-6848f12af107)

Looking into the artifacts we can see how the Token modal is not open, likely due to a react re-render of some component after the network switch.

However, since we are testing the import token feature, we don't need to do all the extra setup steps for selecting Mainnet, as we can use fixtures. Using `withNetworkControllerOnMainnet` allows us to skip the setup steps, so we remove any race condition happening, related to the network switch.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27567?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27568

## **Manual testing steps**

1. Check ci
2. Run locally `ENABLE_MV3=false yarn test:e2e:single test/e2e/tests/tokens/import-tokens.spec.js --browser=chrome --leave-running=true`

## **Screenshots/Recordings**

After clicking Import tokens we can see in the failing artifacts how no modal was open, making the subsequent step for token search fail.

![image](https://github.com/user-attachments/assets/fd91e06e-b46c-4c72-bf10-eed245d263c4)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
