### PR TITLE
fix: Return to send page with different asset types

### DIFF
--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -38,7 +41,26 @@ export const WalletInitiatedHeader = () => {
   const handleBackButtonClick = useCallback(async () => {
     const { id } = currentConfirmation;
 
-    await dispatch(editExistingTransaction(AssetType.token, id.toString()));
+    const isNativeSend =
+      currentConfirmation.type === TransactionType.simpleSend;
+    const isERC20TokenSend =
+      currentConfirmation.type === TransactionType.tokenMethodTransfer;
+    const isNFTTokenSend =
+      currentConfirmation.type === TransactionType.tokenMethodTransferFrom ||
+      currentConfirmation.type === TransactionType.tokenMethodSafeTransferFrom;
+
+    let assetType: AssetType;
+    if (isNativeSend) {
+      assetType = AssetType.native;
+    } else if (isERC20TokenSend) {
+      assetType = AssetType.token;
+    } else if (isNFTTokenSend) {
+      assetType = AssetType.NFT;
+    } else {
+      assetType = AssetType.unknown;
+    }
+
+    await dispatch(editExistingTransaction(assetType, id.toString()));
     dispatch(clearConfirmTransaction());
     dispatch(showSendTokenPage());
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This bug was reproducible by opening a new wallet initiated send confirmation with a Native token ("simple send") from the extension full screen view, and then triggering a dApp initiated confirmation, and trying to return back to the send flow stepper.

The bug was provoked due to having the `editExistingTransaction` action dispatched on back button click hardcoded for asset of type token. The fix involves dynamically determining the asset type.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28382?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/28316

## **Manual testing steps**

See above or check video on the bug report ticket.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
