### PR TITLE
fix: Negate privacy mode in Send screen

### DIFF
--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -222,6 +222,7 @@ export default function CurrencyInput({
         suffix={suffix}
         className="currency-input__conversion-component"
         displayValue={displayValue}
+        privacyModeExempt
       />
     );
   };

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.d.ts
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.d.ts
@@ -16,6 +16,7 @@ export type UserPrefrencedCurrencyDisplayProps = OverridingUnion<
     showCurrencySuffix?: boolean;
     shouldCheckShowNativeToken?: boolean;
     isAggregatedFiatOverviewBalance?: boolean;
+    privacyModeExempt: boolean;
   }
 >;
 

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.d.ts
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.d.ts
@@ -16,7 +16,7 @@ export type UserPrefrencedCurrencyDisplayProps = OverridingUnion<
     showCurrencySuffix?: boolean;
     shouldCheckShowNativeToken?: boolean;
     isAggregatedFiatOverviewBalance?: boolean;
-    privacyModeExempt: boolean;
+    privacyModeExempt?: boolean;
   }
 >;
 

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
@@ -28,6 +28,7 @@ export default function UserPreferencedCurrencyDisplay({
   showNative,
   showCurrencySuffix,
   shouldCheckShowNativeToken,
+  privacyModeExempt,
   ...restProps
 }) {
   // NOTE: When displaying currencies, we need the actual account to detect whether we're in a
@@ -83,6 +84,7 @@ export default function UserPreferencedCurrencyDisplay({
       numberOfDecimals={numberOfDecimals}
       prefixComponent={prefixComponent}
       suffix={showCurrencySuffix && !showEthLogo && currency}
+      privacyModeExempt={privacyModeExempt}
     />
   );
 }
@@ -126,6 +128,7 @@ const UserPreferencedCurrencyDisplayPropTypes = {
   textProps: PropTypes.object,
   suffixProps: PropTypes.object,
   shouldCheckShowNativeToken: PropTypes.bool,
+  privacyModeExempt: PropTypes.bool,
 };
 
 UserPreferencedCurrencyDisplay.propTypes =

--- a/ui/components/multichain/asset-picker-amount/asset-balance/asset-balance-text.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-balance/asset-balance-text.tsx
@@ -105,6 +105,7 @@ export function AssetBalanceText({
         currency={secondaryCurrency}
         numberOfDecimals={2}
         displayValue={`${formattedFiat}${errorText}`}
+        privacyModeExempt
       />
     );
   }
@@ -116,6 +117,7 @@ export function AssetBalanceText({
           {...commonProps}
           value={asset.balance}
           type={PRIMARY}
+          privacyModeExempt
         />
         {errorText ? (
           <Text
@@ -136,6 +138,7 @@ export function AssetBalanceText({
       <UserPreferencedCurrencyDisplay
         {...commonProps}
         displayValue={`${balanceString || ''}${errorText}`}
+        privacyModeExempt
       />
     );
   }

--- a/ui/components/multichain/asset-picker-amount/swappable-currency-input/swappable-currency-input.tsx
+++ b/ui/components/multichain/asset-picker-amount/swappable-currency-input/swappable-currency-input.tsx
@@ -105,6 +105,7 @@ export function SwappableCurrencyInput({
       asset={asset?.details}
       isSkeleton={isAmountLoading}
       isMatchingUpstream={isSetToMax}
+      privacyModeExempt
     />
   );
 

--- a/ui/components/multichain/asset-picker-amount/swappable-currency-input/swappable-currency-input.tsx
+++ b/ui/components/multichain/asset-picker-amount/swappable-currency-input/swappable-currency-input.tsx
@@ -105,7 +105,6 @@ export function SwappableCurrencyInput({
       asset={asset?.details}
       isSkeleton={isAmountLoading}
       isMatchingUpstream={isSetToMax}
-      privacyModeExempt
     />
   );
 

--- a/ui/components/ui/currency-display/currency-display.component.d.ts
+++ b/ui/components/ui/currency-display/currency-display.component.d.ts
@@ -25,6 +25,7 @@ export type CurrencyDisplayProps = OverridingUnion<
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     suffixProps?: Record<string, any>;
+    privacyModeExempt?: boolean;
   }
 >;
 

--- a/ui/components/ui/currency-display/currency-display.component.js
+++ b/ui/components/ui/currency-display/currency-display.component.js
@@ -35,6 +35,7 @@ export default function CurrencyDisplay({
   textProps = {},
   suffixProps = {},
   isAggregatedFiatOverviewBalance = false,
+  privacyModeExempt,
   ...props
 }) {
   const { privacyMode } = useSelector(getPreferences);
@@ -76,7 +77,7 @@ export default function CurrencyDisplay({
         className="currency-display-component__text"
         ellipsis
         variant={TextVariant.inherit}
-        isHidden={privacyMode}
+        isHidden={!privacyModeExempt && privacyMode}
         data-testid="account-value-and-suffix"
         {...textProps}
       >
@@ -125,6 +126,7 @@ const CurrencyDisplayPropTypes = {
   textProps: PropTypes.object,
   suffixProps: PropTypes.object,
   isAggregatedFiatOverviewBalance: PropTypes.bool,
+  privacyModeExempt: PropTypes.bool,
 };
 
 CurrencyDisplay.propTypes = CurrencyDisplayPropTypes;

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -8,6 +8,7 @@ import {
   getCurrentCurrency,
   getIsBridgeChain,
   getIsSwapsChain,
+  getPreferences,
   getSelectedInternalAccount,
   getSwapsDefaultToken,
   getTokensMarketData,
@@ -102,6 +103,7 @@ const AssetPage = ({
   const conversionRate = useSelector(getConversionRate);
   const allMarketData = useSelector(getTokensMarketData);
   const isBridgeChain = useSelector(getIsBridgeChain);
+  const { privacyMode } = useSelector(getPreferences);
   const isBuyableChain = useSelector(getIsNativeTokenBuyable);
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);
   const account = useSelector(getSelectedInternalAccount, isEqual);
@@ -196,6 +198,7 @@ const AssetPage = ({
             tokenImage={image}
             isOriginalTokenSymbol={asset.isOriginalNativeSymbol}
             isNativeCurrency={true}
+            privacyMode={privacyMode}
           />
         ) : (
           <TokenCell


### PR DESCRIPTION

## **Description**

Upon verifying Privacy Mode, it appeared as though the implementation was too aggressive in that it was hiding values on the Send flow.  This is undesirable.  Additionally, we should hide the account asset value in the Asset Details screen.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28248?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Turn on privacy mode by clicking the Eye on the home screen
2. Open the send flow, choose a recipient
3. See the values of the tokens to send as well as balance

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="407" alt="SCR-20241101-offl" src="https://github.com/user-attachments/assets/d006d78f-841a-41e5-b37b-3abd9a8e8369">


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
