### PR TITLE
fix(btc): fix address validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -378,6 +378,7 @@
     "base32-encode": "^1.2.0",
     "base64-js": "^1.5.1",
     "bignumber.js": "^4.1.0",
+    "bitcoin-address-validation": "^2.2.3",
     "blo": "1.2.0",
     "bn.js": "^5.2.1",
     "bowser": "^2.11.0",

--- a/shared/lib/multichain.test.ts
+++ b/shared/lib/multichain.test.ts
@@ -1,22 +1,27 @@
 import { isBtcMainnetAddress, isBtcTestnetAddress } from './multichain';
 
-const MAINNET_ADDRESSES = [
+const BTC_MAINNET_ADDRESSES = [
   // P2WPKH
   'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
   // P2PKH
   '1P5ZEDWTKTFGxQjZphgWPQUpe554WKDfHQ',
 ];
 
-const TESTNET_ADDRESSES = [
+const BTC_TESTNET_ADDRESSES = [
   // P2WPKH
   'tb1q6rmsq3vlfdhjdhtkxlqtuhhlr6pmj09y6w43g8',
 ];
 
 const ETH_ADDRESSES = ['0x6431726EEE67570BF6f0Cf892aE0a3988F03903F'];
 
+const SOL_ADDRESSES = [
+  '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV',
+  'DpNXPNWvWoHaZ9P3WtfGCb2ZdLihW8VW1w1Ph4KDH9iG',
+];
+
 describe('multichain', () => {
   // @ts-expect-error This is missing from the Mocha type definitions
-  it.each(MAINNET_ADDRESSES)(
+  it.each(BTC_MAINNET_ADDRESSES)(
     'returns true if address is compatible with BTC mainnet: %s',
     (address: string) => {
       expect(isBtcMainnetAddress(address)).toBe(true);
@@ -24,7 +29,7 @@ describe('multichain', () => {
   );
 
   // @ts-expect-error This is missing from the Mocha type definitions
-  it.each([...TESTNET_ADDRESSES, ...ETH_ADDRESSES])(
+  it.each([...BTC_TESTNET_ADDRESSES, ...ETH_ADDRESSES, ...SOL_ADDRESSES])(
     'returns false if address is not compatible with BTC mainnet: %s',
     (address: string) => {
       expect(isBtcMainnetAddress(address)).toBe(false);
@@ -32,7 +37,7 @@ describe('multichain', () => {
   );
 
   // @ts-expect-error This is missing from the Mocha type definitions
-  it.each(TESTNET_ADDRESSES)(
+  it.each(BTC_TESTNET_ADDRESSES)(
     'returns true if address is compatible with BTC testnet: %s',
     (address: string) => {
       expect(isBtcTestnetAddress(address)).toBe(true);
@@ -40,7 +45,7 @@ describe('multichain', () => {
   );
 
   // @ts-expect-error This is missing from the Mocha type definitions
-  it.each([...MAINNET_ADDRESSES, ...ETH_ADDRESSES])(
+  it.each([...BTC_MAINNET_ADDRESSES, ...ETH_ADDRESSES, ...SOL_ADDRESSES])(
     'returns false if address is compatible with BTC testnet: %s',
     (address: string) => {
       expect(isBtcTestnetAddress(address)).toBe(false);

--- a/shared/lib/multichain.ts
+++ b/shared/lib/multichain.ts
@@ -1,6 +1,4 @@
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { isEthAddress } from '../../app/scripts/lib/multichain/address';
+import { validate, Network } from 'bitcoin-address-validation';
 
 /**
  * Returns whether an address is on the Bitcoin mainnet.
@@ -14,10 +12,7 @@ import { isEthAddress } from '../../app/scripts/lib/multichain/address';
  * @returns `true` if the address is on the Bitcoin mainnet, `false` otherwise.
  */
 export function isBtcMainnetAddress(address: string): boolean {
-  return (
-    !isEthAddress(address) &&
-    (address.startsWith('bc1') || address.startsWith('1'))
-  );
+  return validate(address, Network.mainnet);
 }
 
 /**
@@ -29,5 +24,5 @@ export function isBtcMainnetAddress(address: string): boolean {
  * @returns `true` if the address is on the Bitcoin testnet, `false` otherwise.
  */
 export function isBtcTestnetAddress(address: string): boolean {
-  return !isEthAddress(address) && !isBtcMainnetAddress(address);
+  return validate(address, Network.testnet);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13263,6 +13263,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base58-js@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "base58-js@npm:1.0.5"
+  checksum: 10/46c1b39d3a70bca0a47d56069c74a25d547680afd0f28609c90f280f5d614f5de36db5df993fa334db24008a68ab784a72fcdaa13eb40078e03c8999915a1100
+  languageName: node
+  linkType: hard
+
 "base64-arraybuffer-es6@npm:^0.7.0":
   version: 0.7.0
   resolution: "base64-arraybuffer-es6@npm:0.7.0"
@@ -13444,6 +13451,17 @@ __metadata:
   dependencies:
     safe-buffer: "npm:^5.0.1"
   checksum: 10/6257e90ff2149aa08740ff4009730c1bceb1a3456571d3006a36b39f30044f2973e05f043ea6977046d6ab66e4a8d6f5c9785094f8317f4ff546a325baece1ab
+  languageName: node
+  linkType: hard
+
+"bitcoin-address-validation@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "bitcoin-address-validation@npm:2.2.3"
+  dependencies:
+    base58-js: "npm:^1.0.0"
+    bech32: "npm:^2.0.0"
+    sha256-uint8array: "npm:^0.10.3"
+  checksum: 10/01603b5edf610ecf0843ae546534313f1cffabc8e7435a3678bc9788f18a54e51302218a539794aafd49beb5be70b5d1d507eb7442cb33970fcd665592a71305
   languageName: node
   linkType: hard
 
@@ -26204,6 +26222,7 @@ __metadata:
     base64-js: "npm:^1.5.1"
     bify-module-groups: "npm:^2.0.0"
     bignumber.js: "npm:^4.1.0"
+    bitcoin-address-validation: "npm:^2.2.3"
     blo: "npm:1.2.0"
     bn.js: "npm:^5.2.1"
     bowser: "npm:^2.11.0"
@@ -32836,6 +32855,13 @@ __metadata:
   bin:
     sha.js: ./bin.js
   checksum: 10/d833bfa3e0a67579a6ce6e1bc95571f05246e0a441dd8c76e3057972f2a3e098465687a4369b07e83a0375a88703577f71b5b2e966809e67ebc340dbedb478c7
+  languageName: node
+  linkType: hard
+
+"sha256-uint8array@npm:^0.10.3":
+  version: 0.10.7
+  resolution: "sha256-uint8array@npm:0.10.7"
+  checksum: 10/e427f9d2f9c521dea552f033d3f0c3bd641ab214d214dd41bde3c805edde393519cf982b3eee7d683b32e5f28fa23b2278d25935940e13fbe831b216a37832be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

The `isBtcTestnetAddress` was fragile and was mainly relying on `isBtcMainnetAddress` and `isEthAddress` to work. However if both of those functions were falsy, then `isBtcTestnetAddress` would become truthy (which is not always correct).

It was spotted with some testing with a "wrong" eth addresss that we use in some tests: `0x0`

```ts
const addr = '0x0';
isEthAddress(addr);        // false <- yes, this is false based on this: https://github.com/MetaMask/utils/blob/v9.2.1/src/hex.ts#L15-L22
isBtcMainnetAddress(addr); // false
isBtcTestnetAddress(addr); // true <- THIS IS WRONG
```

We now rely on a third party library that will test against multiple BTC format addresses (legacy, segwit, etc...)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27690?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
