### PR TITLE
fix: disable buy for btc testnet accounts

### DIFF
--- a/ui/components/app/wallet-overview/btc-overview.test.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.test.tsx
@@ -233,4 +233,34 @@ describe('BtcOverview', () => {
     const receiveButton = queryByTestId(BTC_OVERVIEW_RECEIVE);
     expect(receiveButton).toBeInTheDocument();
   });
+
+  it('"Buy & Sell" button is disabled for testnet accounts', () => {
+    const storeWithBtcBuyable = getStore({
+      metamask: {
+        ...mockMetamaskStore,
+        internalAccounts: {
+          ...mockMetamaskStore.internalAccounts,
+          accounts: {
+            [mockNonEvmAccount.id]: {
+              ...mockNonEvmAccount,
+              address: 'tb1q9lakrt5sw0w0twnc6ww4vxs7hm0q23e03286k8',
+            },
+          },
+        },
+      },
+      ramps: {
+        buyableChains: mockBuyableChainsWithBtc,
+      },
+    });
+
+    const { queryByTestId } = renderWithProvider(
+      <BtcOverview />,
+      storeWithBtcBuyable,
+    );
+
+    const buyButton = queryByTestId(BTC_OVERVIEW_BUY);
+
+    expect(buyButton).toBeInTheDocument();
+    expect(buyButton).toBeDisabled();
+  });
 });

--- a/ui/components/app/wallet-overview/btc-overview.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import {
+  getMultichainIsTestnet,
   getMultichainProviderConfig,
   getMultichainSelectedAccountCachedBalance,
 } from '../../../selectors/multichain';
@@ -8,12 +9,21 @@ import {
 import { getIsBitcoinBuyable } from '../../../ducks/ramps';
 ///: END:ONLY_INCLUDE_IF
 import { CoinOverview } from './coin-overview';
+import { getSelectedInternalAccount } from '../../../selectors';
+import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 
 type BtcOverviewProps = {
   className?: string;
 };
 
 const BtcOverview = ({ className }: BtcOverviewProps) => {
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const isBtcTestnetAccount = useMultichainSelector(
+    getMultichainIsTestnet,
+    selectedAccount,
+  );
+  console.log('isBtcTestnetAccount', isBtcTestnetAccount);
+  console.log('selectedAccount', selectedAccount);
   const { chainId } = useSelector(getMultichainProviderConfig);
   const balance = useSelector(getMultichainSelectedAccountCachedBalance);
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
@@ -31,7 +41,7 @@ const BtcOverview = ({ className }: BtcOverviewProps) => {
       isSwapsChain={false}
       ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
       isBridgeChain={false}
-      isBuyableChain={isBtcBuyable}
+      isBuyableChain={isBtcBuyable && !isBtcTestnetAccount}
       ///: END:ONLY_INCLUDE_IF
     />
   );

--- a/ui/components/app/wallet-overview/btc-overview.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import {
-  getMultichainIsTestnet,
+  getMultichainIsMainnet,
   getMultichainProviderConfig,
   getMultichainSelectedAccountCachedBalance,
 } from '../../../selectors/multichain';
@@ -18,8 +18,8 @@ type BtcOverviewProps = {
 
 const BtcOverview = ({ className }: BtcOverviewProps) => {
   const selectedAccount = useSelector(getSelectedInternalAccount);
-  const isBtcTestnetAccount = useMultichainSelector(
-    getMultichainIsTestnet,
+  const isBtcMainnetAccount = useMultichainSelector(
+    getMultichainIsMainnet,
     selectedAccount,
   );
   const { chainId } = useSelector(getMultichainProviderConfig);
@@ -39,7 +39,7 @@ const BtcOverview = ({ className }: BtcOverviewProps) => {
       isSwapsChain={false}
       ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
       isBridgeChain={false}
-      isBuyableChain={isBtcBuyable && !isBtcTestnetAccount}
+      isBuyableChain={isBtcBuyable && isBtcMainnetAccount}
       ///: END:ONLY_INCLUDE_IF
     />
   );

--- a/ui/components/app/wallet-overview/btc-overview.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.tsx
@@ -8,9 +8,9 @@ import {
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { getIsBitcoinBuyable } from '../../../ducks/ramps';
 ///: END:ONLY_INCLUDE_IF
-import { CoinOverview } from './coin-overview';
 import { getSelectedInternalAccount } from '../../../selectors';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
+import { CoinOverview } from './coin-overview';
 
 type BtcOverviewProps = {
   className?: string;
@@ -22,8 +22,6 @@ const BtcOverview = ({ className }: BtcOverviewProps) => {
     getMultichainIsTestnet,
     selectedAccount,
   );
-  console.log('isBtcTestnetAccount', isBtcTestnetAccount);
-  console.log('selectedAccount', selectedAccount);
   const { chainId } = useSelector(getMultichainProviderConfig);
   const balance = useSelector(getMultichainSelectedAccountCachedBalance);
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)

--- a/ui/components/app/wallet-overview/btc-overview.tsx
+++ b/ui/components/app/wallet-overview/btc-overview.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import {
+  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   getMultichainIsMainnet,
+  ///: END:ONLY_INCLUDE_IF
   getMultichainProviderConfig,
   getMultichainSelectedAccountCachedBalance,
 } from '../../../selectors/multichain';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { getIsBitcoinBuyable } from '../../../ducks/ramps';
-///: END:ONLY_INCLUDE_IF
 import { getSelectedInternalAccount } from '../../../selectors';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
+///: END:ONLY_INCLUDE_IF
 import { CoinOverview } from './coin-overview';
 
 type BtcOverviewProps = {
@@ -17,14 +19,14 @@ type BtcOverviewProps = {
 };
 
 const BtcOverview = ({ className }: BtcOverviewProps) => {
+  const { chainId } = useSelector(getMultichainProviderConfig);
+  const balance = useSelector(getMultichainSelectedAccountCachedBalance);
+  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const isBtcMainnetAccount = useMultichainSelector(
     getMultichainIsMainnet,
     selectedAccount,
   );
-  const { chainId } = useSelector(getMultichainProviderConfig);
-  const balance = useSelector(getMultichainSelectedAccountCachedBalance);
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   const isBtcBuyable = useSelector(getIsBitcoinBuyable);
   ///: END:ONLY_INCLUDE_IF
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR disables the Buy / sell button for btc testnet accounts 

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/655

## **Manual testing steps**

1. Create a testnet btc account
2. Go to the overview page
3. See that the buy/sell button is disabled. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
