### PR TITLE
feat(snaps): Add `min`, `max` and `step` to Snap UI input

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/input.ts
@@ -9,6 +9,11 @@ export const input: UIComponentFactory<InputElement> = ({ element, form }) => ({
     placeholder: element.props.placeholder,
     textFieldProps: {
       type: element.props.type,
+      inputProps: {
+        step: element.props.step,
+        min: element.props.min,
+        max: element.props.max,
+      },
     },
     name: element.props.name,
     form,


### PR DESCRIPTION
## **Description**

This adds the `min`, `max` and `step` props to the `Input` component of Snaps custom UI.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27822?quickstart=1)

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
