### PR TITLE
feat: Better handle very long names in the name component

### DIFF
--- a/ui/components/app/name/__snapshots__/name.test.tsx.snap
+++ b/ui/components/app/name/__snapshots__/name.test.tsx.snap
@@ -24,6 +24,68 @@ exports[`Name renders address with image 1`] = `
 </div>
 `;
 
+exports[`Name renders address with long saved name 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex"
+  >
+    <div
+      class="name name__saved"
+    >
+      <div
+        class=""
+      >
+        <div
+          class="identicon"
+          style="height: 16px; width: 16px; border-radius: 8px;"
+        >
+          <div
+            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 16px; height: 16px; display: inline-block; background: rgb(245, 196, 0);"
+          >
+            <svg
+              height="16"
+              width="16"
+              x="0"
+              y="0"
+            >
+              <rect
+                fill="#C8144D"
+                height="16"
+                transform="translate(-0.8205726313476182 -2.375300755278998) rotate(408.5 8 8)"
+                width="16"
+                x="0"
+                y="0"
+              />
+              <rect
+                fill="#FB1860"
+                height="16"
+                transform="translate(7.733089412585649 -1.3465466417019656) rotate(402.6 8 8)"
+                width="16"
+                x="0"
+                y="0"
+              />
+              <rect
+                fill="#03505E"
+                height="16"
+                transform="translate(1.1000464230208766 -13.147318085284851) rotate(308.0 8 8)"
+                width="16"
+                x="0"
+                y="0"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <p
+        class="mm-box mm-text name__name mm-text--body-md mm-box--color-text-default"
+      >
+        Very long and l...
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Name renders address with no saved name 1`] = `
 <div>
   <div

--- a/ui/components/app/name/name.test.tsx
+++ b/ui/components/app/name/name.test.tsx
@@ -10,7 +10,7 @@ import {
 import { useDisplayName } from '../../../hooks/useDisplayName';
 import { mockNetworkState } from '../../../../test/stub/networks';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import Name, { formatName } from './name';
+import Name from './name';
 
 jest.mock('../../../hooks/useDisplayName');
 
@@ -92,6 +92,24 @@ describe('Name', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('renders address with long saved name', () => {
+    useDisplayNameMock.mockReturnValue({
+      name: "Very long and length saved name that doesn't seem to end, really.",
+      hasPetname: true,
+    });
+
+    const { container } = renderWithProvider(
+      <Name
+        type={NameType.ETHEREUM_ADDRESS}
+        value={ADDRESS_SAVED_NAME_MOCK}
+        variation={VARIATION_MOCK}
+      />,
+      store,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
   it('renders address with image', () => {
     useDisplayNameMock.mockReturnValue({
       name: SAVED_NAME_MOCK,
@@ -147,34 +165,5 @@ describe('Name', () => {
         });
       },
     );
-  });
-});
-
-describe('formatName()', () => {
-  it('returns empty string if name is empty string', () => {
-    const TEST_NAME = '';
-
-    const actual = formatName(TEST_NAME);
-    const expected = '';
-
-    expect(actual).toEqual(expected);
-  });
-
-  it('returns whole name if it is short enough', () => {
-    const TEST_NAME = 'Short name';
-
-    const actual = formatName(TEST_NAME);
-    const expected = 'Short name';
-
-    expect(actual).toEqual(expected);
-  });
-
-  it('returns name with ellipsis if it is long enough', () => {
-    const TEST_NAME = 'Quite a long name';
-
-    const actual = formatName(TEST_NAME);
-    const expected = 'Quite a long na...';
-
-    expect(actual).toEqual(expected);
   });
 });

--- a/ui/components/app/name/name.test.tsx
+++ b/ui/components/app/name/name.test.tsx
@@ -10,7 +10,7 @@ import {
 import { useDisplayName } from '../../../hooks/useDisplayName';
 import { mockNetworkState } from '../../../../test/stub/networks';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import Name from './name';
+import Name, { formatName } from './name';
 
 jest.mock('../../../hooks/useDisplayName');
 
@@ -147,5 +147,34 @@ describe('Name', () => {
         });
       },
     );
+  });
+});
+
+describe('formatName()', () => {
+  it('returns empty string if name is empty string', () => {
+    const TEST_NAME = '';
+
+    const actual = formatName(TEST_NAME);
+    const expected = '';
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns whole name if it is short enough', () => {
+    const TEST_NAME = 'Short name';
+
+    const actual = formatName(TEST_NAME);
+    const expected = 'Short name';
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns name with ellipsis if it is long enough', () => {
+    const TEST_NAME = 'Quite a long name';
+
+    const actual = formatName(TEST_NAME);
+    const expected = 'Quite a long na...';
+
+    expect(actual).toEqual(expected);
   });
 });

--- a/ui/components/app/name/name.tsx
+++ b/ui/components/app/name/name.tsx
@@ -9,7 +9,7 @@ import { NameType } from '@metamask/name-controller';
 import classnames from 'classnames';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { Box, Icon, IconName, IconSize, Text } from '../../component-library';
-import { shortenAddress } from '../../../helpers/utils/util';
+import { shortenAddress, shortenString } from '../../../helpers/utils/util';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
@@ -60,20 +60,6 @@ function formatValue(value: string, type: NameType): string {
   }
 }
 
-export function formatName(name: string): string {
-  const MAX_NAME_CHAR_COUNT = 15;
-
-  if (!name || !name.length) {
-    return name;
-  }
-
-  if (name.length > MAX_NAME_CHAR_COUNT) {
-    return `${name.substring(0, MAX_NAME_CHAR_COUNT)}...`;
-  }
-
-  return name;
-}
-
 const Name = memo(
   ({
     value,
@@ -117,7 +103,12 @@ const Name = memo(
     }, [setModalOpen]);
 
     const formattedValue = formatValue(value, type);
-    const formattedName = formatName(name);
+    const formattedName = shortenString(name || undefined, {
+      truncatedCharLimit: 15,
+      truncatedStartChars: 15,
+      truncatedEndChars: 0,
+      skipCharacterInEnd: true,
+    });
     const hasDisplayName = Boolean(name);
 
     return (

--- a/ui/components/app/name/name.tsx
+++ b/ui/components/app/name/name.tsx
@@ -60,6 +60,20 @@ function formatValue(value: string, type: NameType): string {
   }
 }
 
+export function formatName(name: string): string {
+  const MAX_NAME_CHAR_COUNT = 15;
+
+  if (!name || !name.length) {
+    return name;
+  }
+
+  if (name.length > MAX_NAME_CHAR_COUNT) {
+    return `${name.substring(0, MAX_NAME_CHAR_COUNT)}...`;
+  }
+
+  return name;
+}
+
 const Name = memo(
   ({
     value,
@@ -103,6 +117,7 @@ const Name = memo(
     }, [setModalOpen]);
 
     const formattedValue = formatValue(value, type);
+    const formattedName = formatName(name);
     const hasDisplayName = Boolean(name);
 
     return (
@@ -135,7 +150,7 @@ const Name = memo(
           )}
           {hasDisplayName ? (
             <Text className="name__name" variant={TextVariant.bodyMd}>
-              {name}
+              {formattedName}
             </Text>
           ) : (
             <Text className="name__value" variant={TextVariant.bodyMd}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Truncates long names (>15 characters).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28560?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3630

## **Manual testing steps**

1. Trigger a new confirmation
2. Add a long petname, by clicking an address and writing it in the input field
3. The name should be truncated with an ellipsis.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="360" alt="Screenshot 2024-11-20 at 11 24 21" src="https://github.com/user-attachments/assets/68055ea8-10f4-455c-afa2-ce34c10fbb7c">


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
