### PR TITLE
feat(TXL-435): turn smart transactions on by default for new users

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -215,9 +215,9 @@ import {
   getIsSmartTransaction,
   isHardwareWallet,
   getFeatureFlagsByChainId,
-  getSmartTransactionsOptInStatus,
   getCurrentChainSupportsSmartTransactions,
   getHardwareWalletType,
+  getSmartTransactionsPreferenceEnabled,
 } from '../../shared/modules/selectors';
 import { createCaipStream } from '../../shared/modules/caip-stream';
 import { BaseUrl } from '../../shared/constants/urls';
@@ -1895,7 +1895,7 @@ export default class MetamaskController extends EventEmitter {
         isResubmitEnabled: () => {
           const state = this._getMetaMaskState();
           return !(
-            getSmartTransactionsOptInStatus(state) &&
+            getSmartTransactionsPreferenceEnabled(state) &&
             getCurrentChainSupportsSmartTransactions(state)
           );
         },

--- a/package.json
+++ b/package.json
@@ -461,6 +461,7 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.2",
     "@babel/register": "^7.22.15",
+    "@jest/globals": "^29.7.0",
     "@lavamoat/allow-scripts": "^3.0.4",
     "@lavamoat/lavadome-core": "0.0.10",
     "@lavamoat/lavapack": "^6.1.0",

--- a/shared/modules/selectors/index.test.ts
+++ b/shared/modules/selectors/index.test.ts
@@ -2,11 +2,12 @@ import { createSwapsMockStore } from '../../../test/jest';
 import { CHAIN_IDS } from '../../constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
 import {
-  getSmartTransactionsOptInStatus,
+  getSmartTransactionsOptInStatusForMetrics,
   getCurrentChainSupportsSmartTransactions,
   getSmartTransactionsEnabled,
   getIsSmartTransaction,
   getIsSmartTransactionsOptInModalAvailable,
+  getSmartTransactionsPreferenceEnabled,
 } from '.';
 
 describe('Selectors', () => {
@@ -65,11 +66,56 @@ describe('Selectors', () => {
     };
   };
 
-  describe('getSmartTransactionsOptInStatus', () => {
-    it('should return the smart transactions opt-in status', () => {
-      const state = createMockState();
-      const result = getSmartTransactionsOptInStatus(state);
-      expect(result).toBe(true);
+  describe('getSmartTransactionsOptInStatusForMetrics and getSmartTransactionsPreferenceEnabled', () => {
+    const createMockOptInStatusState = (status: boolean | null) => {
+      return {
+        metamask: {
+          preferences: {
+            smartTransactionsOptInStatus: status,
+          },
+        },
+      };
+    };
+    describe('getSmartTransactionsOptInStatusForMetrics', () => {
+      it('should return the smart transactions opt-in status', () => {
+        const state = createMockState();
+        const result = getSmartTransactionsOptInStatusForMetrics(state);
+        expect(result).toBe(true);
+      });
+
+      it.each([
+        { status: true, expected: true },
+        { status: false, expected: false },
+        { status: null, expected: null },
+      ])(
+        'should return $expected if the smart transactions opt-in status is $status',
+        ({ status, expected }) => {
+          const state = createMockOptInStatusState(status);
+          const result = getSmartTransactionsOptInStatusForMetrics(state);
+          expect(result).toBe(expected);
+        },
+      );
+    });
+
+    describe('getSmartTransactionsPreferenceEnabled', () => {
+      it('should return the smart transactions preference enabled status', () => {
+        const state = createMockState();
+        const result = getSmartTransactionsPreferenceEnabled(state);
+        expect(result).toBe(true);
+      });
+
+      it.each([
+        { status: true, expected: true },
+        { status: false, expected: false },
+        { status: null, expected: true },
+      ])(
+        'should return $expected if the smart transactions opt-in status is $status',
+        ({ status, expected }) => {
+          const state = createMockOptInStatusState(status);
+          const result = getSmartTransactionsPreferenceEnabled(state);
+          expect(result).toBe(expected);
+        },
+      );
     });
   });
 

--- a/shared/modules/selectors/index.test.ts
+++ b/shared/modules/selectors/index.test.ts
@@ -1,3 +1,6 @@
+// Mocha type definitions are conflicting with Jest
+import { it as jestIt } from '@jest/globals';
+
 import { createSwapsMockStore } from '../../../test/jest';
 import { CHAIN_IDS } from '../../constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
@@ -77,13 +80,13 @@ describe('Selectors', () => {
       };
     };
     describe('getSmartTransactionsOptInStatusForMetrics', () => {
-      it('should return the smart transactions opt-in status', () => {
+      jestIt('should return the smart transactions opt-in status', () => {
         const state = createMockState();
         const result = getSmartTransactionsOptInStatusForMetrics(state);
         expect(result).toBe(true);
       });
 
-      it.each([
+      jestIt.each([
         { status: true, expected: true },
         { status: false, expected: false },
         { status: null, expected: null },
@@ -98,13 +101,16 @@ describe('Selectors', () => {
     });
 
     describe('getSmartTransactionsPreferenceEnabled', () => {
-      it('should return the smart transactions preference enabled status', () => {
-        const state = createMockState();
-        const result = getSmartTransactionsPreferenceEnabled(state);
-        expect(result).toBe(true);
-      });
+      jestIt(
+        'should return the smart transactions preference enabled status',
+        () => {
+          const state = createMockState();
+          const result = getSmartTransactionsPreferenceEnabled(state);
+          expect(result).toBe(true);
+        },
+      );
 
-      it.each([
+      jestIt.each([
         { status: true, expected: true },
         { status: false, expected: false },
         { status: null, expected: true },
@@ -120,106 +126,133 @@ describe('Selectors', () => {
   });
 
   describe('getCurrentChainSupportsSmartTransactions', () => {
-    it('should return true if the chain ID is allowed for smart transactions', () => {
-      const state = createMockState();
-      const result = getCurrentChainSupportsSmartTransactions(state);
-      expect(result).toBe(true);
-    });
+    jestIt(
+      'should return true if the chain ID is allowed for smart transactions',
+      () => {
+        const state = createMockState();
+        const result = getCurrentChainSupportsSmartTransactions(state);
+        expect(result).toBe(true);
+      },
+    );
 
-    it('should return false if the chain ID is not allowed for smart transactions', () => {
-      const state = createMockState();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
-        },
-      };
-      const result = getCurrentChainSupportsSmartTransactions(newState);
-      expect(result).toBe(false);
-    });
+    jestIt(
+      'should return false if the chain ID is not allowed for smart transactions',
+      () => {
+        const state = createMockState();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
+          },
+        };
+        const result = getCurrentChainSupportsSmartTransactions(newState);
+        expect(result).toBe(false);
+      },
+    );
   });
 
   describe('getSmartTransactionsEnabled', () => {
-    it('returns true if feature flag is enabled, not a HW and is Ethereum network', () => {
-      const state = createSwapsMockStore();
-      expect(getSmartTransactionsEnabled(state)).toBe(true);
-    });
+    jestIt(
+      'returns true if feature flag is enabled, not a HW and is Ethereum network',
+      () => {
+        const state = createSwapsMockStore();
+        expect(getSmartTransactionsEnabled(state)).toBe(true);
+      },
+    );
 
-    it('returns false if feature flag is disabled, not a HW and is Ethereum network', () => {
-      const state = createSwapsMockStore();
-      state.metamask.swapsState.swapsFeatureFlags.smartTransactions.extensionActive =
-        false;
-      expect(getSmartTransactionsEnabled(state)).toBe(false);
-    });
+    jestIt(
+      'returns false if feature flag is disabled, not a HW and is Ethereum network',
+      () => {
+        const state = createSwapsMockStore();
+        state.metamask.swapsState.swapsFeatureFlags.smartTransactions.extensionActive =
+          false;
+        expect(getSmartTransactionsEnabled(state)).toBe(false);
+      },
+    );
 
-    it('returns false if feature flag is enabled, not a HW, STX liveness is false and is Ethereum network', () => {
-      const state = createSwapsMockStore();
-      state.metamask.smartTransactionsState.liveness = false;
-      expect(getSmartTransactionsEnabled(state)).toBe(false);
-    });
+    jestIt(
+      'returns false if feature flag is enabled, not a HW, STX liveness is false and is Ethereum network',
+      () => {
+        const state = createSwapsMockStore();
+        state.metamask.smartTransactionsState.liveness = false;
+        expect(getSmartTransactionsEnabled(state)).toBe(false);
+      },
+    );
 
-    it('returns true if feature flag is enabled, is a HW and is Ethereum network', () => {
-      const state = createSwapsMockStore();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          internalAccounts: {
-            ...state.metamask.internalAccounts,
-            selectedAccount: 'account2',
-            accounts: {
-              account2: {
-                metadata: {
-                  keyring: {
-                    type: 'Trezor Hardware',
+    jestIt(
+      'returns true if feature flag is enabled, is a HW and is Ethereum network',
+      () => {
+        const state = createSwapsMockStore();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            internalAccounts: {
+              ...state.metamask.internalAccounts,
+              selectedAccount: 'account2',
+              accounts: {
+                account2: {
+                  metadata: {
+                    keyring: {
+                      type: 'Trezor Hardware',
+                    },
                   },
                 },
               },
             },
           },
-        },
-      };
-      expect(getSmartTransactionsEnabled(newState)).toBe(true);
-    });
+        };
+        expect(getSmartTransactionsEnabled(newState)).toBe(true);
+      },
+    );
 
-    it('returns false if feature flag is enabled, not a HW and is Polygon network', () => {
-      const state = createSwapsMockStore();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
-        },
-      };
-      expect(getSmartTransactionsEnabled(newState)).toBe(false);
-    });
+    jestIt(
+      'returns false if feature flag is enabled, not a HW and is Polygon network',
+      () => {
+        const state = createSwapsMockStore();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
+          },
+        };
+        expect(getSmartTransactionsEnabled(newState)).toBe(false);
+      },
+    );
 
-    it('returns false if feature flag is enabled, not a HW and is BSC network', () => {
-      const state = createSwapsMockStore();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          ...mockNetworkState({ chainId: CHAIN_IDS.BSC }),
-        },
-      };
-      expect(getSmartTransactionsEnabled(newState)).toBe(false);
-    });
+    jestIt(
+      'returns false if feature flag is enabled, not a HW and is BSC network',
+      () => {
+        const state = createSwapsMockStore();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            ...mockNetworkState({ chainId: CHAIN_IDS.BSC }),
+          },
+        };
+        expect(getSmartTransactionsEnabled(newState)).toBe(false);
+      },
+    );
 
-    it('returns false if feature flag is enabled, not a HW and is Linea network', () => {
-      const state = createSwapsMockStore();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          ...mockNetworkState({ chainId: CHAIN_IDS.LINEA_MAINNET }),
-        },
-      };
-      expect(getSmartTransactionsEnabled(newState)).toBe(false);
-    });
+    jestIt(
+      'returns false if feature flag is enabled, not a HW and is Linea network',
+      () => {
+        const state = createSwapsMockStore();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            ...mockNetworkState({ chainId: CHAIN_IDS.LINEA_MAINNET }),
+          },
+        };
+        expect(getSmartTransactionsEnabled(newState)).toBe(false);
+      },
+    );
 
-    it('returns false if a snap account is used', () => {
+    jestIt('returns false if a snap account is used', () => {
       const state = createSwapsMockStore();
       state.metamask.internalAccounts.selectedAccount =
         '36eb02e0-7925-47f0-859f-076608f09b69';
@@ -228,13 +261,16 @@ describe('Selectors', () => {
   });
 
   describe('getIsSmartTransaction', () => {
-    it('should return true if smart transactions are opt-in and enabled', () => {
-      const state = createMockState();
-      const result = getIsSmartTransaction(state);
-      expect(result).toBe(true);
-    });
+    jestIt(
+      'should return true if smart transactions are opt-in and enabled',
+      () => {
+        const state = createMockState();
+        const result = getIsSmartTransaction(state);
+        expect(result).toBe(true);
+      },
+    );
 
-    it('should return false if smart transactions are not opt-in', () => {
+    jestIt('should return false if smart transactions are not opt-in', () => {
       const state = createMockState();
       const newState = {
         ...state,
@@ -250,7 +286,7 @@ describe('Selectors', () => {
       expect(result).toBe(false);
     });
 
-    it('should return false if smart transactions are not enabled', () => {
+    jestIt('should return false if smart transactions are not enabled', () => {
       const state = createMockState();
       const newState = {
         ...state,
@@ -282,103 +318,121 @@ describe('Selectors', () => {
   });
 
   describe('getIsSmartTransactionsOptInModalAvailable', () => {
-    it('returns true for Ethereum Mainnet + supported RPC URL + null opt-in status and non-zero balance', () => {
-      const state = createMockState();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          preferences: {
-            ...state.metamask.preferences,
-            smartTransactionsOptInStatus: null,
-          },
-        },
-      };
-      expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(true);
-    });
-
-    it('returns false for Polygon Mainnet + supported RPC URL + null opt-in status and non-zero balance', () => {
-      const state = createMockState();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          preferences: {
-            ...state.metamask.preferences,
-            smartTransactionsOptInStatus: null,
-          },
-          ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
-        },
-      };
-      expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(false);
-    });
-
-    it('returns false for Ethereum Mainnet + unsupported RPC URL + null opt-in status and non-zero balance', () => {
-      const state = createMockState();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          preferences: {
-            ...state.metamask.preferences,
-            smartTransactionsOptInStatus: null,
-          },
-          ...mockNetworkState({
-            chainId: CHAIN_IDS.MAINNET,
-            rpcUrl: 'https://mainnet.quiknode.pro/',
-          }),
-        },
-      };
-      expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(false);
-    });
-
-    it('returns false for Ethereum Mainnet + supported RPC URL + true opt-in status and non-zero balance', () => {
-      const state = createMockState();
-      expect(getIsSmartTransactionsOptInModalAvailable(state)).toBe(false);
-    });
-
-    it('returns false for Ethereum Mainnet + supported RPC URL + null opt-in status and zero balance (0x0)', () => {
-      const state = createMockState();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          preferences: {
-            ...state.metamask.preferences,
-            smartTransactionsOptInStatus: null,
-          },
-          accounts: {
-            ...state.metamask.accounts,
-            '0x123': {
-              address: '0x123',
-              balance: '0x0',
+    jestIt(
+      'returns true for Ethereum Mainnet + supported RPC URL + null opt-in status and non-zero balance',
+      () => {
+        const state = createMockState();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            preferences: {
+              ...state.metamask.preferences,
+              smartTransactionsOptInStatus: null,
             },
           },
-        },
-      };
-      expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(false);
-    });
+        };
+        expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(true);
+      },
+    );
 
-    it('returns false for Ethereum Mainnet + supported RPC URL + null opt-in status and zero balance (0x00)', () => {
-      const state = createMockState();
-      const newState = {
-        ...state,
-        metamask: {
-          ...state.metamask,
-          preferences: {
-            ...state.metamask.preferences,
-            smartTransactionsOptInStatus: null,
+    jestIt(
+      'returns false for Polygon Mainnet + supported RPC URL + null opt-in status and non-zero balance',
+      () => {
+        const state = createMockState();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            preferences: {
+              ...state.metamask.preferences,
+              smartTransactionsOptInStatus: null,
+            },
+            ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
           },
-          accounts: {
-            ...state.metamask.accounts,
-            '0x123': {
-              address: '0x123',
-              balance: '0x00',
+        };
+        expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(false);
+      },
+    );
+
+    jestIt(
+      'returns false for Ethereum Mainnet + unsupported RPC URL + null opt-in status and non-zero balance',
+      () => {
+        const state = createMockState();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            preferences: {
+              ...state.metamask.preferences,
+              smartTransactionsOptInStatus: null,
+            },
+            ...mockNetworkState({
+              chainId: CHAIN_IDS.MAINNET,
+              rpcUrl: 'https://mainnet.quiknode.pro/',
+            }),
+          },
+        };
+        expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(false);
+      },
+    );
+
+    jestIt(
+      'returns false for Ethereum Mainnet + supported RPC URL + true opt-in status and non-zero balance',
+      () => {
+        const state = createMockState();
+        expect(getIsSmartTransactionsOptInModalAvailable(state)).toBe(false);
+      },
+    );
+
+    jestIt(
+      'returns false for Ethereum Mainnet + supported RPC URL + null opt-in status and zero balance (0x0)',
+      () => {
+        const state = createMockState();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            preferences: {
+              ...state.metamask.preferences,
+              smartTransactionsOptInStatus: null,
+            },
+            accounts: {
+              ...state.metamask.accounts,
+              '0x123': {
+                address: '0x123',
+                balance: '0x0',
+              },
             },
           },
-        },
-      };
-      expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(false);
-    });
+        };
+        expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(false);
+      },
+    );
+
+    jestIt(
+      'returns false for Ethereum Mainnet + supported RPC URL + null opt-in status and zero balance (0x00)',
+      () => {
+        const state = createMockState();
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            preferences: {
+              ...state.metamask.preferences,
+              smartTransactionsOptInStatus: null,
+            },
+            accounts: {
+              ...state.metamask.accounts,
+              '0x123': {
+                address: '0x123',
+                balance: '0x00',
+              },
+            },
+          },
+        };
+        expect(getIsSmartTransactionsOptInModalAvailable(newState)).toBe(false);
+      },
+    );
   });
 });

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -60,14 +60,17 @@ type SmartTransactionsMetaMaskState = {
 
 /**
  * Returns the user's explicit opt-in status for the smart transactions feature.
+ * This should only be used for reading the user's internal opt-in status, and
+ * not for determining if the smart transactions user preference is enabled.
  *
- * Do not export this selector. It should only be used internally within this file.
+ * To determine if the smart transactions user preference is enabled, use
+ * getSmartTransactionsPreferenceEnabled instead.
  *
  * @param state - The state object.
  * @returns true if the user has explicitly opted in, false if they have opted out,
  * or null if they have not explicitly opted in or out.
  */
-const getSmartTransactionsOptInStatusInternal = createSelector(
+export const getSmartTransactionsOptInStatusInternal = createSelector(
   getPreferences,
   (preferences: {
     smartTransactionsOptInStatus?: boolean | null;

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect';
 import {
   getAllowedSmartTransactionsChainIds,
   SKIP_STX_RPC_URL_CHECK_CHAIN_IDS,
@@ -7,6 +8,7 @@ import {
   getCurrentNetwork,
   accountSupportsSmartTx,
   getSelectedAccount,
+  getPreferences,
   // TODO: Remove restricted import
   // eslint-disable-next-line import/no-restricted-paths
 } from '../../../ui/selectors/selectors'; // TODO: Migrate shared selectors to this file.
@@ -56,11 +58,57 @@ type SmartTransactionsMetaMaskState = {
   };
 };
 
-export const getSmartTransactionsOptInStatus = (
-  state: SmartTransactionsMetaMaskState,
-): boolean | null => {
-  return state.metamask.preferences?.smartTransactionsOptInStatus ?? null;
-};
+/**
+ * Returns the user's explicit opt-in status for the smart transactions feature.
+ *
+ * Do not export this selector. It should only be used internally within this file.
+ *
+ * @param state - The state object.
+ * @returns true if the user has explicitly opted in, false if they have opted out,
+ * or null if they have not explicitly opted in or out.
+ */
+const getSmartTransactionOptInStatusInternal = createSelector(
+  getPreferences,
+  (preferences: {
+    smartTransactionsOptInStatus?: boolean | null;
+  }): boolean | null => {
+    return preferences?.smartTransactionsOptInStatus ?? null;
+  },
+);
+
+/**
+ * Returns the user's explicit opt-in status for the smart transactions feature.
+ * This should only be used for metrics collection, and not for determining if the
+ * smart transactions user preference is enabled.
+ *
+ * To determine if the smart transactions user preference is enabled, use
+ * getSmartTransactionsPreferenceEnabled instead.
+ *
+ * @param state - The state object.
+ * @returns true if the user has explicitly opted in, false if they have opted out,
+ * or null if they have not explicitly opted in or out.
+ */
+export const getSmartTransactionsOptInStatusForMetrics = createSelector(
+  getSmartTransactionOptInStatusInternal,
+  (optInStatus: boolean | null): boolean | null => optInStatus,
+);
+
+/**
+ * Returns the user's preference for the smart transactions feature.
+ * Defaults to `true` if the user has not set a preference.
+ *
+ * @param state
+ * @returns
+ */
+export const getSmartTransactionsPreferenceEnabled = createSelector(
+  getSmartTransactionOptInStatusInternal,
+  (optInStatus: boolean | null): boolean => {
+    // In the absence of an explicit opt-in or opt-out,
+    // the Smart Transactions toggle is enabled.
+    const DEFAULT_SMART_TRANSACTIONS_ENABLED = true;
+    return optInStatus ?? DEFAULT_SMART_TRANSACTIONS_ENABLED;
+  },
+);
 
 export const getCurrentChainSupportsSmartTransactions = (
   state: SmartTransactionsMetaMaskState,
@@ -105,7 +153,7 @@ export const getIsSmartTransactionsOptInModalAvailable = (
   return (
     getCurrentChainSupportsSmartTransactions(state) &&
     getIsAllowedRpcUrlForSmartTransactions(state) &&
-    getSmartTransactionsOptInStatus(state) === null &&
+    getSmartTransactionsOptInStatusForMetrics(state) === null &&
     hasNonZeroBalance(state)
   );
 };
@@ -132,7 +180,8 @@ export const getSmartTransactionsEnabled = (
 export const getIsSmartTransaction = (
   state: SmartTransactionsMetaMaskState,
 ): boolean => {
-  const smartTransactionsOptInStatus = getSmartTransactionsOptInStatus(state);
+  const smartTransactionsOptInStatus =
+    getSmartTransactionsPreferenceEnabled(state);
   const smartTransactionsEnabled = getSmartTransactionsEnabled(state);
   return Boolean(smartTransactionsOptInStatus && smartTransactionsEnabled);
 };

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -180,8 +180,10 @@ export const getSmartTransactionsEnabled = (
 export const getIsSmartTransaction = (
   state: SmartTransactionsMetaMaskState,
 ): boolean => {
-  const smartTransactionsOptInStatus =
+  const smartTransactionsPreferenceEnabled =
     getSmartTransactionsPreferenceEnabled(state);
   const smartTransactionsEnabled = getSmartTransactionsEnabled(state);
-  return Boolean(smartTransactionsOptInStatus && smartTransactionsEnabled);
+  return Boolean(
+    smartTransactionsPreferenceEnabled && smartTransactionsEnabled,
+  );
 };

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -134,29 +134,8 @@ const getIsAllowedRpcUrlForSmartTransactions = (
   return rpcUrl?.hostname?.endsWith('.infura.io');
 };
 
-/**
- * Checks if the selected account has a non-zero balance.
- *
- * @param state - The state object containing account information.
- * @returns true if the selected account has a non-zero balance, otherwise false.
- */
-const hasNonZeroBalance = (state: SmartTransactionsMetaMaskState) => {
-  const selectedAccount = getSelectedAccount(
-    state as unknown as MultichainState,
-  );
-  return BigInt(selectedAccount?.balance || '0x0') > 0n;
-};
-
-export const getIsSmartTransactionsOptInModalAvailable = (
-  state: SmartTransactionsMetaMaskState,
-) => {
-  return (
-    getCurrentChainSupportsSmartTransactions(state) &&
-    getIsAllowedRpcUrlForSmartTransactions(state) &&
-    getSmartTransactionsOptInStatusForMetrics(state) === null &&
-    hasNonZeroBalance(state)
-  );
-};
+// TODO(dbrans): Remove the opt-in modal once default opt-in is stable.
+export const getIsSmartTransactionsOptInModalAvailable = () => false;
 
 export const getSmartTransactionsEnabled = (
   state: SmartTransactionsMetaMaskState,

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -67,7 +67,7 @@ type SmartTransactionsMetaMaskState = {
  * @returns true if the user has explicitly opted in, false if they have opted out,
  * or null if they have not explicitly opted in or out.
  */
-const getSmartTransactionOptInStatusInternal = createSelector(
+const getSmartTransactionsOptInStatusInternal = createSelector(
   getPreferences,
   (preferences: {
     smartTransactionsOptInStatus?: boolean | null;
@@ -89,7 +89,7 @@ const getSmartTransactionOptInStatusInternal = createSelector(
  * or null if they have not explicitly opted in or out.
  */
 export const getSmartTransactionsOptInStatusForMetrics = createSelector(
-  getSmartTransactionOptInStatusInternal,
+  getSmartTransactionsOptInStatusInternal,
   (optInStatus: boolean | null): boolean | null => optInStatus,
 );
 
@@ -101,7 +101,7 @@ export const getSmartTransactionsOptInStatusForMetrics = createSelector(
  * @returns
  */
 export const getSmartTransactionsPreferenceEnabled = createSelector(
-  getSmartTransactionOptInStatusInternal,
+  getSmartTransactionsOptInStatusInternal,
   (optInStatus: boolean | null): boolean => {
     // In the absence of an explicit opt-in or opt-out,
     // the Smart Transactions toggle is enabled.
@@ -134,8 +134,29 @@ const getIsAllowedRpcUrlForSmartTransactions = (
   return rpcUrl?.hostname?.endsWith('.infura.io');
 };
 
-// TODO(dbrans): Remove the opt-in modal once default opt-in is stable.
-export const getIsSmartTransactionsOptInModalAvailable = () => false;
+/**
+ * Checks if the selected account has a non-zero balance.
+ *
+ * @param state - The state object containing account information.
+ * @returns true if the selected account has a non-zero balance, otherwise false.
+ */
+const hasNonZeroBalance = (state: SmartTransactionsMetaMaskState) => {
+  const selectedAccount = getSelectedAccount(
+    state as unknown as MultichainState,
+  );
+  return BigInt(selectedAccount?.balance || '0x0') > 0n;
+};
+
+export const getIsSmartTransactionsOptInModalAvailable = (
+  state: SmartTransactionsMetaMaskState,
+) => {
+  return (
+    getCurrentChainSupportsSmartTransactions(state) &&
+    getIsAllowedRpcUrlForSmartTransactions(state) &&
+    getSmartTransactionsOptInStatusInternal(state) === null &&
+    hasNonZeroBalance(state)
+  );
+};
 
 export const getSmartTransactionsEnabled = (
   state: SmartTransactionsMetaMaskState,

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -69,8 +69,9 @@ import {
   getSelectedInternalAccount,
 } from '../../selectors';
 import {
-  getSmartTransactionsOptInStatus,
   getSmartTransactionsEnabled,
+  getSmartTransactionsOptInStatusForMetrics,
+  getSmartTransactionsPreferenceEnabled,
 } from '../../../shared/modules/selectors';
 import {
   MetaMetricsEventCategory,
@@ -746,7 +747,6 @@ export const fetchQuotesAndSetQuoteState = (
     const hardwareWalletType = getHardwareWalletType(state);
     const networkAndAccountSupports1559 =
       checkNetworkAndAccountSupports1559(state);
-    const smartTransactionsOptInStatus = getSmartTransactionsOptInStatus(state);
     const smartTransactionsEnabled = getSmartTransactionsEnabled(state);
     const currentSmartTransactionsEnabled =
       getCurrentSmartTransactionsEnabled(state);
@@ -764,7 +764,7 @@ export const fetchQuotesAndSetQuoteState = (
         hardware_wallet_type: hardwareWalletType,
         stx_enabled: smartTransactionsEnabled,
         current_stx_enabled: currentSmartTransactionsEnabled,
-        stx_user_opt_in: smartTransactionsOptInStatus,
+        stx_user_opt_in: getSmartTransactionsOptInStatusForMetrics(state),
         anonymizedData: true,
       },
     });
@@ -784,7 +784,8 @@ export const fetchQuotesAndSetQuoteState = (
             balanceError,
             sourceDecimals: fromTokenDecimals,
             enableGasIncludedQuotes:
-              currentSmartTransactionsEnabled && smartTransactionsOptInStatus,
+              currentSmartTransactionsEnabled &&
+              getSmartTransactionsPreferenceEnabled(state),
           },
           {
             sourceTokenInfo,
@@ -819,7 +820,7 @@ export const fetchQuotesAndSetQuoteState = (
             hardware_wallet_type: hardwareWalletType,
             stx_enabled: smartTransactionsEnabled,
             current_stx_enabled: currentSmartTransactionsEnabled,
-            stx_user_opt_in: smartTransactionsOptInStatus,
+            stx_user_opt_in: getSmartTransactionsOptInStatusForMetrics(state),
           },
         });
         dispatch(setSwapsErrorKey(QUOTES_NOT_AVAILABLE_ERROR));
@@ -856,7 +857,7 @@ export const fetchQuotesAndSetQuoteState = (
             hardware_wallet_type: hardwareWalletType,
             stx_enabled: smartTransactionsEnabled,
             current_stx_enabled: currentSmartTransactionsEnabled,
-            stx_user_opt_in: smartTransactionsOptInStatus,
+            stx_user_opt_in: getSmartTransactionsOptInStatusForMetrics(state),
             anonymizedData: true,
           },
         });
@@ -910,7 +911,6 @@ export const signAndSendSwapsSmartTransaction = ({
       usedQuote.destinationAmount,
       destinationTokenInfo.decimals || 18,
     ).toPrecision(8);
-    const smartTransactionsOptInStatus = getSmartTransactionsOptInStatus(state);
     const smartTransactionsEnabled = getSmartTransactionsEnabled(state);
     const currentSmartTransactionsEnabled =
       getCurrentSmartTransactionsEnabled(state);
@@ -937,7 +937,7 @@ export const signAndSendSwapsSmartTransaction = ({
       hardware_wallet_type: hardwareWalletType,
       stx_enabled: smartTransactionsEnabled,
       current_stx_enabled: currentSmartTransactionsEnabled,
-      stx_user_opt_in: smartTransactionsOptInStatus,
+      stx_user_opt_in: getSmartTransactionsOptInStatusForMetrics(state),
       gas_included: usedQuote.isGasIncludedTrade,
       ...additionalTrackingParams,
     };
@@ -1180,7 +1180,6 @@ export const signAndSendTransactions = (
       numberOfDecimals: 6,
     });
 
-    const smartTransactionsOptInStatus = getSmartTransactionsOptInStatus(state);
     const smartTransactionsEnabled = getSmartTransactionsEnabled(state);
     const currentSmartTransactionsEnabled =
       getCurrentSmartTransactionsEnabled(state);
@@ -1212,7 +1211,7 @@ export const signAndSendTransactions = (
       hardware_wallet_type: getHardwareWalletType(state),
       stx_enabled: smartTransactionsEnabled,
       current_stx_enabled: currentSmartTransactionsEnabled,
-      stx_user_opt_in: smartTransactionsOptInStatus,
+      stx_user_opt_in: getSmartTransactionsOptInStatusForMetrics(state),
       ...additionalTrackingParams,
     };
 

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -178,7 +178,7 @@ export default class ConfirmTransactionBase extends Component {
     isUserOpContractDeployError: PropTypes.bool,
     useMaxValue: PropTypes.bool,
     maxValue: PropTypes.string,
-    smartTransactionsOptInStatus: PropTypes.bool,
+    smartTransactionsPreferenceEnabled: PropTypes.bool,
     currentChainSupportsSmartTransactions: PropTypes.bool,
     selectedNetworkClientId: PropTypes.string,
     isSmartTransactionsEnabled: PropTypes.bool,
@@ -1019,7 +1019,7 @@ export default class ConfirmTransactionBase extends Component {
       txData: { origin, chainId: txChainId } = {},
       getNextNonce,
       tryReverseResolveAddress,
-      smartTransactionsOptInStatus,
+      smartTransactionsPreferenceEnabled,
       currentChainSupportsSmartTransactions,
       setSwapsFeatureFlags,
       fetchSmartTransactionsLiveness,
@@ -1071,7 +1071,10 @@ export default class ConfirmTransactionBase extends Component {
 
     window.addEventListener('beforeunload', this._beforeUnloadForGasPolling);
 
-    if (smartTransactionsOptInStatus && currentChainSupportsSmartTransactions) {
+    if (
+      smartTransactionsPreferenceEnabled &&
+      currentChainSupportsSmartTransactions
+    ) {
       // TODO: Fetching swaps feature flags, which include feature flags for smart transactions, is only a short-term solution.
       // Long-term, we want to have a new proxy service specifically for feature flags.
       Promise.all([

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
@@ -59,10 +59,10 @@ import {
 } from '../../../selectors';
 import {
   getCurrentChainSupportsSmartTransactions,
-  getSmartTransactionsOptInStatus,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   getSmartTransactionsEnabled,
   ///: END:ONLY_INCLUDE_IF
+  getSmartTransactionsPreferenceEnabled,
 } from '../../../../shared/modules/selectors';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import {
@@ -185,7 +185,8 @@ const mapStateToProps = (state, ownProps) => {
     data,
   } = (transaction && transaction.txParams) || txParams;
   const accounts = getMetaMaskAccounts(state);
-  const smartTransactionsOptInStatus = getSmartTransactionsOptInStatus(state);
+  const smartTransactionsPreferenceEnabled =
+    getSmartTransactionsPreferenceEnabled(state);
   const currentChainSupportsSmartTransactions =
     getCurrentChainSupportsSmartTransactions(state);
 
@@ -364,7 +365,7 @@ const mapStateToProps = (state, ownProps) => {
     isUserOpContractDeployError,
     useMaxValue,
     maxValue,
-    smartTransactionsOptInStatus,
+    smartTransactionsPreferenceEnabled,
     currentChainSupportsSmartTransactions,
     hasPriorityApprovalRequest,
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -51,7 +51,6 @@ import {
   getAccountType,
   ///: END:ONLY_INCLUDE_IF
 } from '../../selectors';
-import { getIsSmartTransactionsOptInModalAvailable } from '../../../shared/modules/selectors';
 
 import {
   closeNotificationPopup,

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -223,8 +223,10 @@ const mapStateToProps = (state) => {
     custodianDeepLink: getCustodianDeepLink(state),
     accountType: getAccountType(state),
     ///: END:ONLY_INCLUDE_IF
-    isSmartTransactionsOptInModalAvailable:
-      getIsSmartTransactionsOptInModalAvailable(state),
+
+    // Set to false to prevent the opt-in modal from showing.
+    // TODO(dbrans): Remove opt-in modal once default opt-in is stable.
+    isSmartTransactionsOptInModalAvailable: false,
     showMultiRpcModal: state.metamask.preferences.showMultiRpcModal,
   };
 };

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -30,7 +30,6 @@ import {
   getNftDetectionEnablementToast,
   getCurrentNetwork,
 } from '../../selectors';
-import { getSmartTransactionsOptInStatus } from '../../../shared/modules/selectors';
 import {
   lockMetamask,
   hideImportNftsModal,
@@ -118,7 +117,6 @@ function mapStateToProps(state) {
     allAccountsOnNetworkAreEmpty: getAllAccountsOnNetworkAreEmpty(state),
     isTestNet: getIsTestnet(state),
     showExtensionInFullSizeView: getShowExtensionInFullSizeView(state),
-    smartTransactionsOptInStatus: getSmartTransactionsOptInStatus(state),
     currentChainId: getCurrentChainId(state),
     shouldShowSeedPhraseReminder: getShouldShowSeedPhraseReminder(state),
     forgottenPassword: state.metamask.forgottenPassword,

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -46,12 +46,12 @@ export default class AdvancedTab extends PureComponent {
     sendHexData: PropTypes.bool,
     showFiatInTestnets: PropTypes.bool,
     showTestNetworks: PropTypes.bool,
-    smartTransactionsOptInStatus: PropTypes.bool,
+    smartTransactionsEnabled: PropTypes.bool,
     autoLockTimeLimit: PropTypes.number,
     setAutoLockTimeLimit: PropTypes.func.isRequired,
     setShowFiatConversionOnTestnetsPreference: PropTypes.func.isRequired,
     setShowTestNetworks: PropTypes.func.isRequired,
-    setSmartTransactionsOptInStatus: PropTypes.func.isRequired,
+    setSmartTransactionsEnabled: PropTypes.func.isRequired,
     setDismissSeedBackUpReminder: PropTypes.func.isRequired,
     dismissSeedBackUpReminder: PropTypes.bool.isRequired,
     backupUserData: PropTypes.func.isRequired,
@@ -199,7 +199,7 @@ export default class AdvancedTab extends PureComponent {
 
   renderToggleStxOptIn() {
     const { t } = this.context;
-    const { smartTransactionsOptInStatus, setSmartTransactionsOptInStatus } =
+    const { smartTransactionsEnabled, setSmartTransactionsEnabled } =
       this.props;
 
     const learMoreLink = (
@@ -237,10 +237,10 @@ export default class AdvancedTab extends PureComponent {
 
         <div className="settings-page__content-item-col">
           <ToggleButton
-            value={smartTransactionsOptInStatus}
+            value={smartTransactionsEnabled}
             onToggle={(oldValue) => {
               const newValue = !oldValue;
-              setSmartTransactionsOptInStatus(newValue);
+              setSmartTransactionsEnabled(newValue);
             }}
             offLabel={t('off')}
             onLabel={t('on')}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -9,7 +9,7 @@ import AdvancedTab from '.';
 const mockSetAutoLockTimeLimit = jest.fn().mockReturnValue({ type: 'TYPE' });
 const mockSetShowTestNetworks = jest.fn();
 const mockSetShowFiatConversionOnTestnetsPreference = jest.fn();
-const mockSetStxOptIn = jest.fn();
+const mockSetStxPrefEnabled = jest.fn();
 
 jest.mock('../../../store/actions.ts', () => {
   return {
@@ -17,7 +17,7 @@ jest.mock('../../../store/actions.ts', () => {
     setShowTestNetworks: () => mockSetShowTestNetworks,
     setShowFiatConversionOnTestnetsPreference: () =>
       mockSetShowFiatConversionOnTestnetsPreference,
-    setSmartTransactionsOptInStatus: () => mockSetStxOptIn,
+    setSmartTransactionsPreferenceEnabled: () => mockSetStxPrefEnabled,
   };
 });
 
@@ -102,7 +102,7 @@ describe('AdvancedTab Component', () => {
       const { queryByTestId } = renderWithProvider(<AdvancedTab />, mockStore);
       const toggleButton = queryByTestId('settings-page-stx-opt-in-toggle');
       fireEvent.click(toggleButton);
-      expect(mockSetStxOptIn).toHaveBeenCalled();
+      expect(mockSetStxPrefEnabled).toHaveBeenCalled();
     });
   });
 });

--- a/ui/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.container.js
@@ -12,10 +12,11 @@ import {
   setShowExtensionInFullSizeView,
   setShowFiatConversionOnTestnetsPreference,
   setShowTestNetworks,
-  setSmartTransactionsOptInStatus,
+  setSmartTransactionsPreferenceEnabled,
   setUseNonceField,
   showModal,
 } from '../../../store/actions';
+import { getSmartTransactionsPreferenceEnabled } from '../../../../shared/modules/selectors';
 import AdvancedTab from './advanced-tab.component';
 
 export const mapStateToProps = (state) => {
@@ -32,7 +33,6 @@ export const mapStateToProps = (state) => {
     showFiatInTestnets,
     showTestNetworks,
     showExtensionInFullSizeView,
-    smartTransactionsOptInStatus,
     autoLockTimeLimit = DEFAULT_AUTO_LOCK_TIME_LIMIT,
   } = getPreferences(state);
 
@@ -42,7 +42,7 @@ export const mapStateToProps = (state) => {
     showFiatInTestnets,
     showTestNetworks,
     showExtensionInFullSizeView,
-    smartTransactionsOptInStatus,
+    smartTransactionsEnabled: getSmartTransactionsPreferenceEnabled(state),
     autoLockTimeLimit,
     useNonceField,
     dismissSeedBackUpReminder,
@@ -67,8 +67,8 @@ export const mapDispatchToProps = (dispatch) => {
     setShowExtensionInFullSizeView: (value) => {
       return dispatch(setShowExtensionInFullSizeView(value));
     },
-    setSmartTransactionsOptInStatus: (value) => {
-      return dispatch(setSmartTransactionsOptInStatus(value));
+    setSmartTransactionsEnabled: (value) => {
+      return dispatch(setSmartTransactionsPreferenceEnabled(value));
     },
     setAutoLockTimeLimit: (value) => {
       return dispatch(setAutoLockTimeLimit(value));

--- a/ui/pages/smart-transactions/components/smart-transactions-opt-in-modal.test.tsx
+++ b/ui/pages/smart-transactions/components/smart-transactions-opt-in-modal.test.tsx
@@ -7,7 +7,7 @@ import {
   renderWithProvider,
   createSwapsMockStore,
 } from '../../../../test/jest';
-import { setSmartTransactionsOptInStatus } from '../../../store/actions';
+import { setSmartTransactionsPreferenceEnabled } from '../../../store/actions';
 import SmartTransactionsOptInModal from './smart-transactions-opt-in-modal';
 
 const middleware = [thunk];
@@ -35,8 +35,8 @@ describe('SmartTransactionsOptInModal', () => {
   });
 
   it('calls setSmartTransactionsOptInStatus with false when the "No thanks" link is clicked', () => {
-    (setSmartTransactionsOptInStatus as jest.Mock).mockImplementationOnce(() =>
-      jest.fn(),
+    (setSmartTransactionsPreferenceEnabled as jest.Mock).mockImplementationOnce(
+      () => jest.fn(),
     );
     const store = configureMockStore(middleware)(createSwapsMockStore());
     const { getByText } = renderWithProvider(
@@ -48,12 +48,12 @@ describe('SmartTransactionsOptInModal', () => {
     );
     const noThanksLink = getByText('No thanks');
     fireEvent.click(noThanksLink);
-    expect(setSmartTransactionsOptInStatus).toHaveBeenCalledWith(false);
+    expect(setSmartTransactionsPreferenceEnabled).toHaveBeenCalledWith(false);
   });
 
   it('calls setSmartTransactionsOptInStatus with true when the "Enable" button is clicked', () => {
-    (setSmartTransactionsOptInStatus as jest.Mock).mockImplementationOnce(() =>
-      jest.fn(),
+    (setSmartTransactionsPreferenceEnabled as jest.Mock).mockImplementationOnce(
+      () => jest.fn(),
     );
     const store = configureMockStore(middleware)(createSwapsMockStore());
     const { getByText } = renderWithProvider(
@@ -65,6 +65,6 @@ describe('SmartTransactionsOptInModal', () => {
     );
     const enableButton = getByText('Enable');
     fireEvent.click(enableButton);
-    expect(setSmartTransactionsOptInStatus).toHaveBeenCalledWith(true);
+    expect(setSmartTransactionsPreferenceEnabled).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/pages/smart-transactions/components/smart-transactions-opt-in-modal.tsx
+++ b/ui/pages/smart-transactions/components/smart-transactions-opt-in-modal.tsx
@@ -28,7 +28,7 @@ import {
   Icon,
   IconName,
 } from '../../../components/component-library';
-import { setSmartTransactionsOptInStatus } from '../../../store/actions';
+import { setSmartTransactionsPreferenceEnabled } from '../../../store/actions';
 import { SMART_TRANSACTIONS_LEARN_MORE_URL } from '../../../../shared/constants/smartTransactions';
 
 export type SmartTransactionsOptInModalProps = {
@@ -166,12 +166,12 @@ export default function SmartTransactionsOptInModal({
   const dispatch = useDispatch();
 
   const handleEnableButtonClick = useCallback(() => {
-    dispatch(setSmartTransactionsOptInStatus(true));
+    dispatch(setSmartTransactionsPreferenceEnabled(true));
   }, [dispatch]);
 
   const handleNoThanksLinkClick = useCallback(() => {
     // Set the Smart Transactions opt-in status to false, so the opt-in modal is not shown again.
-    dispatch(setSmartTransactionsOptInStatus(false));
+    dispatch(setSmartTransactionsPreferenceEnabled(false));
   }, [dispatch]);
 
   useEffect(() => {

--- a/ui/pages/swaps/awaiting-signatures/awaiting-signatures.js
+++ b/ui/pages/swaps/awaiting-signatures/awaiting-signatures.js
@@ -15,8 +15,8 @@ import {
   getHardwareWalletType,
 } from '../../../selectors/selectors';
 import {
-  getSmartTransactionsOptInStatus,
   getSmartTransactionsEnabled,
+  getSmartTransactionsOptInStatusForMetrics,
 } from '../../../../shared/modules/selectors';
 import {
   DEFAULT_ROUTE,
@@ -47,7 +47,7 @@ export default function AwaitingSignatures() {
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);
   const smartTransactionsOptInStatus = useSelector(
-    getSmartTransactionsOptInStatus,
+    getSmartTransactionsOptInStatusForMetrics,
   );
   const smartTransactionsEnabled = useSelector(getSmartTransactionsEnabled);
   const currentSmartTransactionsEnabled = useSelector(

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -23,8 +23,8 @@ import {
   getFullTxData,
 } from '../../../selectors';
 import {
-  getSmartTransactionsOptInStatus,
   getSmartTransactionsEnabled,
+  getSmartTransactionsOptInStatusForMetrics,
 } from '../../../../shared/modules/selectors';
 
 import {
@@ -120,7 +120,7 @@ export default function AwaitingSwap({
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);
   const smartTransactionsOptInStatus = useSelector(
-    getSmartTransactionsOptInStatus,
+    getSmartTransactionsOptInStatusForMetrics,
   );
   const smartTransactionsEnabled = useSelector(getSmartTransactionsEnabled);
   const currentSmartTransactionsEnabled = useSelector(

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -46,8 +46,8 @@ import {
 } from '../../ducks/swaps/swaps';
 import { getCurrentNetworkTransactions } from '../../selectors';
 import {
-  getSmartTransactionsOptInStatus,
   getSmartTransactionsEnabled,
+  getSmartTransactionsOptInStatusForMetrics,
 } from '../../../shared/modules/selectors';
 import {
   AWAITING_SIGNATURES_ROUTE,
@@ -133,7 +133,7 @@ export default function Swap() {
   const reviewSwapClickedTimestamp = useSelector(getReviewSwapClickedTimestamp);
   const reviewSwapClicked = Boolean(reviewSwapClickedTimestamp);
   const smartTransactionsOptInStatus = useSelector(
-    getSmartTransactionsOptInStatus,
+    getSmartTransactionsOptInStatusForMetrics,
   );
   const smartTransactionsEnabled = useSelector(getSmartTransactionsEnabled);
   const currentSmartTransactionsEnabled = useSelector(

--- a/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
+++ b/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
@@ -16,8 +16,8 @@ import {
   getHardwareWalletType,
 } from '../../../selectors/selectors';
 import {
-  getSmartTransactionsOptInStatus,
   getSmartTransactionsEnabled,
+  getSmartTransactionsOptInStatusForMetrics,
 } from '../../../../shared/modules/selectors';
 import { I18nContext } from '../../../contexts/i18n';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -51,7 +51,7 @@ export default function LoadingSwapsQuotes({
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);
   const smartTransactionsOptInStatus = useSelector(
-    getSmartTransactionsOptInStatus,
+    getSmartTransactionsOptInStatusForMetrics,
   );
   const smartTransactionsEnabled = useSelector(getSmartTransactionsEnabled);
   const currentSmartTransactionsEnabled = useSelector(

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -69,8 +69,9 @@ import {
   getDataCollectionForMarketing,
 } from '../../../selectors';
 import {
-  getSmartTransactionsOptInStatus,
   getSmartTransactionsEnabled,
+  getSmartTransactionsPreferenceEnabled,
+  getSmartTransactionsOptInStatusForMetrics,
 } from '../../../../shared/modules/selectors';
 import {
   getValueFromWeiHex,
@@ -212,14 +213,15 @@ export default function PrepareSwapPage({
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);
   const smartTransactionsOptInStatus = useSelector(
-    getSmartTransactionsOptInStatus,
+    getSmartTransactionsOptInStatusForMetrics,
   );
   const smartTransactionsEnabled = useSelector(getSmartTransactionsEnabled);
   const currentSmartTransactionsEnabled = useSelector(
     getCurrentSmartTransactionsEnabled,
   );
   const isSmartTransaction =
-    currentSmartTransactionsEnabled && smartTransactionsOptInStatus;
+    useSelector(getSmartTransactionsPreferenceEnabled) &&
+    currentSmartTransactionsEnabled;
   const currentCurrency = useSelector(getCurrentCurrency);
   const fetchingQuotes = useSelector(getFetchingQuotes);
   const loadingComplete = !fetchingQuotes && areQuotesPresent;

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -58,8 +58,9 @@ import {
   getUSDConversionRate,
 } from '../../../selectors';
 import {
-  getSmartTransactionsOptInStatus,
+  getSmartTransactionsOptInStatusForMetrics,
   getSmartTransactionsEnabled,
+  getSmartTransactionsPreferenceEnabled,
 } from '../../../../shared/modules/selectors';
 import { getNativeCurrency, getTokens } from '../../../ducks/metamask/metamask';
 import {
@@ -240,7 +241,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   const nativeCurrencySymbol = useSelector(getNativeCurrency);
   const reviewSwapClickedTimestamp = useSelector(getReviewSwapClickedTimestamp);
   const smartTransactionsOptInStatus = useSelector(
-    getSmartTransactionsOptInStatus,
+    getSmartTransactionsOptInStatusForMetrics,
   );
   const smartTransactionsEnabled = useSelector(getSmartTransactionsEnabled);
   const swapsSTXLoading = useSelector(getSwapsSTXLoading);
@@ -280,7 +281,8 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   const unsignedTransaction = usedQuote.trade;
   const { isGasIncludedTrade } = usedQuote;
   const isSmartTransaction =
-    currentSmartTransactionsEnabled && smartTransactionsOptInStatus;
+    useSelector(getSmartTransactionsPreferenceEnabled) &&
+    currentSmartTransactionsEnabled;
 
   const [slippageErrorKey] = useState(() => {
     const slippage = Number(fetchParams?.slippage);

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -243,6 +243,9 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   const smartTransactionsOptInStatus = useSelector(
     getSmartTransactionsOptInStatusForMetrics,
   );
+  const smartTransactionsPreferenceEnabled = useSelector(
+    getSmartTransactionsPreferenceEnabled,
+  );
   const smartTransactionsEnabled = useSelector(getSmartTransactionsEnabled);
   const swapsSTXLoading = useSelector(getSwapsSTXLoading);
   const currentSmartTransactionsError = useSelector(
@@ -379,7 +382,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
       chainId,
       smartTransactionEstimatedGas:
         smartTransactionsEnabled &&
-        smartTransactionsOptInStatus &&
+        smartTransactionsPreferenceEnabled &&
         smartTransactionFees?.tradeTxFees,
       nativeCurrencySymbol,
       multiLayerL1ApprovalFeeTotal,
@@ -396,7 +399,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
     smartTransactionFees?.tradeTxFees,
     nativeCurrencySymbol,
     smartTransactionsEnabled,
-    smartTransactionsOptInStatus,
+    smartTransactionsPreferenceEnabled,
     multiLayerL1ApprovalFeeTotal,
   ]);
 
@@ -889,7 +892,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
       (currentSmartTransactionsEnabled &&
         (currentSmartTransactionsError || smartTransactionsError)) ||
       (currentSmartTransactionsEnabled &&
-        smartTransactionsOptInStatus &&
+        smartTransactionsPreferenceEnabled &&
         !smartTransactionFees?.tradeTxFees),
   );
 
@@ -1138,7 +1141,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
               initialAggId={usedQuote.aggregator}
               onQuoteDetailsIsOpened={trackQuoteDetailsOpened}
               hideEstimatedGasFee={
-                smartTransactionsEnabled && smartTransactionsOptInStatus
+                smartTransactionsEnabled && smartTransactionsPreferenceEnabled
               }
             />
           )

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -20,8 +20,8 @@ import {
   getRpcPrefsForCurrentProvider,
 } from '../../../selectors';
 import {
-  getSmartTransactionsOptInStatus,
   getSmartTransactionsEnabled,
+  getSmartTransactionsOptInStatusForMetrics,
 } from '../../../../shared/modules/selectors';
 import { SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../shared/constants/swaps';
 import {
@@ -78,9 +78,6 @@ export default function SmartTransactionStatusPage() {
     getCurrentSmartTransactions,
     isEqual,
   );
-  const smartTransactionsOptInStatus = useSelector(
-    getSmartTransactionsOptInStatus,
-  );
   const chainId = useSelector(getCurrentChainId);
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider, shallowEqual);
   const swapsNetworkConfig = useSelector(getSwapsNetworkConfig, shallowEqual);
@@ -128,7 +125,7 @@ export default function SmartTransactionStatusPage() {
     hardware_wallet_type: hardwareWalletType,
     stx_enabled: smartTransactionsEnabled,
     current_stx_enabled: currentSmartTransactionsEnabled,
-    stx_user_opt_in: smartTransactionsOptInStatus,
+    stx_user_opt_in: useSelector(getSmartTransactionsOptInStatusForMetrics),
   };
 
   let destinationValue;

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -102,7 +102,7 @@ import {
 } from '../../shared/constants/metametrics';
 import { parseSmartTransactionsError } from '../pages/swaps/swaps.util';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
-import { getSmartTransactionsOptInStatus } from '../../shared/modules/selectors';
+import { getSmartTransactionsOptInStatusForMetrics } from '../../shared/modules/selectors';
 import { NOTIFICATIONS_EXPIRATION_DELAY } from '../helpers/constants/notifications';
 import {
   fetchLocale,
@@ -3090,13 +3090,12 @@ export function setTokenSortConfig(value: SortCriteria) {
   return setPreference('tokenSortConfig', value, false);
 }
 
-export function setSmartTransactionsOptInStatus(
+export function setSmartTransactionsPreferenceEnabled(
   value: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch, getState) => {
-    const smartTransactionsOptInStatus = getSmartTransactionsOptInStatus(
-      getState(),
-    );
+    const smartTransactionsOptInStatus =
+      getSmartTransactionsOptInStatusForMetrics(getState());
     trackMetaMetricsEvent({
       category: MetaMetricsEventCategory.Settings,
       event: MetaMetricsEventName.SettingsUpdated,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -102,7 +102,7 @@ import {
 } from '../../shared/constants/metametrics';
 import { parseSmartTransactionsError } from '../pages/swaps/swaps.util';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
-import { getSmartTransactionsOptInStatusForMetrics } from '../../shared/modules/selectors';
+import { getSmartTransactionsOptInStatusInternal } from '../../shared/modules/selectors';
 import { NOTIFICATIONS_EXPIRATION_DELAY } from '../helpers/constants/notifications';
 import {
   fetchLocale,
@@ -3095,7 +3095,7 @@ export function setSmartTransactionsPreferenceEnabled(
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch, getState) => {
     const smartTransactionsOptInStatus =
-      getSmartTransactionsOptInStatusForMetrics(getState());
+      getSmartTransactionsOptInStatusInternal(getState());
     trackMetaMetricsEvent({
       category: MetaMetricsEventCategory.Settings,
       event: MetaMetricsEventName.SettingsUpdated,

--- a/yarn.lock
+++ b/yarn.lock
@@ -26100,6 +26100,7 @@ __metadata:
     "@ethersproject/providers": "npm:^5.7.2"
     "@ethersproject/wallet": "npm:^5.7.0"
     "@fortawesome/fontawesome-free": "npm:^5.13.0"
+    "@jest/globals": "npm:^29.7.0"
     "@keystonehq/bc-ur-registry-eth": "npm:^0.19.1"
     "@keystonehq/metamask-airgapped-keyring": "npm:^0.13.1"
     "@lavamoat/allow-scripts": "npm:^3.0.4"


### PR DESCRIPTION
## **Description**
This PR:
* enables smart transactions by default for new users
* prevents the smart transaction opt-in modal from appearing

To enable stx by default, we needed to replace the `getSmartTransactionsOptInStatus` selector with two distinct selectors:

- `getSmartTransactionsOptInStatusForMetrics`
- `getSmartTransactionsPreferenceEnabled` 

Previously, the `getSmartTransactionsOptInStatus` selector was doing double duty for the user's opt-in status and deciding whether the preference was enabled. Since the feature was disabled by default, and a user that has not opted-in or out of smart transactions has an opt-in status of null, this did not pose a problem.

However, since we decided to enable smart transactions by default, we needed a separate selector for checking the preference for deciding to enable stx.

### Why not keep the `getSmartTransactionsOptInStatus` selector as-is and just add a new one?
We considered keeping the `getSmartTransactionsOptInStatus` selector and adding a new one. However, by renaming it to `getSmartTransactionsOptInStatusForMetrics`, we avoid any confusion and make it clear that it is used for metrics collection and not for user preference handling.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27885?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TXL-435

## **Manual testing steps**

1. add an account with funds on mainnet
2. opt-in modal does not display
3. transfer 0ETH to yourself uses smart transaction
4. preferences toggle starts enabled
5. set preferences toggle off
6. transfer 0ETH to yourself uses regular transaction

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
