### PR TITLE
fix: Remove multiple overlapping spinners

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/approve/hooks/use-approve-token-simulation.ts
+++ b/ui/pages/confirmations/components/confirm/info/approve/hooks/use-approve-token-simulation.ts
@@ -1,12 +1,11 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { isHexString } from '@metamask/utils';
-import { BigNumber } from 'bignumber.js';
 import { isBoolean } from 'lodash';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { calcTokenAmount } from '../../../../../../../../shared/lib/transactions-controller-utils';
 import { getIntlLocale } from '../../../../../../../ducks/locale/locale';
 import { SPENDING_CAP_UNLIMITED_MSG } from '../../../../../constants';
-import { toNonScientificString } from '../../hooks/use-token-values';
 import { useDecodedTransactionData } from '../../hooks/useDecodedTransactionData';
 import { useIsNFT } from './use-is-nft';
 
@@ -27,7 +26,7 @@ export const useApproveTokenSimulation = (
 
   const decodedSpendingCap = useMemo(() => {
     if (!value) {
-      return 0;
+      return '0';
     }
 
     const paramIndex = value.data[0].params.findIndex(
@@ -38,23 +37,24 @@ export const useApproveTokenSimulation = (
         !isBoolean(param.value),
     );
     if (paramIndex === -1) {
-      return 0;
+      return '0';
     }
 
-    return new BigNumber(value.data[0].params[paramIndex].value.toString())
-      .dividedBy(new BigNumber(10).pow(Number(decimals)))
-      .toNumber();
+    return calcTokenAmount(
+      value.data[0].params[paramIndex].value,
+      Number(decimals),
+    ).toFixed();
   }, [value, decimals]);
 
   const formattedSpendingCap = useMemo(() => {
     // formatting coerces small numbers to 0
-    return isNFT || decodedSpendingCap < 1
-      ? toNonScientificString(decodedSpendingCap)
-      : new Intl.NumberFormat(locale).format(decodedSpendingCap);
+    return isNFT || parseInt(decodedSpendingCap, 10) < 1
+      ? decodedSpendingCap
+      : new Intl.NumberFormat(locale).format(parseInt(decodedSpendingCap, 10));
   }, [decodedSpendingCap, isNFT, locale]);
 
   const spendingCap = useMemo(() => {
-    if (!isNFT && isSpendingCapUnlimited(decodedSpendingCap)) {
+    if (!isNFT && isSpendingCapUnlimited(parseInt(decodedSpendingCap, 10))) {
       return SPENDING_CAP_UNLIMITED_MSG;
     }
     const tokenPrefix = isNFT ? '#' : '';

--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.test.ts
@@ -5,7 +5,7 @@ import mockState from '../../../../../../../test/data/mock-state.json';
 import { renderHookWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
 import useTokenExchangeRate from '../../../../../../components/app/currency-input/hooks/useTokenExchangeRate';
 import { useAssetDetails } from '../../../../hooks/useAssetDetails';
-import { toNonScientificString, useTokenValues } from './use-token-values';
+import { useTokenValues } from './use-token-values';
 import { useDecodedTransactionData } from './useDecodedTransactionData';
 
 jest.mock('../../../../hooks/useAssetDetails', () => ({
@@ -125,22 +125,4 @@ describe('useTokenValues', () => {
       pending: false,
     });
   });
-});
-
-describe('toNonScientificString', () => {
-  const TEST_CASES = [
-    { scientific: 1.23e-5, expanded: '0.0000123' },
-    { scientific: 1e-10, expanded: '0.0000000001' },
-    { scientific: 1.23e-21, expanded: '1.23e-21' },
-  ];
-
-  // @ts-expect-error This is missing from the Mocha type definitions
-  it.each(TEST_CASES)(
-    'Expand $scientific to "$expanded"',
-    ({ scientific, expanded }: { scientific: number; expanded: string }) => {
-      const actual = toNonScientificString(scientific);
-
-      expect(actual).toEqual(expanded);
-    },
-  );
 });

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -17,49 +17,6 @@ exports[`NativeTransferInfo renders correctly 1`] = `
     </h2>
   </div>
   <div
-    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
-  >
-    <svg
-      class="preloader__icon"
-      fill="none"
-      height="20"
-      viewBox="0 0 16 16"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M8 13.7143C4.84409 13.7143 2.28571 11.1559 2.28571 8C2.28571 4.84409 4.84409 2.28571 8 2.28571C11.1559 2.28571 13.7143 4.84409 13.7143 8C13.7143 11.1559 11.1559 13.7143 8 13.7143ZM8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8C16 12.4183 12.4183 16 8 16Z"
-        fill="var(--color-primary-muted)"
-        fill-rule="evenodd"
-      />
-      <mask
-        height="16"
-        id="mask0"
-        mask-type="alpha"
-        maskUnits="userSpaceOnUse"
-        width="16"
-        x="0"
-        y="0"
-      >
-        <path
-          clip-rule="evenodd"
-          d="M8 13.7143C4.84409 13.7143 2.28571 11.1559 2.28571 8C2.28571 4.84409 4.84409 2.28571 8 2.28571C11.1559 2.28571 13.7143 4.84409 13.7143 8C13.7143 11.1559 11.1559 13.7143 8 13.7143ZM8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8C16 12.4183 12.4183 16 8 16Z"
-          fill="var(--color-primary-default)"
-          fill-rule="evenodd"
-        />
-      </mask>
-      <g
-        mask="url(#mask0)"
-      >
-        <path
-          d="M6.85718 17.9999V11.4285V8.28564H-4.85711V17.9999H6.85718Z"
-          fill="var(--color-primary-default)"
-        />
-      </g>
-    </svg>
-  </div>
-  <div
     class="mm-box mm-box--margin-bottom-4 mm-box--padding-0 mm-box--background-color-background-default mm-box--rounded-md"
   >
     <div

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -18,49 +18,6 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
     />
   </div>
   <div
-    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
-  >
-    <svg
-      class="preloader__icon"
-      fill="none"
-      height="20"
-      viewBox="0 0 16 16"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M8 13.7143C4.84409 13.7143 2.28571 11.1559 2.28571 8C2.28571 4.84409 4.84409 2.28571 8 2.28571C11.1559 2.28571 13.7143 4.84409 13.7143 8C13.7143 11.1559 11.1559 13.7143 8 13.7143ZM8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8C16 12.4183 12.4183 16 8 16Z"
-        fill="var(--color-primary-muted)"
-        fill-rule="evenodd"
-      />
-      <mask
-        height="16"
-        id="mask0"
-        mask-type="alpha"
-        maskUnits="userSpaceOnUse"
-        width="16"
-        x="0"
-        y="0"
-      >
-        <path
-          clip-rule="evenodd"
-          d="M8 13.7143C4.84409 13.7143 2.28571 11.1559 2.28571 8C2.28571 4.84409 4.84409 2.28571 8 2.28571C11.1559 2.28571 13.7143 4.84409 13.7143 8C13.7143 11.1559 11.1559 13.7143 8 13.7143ZM8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8C16 12.4183 12.4183 16 8 16Z"
-          fill="var(--color-primary-default)"
-          fill-rule="evenodd"
-        />
-      </mask>
-      <g
-        mask="url(#mask0)"
-      >
-        <path
-          d="M6.85718 17.9999V11.4285V8.28564H-4.85711V17.9999H6.85718Z"
-          fill="var(--color-primary-default)"
-        />
-      </g>
-    </svg>
-  </div>
-  <div
     class="mm-box mm-box--margin-bottom-4 mm-box--padding-0 mm-box--background-color-background-default mm-box--rounded-md"
   >
     <div

--- a/ui/pages/confirmations/components/confirm/info/shared/confirm-loader/__snapshots__/confirm-loader.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/confirm-loader/__snapshots__/confirm-loader.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ConfirmLoader /> renders component 1`] = `
 <div>
   <div
-    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+    class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
   >
     <svg
       class="preloader__icon"

--- a/ui/pages/confirmations/components/confirm/info/shared/confirm-loader/confirm-loader.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/confirm-loader/confirm-loader.tsx
@@ -13,6 +13,8 @@ export const ConfirmLoader = () => {
       display={Display.Flex}
       justifyContent={JustifyContent.center}
       alignItems={AlignItems.center}
+      paddingTop={4}
+      paddingBottom={4}
     >
       <Preloader size={20} />
     </Box>

--- a/ui/pages/confirmations/components/confirm/info/shared/send-heading/__snapshots__/send-heading.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/send-heading/__snapshots__/send-heading.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<SendHeading /> renders component 1`] = `
 <div>
   <div
-    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+    class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
   >
     <svg
       class="preloader__icon"

--- a/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
@@ -9,7 +9,6 @@ import {
   Text,
 } from '../../../../../../../components/component-library';
 import Tooltip from '../../../../../../../components/ui/tooltip';
-import { getIntlLocale } from '../../../../../../../ducks/locale/locale';
 import {
   AlignItems,
   BackgroundColor,
@@ -19,11 +18,9 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../../../helpers/constants/design-system';
-import { MIN_AMOUNT } from '../../../../../../../hooks/useCurrencyDisplay';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { getPreferences } from '../../../../../../../selectors';
 import { useConfirmContext } from '../../../../../context/confirm';
-import { formatAmountMaxPrecision } from '../../../../simulation-details/formatAmount';
 import { useTokenValues } from '../../hooks/use-token-values';
 import { useTokenDetails } from '../../hooks/useTokenDetails';
 import { ConfirmLoader } from '../confirm-loader/confirm-loader';
@@ -32,7 +29,6 @@ const SendHeading = () => {
   const t = useI18nContext();
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
-  const locale = useSelector(getIntlLocale);
   const { tokenImage, tokenSymbol } = useTokenDetails(transactionMeta);
   const {
     decodedTransferValue,
@@ -66,21 +62,20 @@ const SendHeading = () => {
   );
 
   const TokenValue =
-    displayTransferValue ===
-    `<${formatAmountMaxPrecision(locale, MIN_AMOUNT)}` ? (
-      <Tooltip title={decodedTransferValue.toString()} position="right">
+    displayTransferValue === decodedTransferValue ? (
+      <Text
+        variant={TextVariant.headingLg}
+        color={TextColor.inherit}
+        marginTop={3}
+      >{`${displayTransferValue} ${tokenSymbol}`}</Text>
+    ) : (
+      <Tooltip title={decodedTransferValue} position="right">
         <Text
           variant={TextVariant.headingLg}
           color={TextColor.inherit}
           marginTop={3}
         >{`${displayTransferValue} ${tokenSymbol}`}</Text>
       </Tooltip>
-    ) : (
-      <Text
-        variant={TextVariant.headingLg}
-        color={TextColor.inherit}
-        marginTop={3}
-      >{`${displayTransferValue} ${tokenSymbol}`}</Text>
     );
 
   const TokenFiatValue = Boolean(fiatDisplayValue) &&

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -3,50 +3,7 @@
 exports[`TokenTransferInfo renders correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
-  >
-    <svg
-      class="preloader__icon"
-      fill="none"
-      height="20"
-      viewBox="0 0 16 16"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M8 13.7143C4.84409 13.7143 2.28571 11.1559 2.28571 8C2.28571 4.84409 4.84409 2.28571 8 2.28571C11.1559 2.28571 13.7143 4.84409 13.7143 8C13.7143 11.1559 11.1559 13.7143 8 13.7143ZM8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8C16 12.4183 12.4183 16 8 16Z"
-        fill="var(--color-primary-muted)"
-        fill-rule="evenodd"
-      />
-      <mask
-        height="16"
-        id="mask0"
-        mask-type="alpha"
-        maskUnits="userSpaceOnUse"
-        width="16"
-        x="0"
-        y="0"
-      >
-        <path
-          clip-rule="evenodd"
-          d="M8 13.7143C4.84409 13.7143 2.28571 11.1559 2.28571 8C2.28571 4.84409 4.84409 2.28571 8 2.28571C11.1559 2.28571 13.7143 4.84409 13.7143 8C13.7143 11.1559 11.1559 13.7143 8 13.7143ZM8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8C16 12.4183 12.4183 16 8 16Z"
-          fill="var(--color-primary-default)"
-          fill-rule="evenodd"
-        />
-      </mask>
-      <g
-        mask="url(#mask0)"
-      >
-        <path
-          d="M6.85718 17.9999V11.4285V8.28564H-4.85711V17.9999H6.85718Z"
-          fill="var(--color-primary-default)"
-        />
-      </g>
-    </svg>
-  </div>
-  <div
-    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+    class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
   >
     <svg
       class="preloader__icon"

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
@@ -21,7 +21,6 @@ import {
 } from '../../../../../../helpers/constants/design-system';
 import { useConfirmContext } from '../../../../context/confirm';
 import { useDecodedTransactionData } from '../hooks/useDecodedTransactionData';
-import { ConfirmLoader } from '../shared/confirm-loader/confirm-loader';
 
 export const TransactionFlowSection = () => {
   const { currentConfirmation: transactionMeta } =
@@ -39,7 +38,7 @@ export const TransactionFlowSection = () => {
         addresses?.[addresses.length - 1].value;
 
   if (pending) {
-    return <ConfirmLoader />;
+    return null;
   }
 
   const { chainId } = transactionMeta;

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -115,6 +115,10 @@ import NftFullImage from '../../components/app/assets/nfts/nft-details/nft-full-
 import CrossChainSwap from '../bridge';
 import { ToastMaster } from '../../components/app/toast-master/toast-master';
 import {
+  REDESIGN_APPROVAL_TYPES,
+  REDESIGN_DEV_TRANSACTION_TYPES,
+} from '../confirmations/utils';
+import {
   getConnectingLabel,
   hideAppHeader,
   isConfirmTransactionRoute,
@@ -174,6 +178,9 @@ export default class Routes extends Component {
     currentExtensionPopupId: PropTypes.number,
     useRequestQueue: PropTypes.bool,
     clearEditedNetwork: PropTypes.func.isRequired,
+    oldestPendingApproval: PropTypes.object.isRequired,
+    pendingApprovals: PropTypes.arrayOf(PropTypes.object).isRequired,
+    transactionsMetadata: PropTypes.arrayOf(PropTypes.object).isRequired,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isShowKeyringSnapRemovalResultModal: PropTypes.bool.isRequired,
     hideShowKeyringSnapRemovalResultModal: PropTypes.func.isRequired,
@@ -419,6 +426,9 @@ export default class Routes extends Component {
       clearSwitchedNetworkDetails,
       clearEditedNetwork,
       privacyMode,
+      oldestPendingApproval,
+      pendingApprovals,
+      transactionsMetadata,
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       isShowKeyringSnapRemovalResultModal,
       hideShowKeyringSnapRemovalResultModal,
@@ -454,7 +464,28 @@ export default class Routes extends Component {
       isUnlocked &&
       !shouldShowSeedPhraseReminder;
 
-    let isLoadingShown = isLoading && completedOnboarding;
+    const paramsConfirmationId = location.pathname.split(
+      '/confirm-transaction/',
+    )[1];
+    const confirmationId = paramsConfirmationId ?? oldestPendingApproval?.id;
+    const pendingApproval = pendingApprovals.find(
+      (approval) => approval.id === confirmationId,
+    );
+    const isCorrectApprovalType = REDESIGN_APPROVAL_TYPES.includes(
+      pendingApproval?.type,
+    );
+    const isCorrectDeveloperTransactionType =
+      REDESIGN_DEV_TRANSACTION_TYPES.includes(
+        transactionsMetadata[confirmationId]?.type,
+      );
+
+    let isLoadingShown =
+      isLoading &&
+      completedOnboarding &&
+      // In the redesigned screens, we hide the general loading spinner and the
+      // loading states are on a component by component basis.
+      !isCorrectApprovalType &&
+      !isCorrectDeveloperTransactionType;
 
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isLoadingShown =
@@ -464,7 +495,11 @@ export default class Routes extends Component {
         (confirmation) =>
           confirmation.type ===
           SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect,
-      );
+      ) &&
+      // In the redesigned screens, we hide the general loading spinner and the
+      // loading states are on a component by component basis.
+      !isCorrectApprovalType &&
+      !isCorrectDeveloperTransactionType;
     ///: END:ONLY_INCLUDE_IF
 
     return (

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -22,6 +22,9 @@ import {
   getNumberOfAllUnapprovedTransactionsAndMessages,
   getUseRequestQueue,
   getCurrentNetwork,
+  oldestPendingConfirmationSelector,
+  getUnapprovedTransactions,
+  getPendingApprovals,
 } from '../../selectors';
 import {
   lockMetamask,
@@ -69,6 +72,10 @@ function mapStateToProps(state) {
     getNetworkToAutomaticallySwitchTo(state);
   const switchedNetworkDetails = getSwitchedNetworkDetails(state);
 
+  const oldestPendingApproval = oldestPendingConfirmationSelector(state);
+  const pendingApprovals = getPendingApprovals(state);
+  const transactionsMetadata = getUnapprovedTransactions(state);
+
   return {
     alertOpen,
     alertMessage,
@@ -114,6 +121,9 @@ function mapStateToProps(state) {
       selectSwitchedNetworkNeverShowMessage(state),
     currentExtensionPopupId: state.metamask.currentExtensionPopupId,
     useRequestQueue: getUseRequestQueue(state),
+    oldestPendingApproval,
+    pendingApprovals,
+    transactionsMetadata,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isShowKeyringSnapRemovalResultModal:
       state.appState.showKeyringRemovalSnapModal,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We were previously using a UI blocking, whole page spinner while loading the redesigned confirmations. This overlapped with the individual component spinners we use on some components that decode transaction data. That second pattern is preferable because the spinner is contained and doesn't block the user from taking action.

The global spinner comes from `routes.component`. The first part of this fix is to bypass it in that file for redesigned confirmations.

The second aspect of this fix is to not condense two component spinners into one. Since the transaction flow section always loads before the send heading component, we can omit the spinner for that first component.

Finally, this PR fixes the loading behaviour on the send heading component so that if the decimals amount coming from `useAssetDetails` hasn't been received yet, the heading is not shown, preventing undesireable flickering in the hero value.



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28301?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27972

## **Manual testing steps**

1. Go to test dapp
2. Click on malicious erc20 transfer to see the 2 spinners on top and the different one in the middle
3. Click on malicious erc20 approve to see the different spinner in the middle

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="362" alt="Screenshot 2024-10-18 at 18 11 08" src="https://github.com/user-attachments/assets/9fbc5c1e-229c-4dfa-8231-4957a1ecf713">

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/2f5dd8c2-3b9b-405d-b9b5-0eb8bf793fcb


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
