### PR TITLE
test: Fix data deletion e2e tests

### DIFF
--- a/app/scripts/services/data-deletion-service.ts
+++ b/app/scripts/services/data-deletion-service.ts
@@ -12,11 +12,17 @@ import {
 import getFetchWithTimeout from '../../../shared/modules/fetch-with-timeout';
 import { DeleteRegulationStatus } from '../../../shared/constants/metametrics';
 
-const DEFAULT_ANALYTICS_DATA_DELETION_SOURCE_ID =
-  process.env.ANALYTICS_DATA_DELETION_SOURCE_ID ?? 'test';
-const DEFAULT_ANALYTICS_DATA_DELETION_ENDPOINT =
-  process.env.ANALYTICS_DATA_DELETION_ENDPOINT ??
-  'https://metametrics.metamask.test';
+const inTest = process.env.IN_TEST;
+const fallbackSourceId = 'test';
+const fallbackDataDeletionEndpoint = 'https://metametrics.metamask.test';
+
+const DEFAULT_ANALYTICS_DATA_DELETION_SOURCE_ID = inTest
+  ? fallbackSourceId
+  : process.env.ANALYTICS_DATA_DELETION_SOURCE_ID ?? fallbackSourceId;
+const DEFAULT_ANALYTICS_DATA_DELETION_ENDPOINT = inTest
+  ? fallbackDataDeletionEndpoint
+  : process.env.ANALYTICS_DATA_DELETION_ENDPOINT ??
+    fallbackDataDeletionEndpoint;
 
 /**
  * The number of times we retry a specific failed request to the data deletion API.


### PR DESCRIPTION
## **Description**

The "Delete MetaMetrics Data" e2e tests were recently broken due to a change in CI configuration. The code-under-test was written to always use the environment variable present for the data deletion source ID and endpoint, but the e2e tests wrongly assumed that it would never be present.

The service has been updated to use the fallback values for e2e test builds, even if the environment variable is present.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28221?quickstart=1)

## **Related issues**

Fixes CI failure currently on all branches (e.g. https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/108823/workflows/cbc57b89-8647-4219-b413-24df4fdad95c/jobs/4070258 )

This bug was introduced in #24503, but only began causing failures recently when CI configuration was updated with these new environment variables.

## **Manual testing steps**

See that the data deletion e2e tests succeed even with both data deletion environment variables set.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
