### PR TITLE
fix: updated event name for site cell component

### DIFF
--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
@@ -100,7 +100,7 @@ export const SiteCell: React.FC<SiteCellProps> = ({
             setShowEditAccountsModal(true);
             trackEvent({
               category: MetaMetricsEventCategory.Navigation,
-              event: MetaMetricsEventName.TokenImportButtonClicked,
+              event: MetaMetricsEventName.ViewPermissionedAccounts,
               properties: {
                 location: 'Connect view, Permissions toast, Permissions (dapp)',
               },
@@ -133,7 +133,7 @@ export const SiteCell: React.FC<SiteCellProps> = ({
             setShowEditNetworksModal(true);
             trackEvent({
               category: MetaMetricsEventCategory.Navigation,
-              event: MetaMetricsEventName.TokenImportButtonClicked,
+              event: MetaMetricsEventName.ViewPermissionedNetworks,
               properties: {
                 location: 'Connect view, Permissions toast, Permissions (dapp)',
               },


### PR DESCRIPTION
This PR is to update the event name for metametrics in site cell component

## **Related issues**

Fixes: [https://github.com/MetaMask/MetaMask-planning/issues/3263](https://github.com/MetaMask/MetaMask-planning/issues/3263)

## **Manual testing steps**

1. Go to ui/contexts/metametrics.js
2. In trackEvent in this file, add a log to see the payload
3. Run extension with yarn start. Go to Permissions Page, click on edit button for accounts and networks and check the console to verify the payload.

## **Screenshots/Recordings**


### **Before**

NA
### **After**

NA
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
