### PR TITLE
fix: send simulation metrics no show

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.tsx
@@ -17,7 +17,7 @@ const NativeTransferInfo = () => {
   const isWalletInitiated = transactionMeta.origin === 'metamask';
   useSimulationMetricsNoShow({
     enableMetrics: isWalletInitiated,
-    transactionId: transactionMeta.id,
+    transactionMeta,
   });
 
   return (

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/nft-token-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/nft-token-transfer.tsx
@@ -17,7 +17,7 @@ const NFTTokenTransferInfo = () => {
   const isWalletInitiated = transactionMeta.origin === 'metamask';
   useSimulationMetricsNoShow({
     enableMetrics: isWalletInitiated,
-    transactionId: transactionMeta.id,
+    transactionMeta,
   });
 
   return (

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.tsx
@@ -17,7 +17,7 @@ const TokenTransferInfo = () => {
   const isWalletInitiated = transactionMeta.origin === 'metamask';
   useSimulationMetricsNoShow({
     enableMetrics: isWalletInitiated,
-    transactionId: transactionMeta.id,
+    transactionMeta,
   });
 
   return (

--- a/ui/pages/confirmations/hooks/useSimulationMetricsNoShow.test.ts
+++ b/ui/pages/confirmations/hooks/useSimulationMetricsNoShow.test.ts
@@ -1,0 +1,230 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+import {
+  SimulationData,
+  SimulationErrorCode,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import { BigNumber } from 'bignumber.js';
+import { useSimulationMetrics } from '../components/simulation-details/useSimulationMetrics';
+import { useBalanceChanges } from '../components/simulation-details/useBalanceChanges';
+import { TokenStandard } from '../../../../shared/constants/transaction';
+import { BalanceChange } from '../components/simulation-details/types';
+import { useSimulationMetricsNoShow } from './useSimulationMetricsNoShow';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../components/simulation-details/useSimulationMetrics');
+jest.mock('../components/simulation-details/useBalanceChanges');
+
+const TRANSACTION_ID_MOCK = 'testTransactionId';
+const ADDRESS_MOCK = '0x123';
+
+const BALANCE_CHANGE_MOCK = {
+  asset: { address: ADDRESS_MOCK, standard: TokenStandard.ERC20 },
+  amount: new BigNumber(-1),
+  fiatAmount: 1.23,
+} as unknown as BalanceChange;
+
+const TRANSACTION_BASE_MOCK = {
+  id: TRANSACTION_ID_MOCK,
+  chainId: '0x1',
+};
+
+describe('useSimulationMetricsNoShow', () => {
+  const useSelectorMock = jest.mocked(useSelector);
+  const useSimulationMetricsMock = jest.mocked(useSimulationMetrics);
+  const useBalanceChangesMock = jest.mocked(useBalanceChanges);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useBalanceChangesMock.mockReturnValue({ value: [], pending: false });
+  });
+
+  describe('simulation states', () => {
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      ['simulation in progress', undefined, true],
+      [
+        'simulation reverted',
+        { error: { code: SimulationErrorCode.Reverted } },
+        false,
+      ],
+      ['simulation failed', { error: { message: 'testError' } }, false],
+      [
+        'simulation disabled',
+        { error: { code: SimulationErrorCode.Disabled } },
+        false,
+      ],
+      [
+        'chain not supported',
+        { error: { code: SimulationErrorCode.ChainNotSupported } },
+        false,
+      ],
+      ['no balance changes', { tokenBalanceChanges: [] }, false],
+      [
+        'with balance changes',
+        { tokenBalanceChanges: [{ someChange: 'value' }] },
+        false,
+      ],
+    ])(
+      'handles %s correctly',
+      (_: string, simulationData: SimulationData, expectedLoading: boolean) => {
+        useSelectorMock.mockReturnValue(true);
+        const props = {
+          enableMetrics: true,
+          transactionMeta: {
+            ...TRANSACTION_BASE_MOCK,
+            simulationData,
+          } as TransactionMeta,
+        };
+
+        renderHook(() => useSimulationMetricsNoShow(props));
+
+        expect(useBalanceChangesMock).toHaveBeenCalledWith({
+          chainId: '0x1',
+          simulationData,
+        });
+
+        expect(useSimulationMetricsMock).toHaveBeenCalledWith({
+          enableMetrics: true,
+          balanceChanges: [],
+          loading: expectedLoading,
+          simulationData,
+          transactionId: TRANSACTION_ID_MOCK,
+        });
+      },
+    );
+  });
+
+  describe('loading states', () => {
+    it('sets loading true when balance changes are pending', () => {
+      useBalanceChangesMock.mockReturnValue({ value: [], pending: true });
+      useSelectorMock.mockReturnValue(true);
+
+      const props = {
+        enableMetrics: true,
+        transactionMeta: {
+          ...TRANSACTION_BASE_MOCK,
+          simulationData: { tokenBalanceChanges: [] },
+        } as unknown as TransactionMeta,
+      };
+
+      renderHook(() => useSimulationMetricsNoShow(props));
+
+      expect(useSimulationMetricsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          loading: true,
+        }),
+      );
+    });
+
+    it('sets loading true when simulationData is undefined', () => {
+      useBalanceChangesMock.mockReturnValue({ value: [], pending: false });
+      useSelectorMock.mockReturnValue(true);
+
+      const props = {
+        enableMetrics: true,
+        transactionMeta: {
+          ...TRANSACTION_BASE_MOCK,
+          simulationData: undefined,
+        } as unknown as TransactionMeta,
+      };
+
+      renderHook(() => useSimulationMetricsNoShow(props));
+
+      expect(useSimulationMetricsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          loading: true,
+        }),
+      );
+    });
+  });
+
+  describe('metrics enablement', () => {
+    it('disables metrics when transaction simulations are disabled', () => {
+      useSelectorMock.mockReturnValue(false);
+      const props = {
+        enableMetrics: true,
+        transactionMeta: {
+          ...TRANSACTION_BASE_MOCK,
+          simulationData: { tokenBalanceChanges: [] },
+        } as unknown as TransactionMeta,
+      };
+
+      renderHook(() => useSimulationMetricsNoShow(props));
+
+      expect(useSimulationMetricsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableMetrics: false,
+        }),
+      );
+    });
+
+    it('disables metrics when enableMetrics prop is false', () => {
+      useSelectorMock.mockReturnValue(true);
+      const props = {
+        enableMetrics: false,
+        transactionMeta: {
+          ...TRANSACTION_BASE_MOCK,
+          simulationData: { tokenBalanceChanges: [] },
+        } as unknown as TransactionMeta,
+      };
+
+      renderHook(() => useSimulationMetricsNoShow(props));
+
+      expect(useSimulationMetricsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableMetrics: false,
+        }),
+      );
+    });
+
+    it('enables metrics when both transaction simulations and enableMetrics are true', () => {
+      useSelectorMock.mockReturnValue(true);
+      const props = {
+        enableMetrics: true,
+        transactionMeta: {
+          ...TRANSACTION_BASE_MOCK,
+          simulationData: { tokenBalanceChanges: [] },
+        } as unknown as TransactionMeta,
+      };
+
+      renderHook(() => useSimulationMetricsNoShow(props));
+
+      expect(useSimulationMetricsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableMetrics: true,
+        }),
+      );
+    });
+  });
+
+  describe('balance changes', () => {
+    it('passes balance changes from useBalanceChanges to useSimulationMetrics', () => {
+      useBalanceChangesMock.mockReturnValue({
+        value: [BALANCE_CHANGE_MOCK],
+        pending: false,
+      });
+      useSelectorMock.mockReturnValue(true);
+
+      const props = {
+        enableMetrics: true,
+        transactionMeta: {
+          ...TRANSACTION_BASE_MOCK,
+          simulationData: { tokenBalanceChanges: [] },
+        } as unknown as TransactionMeta,
+      };
+
+      renderHook(() => useSimulationMetricsNoShow(props));
+
+      expect(useSimulationMetricsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          balanceChanges: [BALANCE_CHANGE_MOCK],
+        }),
+      );
+    });
+  });
+});

