### PR TITLE
fix: fix currency display when tokenToFiatConversion rate is not avai…

### DIFF
--- a/ui/components/multichain/asset-picker-amount/swappable-currency-input/swappable-currency-input.tsx
+++ b/ui/components/multichain/asset-picker-amount/swappable-currency-input/swappable-currency-input.tsx
@@ -19,6 +19,7 @@ import {
 import CurrencyInput from '../../../app/currency-input';
 import { getIsFiatPrimary } from '../utils';
 import { NFTInput } from '../nft-input/nft-input';
+import useTokenExchangeRate from '../../../app/currency-input/hooks/useTokenExchangeRate';
 import SwapIcon from './swap-icon';
 
 type BaseProps = {
@@ -81,12 +82,17 @@ export function SwappableCurrencyInput({
   const t = useI18nContext();
 
   const isFiatPrimary = useSelector(getIsFiatPrimary);
+  const tokenToFiatConversionRate = useTokenExchangeRate(
+    asset?.details?.address,
+  );
   const isSetToMax = useSelector(getSendMaxModeState);
 
   const TokenComponent = (
     <CurrencyInput
       className="asset-picker-amount__input"
-      isFiatPreferred={isFiatPrimary}
+      isFiatPreferred={
+        isFiatPrimary && Boolean(tokenToFiatConversionRate?.toNumber())
+      }
       onChange={onAmountChange} // onChange controls disabled state, disabled if undefined
       hexValue={value}
       swapIcon={(onClick: React.MouseEventHandler) => (


### PR DESCRIPTION

## **Description**

When the fiat conversion for a token is not available; we should show the token balance.
The default behavior is working as expected; but when a user switches to a token where fiat conversions are available and clicks on the swap icon then goes back to the token with no conversions it will show USD when it should default to token value.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27893?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27805

## **Manual testing steps**

1. click on send
2. select account to send to
3. select token to send, preferably one with poor pricing data (ETH: 0xaec2e87e0a235266d9c5adc9deb4b2e29b54d009)
4. confirm that balance is undefined
5. select a token that has pricing data
6. use arrows on the right of the amount field to swap USD amount to token amount
7. reselect token to send in prior step
8. confirm that token balance now shows.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/1b97544b-adcd-424b-9da4-e360b7b94968


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/09cc9428-450a-47a8-a111-414c5996149c


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
