### PR TITLE
Cherrypick v12.7.0 feat: Enable simulation metrics for redesign transactions

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.tsx
@@ -22,6 +22,7 @@ const BaseTransactionInfo = () => {
         <SimulationDetails
           transaction={transactionMeta}
           isTransactionsRedesign
+          enableMetrics
         />
       </ConfirmInfoSection>
       <TransactionDetails />

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.tsx
@@ -24,6 +24,7 @@ const NativeTransferInfo = () => {
           <SimulationDetails
             transaction={transactionMeta}
             isTransactionsRedesign
+            enableMetrics
           />
         </ConfirmInfoSection>
       )}

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/nft-token-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/nft-token-transfer.tsx
@@ -24,6 +24,7 @@ const NFTTokenTransferInfo = () => {
           <SimulationDetails
             transaction={transactionMeta}
             isTransactionsRedesign
+            enableMetrics
           />
         </ConfirmInfoSection>
       )}

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.tsx
@@ -24,6 +24,7 @@ const TokenTransferInfo = () => {
           <SimulationDetails
             transaction={transactionMeta}
             isTransactionsRedesign
+            enableMetrics
           />
         </ConfirmInfoSection>
       )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cherry-picks https://github.com/MetaMask/metamask-extension/pull/28280 into V12.7.0

Discovered this missing behavior while working on https://github.com/MetaMask/metamask-extension/pull/28314. The feat was unexpectedly missing 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28324?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/28292

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
