### PR TITLE
fix (cherry-pick): change survey timeout time from a week to a day (#27603)

### DIFF
--- a/ui/components/ui/survey-toast/survey-toast.tsx
+++ b/ui/components/ui/survey-toast/survey-toast.tsx
@@ -59,7 +59,7 @@ export function SurveyToast() {
             signal: controller.signal,
           },
           functionName: 'fetchSurveys',
-          cacheOptions: { cacheRefreshTime: process.env.IN_TEST ? 0 : DAY * 7 },
+          cacheOptions: { cacheRefreshTime: process.env.IN_TEST ? 0 : DAY },
         });
 
         const _survey: Survey = response?.surveys;


### PR DESCRIPTION
Cherry picks the survey cache time from a week to a day