### PR TITLE
ci: Revert minimum E2E timeout to 20 minutes

### DIFF
--- a/.circleci/scripts/test-run-e2e-timeout-minutes.ts
+++ b/.circleci/scripts/test-run-e2e-timeout-minutes.ts
@@ -2,7 +2,7 @@ import { filterE2eChangedFiles } from '../../test/e2e/changedFilesUtil';
 
 const changedOrNewTests = filterE2eChangedFiles();
 
-//15 minutes, plus 3 minutes for every changed file, up to a maximum of 30 minutes
-const extraTime = Math.min(15 + changedOrNewTests.length * 3, 30);
+// 20 minutes, plus 3 minutes for every changed file, up to a maximum of 30 minutes
+const extraTime = Math.min(20 + changedOrNewTests.length * 3, 30);
 
 console.log(extraTime);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reverts the minimum E2E timeout back to 20 minutes to unblock merges to `develop` while we investigate why E2E's have slowed down dramatically.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27827?quickstart=1)

