### PR TITLE
fix(snaps): Restore confirmation switching on routed confirmation

### DIFF
--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -217,16 +217,19 @@ export default function ConfirmationPage({
   );
   const [approvalFlowLoadingText, setApprovalFlowLoadingText] = useState(null);
 
-  const [currentPendingConfirmation, setCurrentPendingConfirmation] =
-    useState(0);
   const { id } = useParams();
-  const pendingRoutedConfirmation = pendingConfirmations.find(
+  const pendingRoutedConfirmation = pendingConfirmations.findIndex(
     (confirmation) => confirmation.id === id,
   );
+
+  const isRoutedConfirmation = id && pendingRoutedConfirmation !== -1;
+
+  const [currentPendingConfirmation, setCurrentPendingConfirmation] = useState(
+    isRoutedConfirmation ? pendingRoutedConfirmation : 0,
+  );
+
   // Confirmations that are directly routed to get priority and will be shown above the current queue.
-  const pendingConfirmation =
-    pendingRoutedConfirmation ??
-    pendingConfirmations[currentPendingConfirmation];
+  const pendingConfirmation = pendingConfirmations[currentPendingConfirmation];
 
   const [matchedChain, setMatchedChain] = useState({});
   const [chainFetchComplete, setChainFetchComplete] = useState(false);

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -225,7 +225,7 @@ export default function ConfirmationPage({
   const isRoutedConfirmation = id && pendingRoutedConfirmation !== -1;
 
   const [currentPendingConfirmation, setCurrentPendingConfirmation] = useState(
-    // Confirmations that are directly routed to get priority and will be shown above the current queue.
+    // Confirmations that are directly routed to get priority and will be initially shown above the current queue.
     isRoutedConfirmation ? pendingRoutedConfirmation : 0,
   );
 

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -225,10 +225,10 @@ export default function ConfirmationPage({
   const isRoutedConfirmation = id && pendingRoutedConfirmation !== -1;
 
   const [currentPendingConfirmation, setCurrentPendingConfirmation] = useState(
+    // Confirmations that are directly routed to get priority and will be shown above the current queue.
     isRoutedConfirmation ? pendingRoutedConfirmation : 0,
   );
 
-  // Confirmations that are directly routed to get priority and will be shown above the current queue.
   const pendingConfirmation = pendingConfirmations[currentPendingConfirmation];
 
   const [matchedChain, setMatchedChain] = useState({});


### PR DESCRIPTION
## **Description**

This PR fixes the inability to switch between pending confirmations when routing to a specific confirmation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27753?quickstart=1)

## **Related issues**

Fixes: #27695

## **Manual testing steps**

1. Redirect to a confirmation
2. Trigger another confirmation after
3. try to switch between the two

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/95b002fd-c4d2-4521-8e21-ac2f6f42e1d8

### **After**

https://github.com/user-attachments/assets/72e95e8d-a2d9-4024-8ba5-e3b91d409078

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
