### PR TITLE
refactor: move `getCurrentCurrency` from `ui/selectors/selectors.js` to `ui/ducks/metamask/metamask.js`

### DIFF
--- a/ui/components/app/assets/asset-list/native-token/use-native-token-balance.ts
+++ b/ui/components/app/assets/asset-list/native-token/use-native-token-balance.ts
@@ -8,10 +8,10 @@ import {
   getMultichainShouldShowFiat,
 } from '../../../../../selectors/multichain';
 import {
-  getCurrentCurrency,
   getPreferences,
   getSelectedInternalAccount,
 } from '../../../../../selectors';
+import { getCurrentCurrency } from '../../../../../ducks/metamask/metamask';
 import { useIsOriginalNativeTokenSymbol } from '../../../../../hooks/useIsOriginalNativeTokenSymbol';
 import { PRIMARY, SECONDARY } from '../../../../../helpers/constants/common';
 import { useUserPreferencedCurrency } from '../../../../../hooks/useUserPreferencedCurrency';

--- a/ui/components/app/assets/asset-list/sort-control/sort-control.test.tsx
+++ b/ui/components/app/assets/asset-list/sort-control/sort-control.test.tsx
@@ -4,7 +4,8 @@ import { useSelector } from 'react-redux';
 import { setTokenSortConfig } from '../../../../../store/actions';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers';
 import { MetaMetricsContext } from '../../../../../contexts/metametrics';
-import { getCurrentCurrency, getPreferences } from '../../../../../selectors';
+import { getPreferences } from '../../../../../selectors';
+import { getCurrentCurrency } from '../../../../../ducks/metamask/metamask';
 import SortControl from './sort-control';
 
 // Mock the sortAssets utility

--- a/ui/components/app/assets/asset-list/sort-control/sort-control.tsx
+++ b/ui/components/app/assets/asset-list/sort-control/sort-control.tsx
@@ -18,7 +18,8 @@ import {
   MetaMetricsEventName,
   MetaMetricsUserTrait,
 } from '../../../../../../shared/constants/metametrics';
-import { getCurrentCurrency, getPreferences } from '../../../../../selectors';
+import { getPreferences } from '../../../../../selectors';
+import { getCurrentCurrency } from '../../../../../ducks/metamask/metamask';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { getCurrencySymbol } from '../../../../../helpers/utils/common.util';
 

--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -21,11 +21,7 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { shortenAddress } from '../../../../../helpers/utils/util';
 import { getNftImageAlt } from '../../../../../helpers/utils/nfts';
 import { getCurrentChainId } from '../../../../../../shared/modules/selectors/networks';
