### PR TITLE
fix: Update Snaps install/update screen scroll offset

### DIFF
--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -51,7 +51,9 @@ export default function SnapInstall({
   const [showAllPermissions, setShowAllPermissions] = useState(false);
 
   const { isScrollable, hasScrolledToBottom, scrollToBottom, ref, onScroll } =
-    useScrollRequired([requestState]);
+    useScrollRequired([requestState], {
+      offsetPxFromBottom: 100,
+    });
 
   const onCancel = useCallback(
     () => rejectSnapInstall(request.metadata.id),

--- a/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
+++ b/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
@@ -48,7 +48,10 @@ export default function SnapUpdate({
   const [showAllPermissions, setShowAllPermissions] = useState(false);
 
   const { isScrollable, hasScrolledToBottom, scrollToBottom, ref, onScroll } =
-    useScrollRequired([requestState]);
+    useScrollRequired([requestState], {
+      offsetPxFromBottom: 100,
+    });
+
   const snapsMetadata = useSelector(getSnapsMetadata);
 
   const onCancel = useCallback(


### PR DESCRIPTION
## **Description**

This updates the scroll offset for Snaps screens (install, update) to allow 100px from the bottom, rather than the default 16px. This avoids situations where a tiny scroll is required in order to continue:

![image](https://github.com/user-attachments/assets/35c34578-bae9-48d7-b507-fb6198d02080)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28558?quickstart=1)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
