### PR TITLE
fix: Fall back to token list for the token symbol

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.test.ts
@@ -2,9 +2,9 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { genUnapprovedTokenTransferConfirmation } from '../../../../../../../test/data/confirmations/token-transfer';
 import mockState from '../../../../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../../../../test/lib/render-helpers';
-import { useTokenImage } from './use-token-image';
+import { useTokenDetails } from './useTokenDetails';
 
-describe('useTokenImage', () => {
+describe('useTokenDetails', () => {
   it('returns iconUrl from selected token if it exists', () => {
     const transactionMeta = genUnapprovedTokenTransferConfirmation(
       {},
@@ -19,11 +19,14 @@ describe('useTokenImage', () => {
     };
 
     const { result } = renderHookWithProvider(
-      () => useTokenImage(transactionMeta, TEST_SELECTED_TOKEN),
+      () => useTokenDetails(transactionMeta, TEST_SELECTED_TOKEN),
       mockState,
     );
 
-    expect(result.current).toEqual({ tokenImage: 'iconUrl' });
+    expect(result.current).toEqual({
+      tokenImage: 'iconUrl',
+      tokenSymbol: 'symbol',
+    });
   });
 
   it('returns selected token image if no iconUrl is included', () => {
@@ -39,11 +42,14 @@ describe('useTokenImage', () => {
     };
 
     const { result } = renderHookWithProvider(
-      () => useTokenImage(transactionMeta, TEST_SELECTED_TOKEN),
+      () => useTokenDetails(transactionMeta, TEST_SELECTED_TOKEN),
       mockState,
     );
 
-    expect(result.current).toEqual({ tokenImage: 'image' });
+    expect(result.current).toEqual({
+      tokenImage: 'image',
+      tokenSymbol: 'symbol',
+    });
   });
 
   it('returns token list icon url if no image is included in the token', () => {
@@ -58,7 +64,7 @@ describe('useTokenImage', () => {
     };
 
     const { result } = renderHookWithProvider(
-      () => useTokenImage(transactionMeta, TEST_SELECTED_TOKEN),
+      () => useTokenDetails(transactionMeta, TEST_SELECTED_TOKEN),
       {
         ...mockState,
         metamask: {
@@ -72,7 +78,10 @@ describe('useTokenImage', () => {
       },
     );
 
-    expect(result.current).toEqual({ tokenImage: 'tokenListIconUrl' });
+    expect(result.current).toEqual({
+      tokenImage: 'tokenListIconUrl',
+      tokenSymbol: 'symbol',
+    });
   });
 
   it('returns undefined if no image is found', () => {
@@ -87,10 +96,13 @@ describe('useTokenImage', () => {
     };
 
     const { result } = renderHookWithProvider(
-      () => useTokenImage(transactionMeta, TEST_SELECTED_TOKEN),
+      () => useTokenDetails(transactionMeta, TEST_SELECTED_TOKEN),
       mockState,
     );
 
-    expect(result.current).toEqual({ tokenImage: undefined });
+    expect(result.current).toEqual({
+      tokenImage: undefined,
+      tokenSymbol: 'symbol',
+    });
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
@@ -1,20 +1,27 @@
 import { TokenListMap } from '@metamask/assets-controllers';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
+import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { getTokenList } from '../../../../../../selectors';
 import { SelectedToken } from '../shared/selected-token';
 
-export const useTokenImage = (
+export const useTokenDetails = (
   transactionMeta: TransactionMeta,
   selectedToken: SelectedToken,
 ) => {
+  const t = useI18nContext();
+
   const tokenList = useSelector(getTokenList) as TokenListMap;
 
-  // TODO: Add support for NFT images in one of the following tasks
   const tokenImage =
     selectedToken?.iconUrl ||
     selectedToken?.image ||
     tokenList[transactionMeta?.txParams?.to as string]?.iconUrl;
 
-  return { tokenImage };
+  const tokenSymbol =
+    selectedToken?.symbol ||
+    tokenList[transactionMeta?.txParams?.to as string]?.symbol ||
+    t('unknown');
+
+  return { tokenImage, tokenSymbol };
 };

--- a/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
@@ -16,22 +16,23 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../../../helpers/constants/design-system';
-import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { getWatchedToken } from '../../../../../../../selectors';
 import { MultichainState } from '../../../../../../../selectors/multichain';
 import { useConfirmContext } from '../../../../../context/confirm';
-import { useTokenImage } from '../../hooks/use-token-image';
+import { useTokenDetails } from '../../hooks/useTokenDetails';
 import { useTokenValues } from '../../hooks/use-token-values';
 import { ConfirmLoader } from '../confirm-loader/confirm-loader';
 
 const SendHeading = () => {
-  const t = useI18nContext();
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const selectedToken = useSelector((state: MultichainState) =>
     getWatchedToken(transactionMeta)(state),
   );
-  const { tokenImage } = useTokenImage(transactionMeta, selectedToken);
+  const { tokenImage, tokenSymbol } = useTokenDetails(
+    transactionMeta,
+    selectedToken,
+  );
   const { decodedTransferValue, fiatDisplayValue, pending } =
     useTokenValues(transactionMeta);
 
@@ -57,9 +58,7 @@ const SendHeading = () => {
         variant={TextVariant.headingLg}
         color={TextColor.inherit}
         marginTop={3}
-      >{`${decodedTransferValue || ''} ${
-        selectedToken?.symbol || t('unknown')
-      }`}</Text>
+      >{`${decodedTransferValue || ''} ${tokenSymbol}`}</Text>
       {fiatDisplayValue && (
         <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
           {fiatDisplayValue}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28003?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27970

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="472" alt="Screenshot 2024-10-22 at 11 19 10" src="https://github.com/user-attachments/assets/c7a09d9f-c5de-44c7-b3bb-c2e759e2b8c8">


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
