### PR TITLE
chore: Add react-beautiful-dnd to deprecated packages list

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -114,15 +114,9 @@ npmAuditIgnoreAdvisories:
   # upon old versions of ethereumjs-utils.
   - 'ethereum-cryptography (deprecation)'
 
-  # Currently only dependent on deprecated @metamask/types as it is brought in
-  # by @metamask/keyring-api. Updating the dependency in keyring-api will
-  # remove this.
-  - '@metamask/types (deprecation)'
-
-  # @metamask/keyring-api also depends on @metamask/snaps-ui which is
-  # deprecated. Replacing that dependency with @metamask/snaps-sdk will remove
-  # this.
-  - '@metamask/snaps-ui (deprecation)'
+  # Currently in use for the network list drag and drop functionality.
+  # Maintenance has stopped and the project will be archived in 2025.
+  - 'react-beautiful-dnd (deprecation)'
 
 npmRegistries:
   'https://npm.pkg.github.com':


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds `react-beautiful-dnd` to list of deprecated packages that are ignored when using `yarn audit`. This unblocks `develop`. The package is currently in use for the network selection drag and drop functionality and cannot be removed.

This PR also removes some packages from the list that were previously ignored, but are no longer in the dependency tree.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27856?quickstart=1)

