### PR TITLE
fix: replace unreliable setTimeout usage with waitFor

### DIFF
--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.test.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers';
@@ -55,7 +55,7 @@ describe('AddContact component', () => {
     expect(getByText('Ethereum public address')).toBeInTheDocument();
   });
 
-  it('should validate the address correctly', () => {
+  it('should validate the address correctly', async () => {
     const store = configureMockStore(middleware)(state);
     const { getByText, getByTestId } = renderWithProvider(
       <AddContact {...props} />,
@@ -64,9 +64,10 @@ describe('AddContact component', () => {
 
     const input = getByTestId('ens-input');
     fireEvent.change(input, { target: { value: 'invalid address' } });
-    setTimeout(() => {
-      expect(getByText('Recipient address is invalid')).toBeInTheDocument();
-    }, 600);
+
+    await waitFor(() =>
+      expect(getByText('Recipient address is invalid')).toBeInTheDocument(),
+    );
   });
 
   it('should get disabled submit button when username field is empty', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR aims to improve a flaky test for the `add-contact` component.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
  - The test is flaky 
3. What is the improvement/solution?
  - Replacing usage of `setTimeout` in the test with `await waitFor(() => ...)`
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28620?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run the test locally 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A

### **After**

<!-- [screenshots/recordings] -->
N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
