### PR TITLE
fix: flaky test `Wallet Revoke Permissions should revoke eth_accounts permissions via test dapp`

### DIFF
--- a/test/e2e/tests/dapp-interactions/revoke-permissions.spec.js
+++ b/test/e2e/tests/dapp-interactions/revoke-permissions.spec.js
@@ -24,7 +24,7 @@ describe('Wallet Revoke Permissions', function () {
         // Get initial accounts permissions
         await driver.clickElement('#getPermissions');
 
-        await driver.findElement({
+        await driver.waitForSelector({
           css: '#permissionsResult',
           text: 'eth_accounts',
         });
@@ -36,7 +36,7 @@ describe('Wallet Revoke Permissions', function () {
         await driver.clickElement('#getPermissions');
 
         // Eth_accounts permissions removed
-        await driver.findElement({
+        await driver.waitForSelector({
           css: '#permissionsResult',
           text: 'No permissions found.',
         });

--- a/test/e2e/tests/dapp-interactions/revoke-permissions.spec.js
+++ b/test/e2e/tests/dapp-interactions/revoke-permissions.spec.js
@@ -1,4 +1,3 @@
-const { strict: assert } = require('assert');
 const {
   withFixtures,
   openDapp,
@@ -25,12 +24,10 @@ describe('Wallet Revoke Permissions', function () {
         // Get initial accounts permissions
         await driver.clickElement('#getPermissions');
 
-        const permissionsResult = await driver.findElement(
-          '#permissionsResult',
-        );
-
-        // Eth_accounts permission
-        assert.equal(await permissionsResult.getText(), 'eth_accounts');
+        await driver.findElement({
+          css: '#permissionsResult',
+          text: 'eth_accounts',
+        });
 
         // Revoke eth_accounts permissions
         await driver.clickElement('#revokeAccountsPermission');
@@ -39,10 +36,10 @@ describe('Wallet Revoke Permissions', function () {
         await driver.clickElement('#getPermissions');
 
         // Eth_accounts permissions removed
-        assert.equal(
-          await permissionsResult.getText(),
-          'No permissions found.',
-        );
+        await driver.findElement({
+          css: '#permissionsResult',
+          text: 'No permissions found.',
+        });
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The problem is that this test is utilizing a wrong pattern where we are asserting the element by its text, instead of wait for the exact selector we want by text.
When when it's trying to assert the text, sometimes the value is empty.

![Screenshot from 2024-10-16 11-28-45](https://github.com/user-attachments/assets/846dcaaa-e15a-4265-87b8-578c820f6569)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27894?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27722

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
