### PR TITLE
fix(snaps): `Copyable` more button color

### DIFF
--- a/ui/components/app/snaps/copyable/index.scss
+++ b/ui/components/app/snaps/copyable/index.scss
@@ -3,7 +3,7 @@
   transition: background-color background 0.2s;
 
   & .show-more__button {
-    background: linear-gradient(90deg, transparent 0%, var(--color-background-primary-muted) 33%);
+    background: linear-gradient(90deg, transparent 0%, var(--color-primary-muted) 33%);
   }
 
   &:hover {
@@ -11,7 +11,7 @@
     color: var(--color-primary-default) !important;
 
     & .show-more__button {
-      background: linear-gradient(90deg, transparent 0%, var(--color-background-primary-muted) 33%);
+      background: linear-gradient(90deg, transparent 0%, var(--color-primary-muted) 33%);
     }
 
     p,
@@ -31,14 +31,14 @@
     opacity: 0.75;
 
     & .show-more__button {
-      background: linear-gradient(90deg, transparent 0%, var(--color-background-primary-muted) 33%);
+      background: linear-gradient(90deg, transparent 0%, var(--color-primary-muted) 33%);
     }
 
     &:hover {
       background-color: var(--color-primary-muted);
 
       & .show-more__button {
-        background: linear-gradient(90deg, transparent 0%, var(--color-background-primary-muted) 33%);
+        background: linear-gradient(90deg, transparent 0%, var(--color-primary-muted) 33%);
       }
     }
   }

--- a/ui/components/app/snaps/show-more/show-more.js
+++ b/ui/components/app/snaps/show-more/show-more.js
@@ -41,7 +41,7 @@ export const ShowMore = ({ children, className = '', ...props }) => {
             bottom: 0,
             right: 0,
             // Avoids see-through with muted colors
-            background: `linear-gradient(90deg, transparent 0%, var(--color-${BackgroundColor.backgroundDefault}) 33%)`,
+            background: `linear-gradient(90deg, transparent 0%, var(--color-${BackgroundColor.backgroundAlternative}) 33%)`,
           }}
         >
           <Button


### PR DESCRIPTION
## **Description**

This fixes the `Copyable` component "more" button color.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27600?quickstart=1)

## **Related issues**

Fixes: #27406 

## **Manual testing steps**

1. Go to test-snaps
2. Use the Interactive UI example snap
3. enter a very large string in the first input
4. submit the form

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/6fd810e3-e669-4148-8478-6f5c31b3f78d)
![image](https://github.com/user-attachments/assets/6796cb52-57df-4de4-970c-02131a1d2c7b)

### **After**

![image](https://github.com/user-attachments/assets/b53c44d4-28a2-42d4-b7b7-08b1844953cc)
![image](https://github.com/user-attachments/assets/066ce166-a09f-4895-89f0-733513083c81)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
