### PR TITLE
fix: hide options menu that was being shown for preinstalled Snaps

### DIFF
--- a/ui/components/app/snaps/snap-authorship-header/snap-authorship-header.js
+++ b/ui/components/app/snaps/snap-authorship-header/snap-authorship-header.js
@@ -39,7 +39,7 @@ const SnapAuthorshipHeader = ({
   const t = useI18nContext();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const { name: snapName } = useSelector((state) =>
+  const { name: snapName, hidden } = useSelector((state) =>
     getSnapMetadata(state, snapId),
   );
 
@@ -105,7 +105,7 @@ const SnapAuthorshipHeader = ({
           </Text>
         </Box>
       </Box>
-      {showInfo && (
+      {showInfo && !hidden && (
         <Box marginLeft="auto">
           <AvatarIcon
             className="snaps-authorship-header__button"

--- a/ui/pages/snaps/snap-view/snap-view.js
+++ b/ui/pages/snaps/snap-view/snap-view.js
@@ -105,12 +105,14 @@ function SnapView() {
             showInfo={false}
             startAccessory={renderBackButton()}
             endAccessory={
-              <SnapHomeMenu
-                snapId={snapId}
-                onSettingsClick={handleSettingsClick}
-                onRemoveClick={handleSnapRemove}
-                isSettingsAvailable={!snap.preinstalled}
-              />
+              !snap.hidden && (
+                <SnapHomeMenu
+                  snapId={snapId}
+                  onSettingsClick={handleSettingsClick}
+                  onRemoveClick={handleSnapRemove}
+                  isSettingsAvailable={!snap.preinstalled}
+                />
+              )
             }
           />
         )}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1612,6 +1612,7 @@ export const getSnapsMetadata = createDeepEqualSelector(
       snapsMetadata[snapId] = {
         name: manifest.proposedName,
         description: manifest.description,
+        hidden: snap.hidden,
       };
       return snapsMetadata;
     }, {});


### PR DESCRIPTION
## **Description**
This PR will hide Snaps `options menu` and `info icon` in Snaps header for **preinstalled Snaps**.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27937?quickstart=1)

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Go to Account watcher Snap and make sure that there is no button with three dots in Snaps header.
2. Go to ordinary Home Page Snap and make sure that three dots are available there.
3. Go to ordinary (non-preinstalled) custom UI Snap with confirmation popup of any type and make sure that there is Info icon in the right corner of the header.

## **Screenshots/Recordings**
### **Before**
![image](https://github.com/user-attachments/assets/8cf66b7e-6719-44ea-a976-da7b0a94eb4e)

### **After**
![Screenshot 2024-10-17 at 17 44 34](https://github.com/user-attachments/assets/c4014f2d-90ac-4ca1-bd92-095c2a859084)
![Screenshot 2024-10-17 at 17 45 26](https://github.com/user-attachments/assets/08e4fc79-ae24-43bd-bdf1-5b6d7883a075)
![Screenshot 2024-10-17 at 17 46 03](https://github.com/user-attachments/assets/43c9ec79-cf0c-4e01-b0b6-c8a301af2c46)

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.