### PR TITLE
fix: Recreate offscreen document if it already exists

### DIFF
--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -22,11 +22,8 @@ async function hasOffscreenDocument() {
     return contexts.length > 0;
   }
   const matchedClients = await clients.matchAll();
-  return matchedClients.some(
-    (client) =>
-      client.url.includes(chrome.runtime.id) &&
-      client.url.endsWith('offscreen.html'),
-  );
+  const url = chrome.runtime.getURL('offscreen.html');
+  return matchedClients.some((client) => client.url === url);
 }
 
 /**

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -13,18 +13,20 @@ import { getSocketBackgroundToMocha } from '../../test/e2e/background-socket/soc
  * @returns True if the offscreen document already is has been opened, otherwise false.
  */
 async function hasOffscreenDocument() {
+  const { chrome, clients } = globalThis;
   // getContexts is only available in Chrome 116+
   if ('getContexts' in chrome.runtime) {
     const contexts = await chrome.runtime.getContexts({
       contextTypes: ['OFFSCREEN_DOCUMENT'],
     });
     return contexts.length > 0;
-  } else {
-    const matchedClients = await clients.matchAll();
-    return await matchedClients.some(client => {
-      client.url.includes(chrome.runtime.id);
-    });
   }
+  const matchedClients = await clients.matchAll();
+  return matchedClients.some(
+    (client) =>
+      client.url.includes(chrome.runtime.id) &&
+      client.url.endsWith('offscreen.html'),
+  );
 }
 
 /**
@@ -67,7 +69,7 @@ export async function createOffscreen() {
 
     // In certain cases the offscreen document may already exist during boot, if it does, we close it and recreate it.
     if (offscreenExists) {
-      console.debug("Found existing offscreen document, closing.");
+      console.debug('Found existing offscreen document, closing.');
       await chrome.offscreen.closeDocument();
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When the service worker is stopped it doesn't seem to guarantee that the offscreen document is closed as well. Our current initialization logic assumes this and thus once the service worker is spun back up, all communication with the offscreen document fails due to initialization failure.

This PR proposes fixing this problem by recreating the offscreen document when an existing document is found during boot. This guarantees a fresh offscreen document that we can await initialization of before using it.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27596?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27503

## **Manual testing steps**

1. Go to `chrome://serviceworker-internals/?devtools` and click stop on the MetaMask service worker
2. Go to https://metamask.github.io/snaps/test-snaps/latest/
3. Try to install any Snap
4. See that it works!
