### PR TITLE
Move sign methods back into eip155:x

### DIFF
--- a/app/scripts/lib/multichain-api/scope/scope.ts
+++ b/app/scripts/lib/multichain-api/scope/scope.ts
@@ -20,11 +20,6 @@ export const KnownWalletRpcMethods: string[] = [
 ];
 const WalletEip155Methods = [
   'wallet_addEthereumChain',
-  'personal_sign',
-  'eth_signTypedData',
-  'eth_signTypedData_v1',
-  'eth_signTypedData_v3',
-  'eth_signTypedData_v4',
 ];
 
 const Eip155Methods = MetaMaskOpenRPCDocument.methods

--- a/test/e2e/run-api-specs-multichain.ts
+++ b/test/e2e/run-api-specs-multichain.ts
@@ -72,8 +72,6 @@ async function main() {
       ];
       const walletEip155Methods = [
         'wallet_addEthereumChain',
-        'personal_sign',
-        'eth_signTypedData_v4',
       ];
 
       const ignoreMethods = [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27771?quickstart=1)

## **Related issues**

See: https://github.com/MetaMask/MetaMask-planning/issues/3483

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
