### PR TITLE
test: fix state fixtures race condition

### DIFF
--- a/test/e2e/fixture-server.js
+++ b/test/e2e/fixture-server.js
@@ -104,11 +104,8 @@ class FixtureServer {
   }
 
   loadJsonState(rawState, contractRegistry) {
-    return new Promise((resolve) => {
-      const state = performStateSubstitutions(rawState, contractRegistry);
-      this._stateMap.set(CURRENT_STATE_KEY, state);
-      resolve();
-    });
+    const state = performStateSubstitutions(rawState, contractRegistry);
+    this._stateMap.set(CURRENT_STATE_KEY, state);
   }
 
   _isStateRequest(ctx) {

--- a/test/e2e/fixture-server.js
+++ b/test/e2e/fixture-server.js
@@ -104,8 +104,11 @@ class FixtureServer {
   }
 
   loadJsonState(rawState, contractRegistry) {
-    const state = performStateSubstitutions(rawState, contractRegistry);
-    this._stateMap.set(CURRENT_STATE_KEY, state);
+    return new Promise((resolve) => {
+      const state = performStateSubstitutions(rawState, contractRegistry);
+      this._stateMap.set(CURRENT_STATE_KEY, state);
+      resolve();
+    });
   }
 
   _isStateRequest(ctx) {

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -120,7 +120,7 @@ async function withFixtures(options, testSuite) {
     }
 
     await fixtureServer.start();
-    await fixtureServer.loadJsonState(fixtures, contractRegistry);
+    fixtureServer.loadJsonState(fixtures, contractRegistry);
 
     if (ganacheOptions?.concurrent) {
       ganacheOptions.concurrent.forEach(async (ganacheSettings) => {

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -119,8 +119,6 @@ async function withFixtures(options, testSuite) {
       contractRegistry = ganacheSeeder.getContractRegistry();
     }
 
-    await fixtureServer.start();
-    await fixtureServer.loadJsonState(fixtures, contractRegistry);
 
     if (ganacheOptions?.concurrent) {
       ganacheOptions.concurrent.forEach(async (ganacheSettings) => {
@@ -141,6 +139,8 @@ async function withFixtures(options, testSuite) {
       await initBundler(bundlerServer, ganacheServer, usePaymaster);
     }
 
+    await fixtureServer.start();
+    await fixtureServer.loadJsonState(fixtures, contractRegistry);
     await phishingPageServer.start();
     if (dapp) {
       if (dappOptions?.numberOfDapps) {

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -119,7 +119,6 @@ async function withFixtures(options, testSuite) {
       contractRegistry = ganacheSeeder.getContractRegistry();
     }
 
-
     if (ganacheOptions?.concurrent) {
       ganacheOptions.concurrent.forEach(async (ganacheSettings) => {
         const { port, chainId, ganacheOptions2 } = ganacheSettings;

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -119,6 +119,9 @@ async function withFixtures(options, testSuite) {
       contractRegistry = ganacheSeeder.getContractRegistry();
     }
 
+    await fixtureServer.start();
+    await fixtureServer.loadJsonState(fixtures, contractRegistry);
+
     if (ganacheOptions?.concurrent) {
       ganacheOptions.concurrent.forEach(async (ganacheSettings) => {
         const { port, chainId, ganacheOptions2 } = ganacheSettings;
@@ -138,8 +141,6 @@ async function withFixtures(options, testSuite) {
       await initBundler(bundlerServer, ganacheServer, usePaymaster);
     }
 
-    await fixtureServer.start();
-    await fixtureServer.loadJsonState(fixtures, contractRegistry);
     await phishingPageServer.start();
     if (dapp) {
       if (dappOptions?.numberOfDapps) {

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -119,6 +119,9 @@ async function withFixtures(options, testSuite) {
       contractRegistry = ganacheSeeder.getContractRegistry();
     }
 
+    await fixtureServer.start();
+    await fixtureServer.loadJsonState(fixtures, contractRegistry);
+
     if (ganacheOptions?.concurrent) {
       ganacheOptions.concurrent.forEach(async (ganacheSettings) => {
         const { port, chainId, ganacheOptions2 } = ganacheSettings;
@@ -138,8 +141,6 @@ async function withFixtures(options, testSuite) {
       await initBundler(bundlerServer, ganacheServer, usePaymaster);
     }
 
-    await fixtureServer.start();
-    fixtureServer.loadJsonState(fixtures, contractRegistry);
     await phishingPageServer.start();
     if (dapp) {
       if (dappOptions?.numberOfDapps) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a race condition in our testing setup, which causes that the expected fixtures state, not being there when we start the test. This has been surfaced in [this branch](https://github.com/MetaMask/metamask-extension/pull/28277), where the account tracker multi polling is being added.
The problem is that if we don't have the AccountTracker in state when  the `resetState` function is called (at the beginning of wallet loading) the balance will remain loading until we refresh the wallet.

Edit: performing the load state early in the test setup fixes the issue.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28421?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3627

## **Manual testing steps**

1. Check all tests continue to pass
2. Check this changes fix this branch ENS test https://github.com/MetaMask/metamask-extension/pull/28402/files#diff-1acb7898d60977530c97169551d22dbe477a4e3aeb74f1f14bf2eea0b4d75d35  . Alternatively, see videos below with before and after behaviours

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**



https://github.com/user-attachments/assets/8f50ec04-cf96-478e-9c3c-dce54254a628



### **After**

https://github.com/user-attachments/assets/0f109b1a-9289-48d9-b337-d51890c9d448




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
