### PR TITLE
feat(deps): use keccak256 from ethereum-cryptography

### DIFF
--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -8,10 +8,11 @@ import {
   size,
   sum,
 } from 'lodash';
-import { bufferToHex, keccak } from 'ethereumjs-util';
+import { keccak256 } from 'ethereum-cryptography/keccak';
 import { v4 as uuidv4 } from 'uuid';
 import { NameType } from '@metamask/name-controller';
 import {
+  add0x,
   getErrorMessage,
   type Hex,
   isErrorWithMessage,
@@ -627,13 +628,15 @@ export default class MetaMetricsController extends BaseController<
   }
 
   generateMetaMetricsId(): string {
-    return bufferToHex(
-      keccak(
-        Buffer.from(
-          String(Date.now()) +
-            String(Math.round(Math.random() * Number.MAX_SAFE_INTEGER)),
+    return add0x(
+      Buffer.from(
+        keccak256(
+          Buffer.from(
+            String(Date.now()) +
+              String(Math.round(Math.random() * Number.MAX_SAFE_INTEGER)),
+          ),
         ),
-      ),
+      ).toString('hex'),
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -426,6 +426,7 @@
     "eth-ens-namehash": "^2.0.8",
     "eth-lattice-keyring": "patch:eth-lattice-keyring@npm%3A0.12.4#~/.yarn/patches/eth-lattice-keyring-npm-0.12.4-c5fb3fcf54.patch",
     "eth-method-registry": "^4.0.0",
+    "ethereum-cryptography": "^2.2.1",
     "ethereumjs-util": "^7.0.10",
     "extension-port-stream": "^5.0.2",
     "fast-json-patch": "^3.1.1",

--- a/test/e2e/json-rpc/eth_call.spec.ts
+++ b/test/e2e/json-rpc/eth_call.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { keccak } from 'ethereumjs-util';
+import { keccak256 } from 'ethereum-cryptography/keccak';
 import { withFixtures } from '../helpers';
 import { Driver } from '../webdriver/driver';
 import FixtureBuilder from '../fixtures/fixture-builder';
@@ -38,8 +38,8 @@ describe('eth_call', function () {
 
         // eth_call
         await driver.openNewPage(`http://127.0.0.1:8080`);
-        const balanceOf = `0x${keccak(
-          Buffer.from('balanceOf(address)'),
+        const balanceOf = `0x${Buffer.from(
+          keccak256(Buffer.from('balanceOf(address)')),
         ).toString('hex')}`;
         const walletAddress = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
         const request = JSON.stringify({

--- a/yarn.lock
+++ b/yarn.lock
@@ -33821,6 +33821,7 @@ __metadata:
     eth-ens-namehash: "npm:^2.0.8"
     eth-lattice-keyring: "patch:eth-lattice-keyring@npm%3A0.12.4#~/.yarn/patches/eth-lattice-keyring-npm-0.12.4-c5fb3fcf54.patch"
     eth-method-registry: "npm:^4.0.0"
+    ethereum-cryptography: "npm:^2.2.1"
     ethereumjs-util: "npm:^7.0.10"
     ethers: "npm:^5.7.0"
     extension-port-stream: "npm:^5.0.2"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- **chore: use keccak256 from ethereum-cryptography**

Legacy `ethereum-util` is deprecated and uses a simialrly legacy version of keccak. This replaces usage with `ethereum-cryptography` (`@noble/hashes`).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28170?quickstart=1)

## **Related issues**
- #28145
- #28171

#### Blocked by
- [x] #28146

#### Blocking
- #28169


## **Manual testing steps**


## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates keccak hashing to `ethereum-cryptography`.
> 
> - Replace `ethereumjs-util` keccak + `bufferToHex` with `keccak256` and `add0x` in `metametrics-controller.ts` (`generateMetaMetricsId`)
> - Update e2e test `eth_call.spec.ts` to compute selector using `keccak256`
> - Add `ethereum-cryptography` dependency in `package.json` and lockfile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f56bcd62ef6ecd63c5c7798278b47cec04ef15e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->