### PR TITLE
Cherrypick v12.7.0 feat: Add simulation metrics to "Transaction Submitted" and "Transaction Finalized" events 

### DIFF
--- a/app/scripts/controllers/metametrics.ts
+++ b/app/scripts/controllers/metametrics.ts
@@ -32,6 +32,7 @@ import { ENVIRONMENT_TYPE_BACKGROUND } from '../../../shared/constants/app';
 import {
   METAMETRICS_ANONYMOUS_ID,
   METAMETRICS_BACKGROUND_PAGE_OBJECT,
+  MetaMetricsEventCategory,
   MetaMetricsEventName,
   MetaMetricsEventFragment,
   MetaMetricsUserTrait,
@@ -312,7 +313,7 @@ export default class MetaMetricsController {
     // fragments that are not marked as persistent will be purged and the
     // failure event will be emitted.
     Object.values(abandonedFragments).forEach((fragment) => {
-      this.finalizeEventFragment(fragment.id, { abandoned: true });
+      this.processAbandonedFragment(fragment);
     });
 
     // Code below submits any pending segmentApiCalls to Segment if/when the controller is re-instantiated
@@ -368,7 +369,7 @@ export default class MetaMetricsController {
         fragment.lastUpdated &&
         Date.now() - fragment.lastUpdated / 1000 > fragment.timeout
       ) {
-        this.finalizeEventFragment(fragment.id, { abandoned: true });
+        this.processAbandonedFragment(fragment);
       }
     });
   }
@@ -414,10 +415,30 @@ export default class MetaMetricsController {
       ...options,
       lastUpdated: Date.now(),
     };
+
+    /**
+     * HACK: "transaction-submitted-<id>" fragment hack
+     * A "transaction-submitted-<id>" fragment may exist following the "Transaction Added"
+     * event to persist accumulated event fragment props to the "Transaction Submitted" event
+     * which fires after a user confirms a transaction. Rejecting a confirmation does not fire the
+     * "Transaction Submitted" event. In this case, these abandoned fragments will be deleted
+     * instead of finalized with canDeleteIfAbandoned set to true.
+     */
+    const hasExistingSubmittedFragment =
+      options.initialEvent === TransactionMetaMetricsEvent.submitted &&
+      fragments[id];
+
+    const additionalFragmentProps = hasExistingSubmittedFragment
+      ? {
+          ...fragments[id],
+          canDeleteIfAbandoned: false,
+        }
+      : {};
+
     this.store.updateState({
       fragments: {
         ...fragments,
-        [id]: fragment,
+        [id]: merge(additionalFragmentProps, fragment),
       },
     });
 
@@ -456,6 +477,19 @@ export default class MetaMetricsController {
   }
 
   /**
+   * Deletes to finalizes event fragment based on the canDeleteIfAbandoned property.
+   *
+   * @param fragment
+   */
+  processAbandonedFragment(fragment: MetaMetricsEventFragment): void {
+    if (fragment.canDeleteIfAbandoned) {
+      this.deleteEventFragment(fragment.id);
+    } else {
+      this.finalizeEventFragment(fragment.id, { abandoned: true });
+    }
+  }
+
+  /**
    * Updates an event fragment in state
    *
    * @param id - The fragment id to update
@@ -469,7 +503,22 @@ export default class MetaMetricsController {
 
     const fragment = fragments[id];
 
-    if (!fragment) {
+    /**
+     * HACK: "transaction-submitted-<id>" fragment hack
+     * Creates a "transaction-submitted-<id>" fragment if it does not exist to persist
+     * accumulated event metrics. In the case it is unused, the abandoned fragment will
+     * eventually be deleted with canDeleteIfAbandoned set to true.
+     */
+    const createIfNotFound = !fragment && id.includes('transaction-submitted-');
+
+    if (createIfNotFound) {
+      fragments[id] = {
+        canDeleteIfAbandoned: true,
+        category: MetaMetricsEventCategory.Transactions,
+        successEvent: TransactionMetaMetricsEvent.finalized,
+        id,
+      };
+    } else if (!fragment) {
       throw new Error(`Event fragment with id ${id} does not exist.`);
     }
 
