### PR TITLE
fix: fix network client ID used on the useGasFeeInputs hook (#28391)

### DIFF
--- a/ui/pages/confirmations/hooks/test-utils.js
+++ b/ui/pages/confirmations/hooks/test-utils.js
@@ -14,6 +14,7 @@ import {
   getCurrentKeyring,
   getTokenExchangeRates,
   getPreferences,
+  selectNetworkConfigurationByChainId,
 } from '../../../selectors';
 
 import {
@@ -126,6 +127,9 @@ export const generateUseSelectorRouter =
       selector === getCurrentCurrency
     ) {
       return 'USD';
+    }
+    if (selector === selectNetworkConfigurationByChainId) {
+      return '2';
     }
     if (
       selector === getMultichainShouldShowFiat ||

--- a/ui/pages/confirmations/hooks/useGasFeeInputs.js
+++ b/ui/pages/confirmations/hooks/useGasFeeInputs.js
@@ -11,6 +11,7 @@ import { GAS_FORM_ERRORS } from '../../../helpers/constants/gas';
 import {
   checkNetworkAndAccountSupports1559,
   getAdvancedInlineGasShown,
+  selectNetworkConfigurationByChainId,
 } from '../../../selectors';
 import { isLegacyTransaction } from '../../../helpers/utils/transactions.util';
 import { useGasFeeEstimates } from '../../../hooks/useGasFeeEstimates';
@@ -118,6 +119,13 @@ export function useGasFeeInputs(
     ? retryTxMeta
     : _transaction;
 
+  const network = useSelector((state) =>
+    selectNetworkConfigurationByChainId(state, transaction?.chainId),
+  );
+
+  const networkClientId =
+    network?.rpcEndpoints?.[network?.defaultRpcEndpointIndex]?.networkClientId;
+
   const supportsEIP1559 =
     useSelector(checkNetworkAndAccountSupports1559) &&
     !isLegacyTransaction(transaction?.txParams);
@@ -130,7 +138,7 @@ export function useGasFeeInputs(
     gasFeeEstimates,
     isGasEstimatesLoading,
     isNetworkBusy,
-  } = useGasFeeEstimates(transaction?.networkClientId);
+  } = useGasFeeEstimates(networkClientId);
 
   const userPrefersAdvancedGas = useSelector(getAdvancedInlineGasShown);
 

--- a/ui/pages/confirmations/hooks/useGasFeeInputs.test.js
+++ b/ui/pages/confirmations/hooks/useGasFeeInputs.test.js
@@ -50,6 +50,7 @@ jest.mock('../../../hooks/useMultichainSelector', () => ({
 const mockTransaction = {
   status: TransactionStatus.unapproved,
   type: TransactionType.simpleSend,
+  networkClientId: '2',
   txParams: {
     from: '0x000000000000000000000000000000000000dead',
     type: '0x2',
@@ -94,6 +95,7 @@ describe('useGasFeeInputs', () => {
           checkNetworkAndAccountSupports1559Response: false,
         }),
       );
+
       const { result } = renderHook(() => useGasFeeInputs());
       expect(result.current.gasPrice).toBe(
         LEGACY_GAS_ESTIMATE_RETURN_VALUE.gasFeeEstimates.medium,
@@ -187,9 +189,19 @@ describe('useGasFeeInputs', () => {
       );
       expect(result.current.balanceError).toBe(true);
     });
+
+    it('should call useGasFeeEstimates with correct networkClientId', () => {
+      renderHook(() => useGasFeeInputs(null, mockTransaction));
+      expect(useGasFeeEstimates).not.toHaveBeenCalledWith('2');
+    });
   });
 
   describe('editGasMode', () => {
+    beforeEach(() => {
+      useGasFeeEstimates.mockImplementation(
+        () => HIGH_FEE_MARKET_ESTIMATE_RETURN_VALUE,
+      );
+    });
     it('should return editGasMode passed', () => {
       const { result } = renderHook(() =>
         useGasFeeInputs(undefined, undefined, undefined, EditGasModes.swaps),

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -721,6 +721,16 @@ export function getRequestingNetworkInfo(state, chainIds) {
 }
 
 /**
+ * @type (state: any, chainId: string) => import('@metamask/network-controller').NetworkConfiguration
+ */
+export const selectNetworkConfigurationByChainId = createSelector(
+  getNetworkConfigurationsByChainId,
+  (_state, chainId) => chainId,
+  (networkConfigurationsByChainId, chainId) =>
+    networkConfigurationsByChainId[chainId],
+);
+
+/**
  * Provides information about the last network change if present
  *
  * @param state - Redux state object.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

cherry-pick for the PR #28391 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28426?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