-import {
-  getCurrentCurrency,
-  getCurrentNetwork,
-  getIpfsGateway,
-} from '../../../../../selectors';
+import { getCurrentNetwork, getIpfsGateway } from '../../../../../selectors';
 import {
   ASSET_ROUTE,
   DEFAULT_ROUTE,
@@ -67,7 +63,10 @@ import { Content, Footer, Page } from '../../../../multichain/pages/page';
 import { formatCurrency } from '../../../../../helpers/utils/confirm-tx.util';
 import { getShortDateFormatterV2 } from '../../../../../pages/asset/util';
 import { CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../../../shared/constants/common';
-import { getConversionRate } from '../../../../../ducks/metamask/metamask';
+import {
+  getConversionRate,
+  getCurrentCurrency,
+} from '../../../../../ducks/metamask/metamask';
 import { Numeric } from '../../../../../../shared/modules/Numeric';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths

--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -5,10 +5,10 @@ import { fireEvent } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers';
 import { useTokenFiatAmount } from '../../../../hooks/useTokenFiatAmount';
+import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import {
   getTokenList,
   getPreferences,
-  getCurrentCurrency,
   getCurrencyRates,
 } from '../../../../selectors';
 import {

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
+import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import {
-  getCurrentCurrency,
   getTokenList,
   selectERC20TokensByChain,
   getNativeCurrencyForChain,

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -5,12 +5,15 @@ import { Box } from '../../component-library';
 import { BlockSize } from '../../../helpers/constants/design-system';
 import UnitInput from '../../ui/unit-input';
 import CurrencyDisplay from '../../ui/currency-display';
-import { getNativeCurrency } from '../../../ducks/metamask/metamask';
+import {
+  getNativeCurrency,
+  getCurrentCurrency,
+} from '../../../ducks/metamask/metamask';
 import {
   getProviderConfig,
   getCurrentChainId,
 } from '../../../../shared/modules/selectors/networks';
-import { getCurrentCurrency, getShouldShowFiat } from '../../../selectors';
+import { getShouldShowFiat } from '../../../selectors';
 import { EtherDenomination } from '../../../../shared/constants/common';
 import { Numeric } from '../../../../shared/modules/Numeric';
 import { useIsOriginalNativeTokenSymbol } from '../../../hooks/useIsOriginalNativeTokenSymbol';

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.test.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import {
-  getCurrentCurrency,
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,
   getPreferences,
@@ -11,6 +10,7 @@ import {
   getAllTokens,
   getChainIdsToPoll,
 } from '../../../selectors';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { useAccountTotalCrossChainFiatBalance } from '../../../hooks/useAccountTotalCrossChainFiatBalance';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/selectors/networks';
 import { AggregatedPercentageOverviewCrossChains } from './aggregated-percentage-overview-cross-chains';
@@ -31,13 +31,16 @@ jest.mock('../../../ducks/locale/locale', () => ({
 }));
 
 jest.mock('../../../selectors', () => ({
-  getCurrentCurrency: jest.fn(),
   getSelectedAccount: jest.fn(),
   getPreferences: jest.fn(),
   getShouldHideZeroBalanceTokens: jest.fn(),
   getMarketData: jest.fn(),
   getAllTokens: jest.fn(),
   getChainIdsToPoll: jest.fn(),
+}));
+
+jest.mock('../../../ducks/metamask/metamask', () => ({
+  getCurrentCurrency: jest.fn(),
 }));
 
 jest.mock('../../../../shared/modules/selectors/networks', () => ({

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -5,13 +5,13 @@ import { toChecksumAddress } from 'ethereumjs-util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
 import {
-  getCurrentCurrency,
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,
   getPreferences,
   getMarketData,
   getChainIdsToPoll,
 } from '../../../selectors';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.test.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { getIntlLocale } from '../../../ducks/locale/locale';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
-  getCurrentCurrency,
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,
   getTokensMarketData,
@@ -21,8 +21,11 @@ jest.mock('../../../ducks/locale/locale', () => ({
   getIntlLocale: jest.fn(),
 }));
 
-jest.mock('../../../selectors', () => ({
+jest.mock('../../../ducks/metamask/metamask', () => ({
   getCurrentCurrency: jest.fn(),
+}));
+
+jest.mock('../../../selectors', () => ({
   getSelectedAccount: jest.fn(),
   getPreferences: jest.fn(),
   getShouldHideZeroBalanceTokens: jest.fn(),

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -3,8 +3,8 @@ import { useSelector } from 'react-redux';
 
 import { toChecksumAddress } from 'ethereumjs-util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
-  getCurrentCurrency,
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,
   getTokensMarketData,

--- a/ui/components/multichain/asset-picker-amount/asset-balance/asset-balance-text.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-balance/asset-balance-text.tsx
@@ -4,10 +4,8 @@ import { Text } from '../../../component-library';
 import UserPreferencedCurrencyDisplay from '../../../app/user-preferenced-currency-display';
 import { PRIMARY } from '../../../../helpers/constants/common';
 import { Asset } from '../../../../ducks/send';
-import {
-  getCurrentCurrency,
-  getSelectedAccountCachedBalance,
-} from '../../../../selectors';
+import { getSelectedAccountCachedBalance } from '../../../../selectors';
+import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import {
   TextColor,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
+import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import {
-  getCurrentCurrency,
   getNetworkConfigurationIdByChainId,
   getTokenList,
 } from '../../../../selectors';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
@@ -7,11 +7,13 @@ import {
 } from '@metamask/network-controller';
 import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import {
-  getCurrentCurrency,
   getCurrentNetwork,
   getSelectedAccountCachedBalance,
 } from '../../../../selectors';
-import { getNativeCurrency } from '../../../../ducks/metamask/metamask';
+import {
+  getCurrentCurrency,
+  getNativeCurrency,
+} from '../../../../ducks/metamask/metamask';
 import { useCurrencyDisplay } from '../../../../hooks/useCurrencyDisplay';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import { Box } from '../../../component-library';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx
@@ -32,7 +32,7 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 ///: END:ONLY_INCLUDE_IF
 import { NetworkListItem } from '../../network-list-item';
 import { getNetworkConfigurationsByChainId } from '../../../../../shared/modules/selectors/networks';
-import { getCurrentCurrency } from '../../../../selectors';
+import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import { formatCurrency } from '../../../../helpers/utils/confirm-tx.util';
 import { useMultichainBalances } from '../../../../hooks/useMultichainBalances';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../shared/constants/bridge';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -12,7 +12,6 @@ import { renderWithProvider } from '../../../../../test/lib/render-helpers';
 import mockState from '../../../../../test/data/mock-send-state.json';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import {
-  getCurrentCurrency,
   getNativeCurrencyImage,
   getSelectedAccountCachedBalance,
   getSelectedInternalAccount,
@@ -24,6 +23,7 @@ import {
   getConversionRate,
   getNativeCurrency,
   getTokens,
+  getCurrentCurrency,
 } from '../../../../ducks/metamask/metamask';
 import { getTopAssets } from '../../../../ducks/swaps/swaps';
 import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -36,7 +36,6 @@ import {
 } from '../../../../../shared/modules/selectors/networks';
 import {
   getAllTokens,
-  getCurrentCurrency,
   getNativeCurrencyImage,
   getSelectedAccountCachedBalance,
   getSelectedInternalAccount,
@@ -46,6 +45,7 @@ import {
 } from '../../../../selectors';
 import {
   getConversionRate,
+  getCurrentCurrency,
   getNativeCurrency,
 } from '../../../../ducks/metamask/metamask';
 import { useTokenTracker } from '../../../../hooks/useTokenTracker';

--- a/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.test.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.test.tsx
@@ -4,10 +4,10 @@ import {
   getNativeCurrency,
   getConversionRate,
   getGasFeeEstimates,
+  getCurrentCurrency,
 } from '../../../../../../../ducks/metamask/metamask';
 import { getUsedSwapsGasPrice } from '../../../../../../../ducks/swaps/swaps';
 import {
-  getCurrentCurrency,
   checkNetworkAndAccountSupports1559,
   getIsSwapsChain,
 } from '../../../../../../../selectors';

--- a/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.tsx
@@ -6,10 +6,10 @@ import {
   getConversionRate,
   getGasFeeEstimates,
   getNativeCurrency,
+  getCurrentCurrency,
 } from '../../../../../../../ducks/metamask/metamask';
 import { EtherDenomination } from '../../../../../../../../shared/constants/common';
 import {
-  getCurrentCurrency,
   checkNetworkAndAccountSupports1559,
   getIsSwapsChain,
 } from '../../../../../../../selectors/selectors';

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.test.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.test.tsx
@@ -5,13 +5,13 @@ import { zeroAddress } from 'ethereumjs-util';
 import { MarketDataDetails } from '@metamask/assets-controllers';
 import { getIntlLocale } from '../../../../../ducks/locale/locale';
 import {
-  getCurrentCurrency,
   getSelectedAccountCachedBalance,
   getTokensMarketData,
 } from '../../../../../selectors';
 import { getCurrentChainId } from '../../../../../../shared/modules/selectors/networks';
 import {
   getConversionRate,
+  getCurrentCurrency,
   getNativeCurrency,
 } from '../../../../../ducks/metamask/metamask';
 import { PercentageAndAmountChange } from './percentage-and-amount-change';
@@ -25,7 +25,6 @@ jest.mock('../../../../../ducks/locale/locale', () => ({
 }));
 
 jest.mock('../../../../../selectors', () => ({
-  getCurrentCurrency: jest.fn(),
   getSelectedAccountCachedBalance: jest.fn(),
   getTokensMarketData: jest.fn(),
 }));
@@ -35,6 +34,7 @@ jest.mock('../../../../../../shared/modules/selectors/networks', () => ({
 }));
 
 jest.mock('../../../../../ducks/metamask/metamask', () => ({
+  getCurrentCurrency: jest.fn(),
   getConversionRate: jest.fn(),
   getNativeCurrency: jest.fn(),
 }));

--- a/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
+++ b/ui/components/multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../../../helpers/constants/design-system';
 import { getCurrentChainId } from '../../../../../../shared/modules/selectors/networks';
 import {
-  getCurrentCurrency,
   getSelectedAccountCachedBalance,
   getTokensMarketData,
 } from '../../../../../selectors';
@@ -20,6 +19,7 @@ import { EtherDenomination } from '../../../../../../shared/constants/common';
 import { Numeric } from '../../../../../../shared/modules/Numeric';
 import {
   getConversionRate,
+  getCurrentCurrency,
   getNativeCurrency,
 } from '../../../../../ducks/metamask/metamask';
 import {

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -604,3 +604,7 @@ export function doesUserHaveALedgerAccount(state) {
     return kr.type === KeyringType.ledger;
   });
 }
+
+export function getCurrentCurrency(state) {
+  return state.metamask.currentCurrency;
+}

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -21,6 +21,7 @@ import reduceMetamask, {
   getSendHexDataFeatureFlagState,
   getSendToAccounts,
   isNotEIP1559Network,
+  getCurrentCurrency,
 } from './metamask';
 
 jest.mock('@metamask/transaction-controller', () => ({
@@ -126,6 +127,7 @@ describe('MetaMask Reducers', () => {
             conversionRate: 1200.88200327,
           },
         },
+        currentCurrency: 'usd',
         ...mockNetworkState({ chainId: CHAIN_IDS.GOERLI }),
         accounts: {
           '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825': {
@@ -381,6 +383,13 @@ describe('MetaMask Reducers', () => {
             },
           }),
         ).toStrictEqual('GoerliETH');
+      });
+    });
+
+    describe('getCurrentCurrency', () => {
+      it('should return the `currentCurrency`', () => {
+        const currentCurrency = getCurrentCurrency(mockState);
+        expect(currentCurrency).toStrictEqual('usd');
       });
     });
 

--- a/ui/hooks/bridge/events/useConvertedUsdAmounts.ts
+++ b/ui/hooks/bridge/events/useConvertedUsdAmounts.ts
@@ -8,7 +8,8 @@ import {
   getToTokenConversionRate,
   getFromAmount,
 } from '../../../ducks/bridge/selectors';
-import { getCurrentCurrency, getUSDConversionRate } from '../../../selectors';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
+import { getUSDConversionRate } from '../../../selectors';
 import { tokenAmountToCurrency } from '../../../ducks/bridge/utils';
 
 const USD_CURRENCY_CODE = 'usd';

--- a/ui/hooks/bridge/useBridgeExchangeRates.ts
+++ b/ui/hooks/bridge/useBridgeExchangeRates.ts
@@ -5,11 +5,8 @@ import {
   getQuoteRequest,
   getToChain,
 } from '../../ducks/bridge/selectors';
-import {
-  getCurrentCurrency,
-  getMarketData,
-  getParticipateInMetaMetrics,
-} from '../../selectors';
+import { getMarketData, getParticipateInMetaMetrics } from '../../selectors';
+import { getCurrentCurrency } from '../../ducks/metamask/metamask';
 import { decimalToPrefixedHex } from '../../../shared/modules/conversion.utils';
 import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
 import {

--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -7,11 +7,13 @@ import { useParams } from 'react-router-dom';
 import { zeroAddress } from 'ethereumjs-util';
 import {
   getAllDetectedTokensForSelectedAddress,
-  getCurrentCurrency,
   getSelectedInternalAccountWithBalance,
   getTokenExchangeRates,
 } from '../../selectors';
-import { getConversionRate } from '../../ducks/metamask/metamask';
+import {
+  getConversionRate,
+  getCurrentCurrency,
+} from '../../ducks/metamask/metamask';
 import { SwapsTokenObject } from '../../../shared/constants/swaps';
 import {
   AssetWithDisplayData,

--- a/ui/hooks/useAccountTotalCrossChainFiatBalance.test.ts
+++ b/ui/hooks/useAccountTotalCrossChainFiatBalance.test.ts
@@ -2,11 +2,13 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-dom/test-utils';
 import {
-  getCurrentCurrency,
   getCrossChainTokenExchangeRates,
   getCrossChainMetaMaskCachedBalances,
 } from '../selectors';
-import { getCurrencyRates } from '../ducks/metamask/metamask';
+import {
+  getCurrentCurrency,
+  getCurrencyRates,
+} from '../ducks/metamask/metamask';
 import { getNetworkConfigurationsByChainId } from '../../shared/modules/selectors/networks';
 import {
   FormattedTokensWithBalances,
@@ -18,11 +20,11 @@ jest.mock('react-redux', () => ({
 }));
 
 jest.mock('../selectors', () => ({
-  getCurrentCurrency: jest.fn(),
   getCrossChainTokenExchangeRates: jest.fn(),
   getCrossChainMetaMaskCachedBalances: jest.fn(),
 }));
 jest.mock('../ducks/metamask/metamask', () => ({
+  getCurrentCurrency: jest.fn(),
   getCurrencyRates: jest.fn(),
 }));
 jest.mock('../../shared/modules/selectors/networks', () => ({

--- a/ui/hooks/useAccountTotalCrossChainFiatBalance.ts
+++ b/ui/hooks/useAccountTotalCrossChainFiatBalance.ts
@@ -2,6 +2,9 @@ import { shallowEqual, useSelector } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
 import {
   getCurrentCurrency,
+  getCurrencyRates,
+} from '../ducks/metamask/metamask';
+import {
   getCrossChainTokenExchangeRates,
   getCrossChainMetaMaskCachedBalances,
 } from '../selectors';
@@ -9,7 +12,6 @@ import {
   getValueFromWeiHex,
   sumDecimals,
 } from '../../shared/modules/conversion.utils';
-import { getCurrencyRates } from '../ducks/metamask/metamask';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';
 import { TokenWithBalance } from '../components/app/assets/asset-list/asset-list';
 import { getNetworkConfigurationsByChainId } from '../../shared/modules/selectors/networks';

--- a/ui/hooks/useAccountTotalFiatBalance.js
+++ b/ui/hooks/useAccountTotalFiatBalance.js
@@ -3,7 +3,6 @@ import { toChecksumAddress } from 'ethereumjs-util';
 import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import {
   getAllTokens,
-  getCurrentCurrency,
   getMetaMaskCachedBalances,
   getTokenExchangeRates,
   getConfirmationExchangeRates,
@@ -18,6 +17,7 @@ import {
 import {
   getConversionRate,
   getNativeCurrency,
+  getCurrentCurrency,
 } from '../ducks/metamask/metamask';
 import { formatCurrency } from '../helpers/utils/confirm-tx.util';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';

--- a/ui/hooks/useEthFiatAmount.js
+++ b/ui/hooks/useEthFiatAmount.js
@@ -1,8 +1,11 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { getCurrentCurrency, getShouldShowFiat } from '../selectors';
+import { getShouldShowFiat } from '../selectors';
 import { formatCurrency } from '../helpers/utils/confirm-tx.util';
-import { getConversionRate } from '../ducks/metamask/metamask';
+import {
+  getConversionRate,
+  getCurrentCurrency,
+} from '../ducks/metamask/metamask';
 import { decEthToConvertedCurrency } from '../../shared/modules/conversion.utils';
 
 /**

--- a/ui/hooks/useFiatFormatter.test.ts
+++ b/ui/hooks/useFiatFormatter.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { getIntlLocale } from '../ducks/locale/locale';
-import { getCurrentCurrency } from '../selectors';
+import { getCurrentCurrency } from '../ducks/metamask/metamask';
 import { useFiatFormatter } from './useFiatFormatter';
 
 jest.mock('react-redux', () => ({
@@ -11,7 +11,7 @@ jest.mock('../ducks/locale/locale', () => ({
   getIntlLocale: jest.fn(),
 }));
 
-jest.mock('../selectors', () => ({
+jest.mock('../ducks/metamask/metamask', () => ({
   getCurrentCurrency: jest.fn(),
 }));
 

--- a/ui/hooks/useFiatFormatter.ts
+++ b/ui/hooks/useFiatFormatter.ts
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 import { getIntlLocale } from '../ducks/locale/locale';
-import { getCurrentCurrency } from '../selectors';
+import { getCurrentCurrency } from '../ducks/metamask/metamask';
 import { shortenString } from '../helpers/utils/util';
 
 /**

--- a/ui/hooks/useTokenFiatAmount.js
+++ b/ui/hooks/useTokenFiatAmount.js
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import {
   getTokenExchangeRates,
-  getCurrentCurrency,
   getShouldShowFiat,
   getConfirmationExchangeRates,
   getMarketData,
@@ -10,7 +9,10 @@ import {
 } from '../selectors';
 import { getNetworkConfigurationsByChainId } from '../../shared/modules/selectors/networks';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';
-import { getConversionRate } from '../ducks/metamask/metamask';
+import {
+  getConversionRate,
+  getCurrentCurrency,
+} from '../ducks/metamask/metamask';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 
 /**

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -6,13 +6,14 @@ import { formatIconUrlWithProxy } from '@metamask/assets-controllers';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';
 import {
   getTokenExchangeRates,
-  getCurrentCurrency,
   getSwapsDefaultToken,
   getTokenList,
 } from '../selectors';
 import { getCurrentChainId } from '../../shared/modules/selectors/networks';
-import { getConversionRate } from '../ducks/metamask/metamask';
-
+import {
+  getConversionRate,
+  getCurrentCurrency,
+} from '../ducks/metamask/metamask';
 import { getSwapsTokens } from '../ducks/swaps/swaps';
 import { isSwapsDefaultTokenSymbol } from '../../shared/modules/swaps.utils';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -6,7 +6,6 @@ import { isEqual } from 'lodash';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
 import {
-  getCurrentCurrency,
   getDataCollectionForMarketing,
   getIsBridgeChain,
   getIsSwapsChain,
@@ -45,7 +44,10 @@ import TokenCell from '../../../components/app/assets/token-cell';
 import TransactionList from '../../../components/app/transaction-list';
 import { getPricePrecision, localizeLargeNumber } from '../util';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
-import { getConversionRate } from '../../../ducks/metamask/metamask';
+import {
+  getConversionRate,
+  getCurrentCurrency,
+} from '../../../ducks/metamask/metamask';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import CoinButtons from '../../../components/app/wallet-overview/coin-buttons';
 import { getIsNativeTokenBuyable } from '../../../ducks/ramps';

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -14,7 +14,8 @@ import {
 import { AssetPicker } from '../../../components/multichain/asset-picker-amount/asset-picker';
 import { TabName } from '../../../components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-tabs';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { getCurrentCurrency, getLocale } from '../../../selectors';
+import { getLocale } from '../../../selectors';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { formatCurrencyAmount, formatTokenAmount } from '../utils/quote';
 import { Column, Row, Tooltip } from '../layout';
 import {

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -21,8 +21,10 @@ import {
   formatTokenAmount,
   formatEtaInMinutes,
 } from '../utils/quote';
-import { getCurrentCurrency, getLocale } from '../../../selectors';
-import { getNativeCurrency } from '../../../ducks/metamask/metamask';
+import {
+  getCurrentCurrency,
+  getNativeCurrency,
+} from '../../../ducks/metamask/metamask';
 import { useCrossChainSwapsEventTracker } from '../../../hooks/bridge/useCrossChainSwapsEventTracker';
 import { useRequestProperties } from '../../../hooks/bridge/events/useRequestProperties';
 import { useRequestMetadataProperties } from '../../../hooks/bridge/events/useRequestMetadataProperties';
@@ -45,6 +47,7 @@ import {
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../shared/constants/network';
 import { decimalToPrefixedHex } from '../../../../shared/modules/conversion.utils';
 import { TERMS_OF_USE_LINK } from '../../../../shared/constants/terms';
+import { getLocale } from '../../../selectors';
 import { BridgeQuotesModal } from './bridge-quotes-modal';
 
 export const BridgeQuoteCard = () => {

--- a/ui/pages/bridge/quotes/bridge-quotes-modal.tsx
+++ b/ui/pages/bridge/quotes/bridge-quotes-modal.tsx
@@ -24,7 +24,7 @@ import {
   formatTokenAmount,
 } from '../utils/quote';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { getCurrentCurrency, getLocale } from '../../../selectors';
+import { getLocale } from '../../../selectors';
 import { setSelectedQuote, setSortOrder } from '../../../ducks/bridge/actions';
 import { QuoteMetadata, QuoteResponse, SortOrder } from '../types';
 import {
@@ -32,7 +32,10 @@ import {
   getBridgeSortOrder,
 } from '../../../ducks/bridge/selectors';
 import { Column, Row } from '../layout';
-import { getNativeCurrency } from '../../../ducks/metamask/metamask';
+import {
+  getCurrentCurrency,
+  getNativeCurrency,
+} from '../../../ducks/metamask/metamask';
 import { useQuoteProperties } from '../../../hooks/bridge/events/useQuoteProperties';
 import { useRequestMetadataProperties } from '../../../hooks/bridge/events/useRequestMetadataProperties';
 import { useRequestProperties } from '../../../hooks/bridge/events/useRequestProperties';

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -14,10 +14,8 @@ import {
 import { Numeric } from '../../../../../../../shared/modules/Numeric';
 import { useFiatFormatter } from '../../../../../../hooks/useFiatFormatter';
 import { useGasFeeEstimates } from '../../../../../../hooks/useGasFeeEstimates';
-import {
-  getCurrentCurrency,
-  selectConversionRateByChainId,
-} from '../../../../../../selectors';
+import { getCurrentCurrency } from '../../../../../../ducks/metamask/metamask';
+import { selectConversionRateByChainId } from '../../../../../../selectors';
 import { getMultichainNetwork } from '../../../../../../selectors/multichain';
 import { HEX_ZERO } from '../shared/constants';
 import { useEIP1559TxFees } from './useEIP1559TxFees';

--- a/ui/pages/confirmations/components/signature-request-header/signature-request-header.js
+++ b/ui/pages/confirmations/components/signature-request-header/signature-request-header.js
@@ -5,9 +5,9 @@ import { RpcEndpointType } from '@metamask/network-controller';
 import { NetworkType } from '@metamask/controller-utils';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
+import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import {
   accountsWithSendEtherInfoSelector,
-  getCurrentCurrency,
   selectDefaultRpcEndpointByChainId,
   selectNetworkConfigurationByChainId,
 } from '../../../../selectors';

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
@@ -17,9 +17,11 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn((selector) => selector()),
 }));
 
-jest.mock('../../../../selectors', () => ({
-  getCurrentChainId: jest.fn(),
+jest.mock('../../../../ducks/metamask/metamask', () => ({
   getCurrentCurrency: jest.fn(),
+}));
+
+jest.mock('../../../../selectors', () => ({
   selectConversionRateByChainId: jest.fn(),
 }));
 

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -10,10 +10,8 @@ import { BigNumber } from 'bignumber.js';
 import { ContractExchangeRates } from '@metamask/assets-controllers';
 import { useAsyncResultOrThrow } from '../../../../hooks/useAsyncResult';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
-import {
-  getCurrentCurrency,
-  selectConversionRateByChainId,
-} from '../../../../selectors';
+import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
+import { selectConversionRateByChainId } from '../../../../selectors';
 import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
 import { ERC20_DEFAULT_DECIMALS, fetchErc20Decimals } from '../../utils/token';
 

--- a/ui/pages/confirmations/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirmations/confirm-approve/confirm-approve.js
@@ -12,10 +12,12 @@ import { getTokenApprovedParam } from '../../../helpers/utils/token-util';
 import { readAddressAsContract } from '../../../../shared/modules/contract-utils';
 import { GasFeeContextProvider } from '../../../contexts/gasFee';
 import { TransactionModalContextProvider } from '../../../contexts/transaction-modal';
-import { isAddressLedger } from '../../../ducks/metamask/metamask';
+import {
+  isAddressLedger,
+  getCurrentCurrency,
+} from '../../../ducks/metamask/metamask';
 import ConfirmContractInteraction from '../confirm-contract-interaction';
 import {
-  getCurrentCurrency,
   getSubjectMetadata,
   getUseNonceField,
   getCustomNonceValue,

--- a/ui/pages/confirmations/confirm-send-token/confirm-send-token.js
+++ b/ui/pages/confirmations/confirm-send-token/confirm-send-token.js
@@ -7,10 +7,10 @@ import { SEND_ROUTE } from '../../../helpers/constants/routes';
 import { editExistingTransaction } from '../../../ducks/send';
 import {
   contractExchangeRateSelector,
-  getCurrentCurrency,
   selectConversionRateByChainId,
   selectNetworkConfigurationByChainId,
 } from '../../../selectors';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { clearConfirmTransaction } from '../../../ducks/confirm-transaction/confirm-transaction.duck';
 import { showSendTokenPage } from '../../../store/actions';
 import {

--- a/ui/pages/confirmations/confirm-token-transaction-base/confirm-token-transaction-base.js
+++ b/ui/pages/confirmations/confirm-token-transaction-base/confirm-token-transaction-base.js
@@ -15,12 +15,12 @@ import {
 import { PRIMARY } from '../../../helpers/constants/common';
 import {
   contractExchangeRateSelector,
-  getCurrentCurrency,
   getSelectedInternalAccount,
   selectConversionRateByChainId,
   selectNetworkConfigurationByChainId,
   selectNftContractsByChainId,
 } from '../../../selectors';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { TokenStandard } from '../../../../shared/constants/transaction';
 import {
   getWeiHexFromDecimalValue,

--- a/ui/pages/confirmations/hooks/test-utils.js
+++ b/ui/pages/confirmations/hooks/test-utils.js
@@ -3,8 +3,8 @@ import { useSelector } from 'react-redux';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 
 import { GasEstimateTypes } from '../../../../shared/constants/gas';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
-  getCurrentCurrency,
   getShouldShowFiat,
   txDataSelector,
   getCurrentKeyring,

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -13,8 +13,8 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
+import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
-  getCurrentCurrency,
   getRpcPrefsForCurrentProvider,
   getUSDConversionRate,
   isHardwareWallet,

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -14,7 +14,11 @@ import {
 } from '../../../hooks/useTokensToSearch';
 import { useEqualityCheck } from '../../../hooks/useEqualityCheck';
 import { I18nContext } from '../../../contexts/i18n';
-import { getTokens, getConversionRate } from '../../../ducks/metamask/metamask';
+import {
+  getTokens,
+  getConversionRate,
+  getCurrentCurrency,
+} from '../../../ducks/metamask/metamask';
 import Box from '../../../components/ui/box';
 import {
   DISPLAY,
@@ -58,7 +62,6 @@ import { getCurrentChainId } from '../../../../shared/modules/selectors/networks
 import {
   getSwapsDefaultToken,
   getTokenExchangeRates,
-  getCurrentCurrency,
   getRpcPrefsForCurrentProvider,
   getTokenList,
   isHardwareWallet,

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -49,7 +49,6 @@ import { getCurrentChainId } from '../../../../shared/modules/selectors/networks
 import {
   conversionRateSelector,
   getSelectedAccount,
-  getCurrentCurrency,
   getTokenExchangeRates,
   getSwapsDefaultToken,
   isHardwareWallet,
@@ -62,7 +61,11 @@ import {
   getSmartTransactionsEnabled,
   getSmartTransactionsPreferenceEnabled,
 } from '../../../../shared/modules/selectors';
-import { getNativeCurrency, getTokens } from '../../../ducks/metamask/metamask';
+import {
+  getNativeCurrency,
+  getTokens,
+  getCurrentCurrency,
+} from '../../../ducks/metamask/metamask';
 import {
   setCustomApproveTxData,
   showModal,

--- a/ui/selectors/multichain.test.ts
+++ b/ui/selectors/multichain.test.ts
@@ -2,7 +2,10 @@ import { Cryptocurrency } from '@metamask/assets-controllers';
 import { InternalAccount } from '@metamask/keyring-api';
 import { Hex } from '@metamask/utils';
 import { NetworkConfiguration } from '@metamask/network-controller';
-import { getNativeCurrency } from '../ducks/metamask/metamask';
+import {
+  getCurrentCurrency,
+  getNativeCurrency,
+} from '../ducks/metamask/metamask';
 import {
   MULTICHAIN_PROVIDER_CONFIGS,
   MultichainNetworks,
@@ -40,11 +43,7 @@ import {
   getMultichainSelectedAccountCachedBalanceIsZero,
   getMultichainIsTestnet,
 } from './multichain';
-import {
-  getCurrentCurrency,
-  getSelectedAccountCachedBalance,
-  getShouldShowFiat,
-} from '.';
+import { getSelectedAccountCachedBalance, getShouldShowFiat } from '.';
 
 type TestState = MultichainState &
   AccountsState & {

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -15,6 +15,7 @@ import {
   getCompletedOnboarding,
   getConversionRate,
   getNativeCurrency,
+  getCurrentCurrency,
 } from '../ducks/metamask/metamask';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
@@ -33,7 +34,6 @@ import {
 } from '../../shared/modules/selectors/networks';
 import { AccountsState, getSelectedInternalAccount } from './accounts';
 import {
-  getCurrentCurrency,
   getIsMainnet,
   getMaybeSelectedInternalAccount,
   getNativeCurrencyImage,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -963,10 +963,6 @@ export function getNftIsStillFetchingIndication(state) {
   return state.appState.isNftStillFetchingIndication;
 }
 
-export function getCurrentCurrency(state) {
-  return state.metamask.currentCurrency;
-}
-
 export function getTotalUnapprovedCount(state) {
   return state.metamask.pendingApprovalCount ?? 0;
 }

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -1088,11 +1088,6 @@ describe('Selectors', () => {
     expect(gasIsLoading).toStrictEqual(false);
   });
 
-  it('#getCurrentCurrency', () => {
-    const currentCurrency = selectors.getCurrentCurrency(mockState);
-    expect(currentCurrency).toStrictEqual('usd');
-  });
-
   it('#getTotalUnapprovedCount', () => {
     const totalUnapprovedCount = selectors.getTotalUnapprovedCount(mockState);
     expect(totalUnapprovedCount).toStrictEqual(1);


### PR DESCRIPTION
This change is related to circular dependency work; no runtime code has changed. QA is not required.

This PR moves `getCurrentCurrency` into `ui/ducks/` instead of keeping it in `ui/selectors/` because `ui/ducks/metamask/metamask.js` already exports a `getNativeCurrency`, so it seems to fit in well there.


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27648?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**

### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->