### PR TITLE
test: Onboarding: Fix vault-decryption-chrome.spec.js

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -550,11 +550,23 @@ const onboardingCompleteWalletCreation = async (driver) => {
   await driver.clickElement('[data-testid="onboarding-complete-done"]');
 };
 
+/**
+ * Move through the steps of pinning extension after successful onboarding
+ *
+ * @param {WebDriver} driver
+ */
+const onboardingPinExtension = async (driver) => {
+  // pin extension
+  await driver.clickElement('[data-testid="pin-extension-next"]');
+  await driver.clickElement('[data-testid="pin-extension-done"]');
+};
+
 const onboardingCompleteWalletCreationWithOptOut = async (driver) => {
   // wait for h2 to appear
-  await driver.findElement({ text: 'Wallet creation successful', tag: 'h2' });
+  await driver.findElement({ text: 'Congratulations!', tag: 'h2' });
   // opt-out from third party API
-  await driver.clickElement({ text: 'Manage default settings', tag: 'a' });
+  await driver.clickElement({ text: 'Manage default settings', tag: 'button' });
+  await driver.clickElement({ text: 'General', tag: 'p' });
   await driver.clickElement(
     '[data-testid="basic-functionality-toggle"] .toggle-button',
   );
@@ -568,19 +580,12 @@ const onboardingCompleteWalletCreationWithOptOut = async (driver) => {
       )
     ).map((toggle) => toggle.click()),
   );
+  await driver.clickElement('[data-testid="category-back-button"]');
+  await driver.clickElement('[data-testid="privacy-settings-back-button"]');
+
   // complete onboarding
   await driver.clickElement({ text: 'Done', tag: 'button' });
-};
-
-/**
- * Move through the steps of pinning extension after successful onboarding
- *
- * @param {WebDriver} driver
- */
-const onboardingPinExtension = async (driver) => {
-  // pin extension
-  await driver.clickElement('[data-testid="pin-extension-next"]');
-  await driver.clickElement('[data-testid="pin-extension-done"]');
+  await onboardingPinExtension(driver);
 };
 
 const completeCreateNewWalletOnboardingFlowWithOptOut = async (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the vault decryption test broken by https://github.com/MetaMask/metamask-extension/pull/24562/files#diff-d62d4e96adf6102c2b13c65f73e2c276fc08d4a93edeb969a2a1c8bb23679f56

The test broke due to (1) text change and (2) forward/backward navigation of onboarding

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27779?quickstart=1)

## **Related issues**

Fixes: #27776

## **Manual testing steps**

1. Run test
2. It succeeds


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
