### PR TITLE
fix: PortfolioView: Selector to determine networks to poll

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2204,6 +2204,29 @@ export const getChainIdsToPoll = createDeepEqualSelector(
   },
 );
 
+export const getNetworkClientIdsToPoll = createDeepEqualSelector(
+  getPreferences,
+  getNetworkConfigurationsByChainId,
+  (preferences, networkConfigurations) => {
+    const { pausedChainIds = [] } = preferences;
+    return Object.entries(networkConfigurations).reduce(
+      (acc, [chainId, network]) => {
+        if (
+          !TEST_CHAINS.includes(chainId) &&
+          !pausedChainIds.includes(chainId)
+        ) {
+          acc.push(
+            network.rpcEndpoints[network.defaultRpcEndpointIndex]
+              .networkClientId,
+          );
+        }
+        return acc;
+      },
+      [],
+    );
+  },
+);
+
 /**
  *  To retrieve the maxBaseFee and priorityFee the user has set as default
  *

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2195,8 +2195,14 @@ export const getAllEnabledNetworks = createDeepEqualSelector(
 export const getChainIdsToPoll = createDeepEqualSelector(
   getPreferences,
   getNetworkConfigurationsByChainId,
-  (preferences, networkConfigurations) => {
+  getCurrentChainId,
+  (preferences, networkConfigurations, currentChainId) => {
     const { pausedChainIds = [] } = preferences;
+
+    if (!process.env.PORTFOLIO_VIEW) {
+      return [currentChainId];
+    }
+
     return Object.keys(networkConfigurations).filter(
       (chainId) =>
         !TEST_CHAINS.includes(chainId) && !pausedChainIds.includes(chainId),
@@ -2207,8 +2213,19 @@ export const getChainIdsToPoll = createDeepEqualSelector(
 export const getNetworkClientIdsToPoll = createDeepEqualSelector(
   getPreferences,
   getNetworkConfigurationsByChainId,
-  (preferences, networkConfigurations) => {
+  getCurrentChainId,
+  (preferences, networkConfigurations, currentChainId) => {
     const { pausedChainIds = [] } = preferences;
+
+    if (!process.env.PORTFOLIO_VIEW) {
+      const networkConfiguration = networkConfigurations[currentChainId];
+      return [
+        networkConfiguration.rpcEndpoints[
+          networkConfiguration.defaultRpcEndpointIndex
+        ].networkClientId,
+      ];
+    }
+
     return Object.entries(networkConfigurations).reduce(
       (acc, [chainId, network]) => {
         if (

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2192,24 +2192,15 @@ export const getAllEnabledNetworks = createDeepEqualSelector(
     ),
 );
 
-export const getNetworkClientIdsToPoll = createDeepEqualSelector(
+export const getChainIdsToPoll = createDeepEqualSelector(
   getPreferences,
   getNetworkConfigurationsByChainId,
   (preferences, networkConfigurations) => {
     const { pausedChainIds = [] } = preferences;
-    const networkClientIds = Object.keys(networkConfigurations).reduce(
-      (acc, chainId) => {
-        if (
-          !TEST_CHAINS.includes(chainId) &&
-          !pausedChainIds.includes(chainId)
-        ) {
-          acc.push(chainId);
-        }
-        return acc;
-      },
-      [],
+    return Object.keys(networkConfigurations).filter(
+      (chainId) =>
+        !TEST_CHAINS.includes(chainId) && !pausedChainIds.includes(chainId),
     );
-    return networkClientIds;
   },
 );
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2192,6 +2192,27 @@ export const getAllEnabledNetworks = createDeepEqualSelector(
     ),
 );
 
+export const getNetworkClientIdsToPoll = createDeepEqualSelector(
+  getPreferences,
+  getNetworkConfigurationsByChainId,
+  (preferences, networkConfigurations) => {
+    const { pausedChainIds = [] } = preferences;
+    const networkClientIds = Object.keys(networkConfigurations).reduce(
+      (acc, chainId) => {
+        if (
+          !TEST_CHAINS.includes(chainId) &&
+          !pausedChainIds.includes(chainId)
+        ) {
+          acc.push(chainId);
+        }
+        return acc;
+      },
+      [],
+    );
+    return networkClientIds;
+  },
+);
+
 /**
  *  To retrieve the maxBaseFee and priorityFee the user has set as default
  *

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -838,7 +838,7 @@ describe('Selectors', () => {
     });
   });
 
-  describe('#getNetworkClientIdsToPoll', () => {
+  describe('#getChainIdsToPoll', () => {
     const networkConfigurationsByChainId = {
       [CHAIN_IDS.MAINNET]: {
         chainId: CHAIN_IDS.MAINNET,
@@ -863,7 +863,7 @@ describe('Selectors', () => {
     };
 
     it('returns only non-test chain IDs', () => {
-      const chainIds = selectors.getNetworkClientIdsToPoll({
+      const chainIds = selectors.getChainIdsToPoll({
         metamask: {
           preferences: { pausedChainIds: [] },
           networkConfigurationsByChainId,
@@ -877,7 +877,7 @@ describe('Selectors', () => {
     });
 
     it('does not return paused chain IDs', () => {
-      const chainIds = selectors.getNetworkClientIdsToPoll({
+      const chainIds = selectors.getChainIdsToPoll({
         metamask: {
           preferences: { pausedChainIds: [CHAIN_IDS.LINEA_MAINNET] },
           networkConfigurationsByChainId,

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -888,6 +888,53 @@ describe('Selectors', () => {
     });
   });
 
+  describe('#getNetworkClientIdsToPoll', () => {
+    const networkConfigurationsByChainId = {
+      [CHAIN_IDS.MAINNET]: {
+        chainId: CHAIN_IDS.MAINNET,
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'mainnet' }],
+      },
+      [CHAIN_IDS.LINEA_MAINNET]: {
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'linea-mainnet' }],
+      },
+      [CHAIN_IDS.SEPOLIA]: {
+        chainId: CHAIN_IDS.SEPOLIA,
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'sepolia' }],
+      },
+      [CHAIN_IDS.LINEA_SEPOLIA]: {
+        chainId: CHAIN_IDS.LINEA_SEPOLIA,
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'linea-sepolia' }],
+      },
+    };
+
+    it('returns only non-test chain IDs', () => {
+      const chainIds = selectors.getNetworkClientIdsToPoll({
+        metamask: {
+          preferences: { pausedChainIds: [] },
+          networkConfigurationsByChainId,
+        },
+      });
+      expect(Object.values(chainIds)).toHaveLength(2);
+      expect(chainIds).toStrictEqual(['mainnet', 'linea-mainnet']);
+    });
+
+    it('does not return paused chain IDs', () => {
+      const chainIds = selectors.getNetworkClientIdsToPoll({
+        metamask: {
+          preferences: { pausedChainIds: [CHAIN_IDS.LINEA_MAINNET] },
+          networkConfigurationsByChainId,
+        },
+      });
+      expect(Object.values(chainIds)).toHaveLength(1);
+      expect(chainIds).toStrictEqual(['mainnet']);
+    });
+  });
+
   describe('#isHardwareWallet', () => {
     it('returns false if it is not a HW wallet', () => {
       const mockStateWithImported = modifyStateWithHWKeyring(

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -862,11 +862,20 @@ describe('Selectors', () => {
       },
     };
 
+    beforeEach(() => {
+      process.env.PORTFOLIO_VIEW = 'true';
+    });
+
+    afterEach(() => {
+      process.env.PORTFOLIO_VIEW = undefined;
+    });
+
     it('returns only non-test chain IDs', () => {
       const chainIds = selectors.getChainIdsToPoll({
         metamask: {
           preferences: { pausedChainIds: [] },
           networkConfigurationsByChainId,
+          selectedNetworkClientId: 'mainnet',
         },
       });
       expect(Object.values(chainIds)).toHaveLength(2);
@@ -881,6 +890,7 @@ describe('Selectors', () => {
         metamask: {
           preferences: { pausedChainIds: [CHAIN_IDS.LINEA_MAINNET] },
           networkConfigurationsByChainId,
+          selectedNetworkClientId: 'mainnet',
         },
       });
       expect(Object.values(chainIds)).toHaveLength(1);
@@ -912,11 +922,20 @@ describe('Selectors', () => {
       },
     };
 
+    beforeEach(() => {
+      process.env.PORTFOLIO_VIEW = 'true';
+    });
+
+    afterEach(() => {
+      process.env.PORTFOLIO_VIEW = undefined;
+    });
+
     it('returns only non-test chain IDs', () => {
       const chainIds = selectors.getNetworkClientIdsToPoll({
         metamask: {
           preferences: { pausedChainIds: [] },
           networkConfigurationsByChainId,
+          selectedNetworkClientId: 'mainnet',
         },
       });
       expect(Object.values(chainIds)).toHaveLength(2);
@@ -928,6 +947,7 @@ describe('Selectors', () => {
         metamask: {
           preferences: { pausedChainIds: [CHAIN_IDS.LINEA_MAINNET] },
           networkConfigurationsByChainId,
+          selectedNetworkClientId: 'mainnet',
         },
       });
       expect(Object.values(chainIds)).toHaveLength(1);

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -838,6 +838,56 @@ describe('Selectors', () => {
     });
   });
 
+  describe('#getNetworkClientIdsToPoll', () => {
+    const networkConfigurationsByChainId = {
+      [CHAIN_IDS.MAINNET]: {
+        chainId: CHAIN_IDS.MAINNET,
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'mainnet' }],
+      },
+      [CHAIN_IDS.LINEA_MAINNET]: {
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'linea-mainnet' }],
+      },
+      [CHAIN_IDS.SEPOLIA]: {
+        chainId: CHAIN_IDS.SEPOLIA,
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'sepolia' }],
+      },
+      [CHAIN_IDS.LINEA_SEPOLIA]: {
+        chainId: CHAIN_IDS.LINEA_SEPOLIA,
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'linea-sepolia' }],
+      },
+    };
+
+    it('returns only non-test chain IDs', () => {
+      const chainIds = selectors.getNetworkClientIdsToPoll({
+        metamask: {
+          preferences: { pausedChainIds: [] },
+          networkConfigurationsByChainId,
+        },
+      });
+      expect(Object.values(chainIds)).toHaveLength(2);
+      expect(chainIds).toStrictEqual([
+        CHAIN_IDS.MAINNET,
+        CHAIN_IDS.LINEA_MAINNET,
+      ]);
+    });
+
+    it('does not return paused chain IDs', () => {
+      const chainIds = selectors.getNetworkClientIdsToPoll({
+        metamask: {
+          preferences: { pausedChainIds: [CHAIN_IDS.LINEA_MAINNET] },
+          networkConfigurationsByChainId,
+        },
+      });
+      expect(Object.values(chainIds)).toHaveLength(1);
+      expect(chainIds).toStrictEqual([CHAIN_IDS.MAINNET]);
+    });
+  });
+
   describe('#isHardwareWallet', () => {
     it('returns false if it is not a HW wallet', () => {
       const mockStateWithImported = modifyStateWithHWKeyring(


### PR DESCRIPTION

## **Description**

Provides a selector which will be used by the Asset List and Total Aggregated Balances so that both components use the same chain contents to display and sum.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28502?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. No visual or manual testing needed, just a selector with unit tests

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
