### PR TITLE
fix (cherry-pick): disable transaction data decode if deployment (#27586)

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.test.ts
@@ -65,6 +65,20 @@ describe('useDecodedTransactionData', () => {
     },
   );
 
+  it('returns undefined if no transaction to', async () => {
+    const result = await runHook({
+      currentConfirmation: {
+        chainId: CHAIN_ID_MOCK,
+        txParams: {
+          data: TRANSACTION_DATA_UNISWAP,
+          to: undefined,
+        } as TransactionParams,
+      },
+    });
+
+    expect(result).toStrictEqual({ pending: false, value: undefined });
+  });
+
   it('returns the decoded data', async () => {
     decodeTransactionDataMock.mockResolvedValue(TRANSACTION_DECODE_SOURCIFY);
 

--- a/ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.ts
@@ -20,9 +20,10 @@ export function useDecodedTransactionData(): AsyncResult<
   const chainId = currentConfirmation?.chainId as Hex;
   const contractAddress = currentConfirmation?.txParams?.to as Hex;
   const transactionData = currentConfirmation?.txParams?.data as Hex;
+  const transactionTo = currentConfirmation?.txParams?.to as Hex;
 
   return useAsyncResult(async () => {
-    if (!hasTransactionData(transactionData)) {
+    if (!hasTransactionData(transactionData) || !transactionTo) {
       return undefined;
     }
 
@@ -31,5 +32,5 @@ export function useDecodedTransactionData(): AsyncResult<
       chainId,
       contractAddress,
     });
-  }, [transactionData, chainId, contractAddress]);
+  }, [transactionData, transactionTo, chainId, contractAddress]);
 }

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFourByte.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFourByte.test.ts
@@ -34,7 +34,7 @@ describe('useFourByte', () => {
     expect(result.current.params).toEqual([]);
   });
 
-  it('returns empty object if resolution is turned off', () => {
+  it('returns null if resolution disabled', () => {
     const currentConfirmation = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
       txData: depositHexData,
@@ -57,7 +57,7 @@ describe('useFourByte', () => {
     expect(result.current).toBeNull();
   });
 
-  it("returns undefined if it's not known even if resolution is enabled", () => {
+  it('returns null if not known even if resolution enabled', () => {
     const currentConfirmation = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
       txData: depositHexData,
@@ -71,6 +71,31 @@ describe('useFourByte', () => {
           ...mockState.metamask,
           use4ByteResolution: true,
           knownMethodData: {},
+        },
+      },
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null if no transaction to', () => {
+    const currentConfirmation = genUnapprovedContractInteractionConfirmation({
+      address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+      txData: depositHexData,
+    }) as TransactionMeta;
+
+    currentConfirmation.txParams.to = undefined;
+
+    const { result } = renderHookWithProvider(
+      () => useFourByte(currentConfirmation),
+      {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          use4ByteResolution: true,
+          knownMethodData: {
+            [depositHexData]: { name: 'Deposit', params: [] },
+          },
         },
       },
     );

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFourByte.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFourByte.ts
@@ -1,28 +1,41 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
+import { Hex } from '@metamask/utils';
 import {
   getKnownMethodData,
   use4ByteResolutionSelector,
 } from '../../../../../../selectors';
 import { getContractMethodData } from '../../../../../../store/actions';
+import { hasTransactionData } from '../../../../../../../shared/modules/transaction.utils';
 
 export const useFourByte = (currentConfirmation: TransactionMeta) => {
   const dispatch = useDispatch();
   const isFourByteEnabled = useSelector(use4ByteResolutionSelector);
-  const transactionData = currentConfirmation?.txParams?.data;
+  const transactionTo = currentConfirmation?.txParams?.to;
+  const transactionData = currentConfirmation?.txParams?.data as
+    | Hex
+    | undefined;
 
   useEffect(() => {
-    if (!isFourByteEnabled || !transactionData) {
+    if (
+      !isFourByteEnabled ||
+      !hasTransactionData(transactionData) ||
+      !transactionTo
+    ) {
       return;
     }
 
     dispatch(getContractMethodData(transactionData));
-  }, [isFourByteEnabled, transactionData, dispatch]);
+  }, [isFourByteEnabled, transactionData, transactionTo, dispatch]);
 
   const methodData = useSelector((state) =>
     getKnownMethodData(state, transactionData),
   );
+
+  if (!transactionTo) {
+    return null;
+  }
 
   return methodData;
 };

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.test.tsx
@@ -24,6 +24,7 @@ async function renderTransactionData(transactionData: string) {
     confirm: {
       currentConfirmation: {
         txParams: {
+          to: '0x1234',
           data: transactionData,
         },
       },


### PR DESCRIPTION
## **Description**

Cherry-pick of #27586 for Version 12.4.0.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27633?quickstart=1)

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
