### PR TITLE
feat: change expand icon per new design

### DIFF
--- a/ui/components/app/confirm/info/row/__snapshots__/expandable-row.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/expandable-row.test.tsx.snap
@@ -22,16 +22,16 @@ exports[`ConfirmInfoExpandableRow should match snapshot 1`] = `
     <div
       class="mm-box mm-box--display-flex"
     >
-      Expandable Value
       <button
         aria-label="expand"
         class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
       >
         <span
           class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-          style="mask-image: url('./images/icons/arrow-left.svg');"
+          style="mask-image: url('./images/icons/arrow-down.svg');"
         />
       </button>
+      Expandable Value
     </div>
   </div>
   <div

--- a/ui/components/app/confirm/info/row/expandable-row.tsx
+++ b/ui/components/app/confirm/info/row/expandable-row.tsx
@@ -47,7 +47,7 @@ export const ConfirmInfoExpandableRow = (
               expandIcon: true,
               expanded,
             })}
-            iconName={IconName.ArrowLeft}
+            iconName={IconName.ArrowUp}
             color={IconColor.primaryDefault}
             size={ButtonIconSize.Sm}
             onClick={handleClick}

--- a/ui/components/app/confirm/info/row/expandable-row.tsx
+++ b/ui/components/app/confirm/info/row/expandable-row.tsx
@@ -47,7 +47,7 @@ export const ConfirmInfoExpandableRow = (
               expandIcon: true,
               expanded,
             })}
-            iconName={IconName.ArrowUp}
+            iconName={IconName.ArrowDown}
             color={IconColor.primaryDefault}
             size={ButtonIconSize.Sm}
             onClick={handleClick}

--- a/ui/components/app/confirm/info/row/expandable-row.tsx
+++ b/ui/components/app/confirm/info/row/expandable-row.tsx
@@ -40,7 +40,6 @@ export const ConfirmInfoExpandableRow = (
     <>
       <ConfirmInfoRow {...rowProps}>
         <Box display={Display.Flex}>
-          {children}
           <ButtonIcon
             marginLeft={1}
             className={classnames({
@@ -53,6 +52,7 @@ export const ConfirmInfoExpandableRow = (
             onClick={handleClick}
             ariaLabel="expand"
           />
+          {children}
         </Box>
       </ConfirmInfoRow>
       <Box

--- a/ui/components/app/confirm/info/row/index.scss
+++ b/ui/components/app/confirm/info/row/index.scss
@@ -8,4 +8,5 @@
 }
 
 .expandIcon.expanded {
-  rotate: -180deg;}
+  rotate: -180deg;
+}

--- a/ui/components/app/confirm/info/row/index.scss
+++ b/ui/components/app/confirm/info/row/index.scss
@@ -8,5 +8,4 @@
 }
 
 .expandIcon.expanded {
-  rotate: -90deg;
-}
+  rotate: -180deg;}

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/__snapshots__/transaction-data.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/__snapshots__/transaction-data.test.tsx.snap
@@ -57,6 +57,15 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
       <div
         class="mm-box mm-box--display-flex"
       >
+        <button
+          aria-label="expand"
+          class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
+        >
+          <span
+            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
+        </button>
         <div
           class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           data-testid="advanced-details-data-function"
@@ -68,15 +77,6 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
             WRAP_ETH
           </p>
         </div>
-        <button
-          aria-label="expand"
-          class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
-        >
-          <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-            style="mask-image: url('./images/icons/arrow-left.svg');"
-          />
-        </button>
       </div>
     </div>
     <div
@@ -216,6 +216,15 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
       <div
         class="mm-box mm-box--display-flex"
       >
+        <button
+          aria-label="expand"
+          class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
+        >
+          <span
+            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
+        </button>
         <div
           class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           data-testid="advanced-details-data-function"
@@ -227,15 +236,6 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
             V3_SWAP_EXACT_IN
           </p>
         </div>
-        <button
-          aria-label="expand"
-          class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
-        >
-          <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-            style="mask-image: url('./images/icons/arrow-left.svg');"
-          />
-        </button>
       </div>
     </div>
     <div
@@ -587,6 +587,15 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
       <div
         class="mm-box mm-box--display-flex"
       >
+        <button
+          aria-label="expand"
+          class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
+        >
+          <span
+            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
+        </button>
         <div
           class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           data-testid="advanced-details-data-function"
@@ -598,15 +607,6 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
             PAY_PORTION
           </p>
         </div>
-        <button
-          aria-label="expand"
-          class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
-        >
-          <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-            style="mask-image: url('./images/icons/arrow-left.svg');"
-          />
-        </button>
       </div>
     </div>
     <div
@@ -802,6 +802,15 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
       <div
         class="mm-box mm-box--display-flex"
       >
+        <button
+          aria-label="expand"
+          class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
+        >
+          <span
+            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
+        </button>
         <div
           class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
           data-testid="advanced-details-data-function"
@@ -813,15 +822,6 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
             SWEEP
           </p>
         </div>
-        <button
-          aria-label="expand"
-          class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
-        >
-          <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-            style="mask-image: url('./images/icons/arrow-left.svg');"
-          />
-        </button>
       </div>
     </div>
     <div


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Changes the expand icon from left-right to up-down
Also moves the arrow to the left of the text

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28267?quickstart=1)

## **Related issues**

Fixes: [#3490](https://github.com/MetaMask/MetaMask-planning/issues/3490)

## **Manual testing steps**

1. Perform a swap on Uniswap and verify data is decoded into multiple functions.
2. Check that the expanded rows have correct arrows per design

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="363" alt="image" src="https://github.com/user-attachments/assets/40494159-1ed5-46ae-9c92-10c75aba4ac2">

### **After**

<img width="351" alt="image" src="https://github.com/user-attachments/assets/8a78eb43-ac9c-4a41-8480-40c9c0283254">


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
