### PR TITLE
test: should switch to the dapps network automatically when handling sendTransaction calls

### DIFF
--- a/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.js
+++ b/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.js
@@ -5,11 +5,9 @@ const {
   unlockWallet,
   DAPP_URL,
   DAPP_ONE_URL,
-  regularDelayMs,
   WINDOW_TITLES,
   defaultGanacheOptions,
   largeDelayMs,
-  switchToNotificationWindow,
 } = require('../../helpers');
 const { PAGES } = require('../../webdriver/driver');
 
@@ -48,14 +46,11 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
         await openDapp(driver, undefined, DAPP_URL);
 
         // Connect to dapp 1
-        await driver.findClickableElement({ text: 'Connect', tag: 'button' });
-        await driver.clickElement('#connectButton');
+        await driver.clickElement({ text: 'Connect', tag: 'button' });
 
-        await driver.delay(regularDelayMs);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        await switchToNotificationWindow(driver);
-
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Connect',
           tag: 'button',
         });
@@ -73,22 +68,16 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
           css: 'p',
         });
 
-        // Wait for the first dapp's connect confirmation to disappear
-        await driver.waitUntilXWindowHandles(2);
-
         // TODO: Request Queuing bug when opening both dapps at the same time will have them stuck on the same network, with will be incorrect for one of them.
         // Open Dapp Two
         await openDapp(driver, undefined, DAPP_ONE_URL);
 
         // Connect to dapp 2
-        await driver.findClickableElement({ text: 'Connect', tag: 'button' });
-        await driver.clickElement('#connectButton');
+        await driver.clickElement({ text: 'Connect', tag: 'button' });
 
-        await driver.delay(regularDelayMs);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        await switchToNotificationWindow(driver, 4);
-
-        await driver.clickElement({
+        await driver.clickElementAndWaitForWindowToClose({
           text: 'Connect',
           tag: 'button',
         });
@@ -98,7 +87,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
         await driver.delay(largeDelayMs);
         await driver.clickElement('#sendButton');
 
-        await driver.delay(largeDelayMs);
+        await driver.waitUntilXWindowHandles(4);
 
         // Dapp two send tx
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
@@ -113,8 +102,6 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
 
         await driver.waitUntilXWindowHandles(4);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-
-        await driver.delay(largeDelayMs);
 
         // Reject Transaction
         await driver.findClickableElement({ text: 'Reject', tag: 'button' });
@@ -140,6 +127,11 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
 
         // Click Unconfirmed Tx
         await driver.clickElement('.transaction-list-item--unconfirmed');
+
+        await driver.assertElementNotPresent({
+          tag: 'p',
+          text: 'Network switched to Localhost 8546',
+        });
 
         // Confirm Tx
         await driver.clickElement('[data-testid="page-container-footer-next"]');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27734?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
