### PR TITLE
fix: UI startup with no Sentry DSN

### DIFF
--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -170,6 +170,27 @@ describe('Trace', () => {
       expect(setMeasurementMock).toHaveBeenCalledTimes(1);
       expect(setMeasurementMock).toHaveBeenCalledWith('tag3', 123, 'none');
     });
+
+    it('supports no global Sentry object', () => {
+      globalThis.sentry = undefined;
+
+      let callbackExecuted = false;
+
+      trace(
+        {
+          name: NAME_MOCK,
+          tags: TAGS_MOCK,
+          data: DATA_MOCK,
+          parentContext: PARENT_CONTEXT_MOCK,
+          startTime: 123,
+        },
+        () => {
+          callbackExecuted = true;
+        },
+      );
+
+      expect(callbackExecuted).toBe(true);
+    });
   });
 
   describe('endTrace', () => {
@@ -263,6 +284,22 @@ describe('Trace', () => {
       endTrace({ name: NAME_MOCK, id: 'invalidId' });
 
       expect(spanEndMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('supports no global Sentry object', () => {
+      globalThis.sentry = undefined;
+
+      expect(() => {
+        trace({
+          name: NAME_MOCK,
+          id: ID_MOCK,
+          tags: TAGS_MOCK,
+          data: DATA_MOCK,
+          parentContext: PARENT_CONTEXT_MOCK,
+        });
+
+        endTrace({ name: NAME_MOCK, id: ID_MOCK });
+      }).not.toThrow();
     });
   });
 });

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -352,7 +352,7 @@ function sentryWithIsolationScope<T>(callback: (scope: Sentry.Scope) => T): T {
   if (!actual) {
     const scope = {
       // eslint-disable-next-line no-empty-function
-      setTags: () => {},
+      setTag: () => {},
     } as unknown as Sentry.Scope;
 
     return callback(scope);


### PR DESCRIPTION
## **Description**

Provide the correct functions to the mock scope used when Sentry is not enabled.

Add unit tests to verify trace functions with no Sentry global object.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27714?quickstart=1)

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
