### PR TITLE
fix: Fix alignment of long RPC labels in Networks menu

### DIFF
--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -200,6 +200,7 @@ export const getDefaultPreferencesControllerState =
     identities: {},
     lostIdentities: {},
     forgottenPassword: false,
+    textDirection: 'auto',
     preferences: {
       autoLockTimeLimit: undefined,
       showExtensionInFullSizeView: false,

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -200,7 +200,6 @@ export const getDefaultPreferencesControllerState =
     identities: {},
     lostIdentities: {},
     forgottenPassword: false,
-    textDirection: 'auto',
     preferences: {
       autoLockTimeLimit: undefined,
       showExtensionInFullSizeView: false,

--- a/ui/components/multichain/network-list-item/index.scss
+++ b/ui/components/multichain/network-list-item/index.scss
@@ -37,4 +37,8 @@
   &__delete {
     visibility: hidden;
   }
+
+  &__rpc-endpoint {
+    max-width: 100%;
+  }
 }

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import {
@@ -14,7 +13,6 @@ import {
   FlexDirection,
   TextVariant,
   BorderColor,
-  TextAlign,
 } from '../../../helpers/constants/design-system';
 import {
   AvatarNetwork,
@@ -77,8 +75,6 @@ export const NetworkListItem = ({
     setNetworkListItemMenuElement(ref);
   };
   const [networkOptionsMenuOpen, setNetworkOptionsMenuOpen] = useState(false);
-
-  const textDirection = useSelector((state) => state.metamask.textDirection);
 
   const renderButton = () => {
     return onDeleteClick || onEditClick ? (
@@ -194,9 +190,6 @@ export const NetworkListItem = ({
               as="button"
               variant={TextVariant.bodySmMedium}
               color={TextColor.textAlternative}
-              textAlign={
-                textDirection === 'rtl' ? TextAlign.Right : TextAlign.Left
-              }
               ellipsis
             >
               {rpcEndpoint.name ?? new URL(rpcEndpoint.url).host}

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import {
@@ -13,6 +14,7 @@ import {
   FlexDirection,
   TextVariant,
   BorderColor,
+  TextAlign,
 } from '../../../helpers/constants/design-system';
 import {
   AvatarNetwork,
@@ -75,6 +77,8 @@ export const NetworkListItem = ({
     setNetworkListItemMenuElement(ref);
   };
   const [networkOptionsMenuOpen, setNetworkOptionsMenuOpen] = useState(false);
+
+  const textDirection = useSelector((state) => state.metamask.textDirection);
 
   const renderButton = () => {
     return onDeleteClick || onEditClick ? (
@@ -190,6 +194,9 @@ export const NetworkListItem = ({
               as="button"
               variant={TextVariant.bodySmMedium}
               color={TextColor.textAlternative}
+              textAlign={
+                textDirection === 'rtl' ? TextAlign.Right : TextAlign.Left
+              }
             >
               {rpcEndpoint.name ?? new URL(rpcEndpoint.url).host}
             </Text>

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -78,7 +78,7 @@ export const NetworkListItem = ({
   };
   const [networkOptionsMenuOpen, setNetworkOptionsMenuOpen] = useState(false);
 
-  const textDirection = useSelector((state) => state.metamask.textDirection);
+  const textDirection = useSelector(({ metamask }) => metamask.textDirection);
 
   const renderButton = () => {
     return onDeleteClick || onEditClick ? (

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -78,7 +78,7 @@ export const NetworkListItem = ({
   };
   const [networkOptionsMenuOpen, setNetworkOptionsMenuOpen] = useState(false);
 
-  const textDirection = useSelector(({ metamask }) => metamask.textDirection);
+  const textDirection = useSelector((state) => state.metamask.textDirection);
 
   const renderButton = () => {
     return onDeleteClick || onEditClick ? (
@@ -197,6 +197,7 @@ export const NetworkListItem = ({
               textAlign={
                 textDirection === 'rtl' ? TextAlign.Right : TextAlign.Left
               }
+              ellipsis
             >
               {rpcEndpoint.name ?? new URL(rpcEndpoint.url).host}
             </Text>


### PR DESCRIPTION
## **Description**

Fixes alignment for long RPC labels in the networks list

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28244?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Add BNB Chain to MetaMask
2. Create a second RPC for it with the label `BNB Smart Chain (previously Binance Smart Chain Mainnet)`
3. See the label left-aligned


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image (2)](https://github.com/user-attachments/assets/eeb1a3e4-257b-42db-9130-abc79928553c)

### **After**

<img width="407" alt="SCR-20241104-iwaw" src="https://github.com/user-attachments/assets/55435958-616e-4874-9a5c-9ef1f0554b3e">




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
