### PR TITLE
feat(3419): sensitive text component

### DIFF
--- a/ui/components/component-library/index.ts
+++ b/ui/components/component-library/index.ts
@@ -69,6 +69,8 @@ export { TagUrl } from './tag-url';
 export type { TagUrlProps } from './tag-url';
 export { Text, ValidTag, TextDirection, InvisibleCharacter } from './text';
 export type { TextProps } from './text';
+export { SensitiveText, SensitiveTextLength } from './sensitive-text';
+export type { SensitiveTextProps } from './sensitive-text';
 export { Input, InputType } from './input';
 export type { InputProps } from './input';
 export { TextField, TextFieldType, TextFieldSize } from './text-field';

--- a/ui/components/component-library/sensitive-text/README.md
+++ b/ui/components/component-library/sensitive-text/README.md
@@ -1,0 +1,71 @@
+# SensitiveText
+
+SensitiveText is a component that extends the Text component to handle sensitive information. It provides the ability to hide or show the text content, replacing it with asterisks when hidden.
+
+## Props
+
+This component extends all props from the [Text](../text/README.md) component and adds the following:
+
+### `isHidden`
+
+Boolean to determine whether the text should be hidden or visible.
+
+| <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
+| :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
+| boolean                                             | No                                                      | false                                                  |
+
+### `length`
+
+Determines the length of the hidden text (number of asterisks). Can be a predefined SensitiveTextLength or a custom string number.
+
+| <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
+| :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
+| [SensitiveTextLengthType](./sensitive-text.types.ts#L14) \| [CustomLength](./sensitive-text.types.ts#L19) | No   | SensitiveTextLength.Short                              |
+
+### `children`
+
+The text content to be displayed or hidden.
+
+| <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
+| :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
+| React.ReactNode                                     | No                                                      | ''                                                     |
+
+## Usage
+```jsx
+import { SensitiveText } from '../sensitive-text';
+import { SensitiveTextLength } from './sensitive-text.types';
+<SensitiveText
+isHidden={true}
+length={SensitiveTextLength.Medium}
+>
+Sensitive Information
+</SensitiveText>
+<SensitiveText
+isHidden={true}
+length="15"
+>
+Custom Length Hidden Text
+</SensitiveText>
+```
+
+This will render a Text component with asterisks instead of the actual text when `isHidden` is true, and the original text when `isHidden` is false. The number of asterisks is determined by the `length` prop.
+
+## Behavior
+
+- When `isHidden` is `true`, the component will display asterisks instead of the actual text.
+- The number of asterisks displayed is determined by the `length` prop.
+- If an invalid `length` is provided, the component will fall back to `SensitiveTextLength.Short` and log a warning.
+- Custom length values can be provided as strings, e.g., "15".
+- The component forwards refs to the underlying Text component.
+- Additional props are passed through to the Text component.
+
+## SensitiveTextLength Options
+
+The following predefined length options are available:
+
+- `SensitiveTextLength.Short`: '6'
+- `SensitiveTextLength.Medium`: '9'
+- `SensitiveTextLength.Long`: '12'
+- `SensitiveTextLength.ExtraLong`: '20'
+
+You can import these options from `./sensitive-text.types`.

--- a/ui/components/component-library/sensitive-text/__snapshots__/sensitive-text.test.tsx.snap
+++ b/ui/components/component-library/sensitive-text/__snapshots__/sensitive-text.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SensitiveText should render correctly 1`] = `
+<div>
+  <p
+    class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+  >
+    Sensitive Information
+  </p>
+</div>
+`;

--- a/ui/components/component-library/sensitive-text/index.ts
+++ b/ui/components/component-library/sensitive-text/index.ts
@@ -1,0 +1,3 @@
+export { SensitiveText } from './sensitive-text';
+export { SensitiveTextLength } from './sensitive-text.types';
+export type { SensitiveTextProps } from './sensitive-text.types';

--- a/ui/components/component-library/sensitive-text/sensitive-text.stories.tsx
+++ b/ui/components/component-library/sensitive-text/sensitive-text.stories.tsx
@@ -1,0 +1,55 @@
+import { StoryFn, Meta } from '@storybook/react';
+import React from 'react';
+import { SensitiveText } from '.';
+import { SensitiveTextLength } from './sensitive-text.types';
+import { Box } from '../box';
+import {
+  Display,
+  FlexDirection,
+} from '../../../helpers/constants/design-system';
+
+export default {
+  title: 'Components/ComponentLibrary/SensitiveText',
+  component: SensitiveText,
+  args: {
+    children: 'Sensitive information',
+    isHidden: false,
+    length: SensitiveTextLength.Short,
+  },
+} as Meta<typeof SensitiveText>;
+
+const Template: StoryFn<typeof SensitiveText> = (args) => {
+  return <SensitiveText {...args} />;
+};
+
+export const DefaultStory = Template.bind({});
+DefaultStory.storyName = 'Default';
+
+export const HiddenText: StoryFn<typeof SensitiveText> = (args) => {
+  return <SensitiveText {...args} />;
+};
+HiddenText.args = {
+  isHidden: true,
+};
+
+export const LengthVariants: StoryFn<typeof SensitiveText> = (args) => {
+  return (
+    <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={2}>
+      <SensitiveText {...args} length={SensitiveTextLength.Short}>
+        Length "short" (6 characters)
+      </SensitiveText>
+      <SensitiveText {...args} length={SensitiveTextLength.Medium}>
+        Length "medium" (9 characters)
+      </SensitiveText>
+      <SensitiveText {...args} length={SensitiveTextLength.Long}>
+        Length "long" (12 characters)
+      </SensitiveText>
+      <SensitiveText {...args} length={SensitiveTextLength.ExtraLong}>
+        Length "extra long" (20 characters)
+      </SensitiveText>
+    </Box>
+  );
+};
+LengthVariants.args = {
+  isHidden: true,
+};

--- a/ui/components/component-library/sensitive-text/sensitive-text.test.tsx
+++ b/ui/components/component-library/sensitive-text/sensitive-text.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SensitiveText } from './sensitive-text';
+import { SensitiveTextLength } from './sensitive-text.types';
+
+describe('SensitiveText', () => {
+  const testProps = {
+    isHidden: false,
+    length: SensitiveTextLength.Short,
+    children: 'Sensitive Information',
+  };
+
+  it('should render correctly', () => {
+    const { container } = render(<SensitiveText {...testProps} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should display the text when isHidden is false', () => {
+    render(<SensitiveText {...testProps} />);
+    expect(screen.getByText('Sensitive Information')).toBeInTheDocument();
+  });
+
+  it('should hide the text when isHidden is true', () => {
+    render(<SensitiveText {...testProps} isHidden />);
+    expect(screen.queryByText('Sensitive Information')).not.toBeInTheDocument();
+    expect(screen.getByText('••••••')).toBeInTheDocument();
+  });
+
+  it('should render the correct number of bullets for different lengths', () => {
+    const lengths = [
+      SensitiveTextLength.Short,
+      SensitiveTextLength.Medium,
+      SensitiveTextLength.Long,
+      SensitiveTextLength.ExtraLong,
+    ];
+
+    lengths.forEach((length) => {
+      render(<SensitiveText {...testProps} isHidden length={length} />);
+      expect(screen.getByText('•'.repeat(Number(length)))).toBeInTheDocument();
+    });
+  });
+
+  it('should handle all predefined SensitiveTextLength values', () => {
+    Object.entries(SensitiveTextLength).forEach(([_, value]) => {
+      render(<SensitiveText {...testProps} isHidden length={value} />);
+      expect(screen.getByText('•'.repeat(Number(value)))).toBeInTheDocument();
+    });
+  });
+
+  it('should handle custom length as a string', () => {
+    render(<SensitiveText {...testProps} isHidden length="15" />);
+    expect(screen.getByText('•'.repeat(15))).toBeInTheDocument();
+  });
+
+  it('should fall back to Short length for invalid custom length', () => {
+    render(<SensitiveText {...testProps} isHidden length="invalid" />);
+    expect(
+      screen.getByText('•'.repeat(Number(SensitiveTextLength.Short))),
+    ).toBeInTheDocument();
+  });
+
+  it('should log a warning for invalid custom length', () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+    render(<SensitiveText {...testProps} isHidden length="abc" />);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Invalid length provided: abc. Falling back to Short.',
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('should apply additional props to the Text component', () => {
+    render(<SensitiveText {...testProps} data-testid="sensitive-text" />);
+    expect(screen.getByTestId('sensitive-text')).toBeInTheDocument();
+  });
+
+  it('should forward ref to the Text component', () => {
+    const ref = React.createRef<HTMLParagraphElement>();
+    render(<SensitiveText {...testProps} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
+  });
+});

--- a/ui/components/component-library/sensitive-text/sensitive-text.tsx
+++ b/ui/components/component-library/sensitive-text/sensitive-text.tsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from 'react';
+import { Text } from '../text';
+import {
+  SensitiveTextProps,
+  SensitiveTextLength,
+} from './sensitive-text.types';
+
+export const SensitiveText = React.forwardRef<
+  HTMLParagraphElement,
+  SensitiveTextProps
+>((props, ref) => {
+  const {
+    isHidden = false,
+    length = SensitiveTextLength.Short,
+    children = '',
+    ...restProps
+  } = props;
+
+  const getFallbackLength = useMemo(
+    () => (len: string) => {
+      const numLength = Number(len);
+      return Number.isNaN(numLength) ? 0 : numLength;
+    },
+    [],
+  );
+
+  const isValidCustomLength = (value: string): boolean => {
+    const num = Number(value);
+    return !Number.isNaN(num) && num > 0;
+  };
+
+  let adjustedLength = length;
+  if (!(length in SensitiveTextLength) && !isValidCustomLength(length)) {
+    console.warn(`Invalid length provided: ${length}. Falling back to Short.`);
+    adjustedLength = SensitiveTextLength.Short;
+  }
+
+  const fallback = useMemo(
+    () => '•'.repeat(getFallbackLength(adjustedLength)),
+    [length, getFallbackLength],
+  );
+
+  return (
+    <Text ref={ref} {...restProps}>
+      {isHidden ? fallback : children}
+    </Text>
+  );
+});

--- a/ui/components/component-library/sensitive-text/sensitive-text.types.ts
+++ b/ui/components/component-library/sensitive-text/sensitive-text.types.ts
@@ -1,0 +1,42 @@
+import type { TextProps } from '../text/text.types';
+
+/**
+ * SensitiveText length options.
+ */
+export const SensitiveTextLength = {
+  Short: '6',
+  Medium: '9',
+  Long: '12',
+  ExtraLong: '20',
+} as const;
+
+/**
+ * Type for SensitiveTextLength values.
+ */
+export type SensitiveTextLengthType =
+  (typeof SensitiveTextLength)[keyof typeof SensitiveTextLength];
+/**
+ * Type for custom length values.
+ */
+export type CustomLength = string;
+
+export type SensitiveTextProps<C extends React.ElementType = 'p'> = Omit<
+  TextProps<C>,
+  'children'
+> & {
+  /**
+   * Boolean to determine whether the text should be hidden or visible.
+   * @default false
+   */
+  isHidden?: boolean;
+  /**
+   * Determines the length of the hidden text (number of asterisks).
+   * Can be a predefined SensitiveTextLength or a custom string number.
+   * @default SensitiveTextLength.Short
+   */
+  length?: SensitiveTextLengthType | CustomLength;
+  /**
+   * The text content to be displayed or hidden.
+   */
+  children?: React.ReactNode;
+};

--- a/ui/components/component-library/sensitive-text/sensitive-text.types.ts
+++ b/ui/components/component-library/sensitive-text/sensitive-text.types.ts
@@ -26,12 +26,15 @@ export type SensitiveTextProps<C extends React.ElementType = 'p'> = Omit<
 > & {
   /**
    * Boolean to determine whether the text should be hidden or visible.
+   *
    * @default false
    */
   isHidden?: boolean;
+
   /**
    * Determines the length of the hidden text (number of asterisks).
    * Can be a predefined SensitiveTextLength or a custom string number.
+   *
    * @default SensitiveTextLength.Short
    */
   length?: SensitiveTextLengthType | CustomLength;


### PR DESCRIPTION
## **Description**

### Overview
This PR introduces a new `SensitiveText` component to our component library. The `SensitiveText` component extends our existing `Text` component to handle sensitive information, providing the ability to hide or show text content as needed.

### Features
- Extends the existing `Text` component functionality
- Allows toggling between visible and hidden states for sensitive information
- Supports different lengths of hidden text (Short, Medium, Long, ExtraLong)
- Maintains all styling capabilities of the `Text` component (variants, colors, etc)

This is dependent on this open PR  [#28021](https://github.com/MetaMask/metamask-extension/pull/28021)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28056?quickstart=1)

## **Related issues**

Fixes: [#3419](https://github.com/MetaMask/MetaMask-planning/issues/3419)

## **Manual testing steps**

1. Go to Storybook to play with new component 👯 

## **Screenshots/Recordings**

NA

### **Before**

NA

### **After**
![Screenshot 2024-10-24 at 11 56 13 AM](https://github.com/user-attachments/assets/58ae3fc8-882d-47f5-8c18-4d69bb033d94)

The screenshots below are from this [pull request](https://github.com/MetaMask/metamask-extension/pull/28021) and NOT apart of this PR. This is just to show how it looks like in extension

https://github.com/user-attachments/assets/2950ac0c-593d-4daa-aa5d-3e6c3a2d5598

https://github.com/user-attachments/assets/6371c2a2-04fa-48a3-8744-991a1540d5f2

<img width="496" alt="Screenshot 2024-10-22 at 18 43 19" src="https://github.com/user-attachments/assets/d7c2f681-75c7-4be0-921b-f3c5186f8d4a">

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
