### PR TITLE
Multichain: Do not add permittedChain scope for snaps. Use new networkConfigurationsByChainId property

### DIFF
--- a/app/scripts/migrations/131.test.ts
+++ b/app/scripts/migrations/131.test.ts
@@ -471,6 +471,14 @@ describe('migration #131', () => {
                               methods: [],
                               notifications: [],
                             },
+                            'wallet:eip155': {
+                              accounts: [
+                                'wallet:eip155:0xdeadbeef',
+                                'wallet:eip155:0x999',
+                              ],
+                              methods: [],
+                              notifications: [],
+                            },
                           },
                           isMultichainOrigin: false,
                         },
@@ -547,6 +555,14 @@ describe('migration #131', () => {
                               methods: [],
                               notifications: [],
                             },
+                            'wallet:eip155': {
+                              accounts: [
+                                'wallet:eip155:0xdeadbeef',
+                                'wallet:eip155:0x999',
+                              ],
+                              methods: [],
+                              notifications: [],
+                            },
                           },
                           isMultichainOrigin: false,
                         },
@@ -619,6 +635,80 @@ describe('migration #131', () => {
                               accounts: [
                                 'eip155:11155111:0xdeadbeef',
                                 'eip155:11155111:0x999',
+                              ],
+                              methods: [],
+                              notifications: [],
+                            },
+                            'wallet:eip155': {
+                              accounts: [
+                                'wallet:eip155:0xdeadbeef',
+                                'wallet:eip155:0x999',
+                              ],
+                              methods: [],
+                              notifications: [],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        });
+      });
+
+      it('replaces the eth_accounts permission with a CAIP-25 permission using the eth_accounts value without permitted chains when the origin is snapId', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            ...baseData(),
+            PermissionController: {
+              subjects: {
+                'npm:snap': {
+                  permissions: {
+                    unrelated: {
+                      foo: 'bar',
+                    },
+                    [PermissionNames.eth_accounts]: {
+                      caveats: [
+                        {
+                          type: 'restrictReturnedAccounts',
+                          value: ['0xdeadbeef', '0x999'],
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        const newStorage = await migrate(oldStorage);
+        expect(newStorage.data).toStrictEqual({
+          ...baseData(),
+          PermissionController: {
+            subjects: {
+              'npm:snap': {
+                permissions: {
+                  unrelated: {
+                    foo: 'bar',
+                  },
+                  'endowment:caip25': {
+                    parentCapability: 'endowment:caip25',
+                    caveats: [
+                      {
+                        type: 'authorizedScopes',
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: [
+                                'wallet:eip155:0xdeadbeef',
+                                'wallet:eip155:0x999',
                               ],
                               methods: [],
                               notifications: [],
@@ -713,6 +803,14 @@ describe('migration #131', () => {
                               accounts: [
                                 'eip155:10:0xdeadbeef',
                                 'eip155:10:0x999',
+                              ],
+                              methods: [],
+                              notifications: [],
+                            },
+                            'wallet:eip155': {
+                              accounts: [
+                                'wallet:eip155:0xdeadbeef',
+                                'wallet:eip155:0x999',
                               ],
                               methods: [],
                               notifications: [],
@@ -843,6 +941,14 @@ describe('migration #131', () => {
                               methods: [],
                               notifications: [],
                             },
+                            'wallet:eip155': {
+                              accounts: [
+                                'wallet:eip155:0xdeadbeef',
+                                'wallet:eip155:0x999',
+                              ],
+                              methods: [],
+                              notifications: [],
+                            },
                           },
                           isMultichainOrigin: false,
                         },
@@ -912,6 +1018,13 @@ describe('migration #131', () => {
                               methods: [],
                               notifications: [],
                             },
+                            'wallet:eip155': {
+                              accounts: [
+                                'wallet:eip155:0xdeadbeef',
+                              ],
+                              methods: [],
+                              notifications: [],
+                            },
                           },
                           isMultichainOrigin: false,
                         },
@@ -932,6 +1045,13 @@ describe('migration #131', () => {
                           optionalScopes: {
                             [currentScope]: {
                               accounts: [`${currentScope}:0xdeadbeef`],
+                              methods: [],
+                              notifications: [],
+                            },
+                            'wallet:eip155': {
+                              accounts: [
+                                'wallet:eip155:0xdeadbeef',
+                              ],
                               methods: [],
                               notifications: [],
                             },

--- a/app/scripts/migrations/131.test.ts
+++ b/app/scripts/migrations/131.test.ts
@@ -189,7 +189,7 @@ describe('migration #131', () => {
     expect(newStorage.data).toStrictEqual(oldStorage.data);
   });
 
-  it('does nothing if NetworkController.networkConfigurations is not an object', async () => {
+  it('does nothing if NetworkController.networkConfigurationsByChainId is not an object', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {
@@ -198,7 +198,7 @@ describe('migration #131', () => {
         },
         NetworkController: {
           selectedNetworkClientId: 'mainnet',
-          networkConfigurations: 'foo',
+          networkConfigurationsByChainId: 'foo',
         },
         SelectedNetworkController: {},
       },
@@ -208,7 +208,7 @@ describe('migration #131', () => {
 
     expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
       new Error(
-        `Migration ${version}: typeof state.NetworkController.networkConfigurations is string`,
+        `Migration ${version}: typeof state.NetworkController.networkConfigurationsByChainId is string`,
       ),
     );
     expect(newStorage.data).toStrictEqual(oldStorage.data);
@@ -223,7 +223,7 @@ describe('migration #131', () => {
         },
         NetworkController: {
           selectedNetworkClientId: 'mainnet',
-          networkConfigurations: {},
+          networkConfigurationsByChainId: {},
         },
         SelectedNetworkController: {
           domains: 'foo',
@@ -241,7 +241,7 @@ describe('migration #131', () => {
     expect(newStorage.data).toStrictEqual(oldStorage.data);
   });
 
-  it('does nothing if the currently selected network client is neither built in nor exists in NetworkController.networkConfigurations', async () => {
+  it('does nothing if NetworkController.networkConfigurationsByChainId[] is not an object', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {
@@ -250,7 +250,98 @@ describe('migration #131', () => {
         },
         NetworkController: {
           selectedNetworkClientId: 'nonExistentNetworkClientId',
-          networkConfigurations: {},
+          networkConfigurationsByChainId: {
+            '0x1': 'foo',
+          },
+        },
+        SelectedNetworkController: {
+          domains: {},
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${version}: typeof state.NetworkController.networkConfigurationsByChainId["0x1"] is string`,
+      ),
+    );
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('does nothing if NetworkController.networkConfigurationsByChainId[].rpcEndpoints is not an array', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        PermissionController: {
+          subjects: {},
+        },
+        NetworkController: {
+          selectedNetworkClientId: 'nonExistentNetworkClientId',
+          networkConfigurationsByChainId: {
+            '0x1': {
+              rpcEndpoints: 'foo',
+            },
+          },
+        },
+        SelectedNetworkController: {
+          domains: {},
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${version}: typeof state.NetworkController.networkConfigurationsByChainId["0x1"].rpcEndpoints is string`,
+      ),
+    );
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('does nothing if NetworkController.networkConfigurationsByChainId[].rpcEndpoints[] is not an object', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        PermissionController: {
+          subjects: {},
+        },
+        NetworkController: {
+          selectedNetworkClientId: 'nonExistentNetworkClientId',
+          networkConfigurationsByChainId: {
+            '0x1': {
+              rpcEndpoints: ['foo'],
+            },
+          },
+        },
+        SelectedNetworkController: {
+          domains: {},
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${version}: typeof state.NetworkController.networkConfigurationsByChainId["0x1"].rpcEndpoints[] is string`,
+      ),
+    );
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('does nothing if the currently selected network client is neither built in nor exists in NetworkController.networkConfigurationsByChainId', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        PermissionController: {
+          subjects: {},
+        },
+        NetworkController: {
+          selectedNetworkClientId: 'nonExistentNetworkClientId',
+          networkConfigurationsByChainId: {},
         },
         SelectedNetworkController: {
           domains: {},
@@ -274,7 +365,7 @@ describe('migration #131', () => {
       data: {
         NetworkController: {
           selectedNetworkClientId: 'mainnet',
-          networkConfigurations: {},
+          networkConfigurationsByChainId: {},
         },
         SelectedNetworkController: {
           domains: {},
@@ -303,7 +394,7 @@ describe('migration #131', () => {
       data: {
         NetworkController: {
           selectedNetworkClientId: 'mainnet',
-          networkConfigurations: {},
+          networkConfigurationsByChainId: {},
         },
         SelectedNetworkController: {
           domains: {},
@@ -334,7 +425,7 @@ describe('migration #131', () => {
       data: {
         NetworkController: {
           selectedNetworkClientId: 'mainnet',
-          networkConfigurations: {},
+          networkConfigurationsByChainId: {},
         },
         SelectedNetworkController: {
           domains: {},
@@ -357,7 +448,7 @@ describe('migration #131', () => {
     expect(newStorage.data).toStrictEqual({
       NetworkController: {
         selectedNetworkClientId: 'mainnet',
-        networkConfigurations: {},
+        networkConfigurationsByChainId: {},
       },
       SelectedNetworkController: {
         domains: {},
@@ -382,7 +473,7 @@ describe('migration #131', () => {
       'built-in',
       {
         selectedNetworkClientId: 'mainnet',
-        networkConfigurations: {},
+        networkConfigurationsByChainId: {},
       },
       '1',
     ],
@@ -390,9 +481,13 @@ describe('migration #131', () => {
       'custom',
       {
         selectedNetworkClientId: 'customId',
-        networkConfigurations: {
-          customId: {
-            chainId: '0xf',
+        networkConfigurationsByChainId: {
+          '0xf': {
+            rpcEndpoints: [
+              {
+                networkClientId: 'customId',
+              },
+            ],
           },
         },
       },
@@ -403,7 +498,12 @@ describe('migration #131', () => {
     (
       _type: string,
       NetworkController: {
-        networkConfigurations: Record<string, unknown>;
+        networkConfigurationsByChainId: Record<
+          string,
+          {
+            rpcEndpoints: { networkClientId: string }[];
+          }
+        >;
       } & Record<string, unknown>,
       chainId: string,
     ) => {
@@ -733,10 +833,14 @@ describe('migration #131', () => {
             ...baseData(),
             NetworkController: {
               ...baseData().NetworkController,
-              networkConfigurations: {
-                ...baseData().NetworkController.networkConfigurations,
-                customNetworkClientId: {
-                  chainId: '0xa',
+              networkConfigurationsByChainId: {
+                ...baseData().NetworkController.networkConfigurationsByChainId,
+                '0xa': {
+                  rpcEndpoints: [
+                    {
+                      networkClientId: 'customNetworkClientId',
+                    },
+                  ],
                 },
               },
             },
@@ -772,10 +876,14 @@ describe('migration #131', () => {
           ...baseData(),
           NetworkController: {
             ...baseData().NetworkController,
-            networkConfigurations: {
-              ...baseData().NetworkController.networkConfigurations,
-              customNetworkClientId: {
-                chainId: '0xa',
+            networkConfigurationsByChainId: {
+              ...baseData().NetworkController.networkConfigurationsByChainId,
+              '0xa': {
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'customNetworkClientId',
+                  },
+                ],
               },
             },
           },
@@ -1019,9 +1127,7 @@ describe('migration #131', () => {
                               notifications: [],
                             },
                             'wallet:eip155': {
-                              accounts: [
-                                'wallet:eip155:0xdeadbeef',
-                              ],
+                              accounts: ['wallet:eip155:0xdeadbeef'],
                               methods: [],
                               notifications: [],
                             },
@@ -1049,9 +1155,7 @@ describe('migration #131', () => {
                               notifications: [],
                             },
                             'wallet:eip155': {
-                              accounts: [
-                                'wallet:eip155:0xdeadbeef',
-                              ],
+                              accounts: ['wallet:eip155:0xdeadbeef'],
                               methods: [],
                               notifications: [],
                             },

--- a/app/scripts/migrations/131.ts
+++ b/app/scripts/migrations/131.ts
@@ -46,6 +46,8 @@ const BUILT_IN_NETWORKS = {
 const Caip25CaveatType = 'authorizedScopes';
 const Caip25EndowmentPermissionName = 'endowment:caip25';
 
+const snapsPrefixes = ['npm:', 'local:'] as const;
+
 type VersionedData = {
   meta: { version: number };
   data: Record<string, unknown>;
@@ -235,10 +237,12 @@ function transformState(state: Record<string, unknown>) {
       }
     }
 
+    const isSnap = snapsPrefixes.some((prefix) => origin.startsWith(prefix))
     const scopes: Record<string, Json> = {};
+    const scopeStrings = isSnap ? [] : chainIds.map(chainId => `eip155:${parseInt(chainId, 16)}`)
+    scopeStrings.push('wallet:eip155')
 
-    chainIds.forEach((chainId) => {
-      const scopeString = `eip155:${parseInt(chainId, 16)}`;
+    scopeStrings.forEach((scopeString) => {
       const caipAccounts = ethAccounts.map(
         (account) => `${scopeString}:${account}`,
       );

--- a/app/scripts/migrations/131.ts
+++ b/app/scripts/migrations/131.ts
@@ -237,10 +237,12 @@ function transformState(state: Record<string, unknown>) {
       }
     }
 
-    const isSnap = snapsPrefixes.some((prefix) => origin.startsWith(prefix))
+    const isSnap = snapsPrefixes.some((prefix) => origin.startsWith(prefix));
     const scopes: Record<string, Json> = {};
-    const scopeStrings = isSnap ? [] : chainIds.map(chainId => `eip155:${parseInt(chainId, 16)}`)
-    scopeStrings.push('wallet:eip155')
+    const scopeStrings = isSnap
+      ? []
+      : chainIds.map((chainId) => `eip155:${parseInt(chainId, 16)}`);
+    scopeStrings.push('wallet:eip155');
 
     scopeStrings.forEach((scopeString) => {
       const caipAccounts = ethAccounts.map(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27849?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
