### PR TITLE
fix: Fix stream re-initialization

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -104,7 +104,7 @@ async function start() {
     if (isManifestV3 && isUIInitialised) {
       // Currently when service worker is revived we create new streams
       // in later version we might try to improve it by reviving same streams.
-      updateUiStreams();
+      updateUiStreams(connectionStream);
     } else {
       await initializeUiWithTab(
         activeTab,


### PR DESCRIPTION
## **Description**

Streams were not correctly re-initialized after a service worker restart, causing a broken UI for any affected window.

This bug was introduced in https://github.com/MetaMask/metamask-extension/pull/26969, which reached production as part of v12.5.0.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28024?quickstart=1)

## **Related issues**

Fixes #28018

## **Manual testing steps**

1. Open a fullscreen page or trigger a dapp confirmation
2. Restart the service worker
3. See that the page is broken

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/38e2d2f4-f555-4a14-87f7-73ff2d95c306

### **After**

https://github.com/user-attachments/assets/1b6d9704-1ce2-4363-bc1d-118f1560b64a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
  - No additional tests have been added yet because this is being considered for a hotfix. This should be covered either by an integration or an e2e test (or not). The affected code is not easy to cover effectively with unit tests.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
