### PR TITLE
fix: Add nullish fallback for tokenNetwork filter Object.keys

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -68,12 +68,13 @@ const AssetListControlBar = ({ showTokensLinks }: AssetListControlBarProps) => {
   }, [currentNetwork.chainId, TEST_CHAINS]);
 
   const allOpts: Record<string, boolean> = {};
-  Object.keys(allNetworks).forEach((chainId) => {
+  Object.keys(allNetworks || {}).forEach((chainId) => {
     allOpts[chainId] = true;
   });
 
   const allNetworksFilterShown =
-    Object.keys(tokenNetworkFilter).length !== Object.keys(allOpts).length;
+    Object.keys(tokenNetworkFilter ?? {}).length !==
+    Object.keys(allOpts ?? {}).length;
 
   useEffect(() => {
     if (isTestNetwork) {
@@ -86,7 +87,7 @@ const AssetListControlBar = ({ showTokensLinks }: AssetListControlBarProps) => {
   // We need to set the default filter for all users to be all included networks, rather than defaulting to empty object
   // This effect is to unblock and derisk in the short-term
   useEffect(() => {
-    if (Object.keys(tokenNetworkFilter).length === 0) {
+    if (Object.keys(tokenNetworkFilter ?? {}).length === 0) {
       dispatch(setTokenNetworkFilter(allOpts));
     }
   }, []);
@@ -94,10 +95,10 @@ const AssetListControlBar = ({ showTokensLinks }: AssetListControlBarProps) => {
   // When a network gets added/removed we want to make sure that we switch to the filtered list of the current network
   // We only want to do this if the "Current Network" filter is selected
   useEffect(() => {
-    if (Object.keys(tokenNetworkFilter).length === 1) {
+    if (Object.keys(tokenNetworkFilter ?? {}).length === 1) {
       dispatch(setTokenNetworkFilter({ [currentNetwork.chainId]: true }));
     }
-  }, [Object.keys(allNetworks).length]);
+  }, [Object.keys(allNetworks ?? {}).length]);
 
   const windowType = getEnvironmentType();
   const isFullScreen =


### PR DESCRIPTION
## **Description**

Reported crash on homepage due to `Object.keys` on an undefined value. I haven't been able to replciate, but here is a temporary fix while we find a more legitimate solution.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28617?quickstart=1)

## **Related issues**

Fixes: https://consensys.slack.com/archives/CTQAGKY5V/p1732199614277099

## **Manual testing steps**

1. Go to homepage
2. Click around tabs, make sure app doesn't crash

## **Screenshots/Recordings**

### **Before**

![Screenshot 2024-11-21 at 14 33 24](https://github.com/user-attachments/assets/c72b77c5-e7cd-4cc4-823f-1ee846a55879)

### **After**

https://github.com/user-attachments/assets/b8e22fd4-535f-4fe5-9771-5a93d1290edf

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
