### PR TITLE
fix: incorrect standard swap gas fee estimation

### DIFF
--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -257,7 +257,8 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   );
   const smartTransactionFees = useSelector(getSmartTransactionFees, isEqual);
   const swapsNetworkConfig = useSelector(getSwapsNetworkConfig, shallowEqual);
-  const { estimatedBaseFee = '0' } = useGasFeeEstimates();
+  const { gasFeeEstimates: networkGasFeeEstimates } = useGasFeeEstimates();
+  const { estimatedBaseFee = '0' } = networkGasFeeEstimates ?? {};
 
   const gasFeeEstimates = useAsyncResult(async () => {
     if (!networkAndAccountSupports1559) {


### PR DESCRIPTION
## **Description**

Fix incorrect non-smart gas fee estimations due to the use of an empty estimated base fee.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28127?quickstart=1)

## **Related issues**

Fixes: #28088 

## **Manual testing steps**

See issue.

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="354" alt="Smart" src="https://github.com/user-attachments/assets/c1c604d3-9b03-4e4f-b819-9c21f230f789">

<img width="353" alt="Standard" src="https://github.com/user-attachments/assets/47acd4d1-c618-4d61-afdc-65ce827454a2">

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
