### PR TITLE
fix: Allow outerclick to close import modal

### DIFF
--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -493,7 +493,6 @@ export const ImportTokensModal = ({ onClose }) => {
   return (
     <Modal
       isOpen
-      isClosedOnOutsideClick={false}
       onClose={() => {
         dispatch(clearPendingTokens());
         onClose();


### PR DESCRIPTION

## **Description**

Clicking outside of modals is generally an assumed "now close the modal" interaction.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28448?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the Import Tokens modal
2. Click the background
3. See the modal go away

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
