### PR TITLE
fix: use PORTFOLIO_VIEW flag to determine token list polling

### DIFF
--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -321,11 +321,7 @@
   "TokenListController": {
     "tokenList": "object",
     "tokensChainsCache": {
-      "0x1": "object",
-      "0x539": "object",
-      "0xaa36a7": "object",
-      "0xe705": "object",
-      "0xe708": "object"
+      "0x539": "object"
     },
     "preventPollingOnNetworkRestart": false
   },

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -175,11 +175,7 @@
     "nonRPCGasFeeApisDisabled": "boolean",
     "tokenList": "object",
     "tokensChainsCache": {
-      "0x1": "object",
-      "0x539": "object",
-      "0xaa36a7": "object",
-      "0xe705": "object",
-      "0xe708": "object"
+      "0x539": "object"
     },
     "tokenBalances": "object",
     "preventPollingOnNetworkRestart": false,

--- a/ui/hooks/useTokenListPolling.test.ts
+++ b/ui/hooks/useTokenListPolling.test.ts
@@ -22,16 +22,23 @@ describe('useTokenListPolling', () => {
     jest.clearAllMocks();
   });
 
-  it('should poll for token lists on each chain when enabled, and stop on dismount', async () => {
+  it('should poll the selected network when enabled, and stop on dismount', async () => {
     const state = {
       metamask: {
         isUnlocked: true,
         completedOnboarding: true,
         useExternalServices: true,
         useTokenDetection: true,
+        selectedNetworkClientId: 'selectedNetworkClientId',
         networkConfigurationsByChainId: {
-          '0x1': {},
-          '0x89': {},
+          '0x1': {
+            chainId: '0x1',
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId',
+              },
+            ],
+          },
         },
       },
     };
@@ -43,18 +50,14 @@ describe('useTokenListPolling', () => {
 
     // Should poll each chain
     await Promise.all(mockPromises);
-    expect(tokenListStartPolling).toHaveBeenCalledTimes(2);
+    expect(tokenListStartPolling).toHaveBeenCalledTimes(1);
     expect(tokenListStartPolling).toHaveBeenCalledWith('0x1');
-    expect(tokenListStartPolling).toHaveBeenCalledWith('0x89');
 
     // Stop polling on dismount
     unmount();
-    expect(tokenListStopPollingByPollingToken).toHaveBeenCalledTimes(2);
+    expect(tokenListStopPollingByPollingToken).toHaveBeenCalledTimes(1);
     expect(tokenListStopPollingByPollingToken).toHaveBeenCalledWith(
       '0x1_token',
-    );
-    expect(tokenListStopPollingByPollingToken).toHaveBeenCalledWith(
-      '0x89_token',
     );
   });
 

--- a/ui/hooks/useTokenListPolling.ts
+++ b/ui/hooks/useTokenListPolling.ts
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 import {
+  getCurrentChainId,
   getNetworkConfigurationsByChainId,
   getPetnamesEnabled,
   getUseExternalServices,
@@ -17,6 +18,7 @@ import {
 import useMultiPolling from './useMultiPolling';
 
 const useTokenListPolling = () => {
+  const currentChainId = useSelector(getCurrentChainId);
   const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
   const useTokenDetection = useSelector(getUseTokenDetection);
   const useTransactionSimulations = useSelector(getUseTransactionSimulations);
@@ -31,10 +33,14 @@ const useTokenListPolling = () => {
     useExternalServices &&
     (useTokenDetection || petnamesEnabled || useTransactionSimulations);
 
+  const chainIds = process.env.PORTFOLIO_VIEW
+    ? Object.keys(networkConfigurations)
+    : [currentChainId];
+
   useMultiPolling({
     startPolling: tokenListStartPolling,
     stopPollingByPollingToken: tokenListStopPollingByPollingToken,
-    input: enabled ? Object.keys(networkConfigurations) : [],
+    input: enabled ? chainIds : [],
   });
 
   return {};


### PR DESCRIPTION
## **Description**

Updates the token list hook to only poll across chains when `PORTFOLIO_VIEW` is set.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28579?quickstart=1)

## **Related issues**

## **Manual testing steps**

1. With `PORTFOLIO_VIEW=1`, requests should go to the token api across all chains.
2. Without `PORTFOLIO_VIEW=1`, requests should go to the token api on the current chain.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
