### PR TITLE
chore: display bridge quotes

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -853,8 +853,18 @@
   "bridgeSelectNetwork": {
     "message": "Select network"
   },
+  "bridgeTimingMinutes": {
+    "message": "$1 minutes",
+    "description": "$1 is the ticker symbol of a an asset the user is being prompted to purchase"
+  },
+  "bridgeTimingTooltipText": {
+    "message": "This is the estimated time it will take for the bridging to be complete."
+  },
   "bridgeTo": {
     "message": "Bridge to"
+  },
+  "bridgeTotalFeesTooltipText": {
+    "message": "This includes gas fees (paid to crypto miners) and relayer fees (paid to power complex services like bridging).\nFees are based on network traffic and transaction complexity. MetaMask does not profit from either fee."
   },
   "browserNotSupported": {
     "message": "Your browser is not supported..."
@@ -1964,6 +1974,9 @@
   },
   "estimatedFeeTooltip": {
     "message": "Amount paid to process the transaction on network."
+  },
+  "estimatedTime": {
+    "message": "Estimated time"
   },
   "ethGasPriceFetchWarning": {
     "message": "Backup gas price is provided as the main gas estimation service is unavailable right now."
@@ -6109,6 +6122,9 @@
   },
   "total": {
     "message": "Total"
+  },
+  "totalFees": {
+    "message": "Total fees"
   },
   "totalVolume": {
     "message": "Total volume"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -844,8 +844,14 @@
   "bridge": {
     "message": "Bridge"
   },
+  "bridgeCalculatingAmount": {
+    "message": "Calculating..."
+  },
   "bridgeDontSend": {
     "message": "Bridge, don't send"
+  },
+  "bridgeEnterAmount": {
+    "message": "Enter amount"
   },
   "bridgeFrom": {
     "message": "Bridge from"
@@ -855,6 +861,9 @@
   },
   "bridgeSelectNetwork": {
     "message": "Select network"
+  },
+  "bridgeSelectTokenAndAmount": {
+    "message": "Select token and amount"
   },
   "bridgeTimingMinutes": {
     "message": "$1 minutes",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -850,6 +850,9 @@
   "bridgeFrom": {
     "message": "Bridge from"
   },
+  "bridgeOverallCost": {
+    "message": "Overall cost"
+  },
   "bridgeSelectNetwork": {
     "message": "Select network"
   },

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -3,6 +3,7 @@ import { CHAIN_IDS, CURRENCY_SYMBOLS } from '../../shared/constants/network';
 import { KeyringType } from '../../shared/constants/keyring';
 import { ETH_EOA_METHODS } from '../../shared/constants/eth-methods';
 import { mockNetworkState } from '../stub/networks';
+import { DEFAULT_BRIDGE_CONTROLLER_STATE } from '../../app/scripts/controllers/bridge/constants';
 
 export const createGetSmartTransactionFeesApiResponse = () => {
   return {
@@ -726,6 +727,8 @@ export const createBridgeMockStore = (
           destNetworkAllowlist: [],
           ...featureFlagOverrides,
         },
+        quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
+        quoteRequest: DEFAULT_BRIDGE_CONTROLLER_STATE.quoteRequest,
         ...bridgeStateOverrides,
       },
     },

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -395,7 +395,7 @@ describe('Bridge selectors', () => {
       const state = createBridgeMockStore();
       const result = getToAmount(state as never);
 
-      expect(result).toStrictEqual('0');
+      expect(result).toStrictEqual(undefined);
     });
   });
 

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -3,6 +3,7 @@ import {
   NetworkState,
 } from '@metamask/network-controller';
 import { uniqBy } from 'lodash';
+import { createSelector } from 'reselect';
 import {
   getNetworkConfigurationsByChainId,
   getIsBridgeEnabled,
@@ -19,6 +20,10 @@ import {
 import { createDeepEqualSelector } from '../../selectors/util';
 import { getProviderConfig } from '../metamask/metamask';
 import { SwapsTokenObject } from '../../../shared/constants/swaps';
+import { calcTokenAmount } from '../../../shared/lib/transactions-controller-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { RequestStatus } from '../../../app/scripts/controllers/bridge/constants';
 import { BridgeState } from './bridge';
 
 type BridgeAppState = {
@@ -124,9 +129,39 @@ export const getToToken = (
 
 export const getFromAmount = (state: BridgeAppState): string | null =>
   state.bridge.fromTokenInputValue;
-export const getToAmount = (_state: BridgeAppState) => {
-  return '0';
+
+export const getBridgeQuotes = (state: BridgeAppState) => {
+  return {
+    quotes: state.metamask.bridgeState.quotes,
+    quotesLastFetchedMs: state.metamask.bridgeState.quotesLastFetched,
+    isLoading:
+      state.metamask.bridgeState.quotesLoadingStatus === RequestStatus.LOADING,
+  };
 };
+
+export const getRecommendedQuote = createSelector(
+  getBridgeQuotes,
+  ({ quotes }) => {
+    // TODO implement sorting
+    return quotes[0];
+  },
+);
+
+export const getQuoteRequest = (state: BridgeAppState) => {
+  const { quoteRequest } = state.metamask.bridgeState;
+  return quoteRequest;
+};
+
+export const getToAmount = createSelector(getRecommendedQuote, (quote) =>
+  quote
+    ? calcTokenAmount(
+        quote.quote.destTokenAmount,
+        quote.quote.destAsset.decimals,
+      )
+        .toFixed(3)
+        .toString()
+    : undefined,
+);
 
 export const getIsBridgeTx = createDeepEqualSelector(
   getFromChain,

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -158,8 +158,6 @@ export const getToAmount = createSelector(getRecommendedQuote, (quote) =>
         quote.quote.destTokenAmount,
         quote.quote.destAsset.decimals,
       )
-        .toFixed(3)
-        .toString()
     : undefined,
 );
 

--- a/ui/hooks/bridge/useCountdownTimer.test.ts
+++ b/ui/hooks/bridge/useCountdownTimer.test.ts
@@ -1,0 +1,34 @@
+import { renderHookWithProvider } from '../../../test/lib/render-helpers';
+import { createBridgeMockStore } from '../../../test/jest/mock-store';
+import { flushPromises } from '../../../test/lib/timer-helpers';
+import { useCountdownTimer } from './useCountdownTimer';
+
+jest.useFakeTimers();
+const renderUseCountdownTimer = (mockStoreState: object) =>
+  renderHookWithProvider(() => useCountdownTimer(), mockStoreState);
+
+describe('useCountdownTimer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  it('returns time remaining', async () => {
+    const quotesLastFetched = Date.now();
+    const { result } = renderUseCountdownTimer(
+      createBridgeMockStore({}, {}, { quotesLastFetched }),
+    );
+
+    let i = 0;
+    while (i <= 30) {
+      const secondsLeft = Math.min(30, 30 - i + 1);
+      expect(result.current).toStrictEqual(
+        `0:${secondsLeft < 10 ? '0' : ''}${secondsLeft}`,
+      );
+      i += 10;
+      jest.advanceTimersByTime(10000);
+      await flushPromises();
+    }
+    expect(result.current).toStrictEqual('0:00');
+  });
+});

--- a/ui/hooks/bridge/useCountdownTimer.ts
+++ b/ui/hooks/bridge/useCountdownTimer.ts
@@ -1,0 +1,29 @@
+import { Duration } from 'luxon';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { getBridgeQuotes } from '../../ducks/bridge/selectors';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { REFRESH_INTERVAL_MS } from '../../../app/scripts/controllers/bridge/constants';
+
+export const useCountdownTimer = () => {
+  const [timeRemaining, setTimeRemaining] = useState(REFRESH_INTERVAL_MS);
+  const { quotesLastFetchedMs } = useSelector(getBridgeQuotes);
+
+  useEffect(() => {
+    if (quotesLastFetchedMs) {
+      setTimeRemaining(
+        REFRESH_INTERVAL_MS - (Date.now() - quotesLastFetchedMs),
+      );
+    }
+  }, [quotesLastFetchedMs]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTimeRemaining(Math.max(0, timeRemaining - 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [timeRemaining]);
+
+  return Duration.fromMillis(timeRemaining).toFormat('m:ss');
+};

--- a/ui/hooks/bridge/useCountdownTimer.ts
+++ b/ui/hooks/bridge/useCountdownTimer.ts
@@ -5,7 +5,15 @@ import { getBridgeQuotes } from '../../ducks/bridge/selectors';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { REFRESH_INTERVAL_MS } from '../../../app/scripts/controllers/bridge/constants';
+import { SECOND } from '../../../shared/constants/time';
 
+/**
+ * Custom hook that provides a countdown timer based on the last fetched quotes timestamp.
+ *
+ * This hook calculates the remaining time until the next refresh interval and updates every second.
+ *
+ * @returns The formatted remaining time in 'm:ss' format.
+ */
 export const useCountdownTimer = () => {
   const [timeRemaining, setTimeRemaining] = useState(REFRESH_INTERVAL_MS);
   const { quotesLastFetchedMs } = useSelector(getBridgeQuotes);
@@ -20,8 +28,8 @@ export const useCountdownTimer = () => {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setTimeRemaining(Math.max(0, timeRemaining - 1000));
-    }, 1000);
+      setTimeRemaining(Math.max(0, timeRemaining - SECOND));
+    }, SECOND);
     return () => clearInterval(interval);
   }, [timeRemaining]);
 

