### PR TITLE
ci: add more time for the Merge Queue E2E tests

### DIFF
--- a/.circleci/scripts/test-run-e2e-timeout-minutes.ts
+++ b/.circleci/scripts/test-run-e2e-timeout-minutes.ts
@@ -2,7 +2,12 @@ import { filterE2eChangedFiles } from '../../test/e2e/changedFilesUtil';
 
 const changedOrNewTests = filterE2eChangedFiles();
 
-//15 minutes, plus 3 minutes for every changed file, up to a maximum of 30 minutes
-const extraTime = Math.min(15 + changedOrNewTests.length * 3, 30);
+// 15 minutes, plus 3 minutes for every changed file, up to a maximum of 30 minutes
+let extraTime = Math.min(15 + changedOrNewTests.length * 3, 30);
+
+// If this is the Merge Queue, add 5 minutes
+if (process.env.CIRCLE_BRANCH?.startsWith('gh-readonly-queue')) {
+  extraTime += 5;
+}
 
 console.log(extraTime);


### PR DESCRIPTION
## **Description**

I think #27146 and #26239 are interacting poorly with the Merge Queue.

We're getting `No timing found for ____` errors for every single file, and then some of the shards run longer than 15 minutes and time out.  In a normal run, you can "Rerun failed tests" or "Rerun workflow from failed," but in the Merge Queue runs, this is not an option.

This PR detects the Merge Queue `process.env.CIRCLE_BRANCH?.startsWith('gh-readonly-queue')` and adds 5 minutes.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27812?quickstart=1)

## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
### **Before**
### **After**
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
