### PR TITLE
fix(btc): fix jazzicons generations

### DIFF
--- a/package.json
+++ b/package.json
@@ -361,7 +361,7 @@
     "@metamask/snaps-utils": "^8.1.1",
     "@metamask/transaction-controller": "^37.2.0",
     "@metamask/user-operation-controller": "^13.0.0",
-    "@metamask/utils": "^9.1.0",
+    "@metamask/utils": "^9.3.0",
     "@ngraveio/bc-ur": "^1.1.12",
     "@noble/hashes": "^1.3.3",
     "@popperjs/core": "^2.4.0",

--- a/shared/lib/multichain.test.ts
+++ b/shared/lib/multichain.test.ts
@@ -1,6 +1,6 @@
+import { KnownCaipNamespace } from '@metamask/utils';
 import {
-  MultichainType,
-  getMultichainTypeFromAddress,
+  getCaipNamespaceFromAddress,
   isBtcMainnetAddress,
   isBtcTestnetAddress,
 } from './multichain';
@@ -66,8 +66,8 @@ describe('multichain', () => {
     it.each([...BTC_MAINNET_ADDRESSES, ...BTC_TESTNET_ADDRESSES])(
       'returns ChainType.Bitcoin for bitcoin address: %s',
       (address: string) => {
-        expect(getMultichainTypeFromAddress(address)).toBe(
-          MultichainType.Bip122,
+        expect(getCaipNamespaceFromAddress(address)).toBe(
+          KnownCaipNamespace.Bip122,
         );
       },
     );
@@ -76,8 +76,8 @@ describe('multichain', () => {
     it.each(ETH_ADDRESSES)(
       'returns ChainType.Ethereum for ethereum address: %s',
       (address: string) => {
-        expect(getMultichainTypeFromAddress(address)).toBe(
-          MultichainType.Eip155,
+        expect(getCaipNamespaceFromAddress(address)).toBe(
+          KnownCaipNamespace.Eip155,
         );
       },
     );
@@ -86,8 +86,8 @@ describe('multichain', () => {
     it.each(SOL_ADDRESSES)(
       'returns ChainType.Ethereum for non-supported address: %s',
       (address: string) => {
-        expect(getMultichainTypeFromAddress(address)).toBe(
-          MultichainType.Eip155,
+        expect(getCaipNamespaceFromAddress(address)).toBe(
+          KnownCaipNamespace.Eip155,
         );
       },
     );

--- a/shared/lib/multichain.test.ts
+++ b/shared/lib/multichain.test.ts
@@ -1,4 +1,9 @@
-import { isBtcMainnetAddress, isBtcTestnetAddress } from './multichain';
+import {
+  MultichainType,
+  getMultichainTypeFromAddress,
+  isBtcMainnetAddress,
+  isBtcTestnetAddress,
+} from './multichain';
 
 const BTC_MAINNET_ADDRESSES = [
   // P2WPKH
@@ -52,6 +57,38 @@ describe('multichain', () => {
       'returns false if address is compatible with BTC testnet: %s',
       (address: string) => {
         expect(isBtcTestnetAddress(address)).toBe(false);
+      },
+    );
+  });
+
+  describe('getChainTypeFromAddress', () => {
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([...BTC_MAINNET_ADDRESSES, ...BTC_TESTNET_ADDRESSES])(
+      'returns ChainType.Bitcoin for bitcoin address: %s',
+      (address: string) => {
+        expect(getMultichainTypeFromAddress(address)).toBe(
+          MultichainType.Bip122,
+        );
+      },
+    );
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(ETH_ADDRESSES)(
+      'returns ChainType.Ethereum for ethereum address: %s',
+      (address: string) => {
+        expect(getMultichainTypeFromAddress(address)).toBe(
+          MultichainType.Eip155,
+        );
+      },
+    );
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(SOL_ADDRESSES)(
+      'returns ChainType.Ethereum for non-supported address: %s',
+      (address: string) => {
+        expect(getMultichainTypeFromAddress(address)).toBe(
+          MultichainType.Eip155,
+        );
       },
     );
   });

--- a/shared/lib/multichain.test.ts
+++ b/shared/lib/multichain.test.ts
@@ -20,35 +20,39 @@ const SOL_ADDRESSES = [
 ];
 
 describe('multichain', () => {
-  // @ts-expect-error This is missing from the Mocha type definitions
-  it.each(BTC_MAINNET_ADDRESSES)(
-    'returns true if address is compatible with BTC mainnet: %s',
-    (address: string) => {
-      expect(isBtcMainnetAddress(address)).toBe(true);
-    },
-  );
+  describe('isBtcMainnetAddress', () => {
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(BTC_MAINNET_ADDRESSES)(
+      'returns true if address is compatible with BTC mainnet: %s',
+      (address: string) => {
+        expect(isBtcMainnetAddress(address)).toBe(true);
+      },
+    );
 
-  // @ts-expect-error This is missing from the Mocha type definitions
-  it.each([...BTC_TESTNET_ADDRESSES, ...ETH_ADDRESSES, ...SOL_ADDRESSES])(
-    'returns false if address is not compatible with BTC mainnet: %s',
-    (address: string) => {
-      expect(isBtcMainnetAddress(address)).toBe(false);
-    },
-  );
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([...BTC_TESTNET_ADDRESSES, ...ETH_ADDRESSES, ...SOL_ADDRESSES])(
+      'returns false if address is not compatible with BTC mainnet: %s',
+      (address: string) => {
+        expect(isBtcMainnetAddress(address)).toBe(false);
+      },
+    );
+  });
 
-  // @ts-expect-error This is missing from the Mocha type definitions
-  it.each(BTC_TESTNET_ADDRESSES)(
-    'returns true if address is compatible with BTC testnet: %s',
-    (address: string) => {
-      expect(isBtcTestnetAddress(address)).toBe(true);
-    },
-  );
+  describe('isBtcTestnetAddress', () => {
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each(BTC_TESTNET_ADDRESSES)(
+      'returns true if address is compatible with BTC testnet: %s',
+      (address: string) => {
+        expect(isBtcTestnetAddress(address)).toBe(true);
+      },
+    );
 
-  // @ts-expect-error This is missing from the Mocha type definitions
-  it.each([...BTC_MAINNET_ADDRESSES, ...ETH_ADDRESSES, ...SOL_ADDRESSES])(
-    'returns false if address is compatible with BTC testnet: %s',
-    (address: string) => {
-      expect(isBtcTestnetAddress(address)).toBe(false);
-    },
-  );
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([...BTC_MAINNET_ADDRESSES, ...ETH_ADDRESSES, ...SOL_ADDRESSES])(
+      'returns false if address is compatible with BTC testnet: %s',
+      (address: string) => {
+        expect(isBtcTestnetAddress(address)).toBe(false);
+      },
+    );
+  });
 });

--- a/shared/lib/multichain.ts
+++ b/shared/lib/multichain.ts
@@ -1,6 +1,16 @@
 import { validate, Network } from 'bitcoin-address-validation';
 
 /**
+ * Multi-chain family type.
+ */
+export enum MultichainType {
+  // Bitcoin-like:
+  Bip122 = 'bip122',
+  // Ethereum:
+  Eip155 = 'eip155',
+}
+
+/**
  * Returns whether an address is on the Bitcoin mainnet.
  *
  * This function only checks the prefix of the address to determine if it's on
@@ -25,4 +35,18 @@ export function isBtcMainnetAddress(address: string): boolean {
  */
 export function isBtcTestnetAddress(address: string): boolean {
   return validate(address, Network.testnet);
+}
+
+/**
+ * Returns the associated chain's type for the given address.
+ *
+ * @param address - The address to check.
+ * @returns The chain's type for that address.
+ */
+export function getMultichainTypeFromAddress(address: string): MultichainType {
+  if (isBtcMainnetAddress(address) || isBtcTestnetAddress(address)) {
+    return MultichainType.Bip122;
+  }
+  // Defaults to "Ethereum" for all other cases for now.
+  return MultichainType.Eip155;
 }

--- a/shared/lib/multichain.ts
+++ b/shared/lib/multichain.ts
@@ -1,14 +1,5 @@
+import { CaipNamespace, KnownCaipNamespace } from '@metamask/utils';
 import { validate, Network } from 'bitcoin-address-validation';
-
-/**
- * Multi-chain family type.
- */
-export enum MultichainType {
-  // Bitcoin-like:
-  Bip122 = 'bip122',
-  // Ethereum:
-  Eip155 = 'eip155',
-}
 
 /**
  * Returns whether an address is on the Bitcoin mainnet.
@@ -43,10 +34,10 @@ export function isBtcTestnetAddress(address: string): boolean {
  * @param address - The address to check.
  * @returns The chain's type for that address.
  */
-export function getMultichainTypeFromAddress(address: string): MultichainType {
+export function getCaipNamespaceFromAddress(address: string): CaipNamespace {
   if (isBtcMainnetAddress(address) || isBtcTestnetAddress(address)) {
-    return MultichainType.Bip122;
+    return KnownCaipNamespace.Bip122;
   }
   // Defaults to "Ethereum" for all other cases for now.
-  return MultichainType.Eip155;
+  return KnownCaipNamespace.Eip155;
 }

--- a/ui/components/component-library/avatar-account/avatar-account.tsx
+++ b/ui/components/component-library/avatar-account/avatar-account.tsx
@@ -7,8 +7,8 @@ import type { PolymorphicRef } from '../box';
 
 import { AvatarBase, AvatarBaseProps } from '../avatar-base';
 import {
-  isBtcMainnetAddress,
-  isBtcTestnetAddress,
+  MultichainType,
+  getMultichainTypeFromAddress,
 } from '../../../../shared/lib/multichain';
 import {
   AvatarAccountDiameter,
@@ -18,19 +18,15 @@ import {
   AvatarAccountProps,
 } from './avatar-account.types';
 
-// TODO: This might not scale well with our new multichain initiative since it would require
-// future account's type to be added here too. The best approach might be to use
-// `InternalAccount` type rather than plain addresses. This way we could use the account's
-// type to "infer" the namespace.
-// For now, keep keep this simple.
 function getJazziconNamespace(address: string): string | undefined {
-  if (isBtcMainnetAddress(address) || isBtcTestnetAddress(address)) {
-    // TODO: Add this to @metamask/utils `KnownCaipNamespaces` and use it here:
-    return 'bip122';
+  switch (getMultichainTypeFromAddress(address)) {
+    case MultichainType.Bip122:
+      return 'bip122';
+    case MultichainType.Eip155:
+      return undefined; // Falls back to default Jazzicon behavior
+    default:
+      return undefined;
   }
-  // We leave it `undefined` to fallback to the default jazzicon behavior (even for
-  // ethereum).
-  return undefined;
 }
 
 export const AvatarAccount: AvatarAccountComponent = React.forwardRef(

--- a/ui/components/component-library/avatar-account/avatar-account.tsx
+++ b/ui/components/component-library/avatar-account/avatar-account.tsx
@@ -7,12 +7,31 @@ import type { PolymorphicRef } from '../box';
 
 import { AvatarBase, AvatarBaseProps } from '../avatar-base';
 import {
+  isBtcMainnetAddress,
+  isBtcTestnetAddress,
+} from '../../../../shared/lib/multichain';
+import {
   AvatarAccountDiameter,
   AvatarAccountVariant,
   AvatarAccountSize,
   AvatarAccountComponent,
   AvatarAccountProps,
 } from './avatar-account.types';
+
+// TODO: This might not scale well with our new multichain initiative since it would require
+// future account's type to be added here too. The best approach might be to use
+// `InternalAccount` type rather than plain addresses. This way we could use the account's
+// type to "infer" the namespace.
+// For now, keep keep this simple.
+function getJazziconNamespace(address: string): string | undefined {
+  if (isBtcMainnetAddress(address) || isBtcTestnetAddress(address)) {
+    // TODO: Add this to @metamask/utils `KnownCaipNamespaces` and use it here:
+    return 'bip122';
+  }
+  // We leave it `undefined` to fallback to the default jazzicon behavior (even for
+  // ethereum).
+  return undefined;
+}
 
 export const AvatarAccount: AvatarAccountComponent = React.forwardRef(
   <C extends React.ElementType = 'div'>(
@@ -35,6 +54,7 @@ export const AvatarAccount: AvatarAccountComponent = React.forwardRef(
         <Jazzicon
           className={classnames('mm-avatar-account__jazzicon')}
           address={address}
+          namespace={getJazziconNamespace(address)}
           diameter={AvatarAccountDiameter[size]}
         />
       ) : (

--- a/ui/components/component-library/avatar-account/avatar-account.tsx
+++ b/ui/components/component-library/avatar-account/avatar-account.tsx
@@ -7,8 +7,7 @@ import type { PolymorphicRef } from '../box';
 
 import { AvatarBase, AvatarBaseProps } from '../avatar-base';
 import {
-  MultichainType,
-  getMultichainTypeFromAddress,
+  getCaipNamespaceFromAddress,
 } from '../../../../shared/lib/multichain';
 import {
   AvatarAccountDiameter,
@@ -17,12 +16,15 @@ import {
   AvatarAccountComponent,
   AvatarAccountProps,
 } from './avatar-account.types';
+import { KnownCaipNamespace } from '@metamask/utils';
 
 function getJazziconNamespace(address: string): string | undefined {
-  switch (getMultichainTypeFromAddress(address)) {
-    case MultichainType.Bip122:
-      return 'bip122';
-    case MultichainType.Eip155:
+  const namespace = getCaipNamespaceFromAddress(address);
+
+  switch (namespace) {
+    case KnownCaipNamespace.Bip122:
+      return namespace;
+    case KnownCaipNamespace.Eip155:
       return undefined; // Falls back to default Jazzicon behavior
     default:
       return undefined;

--- a/ui/components/component-library/avatar-account/avatar-account.tsx
+++ b/ui/components/component-library/avatar-account/avatar-account.tsx
@@ -7,29 +7,12 @@ import type { PolymorphicRef } from '../box';
 
 import { AvatarBase, AvatarBaseProps } from '../avatar-base';
 import {
-  getCaipNamespaceFromAddress,
-} from '../../../../shared/lib/multichain';
-import {
   AvatarAccountDiameter,
   AvatarAccountVariant,
   AvatarAccountSize,
   AvatarAccountComponent,
   AvatarAccountProps,
 } from './avatar-account.types';
-import { KnownCaipNamespace } from '@metamask/utils';
-
-function getJazziconNamespace(address: string): string | undefined {
-  const namespace = getCaipNamespaceFromAddress(address);
-
-  switch (namespace) {
-    case KnownCaipNamespace.Bip122:
-      return namespace;
-    case KnownCaipNamespace.Eip155:
-      return undefined; // Falls back to default Jazzicon behavior
-    default:
-      return undefined;
-  }
-}
 
 export const AvatarAccount: AvatarAccountComponent = React.forwardRef(
   <C extends React.ElementType = 'div'>(
@@ -52,7 +35,6 @@ export const AvatarAccount: AvatarAccountComponent = React.forwardRef(
         <Jazzicon
           className={classnames('mm-avatar-account__jazzicon')}
           address={address}
-          namespace={getJazziconNamespace(address)}
           diameter={AvatarAccountDiameter[size]}
         />
       ) : (

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -32,7 +32,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                   class="mm-avatar-account__jazzicon"
                 >
                   <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 162, 242);"
+                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 47);"
                   >
                     <svg
                       height="32"
@@ -41,25 +41,25 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                       y="0"
                     >
                       <rect
-                        fill="#F29602"
+                        fill="#F2C602"
                         height="32"
-                        transform="translate(0.001112151990700775 -0.0005016734084641463) rotate(358.8 16 16)"
+                        transform="translate(5.020620447504322 0.8103948904236289) rotate(161.5 16 16)"
                         width="32"
                         x="0"
                         y="0"
                       />
                       <rect
-                        fill="#FA6C00"
+                        fill="#F5ED00"
                         height="32"
-                        transform="translate(7.965719514969553 10.506673824525246) rotate(69.5 16 16)"
+                        transform="translate(-9.408121353992403 -10.305042584072448) rotate(246.0 16 16)"
                         width="32"
                         x="0"
                         y="0"
                       />
                       <rect
-                        fill="#236CE1"
+                        fill="#FB183A"
                         height="32"
-                        transform="translate(-19.066706584002095 16.199592375372838) rotate(260.2 16 16)"
+                        transform="translate(9.192555269879563 26.914160820887155) rotate(215.5 16 16)"
                         width="32"
                         x="0"
                         y="0"
@@ -75,7 +75,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                   class="mm-avatar-account__jazzicon"
                 >
                   <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 162, 242);"
+                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 47);"
                   >
                     <svg
                       height="32"
@@ -84,25 +84,25 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                       y="0"
                     >
                       <rect
-                        fill="#F29602"
+                        fill="#F2C602"
                         height="32"
-                        transform="translate(0.001112151990700775 -0.0005016734084641463) rotate(358.8 16 16)"
+                        transform="translate(5.020620447504322 0.8103948904236289) rotate(161.5 16 16)"
                         width="32"
                         x="0"
                         y="0"
                       />
                       <rect
-                        fill="#FA6C00"
+                        fill="#F5ED00"
                         height="32"
-                        transform="translate(7.965719514969553 10.506673824525246) rotate(69.5 16 16)"
+                        transform="translate(-9.408121353992403 -10.305042584072448) rotate(246.0 16 16)"
                         width="32"
                         x="0"
                         y="0"
                       />
                       <rect
-                        fill="#236CE1"
+                        fill="#FB183A"
                         height="32"
-                        transform="translate(-19.066706584002095 16.199592375372838) rotate(260.2 16 16)"
+                        transform="translate(9.192555269879563 26.914160820887155) rotate(215.5 16 16)"
                         width="32"
                         x="0"
                         y="0"
@@ -134,7 +134,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
           class="mm-avatar-account__jazzicon"
         >
           <div
-            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 162, 242);"
+            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 47);"
           >
             <svg
               height="32"
@@ -143,25 +143,25 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
               y="0"
             >
               <rect
-                fill="#F29602"
+                fill="#F2C602"
                 height="32"
-                transform="translate(0.001112151990700775 -0.0005016734084641463) rotate(358.8 16 16)"
+                transform="translate(5.020620447504322 0.8103948904236289) rotate(161.5 16 16)"
                 width="32"
                 x="0"
                 y="0"
               />
               <rect
-                fill="#FA6C00"
+                fill="#F5ED00"
                 height="32"
-                transform="translate(7.965719514969553 10.506673824525246) rotate(69.5 16 16)"
+                transform="translate(-9.408121353992403 -10.305042584072448) rotate(246.0 16 16)"
                 width="32"
                 x="0"
                 y="0"
               />
               <rect
-                fill="#236CE1"
+                fill="#FB183A"
                 height="32"
-                transform="translate(-19.066706584002095 16.199592375372838) rotate(260.2 16 16)"
+                transform="translate(9.192555269879563 26.914160820887155) rotate(215.5 16 16)"
                 width="32"
                 x="0"
                 y="0"
@@ -177,7 +177,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
           class="mm-avatar-account__jazzicon"
         >
           <div
-            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 162, 242);"
+            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 47);"
           >
             <svg
               height="32"
@@ -186,25 +186,25 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
               y="0"
             >
               <rect
-                fill="#F29602"
+                fill="#F2C602"
                 height="32"
-                transform="translate(0.001112151990700775 -0.0005016734084641463) rotate(358.8 16 16)"
+                transform="translate(5.020620447504322 0.8103948904236289) rotate(161.5 16 16)"
                 width="32"
                 x="0"
                 y="0"
               />
               <rect
-                fill="#FA6C00"
+                fill="#F5ED00"
                 height="32"
-                transform="translate(7.965719514969553 10.506673824525246) rotate(69.5 16 16)"
+                transform="translate(-9.408121353992403 -10.305042584072448) rotate(246.0 16 16)"
                 width="32"
                 x="0"
                 y="0"
               />
               <rect
-                fill="#236CE1"
+                fill="#FB183A"
                 height="32"
-                transform="translate(-19.066706584002095 16.199592375372838) rotate(260.2 16 16)"
+                transform="translate(9.192555269879563 26.914160820887155) rotate(215.5 16 16)"
                 width="32"
                 x="0"
                 y="0"

--- a/ui/components/ui/jazzicon/jazzicon.component.tsx
+++ b/ui/components/ui/jazzicon/jazzicon.component.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import jazzicon from '@metamask/jazzicon';
-import { stringToBytes } from '@metamask/utils';
+import { KnownCaipNamespace, stringToBytes } from '@metamask/utils';
 import iconFactoryGenerator, {
   IconFactory,
 } from '../../../helpers/utils/icon-factory';
+import { getCaipNamespaceFromAddress } from '../../../../shared/lib/multichain';
 
 /**
  * Generates a seed for Jazzicon based on the provided address.
@@ -43,7 +44,7 @@ function Jazzicon({
   diameter = 46,
   style,
   tokenList = {},
-  namespace = 'eip155',
+  namespace: namespace_,
 }: {
   address: string;
   className?: string;
@@ -60,8 +61,12 @@ function Jazzicon({
       return;
     }
 
+    // If the address is unknown, `getCaipNamespaceFromAddress` will defaults to "eip155".
+    const namespace = namespace_ ?? getCaipNamespaceFromAddress(address);
     const iconFactory =
-      namespace === 'eip155' ? ethereumIconFactory : multichainIconFactory;
+      namespace === KnownCaipNamespace.Eip155
+        ? ethereumIconFactory
+        : multichainIconFactory;
 
     const imageNode = iconFactory.iconForAddress(
       address,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6542,9 +6542,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0, @metamask/utils@npm:^9.2.1":
-  version: 9.2.1
-  resolution: "@metamask/utils@npm:9.2.1"
+"@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0, @metamask/utils@npm:^9.2.1, @metamask/utils@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "@metamask/utils@npm:9.3.0"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -6555,7 +6555,7 @@ __metadata:
     pony-cause: "npm:^2.1.10"
     semver: "npm:^7.5.4"
     uuid: "npm:^9.0.1"
-  checksum: 10/2192797afd91af19898e107afeaf63e89b61dc7285e0a75d0cc814b5b288e4cdfc856781b01904034c4d2c1efd9bdab512af24c7e4dfe7b77a03f1f3d9dec7e8
+  checksum: 10/ed6648cd973bbf3b4eb0e862903b795a99d27784c820e19f62f0bc0ddf353e98c2858d7e9aaebc0249a586391b344e35b9249d13c08e3ea0c74b23dc1c6b1558
   languageName: node
   linkType: hard
 
@@ -26130,7 +26130,7 @@ __metadata:
     "@metamask/test-dapp": "npm:^8.4.0"
     "@metamask/transaction-controller": "npm:^37.2.0"
     "@metamask/user-operation-controller": "npm:^13.0.0"
-    "@metamask/utils": "npm:^9.1.0"
+    "@metamask/utils": "npm:^9.3.0"
     "@ngraveio/bc-ur": "npm:^1.1.12"
     "@noble/hashes": "npm:^1.3.3"
     "@octokit/core": "npm:^3.6.0"


### PR DESCRIPTION
## **Description**

The jazzicons were all the same for mainnet/testnet accounts. It was probably due to the fact that the namespace being used was `eip155` for all addresses, but Bitcoin addresses have a different format.

Here's the technical details:
1. The current "icon factory" being in used is the ethereum one:
  - https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/ui/jazzicon/jazzicon.component.tsx#L25
  - https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/ui/jazzicon/jazzicon.component.tsx#L64
  - `namespace` always defaults to `eip155`
2. The default constructor used for the ethereum factory uses the `jsNumberForAddress` which is ethereum-specific (or more like, "hex-specific" here):
  - https://github.com/MetaMask/metamask-extension/blob/develop/ui/helpers/utils/icon-factory.ts#L40
  - https://github.com/MetaMask/metamask-extension/blob/develop/ui/helpers/utils/icon-factory.ts#L150-L154
  - It slices the first 2 characters (probably to remove the `0x` prefix) + `parseInt(addr, 16)` will only work hex-strings, but Bitcoin is not using this format
  - the `parseInt` here will only consider the first valid hex-characters of its input
  
To fix this, we check for the current address used for the jazzicon and change the namespace based on this.

Ideally, we would want to use the `InternalAccount` object directly, but that would require quite a lot of changes, so for now we keep this simple.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27662?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

1. `yarn start:flask`
2. Settings > Experimental > "Enable Bitcoin support"
3. Create a Bitcoin mainnet account
4. Create a Bitcoin testnet account
5. Check that both jazzicons are different for those 2 Bitcoin accounts
6. Remove your Bitcoin accounts
7. Re-create them
8. Re-check that jazzicons are the same than step 5
9. "Hard"-restart your extension
10. Re-check that jazzicons are the same than step 5

## **Screenshots/Recordings**

### **Before**

![Screenshot 2024-10-07 at 16 17 35](https://github.com/user-attachments/assets/0a2e28e8-a81d-4468-9261-f1b0c8c3f02d)

### **After**

![Screenshot 2024-10-07 at 16 18 57](https://github.com/user-attachments/assets/81d378c9-6941-4067-9022-660e7dffb7b2)
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
