### PR TITLE
chore (cherry-pick): ignore warning for ethereumjs-wallet (#28145)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -117,7 +117,8 @@ npmAuditIgnoreAdvisories:
   # Currently in use for the network list drag and drop functionality.
   # Maintenance has stopped and the project will be archived in 2025.
   - 'react-beautiful-dnd (deprecation)'
-
+  # New package name format for new versions: @ethereumjs/wallet.
+  - 'ethereumjs-wallet (deprecation)'
 npmRegistries:
   'https://npm.pkg.github.com':
     npmAlwaysAuth: true


### PR DESCRIPTION
Cherry picks https://github.com/MetaMask/metamask-extension/pull/28145

## **Description**

Silent deprecation audit warning for `ethereumjs-wallet`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28162?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
