### PR TITLE
fix: Prevent coercing symbols to zero in the edit spending cap modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1823,6 +1823,9 @@
   "editSpendingCapError": {
     "message": "The spending cap can’t exceed $1 decimal digits. Remove decimal digits to continue."
   },
+  "editSpendingCapSpecialCharError": {
+    "message": "Enter numbers only"
+  },
   "enable": {
     "message": "Enable"
   },

--- a/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.tsx
@@ -124,6 +124,8 @@ export const EditSpendingCapModal = ({
     decimals &&
     parseInt(decimals, 10) < countDecimalDigits(customSpendingCapInputValue);
 
+  const showSpecialCharacterError = /[-+e]/u.test(customSpendingCapInputValue);
+
   return (
     <Modal
       isOpen={isOpenEditSpendingCapModal}
@@ -171,6 +173,15 @@ export const EditSpendingCapModal = ({
               {t('editSpendingCapError', [decimals])}
             </Text>
           )}
+          {showSpecialCharacterError && (
+            <Text
+              variant={TextVariant.bodySm}
+              color={TextColor.errorDefault}
+              paddingTop={1}
+            >
+              {t('editSpendingCapSpecialCharError')}
+            </Text>
+          )}
           <Text
             variant={TextVariant.bodySm}
             color={TextColor.textAlternative}
@@ -188,7 +199,10 @@ export const EditSpendingCapModal = ({
           submitButtonProps={{
             children: t('save'),
             loading: isModalSaving,
-            disabled: showDecimalError,
+            disabled:
+              showDecimalError ||
+              showSpecialCharacterError ||
+              customSpendingCapInputValue === '',
           }}
         />
       </ModalContent>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Since the `TextField` in the "edit spending cap" modal has a type `TextFieldType.Number`, it already blocks most symbols and letters. However, it does currently support `+`, `-` and `e` characters as they can be used to construe numbers.

For example, when a `-` sign is introduced in the input field, the interim value is coerced to `''`, as there is no numerical equivalent to the sign by itself. The first part of this fix was to disable the "Save" button on such cases. If the user wants to revoke the spending cap, they can introduce `0`, but `''` is not a valid response.

Furthermore, when a valid number is introduced but that uses scientific notation or `+`/`-` signs, the submission is disabled and a validation message is shown to the user: "Enter numbers only".

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28192?quickstart=1)

## **Related issues**

Fixes: [#28096](https://github.com/MetaMask/metamask-extension/issues/28096)

## **Manual testing steps**

1. Deploy an erc20 token contract in the test DApp
2. Trigger an approve confirmation
3. Attempt to edit the spending cap with -1, 10e10, or any others.
4. You should be prevented from submitting and see the validation message.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="360" alt="Screenshot 2024-10-30 at 17 46 48" src="https://github.com/user-attachments/assets/1e05da98-e362-45ee-8fd0-a988e853677b">


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
