### PR TITLE
cherry-pick: Recreate offscreen document if it already exists

### DIFF
--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -6,6 +6,27 @@ import {
 import { getSocketBackgroundToMocha } from '../../test/e2e/background-socket/socket-background-to-mocha';
 
 /**
+ * Returns whether the offscreen document already exists or not.
+ *
+ * See https://developer.chrome.com/docs/extensions/reference/api/offscreen#before_chrome_116_check_if_an_offscreen_document_is_open
+ *
+ * @returns True if the offscreen document already is has been opened, otherwise false.
+ */
+async function hasOffscreenDocument() {
+  const { chrome, clients } = globalThis;
+  // getContexts is only available in Chrome 116+
+  if ('getContexts' in chrome.runtime) {
+    const contexts = await chrome.runtime.getContexts({
+      contextTypes: ['OFFSCREEN_DOCUMENT'],
+    });
+    return contexts.length > 0;
+  }
+  const matchedClients = await clients.matchAll();
+  const url = chrome.runtime.getURL('offscreen.html');
+  return matchedClients.some((client) => client.url === url);
+}
+
+/**
  * Creates an offscreen document that can be used to load additional scripts
  * and iframes that can communicate with the extension through the chrome
  * runtime API. Only one offscreen document may exist, so any iframes required
@@ -41,6 +62,14 @@ export async function createOffscreen() {
   });
 
   try {
+    const offscreenExists = await hasOffscreenDocument();
+
+    // In certain cases the offscreen document may already exist during boot, if it does, we close it and recreate it.
+    if (offscreenExists) {
+      console.debug('Found existing offscreen document, closing.');
+      await chrome.offscreen.closeDocument();
+    }
+
     await chrome.offscreen.createDocument({
       url: './offscreen.html',
       reasons: ['IFRAME_SCRIPTING'],
@@ -51,18 +80,10 @@ export async function createOffscreen() {
     if (offscreenDocumentLoadedListener) {
       chrome.runtime.onMessage.removeListener(offscreenDocumentLoadedListener);
     }
-    if (
-      error?.message?.startsWith(
-        'Only a single offscreen document may be created',
-      )
-    ) {
-      console.debug('Offscreen document already exists; skipping creation');
-    } else {
-      // Report unrecongized errors without halting wallet initialization
-      // Failures to create the offscreen document does not compromise wallet data integrity or
-      // core functionality, it's just needed for specific features.
-      captureException(error);
-    }
+    // Report unrecongized errors without halting wallet initialization
+    // Failures to create the offscreen document does not compromise wallet data integrity or
+    // core functionality, it's just needed for specific features.
+    captureException(error);
     return;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**

When the service worker is stopped it doesn't seem to guarantee that the offscreen document is closed as well. Our current initialization logic assumes this and thus once the service worker is spun back up, all communication with the offscreen document fails due to initialization failure.

This PR cherry-picks https://github.com/MetaMask/metamask-extension/commit/03cd7d55e0a1d529655b38976dc8bb7e6f6ae08b to the 12.5 RC, fixing this problem.

[![Open in GitHub
Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27596?quickstart=1)