@@ -482,6 +531,19 @@ export default class MetaMetricsController {
         }),
       },
     });
+  }
+
+  /**
+   * Deletes an event fragment from state
+   *
+   * @param id - The fragment id to delete
+   */
+  deleteEventFragment(id: string): void {
+    const { fragments } = this.store.getState();
+
+    if (fragments[id]) {
+      delete fragments[id];
+    }
   }
 
   /**

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -528,7 +528,12 @@ function createTransactionEventFragment({
       transactionMetricsRequest.getEventFragmentById,
       eventName,
       transactionMeta,
-    )
+    ) &&
+    /**
+     * HACK: "transaction-submitted-<id>" fragment hack
+     * can continue to createEventFragment if "transaction-submitted-<id>"  submitted fragment exists
+     */
+    eventName !== TransactionMetaMetricsEvent.submitted
   ) {
     return;
   }
@@ -642,25 +647,14 @@ function updateTransactionEventFragment({
 
   switch (eventName) {
     case TransactionMetaMetricsEvent.approved:
-      transactionMetricsRequest.updateEventFragment(uniqueId, {
-        properties: payload.properties,
-        sensitiveProperties: payload.sensitiveProperties,
-      });
-      break;
-
     case TransactionMetaMetricsEvent.rejected:
-      transactionMetricsRequest.updateEventFragment(uniqueId, {
-        properties: payload.properties,
-        sensitiveProperties: payload.sensitiveProperties,
-      });
-      break;
-
     case TransactionMetaMetricsEvent.finalized:
       transactionMetricsRequest.updateEventFragment(uniqueId, {
         properties: payload.properties,
         sensitiveProperties: payload.sensitiveProperties,
       });
       break;
+
     default:
       break;
   }
@@ -679,6 +673,7 @@ function finalizeTransactionEventFragment({
 
   switch (eventName) {
     case TransactionMetaMetricsEvent.approved:
+    case TransactionMetaMetricsEvent.finalized:
       transactionMetricsRequest.finalizeEventFragment(uniqueId);
       break;
 
@@ -688,9 +683,6 @@ function finalizeTransactionEventFragment({
       });
       break;
 
-    case TransactionMetaMetricsEvent.finalized:
-      transactionMetricsRequest.finalizeEventFragment(uniqueId);
-      break;
     default:
       break;
   }

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -247,6 +247,13 @@ export type MetaMetricsEventFragment = {
    * The event name.
    */
   event?: string;
+
+  /**
+   * HACK: "transaction-submitted-<id>" fragment hack
+   * If this is true and the fragment is found as an abandoned fragment,
+   * then delete the fragment instead of finalizing it.
+   */
+  canDeleteIfAbandoned?: boolean;
 };
 
 /**

--- a/ui/pages/confirmations/hooks/useTransactionEventFragment.js
+++ b/ui/pages/confirmations/hooks/useTransactionEventFragment.js
@@ -31,6 +31,7 @@ export const useTransactionEventFragment = () => {
         await createTransactionEventFragment(transactionId);
       }
       updateEventFragment(`transaction-added-${transactionId}`, params);
+      updateEventFragment(`transaction-submitted-${transactionId}`, params);
     },
     [fragmentExists, gasTransactionId],
   );


### PR DESCRIPTION
## **Description**

Cherry-picks https://github.com/MetaMask/metamask-extension/pull/28240 into v12.7.0. 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3507

## **Manual testing steps**

1. Turn on "Participate in MetaMetrics" setting
2. Confirm or Reject a Send transaction (old transaction, not redesign transaction)
3. Observe simulation props are added to Transaction Submitted and Transaction Finalized events

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
