### PR TITLE
fix: fix display amount when price checker off

### DIFF
--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -60,7 +60,10 @@ import {
 import Spinner from '../../ui/spinner';
 
 import { PercentageAndAmountChange } from '../../multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change';
-import { getMultichainIsEvm } from '../../../selectors/multichain';
+import {
+  getMultichainIsEvm,
+  getMultichainShouldShowFiat,
+} from '../../../selectors/multichain';
 import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBalance';
 import {
   setAggregatedBalancePopoverShown,
@@ -72,6 +75,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import WalletOverview from './wallet-overview';
 import CoinButtons from './coin-buttons';
 import { AggregatedPercentageOverview } from './aggregated-percentage-overview';
+import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 
 export type CoinOverviewProps = {
   balance: string;
@@ -144,9 +148,14 @@ export const CoinOverview = ({
     shouldHideZeroBalanceTokens,
   );
 
+  const shouldShowFiat = useMultichainSelector(
+    getMultichainShouldShowFiat,
+    account,
+  );
+
   const isEvm = useSelector(getMultichainIsEvm);
   const isNotAggregatedFiatBalance =
-    showNativeTokenAsMainBalance || isTestnet || !isEvm;
+    !shouldShowFiat || showNativeTokenAsMainBalance || isTestnet || !isEvm;
   let balanceToDisplay;
   if (isNotAggregatedFiatBalance) {
     balanceToDisplay = balance;
@@ -278,7 +287,9 @@ export const CoinOverview = ({
                     hideTitle
                     shouldCheckShowNativeToken
                     isAggregatedFiatOverviewBalance={
-                      !showNativeTokenAsMainBalance && !isTestnet
+                      !showNativeTokenAsMainBalance &&
+                      !isTestnet &&
+                      shouldShowFiat
                     }
                     privacyMode={privacyMode}
                   />

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -72,10 +72,10 @@ import {
 import { useTheme } from '../../../hooks/useTheme';
 import { getSpecificSettingsRoute } from '../../../helpers/utils/settings-search';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import WalletOverview from './wallet-overview';
 import CoinButtons from './coin-buttons';
 import { AggregatedPercentageOverview } from './aggregated-percentage-overview';
-import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 
 export type CoinOverviewProps = {
   balance: string;


### PR DESCRIPTION
## **Description**

I eventually did not cherry pick https://github.com/MetaMask/metamask-extension/pull/28569 because it tried to add code related to Portfolio View which is not yet in this version, so i added the fix manually.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28612?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Settings=> Security and privacy and disable price checker setting
2. Go back to home page and you should see correct balance in crypto


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/55931f93-962f-4e30-bc47-56755147c95d


### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/48b3efd2-46f5-43a6-9d10-a4765879cd83


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
