### PR TITLE
chore: remove broken link in docs

### DIFF
--- a/ui/components/component-library/README.md
+++ b/ui/components/component-library/README.md
@@ -4,7 +4,7 @@ This folder contains design system components that are built 1:1 with the Figma 
 
 ## Architecture
 
-All components are built on top of the `Box` component and accept all `Box` [component props](/docs/components-componentlibrary-box--docs#props).
+All components are built on top of the `Box` component and accept all `Box` component props.
 
 ### Layout
 

--- a/ui/components/component-library/text/README.mdx
+++ b/ui/components/component-library/text/README.mdx
@@ -580,7 +580,7 @@ Values using the `TextAlign` object from `./ui/helpers/constants/design-system.j
 
 ### Box Props
 
-Box props are now integrated with the `Text` component. Valid Box props: [Box](/docs/components-componentlibrary-box--docs#props)
+Box props are now integrated with the `Text` component.
 
 You no longer need to pass these props as an object through `boxProps`
 


### PR DESCRIPTION
## **Description**

This PR removes a broken link from the README that was originally intended to point to the `Box` component in Storybook. While the link works in Storybook, it does not function correctly when viewed directly on GitHub or in code editors, leading to potential confusion. To simplify access, we are removing this link; users can still locate the `Box` component by searching for it directly within Storybook.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. View the README file on GitHub.
2. Confirm that the broken link has been removed.
3. Check that references to the `Box` component remain understandable without the link.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/d48cf851-163c-4169-a2f6-b0020ba79b8d

### **After**

https://github.com/user-attachments/assets/46d1f0b1-a2fa-4130-b726-460524118969

No more link references in code base 

<img width="300" alt="Screenshot 2024-10-31 at 4 00 15 PM" src="https://github.com/user-attachments/assets/0857dfc2-17d3-4aae-9250-7282e4107e7b">


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g., pulled and built the branch, reviewed the updated README).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and/or screenshots.