### PR TITLE
fix: flaky test `Add account should not affect public address when using secret recovery phrase to recover account with non-zero balance @no-mmi`

### DIFF
--- a/test/e2e/tests/account/add-account.spec.js
+++ b/test/e2e/tests/account/add-account.spec.js
@@ -7,6 +7,7 @@ const {
   findAnotherAccountFromAccountList,
   locateAccountBalanceDOM,
   logInWithBalanceValidation,
+  regularDelayMs,
   unlockWallet,
   WALLET_PASSWORD,
   generateGanacheOptions,
@@ -41,6 +42,9 @@ describe('Add account', function () {
         );
 
         await driver.fill('[placeholder="Account 2"]', '2nd account');
+        // needed to mitigate a race condition with the state update
+        // there is no condition we can wait for in the UI
+        await driver.delay(regularDelayMs);
         await driver.clickElement({ text: 'Add account', tag: 'button' });
         await driver.findElement({
           css: '[data-testid="account-menu-icon"]',
@@ -85,6 +89,9 @@ describe('Add account', function () {
           '[data-testid="multichain-account-menu-popover-add-account"]',
         );
         await driver.fill('[placeholder="Account 2"]', '2nd account');
+        // needed to mitigate a race condition with the state update
+        // there is no condition we can wait for in the UI
+        await driver.delay(regularDelayMs);
         await driver.clickElement({ text: 'Add account', tag: 'button' });
 
         // Check address of 2nd account
@@ -112,9 +119,7 @@ describe('Add account', function () {
         await driver.waitForSelector('[data-testid="unlock-page"]');
 
         // Recover via SRP in "forget password" option
-        await driver.clickElement(
-          '.unlock-page__link',
-        );
+        await driver.clickElement('.unlock-page__link');
         await driver.pasteIntoField(
           '[data-testid="import-srp__srp-word-0"]',
           TEST_SEED_PHRASE,
@@ -166,6 +171,9 @@ describe('Add account', function () {
           '[data-testid="multichain-account-menu-popover-add-account"]',
         );
         await driver.fill('[placeholder="Account 2"]', '2nd account');
+        // needed to mitigate a race condition with the state update
+        // there is no condition we can wait for in the UI
+        await driver.delay(regularDelayMs);
         await driver.clickElement({ text: 'Add account', tag: 'button' });
 
         // Wait for 2nd account to be created

--- a/test/e2e/tests/account/add-account.spec.js
+++ b/test/e2e/tests/account/add-account.spec.js
@@ -7,7 +7,6 @@ const {
   findAnotherAccountFromAccountList,
   locateAccountBalanceDOM,
   logInWithBalanceValidation,
-  regularDelayMs,
   unlockWallet,
   WALLET_PASSWORD,
   generateGanacheOptions,
@@ -109,16 +108,13 @@ describe('Add account', function () {
           '[data-testid="account-options-menu-button"]',
         );
 
-        await driver.delay(regularDelayMs);
-        await driver.waitForSelector('[data-testid="global-menu-lock"]');
         await driver.clickElement('[data-testid="global-menu-lock"]');
         await driver.waitForSelector('[data-testid="unlock-page"]');
 
         // Recover via SRP in "forget password" option
-        const restoreSeedLink = await driver.findClickableElement(
+        await driver.clickElement(
           '.unlock-page__link',
         );
-        await restoreSeedLink.click();
         await driver.pasteIntoField(
           '[data-testid="import-srp__srp-word-0"]',
           TEST_SEED_PHRASE,
@@ -126,7 +122,6 @@ describe('Add account', function () {
         await driver.fill('#password', 'correct horse battery staple');
         await driver.fill('#confirm-password', 'correct horse battery staple');
 
-        await driver.delay(regularDelayMs);
         await driver.clickElement(
           '[data-testid="create-new-vault-submit-button"]',
         );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a race condition that after clicking Add Account button, for adding an account, the dialog remains open and the account is not added.
Then the test fails when trying to click an element which is below the dialog: `ElementClickInterceptedError: element click intercepted:`

![Screenshot from 2024-10-14 17-40-45](https://github.com/user-attachments/assets/8cb59dfd-d662-460e-a228-a1e033bdecba)


![image](https://github.com/user-attachments/assets/ee45e300-f13b-4daa-a667-b4ea8257483a)

Unfortunately there is no UI condition we can wait for, to know when the form is ready after adding our input, given that the Add Account button is enabled from start, so the click will never fail, despite the component not being ready/needing to update.

You can see an illustration of this in the video below, despite not being able to reproduce it locally.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27834?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27837

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
See how there is no UI way to tell we can click the button, as it is already enabled.
Then, when we update the input and quickly click Add Account, unexpected things can happen: ie in this case the last updated value is not applied

https://github.com/user-attachments/assets/982b2d33-1bd0-42e0-99a3-0f13fa571620




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