--- a/ui/pages/bridge/__snapshots__/index.test.tsx.snap
+++ b/ui/pages/bridge/__snapshots__/index.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Bridge renders the component with initial props 1`] = `
           data-theme="light"
           disabled=""
         >
-          Select token
+          Select token and amount
         </button>
       </div>
     </div>

--- a/ui/pages/bridge/index.scss
+++ b/ui/pages/bridge/index.scss
@@ -1,6 +1,8 @@
 @use "design-system";
 
 @import 'prepare/index';
+@import 'quotes/index';
+
 
 .bridge {
   max-height: 100vh;

--- a/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
       class="mm-box prepare-bridge-page__content"
     >
       <div
-        class="mm-box prepare-bridge-page__from"
+        class="mm-box bridge-box"
       >
         <div
           class="mm-box prepare-bridge-page__input-row"
@@ -130,7 +130,7 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
         </button>
       </div>
       <div
-        class="mm-box prepare-bridge-page__to"
+        class="mm-box bridge-box"
       >
         <div
           class="mm-box prepare-bridge-page__input-row"
@@ -213,7 +213,7 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
       class="mm-box prepare-bridge-page__content"
     >
       <div
-        class="mm-box prepare-bridge-page__from"
+        class="mm-box bridge-box"
       >
         <div
           class="mm-box prepare-bridge-page__input-row"
@@ -340,7 +340,7 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
         </button>
       </div>
       <div
-        class="mm-box prepare-bridge-page__to"
+        class="mm-box bridge-box"
       >
         <div
           class="mm-box prepare-bridge-page__input-row"

--- a/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
@@ -3,7 +3,7 @@ import { renderWithProvider } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import { createBridgeMockStore } from '../../../../test/jest/mock-store';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import { mockBridgeQuotesNativeErc20 } from '../../../../test/data/bridge/mock-quotes-native-erc20';
+import mockBridgeQuotesNativeErc20 from '../../../../test/data/bridge/mock-quotes-native-erc20.json';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { RequestStatus } from '../../../../app/scripts/controllers/bridge/constants';

--- a/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
@@ -3,6 +3,10 @@ import { renderWithProvider } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import { createBridgeMockStore } from '../../../../test/jest/mock-store';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { mockBridgeQuotesNativeErc20 } from '../../../../test/data/bridge/mock-quotes-native-erc20';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { RequestStatus } from '../../../../app/scripts/controllers/bridge/constants';
 import { BridgeCTAButton } from './bridge-cta-button';
 
 describe('BridgeCTAButton', () => {
@@ -25,6 +29,52 @@ describe('BridgeCTAButton', () => {
     expect(getByRole('button')).toBeDisabled();
   });
 
+  it('should render the component when amount is missing', () => {
+    const mockStore = createBridgeMockStore(
+      {
+        srcNetworkAllowlist: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+        destNetworkAllowlist: [CHAIN_IDS.LINEA_MAINNET],
+      },
+      {
+        fromTokenInputValue: null,
+        fromToken: 'ETH',
+        toToken: 'ETH',
+        toChainId: CHAIN_IDS.LINEA_MAINNET,
+      },
+      {},
+    );
+    const { getByText, getByRole } = renderWithProvider(
+      <BridgeCTAButton />,
+      configureStore(mockStore),
+    );
+
+    expect(getByText('Enter amount')).toBeInTheDocument();
+    expect(getByRole('button')).toBeDisabled();
+  });
+
+  it('should render the component when amount and dest token is missing', () => {
+    const mockStore = createBridgeMockStore(
+      {
+        srcNetworkAllowlist: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+        destNetworkAllowlist: [CHAIN_IDS.LINEA_MAINNET],
+      },
+      {
+        fromTokenInputValue: null,
+        fromToken: 'ETH',
+        toToken: null,
+        toChainId: CHAIN_IDS.LINEA_MAINNET,
+      },
+      {},
+    );
+    const { getByText, getByRole } = renderWithProvider(
+      <BridgeCTAButton />,
+      configureStore(mockStore),
+    );
+
+    expect(getByText('Select token and amount')).toBeInTheDocument();
+    expect(getByRole('button')).toBeDisabled();
+  });
+
   it('should render the component when tx is submittable', () => {
     const mockStore = createBridgeMockStore(
       {
@@ -37,14 +87,72 @@ describe('BridgeCTAButton', () => {
         toToken: 'ETH',
         toChainId: CHAIN_IDS.LINEA_MAINNET,
       },
-      {},
+      {
+        quotes: mockBridgeQuotesNativeErc20,
+        quotesLastFetched: Date.now(),
+        quotesLoadingStatus: RequestStatus.FETCHED,
+      },
     );
     const { getByText, getByRole } = renderWithProvider(
       <BridgeCTAButton />,
       configureStore(mockStore),
     );
 
-    expect(getByText('Bridge')).toBeInTheDocument();
+    expect(getByText('Confirm')).toBeInTheDocument();
+    expect(getByRole('button')).not.toBeDisabled();
+  });
+
+  it('should disable the component when quotes are loading and there are no existing quotes', () => {
+    const mockStore = createBridgeMockStore(
+      {
+        srcNetworkAllowlist: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+        destNetworkAllowlist: [CHAIN_IDS.LINEA_MAINNET],
+      },
+      {
+        fromTokenInputValue: 1,
+        fromToken: 'ETH',
+        toToken: 'ETH',
+        toChainId: CHAIN_IDS.LINEA_MAINNET,
+      },
+      {
+        quotes: [],
+        quotesLastFetched: Date.now(),
+        quotesLoadingStatus: RequestStatus.LOADING,
+      },
+    );
+    const { getByText, getByRole } = renderWithProvider(
+      <BridgeCTAButton />,
+      configureStore(mockStore),
+    );
+
+    expect(getByText('Fetching quotes...')).toBeInTheDocument();
+    expect(getByRole('button')).toBeDisabled();
+  });
+
+  it('should enable the component when quotes are loading and there are existing quotes', () => {
+    const mockStore = createBridgeMockStore(
+      {
+        srcNetworkAllowlist: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+        destNetworkAllowlist: [CHAIN_IDS.LINEA_MAINNET],
+      },
+      {
+        fromTokenInputValue: 1,
+        fromToken: 'ETH',
+        toToken: 'ETH',
+        toChainId: CHAIN_IDS.LINEA_MAINNET,
+      },
+      {
+        quotes: mockBridgeQuotesNativeErc20,
+        quotesLastFetched: Date.now(),
+        quotesLoadingStatus: RequestStatus.LOADING,
+      },
+    );
+    const { getByText, getByRole } = renderWithProvider(
+      <BridgeCTAButton />,
+      configureStore(mockStore),
+    );
+
+    expect(getByText('Confirm')).toBeInTheDocument();
     expect(getByRole('button')).not.toBeDisabled();
   });
 });

--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Button } from '../../../components/component-library';
 import {
+  getBridgeQuotes,
   getFromAmount,
   getFromChain,
   getFromToken,
@@ -22,16 +23,29 @@ export const BridgeCTAButton = () => {
   const fromAmount = useSelector(getFromAmount);
   const toAmount = useSelector(getToAmount);
 
+  const { isLoading } = useSelector(getBridgeQuotes);
+
   const isTxSubmittable =
     fromToken && toToken && fromChain && toChain && fromAmount && toAmount;
 
   const label = useMemo(() => {
+    if (isLoading && !isTxSubmittable) {
+      return t('swapFetchingQuotes');
+    }
+
+    if (!fromAmount) {
+      if (!toToken) {
+        return t('bridgeSelectTokenAndAmount');
+      }
+      return t('bridgeEnterAmount');
+    }
+
     if (isTxSubmittable) {
-      return t('bridge');
+      return t('confirm');
     }
 
     return t('swapSelectToken');
-  }, [isTxSubmittable]);
+  }, [isLoading, fromAmount, toToken, isTxSubmittable]);
 
   return (
     <Button

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -69,7 +69,7 @@ export const BridgeInputGroup = ({
   token: SwapsTokenObject | SwapsEthToken | null;
   amountFieldProps?: Pick<
     React.ComponentProps<typeof TextField>,
-    'testId' | 'autoFocus' | 'value' | 'readOnly' | 'disabled'
+    'testId' | 'autoFocus' | 'value' | 'readOnly' | 'disabled' | 'className'
   >;
 } & Pick<
   React.ComponentProps<typeof AssetPicker>,

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Hex } from '@metamask/utils';
+import { useSelector } from 'react-redux';
 import { SwapsTokenObject } from '../../../../shared/constants/swaps';
 import {
   Box,
@@ -27,6 +28,10 @@ import {
   CHAIN_ID_TOKEN_IMAGE_MAP,
 } from '../../../../shared/constants/network';
 import useLatestBalance from '../../../hooks/bridge/useLatestBalance';
+import {
+  getBridgeQuotes,
+  getRecommendedQuote,
+} from '../../../ducks/bridge/selectors';
 
 const generateAssetFromToken = (
   chainId: Hex,
@@ -77,6 +82,9 @@ export const BridgeInputGroup = ({
 >) => {
   const t = useI18nContext();
 
+  const { isLoading } = useSelector(getBridgeQuotes);
+  const recommendedQuote = useSelector(getRecommendedQuote);
+
   const tokenFiatValue = useTokenFiatAmount(
     token?.address || undefined,
     amountFieldProps?.value?.toString() || '0x0',
@@ -125,7 +133,11 @@ export const BridgeInputGroup = ({
           <TextField
             type={TextFieldType.Number}
             className="amount-input"
-            placeholder="0"
+            placeholder={
+              isLoading && !recommendedQuote
+                ? t('bridgeCalculatingAmount')
+                : '0'
+            }
             onChange={(e) => {
               onAmountChange?.(e.target.value);
             }}

--- a/ui/pages/bridge/prepare/index.scss
+++ b/ui/pages/bridge/prepare/index.scss
@@ -11,6 +11,7 @@
   flex-flow: column;
   flex: 1;
   width: 100%;
+  gap: 24px;
 
   &__content {
     display: flex;
@@ -20,8 +21,7 @@
     border: 1px solid var(--color-border-muted);
   }
 
-  &__from,
-  &__to {
+  .bridge-box {
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -54,6 +54,34 @@
       &--focused {
         outline: none;
       }
+    }
+
+    .defined {
+      opacity: 1;
+
+      & > .mm-input--disabled {
+        opacity: 1;
+      }
+    }
+  }
+
+  .amount-input {
+    border: none;
+
+    input {
+      text-align: right;
+      padding-right: 0;
+      font-size: 24px;
+      font-weight: 700;
+
+      &:focus,
+      &:focus-visible {
+        outline: none;
+      }
+    }
+
+    .mm-text-field--focused {
+      outline: none;
     }
   }
 
@@ -93,26 +121,6 @@
       height: 10px;
       width: 10px;
       border: none;
-    }
-  }
-
-  .amount-input {
-    border: none;
-
-    input {
-      text-align: right;
-      padding-right: 0;
-      font-size: 24px;
-      font-weight: 700;
-
-      &:focus,
-      &:focus-visible {
-        outline: none;
-      }
-    }
-
-    .mm-text-field--focused {
-      outline: none;
     }
   }
 

--- a/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.test.tsx
@@ -66,7 +66,16 @@ describe('PrepareBridgePage', () => {
         },
         toChainId: CHAIN_IDS.LINEA_MAINNET,
       },
-      {},
+      {
+        quoteRequest: {
+          srcTokenAddress: '0x3103910',
+          destTokenAddress: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+          srcChainId: 1,
+          destChainId: 10,
+          walletAddress: '0x123',
+          slippage: 0.5,
+        },
+      },
     );
     const { container, getByRole, getByTestId } = renderWithProvider(
       <PrepareBridgePage />,

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -18,6 +18,7 @@ import {
   getFromToken,
   getFromTokens,
   getFromTopAssets,
+  getQuoteRequest,
   getToAmount,
   getToChain,
   getToChains,
@@ -38,6 +39,8 @@ import { setActiveNetwork } from '../../../store/actions';
 import { hexToDecimal } from '../../../../shared/modules/conversion.utils';
 import { QuoteRequest } from '../types';
 import { calcTokenValue } from '../../../../shared/lib/swaps-utils';
+import { BridgeQuoteCard } from '../quotes/bridge-quote-card';
+import { isValidQuoteRequest } from '../utils/quote';
 import { BridgeInputGroup } from './bridge-input-group';
 
 const PrepareBridgePage = () => {
@@ -60,6 +63,8 @@ const PrepareBridgePage = () => {
 
   const fromAmount = useSelector(getFromAmount);
   const toAmount = useSelector(getToAmount);
+
+  const quoteRequest = useSelector(getQuoteRequest);
 
   const fromTokenListGenerator = useTokensWithFiltering(
     fromTokens,
@@ -110,7 +115,7 @@ const PrepareBridgePage = () => {
     <div className="prepare-bridge-page">
       <Box className="prepare-bridge-page__content">
         <BridgeInputGroup
-          className="prepare-bridge-page__from"
+          className="bridge-box"
           header={t('bridgeFrom')}
           token={fromToken}
           onAmountChange={(e) => {
@@ -157,7 +162,7 @@ const PrepareBridgePage = () => {
             data-testid="switch-tokens"
             ariaLabel="switch-tokens"
             iconName={IconName.Arrow2Down}
-            disabled={!toChain}
+            disabled={!isValidQuoteRequest(quoteRequest, false)}
             onClick={() => {
               setRotateSwitchTokens(!rotateSwitchTokens);
               const toChainClientId =
@@ -178,7 +183,7 @@ const PrepareBridgePage = () => {
         </Box>
 
         <BridgeInputGroup
-          className="prepare-bridge-page__to"
+          className="bridge-box"
           header={t('bridgeTo')}
           token={toToken}
           onAssetChange={(token) => dispatch(setToToken(token))}
@@ -199,10 +204,12 @@ const PrepareBridgePage = () => {
             testId: 'to-amount',
             readOnly: true,
             disabled: true,
-            value: toAmount,
+            value: toAmount ?? '0',
+            className: toAmount ? 'amount-input defined' : 'amount-input',
           }}
         />
       </Box>
+      <BridgeQuoteCard />
     </div>
   );
 };

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -204,7 +204,7 @@ const PrepareBridgePage = () => {
             testId: 'to-amount',
             readOnly: true,
             disabled: true,
-            value: toAmount ?? '0',
+            value: toAmount?.toString() ?? '0',
             className: toAmount ? 'amount-input defined' : 'amount-input',
           }}
         />

--- a/ui/pages/bridge/quotes/__snapshots__/bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/bridge-quote-card.test.tsx.snap
@@ -1,0 +1,327 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BridgeQuoteCard should not render when there is a quote fetch error 1`] = `<div />`;
+
+exports[`BridgeQuoteCard should not render when there is no quote 1`] = `<div />`;
+
+exports[`BridgeQuoteCard should render the recommended quote 1`] = `
+<div>
+  <div
+    class="mm-box quote-card"
+  >
+    <div
+      class="mm-box bridge-box quote-card__timer"
+    >
+      <p
+        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      >
+        New quotes in 0:30
+      </p>
+    </div>
+    <div
+      class="mm-box bridge-box prepare-bridge-page__content quote-card__content"
+    >
+      <div
+        class="mm-box quote-card__info-row"
+      >
+        <div
+          class="mm-box quote-card__info-row__label"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            Estimated time
+          </p>
+          <div>
+            <div
+              aria-describedby="tippy-tooltip-1"
+              class="quote-card__info-row__label__tooltip"
+              data-original-title="This is the estimated time it will take for the bridging to be complete."
+              data-tooltipped=""
+              style="display: flex;"
+              tabindex="0"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-icon-muted"
+                style="mask-image: url('./images/icons/question.svg');"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="mm-box quote-card__info-row__description"
+        >
+          <div
+            class="mm-box quote-card__info-row__description__secondary"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            />
+          </div>
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            1 minutes
+          </p>
+        </div>
+      </div>
+      <div
+        class="mm-box quote-card__info-row"
+      >
+        <div
+          class="mm-box quote-card__info-row__label"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            Quote rate
+          </p>
+        </div>
+        <div
+          class="mm-box quote-card__info-row__description"
+        >
+          <div
+            class="mm-box quote-card__info-row__description__secondary"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            />
+          </div>
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            1 USDC = 0.9989 USDC
+          </p>
+        </div>
+      </div>
+      <div
+        class="mm-box quote-card__info-row"
+      >
+        <div
+          class="mm-box quote-card__info-row__label"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            Total fees
+          </p>
+          <div>
+            <div
+              aria-describedby="tippy-tooltip-2"
+              class="quote-card__info-row__label__tooltip"
+              data-original-title="This includes gas fees (paid to crypto miners) and relayer fees (paid to power complex services like bridging).
+Fees are based on network traffic and transaction complexity. MetaMask does not profit from either fee."
+              data-tooltipped=""
+              style="display: flex;"
+              tabindex="0"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-icon-muted"
+                style="mask-image: url('./images/icons/question.svg');"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="mm-box quote-card__info-row__description"
+        >
+          <div
+            class="mm-box quote-card__info-row__description__secondary"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            >
+              0.01 ETH
+            </p>
+          </div>
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            $0.01
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mm-box bridge-box quote-card__footer"
+    >
+      <p
+        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      >
+        Includes a 0.875% MetaMask fee.
+      </p>
+      <button
+        class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+      >
+        <span
+          class="mm-box mm-text mm-text--inherit mm-box--color-primary-default"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            Terms of service
+          </p>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`BridgeQuoteCard should render the recommended quote while loading new quotes 1`] = `
+<div>
+  <div
+    class="mm-box quote-card"
+  >
+    <div
+      class="mm-box bridge-box quote-card__timer"
+    />
+    <div
+      class="mm-box bridge-box prepare-bridge-page__content quote-card__content"
+    >
+      <div
+        class="mm-box quote-card__info-row"
+      >
+        <div
+          class="mm-box quote-card__info-row__label"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            Estimated time
+          </p>
+          <div>
+            <div
+              aria-describedby="tippy-tooltip-3"
+              class="quote-card__info-row__label__tooltip"
+              data-original-title="This is the estimated time it will take for the bridging to be complete."
+              data-tooltipped=""
+              style="display: flex;"
+              tabindex="0"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-icon-muted"
+                style="mask-image: url('./images/icons/question.svg');"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="mm-box quote-card__info-row__description"
+        >
+          <div
+            class="mm-box quote-card__info-row__description__secondary"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            />
+          </div>
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            1 minutes
+          </p>
+        </div>
+      </div>
+      <div
+        class="mm-box quote-card__info-row"
+      >
+        <div
+          class="mm-box quote-card__info-row__label"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            Quote rate
+          </p>
+        </div>
+        <div
+          class="mm-box quote-card__info-row__description"
+        >
+          <div
+            class="mm-box quote-card__info-row__description__secondary"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            />
+          </div>
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            1 ETH = 2465.4630 USDC
+          </p>
+        </div>
+      </div>
+      <div
+        class="mm-box quote-card__info-row"
+      >
+        <div
+          class="mm-box quote-card__info-row__label"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            Total fees
+          </p>
+          <div>
+            <div
+              aria-describedby="tippy-tooltip-4"
+              class="quote-card__info-row__label__tooltip"
+              data-original-title="This includes gas fees (paid to crypto miners) and relayer fees (paid to power complex services like bridging).
+Fees are based on network traffic and transaction complexity. MetaMask does not profit from either fee."
+              data-tooltipped=""
+              style="display: flex;"
+              tabindex="0"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-icon-muted"
+                style="mask-image: url('./images/icons/question.svg');"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="mm-box quote-card__info-row__description"
+        >
+          <div
+            class="mm-box quote-card__info-row__description__secondary"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            >
+              0.01 ETH
+            </p>
+          </div>
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            $0.01
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mm-box bridge-box quote-card__footer"
+    >
+      <p
+        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      >
+        Includes a 0.875% MetaMask fee.
+      </p>
+      <button
+        class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+      >
+        <span
+          class="mm-box mm-text mm-text--inherit mm-box--color-primary-default"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            Terms of service
+          </p>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/ui/pages/bridge/quotes/__snapshots__/bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/bridge-quote-card.test.tsx.snap
@@ -145,11 +145,26 @@ Fees are based on network traffic and transaction complexity. MetaMask does not 
     <div
       class="mm-box bridge-box quote-card__footer"
     >
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      >
-        Includes a 0.875% MetaMask fee.
-      </p>
+      <span>
+        <p
+          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+        >
+          Includes a 0.875% MetaMask fee.
+        </p>
+        <button
+          class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+        >
+          <span
+            class="mm-box mm-text mm-text--inherit mm-box--color-primary-default"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            >
+              view all quotes
+            </p>
+          </span>
+        </button>
+      </span>
       <button
         class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
       >
@@ -303,11 +318,26 @@ Fees are based on network traffic and transaction complexity. MetaMask does not 
     <div
       class="mm-box bridge-box quote-card__footer"
     >
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      >
-        Includes a 0.875% MetaMask fee.
-      </p>
+      <span>
+        <p
+          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+        >
+          Includes a 0.875% MetaMask fee.
+        </p>
+        <button
+          class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+        >
+          <span
+            class="mm-box mm-text mm-text--inherit mm-box--color-primary-default"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            >
+              view all quotes
+            </p>
+          </span>
+        </button>
+      </span>
       <button
         class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
       >

--- a/ui/pages/bridge/quotes/__snapshots__/bridge-quotes-modal.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/bridge-quotes-modal.test.tsx.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BridgeQuotesModal should render the modal 1`] = `
+<body>
+  <div
+    id="popover-content"
+  />
+  <div />
+  <div
+    class="mm-modal quotes-modal"
+  >
+    <div
+      aria-hidden="true"
+      class="mm-box mm-modal-overlay mm-box--width-full mm-box--height-full mm-box--background-color-overlay-default"
+    />
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        class="mm-box mm-modal-content mm-box--padding-top-4 mm-box--sm:padding-top-8 mm-box--md:padding-top-12 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--sm:padding-bottom-8 mm-box--md:padding-bottom-12 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-flex-start mm-box--width-screen mm-box--height-screen"
+      >
+        <section
+          aria-modal="true"
+          class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm mm-box--padding-0 mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
+          role="dialog"
+        >
+          <header
+            class="mm-box mm-header-base mm-modal-header mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
+          >
+            <div
+              class="mm-box mm-box--width-full"
+            >
+              <h4
+                class="mm-box mm-text mm-text--heading-sm mm-text--text-align-center mm-box--color-text-default"
+              >
+                Select a quote
+              </h4>
+            </div>
+            <div
+              class="mm-box mm-box--display-flex mm-box--justify-content-flex-end"
+              style="min-width: 0px;"
+            >
+              <button
+                aria-label="Close"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+              >
+                <span
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  style="mask-image: url('./images/icons/close.svg');"
+                />
+              </button>
+            </div>
+          </header>
+          <div
+            class="mm-box quotes-modal__column-header"
+          >
+            <button
+              aria-label="Back"
+              class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                style="mask-image: url('./images/icons/arrow-2-down.svg');"
+              />
+            </button>
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            >
+              Overall cost
+            </p>
+            <button
+              aria-label="Back"
+              class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                style="mask-image: url('./images/icons/arrow-2-down.svg');"
+              />
+            </button>
+            <p
+              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+            >
+              Time
+            </p>
+          </div>
+          <div
+            class="mm-box quotes-modal__quotes"
+          >
+            <div
+              class="mm-box quotes-modal__quotes__row"
+            >
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                $0.01
+              </p>
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                1 minutes
+              </p>
+            </div>
+            <div
+              class="mm-box quotes-modal__quotes__row"
+            >
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                $0.01
+              </p>
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                26 minutes
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;

--- a/ui/pages/bridge/quotes/__snapshots__/bridge-quotes-modal.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/bridge-quotes-modal.test.tsx.snap
@@ -60,33 +60,39 @@ exports[`BridgeQuotesModal should render the modal 1`] = `
             class="mm-box quotes-modal__column-header"
           >
             <button
-              aria-label="Back"
-              class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+              class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                style="mask-image: url('./images/icons/arrow-2-down.svg');"
-              />
+                class="mm-box mm-text mm-text--inherit mm-box--color-primary-default"
+              >
+                <span
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  style="mask-image: url('./images/icons/arrow-2-down.svg');"
+                />
+                <p
+                  class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+                >
+                  Overall cost
+                </p>
+              </span>
             </button>
-            <p
-              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-            >
-              Overall cost
-            </p>
             <button
-              aria-label="Back"
-              class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+              class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                style="mask-image: url('./images/icons/arrow-2-down.svg');"
-              />
+                class="mm-box mm-text mm-text--inherit mm-box--color-primary-default"
+              >
+                <span
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  style="mask-image: url('./images/icons/arrow-2-down.svg');"
+                />
+                <p
+                  class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+                >
+                  Time
+                </p>
+              </span>
             </button>
-            <p
-              class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-            >
-              Time
-            </p>
           </div>
           <div
             class="mm-box quotes-modal__quotes"

--- a/ui/pages/bridge/quotes/bridge-quote-card.test.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { renderWithProvider } from '../../../../test/jest';
+import configureStore from '../../../store/store';
+import { createBridgeMockStore } from '../../../../test/jest/mock-store';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { mockBridgeQuotesErc20Erc20 } from '../../../../test/data/bridge/mock-quotes-erc20-erc20';
+import { mockBridgeQuotesNativeErc20 } from '../../../../test/data/bridge/mock-quotes-native-erc20';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { RequestStatus } from '../../../../app/scripts/controllers/bridge/constants';
+import { BridgeQuoteCard } from './bridge-quote-card';
+
+describe('BridgeQuoteCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the recommended quote', async () => {
+    const mockStore = createBridgeMockStore(
+      {
+        srcNetworkAllowlist: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+        destNetworkAllowlist: [CHAIN_IDS.OPTIMISM],
+      },
+      { fromTokenInputValue: 1 },
+      {
+        quotes: mockBridgeQuotesErc20Erc20,
+        getQuotesLastFetched: Date.now(),
+        quotesLoadingStatus: RequestStatus.FETCHED,
+      },
+    );
+    const { container } = renderWithProvider(
+      <BridgeQuoteCard />,
+      configureStore(mockStore),
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render the recommended quote while loading new quotes', async () => {
+    const mockStore = createBridgeMockStore(
+      {
+        srcNetworkAllowlist: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+        destNetworkAllowlist: [CHAIN_IDS.OPTIMISM],
+      },
+      { fromTokenInputValue: 1 },
+      {
+        quotes: mockBridgeQuotesNativeErc20,
+        getQuotesLastFetched: Date.now() - 5000,
+        quotesLoadingStatus: RequestStatus.LOADING,
+      },
+    );
+    const { container, queryByText } = renderWithProvider(
+      <BridgeQuoteCard />,
+      configureStore(mockStore),
+    );
+
+    expect(container).toMatchSnapshot();
+    expect(queryByText('New quotes in')).not.toBeInTheDocument();
+  });
+
+  it('should not render when there is no quote', async () => {
+    const mockStore = createBridgeMockStore(
+      {
+        srcNetworkAllowlist: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+        destNetworkAllowlist: [CHAIN_IDS.OPTIMISM],
+      },
+      { fromTokenInputValue: 1 },
+      {
+        quotes: [],
+        getQuotesLastFetched: Date.now() - 5000,
+        quotesLoadingStatus: RequestStatus.FETCHED,
+      },
+    );
+    const { container } = renderWithProvider(
+      <BridgeQuoteCard />,
+      configureStore(mockStore),
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should not render when there is a quote fetch error', async () => {
+    const mockStore = createBridgeMockStore(
+      {
+        srcNetworkAllowlist: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+        destNetworkAllowlist: [CHAIN_IDS.OPTIMISM],
+      },
+      { fromTokenInputValue: 1 },
+      {
+        quotes: [],
+        getQuotesLastFetched: Date.now() - 5000,
+        quotesLoadingStatus: RequestStatus.ERROR,
+      },
+    );
+    const { container } = renderWithProvider(
+      <BridgeQuoteCard />,
+      configureStore(mockStore),
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/ui/pages/bridge/quotes/bridge-quote-card.test.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.test.tsx
@@ -3,8 +3,8 @@ import { renderWithProvider } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import { createBridgeMockStore } from '../../../../test/jest/mock-store';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import { mockBridgeQuotesErc20Erc20 } from '../../../../test/data/bridge/mock-quotes-erc20-erc20';
-import { mockBridgeQuotesNativeErc20 } from '../../../../test/data/bridge/mock-quotes-native-erc20';
+import mockBridgeQuotesErc20Erc20 from '../../../../test/data/bridge/mock-quotes-erc20-erc20.json';
+import mockBridgeQuotesNativeErc20 from '../../../../test/data/bridge/mock-quotes-native-erc20.json';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { RequestStatus } from '../../../../app/scripts/controllers/bridge/constants';

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   Box,
@@ -15,6 +15,7 @@ import { getQuoteDisplayData } from '../utils/quote';
 import { useCountdownTimer } from '../../../hooks/bridge/useCountdownTimer';
 import MascotBackgroundAnimation from '../../swaps/mascot-background-animation/mascot-background-animation';
 import { QuoteInfoRow } from './quote-info-row';
+import { BridgeQuotesModal } from './bridge-quotes-modal';
 
 export const BridgeQuoteCard = () => {
   const t = useI18nContext();
@@ -26,6 +27,8 @@ export const BridgeQuoteCard = () => {
 
   const secondsUntilNextRefresh = useCountdownTimer();
 
+  const [showAllQuotes, setShowAllQuotes] = useState(false);
+
   if (isLoading && !recommendedQuote) {
     return (
       <Box>
@@ -36,6 +39,10 @@ export const BridgeQuoteCard = () => {
 
   return etaInMinutes && totalFees && quoteRate ? (
     <Box className="quote-card">
+      <BridgeQuotesModal
+        isOpen={showAllQuotes}
+        onClose={() => setShowAllQuotes(false)}
+      />
       <Box className="bridge-box quote-card__timer">
         {!isLoading && (
           <Text>{t('swapNewQuoteIn', [secondsUntilNextRefresh])}</Text>
@@ -58,7 +65,17 @@ export const BridgeQuoteCard = () => {
       </Box>
 
       <Box className="bridge-box quote-card__footer">
-        <Text>{t('swapIncludesMMFee', [0.875])}</Text>
+        <span>
+          <Text>{t('swapIncludesMMFee', [0.875])}</Text>
+          <Button
+            variant={ButtonVariant.Link}
+            onClick={() => {
+              setShowAllQuotes(true);
+            }}
+          >
+            <Text>{t('viewAllQuotes')}</Text>
+          </Button>
+        </span>
         <Button variant={ButtonVariant.Link}>
           <Text>{t('termsOfService')}</Text>
         </Button>

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import {
+  Box,
+  Button,
+  ButtonVariant,
+  Text,
+} from '../../../components/component-library';
+import {
+  getBridgeQuotes,
+  getRecommendedQuote,
+} from '../../../ducks/bridge/selectors';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { getQuoteDisplayData } from '../utils/quote';
+import { useCountdownTimer } from '../../../hooks/bridge/useCountdownTimer';
+import MascotBackgroundAnimation from '../../swaps/mascot-background-animation/mascot-background-animation';
+import { QuoteInfoRow } from './quote-info-row';
+
+export const BridgeQuoteCard = () => {
+  const t = useI18nContext();
+  const recommendedQuote = useSelector(getRecommendedQuote);
+  const { isLoading } = useSelector(getBridgeQuotes);
+
+  const { etaInMinutes, totalFees, quoteRate } =
+    getQuoteDisplayData(recommendedQuote);
+
+  const secondsUntilNextRefresh = useCountdownTimer();
+
+  if (isLoading && !recommendedQuote) {
+    return (
+      <Box>
+        <MascotBackgroundAnimation />
+      </Box>
+    );
+  }
+
+  return etaInMinutes && totalFees && quoteRate ? (
+    <Box className="quote-card">
+      <Box className="bridge-box quote-card__timer">
+        {!isLoading && (
+          <Text>{t('swapNewQuoteIn', [secondsUntilNextRefresh])}</Text>
+        )}
+      </Box>
+
+      <Box className="bridge-box prepare-bridge-page__content quote-card__content">
+        <QuoteInfoRow
+          label={t('estimatedTime')}
+          tooltipText={t('bridgeTimingTooltipText')}
+          description={t('bridgeTimingMinutes', [etaInMinutes])}
+        />
+        <QuoteInfoRow label={t('quoteRate')} description={quoteRate} />
+        <QuoteInfoRow
+          label={t('totalFees')}
+          tooltipText={t('bridgeTotalFeesTooltipText')}
+          description={totalFees.fiat}
+          secondaryDescription={totalFees?.amount}
+        />
+      </Box>
+
+      <Box className="bridge-box quote-card__footer">
+        <Text>{t('swapIncludesMMFee', [0.875])}</Text>
+        <Button variant={ButtonVariant.Link}>
+          <Text>{t('termsOfService')}</Text>
+        </Button>
+      </Box>
+    </Box>
+  ) : null;
+};

--- a/ui/pages/bridge/quotes/bridge-quotes-modal.test.tsx
+++ b/ui/pages/bridge/quotes/bridge-quotes-modal.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { RequestStatus } from '../../../../app/scripts/controllers/bridge/constants';
+import { mockBridgeQuotesErc20Erc20 } from '../../../../test/data/bridge/mock-quotes-erc20-erc20';
+import { createBridgeMockStore } from '../../../../test/jest/mock-store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import configureStore from '../../../store/store';
+import { BridgeQuotesModal } from './bridge-quotes-modal';
+
+describe('BridgeQuotesModal', () => {
+  it('should render the modal', () => {
+    const mockStore = createBridgeMockStore(
+      {},
+      {},
+      {
+        quotes: mockBridgeQuotesErc20Erc20,
+        getQuotesLastFetched: Date.now(),
+        quotesLoadingStatus: RequestStatus.FETCHED,
+      },
+    );
+
+    const { baseElement } = renderWithProvider(
+      <BridgeQuotesModal
+        isOpen={true}
+        onClose={() => {
+          console.log('close');
+        }}
+      />,
+      configureStore(mockStore),
+    );
+
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/ui/pages/bridge/quotes/bridge-quotes-modal.test.tsx
+++ b/ui/pages/bridge/quotes/bridge-quotes-modal.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { RequestStatus } from '../../../../app/scripts/controllers/bridge/constants';
-import { mockBridgeQuotesErc20Erc20 } from '../../../../test/data/bridge/mock-quotes-erc20-erc20';
+import mockBridgeQuotesErc20Erc20 from '../../../../test/data/bridge/mock-quotes-erc20-erc20.json';
 import { createBridgeMockStore } from '../../../../test/jest/mock-store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import configureStore from '../../../store/store';

--- a/ui/pages/bridge/quotes/bridge-quotes-modal.tsx
+++ b/ui/pages/bridge/quotes/bridge-quotes-modal.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { IconName } from '@metamask/snaps-sdk/jsx';
+import {
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '../../../components/component-library';
+import {
+  TextAlign,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import { getBridgeQuotes } from '../../../ducks/bridge/selectors';
+import { getQuoteDisplayData } from '../utils/quote';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+export const BridgeQuotesModal = ({
+  onClose,
+  ...modalProps
+}: Omit<React.ComponentProps<typeof Modal>, 'children'>) => {
+  const { quotes } = useSelector(getBridgeQuotes);
+  const t = useI18nContext();
+
+  const [, setSortOrder] = useState(t('bridgeOverallCost'));
+  return (
+    <Modal className="quotes-modal" onClose={onClose} {...modalProps}>
+      <ModalOverlay />
+      <ModalContent modalDialogProps={{ padding: 0 }}>
+        <ModalHeader onClose={onClose}>
+          <Text variant={TextVariant.headingSm} textAlign={TextAlign.Center}>
+            {t('swapSelectAQuote')}
+          </Text>
+        </ModalHeader>
+
+        <Box className="quotes-modal__column-header">
+          {[t('bridgeOverallCost'), t('time')].map((label) => {
+            return (
+              <>
+                <ButtonIcon
+                  iconName={IconName.Arrow2Down}
+                  size={ButtonIconSize.Sm}
+                  ariaLabel={t('back')}
+                  onClick={() => setSortOrder(label)}
+                />
+                <Text>{label}</Text>
+              </>
+            );
+          })}
+        </Box>
+        <Box className="quotes-modal__quotes">
+          {quotes.map((quote, index) => {
+            const { totalFees, etaInMinutes } = getQuoteDisplayData(quote);
+            return (
+              <Box key={index} className="quotes-modal__quotes__row">
+                <Text>{totalFees?.fiat}</Text>
+                <Text>{t('bridgeTimingMinutes', [etaInMinutes])}</Text>
+              </Box>
+            );
+          })}
+        </Box>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/ui/pages/bridge/quotes/bridge-quotes-modal.tsx
+++ b/ui/pages/bridge/quotes/bridge-quotes-modal.tsx
@@ -1,10 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { IconName } from '@metamask/snaps-sdk/jsx';
 import {
   Box,
-  ButtonIcon,
-  ButtonIconSize,
+  Button,
+  ButtonVariant,
+  Icon,
+  IconSize,
   Modal,
   ModalContent,
   ModalHeader,
@@ -26,7 +28,6 @@ export const BridgeQuotesModal = ({
   const { quotes } = useSelector(getBridgeQuotes);
   const t = useI18nContext();
 
-  const [, setSortOrder] = useState(t('bridgeOverallCost'));
   return (
     <Modal className="quotes-modal" onClose={onClose} {...modalProps}>
       <ModalOverlay />
@@ -40,15 +41,10 @@ export const BridgeQuotesModal = ({
         <Box className="quotes-modal__column-header">
           {[t('bridgeOverallCost'), t('time')].map((label) => {
             return (
-              <>
-                <ButtonIcon
-                  iconName={IconName.Arrow2Down}
-                  size={ButtonIconSize.Sm}
-                  ariaLabel={t('back')}
-                  onClick={() => setSortOrder(label)}
-                />
+              <Button key={label} variant={ButtonVariant.Link}>
+                <Icon name={IconName.Arrow2Down} size={IconSize.Sm} />
                 <Text>{label}</Text>
-              </>
+              </Button>
             );
           })}
         </Box>

--- a/ui/pages/bridge/quotes/index.scss
+++ b/ui/pages/bridge/quotes/index.scss
@@ -62,3 +62,22 @@
     }
   }
 }
+
+.quotes-modal {
+  &__column-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  &__quotes {
+    display: flex;
+    flex-direction: column;
+
+    &__row {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
+}

--- a/ui/pages/bridge/quotes/index.scss
+++ b/ui/pages/bridge/quotes/index.scss
@@ -1,0 +1,64 @@
+@use "design-system";
+
+.quote-card {
+  flex-direction: column;
+  display: flex;
+  text-align: center;
+
+  p {
+    font-size: 12px;
+  }
+
+
+  &__content {
+    padding: 16px;
+    gap: 4px;
+  }
+
+  &__timer {
+    height: 32px;
+
+    p {
+      color: var(--color-text-alternative);
+    }
+  }
+
+  .bridge-box > &__footer {
+    gap: 0;
+
+    p {
+      color: var(--color-text-alternative);
+    }
+  }
+
+  &__info-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    &__label {
+      display: inline-flex;
+      gap: 4px;
+
+      p {
+        font-weight: var(--font-weight-medium);
+        font-size: 14px;
+        white-space: nowrap;
+      }
+
+      &__tooltip {
+        align-items: center;
+        height: 100%;
+      }
+    }
+
+    &__description {
+      display: inline-flex;
+      gap: 4px;
+
+      &__secondary {
+        color: var(--color-text-alternative);
+      }
+    }
+  }
+}

--- a/ui/pages/bridge/quotes/quote-info-row.tsx
+++ b/ui/pages/bridge/quotes/quote-info-row.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+  Box,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+} from '../../../components/component-library';
+import Tooltip from '../../../components/ui/tooltip';
+import { IconColor } from '../../../helpers/constants/design-system';
+
+export const QuoteInfoRow = ({
+  label,
+  tooltipText,
+  description,
+  secondaryDescription,
+}: {
+  label: string;
+  tooltipText?: string;
+  description: string;
+  secondaryDescription?: string;
+}) => {
+  return (
+    <Box className="quote-card__info-row">
+      <Box className="quote-card__info-row__label">
+        <Text>{label}</Text>
+        {tooltipText && (
+          <Tooltip
+            position="top"
+            title={tooltipText}
+            containerClassName="quote-card__info-row__label__tooltip"
+            style={{ display: 'flex' }}
+          >
+            <Icon
+              color={IconColor.iconMuted}
+              name={IconName.Question}
+              size={IconSize.Sm}
+            />
+          </Tooltip>
+        )}
+      </Box>
+
+      <Box className="quote-card__info-row__description">
+        <Box className="quote-card__info-row__description__secondary">
+          <Text>{secondaryDescription}</Text>
+        </Box>
+        <Text>{description}</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/ui/pages/bridge/utils/quote.ts
+++ b/ui/pages/bridge/utils/quote.ts
@@ -51,7 +51,7 @@ export const getQuoteDisplayData = (quoteResponse?: QuoteResponse) => {
   return {
     etaInMinutes,
     totalFees: {
-      amount: '0.01 ETH', // TODO implement
+      amount: '0.01 ETH', // TODO implement gas + relayer fee
       fiat: '$0.01',
     },
     quoteRate,

--- a/ui/pages/bridge/utils/quote.ts
+++ b/ui/pages/bridge/utils/quote.ts
@@ -1,4 +1,5 @@
-import { QuoteRequest } from '../types';
+import { calcTokenAmount } from '../../../../shared/lib/transactions-controller-utils';
+import { QuoteResponse, QuoteRequest } from '../types';
 
 export const isValidQuoteRequest = (
   partialRequest: Partial<QuoteRequest>,
@@ -30,4 +31,29 @@ export const isValidQuoteRequest = (
         partialRequest[field as keyof typeof partialRequest] !== null,
     )
   );
+};
+
+export const getQuoteDisplayData = (quoteResponse?: QuoteResponse) => {
+  const { quote, estimatedProcessingTimeInSeconds } = quoteResponse ?? {};
+  if (!quoteResponse || !quote || !estimatedProcessingTimeInSeconds) {
+    return {};
+  }
+
+  const etaInMinutes = (estimatedProcessingTimeInSeconds / 60).toFixed();
+  const quoteRate = `1 ${quote.srcAsset.symbol} = ${calcTokenAmount(
+    quote.destTokenAmount,
+    quote.destAsset.decimals,
+  )
+    .div(calcTokenAmount(quote.srcTokenAmount, quote.srcAsset.decimals))
+    .toFixed(4)
+    .toString()} ${quote.destAsset.symbol}`;
+
+  return {
+    etaInMinutes,
+    totalFees: {
+      amount: '0.01 ETH', // TODO implement
+      fiat: '$0.01',
+    },
+    quoteRate,
+  };
 };

--- a/ui/pages/routes/utils.js
+++ b/ui/pages/routes/utils.js
@@ -12,6 +12,7 @@ import {
   CONFIRMATION_V_NEXT_ROUTE,
   CONNECT_ROUTE,
   CONNECTIONS,
+  CROSS_CHAIN_SWAP_ROUTE,
   NOTIFICATIONS_ROUTE,
   ONBOARDING_ROUTE,
   ONBOARDING_UNLOCK_ROUTE,
@@ -193,6 +194,16 @@ export function hideAppHeader(props) {
     }),
   );
   if (isSnapsHome) {
+    return true;
+  }
+
+  const isCrossChainSwapsPage = Boolean(
+    matchPath(location.pathname, {
+      path: `${CROSS_CHAIN_SWAP_ROUTE}`,
+      exact: false,
+    }),
+  );
+  if (isCrossChainSwapsPage) {
     return true;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Changes:
   - display recommended quote in BridgeQuoteCard
   - add a placeholder modal for displaying alternative quotes

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28031?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMS-1448

## **Manual testing steps**

1. Request bridge quotes
2. Click "Switch" button and verify that new quotes with updated params are requested/shown
3. Verify that bridge parameters are reset when extension is reopened

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**


https://github.com/user-attachments/assets/acb927af-b04e-46cb-9b93-e2cdeb219722



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X]  I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
