### PR TITLE
fix: add snap dummy descriptions copied from ethereum provider and get revoke e2e test passing and snaps permissions unit tests passing

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1336,6 +1336,7 @@ export default class MetamaskController extends EventEmitter {
     const requireAllowlist = process.env.REQUIRE_SNAPS_ALLOWLIST;
 
     this.snapController = new SnapController({
+      dynamicPermissions: ['endowment:caip25'],
       environmentEndowmentPermissions: Object.values(EndowmentPermissions),
       excludedPermissions: {
         ...ExcludedSnapPermissions,

--- a/shared/constants/snaps/permissions.ts
+++ b/shared/constants/snaps/permissions.ts
@@ -3,6 +3,7 @@ export const EndowmentPermissions = Object.freeze({
   'endowment:transaction-insight': 'endowment:transaction-insight',
   'endowment:cronjob': 'endowment:cronjob',
   'endowment:ethereum-provider': 'endowment:ethereum-provider',
+  'endowment:caip25': 'endowment:caip25',
   'endowment:rpc': 'endowment:rpc',
   'endowment:webassembly': 'endowment:webassembly',
   'endowment:lifecycle-hooks': 'endowment:lifecycle-hooks',
@@ -22,4 +23,7 @@ export const ExcludedSnapPermissions = Object.freeze({
 
 export const ExcludedSnapEndowments = Object.freeze({});
 
-export const DynamicSnapPermissions = Object.freeze(['eth_accounts']);
+export const DynamicSnapPermissions = Object.freeze([
+  'eth_accounts',
+  'endowment:caip25',
+]);

--- a/shared/constants/snaps/permissions.ts
+++ b/shared/constants/snaps/permissions.ts
@@ -3,7 +3,6 @@ export const EndowmentPermissions = Object.freeze({
   'endowment:transaction-insight': 'endowment:transaction-insight',
   'endowment:cronjob': 'endowment:cronjob',
   'endowment:ethereum-provider': 'endowment:ethereum-provider',
-  'endowment:caip25': 'endowment:caip25',
   'endowment:rpc': 'endowment:rpc',
   'endowment:webassembly': 'endowment:webassembly',
   'endowment:lifecycle-hooks': 'endowment:lifecycle-hooks',
@@ -21,7 +20,9 @@ export const ExcludedSnapPermissions = Object.freeze({
     'eth_accounts is disabled. For more information please see https://github.com/MetaMask/snaps/issues/990.',
 });
 
-export const ExcludedSnapEndowments = Object.freeze({});
+export const ExcludedSnapEndowments = Object.freeze({
+  'endowment:caip25': 'endowment:caip25',
+});
 
 export const DynamicSnapPermissions = Object.freeze([
   'eth_accounts',

--- a/test/e2e/snaps/test-snap-revoke-perm.spec.js
+++ b/test/e2e/snaps/test-snap-revoke-perm.spec.js
@@ -8,7 +8,6 @@ const {
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
-// TODO: Resolve this before merging. I'm sure the linter will make sure of it though
 describe('Test Snap revoke permission', function () {
   it('can revoke a permission', async function () {
     await withFixtures(

--- a/test/e2e/snaps/test-snap-revoke-perm.spec.js
+++ b/test/e2e/snaps/test-snap-revoke-perm.spec.js
@@ -9,7 +9,7 @@ const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
 // TODO: Resolve this before merging. I'm sure the linter will make sure of it though
-describe.skip('Test Snap revoke permission', function () {
+describe('Test Snap revoke permission', function () {
   it('can revoke a permission', async function () {
     await withFixtures(
       {
@@ -119,7 +119,7 @@ describe.skip('Test Snap revoke permission', function () {
         });
 
         // try to click on options menu
-        await driver.clickElement('[data-testid="eth_accounts"]');
+        await driver.clickElement('[data-testid="endowment:caip25"]');
 
         // try to click on revoke permission
         await driver.clickElement({

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -55,6 +55,11 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     leftIcon: IconName.Eye,
     weight: PermissionWeight.eth_accounts,
   }),
+  [EndowmentPermissions['endowment:caip25']]: ({ t }) => ({
+    label: t('permission_ethereumAccounts'),
+    leftIcon: IconName.Eye,
+    weight: PermissionWeight.eth_accounts,
+  }),
   [PermissionNames.permittedChains]: ({ t }) => ({
     label: t('permission_walletSwitchEthereumChain'),
     leftIcon: IconName.Wifi,
@@ -356,16 +361,6 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     ]),
     leftIcon: IconName.Clock,
     weight: PermissionWeight.endowment_cronjob,
-  }),
-  [EndowmentPermissions['endowment:caip25']]: ({ t, subjectName }) => ({
-    label: t('permission_ethereumProvider'),
-    description: t('permission_ethereumProviderDescription', [
-      getSnapNameComponent(subjectName),
-    ]),
-    leftIcon: IconName.Ethereum,
-    weight: PermissionWeight.endowment_ethereumProvider,
-    id: 'ethereum-provider-access',
-    message: t('ethereumProviderAccess', [getSnapNameComponent(subjectName)]),
   }),
   [EndowmentPermissions['endowment:ethereum-provider']]: ({
     t,

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -357,6 +357,16 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     leftIcon: IconName.Clock,
     weight: PermissionWeight.endowment_cronjob,
   }),
+  [EndowmentPermissions['endowment:caip25']]: ({ t, subjectName }) => ({
+    label: t('permission_ethereumProvider'),
+    description: t('permission_ethereumProviderDescription', [
+      getSnapNameComponent(subjectName),
+    ]),
+    leftIcon: IconName.Ethereum,
+    weight: PermissionWeight.endowment_ethereumProvider,
+    id: 'ethereum-provider-access',
+    message: t('ethereumProviderAccess', [getSnapNameComponent(subjectName)]),
+  }),
   [EndowmentPermissions['endowment:ethereum-provider']]: ({
     t,
     subjectName,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27965?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**
<img width="1041" alt="image" src="https://github.com/user-attachments/assets/97cc5b98-1f65-4327-8d6b-a16df59001bb">
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
