### PR TITLE
fix: flaky test `MultiRpc: should select rpc from settings @no-mmi`

### DIFF
--- a/test/e2e/tests/network/multi-rpc.spec.ts
+++ b/test/e2e/tests/network/multi-rpc.spec.ts
@@ -425,7 +425,7 @@ describe('MultiRpc:', function (this: Suite) {
 
         await driver.clickElement('[data-testid="category-back-button"]');
 
-        await driver.clickElementAndWaitToDisappear(
+        await driver.clickElement(
           '[data-testid="privacy-settings-back-button"]',
         );
 
@@ -454,6 +454,8 @@ describe('MultiRpc:', function (this: Suite) {
           '“Arbitrum One” was successfully edited!',
         );
         // Ensures popover backround doesn't kill test
+        await driver.assertElementNotPresent('.popover-bg');
+
         await driver.clickElementSafe({
           tag: 'button',
           text: 'Got it',

--- a/test/e2e/tests/network/multi-rpc.spec.ts
+++ b/test/e2e/tests/network/multi-rpc.spec.ts
@@ -396,11 +396,9 @@ describe('MultiRpc:', function (this: Suite) {
         await driver.delay(regularDelayMs);
 
         // go to advanced settigns
-        await driver.clickElement({
+        await driver.clickElementAndWaitToDisappear({
           text: 'Manage default settings',
         });
-
-        await driver.delay(regularDelayMs);
 
         await driver.clickElement({
           text: 'General',
@@ -420,23 +418,18 @@ describe('MultiRpc:', function (this: Suite) {
           tag: 'button',
         });
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitToDisappear({
           text: 'Save',
           tag: 'button',
         });
 
-        await driver.delay(regularDelayMs);
-        await driver.waitForSelector('[data-testid="category-back-button"]');
         await driver.clickElement('[data-testid="category-back-button"]');
 
-        await driver.waitForSelector(
-          '[data-testid="privacy-settings-back-button"]',
-        );
-        await driver.clickElement(
+        await driver.clickElementAndWaitToDisappear(
           '[data-testid="privacy-settings-back-button"]',
         );
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitToDisappear({
           text: 'Done',
           tag: 'button',
         });
@@ -446,7 +439,7 @@ describe('MultiRpc:', function (this: Suite) {
           tag: 'button',
         });
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitToDisappear({
           text: 'Done',
           tag: 'button',
         });

--- a/test/e2e/tests/network/multi-rpc.spec.ts
+++ b/test/e2e/tests/network/multi-rpc.spec.ts
@@ -456,6 +456,8 @@ describe('MultiRpc:', function (this: Suite) {
         // Ensures popover backround doesn't kill test
         await driver.assertElementNotPresent('.popover-bg');
 
+        // We need to use clickElementSafe + assertElementNotPresent as sometimes the network dialog doesn't appear, as per this issue (#27870)
+        // TODO: change the 2 actions for clickElementAndWaitToDisappear, once the issue is fixed
         await driver.clickElementSafe({ tag: 'h6', text: 'Got it' });
 
         await driver.assertElementNotPresent({

--- a/test/e2e/tests/network/multi-rpc.spec.ts
+++ b/test/e2e/tests/network/multi-rpc.spec.ts
@@ -331,7 +331,7 @@ describe('MultiRpc:', function (this: Suite) {
     );
   });
 
-  it.only('should select rpc from settings @no-mmi', async function () {
+  it('should select rpc from settings @no-mmi', async function () {
     async function mockRPCURLAndChainId(mockServer: Mockttp) {
       return [
         await mockServer

--- a/test/e2e/tests/network/multi-rpc.spec.ts
+++ b/test/e2e/tests/network/multi-rpc.spec.ts
@@ -456,13 +456,10 @@ describe('MultiRpc:', function (this: Suite) {
         // Ensures popover backround doesn't kill test
         await driver.assertElementNotPresent('.popover-bg');
 
-        await driver.clickElementSafe({
-          tag: 'button',
-          text: 'Got it',
-        });
+        await driver.clickElementSafe({ tag: 'h6', text: 'Got it' });
 
         await driver.assertElementNotPresent({
-          tag: 'button',
+          tag: 'h6',
           text: 'Got it',
         });
 

--- a/test/e2e/tests/network/multi-rpc.spec.ts
+++ b/test/e2e/tests/network/multi-rpc.spec.ts
@@ -331,7 +331,7 @@ describe('MultiRpc:', function (this: Suite) {
     );
   });
 
-  it('should select rpc from settings @no-mmi', async function () {
+  it.only('should select rpc from settings @no-mmi', async function () {
     async function mockRPCURLAndChainId(mockServer: Mockttp) {
       return [
         await mockServer
@@ -454,7 +454,7 @@ describe('MultiRpc:', function (this: Suite) {
           '“Arbitrum One” was successfully edited!',
         );
         // Ensures popover backround doesn't kill test
-        await driver.delay(regularDelayMs);
+        await driver.assertElementNotPresent('.popover-bg');
         await driver.clickElement('[data-testid="network-display"]');
 
         const arbitrumRpcUsed = await driver.findElement({

--- a/test/e2e/tests/network/multi-rpc.spec.ts
+++ b/test/e2e/tests/network/multi-rpc.spec.ts
@@ -454,7 +454,16 @@ describe('MultiRpc:', function (this: Suite) {
           '“Arbitrum One” was successfully edited!',
         );
         // Ensures popover backround doesn't kill test
-        await driver.assertElementNotPresent('.popover-bg');
+        await driver.clickElementSafe({
+          tag: 'button',
+          text: 'Got it',
+        });
+
+        await driver.assertElementNotPresent({
+          tag: 'button',
+          text: 'Got it',
+        });
+
         await driver.clickElement('[data-testid="network-display"]');
 
         const arbitrumRpcUsed = await driver.findElement({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27858?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27851

## **Manual testing steps**

1. Check ci
2. Run test locally

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
