### PR TITLE
fix: flaky test `Phishing Detection Via Iframe should redirect users to the the MetaMask Phishing Detection page when an iframe domain is on the phishing blocklist`

### DIFF
--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -59,7 +59,7 @@ describe('Phishing Detection', function () {
         await openDapp(driver);
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
         await driver.clickElement({
-          text: 'Proceed anyway',
+          testId: 'unsafe-continue-loaded',
         });
         await driver.wait(until.titleIs(WINDOW_TITLES.TestDApp), 10000);
       },
@@ -173,7 +173,7 @@ describe('Phishing Detection', function () {
         });
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
         await driver.clickElement({
-          text: 'Proceed anyway',
+          testId: 'unsafe-continue-loaded',
         });
 
         // We don't really know what we're going to see at this blocked site, so a waitAtLeast guard of 1000ms is the best choice

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -59,10 +59,13 @@ describe('Phishing Detection', function () {
         await openDapp(driver);
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
 
-        // we need to use this selector specifically because is the one that ensures that the event listener has been added
+        // we need to wait for this selector to mitigate a race condition on the phishing page site
         // see more here https://github.com/MetaMask/phishing-warning/pull/173
-        await driver.clickElement({
+        await driver.waitForSelector({
           testId: 'unsafe-continue-loaded',
+        });
+        await driver.clickElement({
+          text: 'Proceed anyway',
         });
         await driver.wait(until.titleIs(WINDOW_TITLES.TestDApp), 10000);
       },
@@ -107,12 +110,14 @@ describe('Phishing Detection', function () {
 
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
 
-        // we need to use this selector specifically because is the one that ensures that the event listener has been added
+        // we need to wait for this selector to mitigate a race condition on the phishing page site
         // see more here https://github.com/MetaMask/phishing-warning/pull/173
-        await driver.clickElement({
+        await driver.waitForSelector({
           testId: 'unsafe-continue-loaded',
         });
-
+        await driver.clickElement({
+          text: 'Proceed anyway',
+        });
         await driver.wait(until.titleIs(WINDOW_TITLES.TestDApp), 10000);
       };
     }
@@ -176,10 +181,13 @@ describe('Phishing Detection', function () {
         });
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
 
-        // we need to use this selector specifically because is the one that ensures that the event listener has been added
+        // we need to wait for this selector to mitigate a race condition on the phishing page site
         // see more here https://github.com/MetaMask/phishing-warning/pull/173
-        await driver.clickElement({
+        await driver.waitForSelector({
           testId: 'unsafe-continue-loaded',
+        });
+        await driver.clickElement({
+          text: 'Proceed anyway',
         });
 
         // We don't really know what we're going to see at this blocked site, so a waitAtLeast guard of 1000ms is the best choice

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -58,6 +58,9 @@ describe('Phishing Detection', function () {
         await unlockWallet(driver);
         await openDapp(driver);
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
+
+        // we need to use this selector specifically because is the one that ensures that the event listener has been added
+        // see more here https://github.com/MetaMask/phishing-warning/pull/173
         await driver.clickElement({
           testId: 'unsafe-continue-loaded',
         });
@@ -172,6 +175,9 @@ describe('Phishing Detection', function () {
           text: 'Open this warning in a new tab',
         });
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
+
+        // we need to use this selector specifically because is the one that ensures that the event listener has been added
+        // see more here https://github.com/MetaMask/phishing-warning/pull/173
         await driver.clickElement({
           testId: 'unsafe-continue-loaded',
         });

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -103,8 +103,11 @@ describe('Phishing Detection', function () {
         }
 
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
+
+        // we need to use this selector specifically because is the one that ensures that the event listener has been added
+        // see more here https://github.com/MetaMask/phishing-warning/pull/173
         await driver.clickElement({
-          text: 'Proceed anyway',
+          testId: 'unsafe-continue-loaded',
         });
 
         await driver.wait(until.titleIs(WINDOW_TITLES.TestDApp), 10000);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a race condition in our Extension e2e tests, where we click the continue to unsafe link before the event listener has been attached. This causes the click to not take any effect and the test fail sometimes.

Here is an example of the failure: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/103699/workflows/b2ef7c35-f54a-4ea8-bd8b-15e57585d6fe/jobs/3865722/artifacts

See how after clicking the anchor element, the redirect never happens, because the click was done before the event listener was added.

![image](https://github.com/user-attachments/assets/92663874-9175-4aa0-af86-0c4859e087bf)




[The fix has been done in the phishing page level](https://github.com/MetaMask/phishing-warning/pull/173), where I added a new test id once the event listener click has been added, so we can now wait for that selector id to be in the page, before clicking.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28293?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27661

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
