### PR TITLE
fix: Remove dApp suggested fees defaults and display only what the user selects

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`Info renders info section for approve request 1`] = `
           class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
           data-testid="native-currency"
         >
-          $0.04
+          $0.08
         </p>
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-link mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
@@ -819,7 +819,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
           data-testid="native-currency"
         >
-          $0.04
+          $0.08
         </p>
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-link mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"

--- a/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
@@ -483,7 +483,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
           class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
           data-testid="native-currency"
         >
-          $0.04
+          $0.08
         </p>
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-link mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
@@ -582,12 +582,12 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--margin-right-1 mm-box--color-text-default"
         >
-          0.0011 ETH
+          0.0023 ETH
         </p>
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
         >
-          $0.60
+          $1.26
         </p>
       </div>
     </div>

--- a/ui/pages/confirmations/components/confirm/info/hooks/useEIP1559TxFees.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useEIP1559TxFees.ts
@@ -1,6 +1,5 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useMemo } from 'react';
-import { PriorityLevels } from '../../../../../../../shared/constants/gas';
 import { hexToDecimal } from '../../../../../../../shared/modules/conversion.utils';
 
 export const useEIP1559TxFees = (
@@ -9,15 +8,10 @@ export const useEIP1559TxFees = (
   maxFeePerGas: string;
   maxPriorityFeePerGas: string;
 } => {
-  const hexMaxFeePerGas =
-    transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
-      ? transactionMeta.dappSuggestedGasFees?.maxFeePerGas
-      : transactionMeta?.txParams?.maxFeePerGas;
+  const hexMaxFeePerGas = transactionMeta?.txParams?.maxFeePerGas;
 
   const hexMaxPriorityFeePerGas =
-    transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
-      ? transactionMeta.dappSuggestedGasFees?.maxPriorityFeePerGas
-      : transactionMeta?.txParams?.maxPriorityFeePerGas;
+    transactionMeta?.txParams?.maxPriorityFeePerGas;
 
   return useMemo(() => {
     const maxFeePerGas = hexMaxFeePerGas ? hexToDecimal(hexMaxFeePerGas) : '0';

--- a/ui/pages/confirmations/components/confirm/info/hooks/useEIP1559TxFees.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useEIP1559TxFees.ts
@@ -1,5 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useMemo } from 'react';
+import { PriorityLevels } from '../../../../../../../shared/constants/gas';
 import { hexToDecimal } from '../../../../../../../shared/modules/conversion.utils';
 
 export const useEIP1559TxFees = (
@@ -9,11 +10,14 @@ export const useEIP1559TxFees = (
   maxPriorityFeePerGas: string;
 } => {
   const hexMaxFeePerGas =
-    transactionMeta.dappSuggestedGasFees?.maxFeePerGas ||
-    transactionMeta?.txParams?.maxFeePerGas;
+    transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
+      ? transactionMeta.dappSuggestedGasFees?.maxFeePerGas
+      : transactionMeta?.txParams?.maxFeePerGas;
+
   const hexMaxPriorityFeePerGas =
-    transactionMeta.dappSuggestedGasFees?.maxPriorityFeePerGas ||
-    transactionMeta?.txParams?.maxPriorityFeePerGas;
+    transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
+      ? transactionMeta.dappSuggestedGasFees?.maxPriorityFeePerGas
+      : transactionMeta?.txParams?.maxPriorityFeePerGas;
 
   return useMemo(() => {
     const maxFeePerGas = hexMaxFeePerGas ? hexToDecimal(hexMaxFeePerGas) : '0';

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -4,6 +4,7 @@ import { Hex } from '@metamask/utils';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { EtherDenomination } from '../../../../../../../shared/constants/common';
+import { PriorityLevels } from '../../../../../../../shared/constants/gas';
 import {
   addHexes,
   decGWEIToHexWEI,
@@ -100,9 +101,9 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
 
   // Max fee
   const gasLimit =
-    transactionMeta?.dappSuggestedGasFees?.gas ||
-    transactionMeta?.txParams?.gas ||
-    HEX_ZERO;
+    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
+      ? transactionMeta?.dappSuggestedGasFees?.gas
+      : transactionMeta?.txParams?.gas) || HEX_ZERO;
   const gasPrice = transactionMeta?.txParams?.gasPrice || HEX_ZERO;
 
   const maxFee = useMemo(() => {
@@ -146,7 +147,13 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     );
 
     return getFeesFromHex(estimatedFee);
-  }, [gasFeeEstimate, transactionMeta, estimatedBaseFee, getFeesFromHex]);
+  }, [
+    gasFeeEstimate,
+    transactionMeta,
+    estimatedBaseFee,
+    maxPriorityFeePerGas,
+    getFeesFromHex,
+  ]);
 
   return {
     estimatedFeeFiat: estimatedFees.currentCurrencyFee,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -4,7 +4,6 @@ import { Hex } from '@metamask/utils';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { EtherDenomination } from '../../../../../../../shared/constants/common';
-import { PriorityLevels } from '../../../../../../../shared/constants/gas';
 import {
   addHexes,
   decGWEIToHexWEI,
@@ -100,10 +99,7 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
   );
 
   // Max fee
-  const gasLimit =
-    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
-      ? transactionMeta?.dappSuggestedGasFees?.gas
-      : transactionMeta?.txParams?.gas) || HEX_ZERO;
+  const gasLimit = transactionMeta?.txParams?.gas || HEX_ZERO;
   const gasPrice = transactionMeta?.txParams?.gasPrice || HEX_ZERO;
 
   const maxFee = useMemo(() => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
@@ -1,6 +1,7 @@
 import { GasFeeEstimates } from '@metamask/gas-fee-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
+import { PriorityLevels } from '../../../../../../../shared/constants/gas';
 import {
   addHexes,
   multiplyHexes,
@@ -22,17 +23,22 @@ export function useTransactionGasFeeEstimate(
     ?.estimatedBaseFee;
 
   // override with values from `dappSuggestedGasFees` if they exist
-  gasLimit = transactionMeta.dappSuggestedGasFees?.gas || gasLimit || HEX_ZERO;
+  gasLimit =
+    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
+      ? transactionMeta.dappSuggestedGasFees?.gas
+      : gasLimit) || HEX_ZERO;
   gasPrice =
-    transactionMeta.dappSuggestedGasFees?.gasPrice || gasPrice || HEX_ZERO;
+    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
+      ? transactionMeta.dappSuggestedGasFees?.gasPrice
+      : gasPrice) || HEX_ZERO;
   const maxPriorityFeePerGas =
-    transactionMeta.dappSuggestedGasFees?.maxPriorityFeePerGas ||
-    transactionMeta.txParams?.maxPriorityFeePerGas ||
-    HEX_ZERO;
+    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
+      ? transactionMeta.dappSuggestedGasFees?.maxPriorityFeePerGas
+      : transactionMeta.txParams?.maxPriorityFeePerGas) || HEX_ZERO;
   const maxFeePerGas =
-    transactionMeta.dappSuggestedGasFees?.maxFeePerGas ||
-    transactionMeta.txParams?.maxFeePerGas ||
-    HEX_ZERO;
+    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
+      ? transactionMeta.dappSuggestedGasFees?.maxFeePerGas
+      : transactionMeta.txParams?.maxFeePerGas) || HEX_ZERO;
 
   let gasEstimate: Hex;
   if (supportsEIP1559) {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
@@ -1,7 +1,6 @@
 import { GasFeeEstimates } from '@metamask/gas-fee-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
-import { PriorityLevels } from '../../../../../../../shared/constants/gas';
 import {
   addHexes,
   multiplyHexes,
@@ -23,22 +22,11 @@ export function useTransactionGasFeeEstimate(
     ?.estimatedBaseFee;
 
   // override with values from `dappSuggestedGasFees` if they exist
-  gasLimit =
-    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
-      ? transactionMeta.dappSuggestedGasFees?.gas
-      : gasLimit) || HEX_ZERO;
-  gasPrice =
-    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
-      ? transactionMeta.dappSuggestedGasFees?.gasPrice
-      : gasPrice) || HEX_ZERO;
+  gasLimit = gasLimit || HEX_ZERO;
+  gasPrice = gasPrice || HEX_ZERO;
   const maxPriorityFeePerGas =
-    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
-      ? transactionMeta.dappSuggestedGasFees?.maxPriorityFeePerGas
-      : transactionMeta.txParams?.maxPriorityFeePerGas) || HEX_ZERO;
-  const maxFeePerGas =
-    (transactionMeta.userFeeLevel === PriorityLevels.dAppSuggested
-      ? transactionMeta.dappSuggestedGasFees?.maxFeePerGas
-      : transactionMeta.txParams?.maxFeePerGas) || HEX_ZERO;
+    transactionMeta.txParams?.maxPriorityFeePerGas || HEX_ZERO;
+  const maxFeePerGas = transactionMeta.txParams?.maxFeePerGas || HEX_ZERO;
 
   let gasEstimate: Hex;
   if (supportsEIP1559) {

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
           class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
           data-testid="native-currency"
         >
-          $0.04
+          $0.08
         </p>
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-link mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -327,7 +327,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
           class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
           data-testid="native-currency"
         >
-          $0.04
+          $0.08
         </p>
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-link mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"

--- a/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
           class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
           data-testid="native-currency"
         >
-          $0.04
+          $0.08
         </p>
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-link mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -355,7 +355,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
           class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
           data-testid="native-currency"
         >
-          $0.04
+          $0.08
         </p>
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-link mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Previously, some gas fee parameters defaulted to dApp suggested fee values. This was problematic, because these values are always defined, even when the user changed to a custom priority.

To fix the issue, we now only show the fees contained in txParams, trusting they match the user selected priority level in the gas fees modal.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28403?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

See screen recording below.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/3874d3b6-ad96-4fd9-9f40-361b38a0253b



### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
