### PR TITLE
fix: Flaky add-hide-token.spec file by programatically closing flashi…

### DIFF
--- a/test/e2e/tests/tokens/add-hide-token.spec.js
+++ b/test/e2e/tests/tokens/add-hide-token.spec.js
@@ -104,7 +104,8 @@ describe('Add existing token using search', function () {
         }),
     ];
   }
-  it('renders the balance for the chosen token', async function () {
+
+  it.only('renders the balance for the chosen token', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.BSC })
@@ -128,6 +129,19 @@ describe('Add existing token using search', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+
+        // there is a race condition where "You are now using" new network modal temporarily flashes
+        // this modal obscures the elements beneath it, including the import tokens button
+        // this check mitigates this flakiness. However, the modal itself maybe isn't super useful to have at all
+        const closeButton = await driver.findElement(
+          '[data-testid="new-network-info-popup-close-button"]',
+        );
+
+        if (closeButton) {
+          await driver.clickElement(
+            '[data-testid="new-network-info-popup-close-button"]',
+          );
+        }
 
         await driver.clickElement(`[data-testid="import-token-button"]`);
         await driver.clickElement(`[data-testid="importTokens"]`);

--- a/test/e2e/tests/tokens/add-hide-token.spec.js
+++ b/test/e2e/tests/tokens/add-hide-token.spec.js
@@ -105,7 +105,7 @@ describe('Add existing token using search', function () {
     ];
   }
 
-  it.only('renders the balance for the chosen token', async function () {
+  it('renders the balance for the chosen token', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.BSC })

--- a/ui/components/ui/new-network-info/new-network-info.js
+++ b/ui/components/ui/new-network-info/new-network-info.js
@@ -103,6 +103,7 @@ export default function NewNetworkInfo() {
               </Text>
             </Button>
             <Button
+              data-testid="new-network-info-popup-close-button"
               variant="primary"
               onClick={onCloseClick}
               size={ButtonPrimarySize.Md}


### PR DESCRIPTION
## **Description**

Mitigates flakiness in `add-hide-token.spec` on firefox related to a flashing modal obscuring buttons beneath it, causing tests to fail consistently.

Introduces a change that programmatically closes this modal if present. However, I'm not convinced that this modal provides any real value to the user, and there have been several other related bug issues raised.

![test-failure-screenshot-1](https://github.com/user-attachments/assets/cca6e532-159d-4060-ae68-761fc78e4450)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28624?quickstart=1)

## **Related issues**

Related bug reports:
https://github.com/MetaMask/metamask-extension/issues/23255
https://github.com/MetaMask/metamask-extension/issues/25196

Note that this does not fix the above issues, this only mitigates the flakiness in firefox e2e ci.

## **Manual testing steps**

`yarn build:test:mv2`
`yarn start:test:mv2`
`ENABLE_MV3=false SELENIUM_BROWSER=firefox yarn test:e2e:single add-hide-token.spec.js --browser=firefox --debug --leave-running`

## **Screenshots/Recordings**

Before:

```
ElementClickInterceptedError: Element <div class="mm-box selectable-list-item-wrapper"> is not clickable at point (866,482) because another element <div class="popover-bg"> obscures it
  (Ran on CircleCI Node 0 of 24, Job test-e2e-firefox)
    at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:524:15)
    at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:601:13)
    at Executor.execute (node_modules/selenium-webdriver/lib/http.js:529:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async thenableWebDriverProxy.execute (node_modules/selenium-webdriver/lib/webdriver.js:745:17)
    at async element.click (test/e2e/webdriver/driver.js:96:9)
    at async Driver.clickElement (test/e2e/webdriver/driver.js:601:9)
    at async /home/circleci/project/test/e2e/tests/tokens/add-hide-token.spec.js:133:9
    at async withFixtures (test/e2e/helpers.js:220:5)
    at async Context.<anonymous> (test/e2e/tests/tokens/add-hide-token.spec.js:108:5)
```

After:

```
Success on testcase: 'Add existing token using search renders the balance for the chosen token'

ServerMochaToBackground disconnected from client
Failed to handle request: socket hang up
manifest-flag-mocha-hooks.ts -- afterEach hook
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="Mocha Tests" time="8.406" tests="1" failures="0">
  <testsuite name="Root Suite" timestamp="2024-11-21T19:41:23" tests="0" time="0.000" failures="0">
  </testsuite>
  <testsuite name="Add existing token using search" timestamp="2024-11-21T19:41:23" tests="1" file="/Users/nicholasgambino/code/clones/metamask-extension/test/e2e/tests/tokens/add-hide-token.spec.js" time="8.405" failures="0">
    <testcase name="Add existing token using search renders the balance for the chosen token" time="8.400" classname="renders the balance for the chosen token">
    </testcase>
  </testsuite>
</testsuites>
```

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
