### PR TITLE
fix bug where chain permissions were not properly represented in the permission confirmation

### DIFF
--- a/ui/components/app/permission-cell/permission-cell.js
+++ b/ui/components/app/permission-cell/permission-cell.js
@@ -42,7 +42,7 @@ const PermissionCell = ({
   showOptions,
   hideStatus,
   accounts,
-  permissionValue,
+  chainIds,
 }) => {
   const infoIcon = IconName.Info;
   let infoIconColor = IconColor.iconMuted;
@@ -71,7 +71,7 @@ const PermissionCell = ({
   }
 
   const networksInfo = useSelector((state) =>
-    getRequestingNetworkInfo(state, permissionValue),
+    getRequestingNetworkInfo(state, chainIds),
   );
 
   return (
@@ -171,7 +171,7 @@ PermissionCell.propTypes = {
   showOptions: PropTypes.bool,
   hideStatus: PropTypes.bool,
   accounts: PropTypes.array,
-  permissionValue: PropTypes.array,
+  chainIds: PropTypes.array,
 };
 
 export default PermissionCell;

--- a/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
+++ b/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
@@ -17,6 +17,9 @@ import { Box } from '../../component-library';
  * @returns {JSX.Element} A permission description node.
  */
 function getDescriptionNode(permission, index, accounts) {
+  const chainIds = permission.permissionValue.caveats.find(
+    (caveat) => caveat.type === 'restrictNetworkSwitching',
+  )?.value;
   return (
     <PermissionCell
       permissionName={permission.name}
@@ -26,7 +29,7 @@ function getDescriptionNode(permission, index, accounts) {
       avatarIcon={permission.leftIcon}
       key={`${permission.permissionName}-${index}`}
       accounts={accounts}
-      permissionValue={permission.permissionValue.restrictNetworkSwitching}
+      chainIds={chainIds}
     />
   );
 }


### PR DESCRIPTION
## **Description**
Fixes a small bug in the permissions confirmation whe `endowment:permittedChain` permissions are requested via `wallet_switchEthereumChain`. We should eventually clean up the upstream logic here to make the props passed down to these low level components not need to handle variations in permission formatting.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27883?quickstart=1)

## **Manual testing steps**

1. Go to https://docs.metamask.io/wallet/reference/wallet_switchethereumchain/
2. Modify the request to switch to a chainId for a network already added to (but not yet permissioned in) the wallet
3. See that the avatar and name of the network you're switching to show up correctly on the permission request confirmation.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/2c932e6f-88be-443a-97c9-c96ccb9a42ad



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
