### PR TITLE
[cherry pick] chore: Reduce E2E test jobs run on PRs (#28525)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,7 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
+          <<: *develop_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -205,6 +206,7 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
+          <<: *develop_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff


### PR DESCRIPTION
This is a cherry-pick of #28525 for v12.8.0. This won't actually impact the release candidate branch or release, but this is being cherry-picked to reduce credit usage from cherry-pick PRs targeting this release. E2e test runs from cherry-pick PRs aren't a major source of credit usage, but these have been making it difficult for us to gauge how many branches are still running these jobs "illegitimately" due to being out-of-date. The hope is that after merging this, we can more easily detect which branches need to be updated, and be able to evaluate the success of this strategy in reducing credit usage.

Original description:

## **Description**

The number of E2E test jobs run on PRs has been reduced to save on CircleCI credits. We still run the "chrome MV3" test job, but the Firefox and "chrome MV2/webpack build" E2E test jobs are now only run on `develop`, `master`, and RC branches. This should result in huge CircleCI credit savings.

These jobs were chosen because it's uncommon for test failures or flakiness to manifest in these jobs without also appearing in the Chrome MV3 E2E test job, and this job represents the mmajority of our userbase (the Chrome MV2/webpack build is only used for development).


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28525?quickstart=1)

## **Related issues**

This is intended to reduce credit usage. There is no linked issue.

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
