### PR TITLE
fix(btc): do not show percentage for tokens

### DIFF
--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -6,7 +6,10 @@ import { useSelector } from 'react-redux';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers';
 import { useTokenFiatAmount } from '../../../../hooks/useTokenFiatAmount';
 import { getTokenList } from '../../../../selectors';
-import { getMultichainCurrentChainId } from '../../../../selectors/multichain';
+import {
+  getMultichainCurrentChainId,
+  getMultichainIsEvm,
+} from '../../../../selectors/multichain';
 
 import { useIsOriginalTokenSymbol } from '../../../../hooks/useIsOriginalTokenSymbol';
 import { getIntlLocale } from '../../../../ducks/locale/locale';
@@ -100,6 +103,9 @@ describe('Token Cell', () => {
     }
     if (selector === getMultichainCurrentChainId) {
       return '0x89';
+    }
+    if (selector === getMultichainIsEvm) {
+      return true;
     }
     if (selector === getIntlLocale) {
       return 'en-US';

--- a/ui/components/multichain/token-list-item/token-list-item.tsx
+++ b/ui/components/multichain/token-list-item/token-list-item.tsx
@@ -116,9 +116,13 @@ export const TokenListItem = ({
     return undefined;
   });
 
+  // We do not want to display any percentage with non-EVM since we don't have the data for this yet. So
+  // we only use this option for EVM here:
+  const shouldShowPercentage = isEvm && showPercentage;
+
   // Scam warning
   const showScamWarning =
-    isNativeCurrency && !isOriginalTokenSymbol && showPercentage;
+    isNativeCurrency && !isOriginalTokenSymbol && shouldShowPercentage;
 
   const dispatch = useDispatch();
   const [showScamWarningModal, setShowScamWarningModal] = useState(false);
@@ -146,7 +150,9 @@ export const TokenListItem = ({
     : null;
 
   const tokenTitle = getTokenTitle();
-  const tokenMainTitleToDisplay = showPercentage ? tokenTitle : tokenSymbol;
+  const tokenMainTitleToDisplay = shouldShowPercentage
+    ? tokenTitle
+    : tokenSymbol;
 
   const stakeableTitle = (
     <Box
@@ -319,16 +325,7 @@ export const TokenListItem = ({
                 </Text>
               )}
 
-              {isEvm && !showPercentage ? (
-                <Text
-                  variant={TextVariant.bodyMd}
-                  color={TextColor.textAlternative}
-                  data-testid="multichain-token-list-item-token-name"
-                  ellipsis
-                >
-                  {tokenTitle}
-                </Text>
-              ) : (
+              {shouldShowPercentage ? (
                 <PercentageChange
                   value={
                     isNativeCurrency
@@ -341,6 +338,15 @@ export const TokenListItem = ({
                       : (address as `0x${string}`)
                   }
                 />
+              ) : (
+                <Text
+                  variant={TextVariant.bodyMd}
+                  color={TextColor.textAlternative}
+                  data-testid="multichain-token-list-item-token-name"
+                  ellipsis
+                >
+                  {tokenTitle}
+                </Text>
               )}
             </Box>
 


### PR DESCRIPTION
## **Description**

We were wrongly displaying some percentage (with Ethereum token values) for Bitcoin, but we don't have any data for Bitcoin right now, so we just get rid of those for now. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27637?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

1. `yarn start:flask`
2. Make sure to select Ethereum mainnet (we do not display any percentage for testnets)
3. Enable Bitcoin support: Settings > Experimental > "Enable Bitcoin support"
4. Create a Bitcoin account
5. You should not see any percentage on the token tab

## **Screenshots/Recordings**

### **Before**

![Screenshot 2024-10-04 at 18 28 32](https://github.com/user-attachments/assets/e939cfb5-54bf-43e2-bf8e-49c5363c6e05)
![Screenshot 2024-10-04 at 18 28 38](https://github.com/user-attachments/assets/91d44bb8-8eb6-475c-885e-b773af0f76b6)


### **After**

![Screenshot 2024-10-04 at 18 27 26](https://github.com/user-attachments/assets/41495464-98f3-400e-b15e-bf412b26ff11)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
