### PR TITLE
test(mock-e2e): add private domains logic for the privacy report

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -68,11 +68,15 @@ const browserAPIRequestDomains =
 
 /**
  * Some third-party providers might use random URLs that we don't want to track
- * in the privacy report "in clear". We use a pattern to match those URLs and
- * adds a generic `host` to the report so that we still keep track of those URLs
- * in a generic way.
+ * in the privacy report "in clear". We identify those private hosts with a
+ * `pattern` regexp and replace the original host by a more generic one (`host`).
+ * For example, "my-secret-host.provider.com" could be denoted as "*.provider.com" in
+ * the privacy report. This would prevent disclosing the "my-secret-host" subdomain
+ * in this case.
  */
-const privateHostMatchers = [];
+const privateHostMatchers = [
+  // { pattern: RegExp, host: string }
+];
 
 /**
  * @typedef {import('mockttp').Mockttp} Mockttp

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -72,7 +72,7 @@ const browserAPIRequestDomains =
  * adds a generic `host` to the report so that we still keep track of those URLs
  * in a generic way.
  */
-const privateDomains = [];
+const privateHostMatchers = [];
 
 /**
  * @typedef {import('mockttp').Mockttp} Mockttp
@@ -732,7 +732,7 @@ async function setupMocking(
   const matchPrivateHosts = (request) => {
     const privateHosts = new Set();
 
-    for (const { pattern, host: privateHost } of privateDomains) {
+    for (const { pattern, host: privateHost } of privateHostMatchers) {
       if (request.headers.host.match(pattern)) {
         privateHosts.add(privateHost);
       }


### PR DESCRIPTION
## **Description**

Introduce the concept of "private domains" for the `privacy-snapshot.json`.

This allow to hide some part of a host 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27844?quickstart=1)

## **Related issues**

Required by:
- https://github.com/MetaMask/metamask-extension/pull/27730

## **Manual testing steps**

1. Use this PR to test the feature:
- https://github.com/MetaMask/metamask-extension/pull/27730
2. `yarn build:test:flask`
3. Remove the this line https://github.com/MetaMask/metamask-extension/blob/d5715503202bfaf451f60a6392e48366291942f7/privacy-snapshot.json#L2
4. `yarn test:e2e:single test/e2e/flask/btc/btc-account-overview.spec.ts --browser=chrome --update-privacy-snapshot`
5. The `privacy-snapshot.json` should have been updated again with the line you just removed

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
