### PR TITLE
fix(account-list-menu): set empty className to string instead of boolean

### DIFF
--- a/ui/components/component-library/text-field-search/deprecated/text-field-search.js
+++ b/ui/components/component-library/text-field-search/deprecated/text-field-search.js
@@ -19,11 +19,11 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
  */
 
 export const TextFieldSearch = ({
-  className,
+  className = '',
   showClearButton = true, // only works with a controlled input
   clearButtonOnClick,
   clearButtonProps,
-  endAccessory,
+  endAccessory = null,
   inputProps,
   value,
   onChange,
@@ -108,11 +108,16 @@ TextFieldSearch.propTypes = {
   /**
    * Component to appear on the right side of the input
    */
-  endAccessory: PropTypes.node,
+  endAccessory: PropTypes.oneOfType([PropTypes.node, PropTypes.any]),
   /**
    * Attributes applied to the `input` element.
    */
   inputProps: PropTypes.object,
+};
+
+TextFieldSearch.defaultProps = {
+  className: '',
+  endAccessory: null,
 };
 
 TextFieldSearch.displayName = 'TextFieldSearch';

--- a/ui/components/multichain/account-list-menu/account-list-menu.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.tsx
@@ -595,8 +595,8 @@ export const AccountListMenu = ({
                   }}
                   inputProps={{ autoFocus: true }}
                   // TODO: These props are required in the TextFieldSearch component. These should be optional
-                  endAccessory
-                  className
+                  endAccessory={null}
+                  className=''
                 />
               </Box>
             ) : null}


### PR DESCRIPTION
## **Description**
- **fix(text-field-search): make className and endOfAccessory optional**
- **fix(account-list-menu): set empty className to string instead of boolean**


Fix browser error:

```
    Warning: Failed prop type: Invalid prop `className` of type `boolean` supplied to `TextFieldSearch`, expected `string`.
        in TextFieldSearch (at account-list-menu.tsx:396)
        in AccountListMenu (at routes.component.js:916)
        in div (at routes.component.js:891)
        in Routes (created by Connect(Routes))
        in Connect(Routes) (created by Context.Consumer)
        in withRouter(Connect(Routes)) (at pages/index.js:54)
        in MetamaskNotificationsProvider (at pages/index.js:53)
        in CurrencyRateProvider (at pages/index.js:52)
        in LegacyI18nProvider (at pages/index.js:51)
        in I18nProvider (at pages/index.js:50)
        in LegacyMetaMetricsProvider (at pages/index.js:49)
        in MetaMetricsProvider (at pages/index.js:48)
        in RenderedRoute (created by Routes)
        in Routes (created by CompatRouter)
        in Router (created by CompatRouter)
        in CompatRouter (at pages/index.js:47)
        in Router (created by HashRouter)
        in HashRouter (at pages/index.js:46)
        in Provider (at pages/index.js:45)
        in Index (at ui/index.js:214)
    Warning: Failed prop type: Invalid prop `endAccessory` supplied to `TextFieldSearch`, expected a ReactNode.
        in TextFieldSearch (at account-list-menu.tsx:396)
        in AccountListMenu (at routes.component.js:916)
        in div (at routes.component.js:891)
        in Routes (created by Connect(Routes))
        in Connect(Routes) (created by Context.Consumer)
        in withRouter(Connect(Routes)) (at pages/index.js:54)
        in MetamaskNotificationsProvider (at pages/index.js:53)
        in CurrencyRateProvider (at pages/index.js:52)
        in LegacyI18nProvider (at pages/index.js:51)
        in I18nProvider (at pages/index.js:50)
        in LegacyMetaMetricsProvider (at pages/index.js:49)
        in MetaMetricsProvider (at pages/index.js:48)
        in RenderedRoute (created by Routes)
        in Routes (created by CompatRouter)
        in Router (created by CompatRouter)
        in CompatRouter (at pages/index.js:47)
        in Router (created by HashRouter)
        in HashRouter (at pages/index.js:46)
        in Provider (at pages/index.js:45)
        in Index (at ui/index.js:214)
```

https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/104778/workflows/8ed1ca7f-3077-43ff-8f59-e423ea11b9ed/jobs/3906701

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27780?quickstart=1)

## **Related issues**

## **Manual testing steps**


## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
