### PR TITLE
test: Fix flakiness caused by display of newly switched to network modal

### DIFF
--- a/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
@@ -146,6 +146,9 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
               },
               useTransactionSimulations: false,
             })
+            .withAppStateController({
+              [CHAIN_IDS.OPTIMISM]: true,
+            })
             .withNetworkControllerOnOptimism()
             .build(),
           ganacheOptions: {

--- a/test/e2e/tests/tokens/add-hide-token.spec.js
+++ b/test/e2e/tests/tokens/add-hide-token.spec.js
@@ -118,6 +118,9 @@ describe('Add existing token using search', function () {
               },
             ],
           })
+          .withAppStateController({
+            [CHAIN_IDS.OPTIMISM]: true,
+          })
           .build(),
         ganacheOptions: {
           ...defaultGanacheOptions,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the flakiness seen, for example, in https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/111818/workflows/f974462c-8208-4189-8592-928b21f0cfde/jobs/4189413/tests

See this screenshot:

![Screenshot from 2024-11-21 16-39-14](https://github.com/user-attachments/assets/e5523440-82a8-462e-9ad3-fa2280e97826)

The test failure error is: `ElementClickInterceptedError: Element <div class="mm-box selectable-list-item-wrapper"> is not clickable at point (866,482) because another element <div class="popover-bg"> obscures it`

So the test is attempting to clikc the "Import tokens" button in the opened menu behind the "You are now using Binance" modal, but the Import Tokens button cannot be clicked because the modal intercepts the click

So there is a race condition whereby the test assumes that no modal will interfere with the click, and the test will pass if the click can occur before the modal is rendered, but it will fail the the click is attempted after the modal is rendered.
Prior to the PR in question (https://github.com/MetaMask/metamask-extension/pull/28575) there was no menu, and the "Import tokens" button could be clicked directly. The PR added the menu and move "Import tokens" into that menu, so now the test has to wait for that menu to open before the "Import tokens" button can be clicked, exacerbating the race condition.

That new network modal should not be shown in that scenario

this is the logic that controls whether that network modal should be shown:
```
    const shouldShowNetworkInfo =
      isUnlocked &&
      currentChainId &&
      !isTestNet &&
      !isSendRoute &&
      !isNetworkUsed &&
      !isCurrentProviderCustom &&
      completedOnboarding &&
      allAccountsOnNetworkAreEmpty &&
      switchedNetworkDetails === null;
```
(I think that is what folks are above referring to as the "Got it" modal)
Meanwhile, in fixture-builder.js we have:
```
        usedNetworks: {
          [CHAIN_IDS.MAINNET]: true,
          [CHAIN_IDS.LINEA_MAINNET]: true,
          [CHAIN_IDS.GOERLI]: true,
          [CHAIN_IDS.LOCALHOST]: true,
        },
```
So for any test that sets the network to something other than those four networks, !isNetworkUsed will evaluate to true, which will result in that modal being shown.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28625?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

e2e tests should

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
