### PR TITLE
fix: Reduce usage of scientific notation

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.test.ts
@@ -5,11 +5,7 @@ import mockState from '../../../../../../../test/data/mock-state.json';
 import { renderHookWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
 import useTokenExchangeRate from '../../../../../../components/app/currency-input/hooks/useTokenExchangeRate';
 import { useAssetDetails } from '../../../../hooks/useAssetDetails';
-import {
-  roundDisplayValue,
-  toNonScientificString,
-  useTokenValues,
-} from './use-token-values';
+import { toNonScientificString, useTokenValues } from './use-token-values';
 import { useDecodedTransactionData } from './useDecodedTransactionData';
 
 jest.mock('../../../../hooks/useAssetDetails', () => ({
@@ -129,38 +125,6 @@ describe('useTokenValues', () => {
       pending: false,
     });
   });
-});
-
-describe('roundDisplayValue', () => {
-  const TEST_CASES = [
-    { value: 0, rounded: '0' },
-    { value: 0.0000009, rounded: '<0.000001' },
-    { value: 0.0000456, rounded: '0.000046' },
-    { value: 0.0004567, rounded: '0.000457' },
-    { value: 0.003456, rounded: '0.00346' },
-    { value: 0.023456, rounded: '0.0235' },
-    { value: 0.125456, rounded: '0.125' },
-    { value: 1.0034, rounded: '1.003' },
-    { value: 1.034, rounded: '1.034' },
-    { value: 1.3034, rounded: '1.303' },
-    { value: 7, rounded: '7' },
-    { value: 7.1, rounded: '7.1' },
-    { value: 12.0345, rounded: '12.03' },
-    { value: 121.456, rounded: '121.5' },
-    { value: 1034.123, rounded: '1034' },
-    { value: 47361034.006, rounded: '47361034' },
-    { value: 12130982923409.555, rounded: '12130982923410' },
-  ];
-
-  // @ts-expect-error This is missing from the Mocha type definitions
-  it.each(TEST_CASES)(
-    'Round $value to "$rounded"',
-    ({ value, rounded }: { value: number; rounded: string }) => {
-      const actual = roundDisplayValue(value);
-
-      expect(actual).toEqual(rounded);
-    },
-  );
 });
 
 describe('toNonScientificString', () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
@@ -56,9 +56,46 @@ export const useTokenValues = (transactionMeta: TransactionMeta) => {
   const fiatDisplayValue =
     fiatValue && fiatFormatter(fiatValue, { shorten: true });
 
+  const displayTransferValue = roundDisplayValue(decodedTransferValue);
+
   return {
-    decodedTransferValue,
+    decodedTransferValue: toNonScientificString(decodedTransferValue),
+    displayTransferValue,
     fiatDisplayValue,
     pending,
   };
 };
+
+export function roundDisplayValue(decodedTransferValue: number): string {
+  switch (true) {
+    case decodedTransferValue === 0:
+      return '0';
+    case decodedTransferValue < 0.000001:
+      return '<0.000001';
+    case decodedTransferValue < 0.001:
+      return parseFloat(decodedTransferValue.toFixed(6)).toString();
+    case decodedTransferValue < 0.01:
+      return parseFloat(decodedTransferValue.toFixed(5)).toString();
+    case decodedTransferValue < 0.1:
+      return parseFloat(decodedTransferValue.toFixed(4)).toString();
+    case decodedTransferValue < 10:
+      return parseFloat(decodedTransferValue.toFixed(3)).toString();
+    case decodedTransferValue < 100:
+      return parseFloat(decodedTransferValue.toFixed(2)).toString();
+    case decodedTransferValue < 1000:
+      return parseFloat(decodedTransferValue.toFixed(1)).toString();
+    case decodedTransferValue < 10000:
+      return parseFloat(decodedTransferValue.toFixed(0)).toString();
+    default:
+      return parseFloat(decodedTransferValue.toFixed(0)).toString();
+  }
+}
+
+export function toNonScientificString(num: number): string {
+  if (num >= 10e-18) {
+    return num.toFixed(18).replace(/\.?0+$/u, '');
+  }
+
+  // keep in scientific notation
+  return num.toString();
+}

--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
@@ -3,10 +3,13 @@ import { isHexString } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 import { isBoolean } from 'lodash';
 import { useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Numeric } from '../../../../../../../shared/modules/Numeric';
 import useTokenExchangeRate from '../../../../../../components/app/currency-input/hooks/useTokenExchangeRate';
+import { getIntlLocale } from '../../../../../../ducks/locale/locale';
 import { useFiatFormatter } from '../../../../../../hooks/useFiatFormatter';
 import { useAssetDetails } from '../../../../hooks/useAssetDetails';
+import { formatAmount } from '../../../simulation-details/formatAmount';
 import { useDecodedTransactionData } from './useDecodedTransactionData';
 
 export const useTokenValues = (transactionMeta: TransactionMeta) => {
@@ -56,7 +59,11 @@ export const useTokenValues = (transactionMeta: TransactionMeta) => {
   const fiatDisplayValue =
     fiatValue && fiatFormatter(fiatValue, { shorten: true });
 
-  const displayTransferValue = roundDisplayValue(decodedTransferValue);
+  const locale = useSelector(getIntlLocale);
+  const displayTransferValue = formatAmount(
+    locale,
+    new BigNumber(decodedTransferValue),
+  );
 
   return {
     decodedTransferValue: toNonScientificString(decodedTransferValue),
@@ -65,31 +72,6 @@ export const useTokenValues = (transactionMeta: TransactionMeta) => {
     pending,
   };
 };
-
-export function roundDisplayValue(decodedTransferValue: number): string {
-  switch (true) {
-    case decodedTransferValue === 0:
-      return '0';
-    case decodedTransferValue < 0.000001:
-      return '<0.000001';
-    case decodedTransferValue < 0.001:
-      return parseFloat(decodedTransferValue.toFixed(6)).toString();
-    case decodedTransferValue < 0.01:
-      return parseFloat(decodedTransferValue.toFixed(5)).toString();
-    case decodedTransferValue < 0.1:
-      return parseFloat(decodedTransferValue.toFixed(4)).toString();
-    case decodedTransferValue < 10:
-      return parseFloat(decodedTransferValue.toFixed(3)).toString();
-    case decodedTransferValue < 100:
-      return parseFloat(decodedTransferValue.toFixed(2)).toString();
-    case decodedTransferValue < 1000:
-      return parseFloat(decodedTransferValue.toFixed(1)).toString();
-    case decodedTransferValue < 10000:
-      return parseFloat(decodedTransferValue.toFixed(0)).toString();
-    default:
-      return parseFloat(decodedTransferValue.toFixed(0)).toString();
-  }
-}
 
 export function toNonScientificString(num: number): string {
   if (num >= 10e-18) {

--- a/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from '../../../../../../../components/component-library';
 import Tooltip from '../../../../../../../components/ui/tooltip';
+import { getIntlLocale } from '../../../../../../../ducks/locale/locale';
 import {
   AlignItems,
   BackgroundColor,
@@ -17,18 +18,19 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../../../helpers/constants/design-system';
-import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
+import { MIN_AMOUNT } from '../../../../../../../hooks/useCurrencyDisplay';
 import { getWatchedToken } from '../../../../../../../selectors';
 import { MultichainState } from '../../../../../../../selectors/multichain';
 import { useConfirmContext } from '../../../../../context/confirm';
+import { formatAmountMaxPrecision } from '../../../../simulation-details/formatAmount';
 import { useTokenValues } from '../../hooks/use-token-values';
 import { useTokenDetails } from '../../hooks/useTokenDetails';
 import { ConfirmLoader } from '../confirm-loader/confirm-loader';
 
 const SendHeading = () => {
-  const t = useI18nContext();
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
+  const locale = useSelector(getIntlLocale);
   const selectedToken = useSelector((state: MultichainState) =>
     getWatchedToken(transactionMeta)(state),
   );
@@ -60,20 +62,21 @@ const SendHeading = () => {
   );
 
   const TokenValue =
-    displayTransferValue === decodedTransferValue.toString() ? (
-      <Text
-        variant={TextVariant.headingLg}
-        color={TextColor.inherit}
-        marginTop={3}
-      >{`${displayTransferValue} ${tokenSymbol || t('unknown')}`}</Text>
-    ) : (
+    displayTransferValue ===
+    `<${formatAmountMaxPrecision(locale, MIN_AMOUNT)}` ? (
       <Tooltip title={decodedTransferValue.toString()} position="right">
         <Text
           variant={TextVariant.headingLg}
           color={TextColor.inherit}
           marginTop={3}
-        >{`${displayTransferValue} ${tokenSymbol || t('unknown')}`}</Text>
+        >{`${displayTransferValue} ${tokenSymbol}`}</Text>
       </Tooltip>
+    ) : (
+      <Text
+        variant={TextVariant.headingLg}
+        color={TextColor.inherit}
+        marginTop={3}
+      >{`${displayTransferValue} ${tokenSymbol}`}</Text>
     );
 
   const TokenFiatValue = fiatDisplayValue && (

--- a/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Text,
 } from '../../../../../../../components/component-library';
+import Tooltip from '../../../../../../../components/ui/tooltip';
 import {
   AlignItems,
   BackgroundColor,
@@ -16,14 +17,16 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { getWatchedToken } from '../../../../../../../selectors';
 import { MultichainState } from '../../../../../../../selectors/multichain';
 import { useConfirmContext } from '../../../../../context/confirm';
-import { useTokenDetails } from '../../hooks/useTokenDetails';
 import { useTokenValues } from '../../hooks/use-token-values';
+import { useTokenDetails } from '../../hooks/useTokenDetails';
 import { ConfirmLoader } from '../confirm-loader/confirm-loader';
 
 const SendHeading = () => {
+  const t = useI18nContext();
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const selectedToken = useSelector((state: MultichainState) =>
@@ -33,8 +36,12 @@ const SendHeading = () => {
     transactionMeta,
     selectedToken,
   );
-  const { decodedTransferValue, fiatDisplayValue, pending } =
-    useTokenValues(transactionMeta);
+  const {
+    decodedTransferValue,
+    displayTransferValue,
+    fiatDisplayValue,
+    pending,
+  } = useTokenValues(transactionMeta);
 
   const TokenImage = (
     <AvatarToken
@@ -52,19 +59,27 @@ const SendHeading = () => {
     />
   );
 
-  const TokenValue = (
-    <>
+  const TokenValue =
+    displayTransferValue === decodedTransferValue.toString() ? (
       <Text
         variant={TextVariant.headingLg}
         color={TextColor.inherit}
         marginTop={3}
-      >{`${decodedTransferValue || ''} ${tokenSymbol}`}</Text>
-      {fiatDisplayValue && (
-        <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
-          {fiatDisplayValue}
-        </Text>
-      )}
-    </>
+      >{`${displayTransferValue} ${tokenSymbol || t('unknown')}`}</Text>
+    ) : (
+      <Tooltip title={decodedTransferValue.toString()} position="right">
+        <Text
+          variant={TextVariant.headingLg}
+          color={TextColor.inherit}
+          marginTop={3}
+        >{`${displayTransferValue} ${tokenSymbol || t('unknown')}`}</Text>
+      </Tooltip>
+    );
+
+  const TokenFiatValue = fiatDisplayValue && (
+    <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
+      {fiatDisplayValue}
+    </Text>
   );
 
   if (pending) {
@@ -81,6 +96,7 @@ const SendHeading = () => {
     >
       {TokenImage}
       {TokenValue}
+      {TokenFiatValue}
     </Box>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
     <h2
       class="mm-box mm-text mm-text--heading-lg mm-box--margin-top-3 mm-box--color-inherit"
     >
-       Unknown
+      0 Unknown
     </h2>
   </div>
   <div


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Implements the decimals rounding strategy outlined [in this document](https://www.notion.so/metamask-consensys/Simulation-Release-Candidate-Testing-Feedback-7dd07ced652f4a2b8dc2ae96cedc69a4#69762dea121347fda33440b6377b0994).

When the transfer value is rounded, a tooltip is shown with the full value without rounding. If the number has up to 18 decimal places, it is shown in a user readable format, without rounding. If the number has more than 18 decimal places, the tooltip defaults to showing the scientific notation format. This scenario is unlikely, and only possible through dApp API initiated transfers.

Includes unit tests.


Fixes: https://github.com/orgs/MetaMask/projects/78/views/1?pane=issue&itemId=83995460&issue=MetaMask%7Cmetamask-extension%7C27971

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/27992?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27971

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="365" alt="Screenshot 2024-10-21 at 17 27 13" src="https://github.com/user-attachments/assets/8381e6f1-31bf-4a72-8f82-63ae0d187851">
<img width="361" alt="Screenshot 2024-10-21 at 18 19 08" src="https://github.com/user-attachments/assets/0ef66f29-7e8d-451b-bad1-b122c72ad387">


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
