### PR TITLE
fix(multichain): fix getMultichainCurrentCurrency selector

### DIFF
--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -244,10 +244,13 @@ export function getMultichainNativeCurrency(
     : getMultichainProviderConfig(state, account).ticker;
 }
 
-export function getMultichainCurrentCurrency(state: MultichainState) {
+export function getMultichainCurrentCurrency(
+  state: MultichainState,
+  account?: InternalAccount,
+) {
   const currentCurrency = getCurrentCurrency(state);
 
-  if (getMultichainIsEvm(state)) {
+  if (getMultichainIsEvm(state, account)) {
     return currentCurrency;
   }
 
@@ -256,7 +259,7 @@ export function getMultichainCurrentCurrency(state: MultichainState) {
   // fallback to the current ticker symbol value
   return currentCurrency && currentCurrency.toLowerCase() === 'usd'
     ? 'usd'
-    : getMultichainProviderConfig(state).ticker;
+    : getMultichainProviderConfig(state, account).ticker;
 }
 
 export function getMultichainCurrencyImage(


### PR DESCRIPTION
## **Description**

The `getMultichainCurrentCurrency` selector was buggy. It resulted in a very weird interactions where the "current currency" was being selected based on the currently selected account.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27726?quickstart=1)

## **Related issues**

Fixes:
- https://github.com/MetaMask/accounts-planning/issues/612

## **Manual testing steps**

1. `yarn start:flask`
2. Settings > Experimental > "Enable Bitcoin support"
3. Create some Bitcoin accounts
4. Change your preferred currency on: Settings > General
5. Look at the account list:
  - Bitcoin should always use USD or BTC unit
  - Other EVM acounts should always use the preferred unit (fiat or crypto) 

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/0ea7e341-8d04-43c6-aea6-8ff5f004c024

### **After**

https://github.com/user-attachments/assets/9e2feafd-97ed-4b51-b712-aad21f7d99b7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
