### PR TITLE
chore: Cherry pick f523617a9 to v12.4.2

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -120,15 +120,9 @@ npmAuditIgnoreAdvisories:
   # upon old versions of ethereumjs-utils.
   - 'ethereum-cryptography (deprecation)'
 
-  # Currently only dependent on deprecated @metamask/types as it is brought in
-  # by @metamask/keyring-api. Updating the dependency in keyring-api will
-  # remove this.
-  - '@metamask/types (deprecation)'
-
-  # @metamask/keyring-api also depends on @metamask/snaps-ui which is
-  # deprecated. Replacing that dependency with @metamask/snaps-sdk will remove
-  # this.
-  - '@metamask/snaps-ui (deprecation)'
+  # Currently in use for the network list drag and drop functionality.
+  # Maintenance has stopped and the project will be archived in 2025.
+  - 'react-beautiful-dnd (deprecation)'
 
 npmRegistries:
   'https://npm.pkg.github.com':


### PR DESCRIPTION
Cherry picks f523617a9 (https://github.com/MetaMask/metamask-extension/pull/27856) to v12.4.2 RC branch