### PR TITLE
feat: Display '< 0.01' instead of '0.00' for the fiat value of networ…

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -21,13 +21,17 @@ describe('useFeeCalculations', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       {
-        "estimatedFeeFiat": "$0.00",
+        "estimatedFeeFiat": "< $0.01",
+        "estimatedFeeFiatWith18SignificantDigits": "0",
         "estimatedFeeNative": "0 ETH",
         "l1FeeFiat": "",
+        "l1FeeFiatWith18SignificantDigits": "",
         "l1FeeNative": "",
         "l2FeeFiat": "",
+        "l2FeeFiatWith18SignificantDigits": "",
         "l2FeeNative": "",
-        "maxFeeFiat": "$0.00",
+        "maxFeeFiat": "< $0.01",
+        "maxFeeFiatWith18SignificantDigits": "0",
         "maxFeeNative": "0 ETH",
       }
     `);
@@ -46,12 +50,16 @@ describe('useFeeCalculations', () => {
     expect(result.current).toMatchInlineSnapshot(`
       {
         "estimatedFeeFiat": "$0.04",
+        "estimatedFeeFiatWith18SignificantDigits": null,
         "estimatedFeeNative": "0.0001 ETH",
         "l1FeeFiat": "",
+        "l1FeeFiatWith18SignificantDigits": "",
         "l1FeeNative": "",
         "l2FeeFiat": "",
+        "l2FeeFiatWith18SignificantDigits": "",
         "l2FeeNative": "",
         "maxFeeFiat": "$0.07",
+        "maxFeeFiatWith18SignificantDigits": null,
         "maxFeeNative": "0.0001 ETH",
       }
     `);
@@ -72,12 +80,16 @@ describe('useFeeCalculations', () => {
     expect(result.current).toMatchInlineSnapshot(`
       {
         "estimatedFeeFiat": "$2.54",
+        "estimatedFeeFiatWith18SignificantDigits": null,
         "estimatedFeeNative": "0.0046 ETH",
         "l1FeeFiat": "$2.50",
+        "l1FeeFiatWith18SignificantDigits": null,
         "l1FeeNative": "0.0045 ETH",
         "l2FeeFiat": "$0.04",
+        "l2FeeFiatWith18SignificantDigits": null,
         "l2FeeNative": "0.0001 ETH",
         "maxFeeFiat": "$0.07",
+        "maxFeeFiatWith18SignificantDigits": null,
         "maxFeeNative": "0.0001 ETH",
       }
     `);

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/__snapshots__/edit-gas-fees-row.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/__snapshots__/edit-gas-fees-row.test.tsx.snap
@@ -45,12 +45,23 @@ exports[`<EditGasFeesRow /> renders component 1`] = `
       >
         0.001 ETH
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
-        data-testid="native-currency"
-      >
-        $1
-      </p>
+      <div>
+        <div
+          aria-describedby="tippy-tooltip-2"
+          class=""
+          data-original-title="0.001234"
+          data-tooltipped=""
+          style="display: inline;"
+          tabindex="0"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--margin-right-2 mm-box--color-text-alternative"
+            data-testid="native-currency"
+          >
+            $1
+          </p>
+        </div>
+      </div>
       <button
         class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-link mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
         data-testid="edit-gas-fee-icon"

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.stories.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.stories.tsx
@@ -35,6 +35,7 @@ export const DefaultStory = () => (
   <EditGasFeesRow
     fiatFee="$1"
     nativeFee="0.001 ETH"
+    fiatFeeWith18SignificantDigits="0.001234"
     supportsEIP1559={true}
     setShowCustomizeGasPopover={() => {}}
   />

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
@@ -25,6 +25,7 @@ describe('<EditGasFeesRow />', () => {
       <EditGasFeesRow
         fiatFee="$1"
         nativeFee="0.001 ETH"
+        fiatFeeWith18SignificantDigits="0.001234"
         supportsEIP1559={true}
         setShowCustomizeGasPopover={() => console.log('open popover')}
       />,

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -5,6 +5,7 @@ import { TEST_CHAINS } from '../../../../../../../../shared/constants/network';
 import { ConfirmInfoAlertRow } from '../../../../../../../components/app/confirm/info/row/alert-row/alert-row';
 import { RowAlertKey } from '../../../../../../../components/app/confirm/info/row/constants';
 import { Box, Text } from '../../../../../../../components/component-library';
+import Tooltip from '../../../../../../../components/ui/tooltip';
 import {
   AlignItems,
   Display,
@@ -20,11 +21,13 @@ import { EditGasIconButton } from '../edit-gas-icon/edit-gas-icon-button';
 
 export const EditGasFeesRow = ({
   fiatFee,
+  fiatFeeWith18SignificantDigits,
   nativeFee,
   supportsEIP1559,
   setShowCustomizeGasPopover,
 }: {
   fiatFee: string;
+  fiatFeeWith18SignificantDigits: string;
   nativeFee: string;
   supportsEIP1559: boolean;
   setShowCustomizeGasPopover: Dispatch<SetStateAction<boolean>>;
@@ -62,7 +65,18 @@ export const EditGasFeesRow = ({
         >
           {nativeFee}
         </Text>
-        {(!isTestnet || showFiatInTestnets) && (
+        {(!isTestnet || showFiatInTestnets) &&
+        fiatFeeWith18SignificantDigits ? (
+          <Tooltip title={fiatFeeWith18SignificantDigits}>
+            <Text
+              marginRight={2}
+              color={TextColor.textAlternative}
+              data-testid="native-currency"
+            >
+              {fiatFee}
+            </Text>
+          </Tooltip>
+        ) : (
           <Text
             marginRight={2}
             color={TextColor.textAlternative}

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -27,7 +27,7 @@ export const EditGasFeesRow = ({
   setShowCustomizeGasPopover,
 }: {
   fiatFee: string;
-  fiatFeeWith18SignificantDigits: string;
+  fiatFeeWith18SignificantDigits: string | null;
   nativeFee: string;
   supportsEIP1559: boolean;
   setShowCustomizeGasPopover: Dispatch<SetStateAction<boolean>>;

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
@@ -36,12 +36,16 @@ export const GasFeesDetails = ({
 
   const {
     estimatedFeeFiat,
+    estimatedFeeFiatWith18SignificantDigits,
     estimatedFeeNative,
     l1FeeFiat,
+    l1FeeFiatWith18SignificantDigits,
     l1FeeNative,
     l2FeeFiat,
+    l2FeeFiatWith18SignificantDigits,
     l2FeeNative,
     maxFeeFiat,
+    maxFeeFiatWith18SignificantDigits,
     maxFeeNative,
   } = useFeeCalculations(transactionMeta);
 
@@ -57,6 +61,7 @@ export const GasFeesDetails = ({
     <>
       <EditGasFeesRow
         fiatFee={estimatedFeeFiat}
+        fiatFeeWith18SignificantDigits={estimatedFeeFiatWith18SignificantDigits}
         nativeFee={estimatedFeeNative}
         supportsEIP1559={supportsEIP1559}
         setShowCustomizeGasPopover={setShowCustomizeGasPopover}
@@ -68,6 +73,7 @@ export const GasFeesDetails = ({
             label={t('l1Fee')}
             tooltipText={t('l1FeeTooltip')}
             fiatFee={l1FeeFiat}
+            fiatFeeWith18SignificantDigits={l1FeeFiatWith18SignificantDigits}
             nativeFee={l1FeeNative}
           />
           <GasFeesRow
@@ -75,6 +81,7 @@ export const GasFeesDetails = ({
             label={t('l2Fee')}
             tooltipText={t('l2FeeTooltip')}
             fiatFee={l2FeeFiat}
+            fiatFeeWith18SignificantDigits={l2FeeFiatWith18SignificantDigits}
             nativeFee={l2FeeNative}
           />
         </>
@@ -100,6 +107,7 @@ export const GasFeesDetails = ({
           label={t('maxFee')}
           tooltipText={t('maxFeeTooltip')}
           fiatFee={maxFeeFiat}
+          fiatFeeWith18SignificantDigits={maxFeeFiatWith18SignificantDigits}
           nativeFee={maxFeeNative}
         />
       )}

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/__snapshots__/gas-fees-row.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/__snapshots__/gas-fees-row.test.tsx.snap
@@ -42,11 +42,22 @@ exports[`<GasFeesRow /> renders component 1`] = `
       >
         0.0001 ETH
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
-      >
-        $1
-      </p>
+      <div>
+        <div
+          aria-describedby="tippy-tooltip-2"
+          class=""
+          data-original-title="0.001234"
+          data-tooltipped=""
+          style="display: inline;"
+          tabindex="0"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
+          >
+            $1
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.stories.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.stories.tsx
@@ -38,6 +38,7 @@ export const DefaultStory = () => (
       label="Some kind of fee"
       tooltipText="Tooltip text"
       fiatFee="$1"
+      fiatFeeWith18SignificantDigits="0.001234"
       nativeFee="0.0001 ETH"
     />
   </ConfirmContextProvider>

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.test.tsx
@@ -17,6 +17,7 @@ describe('<GasFeesRow />', () => {
         label="Some kind of fee"
         tooltipText="Tooltip text"
         fiatFee="$1"
+        fiatFeeWith18SignificantDigits="0.001234"
         nativeFee="0.0001 ETH"
       />,
       mockStore,

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.tsx
@@ -30,7 +30,7 @@ export const GasFeesRow = ({
   label: string;
   tooltipText: string;
   fiatFee: string;
-  fiatFeeWith18SignificantDigits: string;
+  fiatFeeWith18SignificantDigits: string | null;
   nativeFee: string;
   'data-testid'?: string;
 }) => {

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.tsx
@@ -7,6 +7,7 @@ import {
   ConfirmInfoRowVariant,
 } from '../../../../../../../components/app/confirm/info/row';
 import { Box, Text } from '../../../../../../../components/component-library';
+import Tooltip from '../../../../../../../components/ui/tooltip';
 import {
   AlignItems,
   Display,
@@ -22,12 +23,14 @@ export const GasFeesRow = ({
   label,
   tooltipText,
   fiatFee,
+  fiatFeeWith18SignificantDigits,
   nativeFee,
   'data-testid': dataTestId,
 }: {
   label: string;
   tooltipText: string;
   fiatFee: string;
+  fiatFeeWith18SignificantDigits: string;
   nativeFee: string;
   'data-testid'?: string;
 }) => {
@@ -58,7 +61,12 @@ export const GasFeesRow = ({
         <Text marginRight={1} color={TextColor.textDefault}>
           {nativeFee}
         </Text>
-        {(!isTestnet || showFiatInTestnets) && (
+        {(!isTestnet || showFiatInTestnets) &&
+        fiatFeeWith18SignificantDigits ? (
+          <Tooltip title={fiatFeeWith18SignificantDigits}>
+            <Text color={TextColor.textAlternative}>{fiatFee}</Text>
+          </Tooltip>
+        ) : (
           <Text color={TextColor.textAlternative}>{fiatFee}</Text>
         )}
       </Box>


### PR DESCRIPTION
…k fee


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28543?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3631

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="320" alt="Screenshot 2024-11-19 at 14 31 24" src="https://github.com/user-attachments/assets/4418d10a-39d8-4412-9d16-93652d069b0d">


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
