### PR TITLE
chore: improve token lookup performance in `useAccountTotalFiatBalance`

### DIFF
--- a/ui/hooks/useAccountTotalFiatBalance.js
+++ b/ui/hooks/useAccountTotalFiatBalance.js
@@ -51,7 +51,6 @@ export const useAccountTotalFiatBalance = (
   const tokens = detectedTokens?.[currentChainId]?.[account?.address] ?? [];
   // This selector returns all the tokens, we need it to get the image of token
   const allTokenList = useSelector(getTokenList);
-  const allTokenListValues = Object.values(allTokenList);
   const primaryTokenImage = useSelector(getNativeCurrencyImage);
   const nativeCurrency = useSelector(getNativeCurrency);
 
@@ -92,20 +91,18 @@ export const useAccountTotalFiatBalance = (
   };
 
   // To match the list of detected tokens with the entire token list to find the image for tokens
-  const findMatchingTokens = (array1, array2) => {
+  const findMatchingTokens = (tokenList, _tokensWithBalances) => {
     const result = [];
 
-    array2.forEach((token2) => {
-      const matchingToken = array1.find(
-        (token1) => token1.symbol === token2.symbol,
-      );
+    _tokensWithBalances.forEach((token) => {
+      const matchingToken = tokenList[token.address.toLowerCase()];
 
       if (matchingToken) {
         result.push({
           ...matchingToken,
-          balance: token2.balance,
-          string: token2.string,
-          balanceError: token2.balanceError,
+          balance: token.balance,
+          string: token.string,
+          balanceError: token.balanceError,
         });
       }
     });
@@ -113,10 +110,7 @@ export const useAccountTotalFiatBalance = (
     return result;
   };
 
-  const matchingTokens = findMatchingTokens(
-    allTokenListValues,
-    tokensWithBalances,
-  );
+  const matchingTokens = findMatchingTokens(allTokenList, tokensWithBalances);
 
   // Combine native token, detected token with image in an array
   const allTokensWithFiatValues = [


### PR DESCRIPTION

## **Description**

`useAccountTotalFiatBalance` looks up each token in the token list to add additional fields.  But it was O(n) searching through the entire list, which can be thousands of tokens.  The token list is keyed on token address, and can be queried directly instead.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28233?quickstart=1)

## **Related issues**



## **Manual testing steps**

No visual changes.  In the account picker, erc20 tokens should still have icons on the right of each account.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
