### PR TITLE
feat: Capture 3 existing properties within non-anonymous transaction …

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -157,6 +157,7 @@ describe('Transaction metrics', () => {
       transaction_type: TransactionType.simpleSend,
       ui_customizations: null,
       transaction_advanced_view: null,
+      transaction_contract_method: undefined,
     };
 
     expectedSensitiveProperties = {
@@ -165,7 +166,6 @@ describe('Transaction metrics', () => {
       first_seen: 1624408066355,
       gas_limit: '0x7b0d',
       gas_price: '2',
-      transaction_contract_method: undefined,
       transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
       transaction_replaced: undefined,
     };

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -1060,6 +1060,7 @@ async function buildEventFragmentProperties({
     // ui_customizations must come after ...blockaidProperties
     ui_customizations: uiCustomizations.length > 0 ? uiCustomizations : null,
     transaction_advanced_view: isAdvancedDetailsOpen,
+    transaction_contract_method: transactionContractMethod,
     ...smartTransactionMetricsProperties,
     ...swapAndSendMetricsProperties,
     // TODO: Replace `any` with type
@@ -1086,7 +1087,6 @@ async function buildEventFragmentProperties({
       : TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
     first_seen: time,
     gas_limit: gasLimit,
-    transaction_contract_method: transactionContractMethod,
     transaction_replaced: transactionReplaced,
     ...extraParams,
     ...gasParamsInGwei,

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.test.ts
@@ -492,7 +492,7 @@ describe('useSimulationMetrics', () => {
             balanceChanges: [balanceChange1, balanceChange2],
           },
           expect.objectContaining({
-            sensitiveProperties: expect.objectContaining({
+            properties: expect.objectContaining({
               [property]: 2.46,
             }),
           }),

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
@@ -122,10 +122,7 @@ export function useSimulationMetrics({
     ),
   };
 
-  const sensitiveProperties = {
-    ...getSensitiveProperties(receivingAssets, 'simulation_receiving_assets_'),
-    ...getSensitiveProperties(sendingAssets, 'simulation_sending_assets_'),
-  };
+  const sensitiveProperties = {};
 
   const params = { properties, sensitiveProperties };
 
@@ -215,15 +212,14 @@ function getProperties(
     ),
   );
 
-  return getPrefixProperties({ petname, quantity, type, value }, prefix);
-}
-
-function getSensitiveProperties(changes: BalanceChange[], prefix: string) {
   const fiatAmounts = changes.map((change) => change.fiatAmount);
   const totalFiat = calculateTotalFiat(fiatAmounts);
   const totalValue = totalFiat ? Math.abs(totalFiat) : undefined;
 
-  return getPrefixProperties({ total_value: totalValue }, prefix);
+  return getPrefixProperties(
+    { petname, quantity, type, value, total_value: totalValue },
+    prefix,
+  );
 }
 
 // TODO: Replace `any` with type


### PR DESCRIPTION
…events


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Moved properties `simulations_sending_assets_total_value`, `simulations_receiving_assets_total_value` and `transaction_contract_method` from `sensitiveProperties` to `properties`. They now show up in both Anon and non-Anon events.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28144?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3506

## **Manual testing steps**

1. Build the app with a segment key to a personal test workspace.
2. Create a transaction with simulations
3. Check the debugger screen to inspect the events

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1728" alt="Screenshot 2024-10-29 at 10 17 29" src="https://github.com/user-attachments/assets/98941f82-934b-418c-ae16-59b37082f524">
<img width="1728" alt="Screenshot 2024-10-29 at 10 17 26" src="https://github.com/user-attachments/assets/9bcd838d-db7e-405b-9228-756debaa4b20">


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
