### PR TITLE
refactor: move `getCurrentChainId` from `selectors/selectors.js` to `shared/modules/selectors/networks.ts`

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -53,9 +53,7 @@ import {
   FakeLedgerBridge,
   FakeTrezorBridge,
 } from '../../test/stub/keyring-bridge';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { getCurrentChainId } from '../../ui/selectors';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { addNonceToCsp } from '../../shared/modules/add-nonce-to-csp';
 import { checkURLForProviderInjection } from '../../shared/modules/provider-injection';
 import migrations from './migrations';

--- a/app/scripts/lib/tx-verification/tx-verification-middleware.ts
+++ b/app/scripts/lib/tx-verification/tx-verification-middleware.ts
@@ -20,9 +20,7 @@ import {
   TRUSTED_SIGNERS,
 } from '../../../../shared/constants/verification';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { getCurrentChainId } from '../../../../ui/selectors';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 
 export type TxParams = {
   chainId?: `0x${string}`;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -236,10 +236,10 @@ import {
   TOKEN_TRANSFER_LOG_TOPIC_HASH,
   TRANSFER_SINFLE_LOG_TOPIC_HASH,
 } from '../../shared/lib/transactions-controller-utils';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { getCurrentChainId } from '../../ui/selectors/selectors';
-import { getProviderConfig } from '../../shared/modules/selectors/networks';
+import {
+  getCurrentChainId,
+  getProviderConfig,
+} from '../../shared/modules/selectors/networks';
 import { endTrace, trace } from '../../shared/lib/trace';
 // eslint-disable-next-line import/no-restricted-paths
 import { isSnapId } from '../../ui/helpers/utils/snaps';

--- a/shared/modules/selectors/feature-flags.ts
+++ b/shared/modules/selectors/feature-flags.ts
@@ -1,7 +1,5 @@
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { getCurrentChainId } from '../../../ui/selectors/selectors'; // TODO: Migrate shared selectors to this file.
 import { getNetworkNameByChainId } from '../feature-flags';
+import { ProviderConfigState, getCurrentChainId } from './networks';
 
 type FeatureFlagsMetaMaskState = {
   metamask: {
@@ -21,7 +19,9 @@ type FeatureFlagsMetaMaskState = {
   };
 };
 
-export function getFeatureFlagsByChainId(state: FeatureFlagsMetaMaskState) {
+export function getFeatureFlagsByChainId(
+  state: ProviderConfigState & FeatureFlagsMetaMaskState,
+) {
   const chainId = getCurrentChainId(state);
   const networkName = getNetworkNameByChainId(chainId);
   const featureFlags = state.metamask.swapsState?.swapsFeatureFlags;

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -4,7 +4,6 @@ import {
   SKIP_STX_RPC_URL_CHECK_CHAIN_IDS,
 } from '../../constants/smartTransactions';
 import {
-  getCurrentChainId,
   getCurrentNetwork,
   accountSupportsSmartTx,
   getPreferences,
@@ -12,7 +11,7 @@ import {
   // eslint-disable-next-line import/no-restricted-paths
 } from '../../../ui/selectors/selectors'; // TODO: Migrate shared selectors to this file.
 import { isProduction } from '../environment';
-import { NetworkState } from './networks';
+import { getCurrentChainId, NetworkState } from './networks';
 
 type SmartTransactionsMetaMaskState = {
   metamask: {
@@ -108,7 +107,7 @@ export const getSmartTransactionsPreferenceEnabled = createSelector(
 );
 
 export const getCurrentChainSupportsSmartTransactions = (
-  state: SmartTransactionsMetaMaskState,
+  state: NetworkState,
 ): boolean => {
   const chainId = getCurrentChainId(state);
   return getAllowedSmartTransactionsChainIds().includes(chainId);

--- a/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
+++ b/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
@@ -2,14 +2,16 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { setTokenNetworkFilter } from '../../../../../store/actions';
 import {
-  getCurrentChainId,
   getCurrentNetwork,
   getPreferences,
   getShouldHideZeroBalanceTokens,
   getSelectedAccount,
   getAllChainsToPoll,
 } from '../../../../../selectors';
-import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
+import {
+  getCurrentChainId,
+  getNetworkConfigurationsByChainId,
+} from '../../../../../../shared/modules/selectors/networks';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { SelectableListItem } from '../sort-control/sort-control';
 import { Text } from '../../../../component-library/text/text';

--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -20,8 +20,8 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { shortenAddress } from '../../../../../helpers/utils/util';
 import { getNftImageAlt } from '../../../../../helpers/utils/nfts';
+import { getCurrentChainId } from '../../../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getCurrentCurrency,
   getCurrentNetwork,
   getIpfsGateway,

--- a/ui/components/app/assets/nfts/nfts-items/nfts-items.js
+++ b/ui/components/app/assets/nfts/nfts-items/nfts-items.js
@@ -19,8 +19,8 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../../../shared/constants/app';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
+import { getCurrentChainId } from '../../../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getIpfsGateway,
   getSelectedInternalAccount,
   getCurrentNetwork,

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -6,12 +6,11 @@ import { BlockSize } from '../../../helpers/constants/design-system';
 import UnitInput from '../../ui/unit-input';
 import CurrencyDisplay from '../../ui/currency-display';
 import { getNativeCurrency } from '../../../ducks/metamask/metamask';
-import { getProviderConfig } from '../../../../shared/modules/selectors/networks';
 import {
+  getProviderConfig,
   getCurrentChainId,
-  getCurrentCurrency,
-  getShouldShowFiat,
-} from '../../../selectors';
+} from '../../../../shared/modules/selectors/networks';
+import { getCurrentCurrency, getShouldShowFiat } from '../../../selectors';
 import { EtherDenomination } from '../../../../shared/constants/common';
 import { Numeric } from '../../../../shared/modules/Numeric';
 import { useIsOriginalNativeTokenSymbol } from '../../../hooks/useIsOriginalNativeTokenSymbol';

--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
@@ -1,10 +1,8 @@
 import { useMemo, useState } from 'react';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { shallowEqual, useSelector } from 'react-redux';
-import {
-  getCurrentChainId,
-  getTokenExchangeRates,
-} from '../../../../selectors';
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
+import { getTokenExchangeRates } from '../../../../selectors';
 import { Numeric } from '../../../../../shared/modules/Numeric';
 import {
   getConversionRate,

--- a/ui/components/app/detected-token/detected-token-selection-popover/detected-token-selection-popover.js
+++ b/ui/components/app/detected-token/detected-token-selection-popover/detected-token-selection-popover.js
@@ -10,13 +10,15 @@ import {
   MetaMetricsTokenEventSource,
 } from '../../../../../shared/constants/metametrics';
 import {
-  getAllDetectedTokensForSelectedAddress,
   getCurrentChainId,
+  getNetworkConfigurationsByChainId,
+} from '../../../../../shared/modules/selectors/networks';
+import {
+  getAllDetectedTokensForSelectedAddress,
   getCurrentNetwork,
   getDetectedTokensInCurrentNetwork,
   getPreferences,
 } from '../../../../selectors';
-import { getNetworkConfigurationsByChainId } from '../../../../../shared/modules/selectors/networks';
 
 import Popover from '../../../ui/popover';
 import Box from '../../../ui/box';

--- a/ui/components/app/detected-token/detected-token-values/detected-token-values.js
+++ b/ui/components/app/detected-token/detected-token-values/detected-token-values.js
@@ -8,8 +8,8 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { useTokenFiatAmount } from '../../../../hooks/useTokenFiatAmount';
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getSelectedAddress,
   getUseCurrencyRateCheck,
 } from '../../../../selectors';

--- a/ui/components/app/detected-token/detected-token.js
+++ b/ui/components/app/detected-token/detected-token.js
@@ -9,15 +9,15 @@ import {
   setNewTokensImported,
 } from '../../../store/actions';
 import {
-  getAllDetectedTokensForSelectedAddress,
   getCurrentChainId,
-  getDetectedTokensInCurrentNetwork,
-  getPreferences,
-} from '../../../selectors';
-import {
   getSelectedNetworkClientId,
   getNetworkConfigurationsByChainId,
 } from '../../../../shared/modules/selectors/networks';
+import {
+  getAllDetectedTokensForSelectedAddress,
+  getDetectedTokensInCurrentNetwork,
+  getPreferences,
+} from '../../../selectors';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 
 import {

--- a/ui/components/app/modals/hide-token-confirmation-modal/hide-token-confirmation-modal.js
+++ b/ui/components/app/modals/hide-token-confirmation-modal/hide-token-confirmation-modal.js
@@ -9,8 +9,10 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../../shared/constants/metametrics';
-import { getCurrentChainId } from '../../../../selectors';
-import { getNetworkConfigurationsByChainId } from '../../../../../shared/modules/selectors/networks';
+import {
+  getCurrentChainId,
+  getNetworkConfigurationsByChainId,
+} from '../../../../../shared/modules/selectors/networks';
 
 function mapStateToProps(state) {
   return {

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import InfoTooltip from '../../../ui/info-tooltip';
-import { getCurrentChainId } from '../../../../selectors';
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import { KeyringAccountListItem } from './keyring-account-list-item';
 
 export default function KeyringRemovalSnapWarning({

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -13,8 +13,8 @@ import {
   nonceSortedCompletedTransactionsSelector,
   nonceSortedPendingTransactionsSelector,
 } from '../../../selectors/transactions';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getSelectedAccount,
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   getShouldHideZeroBalanceTokens,

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -13,7 +13,10 @@ import {
   nonceSortedCompletedTransactionsSelector,
   nonceSortedPendingTransactionsSelector,
 } from '../../../selectors/transactions';
-import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
+import {
+  getCurrentChainId,
+  getNetworkConfigurationsByChainId,
+} from '../../../../shared/modules/selectors/networks';
 import {
   getSelectedAccount,
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
@@ -55,7 +58,6 @@ import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { getMultichainNetwork } from '../../../selectors/multichain';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
-import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/selectors/networks';
 
 const PAGE_INCREMENT = 10;
 

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.test.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.test.tsx
@@ -8,8 +8,8 @@ import {
   getShouldHideZeroBalanceTokens,
   getTokensMarketData,
   getPreferences,
-  getCurrentChainId,
 } from '../../../selectors';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBalance';
 import { AggregatedPercentageOverview } from './aggregated-percentage-overview';
 
@@ -27,6 +27,9 @@ jest.mock('../../../selectors', () => ({
   getPreferences: jest.fn(),
   getShouldHideZeroBalanceTokens: jest.fn(),
   getTokensMarketData: jest.fn(),
+}));
+
+jest.mock('../../../../shared/modules/selectors/networks', () => ({
   getCurrentChainId: jest.fn(),
 }));
 

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -9,8 +9,8 @@ import {
   getShouldHideZeroBalanceTokens,
   getTokensMarketData,
   getPreferences,
-  getCurrentChainId,
 } from '../../../selectors';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 
 import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBalance';
 // TODO: Remove restricted import

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -55,7 +55,6 @@ import {
   getMemoizedUnapprovedTemplatedConfirmations,
   ///: END:ONLY_INCLUDE_IF
   getNetworkConfigurationIdByChainId,
-  getCurrentChainId,
 } from '../../../selectors';
 import Tooltip from '../../ui/tooltip';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
@@ -100,6 +99,7 @@ import {
   getMultichainNativeCurrency,
 } from '../../../selectors/multichain';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 
 type CoinButtonsProps = {
   account: InternalAccount;

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { EthMethod } from '@metamask/keyring-api';
 import { isEqual } from 'lodash';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
   isBalanceCached,
   getIsSwapsChain,
-  getCurrentChainId,
   getSelectedInternalAccount,
   getSelectedAccountCachedBalance,
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)

--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -7,7 +7,6 @@ import EditableLabel from '../../ui/editable-label/editable-label';
 
 import { setAccountLabel } from '../../../store/actions';
 import {
-  getCurrentChainId,
   getHardwareWalletType,
   getInternalAccountByAddress,
 } from '../../../selectors';
@@ -30,6 +29,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 
 export const AccountDetailsDisplay = ({
   accounts,

--- a/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
+++ b/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
@@ -6,8 +6,8 @@ import { mmiActionsFactory } from '../../../store/institutional/institution-back
 ///: END:ONLY_INCLUDE_IF
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getHardwareWalletType,
   getAccountTypeForKeyring,
   getPinnedAccountsList,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
-import { getTokenList, getCurrentChainId } from '../../../../selectors';
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
+import { getTokenList } from '../../../../selectors';
 import { useTokenFiatAmount } from '../../../../hooks/useTokenFiatAmount';
 import { TokenListItem } from '../../token-list-item';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import classnames from 'classnames';
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getCurrentCurrency,
   getSelectedAccountCachedBalance,
 } from '../../../../selectors';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -12,7 +12,6 @@ import { renderWithProvider } from '../../../../../test/lib/render-helpers';
 import mockState from '../../../../../test/data/mock-send-state.json';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import {
-  getCurrentChainId,
   getCurrentCurrency,
   getNativeCurrencyImage,
   getSelectedAccountCachedBalance,
@@ -30,6 +29,7 @@ import { getTopAssets } from '../../../../ducks/swaps/swaps';
 import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';
 import * as actions from '../../../../store/actions';
 import { getSwapsBlockedTokens } from '../../../../ducks/send';
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import { AssetPickerModal } from './asset-picker-modal';
 import AssetList from './AssetList';
 import { ERC20Asset } from './types';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -29,10 +29,9 @@ import {
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { AssetType } from '../../../../../shared/constants/transaction';
-
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import {
   getAllTokens,
-  getCurrentChainId,
   getCurrentCurrency,
   getNativeCurrencyImage,
   getSelectedAccountCachedBalance,

--- a/ui/components/multichain/detected-token-banner/detected-token-banner.js
+++ b/ui/components/multichain/detected-token-banner/detected-token-banner.js
@@ -6,11 +6,13 @@ import classNames from 'classnames';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getCurrentChainId,
+  getNetworkConfigurationsByChainId,
+} from '../../../../shared/modules/selectors/networks';
+import {
   getDetectedTokensInCurrentNetwork,
   getAllDetectedTokensForSelectedAddress,
   getPreferences,
 } from '../../../selectors';
-import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/selectors/networks';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,

--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
@@ -22,8 +22,8 @@ import {
 } from '../../../helpers/constants/design-system';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getIsMainnet,
   getSelectedInternalAccount,
   getOpenSeaEnabled,

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -13,6 +13,9 @@ import { Tab, Tabs } from '../../ui/tabs';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getCurrentChainId,
+  getSelectedNetworkClientId,
+} from '../../../../shared/modules/selectors/networks';
+import {
   getInternalAccounts,
   getIsDynamicTokenListAvailable,
   getIsMainnet,
@@ -27,7 +30,6 @@ import {
   getTestNetworkBackgroundColor,
   getTokenExchangeRates,
 } from '../../../selectors';
-import { getSelectedNetworkClientId } from '../../../../shared/modules/selectors/networks';
 import {
   addImportedTokens,
   clearPendingTokens,

--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -36,9 +36,11 @@ import {
   FEATURED_RPCS,
   TEST_CHAINS,
 } from '../../../../shared/constants/network';
-import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/selectors/networks';
 import {
+  getNetworkConfigurationsByChainId,
   getCurrentChainId,
+} from '../../../../shared/modules/selectors/networks';
+import {
   getShowTestNetworks,
   getOnboardedInThisUISession,
   getShowNetworkBanner,

--- a/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.test.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.test.tsx
@@ -9,9 +9,9 @@ import { getUsedSwapsGasPrice } from '../../../../../../../ducks/swaps/swaps';
 import {
   getCurrentCurrency,
   checkNetworkAndAccountSupports1559,
-  getCurrentChainId,
   getIsSwapsChain,
 } from '../../../../../../../selectors';
+import { getCurrentChainId } from '../../../../../../../../shared/modules/selectors/networks';
 import useEthFeeData from './useEthFeeData';
 
 jest.mock('react-redux', () => ({

--- a/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.tsx
@@ -11,9 +11,9 @@ import { EtherDenomination } from '../../../../../../../../shared/constants/comm
 import {
   getCurrentCurrency,
   checkNetworkAndAccountSupports1559,
-  getCurrentChainId,
   getIsSwapsChain,
 } from '../../../../../../../selectors/selectors';
+import { getCurrentChainId } from '../../../../../../../../shared/modules/selectors/networks';
 import {
   fetchAndSetSwapsGasPriceInfo,
   getUsedSwapsGasPrice,

--- a/ui/components/multichain/pages/send/components/quote-card/hooks/useTranslatedNetworkName.test.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/hooks/useTranslatedNetworkName.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useSelector } from 'react-redux';
 import { CHAIN_IDS } from '../../../../../../../../shared/constants/network';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
-import { getCurrentChainId } from '../../../../../../../selectors';
+import { getCurrentChainId } from '../../../../../../../../shared/modules/selectors/networks';
 import useTranslatedNetworkName from './useTranslatedNetworkName';
 
 jest.mock('react-redux', () => ({

--- a/ui/components/multichain/pages/send/components/quote-card/hooks/useTranslatedNetworkName.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/hooks/useTranslatedNetworkName.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 import { toHex } from '@metamask/controller-utils';
 import { CHAIN_IDS } from '../../../../../../../../shared/constants/network';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
-import { getCurrentChainId } from '../../../../../../../selectors';
+import { getCurrentChainId } from '../../../../../../../../shared/modules/selectors/networks';
 
 export default function useTranslatedNetworkName() {
   const chainId = useSelector(getCurrentChainId);

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.test.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.test.tsx
@@ -8,8 +8,8 @@ import {
   getCurrentCurrency,
   getSelectedAccountCachedBalance,
   getTokensMarketData,
-  getCurrentChainId,
 } from '../../../../../selectors';
+import { getCurrentChainId } from '../../../../../../shared/modules/selectors/networks';
 import {
   getConversionRate,
   getNativeCurrency,
@@ -28,6 +28,9 @@ jest.mock('../../../../../selectors', () => ({
   getCurrentCurrency: jest.fn(),
   getSelectedAccountCachedBalance: jest.fn(),
   getTokensMarketData: jest.fn(),
+}));
+
+jest.mock('../../../../../../shared/modules/selectors/networks', () => ({
   getCurrentChainId: jest.fn(),
 }));
 

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
@@ -9,8 +9,8 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
+import { getCurrentChainId } from '../../../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getCurrentCurrency,
   getSelectedAccountCachedBalance,
   getTokensMarketData,

--- a/ui/ducks/domains.js
+++ b/ui/ducks/domains.js
@@ -7,11 +7,11 @@ import {
 } from '@metamask/snaps-rpc-methods';
 import {
   getAddressBookEntry,
-  getCurrentChainId,
   getNameLookupSnapsIds,
   getPermissionSubjects,
   getSnapMetadata,
 } from '../selectors';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { handleSnapRequest } from '../store/actions';
 import { NO_RESOLUTION_FOR_DOMAIN } from '../pages/confirmations/send/send.constants';
 import { CHAIN_CHANGED } from '../store/actionConstants';

--- a/ui/ducks/ramps/ramps.test.ts
+++ b/ui/ducks/ramps/ramps.test.ts
@@ -1,6 +1,7 @@
 import { configureStore, Store } from '@reduxjs/toolkit';
 import RampAPI from '../../helpers/ramps/rampApi/rampAPI';
-import { getCurrentChainId, getUseExternalServices } from '../../selectors';
+import { getUseExternalServices } from '../../selectors';
+import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { getMultichainIsBitcoin } from '../../selectors/multichain';
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
@@ -15,9 +16,14 @@ import { defaultBuyableChains } from './constants';
 jest.mock('../../helpers/ramps/rampApi/rampAPI');
 const mockedRampAPI = RampAPI as jest.Mocked<typeof RampAPI>;
 
+jest.mock('../../../shared/modules/selectors/networks', () => ({
+  getCurrentChainId: jest.fn(),
+  getNetworkConfigurationsByChainId: jest.fn(),
+  getSelectedNetworkClientId: jest.fn(),
+}));
+
 jest.mock('../../selectors', () => ({
   ...jest.requireActual('../../selectors'),
-  getCurrentChainId: jest.fn(),
   getUseExternalServices: jest.fn(),
   getNames: jest.fn(),
 }));

--- a/ui/ducks/ramps/ramps.ts
+++ b/ui/ducks/ramps/ramps.ts
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { getCurrentChainId, getUseExternalServices } from '../../selectors';
+import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
+import { getUseExternalServices } from '../../selectors';
 import RampAPI from '../../helpers/ramps/rampApi/rampAPI';
 import { hexToDecimal } from '../../../shared/modules/conversion.utils';
 import { getMultichainIsBitcoin } from '../../selectors/multichain';

--- a/ui/ducks/send/helpers.js
+++ b/ui/ducks/send/helpers.js
@@ -18,10 +18,10 @@ import {
   generateERC1155TransferData,
   getAssetTransferData,
 } from '../../pages/confirmations/send/send.utils';
+import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
 import {
   checkNetworkAndAccountSupports1559,
   getConfirmationExchangeRates,
-  getCurrentChainId,
   getGasPriceInHexWei,
   getTokenExchangeRates,
 } from '../../selectors';

--- a/ui/ducks/send/helpers.test.js
+++ b/ui/ducks/send/helpers.test.js
@@ -12,10 +12,10 @@ import {
   generateERC20TransferData,
   generateERC721TransferData,
 } from '../../pages/confirmations/send/send.utils';
+import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
 import {
   checkNetworkAndAccountSupports1559,
   getConfirmationExchangeRates,
-  getCurrentChainId,
   getTokenExchangeRates,
 } from '../../selectors';
 import { getGasFeeEstimates, getNativeCurrency } from '../metamask/metamask';
@@ -48,10 +48,15 @@ jest.mock('../../pages/confirmations/send/send.utils', () => ({
   getAssetTransferData: jest.fn(),
 }));
 
+jest.mock('../../../shared/modules/selectors/networks', () => ({
+  getCurrentChainId: jest.fn(),
+  getNetworkConfigurationsByChainId: jest.fn(),
+  getSelectedNetworkClientId: jest.fn(),
+}));
+
 jest.mock('../../selectors', () => ({
   checkNetworkAndAccountSupports1559: jest.fn(),
   getConfirmationExchangeRates: jest.fn(),
-  getCurrentChainId: jest.fn(),
   getGasPriceInHexWei: jest.fn(),
   getTokenExchangeRates: jest.fn(),
 }));

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -38,8 +38,12 @@ import {
   isTokenBalanceSufficient,
 } from '../../pages/confirmations/send/send.utils';
 import {
-  getAdvancedInlineGasShown,
   getCurrentChainId,
+  getSelectedNetworkClientId,
+  getProviderConfig,
+} from '../../../shared/modules/selectors/networks';
+import {
+  getAdvancedInlineGasShown,
   getGasPriceInHexWei,
   getIsMainnet,
   getTargetAccount,
@@ -56,10 +60,6 @@ import {
   getIsSwapsChain,
   getUseExternalServices,
 } from '../../selectors';
-import {
-  getSelectedNetworkClientId,
-  getProviderConfig,
-} from '../../../shared/modules/selectors/networks';
 import {
   displayWarning,
   hideLoadingIndication,

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -56,12 +56,12 @@ import {
   getValueFromWeiHex,
   hexWEIToDecGWEI,
 } from '../../../shared/modules/conversion.utils';
+import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
 import {
   getSelectedAccount,
   getTokenExchangeRates,
   getUSDConversionRate,
   getSwapsDefaultToken,
-  getCurrentChainId,
   isHardwareWallet,
   getHardwareWalletType,
   checkNetworkAndAccountSupports1559,

--- a/ui/hooks/bridge/useLatestBalance.ts
+++ b/ui/hooks/bridge/useLatestBalance.ts
@@ -2,11 +2,8 @@ import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { Numeric } from '../../../shared/modules/Numeric';
 import { DEFAULT_PRECISION } from '../useCurrencyDisplay';
-import {
-  getCurrentChainId,
-  getSelectedInternalAccount,
-  SwapsEthToken,
-} from '../../selectors';
+import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
+import { getSelectedInternalAccount, SwapsEthToken } from '../../selectors';
 import { SwapsTokenObject } from '../../../shared/constants/swaps';
 import { calcLatestSrcBalance } from '../../../shared/modules/bridge-utils/balance';
 import { useAsyncResult } from '../useAsyncResult';

--- a/ui/hooks/ramps/useRamps/useRamps.ts
+++ b/ui/hooks/ramps/useRamps/useRamps.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { CaipChainId } from '@metamask/utils';
+import { CaipChainId, Hex } from '@metamask/utils';
 import { ChainId } from '../../../../shared/constants/network';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getDataCollectionForMarketing,
   getMetaMetricsId,
   getParticipateInMetaMetrics,
@@ -32,7 +32,7 @@ const useRamps = (
   const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
 
   const getBuyURI = useCallback(
-    (_chainId: ChainId | CaipChainId) => {
+    (_chainId: Hex | CaipChainId) => {
       const params = new URLSearchParams();
       params.set('metamaskEntry', metamaskEntry);
       params.set('chainId', _chainId);

--- a/ui/hooks/useAccountTotalCrossChainFiatBalance.test.ts
+++ b/ui/hooks/useAccountTotalCrossChainFiatBalance.test.ts
@@ -28,6 +28,7 @@ jest.mock('../ducks/metamask/metamask', () => ({
 jest.mock('../../shared/modules/selectors/networks', () => ({
   getSelectedNetworkClientId: jest.fn(),
   getNetworkConfigurationsByChainId: jest.fn(),
+  getCurrentChainId: jest.fn(),
 }));
 
 const mockGetCurrencyRates = getCurrencyRates as jest.Mock;

--- a/ui/hooks/useAccountTotalFiatBalance.js
+++ b/ui/hooks/useAccountTotalFiatBalance.js
@@ -1,8 +1,8 @@
 import { shallowEqual, useSelector } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import {
   getAllTokens,
-  getCurrentChainId,
   getCurrentCurrency,
   getMetaMaskCachedBalances,
   getTokenExchangeRates,

--- a/ui/hooks/useCurrentAsset.js
+++ b/ui/hooks/useCurrentAsset.js
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
 import { getTokens } from '../ducks/metamask/metamask';
-import { getCurrentChainId } from '../selectors';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { ASSET_ROUTE } from '../helpers/constants/routes';
 import {
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,

--- a/ui/hooks/useGetFormattedTokensPerChain.test.ts
+++ b/ui/hooks/useGetFormattedTokensPerChain.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-dom/test-utils';
-import { getAllTokens, getCurrentChainId } from '../selectors';
+import { getAllTokens } from '../selectors';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { useGetFormattedTokensPerChain } from './useGetFormattedTokensPerChain';
 import { stringifyBalance } from './useTokenBalances';
 
@@ -9,8 +10,11 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn((selector) => selector()),
 }));
 
-jest.mock('../selectors', () => ({
+jest.mock('../../shared/modules/selectors/networks', () => ({
   getCurrentChainId: jest.fn(),
+}));
+
+jest.mock('../selectors', () => ({
   getAllTokens: jest.fn(),
 }));
 

--- a/ui/hooks/useGetFormattedTokensPerChain.ts
+++ b/ui/hooks/useGetFormattedTokensPerChain.ts
@@ -1,7 +1,8 @@
 import { useSelector } from 'react-redux';
 import { BN } from 'bn.js';
 import { Token } from '@metamask/assets-controllers';
-import { getAllTokens, getCurrentChainId } from '../selectors';
+import { getAllTokens } from '../selectors';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { hexToDecimal } from '../../shared/modules/conversion.utils';
 
 import { TokenWithBalance } from '../components/multichain/asset-picker-amount/asset-picker-modal/types';

--- a/ui/hooks/useNftsCollections.js
+++ b/ui/hooks/useNftsCollections.js
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isEqual } from 'lodash';
 import { getNfts, getNftContracts } from '../ducks/metamask/metamask';
-import { getCurrentChainId, getSelectedInternalAccount } from '../selectors';
+import { getSelectedInternalAccount } from '../selectors';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { usePrevious } from './usePrevious';
 import { useI18nContext } from './useI18nContext';
 

--- a/ui/hooks/useSwappedTokenValue.js
+++ b/ui/hooks/useSwappedTokenValue.js
@@ -5,7 +5,7 @@ import {
   isSwapsDefaultTokenAddress,
   isSwapsDefaultTokenSymbol,
 } from '../../shared/modules/swaps.utils';
-import { getCurrentChainId } from '../selectors';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { useTokenFiatAmount } from './useTokenFiatAmount';
 
 /**

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -8,9 +8,9 @@ import {
   getTokenExchangeRates,
   getCurrentCurrency,
   getSwapsDefaultToken,
-  getCurrentChainId,
   getTokenList,
 } from '../selectors';
+import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { getConversionRate } from '../ducks/metamask/metamask';
 
 import { getSwapsTokens } from '../ducks/swaps/swaps';

--- a/ui/index.js
+++ b/ui/index.js
@@ -19,6 +19,7 @@ import { COPY_OPTIONS } from '../shared/constants/copy';
 import switchDirection from '../shared/lib/switch-direction';
 import { setupLocale } from '../shared/lib/error-utils';
 import { trace, TraceName } from '../shared/lib/trace';
+import { getCurrentChainId } from '../shared/modules/selectors/networks';
 import * as actions from './store/actions';
 import configureStore from './store/store';
 import {
@@ -29,7 +30,6 @@ import {
   getNetworkToAutomaticallySwitchTo,
   getSwitchedNetworkDetails,
   getUseRequestQueue,
-  getCurrentChainId,
 } from './selectors';
 import { ALERT_STATE } from './ducks/alerts';
 import {

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -27,9 +27,9 @@ import {
   getIsBridgeChain,
   getCurrentKeyring,
   ///: END:ONLY_INCLUDE_IF
-  getCurrentChainId,
   getNetworkConfigurationIdByChainId,
 } from '../../../selectors';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import useBridging from '../../../hooks/bridge/useBridging';
 ///: END:ONLY_INCLUDE_IF

--- a/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.js
+++ b/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.js
@@ -27,8 +27,8 @@ import {
   Box,
   Text,
 } from '../../components/component-library';
+import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getRpcPrefsForCurrentProvider,
   getSuggestedNfts,
   getIpfsGateway,

--- a/ui/pages/create-account/connect-hardware/index.js
+++ b/ui/pages/create-account/connect-hardware/index.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import * as actions from '../../../store/actions';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getMetaMaskAccounts,
   getRpcPrefsForCurrentProvider,
   getMetaMaskAccountsConnected,

--- a/ui/pages/institutional/custody/custody.tsx
+++ b/ui/pages/institutional/custody/custody.tsx
@@ -39,10 +39,8 @@ import {
   CUSTODY_ACCOUNT_ROUTE,
   DEFAULT_ROUTE,
 } from '../../../helpers/constants/routes';
-import {
-  getCurrentChainId,
-  getSelectedInternalAccount,
-} from '../../../selectors';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
+import { getSelectedInternalAccount } from '../../../selectors';
 import { getMMIConfiguration } from '../../../selectors/institutional/selectors';
 import { getInstitutionalConnectRequests } from '../../../ducks/institutional/institutional';
 import CustodyAccountList from '../account-list';

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -2,13 +2,17 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 import {
+  getCurrentChainId,
+  isNetworkLoading,
+  getProviderConfig,
+} from '../../../shared/modules/selectors/networks';
+import {
   getAllAccountsOnNetworkAreEmpty,
   getIsNetworkUsed,
   getNetworkIdentifier,
   getPreferences,
   getTheme,
   getIsTestnet,
-  getCurrentChainId,
   getShouldShowSeedPhraseReminder,
   isCurrentProviderCustom,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
@@ -25,10 +29,6 @@ import {
   getUnapprovedTransactions,
   getPendingApprovals,
 } from '../../selectors';
-import {
-  isNetworkLoading,
-  getProviderConfig,
-} from '../../../shared/modules/selectors/networks';
 import {
   lockMetamask,
   hideImportNftsModal,

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
@@ -26,7 +26,8 @@ import {
   IconColor,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { getCurrentChainId, getFullTxData } from '../../../selectors';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
+import { getFullTxData } from '../../../selectors';
 import { BaseUrl } from '../../../../shared/constants/urls';
 import { hideLoadingIndication } from '../../../store/actions';
 import { hexToDecimal } from '../../../../shared/modules/conversion.utils';

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -12,9 +12,8 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getCurrentCurrency,
   getRpcPrefsForCurrentProvider,
   getUSDConversionRate,

--- a/ui/pages/swaps/hooks/useUpdateSwapsState.test.ts
+++ b/ui/pages/swaps/hooks/useUpdateSwapsState.test.ts
@@ -13,9 +13,9 @@ import {
   setTopAssets,
 } from '../../../ducks/swaps/swaps';
 import { setSwapsTokens } from '../../../store/actions';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
   checkNetworkAndAccountSupports1559,
-  getCurrentChainId,
   getIsSwapsChain,
   getUseExternalServices,
 } from '../../../selectors';

--- a/ui/pages/swaps/hooks/useUpdateSwapsState.ts
+++ b/ui/pages/swaps/hooks/useUpdateSwapsState.ts
@@ -12,9 +12,9 @@ import {
   setTopAssets,
 } from '../../../ducks/swaps/swaps';
 import { setSwapsTokens } from '../../../store/actions';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
   checkNetworkAndAccountSupports1559,
-  getCurrentChainId,
   getIsSwapsChain,
   getUseExternalServices,
 } from '../../../selectors';

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -19,12 +19,12 @@ import { I18nContext } from '../../contexts/i18n';
 
 import {
   getSelectedAccount,
-  getCurrentChainId,
   getIsSwapsChain,
   isHardwareWallet,
   getHardwareWalletType,
   getTokenList,
 } from '../../selectors/selectors';
+import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
 import {
   getQuotes,
   clearSwapsState,

--- a/ui/pages/swaps/list-with-search/list-with-search.js
+++ b/ui/pages/swaps/list-with-search/list-with-search.js
@@ -19,7 +19,7 @@ import ItemList from '../searchable-item-list/item-list';
 import { isValidHexAddress } from '../../../../shared/modules/hexstring-utils';
 import { I18nContext } from '../../../contexts/i18n';
 import { fetchToken } from '../swaps.util';
-import { getCurrentChainId } from '../../../selectors/selectors';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 
 let timeoutIdForSearch;
 

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -54,11 +54,11 @@ import {
   getLatestAddedTokenTo,
   getUsedQuote,
 } from '../../../ducks/swaps/swaps';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
   getSwapsDefaultToken,
   getTokenExchangeRates,
   getCurrentCurrency,
-  getCurrentChainId,
   getRpcPrefsForCurrentProvider,
   getTokenList,
   isHardwareWallet,

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -45,13 +45,13 @@ import {
   getSmartTransactionFees,
   getCurrentSmartTransactionsEnabled,
 } from '../../../ducks/swaps/swaps';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
   conversionRateSelector,
   getSelectedAccount,
   getCurrentCurrency,
   getTokenExchangeRates,
   getSwapsDefaultToken,
-  getCurrentChainId,
   isHardwareWallet,
   getHardwareWalletType,
   checkNetworkAndAccountSupports1559,

--- a/ui/pages/swaps/searchable-item-list/item-list/item-list.component.js
+++ b/ui/pages/swaps/searchable-item-list/item-list/item-list.component.js
@@ -7,8 +7,8 @@ import UrlIcon from '../../../../components/ui/url-icon';
 import Button from '../../../../components/ui/button';
 import ActionableMessage from '../../../../components/ui/actionable-message/actionable-message';
 import { I18nContext } from '../../../../contexts/i18n';
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import {
-  getCurrentChainId,
   getRpcPrefsForCurrentProvider,
   getUseCurrencyRateCheck,
 } from '../../../../selectors';

--- a/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
+++ b/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
@@ -8,7 +8,7 @@ import TextField from '../../../../components/ui/text-field';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { isValidHexAddress } from '../../../../../shared/modules/hexstring-utils';
 import { fetchToken } from '../../swaps.util';
-import { getCurrentChainId } from '../../../../selectors/selectors';
+import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import SearchIcon from '../../../../components/ui/icon/search-icon';
 
 const renderAdornment = () => (

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -13,10 +13,10 @@ import {
   cancelSwapsSmartTransaction,
   getUsedQuote,
 } from '../../../ducks/swaps/swaps';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
   isHardwareWallet,
   getHardwareWalletType,
-  getCurrentChainId,
   getRpcPrefsForCurrentProvider,
 } from '../../../selectors';
 import {

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -28,11 +28,13 @@ import {
   subtractHexes,
   sumHexes,
 } from '../../shared/modules/conversion.utils';
-import { getProviderConfig } from '../../shared/modules/selectors/networks';
+import {
+  getProviderConfig,
+  getCurrentChainId,
+} from '../../shared/modules/selectors/networks';
 import { getAveragePriceEstimateInHexWEI } from './custom-gas';
 import {
   checkNetworkAndAccountSupports1559,
-  getCurrentChainId,
   getMetaMaskAccounts,
   getTokenExchangeRates,
 } from './selectors';

--- a/ui/selectors/institutional/selectors.ts
+++ b/ui/selectors/institutional/selectors.ts
@@ -175,11 +175,12 @@ export function getIsCustodianSupportedChain(
     // @ts-expect-error state types don't match
     const selectedAccount = getSelectedInternalAccount(state);
     const accountType = getAccountType(state);
-    const providerConfig = getProviderConfig(state);
 
-    if (!selectedAccount || !accountType || !providerConfig) {
+    if (!selectedAccount || !accountType) {
       throw new Error('Invalid state');
     }
+
+    const providerConfig = getProviderConfig(state);
 
     if (typeof providerConfig.chainId !== 'string') {
       throw new Error('Chain ID must be a string');

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -29,10 +29,10 @@ import {
   getProviderConfig,
   NetworkState,
   getNetworkConfigurationsByChainId,
+  getCurrentChainId,
 } from '../../shared/modules/selectors/networks';
 import { AccountsState, getSelectedInternalAccount } from './accounts';
 import {
-  getCurrentChainId,
   getCurrentCurrency,
   getIsMainnet,
   getMaybeSelectedInternalAccount,

--- a/ui/selectors/nft.ts
+++ b/ui/selectors/nft.ts
@@ -1,5 +1,6 @@
 import { Nft, NftContract } from '@metamask/assets-controllers';
 import { createSelector } from 'reselect';
+import { NetworkState } from '../../shared/modules/selectors/networks';
 import { getMemoizedCurrentChainId } from './selectors';
 
 export type NftState = {
@@ -62,9 +63,9 @@ export const getNftContractsByAddressByChain = createSelector(
 );
 
 export const getNftContractsByAddressOnCurrentChain = createSelector(
+  (state: NftState & NetworkState) => getMemoizedCurrentChainId(state),
   getNftContractsByAddressByChain,
-  getMemoizedCurrentChainId,
-  (nftContractsByAddressByChain, currentChainId) => {
+  (currentChainId, nftContractsByAddressByChain) => {
     return nftContractsByAddressByChain[currentChainId] ?? {};
   },
 );

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -12,6 +12,12 @@ import { NameType } from '@metamask/name-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { RpcEndpointType } from '@metamask/network-controller';
+import {
+  getCurrentChainId,
+  getProviderConfig,
+  getSelectedNetworkClientId,
+  getNetworkConfigurationsByChainId,
+} from '../../shared/modules/selectors/networks';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { addHexPrefix, getEnvironmentType } from '../../app/scripts/lib/util';
@@ -104,11 +110,6 @@ import { MultichainNativeAssets } from '../../shared/constants/multichain/assets
 import { BridgeFeatureFlagsKey } from '../../app/scripts/controllers/bridge/types';
 import { hasTransactionData } from '../../shared/modules/transaction.utils';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
-import {
-  getProviderConfig,
-  getSelectedNetworkClientId,
-  getNetworkConfigurationsByChainId,
-} from '../../shared/modules/selectors/networks';
 import { createDeepEqualSelector } from '../../shared/modules/selectors/util';
 import {
   getAllUnapprovedTransactions,
@@ -130,11 +131,6 @@ export function getNetworkIdentifier(state) {
   const { type, nickname, rpcUrl } = getProviderConfig(state);
 
   return nickname || rpcUrl || type;
-}
-
-export function getCurrentChainId(state) {
-  const { chainId } = getProviderConfig(state);
-  return chainId;
 }
 
 export function getMetaMetricsId(state) {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -13,8 +13,12 @@ import { createMockInternalAccount } from '../../test/jest/mocks';
 import { mockNetworkState } from '../../test/stub/networks';
 import { DeleteRegulationStatus } from '../../shared/constants/metametrics';
 import { selectSwitchedNetworkNeverShowMessage } from '../components/app/toast-master/selectors';
-import { getProviderConfig } from '../../shared/modules/selectors/networks';
+import * as networkSelectors from '../../shared/modules/selectors/networks';
 import * as selectors from './selectors';
+
+jest.mock('../../shared/modules/selectors/networks', () => ({
+  ...jest.requireActual('../../shared/modules/selectors/networks'),
+}));
 
 jest.mock('../../app/scripts/lib/util', () => ({
   ...jest.requireActual('../../app/scripts/lib/util'),
@@ -189,7 +193,7 @@ describe('Selectors', () => {
 
       expect(selectors.getSwitchedNetworkDetails(state)).toStrictEqual({
         imageUrl: './images/eth_logo.svg',
-        nickname: getProviderConfig(state).nickname,
+        nickname: networkSelectors.getProviderConfig(state).nickname,
         origin,
       });
     });
@@ -1997,7 +2001,10 @@ describe('#getConnectedSitesList', () => {
     });
 
     it('returns the token object for the overridden chainId when overrideChainId is provided', () => {
-      const getCurrentChainIdSpy = jest.spyOn(selectors, 'getCurrentChainId');
+      const getCurrentChainIdSpy = jest.spyOn(
+        networkSelectors,
+        'getCurrentChainId',
+      );
       const expectedToken = {
         symbol: 'POL',
         name: 'Polygon',
@@ -2116,7 +2123,10 @@ describe('#getConnectedSitesList', () => {
     it('respects the overrideChainId parameter', () => {
       process.env.METAMASK_ENVIRONMENT = 'production';
 
-      const getCurrentChainIdSpy = jest.spyOn(selectors, 'getCurrentChainId');
+      const getCurrentChainIdSpy = jest.spyOn(
+        networkSelectors,
+        'getCurrentChainId',
+      );
 
       const result = selectors.getIsSwapsChain(mockState, '0x89');
       expect(result).toBe(true);
@@ -2169,7 +2179,10 @@ describe('#getConnectedSitesList', () => {
     });
 
     it('respects the overrideChainId parameter', () => {
-      const getCurrentChainIdSpy = jest.spyOn(selectors, 'getCurrentChainId');
+      const getCurrentChainIdSpy = jest.spyOn(
+        networkSelectors,
+        'getCurrentChainId',
+      );
 
       const result = selectors.getIsBridgeChain(mockState, '0x89');
 

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -12,12 +12,14 @@ import {
 import txHelper from '../helpers/utils/tx-helper';
 import { SmartTransactionStatus } from '../../shared/constants/transaction';
 import { hexToDecimal } from '../../shared/modules/conversion.utils';
-import { getProviderConfig } from '../../shared/modules/selectors/networks';
+import {
+  getProviderConfig,
+  getCurrentChainId,
+} from '../../shared/modules/selectors/networks';
 import {
   createDeepEqualSelector,
   filterAndShapeUnapprovedTransactions,
 } from '../../shared/modules/selectors/util';
-import { getCurrentChainId } from './selectors';
 import { getSelectedInternalAccount } from './accounts';
 import { hasPendingApprovals, getApprovalRequestsByType } from './approvals';
 


### PR DESCRIPTION
Converts the selector `getCurrentChainId` from functions from JS to TS and moves it to the `shared` folder. Also updates some functions to match the actual expect return values and fixes some types.

Why only this function? I'm trying to solve circular dependency issues. `getCurrentChainId` is so widely used in the codebase, it makes it very complicated to untangle. I've moved it to `shared/modules/selectors/networks.ts`

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27647?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->