### PR TITLE
chore: add unit test for `useMultiPolling`

### DIFF
--- a/ui/hooks/useMultiPolling.test.ts
+++ b/ui/hooks/useMultiPolling.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useMultiPolling from './useMultiPolling';
+
+describe('useMultiPolling', () => {
+  it('Should start/stop polling when inputs are added/removed, and stop on dismount', async () => {
+    const promises: Promise<string>[] = [];
+    const mockStartPolling = jest.fn().mockImplementation((input) => {
+      const promise = Promise.resolve(`${input}_token`);
+      promises.push(promise);
+      return promise;
+    });
+
+    const mockStopPollingByPollingToken = jest.fn();
+    const inputs = ['foo', 'bar'];
+
+    const { unmount, rerender } = renderHook(() =>
+      useMultiPolling({
+        startPolling: mockStartPolling,
+        stopPollingByPollingToken: mockStopPollingByPollingToken,
+        input: inputs,
+      }),
+    );
+
+    // All inputs should start polling
+    await Promise.all(promises);
+    for (const input of inputs) {
+      expect(mockStartPolling).toHaveBeenCalledWith(input);
+    }
+
+    // Remove one input, and add another
+    inputs[0] = 'baz';
+    rerender({ input: inputs });
+    expect(mockStopPollingByPollingToken).toHaveBeenCalledWith('foo_token');
+    expect(mockStartPolling).toHaveBeenCalledWith('baz');
+
+    // All inputs should stop polling on dismount
+    await Promise.all(promises);
+    unmount();
+    for (const input of inputs) {
+      expect(mockStopPollingByPollingToken).toHaveBeenCalledWith(
+        `${input}_token`,
+      );
+    }
+  });
+});

--- a/ui/hooks/useMultiPolling.ts
+++ b/ui/hooks/useMultiPolling.ts
@@ -32,7 +32,6 @@ const useMultiPolling = <PollingInput>(
       );
 
       if (!exists) {
-        console.log('stopping polling', token);
         usePollingOptions.stopPollingByPollingToken(token);
         pollingTokens.current.delete(inputKey);
       }

--- a/ui/hooks/useMultiPolling.ts
+++ b/ui/hooks/useMultiPolling.ts
@@ -19,9 +19,9 @@ const useMultiPolling = <PollingInput>(
     for (const input of usePollingOptions.input) {
       const key = JSON.stringify(input);
       if (!pollingTokens.current.has(key)) {
-        usePollingOptions.startPolling(input).then((token) => {
-          pollingTokens.current.set(key, token);
-        });
+        usePollingOptions
+          .startPolling(input)
+          .then((token) => pollingTokens.current.set(key, token));
       }
     }
 

--- a/ui/hooks/useMultiPolling.ts
+++ b/ui/hooks/useMultiPolling.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 type UseMultiPollingOptions<PollingInput> = {
   startPolling: (input: PollingInput) => Promise<string>;
@@ -12,34 +12,29 @@ type UseMultiPollingOptions<PollingInput> = {
 const useMultiPolling = <PollingInput>(
   usePollingOptions: UseMultiPollingOptions<PollingInput>,
 ) => {
-  const [polls, setPolls] = useState(new Map());
+  const pollingTokens = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     // start new polls
     for (const input of usePollingOptions.input) {
       const key = JSON.stringify(input);
-      if (!polls.has(key)) {
-        usePollingOptions
-          .startPolling(input)
-          .then((token) =>
-            setPolls((prevPolls) => new Map(prevPolls).set(key, token)),
-          );
+      if (!pollingTokens.current.has(key)) {
+        usePollingOptions.startPolling(input).then((token) => {
+          pollingTokens.current.set(key, token);
+        });
       }
     }
 
     // stop existing polls
-    for (const [inputKey, token] of polls.entries()) {
+    for (const [inputKey, token] of pollingTokens.current.entries()) {
       const exists = usePollingOptions.input.some(
         (i) => inputKey === JSON.stringify(i),
       );
 
       if (!exists) {
+        console.log('stopping polling', token);
         usePollingOptions.stopPollingByPollingToken(token);
-        setPolls((prevPolls) => {
-          const newPolls = new Map(prevPolls);
-          newPolls.delete(inputKey);
-          return newPolls;
-        });
+        pollingTokens.current.delete(inputKey);
       }
     }
   }, [usePollingOptions.input && JSON.stringify(usePollingOptions.input)]);
@@ -47,7 +42,7 @@ const useMultiPolling = <PollingInput>(
   // stop all polling on dismount
   useEffect(() => {
     return () => {
-      for (const token of polls.values()) {
+      for (const token of pollingTokens.current.values()) {
         usePollingOptions.stopPollingByPollingToken(token);
       }
     };


### PR DESCRIPTION

## **Description**

Adds a unit test for the `useMultiPolling`, and changes it to use refs instead of state.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28387?quickstart=1)

## **Related issues**


## **Manual testing steps**

No expected changes.  ERC20 token prices should still be accurate when switching, adding, and removing networks.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
