### PR TITLE
feat(NOTIFY-1260): enable account syncing

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1565,7 +1565,7 @@ export default class MetamaskController extends EventEmitter {
         },
       },
       env: {
-        isAccountSyncingEnabled: !isProduction() && isManifestV3,
+        isAccountSyncingEnabled: isManifestV3,
       },
       messenger: this.controllerMessenger.getRestricted({
         name: 'UserStorageController',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -156,7 +156,6 @@ import {
   NotificationServicesPushController,
   NotificationServicesController,
 } from '@metamask/notification-services-controller';
-import { isProduction } from '../../shared/modules/environment';
 import { methodsRequiringNetworkSwitch } from '../../shared/constants/methods-tags';
 
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)


### PR DESCRIPTION
## **Description**

This PR adds [account syncing](https://www.figma.com/board/sx26FtZcQc0zs0z5hpdqBh/Account-Syncing-Solution?t=5Oy00gbHLnoPqyYP-0) to MetaMask.
As part of profile syncing, with this new feature, users will be able to synchronize all of their accounts and accounts' names across all of their devices.

Account syncing is now covered by E2E tests (6 at the time of this PR).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28120?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Log in with SRP
2. Activate profile syncing in preferences
3. Add new accounts and rename others
4. Using another browser, log in with SRP
5. Activate profile syncing in preferences
6. Watch the magic happen!

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
