### PR TITLE
fix: Provide maximal asset list filter space

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/index.scss
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/index.scss
@@ -2,10 +2,6 @@
   padding-top: 4px;
   padding-bottom: 4px;
 
-  &__button {
-    max-width: 35%;
-  }
-
   &__network_control {
     justify-content: space-between;
     width: auto;


### PR DESCRIPTION

## **Description**

"All networks" is being ellipsized in the popup view.  This maximum length is not useful; removing it makes it still ellipsize well.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28590?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the popup
2. See "All networks" text fully
3. Open the console elements panel and set an account name a mile long
4. See it ellipsize properly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="362" alt="SCR-20241120-scod" src="https://github.com/user-attachments/assets/11b8dfb3-a78c-4cf3-976a-8ee725aa4d0c">



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
