### PR TITLE
chore: Temporarily ignore advisory

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -43,6 +43,12 @@ npmAuditIgnoreAdvisories:
   # not appear to be used.
   - 1092461
 
+  # Issue: Sentry SDK Prototype Pollution gadget in JavaScript SDKs
+  # URL: https://github.com/advisories/GHSA-593m-55hh-j8gv
+  # Not easily fixed in this version, will be fixed in v12.5.0
+  # Minimally effects the extension due to usage of LavaMoat + SES lockdown.
+  - 1099839
+
   # Temp fix for https://github.com/MetaMask/metamask-extension/pull/16920 for the sake of 11.7.1 hotfix
   # This will be removed in this ticket https://github.com/MetaMask/metamask-extension/issues/22299
   - 'ts-custom-error (deprecation)'


### PR DESCRIPTION
## **Description**

The advisory https://github.com/advisories/GHSA-593m-55hh-j8gv has been temporarily ignored, just for v12.4.x. This is resolved by a dependency update in v12.5.0, but the update included too many functional changes, so we deemed it too risky to backport in this release.

The impact is expected to be negligable due to our use of LavaMoat and SES lockdown.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27676?quickstart=1)

## **Related issues**

The audit advisory was resolved here on `develop`: https://github.com/MetaMask/metamask-extension/pull/27620

And it was back ported to v12.5.0 here: https://github.com/MetaMask/metamask-extension/pull/27673

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
