### PR TITLE
fix: Automatically expand first insight

### DIFF
--- a/test/e2e/snaps/test-snap-siginsights.spec.js
+++ b/test/e2e/snaps/test-snap-siginsights.spec.js
@@ -79,16 +79,6 @@ describe('Test Snap Signature Insights', function () {
           tag: 'p',
         });
 
-        // click down arrow
-        await driver.waitForSelector({
-          text: 'Signature Insights Example Snap',
-          tag: 'span',
-        });
-        await driver.clickElement({
-          text: 'Signature Insights Example Snap',
-          tag: 'span',
-        });
-
         // look for returned signature insights data
         await driver.waitForSelector({
           text: '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765',

--- a/test/e2e/snaps/test-snap-siginsights.spec.js
+++ b/test/e2e/snaps/test-snap-siginsights.spec.js
@@ -85,6 +85,9 @@ describe('Test Snap Signature Insights', function () {
           tag: 'p',
         });
 
+        // Click down arrow
+        await driver.clickElementSafe('[aria-label="Scroll down"]');
+
         // click sign button
         await driver.clickElementAndWaitForWindowToClose(
           '[data-testid="confirm-footer-button"]',
@@ -115,21 +118,10 @@ describe('Test Snap Signature Insights', function () {
         });
 
         // click down arrow
-        // await driver.waitForSelector('[aria-label="Scroll down"]');
         await driver.clickElementSafe('[aria-label="Scroll down"]');
 
         // required: delay for scroll to render
         await driver.delay(500);
-
-        // click down arrow
-        await driver.waitForSelector({
-          text: 'Signature Insights Example Snap',
-          tag: 'span',
-        });
-        await driver.clickElement({
-          text: 'Signature Insights Example Snap',
-          tag: 'span',
-        });
 
         // look for returned signature insights data
         await driver.waitForSelector({
@@ -178,16 +170,6 @@ describe('Test Snap Signature Insights', function () {
         // required: delay for scroll to render
         await driver.delay(500);
 
-        // click signature insights
-        await driver.waitForSelector({
-          text: 'Signature Insights Example Snap',
-          tag: 'span',
-        });
-        await driver.clickElement({
-          text: 'Signature Insights Example Snap',
-          tag: 'span',
-        });
-
         // look for returned signature insights data
         await driver.waitForSelector({
           text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
@@ -234,16 +216,6 @@ describe('Test Snap Signature Insights', function () {
 
         // required: delay for scroll to render
         await driver.delay(500);
-
-        // click signature insights
-        await driver.waitForSelector({
-          text: 'Signature Insights Example Snap',
-          tag: 'span',
-        });
-        await driver.clickElement({
-          text: 'Signature Insights Example Snap',
-          tag: 'span',
-        });
 
         // look for returned signature insights data
         await driver.waitForSelector({

--- a/ui/pages/confirmations/components/confirm/snaps/snaps-section/snap-insight.tsx
+++ b/ui/pages/confirmations/components/confirm/snaps/snaps-section/snap-insight.tsx
@@ -16,12 +16,14 @@ export type SnapInsightProps = {
   snapId: string;
   interfaceId: string;
   loading: boolean;
+  isExpanded?: boolean | undefined;
 };
 
 export const SnapInsight: React.FunctionComponent<SnapInsightProps> = ({
   snapId,
   interfaceId,
   loading,
+  isExpanded,
 }) => {
   const t = useI18nContext();
   const { name: snapName } = useSelector((state) =>
@@ -57,6 +59,7 @@ export const SnapInsight: React.FunctionComponent<SnapInsightProps> = ({
     <Delineator
       headerComponent={headerComponent}
       isLoading={loading}
+      isExpanded={isExpanded}
       contentBoxProps={
         loading
           ? undefined

--- a/ui/pages/confirmations/components/confirm/snaps/snaps-section/snaps-section.test.tsx
+++ b/ui/pages/confirmations/components/confirm/snaps/snaps-section/snaps-section.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { Text } from '@metamask/snaps-sdk/jsx';
-import { fireEvent } from '@testing-library/react';
 
 import {
   getMockPersonalSignConfirmState,
@@ -58,8 +57,6 @@ describe('SnapsSection', () => {
       mockStore,
     );
 
-    fireEvent.click(getByText('Insights from'));
-
     expect(container).toMatchSnapshot();
     expect(getByText('Hello world!')).toBeDefined();
   });
@@ -78,8 +75,6 @@ describe('SnapsSection', () => {
       <SnapsSection />,
       mockStore,
     );
-
-    fireEvent.click(getByText('Insights from'));
 
     expect(container).toMatchSnapshot();
     expect(getByText('Hello world again!')).toBeDefined();

--- a/ui/pages/confirmations/components/confirm/snaps/snaps-section/snaps-section.tsx
+++ b/ui/pages/confirmations/components/confirm/snaps/snaps-section/snaps-section.tsx
@@ -23,12 +23,13 @@ export const SnapsSection = () => {
       gap={4}
       marginBottom={4}
     >
-      {data.map(({ snapId, interfaceId, loading }) => (
+      {data.map(({ snapId, interfaceId, loading }, index) => (
         <SnapInsight
           key={snapId}
           snapId={snapId}
           interfaceId={interfaceId}
           loading={loading}
+          isExpanded={index === 0}
         />
       ))}
     </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Automatically expands the first insight on the confirmation page, if any.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27872?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27869

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/a23f811f-ab9d-456d-9572-183e953b8802)

