### PR TITLE
fix: Fix #28097 - Prevent redirect after adding network in Onboarding Settings

### DIFF
--- a/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.js
@@ -11,7 +11,10 @@ import {
   Severity,
   TypographyVariant,
 } from '../../../../helpers/constants/design-system';
-import { DEFAULT_ROUTE } from '../../../../helpers/constants/routes';
+import {
+  DEFAULT_ROUTE,
+  ONBOARDING_PRIVACY_SETTINGS_ROUTE,
+} from '../../../../helpers/constants/routes';
 import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
 import { jsonRpcRequest } from '../../../../../shared/modules/rpc.utils';
 import { isValidASCIIURL, toPunycodeURL } from '../../utils/confirm';
@@ -381,7 +384,13 @@ function getValues(pendingApproval, t, actions, history, data) {
           nickname: pendingApproval.requestData.chainName,
         });
 
-        history.push(DEFAULT_ROUTE);
+        const locationPath = document.location.hash.replace('#', '/');
+        const isOnboardingRoute =
+          locationPath === ONBOARDING_PRIVACY_SETTINGS_ROUTE;
+
+        if (!isOnboardingRoute) {
+          history.push(DEFAULT_ROUTE);
+        }
       }
       return [];
     },


### PR DESCRIPTION
## **Description**

Prevents the post-add-network redirect from happening if the user is on the onboarding screen.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/28097

## **Manual testing steps**

STR's are in https://github.com/MetaMask/metamask-extension/issues/28097

## **Screenshots/Recordings**

### **Before**

### **After**


https://github.com/user-attachments/assets/ed136a3f-e06c-4c78-a76f-fd08a9865390



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask
Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [X] I’ve applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->
