### PR TITLE
build: update yarn to v4.5.1

### DIFF
--- a/development/generate-attributions/package.json
+++ b/development/generate-attributions/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": ">= 20",
-    "yarn": "^4.4.1"
+    "yarn": "^4.5.1"
   },
   "lavamoat": {
     "allowScripts": {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -3004,23 +3004,12 @@
         "eslint-plugin-prettier": true,
         "eslint-plugin-react": true,
         "eslint-plugin-react-hooks": true,
-        "eslint>@eslint/eslintrc>ajv": true,
+        "eslint>ajv": true,
         "eslint>globals": true,
         "eslint>ignore": true,
         "eslint>minimatch": true,
         "mocha>strip-json-comments": true,
         "nock>debug": true
-      }
-    },
-    "eslint>@eslint/eslintrc>ajv": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@metamask/snaps-utils>fast-json-stable-stringify": true,
-        "eslint>@eslint/eslintrc>ajv>json-schema-traverse": true,
-        "eslint>fast-deep-equal": true,
-        "uri-js": true
       }
     },
     "eslint>@eslint/eslintrc>import-fresh": {
@@ -8491,15 +8480,10 @@
         "process.stdout.write": true
       },
       "packages": {
+        "eslint>ajv": true,
         "lodash": true,
-        "stylelint>table>ajv": true,
         "stylelint>table>slice-ansi": true,
         "stylelint>table>string-width": true
-      }
-    },
-    "stylelint>table>ajv": {
-      "packages": {
-        "eslint>fast-deep-equal": true
       }
     },
     "stylelint>table>slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -750,5 +750,5 @@
       "jest-preview": false
     }
   },
-  "packageManager": "yarn@4.4.1"
+  "packageManager": "yarn@4.5.1"
 }


### PR DESCRIPTION
## **Description**

Updates yarn to the latest v4.5.1, and adjusts LavaMoat policies to accommodate.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28365?quickstart=1)

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
### **Before**
### **After**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->