### PR TITLE
refactor: migrate TextField to Component Library version

### DIFF
--- a/test/e2e/tests/settings/auto-lock.spec.js
+++ b/test/e2e/tests/settings/auto-lock.spec.js
@@ -28,18 +28,19 @@ describe('Auto-Lock Timer', function () {
         await driver.scrollToElement(autoLockTimerInput);
         await autoLockTimerInput.fill(10081);
         await driver.waitForSelector({
-          css: '#autoTimeout-helper-text',
+          css: '[data-testid="auto-lockout-time"] p',
           text: 'Lock time must be a number between 0 and 10080',
         });
         await autoLockTimerInput.fill(sixSecsInMins);
 
-        await driver.assertElementNotPresent('#autoTimeout-helper-text', {
-          waitAtLeastGuard: 100, // A findElementGuard is not possible here, because only this element changes, but a waitAtLeast of 100ms should be sufficient
-        });
-
-        await driver.clickElement(
-          '[data-testid="advanced-setting-auto-lock"] button',
+        await driver.assertElementNotPresent(
+          '[data-testid="auto-lockout-time"] p',
+          {
+            waitAtLeastGuard: 100, // A findElementGuard is not possible here, because only this element changes, but a waitAtLeast of 100ms should be sufficient
+          },
         );
+
+        await driver.clickElement('[data-testid="auto-lockout-button"]');
         // Verify the wallet is locked
         const pageTitle = await driver.findElement(
           '[data-testid="unlock-page-title"]',

--- a/test/e2e/tests/settings/auto-lock.spec.js
+++ b/test/e2e/tests/settings/auto-lock.spec.js
@@ -28,13 +28,16 @@ describe('Auto-Lock Timer', function () {
         await driver.scrollToElement(autoLockTimerInput);
         await autoLockTimerInput.fill(10081);
         await driver.waitForSelector({
-          css: '[data-testid="auto-lockout-time"] p',
+          css: 'p',
           text: 'Lock time must be a number between 0 and 10080',
         });
         await autoLockTimerInput.fill(sixSecsInMins);
 
         await driver.assertElementNotPresent(
-          '[data-testid="auto-lockout-time"] p',
+          {
+            css: 'p',
+            text: 'Lock time must be a number between 0 and 10080',
+          },
           {
             waitAtLeastGuard: 100, // A findElementGuard is not possible here, because only this element changes, but a waitAtLeast of 100ms should be sufficient
           },

--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -103,7 +103,7 @@ export default function CreateNewVault({
       <SrpInput onChange={setSeedPhrase} srpText={t('secretRecoveryPhrase')} />
       <div className="create-new-vault__create-password">
         <TextField
-          data-testid="create-vault-password"
+          testId="create-vault-password"
           id="password"
           label={t('newPassword')}
           type="password"
@@ -115,7 +115,7 @@ export default function CreateNewVault({
           largeLabel
         />
         <TextField
-          data-testid="create-vault-confirm-password"
+          testId="create-vault-confirm-password"
           id="confirm-password"
           label={t('confirmPassword')}
           type="password"

--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -5,7 +5,7 @@ import {
   ButtonVariant,
   Button,
   Checkbox,
-  TextField,
+  FormTextField,
 } from '../../component-library';
 import SrpInput from '../srp-input';
 import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
@@ -102,26 +102,28 @@ export default function CreateNewVault({
     <form className="create-new-vault__form" onSubmit={onImport}>
       <SrpInput onChange={setSeedPhrase} srpText={t('secretRecoveryPhrase')} />
       <div className="create-new-vault__create-password">
-        <TextField
-          testId="create-vault-password"
+        <FormTextField
+          inputProps={{ 'data-testid': 'create-vault-password' }}
           id="password"
           label={t('newPassword')}
           type="password"
           value={password}
           onChange={(event) => onPasswordChange(event.target.value)}
           error={passwordError}
+          helpText={passwordError}
           autoComplete="new-password"
           margin="normal"
           largeLabel
         />
-        <TextField
-          testId="create-vault-confirm-password"
+        <FormTextField
+          inputProps={{ 'data-testid': 'create-vault-confirm-password' }}
           id="confirm-password"
           label={t('confirmPassword')}
           type="password"
           value={confirmPassword}
           onChange={(event) => onConfirmPasswordChange(event.target.value)}
           error={confirmPasswordError}
+          helpText={confirmPasswordError}
           autoComplete="new-password"
           margin="normal"
           largeLabel

--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -6,6 +6,7 @@ import {
   Button,
   Checkbox,
   FormTextField,
+  FormTextFieldSize,
 } from '../../component-library';
 import SrpInput from '../srp-input';
 import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
@@ -111,9 +112,9 @@ export default function CreateNewVault({
           onChange={(event) => onPasswordChange(event.target.value)}
           error={passwordError}
           helpText={passwordError}
-          autoComplete="new-password"
-          margin="normal"
-          largeLabel
+          autoComplete
+          size={FormTextFieldSize.Lg}
+          marginBottom={4}
         />
         <FormTextField
           inputProps={{ 'data-testid': 'create-vault-confirm-password' }}
@@ -124,9 +125,8 @@ export default function CreateNewVault({
           onChange={(event) => onConfirmPasswordChange(event.target.value)}
           error={confirmPasswordError}
           helpText={confirmPasswordError}
-          autoComplete="new-password"
-          margin="normal"
-          largeLabel
+          autoComplete
+          size={FormTextFieldSize.Lg}
         />
       </div>
       {includeTerms ? (

--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -1,8 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import TextField from '../../ui/text-field';
-import { ButtonVariant, Button, Checkbox } from '../../component-library';
+import {
+  ButtonVariant,
+  Button,
+  Checkbox,
+  TextField,
+} from '../../component-library';
 import SrpInput from '../srp-input';
 import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
 

--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -8,7 +8,6 @@ import Box from '../../ui/box';
 import MetaMaskTranslation from '../metamask-translation';
 import NetworkDisplay from '../network-display';
 import TextArea from '../../ui/textarea/textarea';
-import TextField from '../../ui/text-field';
 import ConfirmationNetworkSwitch from '../../../pages/confirmations/confirmation/components/confirmation-network-switch';
 import UrlIcon from '../../ui/url-icon';
 import Tooltip from '../../ui/tooltip/tooltip';
@@ -16,6 +15,7 @@ import {
   AvatarIcon,
   FormTextField,
   Text,
+  TextField,
   BannerAlert,
 } from '../../component-library';
 import ActionableMessage from '../../ui/actionable-message/actionable-message';

--- a/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
+++ b/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
@@ -72,8 +72,7 @@ exports[`Customize Nonce should match snapshot 1`] = `
             class="customize-nonce-modal__input"
           >
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--width-full mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
-              min="0"
+              class="mm-box mm-text-field mm-text-field--size-lg mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--width-full mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
             >
               <input
                 autocomplete="off"
@@ -81,6 +80,7 @@ exports[`Customize Nonce should match snapshot 1`] = `
                 data-testid="custom-nonce-input"
                 focused="false"
                 id="custom-nonce-id"
+                min="0"
                 placeholder="1"
                 type="number"
                 value=""

--- a/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
+++ b/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
@@ -72,23 +72,19 @@ exports[`Customize Nonce should match snapshot 1`] = `
             class="customize-nonce-modal__input"
           >
             <div
-              class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--width-full mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
+              min="0"
             >
-              <div
-                class="MuiInputBase-root MuiInput-root TextField-inputRoot-12 MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
-              >
-                <input
-                  aria-invalid="false"
-                  class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
-                  data-testid="custom-nonce-input"
-                  dir="auto"
-                  id="custom-nonce-id"
-                  min="0"
-                  placeholder="1"
-                  type="number"
-                  value=""
-                />
-              </div>
+              <input
+                autocomplete="off"
+                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+                data-testid="custom-nonce-input"
+                focused="false"
+                id="custom-nonce-id"
+                placeholder="1"
+                type="number"
+                value=""
+              />
             </div>
           </div>
         </div>

--- a/ui/components/app/modals/customize-nonce/customize-nonce.component.js
+++ b/ui/components/app/modals/customize-nonce/customize-nonce.component.js
@@ -18,6 +18,7 @@ import {
   IconName,
   Text,
   TextField,
+  TextFieldSize,
 } from '../../../component-library';
 
 const CustomizeNonce = ({
@@ -105,8 +106,10 @@ const CustomizeNonce = ({
           <div className="customize-nonce-modal__input">
             <TextField
               type="number"
-              testId="custom-nonce-input"
-              min="0"
+              inputProps={{
+                'data-testid': 'custom-nonce-input',
+                min: '0',
+              }}
               placeholder={
                 customNonceValue ||
                 (typeof nextNonce === 'number' && nextNonce.toString())
@@ -115,9 +118,9 @@ const CustomizeNonce = ({
                 setCustomNonce(e.target.value);
               }}
               width={BlockSize.Full}
-              margin="dense"
               value={customNonce}
               id="custom-nonce-id"
+              size={TextFieldSize.Lg}
             />
           </div>
         </Box>

--- a/ui/components/app/modals/customize-nonce/customize-nonce.component.js
+++ b/ui/components/app/modals/customize-nonce/customize-nonce.component.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '../../modal';
-import TextField from '../../../ui/text-field';
 import {
   TextVariant,
   AlignItems,
@@ -18,6 +17,7 @@ import {
   ButtonLink,
   IconName,
   Text,
+  TextField,
 } from '../../../component-library';
 
 const CustomizeNonce = ({
@@ -114,7 +114,7 @@ const CustomizeNonce = ({
               onChange={(e) => {
                 setCustomNonce(e.target.value);
               }}
-              fullWidth
+              width={BlockSize.Full}
               margin="dense"
               value={customNonce}
               id="custom-nonce-id"

--- a/ui/components/app/modals/customize-nonce/customize-nonce.component.js
+++ b/ui/components/app/modals/customize-nonce/customize-nonce.component.js
@@ -105,7 +105,7 @@ const CustomizeNonce = ({
           <div className="customize-nonce-modal__input">
             <TextField
               type="number"
-              data-testid="custom-nonce-input"
+              testId="custom-nonce-input"
               min="0"
               placeholder={
                 customNonceValue ||

--- a/ui/components/app/modals/edit-approval-permission/edit-approval-permission.component.js
+++ b/ui/components/app/modals/edit-approval-permission/edit-approval-permission.component.js
@@ -15,6 +15,7 @@ import {
   IconName,
   TextField,
 } from '../../../component-library';
+import { BlockSize } from '../../../../helpers/constants/design-system';
 
 const MAX_UNSIGNED_256_INT = new BigNumber(2).pow(256).minus(1).toString(10);
 

--- a/ui/components/app/modals/edit-approval-permission/edit-approval-permission.component.js
+++ b/ui/components/app/modals/edit-approval-permission/edit-approval-permission.component.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import BigNumber from 'bignumber.js';
 import Modal from '../../modal';
 import Identicon from '../../../ui/identicon';
-import TextField from '../../../ui/text-field';
 import {
   calcTokenAmount,
   toPrecisionWithoutTrailingZeros,
@@ -14,6 +13,7 @@ import {
   ButtonIcon,
   ButtonIconSize,
   IconName,
+  TextField,
 } from '../../../component-library';
 
 const MAX_UNSIGNED_256_INT = new BigNumber(2).pow(256).minus(1).toString(10);
@@ -180,7 +180,7 @@ export default class EditApprovalPermission extends PureComponent {
                       this.setState({ selectedOptionIsUnlimited: false });
                     }
                   }}
-                  fullWidth
+                  width={BlockSize.Full}
                   margin="dense"
                   value={this.state.customSpendLimit}
                   error={error}

--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -2,9 +2,8 @@ import { isValidMnemonic } from '@ethersproject/hdnode';
 import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import TextField from '../../ui/text-field';
 import { clearClipboard } from '../../../helpers/utils/util';
-import { BannerAlert, Text } from '../../component-library';
+import { BannerAlert, Text, TextField } from '../../component-library';
 import Dropdown from '../../ui/dropdown';
 import ShowHideToggle from '../../ui/show-hide-toggle';
 import {

--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -168,7 +168,7 @@ export default function SrpInput({ onChange, srpText }) {
               </label>
               <TextField
                 id={id}
-                data-testid={id}
+                testId={id}
                 type={showSrp[index] ? 'text' : 'password'}
                 onChange={(e) => {
                   e.preventDefault();

--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.js
@@ -1,15 +1,13 @@
+import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useState } from 'react';
 import { useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
-
-import Popover from '../popover';
-import Button from '../button';
-import { TextField } from '../../component-library';
-
 import { I18nContext } from '../../../contexts/i18n';
-
-import Identicon from '../identicon';
+import { BlockSize } from '../../../helpers/constants/design-system';
 import { getTokenList } from '../../../selectors';
+import { TextField } from '../../component-library';
+import Button from '../button';
+import Identicon from '../identicon';
+import Popover from '../popover';
 
 export default function UpdateNicknamePopover({
   address,

--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import Popover from '../popover';
 import Button from '../button';
-import TextField from '../text-field';
+import { TextField } from '../../component-library';
 
 import { I18nContext } from '../../../contexts/i18n';
 
@@ -92,7 +92,7 @@ export default function UpdateNicknamePopover({
           value={nicknameInput}
           onChange={handleNicknameChange}
           placeholder={t('addANickname')}
-          fullWidth
+          width={BlockSize.Full}
         />
         <div className="update-nickname__content__label--capitalized">
           {t('memo')}
@@ -103,7 +103,7 @@ export default function UpdateNicknamePopover({
           value={memoInput}
           onChange={handleMemoChange}
           placeholder={t('addMemo')}
-          fullWidth
+          width={BlockSize.Full}
           margin="dense"
           multiline
           rows={3}

--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.test.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.test.js
@@ -24,6 +24,6 @@ const render = () => {
 describe('UpdateNicknamePopover', () => {
   it('renders UpdateNicknamePopover component and shows This is a memo text', () => {
     render();
-    expect(screen.getByText('This is a memo')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('This is a memo')).toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.tsx
@@ -160,7 +160,7 @@ export const EditSpendingCapModal = ({
             }
             placeholder={`${formattedSpendingCap} ${tokenSymbol}`}
             style={{ width: '100%' }}
-            inputProps={{ 'data-testid': 'custom-spending-cap-input' }}
+            testId="custom-spending-cap-input"
           />
           {showDecimalError && (
             <Text

--- a/ui/pages/confirmations/confirm-transaction-base/__snapshots__/confirm-transaction-base.test.js.snap
+++ b/ui/pages/confirmations/confirm-transaction-base/__snapshots__/confirm-transaction-base.test.js.snap
@@ -472,7 +472,7 @@ exports[`Confirm Transaction Base should match snapshot 1`] = `
                   class="custom-nonce-input"
                 >
                   <div
-                    class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
+                    class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--width-full mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
                     min="0"
                   >
                     <input

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -524,7 +524,7 @@ export default class ConfirmTransactionBase extends Component {
               min={0}
               placeholder={nextNonceValue}
               onChange={handleNonceChange}
-              fullWidth
+              width={BlockSize.Full}
               margin="dense"
               value={customNonceValue ?? ''}
             />

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -8,6 +8,7 @@ import ConfirmPageContainer from '../components/confirm-page-container';
 import { isBalanceSufficient } from '../send/send.utils';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import {
+  BlockSize,
   TextVariant,
   TextColor,
 } from '../../../helpers/constants/design-system';

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -124,9 +124,7 @@ export default function RevealSeedPage() {
       <form onSubmit={handleSubmit}>
         <Label htmlFor="password-box">{t('enterPasswordContinue')}</Label>
         <TextField
-          inputProps={{
-            'data-testid': 'input-password',
-          }}
+          testId="input-password"
           type={TextFieldType.Password}
           placeholder={t('makeSureNoOneWatching')}
           id="password-box"

--- a/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
+++ b/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
@@ -498,18 +498,18 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
           class="settings-page__content-item-col"
         >
           <div
-            class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+            class="mm-box mm-form-text-field mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+            min="0"
           >
             <div
-              class="MuiInputBase-root MuiInput-root TextField-inputRoot-12 MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
             >
               <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
+                autocomplete="off"
+                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
                 data-testid="auto-lockout-time"
-                dir="auto"
+                focused="false"
                 id="autoTimeout"
-                min="0"
                 placeholder="0"
                 type="text"
                 value="0"

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -446,7 +446,7 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <TextField
               id="autoTimeout"
-              data-testid="auto-lockout-time"
+              testId="auto-lockout-time"
               placeholder="0"
               value={this.state.autoLockTimeLimitBeforeNormalization}
               onChange={(e) => this.handleLockChange(e.target.value)}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -10,7 +10,7 @@ import {
   Box,
   ButtonLink,
   ButtonLinkSize,
-  TextField,
+  FormTextField,
 } from '../../../components/component-library';
 import Button from '../../../components/ui/button';
 import ToggleButton from '../../../components/ui/toggle-button';
@@ -444,13 +444,14 @@ export default class AdvancedTab extends PureComponent {
         </div>
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">
-            <TextField
+            <FormTextField
               id="autoTimeout"
-              testId="auto-lockout-time"
+              data-testid="auto-lockout-time"
               placeholder="0"
               value={this.state.autoLockTimeLimitBeforeNormalization}
               onChange={(e) => this.handleLockChange(e.target.value)}
               error={lockTimeError}
+              helpText={lockTimeError}
               width={BlockSize.Full}
               margin="dense"
               min={0}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -446,7 +446,7 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <FormTextField
               id="autoTimeout"
-              data-testid="auto-lockout-time"
+              inputProps={{ 'data-testid': 'auto-lockout-time' }}
               placeholder="0"
               value={this.state.autoLockTimeLimitBeforeNormalization}
               onChange={(e) => this.handleLockChange(e.target.value)}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -10,16 +10,17 @@ import {
   Box,
   ButtonLink,
   ButtonLinkSize,
+  TextField,
 } from '../../../components/component-library';
 import Button from '../../../components/ui/button';
-import TextField from '../../../components/ui/text-field';
 import ToggleButton from '../../../components/ui/toggle-button';
 import {
+  AlignItems,
+  BlockSize,
   Display,
   FlexDirection,
   JustifyContent,
   TextVariant,
-  AlignItems,
 } from '../../../helpers/constants/design-system';
 import {
   ExportableContentType,
@@ -202,7 +203,7 @@ export default class AdvancedTab extends PureComponent {
     const { smartTransactionsOptInStatus, setSmartTransactionsOptInStatus } =
       this.props;
 
-    const learMoreLink = (
+    const learnMoreLink = (
       <ButtonLink
         size={ButtonLinkSize.Inherit}
         textProps={{
@@ -231,7 +232,7 @@ export default class AdvancedTab extends PureComponent {
         <div className="settings-page__content-item">
           <span>{t('smartTransactions')}</span>
           <div className="settings-page__content-description">
-            {t('stxOptInDescription', [learMoreLink])}
+            {t('stxOptInDescription', [learnMoreLink])}
           </div>
         </div>
 
@@ -450,7 +451,7 @@ export default class AdvancedTab extends PureComponent {
               value={this.state.autoLockTimeLimitBeforeNormalization}
               onChange={(e) => this.handleLockChange(e.target.value)}
               error={lockTimeError}
-              fullWidth
+              width={BlockSize.Full}
               margin="dense"
               min={0}
             />

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
-import TextField from '../../../../components/ui/text-field';
+import { TextField } from '../../../../components/component-library';
 import { CONTACT_LIST_ROUTE } from '../../../../helpers/constants/routes';
 import { isValidDomainName } from '../../../../helpers/utils/util';
 import DomainInput from '../../../confirmations/send/send-content/add-recipient/domain-input';
@@ -123,7 +123,7 @@ export default class AddContact extends PureComponent {
               id="nickname"
               value={this.state.newName}
               onChange={(e) => this.setState({ newName: e.target.value })}
-              fullWidth
+              width={BlockSize.Full}
               margin="dense"
             />
           </div>

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -12,6 +12,7 @@ import {
 } from '../../../../../shared/modules/hexstring-utils';
 import { INVALID_RECIPIENT_ADDRESS_ERROR } from '../../../confirmations/send/send.constants';
 import { DomainInputResolutionCell } from '../../../../components/multichain/pages/send/components';
+import { BlockSize } from '../../../../helpers/constants/design-system';
 
 export default class AddContact extends PureComponent {
   static contextTypes = {

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
 import Button from '../../../../components/ui/button/button.component';
-import TextField from '../../../../components/ui/text-field';
 import PageContainerFooter from '../../../../components/ui/page-container/page-container-footer';
 import {
   isBurnAddress,
@@ -13,6 +12,7 @@ import {
   AvatarAccountSize,
   Box,
   Text,
+  TextField,
 } from '../../../../components/component-library';
 
 import {
@@ -119,7 +119,7 @@ export default class EditContact extends PureComponent {
               placeholder={this.context.t('addAlias')}
               value={this.state.newName}
               onChange={(e) => this.setState({ newName: e.target.value })}
-              fullWidth
+              width={BlockSize.Full}
               margin="dense"
             />
           </div>
@@ -134,7 +134,7 @@ export default class EditContact extends PureComponent {
               value={this.state.newAddress}
               error={this.state.error}
               onChange={(e) => this.setState({ newAddress: e.target.value })}
-              fullWidth
+              width={BlockSize.Full}
               multiline
               rows={4}
               margin="dense"
@@ -156,7 +156,7 @@ export default class EditContact extends PureComponent {
               placeholder={memo}
               value={this.state.newMemo}
               onChange={(e) => this.setState({ newMemo: e.target.value })}
-              fullWidth
+              width={BlockSize.Full}
               margin="dense"
               multiline
               rows={3}

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -1017,15 +1017,15 @@ exports[`Security Tab should match snapshot 1`] = `
             class="settings-page__content-item-col"
           >
             <div
-              class="MuiFormControl-root MuiTextField-root MuiFormControl-marginDense MuiFormControl-fullWidth"
+              class="mm-box mm-form-text-field mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             >
               <div
-                class="MuiInputBase-root MuiInput-root TextField-inputRoot-12 MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
+                class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
               >
                 <input
-                  aria-invalid="false"
-                  class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
-                  dir="auto"
+                  autocomplete="off"
+                  class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+                  focused="false"
                   type="text"
                   value="dweb.link"
                 />

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -32,7 +32,7 @@ import {
   IconName,
   Box,
   Text,
-  TextField,
+  FormTextField,
 } from '../../../components/component-library';
 import ToggleButton from '../../../components/ui/toggle-button';
 import Popover from '../../../components/ui/popover';
@@ -589,11 +589,12 @@ export default class SecurityTab extends PureComponent {
           <div className="settings-page__content-item">
             <span>{t('addIPFSGateway')}</span>
             <div className="settings-page__content-item-col">
-              <TextField
+              <FormTextField
                 type="text"
                 value={this.state.ipfsGateway}
                 onChange={(e) => handleIpfsGatewayChange(e.target.value)}
                 error={this.state.ipfsGatewayError}
+                helpText={this.state.ipfsGatewayError}
                 width={BlockSize.Full}
                 margin="dense"
               />

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -32,8 +32,8 @@ import {
   IconName,
   Box,
   Text,
+  TextField,
 } from '../../../components/component-library';
-import TextField from '../../../components/ui/text-field';
 import ToggleButton from '../../../components/ui/toggle-button';
 import Popover from '../../../components/ui/popover';
 import {
@@ -594,7 +594,7 @@ export default class SecurityTab extends PureComponent {
                 value={this.state.ipfsGateway}
                 onChange={(e) => handleIpfsGatewayChange(e.target.value)}
                 error={this.state.ipfsGatewayError}
-                fullWidth
+                width={BlockSize.Full}
                 margin="dense"
               />
             </div>

--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -2,15 +2,15 @@ import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import Fuse from 'fuse.js';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import TextField from '../../../components/ui/text-field';
 import { I18nContext } from '../../../contexts/i18n';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 import {
   Icon,
   IconName,
   IconSize,
+  TextField,
 } from '../../../components/component-library';
-import { IconColor } from '../../../helpers/constants/design-system';
+import { BlockSize, IconColor } from '../../../helpers/constants/design-system';
 
 export default function SettingsSearch({
   onSearch,
@@ -57,7 +57,7 @@ export default function SettingsSearch({
     onSearch({ searchQuery: sanitizedSearchQuery, results });
   };
 
-  const renderStartAdornment = () => {
+  const renderStartAccessory = () => {
     return (
       <InputAdornment position="start" style={{ marginRight: '12px' }}>
         <Icon
@@ -69,7 +69,7 @@ export default function SettingsSearch({
     );
   };
 
-  const renderEndAdornment = () => {
+  const renderEndAccessory = () => {
     return (
       <>
         {searchQuery && (
@@ -98,11 +98,11 @@ export default function SettingsSearch({
       value={searchQuery}
       onChange={(e) => handleSearch(e.target.value)}
       error={error}
-      fullWidth
+      width={BlockSize.Full}
       autoFocus
       autoComplete="off"
-      startAdornment={renderStartAdornment()}
-      endAdornment={renderEndAdornment()}
+      startAccessory={renderStartAccessory()}
+      endAccessory={renderEndAccessory()}
       theme="bordered"
     />
   );

--- a/ui/pages/swaps/dropdown-input-pair/__snapshots__/dropdown-input-pair.test.js.snap
+++ b/ui/pages/swaps/dropdown-input-pair/__snapshots__/dropdown-input-pair.test.js.snap
@@ -2,19 +2,15 @@
 
 exports[`DropdownInputPair renders the component with initial props 1`] = `
 <div
-  class="MuiFormControl-root MuiTextField-root dropdown-input-pair__input MuiFormControl-marginDense MuiFormControl-fullWidth"
+  class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate dropdown-input-pair__input mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--width-full mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
 >
-  <div
-    class="MuiInputBase-root MuiInput-root TextField-inputRoot-12 MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-marginDense MuiInput-marginDense"
-  >
-    <input
-      aria-invalid="false"
-      class="MuiInputBase-input MuiInput-input MuiInputBase-inputMarginDense MuiInput-inputMarginDense"
-      dir="auto"
-      placeholder="0"
-      type="text"
-      value=""
-    />
-  </div>
+  <input
+    autocomplete="off"
+    class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+    focused="false"
+    placeholder="0"
+    type="text"
+    value=""
+  />
 </div>
 `;

--- a/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.js
+++ b/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import DropdownSearchList from '../dropdown-search-list';
 import { TextField } from '../../../components/component-library';
+import { BlockSize } from '../../../helpers/constants/design-system';
 
 const characterWidthMap = {
   1: 5.86,

--- a/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.js
+++ b/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.js
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import DropdownSearchList from '../dropdown-search-list';
-import TextField from '../../../components/ui/text-field';
+import { TextField } from '../../../components/component-library';
 
 const characterWidthMap = {
   1: 5.86,
@@ -101,7 +101,7 @@ export default function DropdownInputPair({
           type="text"
           placeholder="0"
           onChange={onTextFieldChange}
-          fullWidth
+          width={BlockSize.Full}
           margin="dense"
           value={inputValue}
           autoFocus={autoFocus}

--- a/ui/pages/swaps/searchable-item-list/__snapshots__/searchable-item-list.test.js.snap
+++ b/ui/pages/swaps/searchable-item-list/__snapshots__/searchable-item-list.test.js.snap
@@ -2,37 +2,32 @@
 
 exports[`SearchableItemList renders the component with initial props 1`] = `
 <div
-  class="MuiFormControl-root MuiTextField-root searchable-item-list__search MuiFormControl-fullWidth"
+  class="mm-box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate searchable-item-list__search mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--width-full mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
 >
   <div
-    class="MuiInputBase-root MuiInput-root TextField-inputRoot-12 MuiInputBase-fullWidth MuiInput-fullWidth Mui-focused Mui-focused TextField-inputFocused-11 MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedStart"
+    class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+    style="margin-right: 12px;"
   >
-    <div
-      class="MuiInputAdornment-root MuiInputAdornment-positionStart"
-      style="margin-right: 12px;"
+    <svg
+      fill="var(--color-icon-muted)"
+      height="20"
+      viewBox="0 0 512 512"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        fill="var(--color-icon-muted)"
-        height="20"
-        viewBox="0 0 512 512"
-        width="20"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m235 427c-51 0-100-21-136-57-36-36-56-84-56-135 0-26 5-51 14-74 10-23 24-44 42-62 18-18 39-32 62-42 23-9 48-14 74-14 25 0 50 5 73 14 23 10 45 24 62 42 18 18 32 39 42 62 10 23 15 48 15 74 0 43-15 86-42 119l78 79c2 2 4 4 5 7 1 2 1 5 1 8 0 3 0 6-1 8-1 3-3 5-5 7-2 2-4 4-7 5-2 1-5 1-8 1-3 0-6 0-8-1-3-1-5-3-7-5l-79-78c-33 27-76 42-119 42z m0-43c82 0 149-67 149-149 0-83-67-150-149-150-83 0-150 67-150 150 0 82 67 149 150 149z"
-        />
-      </svg>
-    </div>
-    <input
-      aria-invalid="false"
-      autocomplete="off"
-      class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedStart"
-      data-testid="search-list-items"
-      dir="auto"
-      type="text"
-      value=""
-    />
+      <path
+        d="m235 427c-51 0-100-21-136-57-36-36-56-84-56-135 0-26 5-51 14-74 10-23 24-44 42-62 18-18 39-32 62-42 23-9 48-14 74-14 25 0 50 5 73 14 23 10 45 24 62 42 18 18 32 39 42 62 10 23 15 48 15 74 0 43-15 86-42 119l78 79c2 2 4 4 5 7 1 2 1 5 1 8 0 3 0 6-1 8-1 3-3 5-5 7-2 2-4 4-7 5-2 1-5 1-8 1-3 0-6 0-8-1-3-1-5-3-7-5l-79-78c-33 27-76 42-119 42z m0-43c82 0 149-67 149-149 0-83-67-150-149-150-83 0-150 67-150 150 0 82 67 149 150 149z"
+      />
+    </svg>
   </div>
+  <input
+    autocomplete="on"
+    class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+    data-testid="search-list-items"
+    focused="true"
+    type="text"
+    value=""
+  />
 </div>
 `;
 

--- a/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
+++ b/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
@@ -117,7 +117,7 @@ export default function ListItemSearch({
 
   return (
     <TextField
-      data-testid="search-list-items"
+      testId="search-list-items"
       className="searchable-item-list__search"
       placeholder={searchPlaceholderText}
       type="text"

--- a/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
+++ b/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 import Fuse from 'fuse.js';
 import log from 'loglevel';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import TextField from '../../../../components/ui/text-field';
+import { TextField } from '../../../../components/component-library/';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { isValidHexAddress } from '../../../../../shared/modules/hexstring-utils';
 import { fetchToken } from '../../swaps.util';
 import { getCurrentChainId } from '../../../../selectors/selectors';
 import SearchIcon from '../../../../components/ui/icon/search-icon';
 
-const renderAdornment = () => (
+const renderStartAccessory = () => (
   <InputAdornment position="start" style={{ marginRight: '12px' }}>
     <SearchIcon size={20} color="var(--color-icon-muted)" />
   </InputAdornment>
@@ -123,8 +123,8 @@ export default function ListItemSearch({
       value={searchQuery}
       onChange={(e) => handleSearch(e.target.value)}
       error={error}
-      fullWidth
-      startAdornment={renderAdornment()}
+      width={BlockSize.Full}
+      startAccessory={renderStartAccessory()}
       autoComplete="off"
       autoFocus
     />

--- a/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
+++ b/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
@@ -4,12 +4,13 @@ import PropTypes from 'prop-types';
 import Fuse from 'fuse.js';
 import log from 'loglevel';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import { TextField } from '../../../../components/component-library/';
+import { TextField } from '../../../../components/component-library';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { isValidHexAddress } from '../../../../../shared/modules/hexstring-utils';
 import { fetchToken } from '../../swaps.util';
 import { getCurrentChainId } from '../../../../selectors/selectors';
 import SearchIcon from '../../../../components/ui/icon/search-icon';
+import { BlockSize } from '../../../../helpers/constants/design-system';
 
 const renderStartAccessory = () => (
   <InputAdornment position="start" style={{ marginRight: '12px' }}>

--- a/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
+++ b/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
@@ -31,25 +31,23 @@ exports[`Unlock Page should match snapshot 1`] = `
         class="unlock-page__form"
       >
         <div
-          class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+          class="mm-box mm-form-text-field mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+          theme="material"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root TextField-materialLabel-1 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink Mui-focused Mui-focused TextField-materialFocused-2"
-            data-shrink="true"
+            class="mm-box mm-text mm-label mm-label--html-for mm-form-text-field__label mm-text--body-md mm-text--font-weight-medium mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
             for="password"
-            id="password-label"
           >
             Password
           </label>
           <div
-            class="MuiInputBase-root MuiInput-root MuiInput-underline TextField-materialUnderline-3 MuiInputBase-fullWidth MuiInput-fullWidth Mui-focused Mui-focused MuiInputBase-formControl MuiInput-formControl"
+            class="mm-box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-width-1 box--border-style-solid"
           >
             <input
-              aria-invalid="false"
-              autocomplete="current-password"
-              class="MuiInputBase-input MuiInput-input"
+              autocomplete="on"
+              class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
               data-testid="unlock-password"
-              dir="auto"
+              focused="true"
               id="password"
               type="password"
               value=""

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -194,7 +194,7 @@ export default class UnlockPage extends Component {
           <form className="unlock-page__form" onSubmit={this.handleSubmit}>
             <TextField
               id="password"
-              data-testid="unlock-password"
+              testId="unlock-password"
               label={t('password')}
               type="password"
               value={password}

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Text, TextField } from '../../components/component-library';
+import { FormTextField, Text } from '../../components/component-library';
 import {
   BlockSize,
   TextColor,
@@ -192,14 +192,15 @@ export default class UnlockPage extends Component {
           </Text>
           <div>{t('unlockMessage')}</div>
           <form className="unlock-page__form" onSubmit={this.handleSubmit}>
-            <TextField
+            <FormTextField
               id="password"
-              testId="unlock-password"
+              inputProps={{ 'data-testid': 'unlock-password' }}
               label={t('password')}
               type="password"
               value={password}
               onChange={(event) => this.handleInputChange(event)}
               error={error}
+              helpText={error}
               autoFocus
               autoComplete="current-password"
               theme="material"

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -1,10 +1,13 @@
 import { EventEmitter } from 'events';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Text } from '../../components/component-library';
-import { TextVariant, TextColor } from '../../helpers/constants/design-system';
+import { Text, TextField } from '../../components/component-library';
+import {
+  BlockSize,
+  TextColor,
+  TextVariant,
+} from '../../helpers/constants/design-system';
 import Button from '../../components/ui/button';
-import TextField from '../../components/ui/text-field';
 import Mascot from '../../components/ui/mascot';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import {
@@ -200,7 +203,7 @@ export default class UnlockPage extends Component {
               autoFocus
               autoComplete="current-password"
               theme="material"
-              fullWidth
+              width={BlockSize.Full}
             />
           </form>
           {this.renderSubmitButton()}


### PR DESCRIPTION
## **Description**

Replaced all the deprecated `ui/components/ui/text-field` with `ui/components/component-library`

This removes the following Warning:
```
Warning: Failed prop type: Invalid prop `disableUnderline` of type `string` supplied to `ForwardRef(Input)`, expected `boolean`.
    in ForwardRef(Input) (created by WithStyles(ForwardRef(Input)))
    in WithStyles(ForwardRef(Input)) (created by ForwardRef(TextField))
    in div (created by ForwardRef(FormControl))
    in ForwardRef(FormControl) (created by WithStyles(ForwardRef(FormControl)))
    in WithStyles(ForwardRef(FormControl)) (created by ForwardRef(TextField))
    in ForwardRef(TextField) (created by WithStyles(ForwardRef(TextField)))
    in WithStyles(ForwardRef(TextField)) (at text-field.component.js:264)
    in TextField (created by WithStyles(TextField))
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27768?quickstart=1)

## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
### **Before**
### **After**
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
