### PR TITLE
fix: Fix attribution generation

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -70,7 +70,6 @@ ignores:
   - 'crypto-browserify' # polyfill
   - 'process' # polyfill
   - 'stream-http' # polyfill
-  - 'rimraf' # misc: install helper
   - 'json-schema-to-ts' # misc: typescript helper
   - 'https-browserify' # polyfill
   - 'path-browserify' # polyfill

--- a/development/clear-webpack-cache.js
+++ b/development/clear-webpack-cache.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const WEBPACK_CACHE_DIRECTORY = path.resolve(
+  __dirname,
+  '..',
+  'node_modules',
+  '.cache',
+  'webpack',
+);
+
+/**
+ * Clear the Webpack cache.
+ *
+ * This is typically run in the `postinstall` npm/Yarn lifecycle script.
+ */
+async function main() {
+  await fs.rm(WEBPACK_CACHE_DIRECTORY, { force: true, recursive: true });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/development/generate-attributions.sh
+++ b/development/generate-attributions.sh
@@ -27,6 +27,13 @@ main() {
   # relative to the project root irrespective of where this script was run.
   cd "${PROJECT_DIRECTORY}"
 
+  # Remove allow-scripts plugin.
+  # Allow-scripts won't run correctly after a production-only install because the configuration
+  # includes exact paths to each dependency, and those paths can change in a production-only
+  # install because of the hoisting algorithm.
+  # We don't need postinstall scripts to run in order to generate attributions anyway.
+  yarn plugin remove @yarnpkg/plugin-allow-scripts
+
   # Instruct Yarn to only install production dependencies
   yarn workspaces focus --production
 
@@ -38,7 +45,9 @@ main() {
 
   # Check if the script is running in a CI environment (GitHub Actions sets the CI variable to true)
   if [ -z "${CI:-}" ]; then
-    # If not running in CI, restore development dependencies
+    # If not running in CI, restore the allow-scripts plugin and development dependencies.
+    cd "${PROJECT_DIRECTORY}"
+    git checkout -- .yarnrc.yml .yarn
     yarn
   fi
 }

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -3174,22 +3174,8 @@
         "__dirname": true
       },
       "packages": {
-        "eslint>file-entry-cache>flat-cache>flatted": true,
-        "eslint>file-entry-cache>flat-cache>rimraf": true
-      }
-    },
-    "eslint>file-entry-cache>flat-cache>rimraf": {
-      "builtin": {
-        "assert": true,
-        "fs": true,
-        "path.join": true
-      },
-      "globals": {
-        "process.platform": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "nyc>glob": true
+        "del>rimraf": true,
+        "eslint>file-entry-cache>flat-cache>flatted": true
       }
     },
     "eslint>glob-parent": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "webpack": "tsx ./development/webpack/launch.ts",
-    "webpack:clearcache": "rimraf node_modules/.cache/webpack",
+    "webpack:clearcache": "./development/clear-webpack-cache.js",
     "postinstall": "yarn webpack:clearcache",
     "env:e2e": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' yarn",
     "start": "yarn build:dev dev --apply-lavamoat=false --snow=false",
@@ -640,7 +640,6 @@
     "redux-mock-store": "^1.5.4",
     "remote-redux-devtools": "^0.5.16",
     "resolve-url-loader": "^3.1.5",
-    "rimraf": "^5.0.5",
     "sass-embedded": "^1.71.0",
     "sass-loader": "^14.1.1",
     "schema-utils": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26841,7 +26841,6 @@ __metadata:
     remove-trailing-slash: "npm:^0.1.1"
     reselect: "npm:^3.0.1"
     resolve-url-loader: "npm:^3.1.5"
-    rimraf: "npm:^5.0.5"
     sass-embedded: "npm:^1.71.0"
     sass-loader: "npm:^14.1.1"
     schema-utils: "npm:^4.2.0"


### PR DESCRIPTION
## **Description**

Fix the `attribution:generate` command by ensuring that it is possible to install just production dependencies.

Previously the command `yarn workspaces focus --production` (used to discard development dependencies, keeping just production dependencies installed) would fail because `rimraf` was not found. `rimraf` was a development dependency used in the `postinstall` script. This was resolved by replacing `rimraf` with a Node.js script that does the same thing without needing any dependency.

Once that failure was resolved, another was revealed. The `allow-scripts` step of the installation began failing because there was a package detected that had an install script that was missing from our configuration. This package was in our configuration already, but the `allow-scripts` configuration is sensitive to changes in the directory structure of `node_modules`, and that structure changed due to differences in which packages were hoisted in the production-only install.

That failure was resolved by updating `generate-attributions.sh` to remove the `allow-scripts` plugin while generating attributions. We don't need `postinstall` scripts to run in order to read licences from disk.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28415?quickstart=1)

## **Related issues**

Fixes #28412

## **Manual testing steps**

1. Run `yarn attributions:generate`, and see that it completes successfully
    * Locally, it should also re-install the `allow-scripts` plugin and development dependencies
    * If this command is run with `CI=true` (e.g. `CI=true yarn attributions:generate`), it will skip the step of re-installing the `allow-scripts` plugin and development dependencies. This is what would happen on CI, where the environment gets discarded after this is run so there is no point in re-installing things.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
