### PR TITLE
feat: share the same user storage mock instance in tests

### DIFF
--- a/test/e2e/tests/notifications/mocks.ts
+++ b/test/e2e/tests/notifications/mocks.ts
@@ -20,11 +20,11 @@ type MockResponse = {
  * E2E mock setup for notification APIs (Auth, UserStorage, Notifications, Push Notifications, Profile syncing)
  *
  * @param server - server obj used to mock our endpoints
- * @param userStorageMockttpController - optional controller to mock user storage endpoints
+ * @param userStorageMockttpControllerInstance - optional instance of UserStorageMockttpController, useful if you need persisted user storage between tests
  */
 export async function mockNotificationServices(
   server: Mockttp,
-  userStorageMockttpController?: UserStorageMockttpController,
+  userStorageMockttpControllerInstance: UserStorageMockttpController = new UserStorageMockttpController(),
 ) {
   // Auth
   mockAPICall(server, AuthMocks.getMockAuthNonceResponse());
@@ -32,14 +32,14 @@ export async function mockNotificationServices(
   mockAPICall(server, AuthMocks.getMockAuthAccessTokenResponse());
 
   // Storage
-  if (!userStorageMockttpController?.paths.get('accounts')) {
-    new UserStorageMockttpController().setupPath('accounts', server);
+  if (!userStorageMockttpControllerInstance?.paths.get('accounts')) {
+    userStorageMockttpControllerInstance.setupPath('accounts', server);
   }
-  if (!userStorageMockttpController?.paths.get('networks')) {
-    new UserStorageMockttpController().setupPath('networks', server);
+  if (!userStorageMockttpControllerInstance?.paths.get('networks')) {
+    userStorageMockttpControllerInstance.setupPath('networks', server);
   }
-  if (!userStorageMockttpController?.paths.get('notifications')) {
-    new UserStorageMockttpController().setupPath('notifications', server);
+  if (!userStorageMockttpControllerInstance?.paths.get('notifications')) {
+    userStorageMockttpControllerInstance.setupPath('notifications', server);
   }
 
   // Notifications


### PR DESCRIPTION
## **Description**

This PR ensures we share the same `UserStorageMockttpController` instance for every user storage endpoint.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28119?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Start E2E tests
2. Make sure they pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
