### PR TITLE
fix: Add metric trait for privacy mode

### DIFF
--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -1453,6 +1453,7 @@ describe('MetaMetricsController', function () {
           participateInMetaMetrics: true,
           currentCurrency: 'usd',
           dataCollectionForMarketing: false,
+          preferences: { privacyMode: true },
           ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
           custodyAccountDetails: {},
           ///: END:ONLY_INCLUDE_IF
@@ -1492,6 +1493,7 @@ describe('MetaMetricsController', function () {
           [MetaMetricsUserTrait.PetnameAddressCount]: 3,
           ///: END:ONLY_INCLUDE_IF
           [MetaMetricsUserTrait.TokenSortPreference]: 'token-sort-key',
+          [MetaMetricsUserTrait.PrivacyModeEnabled]: true,
         });
       });
     });
@@ -1541,6 +1543,7 @@ describe('MetaMetricsController', function () {
           allNfts: {},
           participateInMetaMetrics: true,
           dataCollectionForMarketing: false,
+          preferences: { privacyMode: true },
           securityAlertsEnabled: true,
           names: {
             ethereumAddress: {},
@@ -1604,6 +1607,7 @@ describe('MetaMetricsController', function () {
           allNfts: {},
           participateInMetaMetrics: true,
           dataCollectionForMarketing: false,
+          preferences: { privacyMode: true },
           securityAlertsEnabled: true,
           ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
           custodyAccountDetails: {},
@@ -1668,6 +1672,7 @@ describe('MetaMetricsController', function () {
           },
           participateInMetaMetrics: true,
           dataCollectionForMarketing: false,
+          preferences: { privacyMode: true },
           securityAlertsEnabled: true,
           security_providers: ['blockaid'],
           currentCurrency: 'usd',
@@ -1713,6 +1718,7 @@ describe('MetaMetricsController', function () {
           allNfts: {},
           participateInMetaMetrics: true,
           dataCollectionForMarketing: false,
+          preferences: { privacyMode: true },
           names: {
             ethereumAddress: {},
           },

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -164,6 +164,9 @@ export type MetaMaskState = {
   security_providers: string[];
   addressBook: AddressBookControllerState['addressBook'];
   currentCurrency: string;
+  preferences: {
+    privacyMode: PreferencesControllerState['preferences']['privacyMode'];
+  };
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   custodyAccountDetails: {
     [address: string]: {
@@ -1228,6 +1231,8 @@ export default class MetaMetricsController extends BaseController<
         metamaskState.dataCollectionForMarketing,
       [MetaMetricsUserTrait.TokenSortPreference]:
         metamaskState.tokenSortConfig?.key || '',
+      [MetaMetricsUserTrait.PrivacyModeEnabled]:
+        metamaskState.preferences.privacyMode,
     };
 
     if (!previousUserTraits) {

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -590,6 +590,10 @@ export enum MetaMetricsUserTrait {
    * Identified when the user changes token sort order on asset-list
    */
   TokenSortPreference = 'token_sort_preference',
+  /**
+   * Identifies if the Privacy Mode is enabled
+   */
+  PrivacyModeEnabled = 'privacy_mode_toggle',
 }
 
 /**


### PR DESCRIPTION

## **Description**

Adds a user trait for if privacy mode is enabled.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28335?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open debugger
2. Put a breakpoint in `app/scripts/controllers/metametrics.ts`'s `_buildUserTraitsObject` function
3. See value being passed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
