### PR TITLE
feat: add `account_type`/`snap_id` for buy/send metrics

### DIFF
--- a/test/e2e/tests/metrics/swaps.spec.js
+++ b/test/e2e/tests/metrics/swaps.spec.js
@@ -182,6 +182,7 @@ async function assertReqsNumAndFilterMetrics(driver, mockedEndpoints) {
 async function assertNavSwapButtonClickedEvent(reqs) {
   assert.equal(reqs[0].event, MetaMetricsEventName.NavSwapButtonClicked);
   assert.deepStrictEqual(reqs[0].properties, {
+    account_type: 'eip155:eoa',
     category: MetaMetricsEventCategory.Swaps,
     chain_id: toHex(1337),
     environment_type: 'fullscreen',

--- a/test/e2e/tests/metrics/swaps.spec.js
+++ b/test/e2e/tests/metrics/swaps.spec.js
@@ -182,7 +182,6 @@ async function assertReqsNumAndFilterMetrics(driver, mockedEndpoints) {
 async function assertNavSwapButtonClickedEvent(reqs) {
   assert.equal(reqs[0].event, MetaMetricsEventName.NavSwapButtonClicked);
   assert.deepStrictEqual(reqs[0].properties, {
-    account_type: 'eip155:eoa',
     category: MetaMetricsEventCategory.Swaps,
     chain_id: toHex(1337),
     environment_type: 'fullscreen',

--- a/ui/components/app/wallet-overview/btc-overview.test.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.test.tsx
@@ -267,19 +267,17 @@ describe('BtcOverview', () => {
     expect(buyButton).not.toBeDisabled();
     fireEvent.click(buyButton as HTMLElement);
 
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      {
-        event: MetaMetricsEventName.NavBuyButtonClicked,
-        category: MetaMetricsEventCategory.Navigation,
-        properties: {
-          account_type: mockNonEvmAccount.type,
-          chain_id: MultichainNetworks.BITCOIN,
-          location: 'Home',
-          snap_id: mockNonEvmAccount.metadata.snap.id,
-          text: 'Buy',
-        },
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.NavBuyButtonClicked,
+      category: MetaMetricsEventCategory.Navigation,
+      properties: {
+        account_type: mockNonEvmAccount.type,
+        chain_id: MultichainNetworks.BITCOIN,
+        location: 'Home',
+        snap_id: mockNonEvmAccount.metadata.snap.id,
+        text: 'Buy',
       },
-    );
+    });
   });
 
   it('always show the Receive button', () => {

--- a/ui/components/app/wallet-overview/btc-overview.test.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.test.tsx
@@ -247,6 +247,41 @@ describe('BtcOverview', () => {
     });
   });
 
+  it('sends an event when clicking the Buy button', () => {
+    const storeWithBtcBuyable = getStore({
+      ramps: {
+        buyableChains: mockBuyableChainsWithBtc,
+      },
+    });
+
+    const mockTrackEvent = jest.fn();
+    const { queryByTestId } = renderWithProvider(
+      <MetaMetricsContext.Provider value={mockTrackEvent}>
+        <BtcOverview />
+      </MetaMetricsContext.Provider>,
+      storeWithBtcBuyable,
+    );
+
+    const buyButton = queryByTestId(BTC_OVERVIEW_BUY);
+    expect(buyButton).toBeInTheDocument();
+    expect(buyButton).not.toBeDisabled();
+    fireEvent.click(buyButton as HTMLElement);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      {
+        event: MetaMetricsEventName.NavBuyButtonClicked,
+        category: MetaMetricsEventCategory.Navigation,
+        properties: {
+          account_type: mockNonEvmAccount.type,
+          chain_id: MultichainNetworks.BITCOIN,
+          location: 'Home',
+          snap_id: mockNonEvmAccount.metadata.snap.id,
+          text: 'Buy',
+        },
+      },
+    );
+  });
+
   it('always show the Receive button', () => {
     const { queryByTestId } = renderWithProvider(<BtcOverview />, getStore());
     const receiveButton = queryByTestId(BTC_OVERVIEW_RECEIVE);

--- a/ui/components/app/wallet-overview/btc-overview.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { isEqual } from 'lodash';
 import {
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   getMultichainIsMainnet,
@@ -10,7 +9,6 @@ import {
 } from '../../../selectors/multichain';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { getIsBitcoinBuyable } from '../../../ducks/ramps';
-import { getSelectedInternalAccount } from '../../../selectors';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 ///: END:ONLY_INCLUDE_IF
 import { getSelectedInternalAccount } from '../../../selectors';
@@ -23,17 +21,14 @@ type BtcOverviewProps = {
 const BtcOverview = ({ className }: BtcOverviewProps) => {
   const { chainId } = useSelector(getMultichainProviderConfig);
   const balance = useSelector(getMultichainSelectedAccountCachedBalance);
+  const account = useSelector(getSelectedInternalAccount);
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-  const selectedAccount = useSelector(getSelectedInternalAccount);
   const isBtcMainnetAccount = useMultichainSelector(
     getMultichainIsMainnet,
-    selectedAccount,
+    account,
   );
   const isBtcBuyable = useSelector(getIsBitcoinBuyable);
   ///: END:ONLY_INCLUDE_IF
-
-  // FIXME: Use `isEqual` to avoid potential re-renders
-  const account = useSelector(getSelectedInternalAccount, isEqual);
 
   return (
     <CoinOverview

--- a/ui/components/app/wallet-overview/btc-overview.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.tsx
@@ -32,7 +32,7 @@ const BtcOverview = ({ className }: BtcOverviewProps) => {
   const isBtcBuyable = useSelector(getIsBitcoinBuyable);
   ///: END:ONLY_INCLUDE_IF
 
-  // FIXME: This causes re-renders, so use isEqual to avoid this
+  // FIXME: Use `isEqual` to avoid potential re-renders
   const account = useSelector(getSelectedInternalAccount, isEqual);
 
   return (

--- a/ui/components/app/wallet-overview/btc-overview.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { isEqual } from 'lodash';
 import {
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   getMultichainIsMainnet,
@@ -12,6 +13,7 @@ import { getIsBitcoinBuyable } from '../../../ducks/ramps';
 import { getSelectedInternalAccount } from '../../../selectors';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 ///: END:ONLY_INCLUDE_IF
+import { getSelectedInternalAccount } from '../../../selectors';
 import { CoinOverview } from './coin-overview';
 
 type BtcOverviewProps = {
@@ -30,8 +32,12 @@ const BtcOverview = ({ className }: BtcOverviewProps) => {
   const isBtcBuyable = useSelector(getIsBitcoinBuyable);
   ///: END:ONLY_INCLUDE_IF
 
+  // FIXME: This causes re-renders, so use isEqual to avoid this
+  const account = useSelector(getSelectedInternalAccount, isEqual);
+
   return (
     <CoinOverview
+      account={account}
       balance={balance}
       // We turn this off to avoid having that asterisk + the "Balance maybe be outdated" message for now
       balanceIsCached={false}

--- a/ui/components/app/wallet-overview/coin-buttons.stories.js
+++ b/ui/components/app/wallet-overview/coin-buttons.stories.js
@@ -1,9 +1,13 @@
 import React from 'react';
+import testData from '../../../../.storybook/test-data';
 import CoinButtons from './coin-buttons';
+
+const { accounts, selectedAccount } = testData.metamask.internalAccounts;
 
 export default {
   title: 'Components/App/WalletOverview/CoinButtons',
   args: {
+    account: accounts[selectedAccount],
     chainId: '1',
     trackingLocation: 'home',
     isSwapsChain: true,

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -88,12 +88,12 @@ import {
   setDefaultHomeActiveTabName,
 } from '../../../store/actions';
 import { BITCOIN_WALLET_SNAP_ID } from '../../../../shared/lib/accounts/bitcoin-wallet-snap';
-import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
+///: END:ONLY_INCLUDE_IF
 import {
   getMultichainIsEvm,
   getMultichainNativeCurrency,
 } from '../../../selectors/multichain';
-///: END:ONLY_INCLUDE_IF
+import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 
 type CoinButtonsProps = {
   account: InternalAccount;

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -24,7 +24,7 @@ import {
 } from '@metamask/utils';
 
 ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
-import { BtcAccountType } from '@metamask/keyring-api';
+import { BtcAccountType, InternalAccount } from '@metamask/keyring-api';
 ///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { ChainId } from '../../../../shared/constants/network';
@@ -51,7 +51,6 @@ import {
   getCurrentKeyring,
   ///: END:ONLY_INCLUDE_IF
   getUseExternalServices,
-  getSelectedAccount,
   ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   getMemoizedUnapprovedTemplatedConfirmations,
   ///: END:ONLY_INCLUDE_IF
@@ -89,21 +88,15 @@ import {
   setDefaultHomeActiveTabName,
 } from '../../../store/actions';
 import { BITCOIN_WALLET_SNAP_ID } from '../../../../shared/lib/accounts/bitcoin-wallet-snap';
+import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
+import {
+  getMultichainIsEvm,
+  getMultichainNativeCurrency,
+} from '../../../selectors/multichain';
 ///: END:ONLY_INCLUDE_IF
 
-const CoinButtons = ({
-  chainId,
-  trackingLocation,
-  isSwapsChain,
-  isSigningEnabled,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-  isBridgeChain,
-  isBuyableChain,
-  defaultSwapsToken,
-  ///: END:ONLY_INCLUDE_IF
-  classPrefix = 'coin',
-  iconButtonClassName = '',
-}: {
+type CoinButtonsProps = {
+  account: InternalAccount;
   chainId: `0x${string}` | CaipChainId | number;
   trackingLocation: string;
   isSwapsChain: boolean;
@@ -115,14 +108,28 @@ const CoinButtons = ({
   ///: END:ONLY_INCLUDE_IF
   classPrefix?: string;
   iconButtonClassName?: string;
-}) => {
+};
+
+const CoinButtons = ({
+  account,
+  chainId,
+  trackingLocation,
+  isSwapsChain,
+  isSigningEnabled,
+  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
+  isBridgeChain,
+  isBuyableChain,
+  defaultSwapsToken,
+  ///: END:ONLY_INCLUDE_IF
+  classPrefix = 'coin',
+  iconButtonClassName = '',
+}: CoinButtonsProps) => {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
 
   const trackEvent = useContext(MetaMetricsContext);
   const [showReceiveModal, setShowReceiveModal] = useState(false);
 
-  const account = useSelector(getSelectedAccount);
   const { address: selectedAddress } = account;
   const history = useHistory();
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
@@ -130,6 +137,16 @@ const CoinButtons = ({
   const keyring = useSelector(getCurrentKeyring);
   const usingHardwareWallet = isHardwareKeyring(keyring?.type);
   ///: END:ONLY_INCLUDE_IF
+
+  // Initially, those events were using a "ETH" as `token_symbol`, so we keep this behavior
+  // for EVM, no matter the currently selected native token (e.g. SepoliaETH if you are on Sepolia
+  // network).
+  const isEvm = useMultichainSelector(getMultichainIsEvm, account);
+  const multichainNativeToken = useMultichainSelector(
+    getMultichainNativeCurrency,
+    account,
+  );
+  const nativeToken = isEvm ? 'ETH' : multichainNativeToken;
 
   const isExternalServicesEnabled = useSelector(getUseExternalServices);
 
@@ -179,6 +196,21 @@ const CoinButtons = ({
     return toHex(chainId) as ChainId;
   };
   ///: END:ONLY_INCLUDE_IF
+
+  const getSnapAccountMetaMetricsPropertiesIfAny = (
+    internalAccount: InternalAccount,
+  ): { snap_id?: string } => {
+    // Some accounts might be Snap accounts, in this case we add some extra properties
+    // to the metrics:
+    if (internalAccount.metadata.snap) {
+      return {
+        snap_id: internalAccount.metadata.snap?.id,
+      };
+    }
+
+    // If the account is not a Snap account, then there's no extra property
+    return {};
+  };
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   const mmiPortfolioEnabled = useSelector(getMmiPortfolioEnabled);
@@ -276,6 +308,21 @@ const CoinButtons = ({
   ///: END:ONLY_INCLUDE_IF
 
   const handleSendOnClick = useCallback(async () => {
+    trackEvent(
+      {
+        event: MetaMetricsEventName.NavSendButtonClicked,
+        category: MetaMetricsEventCategory.Navigation,
+        properties: {
+          account_type: account.type,
+          token_symbol: nativeToken,
+          location: 'Home',
+          text: 'Send',
+          chain_id: chainId,
+          ...getSnapAccountMetaMetricsPropertiesIfAny(account),
+        },
+      },
+      { excludeMetaMetricsId: false },
+    );
     switch (account.type) {
       ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
       case BtcAccountType.P2wpkh: {
@@ -291,19 +338,6 @@ const CoinButtons = ({
       }
       ///: END:ONLY_INCLUDE_IF
       default: {
-        trackEvent(
-          {
-            event: MetaMetricsEventName.NavSendButtonClicked,
-            category: MetaMetricsEventCategory.Navigation,
-            properties: {
-              token_symbol: 'ETH',
-              location: 'Home',
-              text: 'Send',
-              chain_id: chainId,
-            },
-          },
-          { excludeMetaMetricsId: false },
-        );
         await dispatch(startNewDraftTransaction({ type: AssetType.native }));
         history.push(SEND_ROUTE);
       }
@@ -323,7 +357,8 @@ const CoinButtons = ({
         event: MetaMetricsEventName.NavSwapButtonClicked,
         category: MetaMetricsEventCategory.Swaps,
         properties: {
-          token_symbol: 'ETH',
+          account_type: account.type,
+          token_symbol: nativeToken,
           location: MetaMetricsSwapsEventSource.MainView,
           text: 'Swap',
           chain_id: chainId,
@@ -358,10 +393,12 @@ const CoinButtons = ({
       event: MetaMetricsEventName.NavBuyButtonClicked,
       category: MetaMetricsEventCategory.Navigation,
       properties: {
+        account_type: account.type,
         location: 'Home',
         text: 'Buy',
         chain_id: chainId,
         token_symbol: defaultSwapsToken,
+        ...getSnapAccountMetaMetricsPropertiesIfAny(account),
       },
     });
   }, [chainId, defaultSwapsToken]);

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -357,8 +357,7 @@ const CoinButtons = ({
         event: MetaMetricsEventName.NavSwapButtonClicked,
         category: MetaMetricsEventCategory.Swaps,
         properties: {
-          account_type: account.type,
-          token_symbol: nativeToken,
+          token_symbol: 'ETH',
           location: MetaMetricsSwapsEventSource.MainView,
           text: 'Swap',
           chain_id: chainId,

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -202,13 +202,15 @@ const CoinButtons = ({
   ): { snap_id?: string } => {
     // Some accounts might be Snap accounts, in this case we add some extra properties
     // to the metrics:
-    if (internalAccount.metadata.snap) {
+    const snapId = internalAccount.metadata.snap?.id;
+    if (snapId) {
       return {
-        snap_id: internalAccount.metadata.snap?.id,
+        snap_id: snapId,
       };
     }
 
-    // If the account is not a Snap account, then there's no extra property
+    // If the account is not a Snap account or that we could not get the Snap ID for
+    // some reason, we don't add any extra property.
     return {};
   };
 

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -11,6 +11,7 @@ import { zeroAddress } from 'ethereumjs-util';
 import { CaipChainId } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
+import { InternalAccount } from '@metamask/keyring-api';
 import {
   Box,
   ButtonIcon,
@@ -45,7 +46,6 @@ import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display
 import { PRIMARY } from '../../../helpers/constants/common';
 import {
   getPreferences,
-  getSelectedAccount,
   getShouldHideZeroBalanceTokens,
   getTokensMarketData,
   getIsTestnet,
@@ -74,6 +74,7 @@ import CoinButtons from './coin-buttons';
 import { AggregatedPercentageOverview } from './aggregated-percentage-overview';
 
 export type CoinOverviewProps = {
+  account: InternalAccount;
   balance: string;
   balanceIsCached: boolean;
   className?: string;
@@ -90,6 +91,7 @@ export type CoinOverviewProps = {
 };
 
 export const CoinOverview = ({
+  account,
   balance,
   balanceIsCached,
   className,
@@ -121,7 +123,6 @@ export const CoinOverview = ({
 
   ///: END:ONLY_INCLUDE_IF
 
-  const account = useSelector(getSelectedAccount);
   const showNativeTokenAsMainBalanceRoute = getSpecificSettingsRoute(
     t,
     t('general'),
@@ -135,12 +136,11 @@ export const CoinOverview = ({
   const { showFiatInTestnets, privacyMode, showNativeTokenAsMainBalance } =
     useSelector(getPreferences);
 
-  const selectedAccount = useSelector(getSelectedAccount);
   const shouldHideZeroBalanceTokens = useSelector(
     getShouldHideZeroBalanceTokens,
   );
   const { totalFiatBalance, loading } = useAccountTotalFiatBalance(
-    selectedAccount,
+    account,
     shouldHideZeroBalanceTokens,
   );
 
@@ -368,6 +368,7 @@ export const CoinOverview = ({
       buttons={
         <CoinButtons
           {...{
+            account,
             trackingLocation: 'home',
             chainId,
             isSwapsChain,

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -39,6 +39,7 @@ const EthOverview = ({ className }) => {
 
   return (
     <CoinOverview
+      account={account}
       balance={balance}
       balanceIsCached={balanceIsCached}
       className={className}

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -12,7 +12,19 @@ import { ETH_EOA_METHODS } from '../../../../shared/constants/eth-methods';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import { setBackgroundConnection } from '../../../store/background-connection';
 import { mockNetworkState } from '../../../../test/stub/networks';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import EthOverview from './eth-overview';
+
+// We need to mock `dispatch` since we use it for `setDefaultHomeActiveTabName`.
+const mockDispatch = jest.fn().mockReturnValue(() => jest.fn());
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
 
 jest.mock('../../../hooks/useIsOriginalNativeTokenSymbol', () => {
   return {
@@ -24,6 +36,10 @@ jest.mock('../../../ducks/locale/locale', () => ({
   getIntlLocale: jest.fn(),
 }));
 
+jest.mock('../../../store/actions', () => ({
+  startNewDraftTransaction: jest.fn(),
+}));
+
 const mockGetIntlLocale = getIntlLocale;
 
 let openTabSpy;
@@ -32,18 +48,46 @@ describe('EthOverview', () => {
   useIsOriginalNativeTokenSymbol.mockReturnValue(true);
   mockGetIntlLocale.mockReturnValue('en-US');
 
+  const mockEvmAccount1 = {
+    address: '0x1',
+    id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+    metadata: {
+      name: 'Account 1',
+      keyring: {
+        type: KeyringType.imported,
+      },
+    },
+    options: {},
+    methods: ETH_EOA_METHODS,
+    type: EthAccountType.Eoa,
+  };
+
+  const mockEvmAccount2 = {
+    address: '0x2',
+    id: 'e9b992f9-e151-4317-b8b7-c771bb73dd02',
+    metadata: {
+      name: 'Account 2',
+      keyring: {
+        type: KeyringType.imported,
+      },
+    },
+    options: {},
+    methods: ETH_EOA_METHODS,
+    type: EthAccountType.Eoa,
+  };
+
   const mockStore = {
     metamask: {
       ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
       accountsByChainId: {
         [CHAIN_IDS.MAINNET]: {
-          '0x1': { address: '0x1', balance: '0x1F4' },
+          '0x1': { address: mockEvmAccount1.address, balance: '0x1F4' },
         },
       },
       tokenList: [],
       cachedBalances: {
         '0x1': {
-          '0x1': '0x1F4',
+          [mockEvmAccount1.address]: '0x1F4',
         },
       },
       preferences: {
@@ -58,46 +102,22 @@ describe('EthOverview', () => {
         },
       },
       accounts: {
-        '0x1': {
-          address: '0x1',
+        [mockEvmAccount1.address]: {
+          address: mockEvmAccount1.address,
           balance: '0x1F4',
         },
       },
       internalAccounts: {
         accounts: {
-          'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3': {
-            address: '0x1',
-            id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
-            metadata: {
-              name: 'Account 1',
-              keyring: {
-                type: KeyringType.imported,
-              },
-            },
-            options: {},
-            methods: ETH_EOA_METHODS,
-            type: EthAccountType.Eoa,
-          },
-          'e9b992f9-e151-4317-b8b7-c771bb73dd02': {
-            address: '0x2',
-            id: 'e9b992f9-e151-4317-b8b7-c771bb73dd02',
-            metadata: {
-              name: 'Account 2',
-              keyring: {
-                type: KeyringType.imported,
-              },
-            },
-            options: {},
-            methods: ETH_EOA_METHODS,
-            type: EthAccountType.Eoa,
-          },
+          [mockEvmAccount1.id]: mockEvmAccount1,
+          [mockEvmAccount2.id]: mockEvmAccount2,
         },
-        selectedAccount: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+        selectedAccount: mockEvmAccount1.id,
       },
       keyrings: [
         {
           type: KeyringType.imported,
-          accounts: ['0x1', '0x2'],
+          accounts: [mockEvmAccount1.address, mockEvmAccount2.address],
         },
         {
           type: KeyringType.ledger,
@@ -391,15 +411,30 @@ describe('EthOverview', () => {
     it.each(buttonTestCases)(
       'should have the $buttonText button disabled when an account cannot sign transactions or user operations',
       ({ testId, buttonText }) => {
-        mockStore.metamask.internalAccounts.accounts[
-          'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3'
-        ].methods = Object.values(EthMethod).filter(
-          (method) =>
-            method !== EthMethod.SignTransaction &&
-            method !== EthMethod.SignUserOperation,
-        );
+        const mockedStoreWithoutSigningMethods = {
+          ...mockStore,
+          metamask: {
+            ...mockStore.metamask,
+            internalAccounts: {
+              ...mockStore.metamask.internalAccounts,
+              accounts: {
+                [mockEvmAccount1.id]: {
+                  ...mockEvmAccount1,
+                  // Filter out all methods used for signing transactions.
+                  methods: Object.values(EthMethod).filter(
+                    (method) =>
+                      method !== EthMethod.SignTransaction &&
+                      method !== EthMethod.SignUserOperation,
+                  ),
+                },
+              },
+            },
+          },
+        };
 
-        const mockedStore = configureMockStore([thunk])(mockStore);
+        const mockedStore = configureMockStore([thunk])(
+          mockedStoreWithoutSigningMethods,
+        );
         const { queryByTestId, queryByText } = renderWithProvider(
           <EthOverview />,
           mockedStore,
@@ -413,6 +448,52 @@ describe('EthOverview', () => {
           'Not supported with this account.',
         );
       },
+    );
+  });
+
+  it.each([
+    CHAIN_IDS.MAINNET,
+    // We want to test with a different chain ID than mainnet to make sure the events are still using
+    // the right `token_symbol`.
+    CHAIN_IDS.SEPOLIA,
+  ])('sends an event when clicking the Send button: %s', (chainId) => {
+    const mockTrackEvent = jest.fn();
+    const mockedStoreWithSpecificChainId = {
+      ...mockStore,
+      metamask: {
+        ...mockStore.metamask,
+        ...mockNetworkState({ chainId }),
+      },
+    };
+
+    const mockedStore = configureMockStore([thunk])(
+      mockedStoreWithSpecificChainId,
+    );
+    const { queryByTestId } = renderWithProvider(
+      <MetaMetricsContext.Provider value={mockTrackEvent}>
+        <EthOverview />
+      </MetaMetricsContext.Provider>,
+      mockedStore,
+    );
+
+    const sendButton = queryByTestId(ETH_OVERVIEW_SEND);
+    expect(sendButton).toBeInTheDocument();
+    expect(sendButton).not.toBeDisabled();
+    fireEvent.click(sendButton);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      {
+        event: MetaMetricsEventName.NavSendButtonClicked,
+        category: MetaMetricsEventCategory.Navigation,
+        properties: {
+          account_type: mockEvmAccount1.type,
+          chain_id: chainId,
+          location: 'Home',
+          text: 'Send',
+          token_symbol: 'ETH',
+        },
+      },
+      expect.any(Object),
     );
   });
 });

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -417,19 +417,17 @@ describe('EthOverview', () => {
     expect(buyButton).not.toBeDisabled();
     fireEvent.click(buyButton);
 
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      {
-        event: MetaMetricsEventName.NavBuyButtonClicked,
-        category: MetaMetricsEventCategory.Navigation,
-        properties: {
-          account_type: mockEvmAccount1.type,
-          chain_id: CHAIN_IDS.MAINNET,
-          location: 'Home',
-          text: 'Buy',
-          token_symbol: expect.any(Object), // FIXME: Is this wrong?
-        },
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.NavBuyButtonClicked,
+      category: MetaMetricsEventCategory.Navigation,
+      properties: {
+        account_type: mockEvmAccount1.type,
+        chain_id: CHAIN_IDS.MAINNET,
+        location: 'Home',
+        text: 'Buy',
+        token_symbol: expect.any(Object), // FIXME: Is this wrong?
       },
-    );
+    });
   });
 
   describe('Disabled buttons when an account cannot sign transactions', () => {

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -401,6 +401,37 @@ describe('EthOverview', () => {
     });
   });
 
+  it('sends an event when clicking the Buy button: %s', () => {
+    const mockTrackEvent = jest.fn();
+
+    const mockedStore = configureMockStore([thunk])(mockStore);
+    const { queryByTestId } = renderWithProvider(
+      <MetaMetricsContext.Provider value={mockTrackEvent}>
+        <EthOverview />
+      </MetaMetricsContext.Provider>,
+      mockedStore,
+    );
+
+    const buyButton = queryByTestId(ETH_OVERVIEW_BUY);
+    expect(buyButton).toBeInTheDocument();
+    expect(buyButton).not.toBeDisabled();
+    fireEvent.click(buyButton);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      {
+        event: MetaMetricsEventName.NavBuyButtonClicked,
+        category: MetaMetricsEventCategory.Navigation,
+        properties: {
+          account_type: mockEvmAccount1.type,
+          chain_id: CHAIN_IDS.MAINNET,
+          location: 'Home',
+          text: 'Buy',
+          token_symbol: expect.any(Object), // FIXME: Is this wrong?
+        },
+      },
+    );
+  });
+
   describe('Disabled buttons when an account cannot sign transactions', () => {
     const buttonTestCases = [
       { testId: ETH_OVERVIEW_SEND, buttonText: 'Send' },

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -425,7 +425,8 @@ describe('EthOverview', () => {
         chain_id: CHAIN_IDS.MAINNET,
         location: 'Home',
         text: 'Buy',
-        token_symbol: expect.any(Object), // FIXME: Is this wrong?
+        // We use a `SwapsEthToken` in this case, so we're expecting an entire object here.
+        token_symbol: expect.any(Object),
       },
     });
   });

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -166,6 +166,7 @@ const AssetPage = ({
         {type === AssetType.native ? (
           <CoinButtons
             {...{
+              account,
               trackingLocation: 'asset-page',
               isBuyableChain,
               isSigningEnabled,


### PR DESCRIPTION
## **Description**

Adds more context/info to the Send/Buy events for both Ethereum and Bitcoin overview screens.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28011?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/636, https://github.com/MetaMask/accounts-planning/issues/637

## **Manual testing steps**

- Cherry-pick this commit: f938d6d18cd977ba53eb68668a2d475e26b8a131
  * This will allow you to use the verbose mode for the local segment server
- `node development/mock-segment.js -v`
- `yarn start:flask`
- Create a Bitcoin account (enable support from the experimental settings)
- Select a Bitcoin account
- Click on "Buy" button using your Bitcoin account
- Click on "Send" button using your Bitcoin account
- Create an Ethereum account
- Click on "Buy" button using your Bitcoin account
- Click on "Send" button using your Bitcoin account

You should see those events from the `mock-segment.js` server output:
```
...
[mock-segment]: Events received: Buy Button Clicked {
  "account_type": "bip122:p2wpkh",
  "location": "Home",
  "text": "Buy",
  "chain_id": "bip122:000000000019d6689c085ae165831e93",
  "snap_id": "npm:@metamask/bitcoin-wallet-snap",
  "category": "Navigation",
  "locale": "en",
  "environment_type": "popup"
}
...
[mock-segment]: Events received: Send Button Clicked {
  "account_type": "bip122:p2wpkh",
  "token_symbol": "BTC",
  "location": "Home",
  "text": "Send",
  "chain_id": "bip122:000000000019d6689c085ae165831e93",
  "snap_id": "npm:@metamask/bitcoin-wallet-snap",
  "category": "Navigation",
  "locale": "en",
  "environment_type": "popup"
}
...
[mock-segment]: Events received: Buy Button Clicked {
  "account_type": "eip155:eoa",
  "location": "Home",
  "text": "Buy",
  "chain_id": "0x1",
  "token_symbol": {
    "symbol": "ETH",
    "name": "Ether",
    "address": "0x0000000000000000000000000000000000000000",
    "decimals": 18,
    "iconUrl": "./images/eth_logo.svg",
    "balance": "0",
    "string": "0"
  },
  "category": "Navigation",
  "locale": "en",
  "environment_type": "popup"
}
...
[mock-segment]: Events received: Send Button Clicked {
  "account_type": "eip155:eoa",
  "token_symbol": "ETH",
  "location": "Home",
  "text": "Send",
  "chain_id": "0x1",
  "category": "Navigation",
  "locale": "en",
  "environment_type": "popup"
}
...
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
