### PR TITLE
fix: Max approval and array value spending cap bugs

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/approve/hooks/use-approve-token-simulation.ts
+++ b/ui/pages/confirmations/components/confirm/info/approve/hooks/use-approve-token-simulation.ts
@@ -33,13 +33,14 @@ export const useApproveTokenSimulation = (
       (param) =>
         param.value !== undefined &&
         !isHexString(param.value) &&
+        param.value.length === undefined &&
         !isBoolean(param.value),
     );
     if (paramIndex === -1) {
       return 0;
     }
 
-    return new BigNumber(value.data[0].params[paramIndex].value)
+    return new BigNumber(value.data[0].params[paramIndex].value.toString())
       .dividedBy(new BigNumber(10).pow(Number(decimals)))
       .toNumber();
   }, [value, decimals]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes two bugs.

The first happens when the user approves a token for the max amount. This value is decoded by sourcify and is tipically expressed in scientific notation. However, this number has more than 15 significant digits. The fix is to coerce the number to a string (also accepted by bignumber js), forcing it to be expressed with 15 significant digits only.

<img width="320" alt="Screenshot 2024-10-02 at 17 26 55" src="https://github.com/user-attachments/assets/50ad83e0-a497-4b0b-92f5-aa9b30fb765f">

The second bug happens because sometimes the decoded data from sourcify expresses a value of a param as an array of elements. An exception was added to the param lookup, so that we don't try to use an array value as the spending cap to be displayed.

<img width="320" alt="Screenshot 2024-10-02 at 17 13 34" src="https://github.com/user-attachments/assets/fc31bdc3-3db3-48a6-be35-54a9abfc0409">


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27573?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27535

## **Manual testing steps**

### First bug
1. Go to Uniswap
2. Select a token that hasn't been approved yet, and click to approve
3. The app shouldn't crash

### Second bug
1. Go to https://ethereumfilm.xyz/ethereum-stories
2. Click mint on one of the posters or mini-movies
3. The app shouldn't crash

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
