### PR TITLE
ci: Fix `attributions:check` silent failure

### DIFF
--- a/development/attributions-check.sh
+++ b/development/attributions-check.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
 yarn attributions:generate
 
 ATTRIBUTIONS_FILE="./attribution.txt"


### PR DESCRIPTION
## **Description**

The script `attributions:check` was silently failing when the attempt to generate attributions failed. This led to the attributions in v12.6.0 being out-of-date.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28413?quickstart=1)

## **Related issues**

Relates to #28412

## **Manual testing steps**

1. Run `yarn attributions:check`. See that the exit code is non-zero
    * on `develop` it also fails, but with a zero exit code, indicating success despite the fact that it failed.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