--- a/ui/pages/confirmations/hooks/useSimulationMetricsNoShow.ts
+++ b/ui/pages/confirmations/hooks/useSimulationMetricsNoShow.ts
@@ -1,35 +1,40 @@
 import { useSelector } from 'react-redux';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import {
   UseSimulationMetricsProps,
   useSimulationMetrics,
 } from '../components/simulation-details/useSimulationMetrics';
 import { selectUseTransactionSimulations } from '../selectors/preferences';
+import { useBalanceChanges } from '../components/simulation-details/useBalanceChanges';
 
 /**
  * This hook is to capture simulation metrics in the case where the simulation UI is not visible
  * e.g. when a send transaction is initiated through the wallet itself.
  * (only exception is if the user had disabled it themselves).
  *
- * @param options0
- * @param options0.enableMetrics
- * @param options0.transactionId
+ * @param options
+ * @param options.enableMetrics
+ * @param options.transactionMeta
  */
 export function useSimulationMetricsNoShow({
   enableMetrics,
-  transactionId,
+  transactionMeta,
 }: {
   enableMetrics: boolean;
-  transactionId: string;
+  transactionMeta: TransactionMeta;
 }) {
+  const { chainId, id: transactionId, simulationData } = transactionMeta;
+  const balanceChangesResult = useBalanceChanges({ chainId, simulationData });
   const useTransactionSimulations = useSelector(
     selectUseTransactionSimulations,
   );
+  const loading = !simulationData || balanceChangesResult.pending;
 
   useSimulationMetrics({
     enableMetrics: useTransactionSimulations && enableMetrics,
-    balanceChanges: [],
-    loading: false,
-    simulationData: { tokenBalanceChanges: [] },
+    balanceChanges: balanceChangesResult.value,
+    loading,
+    simulationData,
     transactionId,
   } as UseSimulationMetricsProps);
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28432?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

[tx-metrics.webm](https://github.com/user-attachments/assets/2b3e98c2-17b3-42c5-8bc3-4bbbe2fe12b4)

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
