### PR TITLE
fix: Gas changes for low Max base fee and Priority fee

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useEIP1559TxFees.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useEIP1559TxFees.ts
@@ -8,8 +8,11 @@ export const useEIP1559TxFees = (
   maxFeePerGas: string;
   maxPriorityFeePerGas: string;
 } => {
-  const hexMaxFeePerGas = transactionMeta?.txParams?.maxFeePerGas;
+  const hexMaxFeePerGas =
+    transactionMeta.dappSuggestedGasFees?.maxFeePerGas ||
+    transactionMeta?.txParams?.maxFeePerGas;
   const hexMaxPriorityFeePerGas =
+    transactionMeta.dappSuggestedGasFees?.maxPriorityFeePerGas ||
     transactionMeta?.txParams?.maxPriorityFeePerGas;
 
   return useMemo(() => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -12,6 +12,7 @@ import {
   getValueFromWeiHex,
   multiplyHexes,
 } from '../../../../../../../shared/modules/conversion.utils';
+import { Numeric } from '../../../../../../../shared/modules/Numeric';
 import { getConversionRate } from '../../../../../../ducks/metamask/metamask';
 import { useFiatFormatter } from '../../../../../../hooks/useFiatFormatter';
 import { useGasFeeEstimates } from '../../../../../../hooks/useGasFeeEstimates';
@@ -114,10 +115,20 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     }
 
     // Logic for any network without L1 and L2 fee components
-    const minimumFeePerGas = addHexes(
+    let minimumFeePerGas = addHexes(
       decGWEIToHexWEI(estimatedBaseFee) || HEX_ZERO,
       decimalToHex(maxPriorityFeePerGas),
     );
+
+    // `minimumFeePerGas` should never be higher than the `maxFeePerGas`
+    if (
+      new Numeric(minimumFeePerGas, 16).greaterThan(
+        decimalToHex(maxFeePerGas),
+        16,
+      )
+    ) {
+      minimumFeePerGas = decimalToHex(maxFeePerGas);
+    }
 
     const estimatedFee = multiplyHexes(
       supportsEIP1559 ? (minimumFeePerGas as Hex) : (gasPrice as Hex),

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
@@ -5,6 +5,7 @@ import {
   addHexes,
   multiplyHexes,
 } from '../../../../../../../shared/modules/conversion.utils';
+import { Numeric } from '../../../../../../../shared/modules/Numeric';
 import { useGasFeeEstimates } from '../../../../../../hooks/useGasFeeEstimates';
 import { HEX_ZERO } from '../shared/constants';
 
@@ -28,14 +29,23 @@ export function useTransactionGasFeeEstimate(
     transactionMeta.dappSuggestedGasFees?.maxPriorityFeePerGas ||
     transactionMeta.txParams?.maxPriorityFeePerGas ||
     HEX_ZERO;
+  const maxFeePerGas =
+    transactionMeta.dappSuggestedGasFees?.maxFeePerGas ||
+    transactionMeta.txParams?.maxFeePerGas ||
+    HEX_ZERO;
 
   let gasEstimate: Hex;
   if (supportsEIP1559) {
     // Minimum Total Fee = (estimatedBaseFee + maxPriorityFeePerGas) * gasLimit
-    const minimumFeePerGas = addHexes(
+    let minimumFeePerGas = addHexes(
       estimatedBaseFee || HEX_ZERO,
       maxPriorityFeePerGas,
     );
+
+    // `minimumFeePerGas` should never be higher than the `maxFeePerGas`
+    if (new Numeric(minimumFeePerGas, 16).greaterThan(maxFeePerGas, 16)) {
+      minimumFeePerGas = maxFeePerGas;
+    }
 
     gasEstimate = multiplyHexes(minimumFeePerGas as Hex, gasLimit as Hex);
   } else {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Previously, if the Max base fee and Priority fee were reduced to very low values, the Network fee wouldn't update accordingly. This is a discrepancy with the gas calculations in the old flows.

What fixes it is, for low enough values of `maxFeePerGas` (low enough to be lower than `minimumFeePerGas`), the Network fee becomes the Max fee -- `maxFeePerGas` times `gasLimit` directly. Apart from fixing the symptom explained above, this ensures that the Network fee is never higher than the Max fee.

The PR also fixes this calculation when it comes to the L2 fees (inside `useTransactionGasFeeEstimate`).

It also adds a missing override of `dappSuggestedFees` for both `maxFeePerGas` and `maxPriorityFeePerGas` (inside `useEIP1559TxFees`).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28037?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27802

## **Manual testing steps**

See original report above.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
