### PR TITLE
feat(snaps): Add `size` prop to `Heading`

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/heading.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/heading.ts
@@ -8,7 +8,7 @@ import { UIComponentFactory } from './types';
 export const generateSize = (size: HeadingElement['props']['size']) => {
   switch (size) {
     case 'md':
-      return TextVariant.headingSm;
+      return TextVariant.headingMd;
     case 'lg':
       return TextVariant.headingLg;
     default:

--- a/ui/components/app/snaps/snap-ui-renderer/components/heading.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/heading.ts
@@ -5,11 +5,22 @@ import {
 } from '../../../../../helpers/constants/design-system';
 import { UIComponentFactory } from './types';
 
+export const generateSize = (size: HeadingElement['props']['size']) => {
+  switch (size) {
+    case 'md':
+      return TextVariant.headingSm;
+    case 'lg':
+      return TextVariant.headingLg;
+    default:
+      return TextVariant.headingSm;
+  }
+};
+
 export const heading: UIComponentFactory<HeadingElement> = ({ element }) => ({
   element: 'Text',
   children: element.props.children,
   props: {
-    variant: TextVariant.headingSm,
+    variant: generateSize(element.props.size),
     overflowWrap: OverflowWrap.Anywhere,
   },
 });


### PR DESCRIPTION
## **Description

This PR adds support for the `size` prop to the `Heading` component. Right now `md` is bind to `headingMd`, `lg` is bind to `headingLg` to match https://www.figma.com/design/2cqqTWJKoHcjYVGfNXxLbQ/Beyond-Ethereum?node-id=3458-5041&node-type=text&m=dev as requested by @eriknson. The default behavior if `size` is not defined si `headingSm`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27721?quickstart=1)

## **Related issues**

## **Manual testing steps**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
