### PR TITLE
fix: adjust spacing of quote rate in swaps

### DIFF
--- a/ui/pages/swaps/prepare-swap-page/index.scss
+++ b/ui/pages/swaps/prepare-swap-page/index.scss
@@ -263,7 +263,7 @@
   }
 
   &__exchange-rate-display {
-    color: var(--color-text-alternative);
+    width: auto !important;
   }
 }
 


### PR DESCRIPTION
## **Description**

Cherry-pick of https://github.com/MetaMask/metamask-extension/pull/28016 into v12.6

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28016?quickstart=1)

## **Manual testing steps**

1. Start a swap
2. Notice that the quote rate is back on one line and the value is left-aligned

## **Screenshots/Recordings**

### **Before**

![Screenshot 2024-10-11 at 11 32 09 AM](https://github.com/user-attachments/assets/aae5da2f-ae66-46f5-9168-6c6ed496a2a8)


### **After**

<img width="359" alt="Screenshot 2024-10-22 at 12 13 50 PM" src="https://github.com/user-attachments/assets/f5974e8a-62a6-464e-a037-b7ce38774f42">


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
