### PR TITLE
fix: mock locale in unit test

### DIFF
--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -9,6 +9,7 @@ import { getTokenList } from '../../../../selectors';
 import { getMultichainCurrentChainId } from '../../../../selectors/multichain';
 
 import { useIsOriginalTokenSymbol } from '../../../../hooks/useIsOriginalTokenSymbol';
+import { getIntlLocale } from '../../../../ducks/locale/locale';
 import TokenCell from '.';
 
 jest.mock('react-redux', () => {
@@ -99,6 +100,9 @@ describe('Token Cell', () => {
     }
     if (selector === getMultichainCurrentChainId) {
       return '0x89';
+    }
+    if (selector === getIntlLocale) {
+      return 'en-US';
     }
     return undefined;
   });


### PR DESCRIPTION
## **Description**

Fixes an issue where locale was not mocked in unit test, which broke when running on a machine in different locale:

```
LANG=es_ES ./node_modules/jest/bin/jest.js ui/components/app/assets/token-cell/token-cell.test.tsx
...
Expected: "5,000,000 TEST"
Received: "5.000.000 TEST"
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27574?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

Run `LANG=es_ES ./node_modules/jest/bin/jest.js ui/components/app/assets/token-cell/token-cell.test.tsx`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
