### PR TITLE
experimenting with lavamoat policy stats

### DIFF
--- a/lavamoat-stats.json
+++ b/lavamoat-stats.json
@@ -1,0 +1,7796 @@
+{
+  "stats": {
+    "savedEntries": 2747,
+    "totalEntries": 6600,
+    "savedEntriesPercent": "41.62"
+  },
+  "suggestedDefaults": [
+    "globalThis",
+    "WeakRef",
+    "FinalizationRegistry",
+    "Error",
+    "AggregateError",
+    "console",
+    "TextEncoder",
+    "TextDecoder",
+    "atob",
+    "btoa",
+    "URL",
+    "URLSearchParams",
+    "Headers",
+    "FormData",
+    "Response",
+    "setTimeout",
+    "clearTimeout",
+    "setInterval",
+    "clearInterval",
+    "setImmediate",
+    "clearImmediate",
+    "queueMicrotask",
+    "AbortController",
+    "AbortSignal",
+    "self",
+    "window",
+    "__dirname",
+    "__filename",
+    "define"
+  ],
+  "globalToPackage": {
+    "regeneratorRuntime": [
+      "app/main:@babel/runtime",
+      "app/flask:@babel/runtime",
+      "app/beta:@babel/runtime",
+      "app/mmi:@babel/runtime"
+    ],
+    "console": [
+      "app/main:@ensdomains/content-hash",
+      "app/main:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/main:@ethereumjs/tx>@ethereumjs/util",
+      "app/main:@ethersproject/abi",
+      "app/main:@ethersproject/providers",
+      "app/main:@lavamoat/lavadome-react",
+      "app/main:@material-ui/core",
+      "app/main:@material-ui/core>@material-ui/styles",
+      "app/main:@material-ui/core>@material-ui/system",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@metamask/approval-controller",
+      "app/main:@metamask/assets-controllers",
+      "app/main:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/main:@metamask/controller-utils",
+      "app/main:@metamask/controller-utils>@spruceid/siwe-parser",
+      "app/main:@metamask/eth-json-rpc-filters",
+      "app/main:@metamask/eth-json-rpc-middleware",
+      "app/main:@metamask/eth-ledger-bridge-keyring",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@metamask/eth-snap-keyring",
+      "app/main:@metamask/eth-token-tracker",
+      "app/main:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/main:@metamask/ethjs-query",
+      "app/main:@metamask/gas-fee-controller",
+      "app/main:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/main:@metamask/json-rpc-middleware-stream",
+      "app/main:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/main:@metamask/network-controller>reselect",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@metamask/object-multiplex",
+      "app/main:@metamask/permission-controller",
+      "app/main:@metamask/phishing-controller",
+      "app/main:@metamask/polling-controller",
+      "app/main:@metamask/ppom-validator",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@metamask/profile-sync-controller>siwe",
+      "app/main:@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser",
+      "app/main:@metamask/smart-transactions-controller",
+      "app/main:@metamask/smart-transactions-controller>@ethereumjs/util",
+      "app/main:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller>@ethereumjs/util",
+      "app/main:@metamask/snaps-controllers>@metamask/permission-controller",
+      "app/main:@metamask/snaps-rpc-methods>@metamask/permission-controller",
+      "app/main:@metamask/snaps-utils",
+      "app/main:@metamask/snaps-utils>@metamask/permission-controller",
+      "app/main:@metamask/snaps-utils>marked",
+      "app/main:@metamask/transaction-controller",
+      "app/main:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/main:@popperjs/core",
+      "app/main:@reduxjs/toolkit",
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@sentry/utils",
+      "app/main:@trezor/connect-web",
+      "app/main:@trezor/connect-web>@trezor/connect-common",
+      "app/main:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen",
+      "app/main:@trezor/connect-web>@trezor/connect>@trezor/schema-utils",
+      "app/main:@trezor/connect-web>@trezor/utils",
+      "app/main:@welldone-software/why-did-you-render",
+      "app/main:@zxing/browser",
+      "app/main:@zxing/library",
+      "app/main:browserify>assert>util",
+      "app/main:browserify>buffer",
+      "app/main:browserify>util",
+      "app/main:buffer",
+      "app/main:chart.js",
+      "app/main:copy-to-clipboard",
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/main:eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util",
+      "app/main:eth-lattice-keyring>gridplus-sdk>borc",
+      "app/main:ethers>@ethersproject/logger",
+      "app/main:ethers>@ethersproject/providers",
+      "app/main:fuse.js",
+      "app/main:history",
+      "app/main:localforage",
+      "app/main:loglevel",
+      "app/main:lottie-web",
+      "app/main:nock>debug",
+      "app/main:prop-types",
+      "app/main:prop-types>react-is",
+      "app/main:react",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-dom",
+      "app/main:react-dom>scheduler",
+      "app/main:react-focus-lock",
+      "app/main:react-focus-lock>focus-lock",
+      "app/main:react-focus-lock>use-sidecar",
+      "app/main:react-markdown",
+      "app/main:react-markdown>react-is",
+      "app/main:react-markdown>remark-rehype>mdast-util-to-hast",
+      "app/main:react-popper>react-fast-compare",
+      "app/main:react-popper>warning",
+      "app/main:react-redux",
+      "app/main:react-redux>react-is",
+      "app/main:react-responsive-carousel",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/main:react-router-dom-v5-compat>react-router",
+      "app/main:react-router-dom>tiny-warning",
+      "app/main:react-simple-file-input",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/main:react-toggle-button",
+      "app/main:readable-stream>util-deprecate",
+      "app/main:redux",
+      "app/main:semver",
+      "app/main:superstruct",
+      "app/main:webextension-polyfill",
+      "app/main:webpack>events",
+      "app/flask:@ensdomains/content-hash",
+      "app/flask:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/flask:@ethereumjs/tx>@ethereumjs/util",
+      "app/flask:@ethersproject/abi",
+      "app/flask:@ethersproject/providers",
+      "app/flask:@lavamoat/lavadome-react",
+      "app/flask:@material-ui/core",
+      "app/flask:@material-ui/core>@material-ui/styles",
+      "app/flask:@material-ui/core>@material-ui/system",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@metamask/approval-controller",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/flask:@metamask/controller-utils",
+      "app/flask:@metamask/controller-utils>@spruceid/siwe-parser",
+      "app/flask:@metamask/eth-json-rpc-filters",
+      "app/flask:@metamask/eth-json-rpc-middleware",
+      "app/flask:@metamask/eth-ledger-bridge-keyring",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@metamask/eth-snap-keyring",
+      "app/flask:@metamask/eth-token-tracker",
+      "app/flask:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/flask:@metamask/ethjs-query",
+      "app/flask:@metamask/gas-fee-controller",
+      "app/flask:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/flask:@metamask/json-rpc-middleware-stream",
+      "app/flask:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/flask:@metamask/network-controller>reselect",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@metamask/object-multiplex",
+      "app/flask:@metamask/permission-controller",
+      "app/flask:@metamask/phishing-controller",
+      "app/flask:@metamask/polling-controller",
+      "app/flask:@metamask/ppom-validator",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@metamask/profile-sync-controller>siwe",
+      "app/flask:@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser",
+      "app/flask:@metamask/smart-transactions-controller",
+      "app/flask:@metamask/smart-transactions-controller>@ethereumjs/util",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller>@ethereumjs/util",
+      "app/flask:@metamask/snaps-controllers>@metamask/permission-controller",
+      "app/flask:@metamask/snaps-rpc-methods>@metamask/permission-controller",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:@metamask/snaps-utils>@metamask/permission-controller",
+      "app/flask:@metamask/snaps-utils>marked",
+      "app/flask:@metamask/transaction-controller",
+      "app/flask:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/flask:@popperjs/core",
+      "app/flask:@reduxjs/toolkit",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/utils",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@trezor/connect-web>@trezor/connect-common",
+      "app/flask:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen",
+      "app/flask:@trezor/connect-web>@trezor/connect>@trezor/schema-utils",
+      "app/flask:@trezor/connect-web>@trezor/utils",
+      "app/flask:@welldone-software/why-did-you-render",
+      "app/flask:@zxing/browser",
+      "app/flask:@zxing/library",
+      "app/flask:browserify>assert>util",
+      "app/flask:browserify>buffer",
+      "app/flask:browserify>util",
+      "app/flask:buffer",
+      "app/flask:chart.js",
+      "app/flask:copy-to-clipboard",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>borc",
+      "app/flask:ethers>@ethersproject/logger",
+      "app/flask:ethers>@ethersproject/providers",
+      "app/flask:fuse.js",
+      "app/flask:history",
+      "app/flask:localforage",
+      "app/flask:loglevel",
+      "app/flask:lottie-web",
+      "app/flask:nock>debug",
+      "app/flask:prop-types",
+      "app/flask:prop-types>react-is",
+      "app/flask:react",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-dom",
+      "app/flask:react-dom>scheduler",
+      "app/flask:react-focus-lock",
+      "app/flask:react-focus-lock>focus-lock",
+      "app/flask:react-focus-lock>use-sidecar",
+      "app/flask:react-markdown",
+      "app/flask:react-markdown>react-is",
+      "app/flask:react-markdown>remark-rehype>mdast-util-to-hast",
+      "app/flask:react-popper>react-fast-compare",
+      "app/flask:react-popper>warning",
+      "app/flask:react-redux",
+      "app/flask:react-redux>react-is",
+      "app/flask:react-responsive-carousel",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:react-router-dom-v5-compat>react-router",
+      "app/flask:react-router-dom>tiny-warning",
+      "app/flask:react-simple-file-input",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/flask:react-toggle-button",
+      "app/flask:readable-stream>util-deprecate",
+      "app/flask:redux",
+      "app/flask:semver",
+      "app/flask:superstruct",
+      "app/flask:webextension-polyfill",
+      "app/flask:webpack>events",
+      "app/beta:@ensdomains/content-hash",
+      "app/beta:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/beta:@ethereumjs/tx>@ethereumjs/util",
+      "app/beta:@ethersproject/abi",
+      "app/beta:@ethersproject/providers",
+      "app/beta:@lavamoat/lavadome-react",
+      "app/beta:@material-ui/core",
+      "app/beta:@material-ui/core>@material-ui/styles",
+      "app/beta:@material-ui/core>@material-ui/system",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@metamask/approval-controller",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/beta:@metamask/controller-utils",
+      "app/beta:@metamask/controller-utils>@spruceid/siwe-parser",
+      "app/beta:@metamask/eth-json-rpc-filters",
+      "app/beta:@metamask/eth-json-rpc-middleware",
+      "app/beta:@metamask/eth-ledger-bridge-keyring",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@metamask/eth-snap-keyring",
+      "app/beta:@metamask/eth-token-tracker",
+      "app/beta:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/beta:@metamask/ethjs-query",
+      "app/beta:@metamask/gas-fee-controller",
+      "app/beta:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/beta:@metamask/json-rpc-middleware-stream",
+      "app/beta:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/beta:@metamask/network-controller>reselect",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@metamask/object-multiplex",
+      "app/beta:@metamask/permission-controller",
+      "app/beta:@metamask/phishing-controller",
+      "app/beta:@metamask/polling-controller",
+      "app/beta:@metamask/ppom-validator",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@metamask/profile-sync-controller>siwe",
+      "app/beta:@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser",
+      "app/beta:@metamask/smart-transactions-controller",
+      "app/beta:@metamask/smart-transactions-controller>@ethereumjs/util",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller>@ethereumjs/util",
+      "app/beta:@metamask/snaps-controllers>@metamask/permission-controller",
+      "app/beta:@metamask/snaps-rpc-methods>@metamask/permission-controller",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:@metamask/snaps-utils>@metamask/permission-controller",
+      "app/beta:@metamask/snaps-utils>marked",
+      "app/beta:@metamask/transaction-controller",
+      "app/beta:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/beta:@popperjs/core",
+      "app/beta:@reduxjs/toolkit",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/utils",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@trezor/connect-web>@trezor/connect-common",
+      "app/beta:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen",
+      "app/beta:@trezor/connect-web>@trezor/connect>@trezor/schema-utils",
+      "app/beta:@trezor/connect-web>@trezor/utils",
+      "app/beta:@welldone-software/why-did-you-render",
+      "app/beta:@zxing/browser",
+      "app/beta:@zxing/library",
+      "app/beta:browserify>assert>util",
+      "app/beta:browserify>buffer",
+      "app/beta:browserify>util",
+      "app/beta:buffer",
+      "app/beta:chart.js",
+      "app/beta:copy-to-clipboard",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>borc",
+      "app/beta:ethers>@ethersproject/logger",
+      "app/beta:ethers>@ethersproject/providers",
+      "app/beta:fuse.js",
+      "app/beta:history",
+      "app/beta:localforage",
+      "app/beta:loglevel",
+      "app/beta:lottie-web",
+      "app/beta:nock>debug",
+      "app/beta:prop-types",
+      "app/beta:prop-types>react-is",
+      "app/beta:react",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-dom",
+      "app/beta:react-dom>scheduler",
+      "app/beta:react-focus-lock",
+      "app/beta:react-focus-lock>focus-lock",
+      "app/beta:react-focus-lock>use-sidecar",
+      "app/beta:react-markdown",
+      "app/beta:react-markdown>react-is",
+      "app/beta:react-markdown>remark-rehype>mdast-util-to-hast",
+      "app/beta:react-popper>react-fast-compare",
+      "app/beta:react-popper>warning",
+      "app/beta:react-redux",
+      "app/beta:react-redux>react-is",
+      "app/beta:react-responsive-carousel",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:react-router-dom-v5-compat>react-router",
+      "app/beta:react-router-dom>tiny-warning",
+      "app/beta:react-simple-file-input",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/beta:react-toggle-button",
+      "app/beta:readable-stream>util-deprecate",
+      "app/beta:redux",
+      "app/beta:semver",
+      "app/beta:superstruct",
+      "app/beta:webextension-polyfill",
+      "app/beta:webpack>events",
+      "app/mmi:@ensdomains/content-hash",
+      "app/mmi:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/util",
+      "app/mmi:@ethersproject/abi",
+      "app/mmi:@ethersproject/providers",
+      "app/mmi:@lavamoat/lavadome-react",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@material-ui/core>@material-ui/styles",
+      "app/mmi:@material-ui/core>@material-ui/system",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@metamask-institutional/custody-keyring",
+      "app/mmi:@metamask-institutional/custody-keyring>@metamask-institutional/configuration-client",
+      "app/mmi:@metamask-institutional/extension",
+      "app/mmi:@metamask-institutional/sdk",
+      "app/mmi:@metamask-institutional/transaction-update",
+      "app/mmi:@metamask-institutional/transaction-update>@metamask-institutional/websocket-client",
+      "app/mmi:@metamask/approval-controller",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/mmi:@metamask/controller-utils",
+      "app/mmi:@metamask/controller-utils>@spruceid/siwe-parser",
+      "app/mmi:@metamask/eth-json-rpc-filters",
+      "app/mmi:@metamask/eth-json-rpc-middleware",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@metamask/eth-snap-keyring",
+      "app/mmi:@metamask/eth-token-tracker",
+      "app/mmi:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/mmi:@metamask/ethjs-query",
+      "app/mmi:@metamask/gas-fee-controller",
+      "app/mmi:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/mmi:@metamask/json-rpc-middleware-stream",
+      "app/mmi:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/mmi:@metamask/network-controller>reselect",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@metamask/object-multiplex",
+      "app/mmi:@metamask/permission-controller",
+      "app/mmi:@metamask/phishing-controller",
+      "app/mmi:@metamask/polling-controller",
+      "app/mmi:@metamask/ppom-validator",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@metamask/profile-sync-controller>siwe",
+      "app/mmi:@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser",
+      "app/mmi:@metamask/smart-transactions-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@ethereumjs/util",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller>@ethereumjs/util",
+      "app/mmi:@metamask/snaps-controllers>@metamask/permission-controller",
+      "app/mmi:@metamask/snaps-rpc-methods>@metamask/permission-controller",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:@metamask/snaps-utils>@metamask/permission-controller",
+      "app/mmi:@metamask/snaps-utils>marked",
+      "app/mmi:@metamask/transaction-controller",
+      "app/mmi:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/mmi:@popperjs/core",
+      "app/mmi:@reduxjs/toolkit",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common",
+      "app/mmi:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen",
+      "app/mmi:@trezor/connect-web>@trezor/connect>@trezor/schema-utils",
+      "app/mmi:@trezor/connect-web>@trezor/utils",
+      "app/mmi:@welldone-software/why-did-you-render",
+      "app/mmi:@zxing/browser",
+      "app/mmi:@zxing/library",
+      "app/mmi:browserify>assert>util",
+      "app/mmi:browserify>buffer",
+      "app/mmi:browserify>util",
+      "app/mmi:buffer",
+      "app/mmi:chart.js",
+      "app/mmi:copy-to-clipboard",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>borc",
+      "app/mmi:ethers>@ethersproject/logger",
+      "app/mmi:ethers>@ethersproject/providers",
+      "app/mmi:fuse.js",
+      "app/mmi:history",
+      "app/mmi:localforage",
+      "app/mmi:loglevel",
+      "app/mmi:lottie-web",
+      "app/mmi:nock>debug",
+      "app/mmi:prop-types",
+      "app/mmi:prop-types>react-is",
+      "app/mmi:react",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-dom",
+      "app/mmi:react-dom>scheduler",
+      "app/mmi:react-focus-lock",
+      "app/mmi:react-focus-lock>focus-lock",
+      "app/mmi:react-focus-lock>use-sidecar",
+      "app/mmi:react-markdown",
+      "app/mmi:react-markdown>react-is",
+      "app/mmi:react-markdown>remark-rehype>mdast-util-to-hast",
+      "app/mmi:react-popper>react-fast-compare",
+      "app/mmi:react-popper>warning",
+      "app/mmi:react-redux",
+      "app/mmi:react-redux>react-is",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:react-router-dom-v5-compat>react-router",
+      "app/mmi:react-router-dom>tiny-warning",
+      "app/mmi:react-simple-file-input",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js",
+      "app/mmi:react-toggle-button",
+      "app/mmi:readable-stream>util-deprecate",
+      "app/mmi:redux",
+      "app/mmi:semver",
+      "app/mmi:superstruct",
+      "app/mmi:webextension-polyfill",
+      "app/mmi:webpack>events",
+      "build/main:@babel/code-frame",
+      "build/main:@babel/core",
+      "build/main:@babel/core>@babel/generator",
+      "build/main:@babel/core>@babel/helper-compilation-targets",
+      "build/main:@babel/core>@babel/helper-compilation-targets>semver",
+      "build/main:@babel/core>@babel/types",
+      "build/main:@babel/core>semver",
+      "build/main:@babel/eslint-parser>semver",
+      "build/main:@babel/preset-env",
+      "build/main:@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>semver",
+      "build/main:@babel/preset-env>@babel/plugin-transform-modules-systemjs",
+      "build/main:@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin",
+      "build/main:@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin>semver",
+      "build/main:@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider",
+      "build/main:@babel/preset-env>babel-plugin-polyfill-corejs2>semver",
+      "build/main:@babel/preset-env>semver",
+      "build/main:@babel/preset-typescript>@babel/plugin-transform-typescript",
+      "build/main:@lavamoat/lavapack",
+      "build/main:@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils>debug",
+      "build/main:autoprefixer",
+      "build/main:browserslist",
+      "build/main:chokidar",
+      "build/main:chokidar>fsevents",
+      "build/main:del>graceful-fs",
+      "build/main:depcheck>@babel/traverse",
+      "build/main:depcheck>json5",
+      "build/main:eslint",
+      "build/main:eslint-import-resolver-node>debug",
+      "build/main:eslint-import-resolver-typescript",
+      "build/main:eslint-plugin-import>debug",
+      "build/main:eslint-plugin-import>eslint-module-utils",
+      "build/main:eslint-plugin-import>eslint-module-utils>debug",
+      "build/main:eslint-plugin-import>tsconfig-paths",
+      "build/main:eslint-plugin-import>tsconfig-paths>json5",
+      "build/main:eslint-plugin-node>semver",
+      "build/main:eslint-plugin-react",
+      "build/main:eslint-plugin-react>jsx-ast-utils",
+      "build/main:eslint-plugin-react>semver",
+      "build/main:eslint>ajv",
+      "build/main:eslint>minimatch",
+      "build/main:fs-extra",
+      "build/main:gulp-livereload>debug",
+      "build/main:gulp-livereload>event-stream",
+      "build/main:gulp-livereload>tiny-lr",
+      "build/main:gulp-livereload>tiny-lr>debug",
+      "build/main:gulp-postcss>postcss-load-config>yaml",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss",
+      "build/main:gulp-sourcemaps>debug-fabulous>debug",
+      "build/main:gulp-watch>chokidar",
+      "build/main:gulp-watch>chokidar>fsevents",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>nopt",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>semver",
+      "build/main:gulp-watch>fancy-log",
+      "build/main:gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug",
+      "build/main:gulp>glob-watcher>chokidar>fsevents",
+      "build/main:gulp>gulp-cli>matchdep>micromatch>snapdragon>debug",
+      "build/main:jsdom>acorn",
+      "build/main:lavamoat-browserify",
+      "build/main:lavamoat-viz>lavamoat-core",
+      "build/main:lavamoat-viz>lavamoat-core>lavamoat-tofu",
+      "build/main:lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse",
+      "build/main:lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/types",
+      "build/main:nock>debug",
+      "build/main:nyc>glob",
+      "build/main:nyc>glob>fs.realpath",
+      "build/main:postcss",
+      "build/main:postcss-discard-font-face>postcss",
+      "build/main:postcss>source-map-js",
+      "build/main:prettier",
+      "build/main:prop-types",
+      "build/main:prop-types>react-is",
+      "build/main:sass-embedded",
+      "build/main:sass-embedded>immutable",
+      "build/main:semver",
+      "build/main:source-map",
+      "build/main:stylelint",
+      "build/main:stylelint>autoprefixer",
+      "build/main:stylelint>cosmiconfig>yaml",
+      "build/main:stylelint>postcss",
+      "build/main:stylelint>postcss-less>postcss",
+      "build/main:stylelint>postcss-safe-parser>postcss",
+      "build/main:stylelint>postcss-sass>gonzales-pe",
+      "build/main:stylelint>postcss-sass>postcss",
+      "build/main:stylelint>postcss-scss>postcss",
+      "build/main:stylelint>sugarss>postcss",
+      "build/main:superstruct",
+      "build/main:terser",
+      "build/main:terser>source-map-support",
+      "build/main:ts-node",
+      "build/main:ts-node>@cspotcode/source-map-support",
+      "build/main:typescript",
+      "build/main:yaml",
+      "build/main:yargs",
+      "build/override:@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils>debug",
+      "build/override:yargs",
+      "build/override:gulp-watch>chokidar",
+      "build/override:gulp-watch>chokidar>fsevents",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>nopt",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>semver",
+      "build/override:chokidar>fsevents",
+      "build/override:gulp>glob-watcher>chokidar>fsevents"
+    ],
+    "TextDecoder": [
+      "app/main:@ensdomains/content-hash>cids>multibase",
+      "app/main:@ensdomains/content-hash>cids>uint8arrays",
+      "app/main:@ensdomains/content-hash>js-base64",
+      "app/main:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/main:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/main:@ensdomains/content-hash>multihashes>web-encoding",
+      "app/main:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/main:@ethereumjs/tx>ethereum-cryptography",
+      "app/main:@metamask/abi-utils>@metamask/utils",
+      "app/main:@metamask/accounts-controller>@metamask/utils",
+      "app/main:@metamask/browser-passworder>@metamask/utils",
+      "app/main:@metamask/ens-controller>@metamask/utils",
+      "app/main:@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/main:@metamask/eth-sig-util>@metamask/utils",
+      "app/main:@metamask/eth-snap-keyring>@metamask/utils",
+      "app/main:@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils",
+      "app/main:@metamask/keyring-api>@metamask/utils",
+      "app/main:@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils",
+      "app/main:@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils",
+      "app/main:@metamask/keyring-controller>@metamask/utils",
+      "app/main:@metamask/message-manager>@metamask/utils",
+      "app/main:@metamask/message-signing-snap>@noble/ciphers",
+      "app/main:@metamask/name-controller>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/utils",
+      "app/main:@metamask/notification-controller>@metamask/utils",
+      "app/main:@metamask/notification-services-controller>@metamask/utils",
+      "app/main:@metamask/permission-controller>@metamask/json-rpc-engine>@metamask/utils",
+      "app/main:@metamask/permission-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/permission-controller>@metamask/utils",
+      "app/main:@metamask/permission-log-controller>@metamask/utils",
+      "app/main:@metamask/post-message-stream>@metamask/utils",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/rate-limit-controller>@metamask/utils",
+      "app/main:@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/utils",
+      "app/main:@metamask/snaps-controllers>tar-stream>b4a",
+      "app/main:@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils",
+      "app/main:@metamask/snaps-utils",
+      "app/main:@metamask/user-operation-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/user-operation-controller>@metamask/utils",
+      "app/main:@metamask/utils",
+      "app/main:@metamask/utils>@scure/base",
+      "app/main:@sentry/utils",
+      "app/main:@solana/addresses>@solana/codecs-strings",
+      "app/main:@zxing/library",
+      "app/flask:@ensdomains/content-hash>cids>multibase",
+      "app/flask:@ensdomains/content-hash>cids>uint8arrays",
+      "app/flask:@ensdomains/content-hash>js-base64",
+      "app/flask:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/flask:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/flask:@ensdomains/content-hash>multihashes>web-encoding",
+      "app/flask:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/flask:@ethereumjs/tx>ethereum-cryptography",
+      "app/flask:@metamask/abi-utils>@metamask/utils",
+      "app/flask:@metamask/accounts-controller>@metamask/utils",
+      "app/flask:@metamask/browser-passworder>@metamask/utils",
+      "app/flask:@metamask/ens-controller>@metamask/utils",
+      "app/flask:@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/flask:@metamask/eth-sig-util>@metamask/utils",
+      "app/flask:@metamask/eth-snap-keyring>@metamask/utils",
+      "app/flask:@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils",
+      "app/flask:@metamask/keyring-api>@metamask/utils",
+      "app/flask:@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils",
+      "app/flask:@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils",
+      "app/flask:@metamask/keyring-controller>@metamask/utils",
+      "app/flask:@metamask/message-manager>@metamask/utils",
+      "app/flask:@metamask/message-signing-snap>@noble/ciphers",
+      "app/flask:@metamask/name-controller>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/utils",
+      "app/flask:@metamask/notification-controller>@metamask/utils",
+      "app/flask:@metamask/notification-services-controller>@metamask/utils",
+      "app/flask:@metamask/permission-controller>@metamask/json-rpc-engine>@metamask/utils",
+      "app/flask:@metamask/permission-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/permission-controller>@metamask/utils",
+      "app/flask:@metamask/permission-log-controller>@metamask/utils",
+      "app/flask:@metamask/post-message-stream>@metamask/utils",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/rate-limit-controller>@metamask/utils",
+      "app/flask:@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/utils",
+      "app/flask:@metamask/snaps-controllers>tar-stream>b4a",
+      "app/flask:@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:@metamask/user-operation-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/user-operation-controller>@metamask/utils",
+      "app/flask:@metamask/utils",
+      "app/flask:@metamask/utils>@scure/base",
+      "app/flask:@sentry/utils",
+      "app/flask:@solana/addresses>@solana/codecs-strings",
+      "app/flask:@zxing/library",
+      "app/beta:@ensdomains/content-hash>cids>multibase",
+      "app/beta:@ensdomains/content-hash>cids>uint8arrays",
+      "app/beta:@ensdomains/content-hash>js-base64",
+      "app/beta:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/beta:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/beta:@ensdomains/content-hash>multihashes>web-encoding",
+      "app/beta:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/beta:@ethereumjs/tx>ethereum-cryptography",
+      "app/beta:@metamask/abi-utils>@metamask/utils",
+      "app/beta:@metamask/accounts-controller>@metamask/utils",
+      "app/beta:@metamask/browser-passworder>@metamask/utils",
+      "app/beta:@metamask/ens-controller>@metamask/utils",
+      "app/beta:@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/beta:@metamask/eth-sig-util>@metamask/utils",
+      "app/beta:@metamask/eth-snap-keyring>@metamask/utils",
+      "app/beta:@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils",
+      "app/beta:@metamask/keyring-api>@metamask/utils",
+      "app/beta:@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils",
+      "app/beta:@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils",
+      "app/beta:@metamask/keyring-controller>@metamask/utils",
+      "app/beta:@metamask/message-manager>@metamask/utils",
+      "app/beta:@metamask/message-signing-snap>@noble/ciphers",
+      "app/beta:@metamask/name-controller>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/utils",
+      "app/beta:@metamask/notification-controller>@metamask/utils",
+      "app/beta:@metamask/notification-services-controller>@metamask/utils",
+      "app/beta:@metamask/permission-controller>@metamask/json-rpc-engine>@metamask/utils",
+      "app/beta:@metamask/permission-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/permission-controller>@metamask/utils",
+      "app/beta:@metamask/permission-log-controller>@metamask/utils",
+      "app/beta:@metamask/post-message-stream>@metamask/utils",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/rate-limit-controller>@metamask/utils",
+      "app/beta:@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/utils",
+      "app/beta:@metamask/snaps-controllers>tar-stream>b4a",
+      "app/beta:@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:@metamask/user-operation-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/user-operation-controller>@metamask/utils",
+      "app/beta:@metamask/utils",
+      "app/beta:@metamask/utils>@scure/base",
+      "app/beta:@sentry/utils",
+      "app/beta:@solana/addresses>@solana/codecs-strings",
+      "app/beta:@zxing/library",
+      "app/mmi:@ensdomains/content-hash>cids>multibase",
+      "app/mmi:@ensdomains/content-hash>cids>uint8arrays",
+      "app/mmi:@ensdomains/content-hash>js-base64",
+      "app/mmi:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/mmi:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/mmi:@ensdomains/content-hash>multihashes>web-encoding",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/mmi:@ethereumjs/tx>ethereum-cryptography",
+      "app/mmi:@metamask/abi-utils>@metamask/utils",
+      "app/mmi:@metamask/accounts-controller>@metamask/utils",
+      "app/mmi:@metamask/browser-passworder>@metamask/utils",
+      "app/mmi:@metamask/ens-controller>@metamask/utils",
+      "app/mmi:@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/mmi:@metamask/eth-sig-util>@metamask/utils",
+      "app/mmi:@metamask/eth-snap-keyring>@metamask/utils",
+      "app/mmi:@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils",
+      "app/mmi:@metamask/keyring-api>@metamask/utils",
+      "app/mmi:@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils",
+      "app/mmi:@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils",
+      "app/mmi:@metamask/keyring-controller>@metamask/utils",
+      "app/mmi:@metamask/message-manager>@metamask/utils",
+      "app/mmi:@metamask/message-signing-snap>@noble/ciphers",
+      "app/mmi:@metamask/name-controller>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/utils",
+      "app/mmi:@metamask/notification-controller>@metamask/utils",
+      "app/mmi:@metamask/notification-services-controller>@metamask/utils",
+      "app/mmi:@metamask/permission-controller>@metamask/json-rpc-engine>@metamask/utils",
+      "app/mmi:@metamask/permission-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/permission-controller>@metamask/utils",
+      "app/mmi:@metamask/permission-log-controller>@metamask/utils",
+      "app/mmi:@metamask/post-message-stream>@metamask/utils",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/rate-limit-controller>@metamask/utils",
+      "app/mmi:@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/utils",
+      "app/mmi:@metamask/snaps-controllers>tar-stream>b4a",
+      "app/mmi:@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:@metamask/user-operation-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/user-operation-controller>@metamask/utils",
+      "app/mmi:@metamask/utils",
+      "app/mmi:@metamask/utils>@scure/base",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@solana/addresses>@solana/codecs-strings",
+      "app/mmi:@zxing/library",
+      "build/main:@metamask/build-utils>@metamask/utils",
+      "build/main:@metamask/utils>@scure/base",
+      "build/main:gulp-sourcemaps>css>source-map-resolve",
+      "build/main:resolve-url-loader>rework>css>source-map-resolve",
+      "build/main:sass-embedded>@bufbuild/protobuf",
+      "build/main:terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec"
+    ],
+    "TextEncoder": [
+      "app/main:@ensdomains/content-hash>cids>multibase",
+      "app/main:@ensdomains/content-hash>cids>uint8arrays",
+      "app/main:@ensdomains/content-hash>js-base64",
+      "app/main:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/main:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/main:@ensdomains/content-hash>multihashes>web-encoding",
+      "app/main:@ethereumjs/tx>@ethereumjs/rlp",
+      "app/main:@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp",
+      "app/main:@ethereumjs/tx>ethereum-cryptography>@noble/hashes",
+      "app/main:@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes",
+      "app/main:@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp",
+      "app/main:@metamask/abi-utils>@metamask/utils",
+      "app/main:@metamask/accounts-controller>@metamask/utils",
+      "app/main:@metamask/browser-passworder>@metamask/utils",
+      "app/main:@metamask/ens-controller>@metamask/utils",
+      "app/main:@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp",
+      "app/main:@metamask/eth-sig-util>@metamask/utils",
+      "app/main:@metamask/eth-snap-keyring>@metamask/utils",
+      "app/main:@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils",
+      "app/main:@metamask/keyring-api>@metamask/utils",
+      "app/main:@metamask/keyring-controller>@metamask/eth-hd-keyring",
+      "app/main:@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils",
+      "app/main:@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils",
+      "app/main:@metamask/keyring-controller>@metamask/utils",
+      "app/main:@metamask/message-manager>@metamask/utils",
+      "app/main:@metamask/message-signing-snap>@noble/ciphers",
+      "app/main:@metamask/message-signing-snap>@noble/curves",
+      "app/main:@metamask/message-signing-snap>@noble/curves>@noble/hashes",
+      "app/main:@metamask/name-controller>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/main:@metamask/network-controller>@metamask/utils",
+      "app/main:@metamask/notification-controller>@metamask/utils",
+      "app/main:@metamask/notification-services-controller>@metamask/utils",
+      "app/main:@metamask/permission-controller>@metamask/json-rpc-engine>@metamask/utils",
+      "app/main:@metamask/permission-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/permission-controller>@metamask/utils",
+      "app/main:@metamask/permission-log-controller>@metamask/utils",
+      "app/main:@metamask/phishing-controller",
+      "app/main:@metamask/post-message-stream>@metamask/utils",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/rate-limit-controller>@metamask/utils",
+      "app/main:@metamask/scure-bip39",
+      "app/main:@metamask/scure-bip39>@noble/hashes",
+      "app/main:@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller>@ethereumjs/tx>@ethereumjs/rlp",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/utils",
+      "app/main:@metamask/snaps-controllers>tar-stream>b4a",
+      "app/main:@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils",
+      "app/main:@metamask/snaps-utils",
+      "app/main:@metamask/user-operation-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/main:@metamask/user-operation-controller>@metamask/utils",
+      "app/main:@metamask/utils",
+      "app/main:@metamask/utils>@scure/base",
+      "app/main:@noble/hashes",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/utils",
+      "app/main:@solana/addresses",
+      "app/main:@solana/addresses>@solana/codecs-strings",
+      "app/main:@zxing/library",
+      "app/main:eth-lattice-keyring>rlp",
+      "app/flask:@ensdomains/content-hash>cids>multibase",
+      "app/flask:@ensdomains/content-hash>cids>uint8arrays",
+      "app/flask:@ensdomains/content-hash>js-base64",
+      "app/flask:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/flask:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/flask:@ensdomains/content-hash>multihashes>web-encoding",
+      "app/flask:@ethereumjs/tx>@ethereumjs/rlp",
+      "app/flask:@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp",
+      "app/flask:@ethereumjs/tx>ethereum-cryptography>@noble/hashes",
+      "app/flask:@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes",
+      "app/flask:@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp",
+      "app/flask:@metamask/abi-utils>@metamask/utils",
+      "app/flask:@metamask/accounts-controller>@metamask/utils",
+      "app/flask:@metamask/browser-passworder>@metamask/utils",
+      "app/flask:@metamask/ens-controller>@metamask/utils",
+      "app/flask:@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp",
+      "app/flask:@metamask/eth-sig-util>@metamask/utils",
+      "app/flask:@metamask/eth-snap-keyring>@metamask/utils",
+      "app/flask:@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils",
+      "app/flask:@metamask/keyring-api>@metamask/utils",
+      "app/flask:@metamask/keyring-controller>@metamask/eth-hd-keyring",
+      "app/flask:@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils",
+      "app/flask:@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils",
+      "app/flask:@metamask/keyring-controller>@metamask/utils",
+      "app/flask:@metamask/message-manager>@metamask/utils",
+      "app/flask:@metamask/message-signing-snap>@noble/ciphers",
+      "app/flask:@metamask/message-signing-snap>@noble/curves",
+      "app/flask:@metamask/message-signing-snap>@noble/curves>@noble/hashes",
+      "app/flask:@metamask/name-controller>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/flask:@metamask/network-controller>@metamask/utils",
+      "app/flask:@metamask/notification-controller>@metamask/utils",
+      "app/flask:@metamask/notification-services-controller>@metamask/utils",
+      "app/flask:@metamask/permission-controller>@metamask/json-rpc-engine>@metamask/utils",
+      "app/flask:@metamask/permission-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/permission-controller>@metamask/utils",
+      "app/flask:@metamask/permission-log-controller>@metamask/utils",
+      "app/flask:@metamask/phishing-controller",
+      "app/flask:@metamask/post-message-stream>@metamask/utils",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/rate-limit-controller>@metamask/utils",
+      "app/flask:@metamask/scure-bip39",
+      "app/flask:@metamask/scure-bip39>@noble/hashes",
+      "app/flask:@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller>@ethereumjs/tx>@ethereumjs/rlp",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/utils",
+      "app/flask:@metamask/snaps-controllers>tar-stream>b4a",
+      "app/flask:@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:@metamask/user-operation-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/flask:@metamask/user-operation-controller>@metamask/utils",
+      "app/flask:@metamask/utils",
+      "app/flask:@metamask/utils>@scure/base",
+      "app/flask:@noble/hashes",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/utils",
+      "app/flask:@solana/addresses",
+      "app/flask:@solana/addresses>@solana/codecs-strings",
+      "app/flask:@zxing/library",
+      "app/flask:eth-lattice-keyring>rlp",
+      "app/beta:@ensdomains/content-hash>cids>multibase",
+      "app/beta:@ensdomains/content-hash>cids>uint8arrays",
+      "app/beta:@ensdomains/content-hash>js-base64",
+      "app/beta:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/beta:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/beta:@ensdomains/content-hash>multihashes>web-encoding",
+      "app/beta:@ethereumjs/tx>@ethereumjs/rlp",
+      "app/beta:@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp",
+      "app/beta:@ethereumjs/tx>ethereum-cryptography>@noble/hashes",
+      "app/beta:@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes",
+      "app/beta:@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp",
+      "app/beta:@metamask/abi-utils>@metamask/utils",
+      "app/beta:@metamask/accounts-controller>@metamask/utils",
+      "app/beta:@metamask/browser-passworder>@metamask/utils",
+      "app/beta:@metamask/ens-controller>@metamask/utils",
+      "app/beta:@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp",
+      "app/beta:@metamask/eth-sig-util>@metamask/utils",
+      "app/beta:@metamask/eth-snap-keyring>@metamask/utils",
+      "app/beta:@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils",
+      "app/beta:@metamask/keyring-api>@metamask/utils",
+      "app/beta:@metamask/keyring-controller>@metamask/eth-hd-keyring",
+      "app/beta:@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils",
+      "app/beta:@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils",
+      "app/beta:@metamask/keyring-controller>@metamask/utils",
+      "app/beta:@metamask/message-manager>@metamask/utils",
+      "app/beta:@metamask/message-signing-snap>@noble/ciphers",
+      "app/beta:@metamask/message-signing-snap>@noble/curves",
+      "app/beta:@metamask/message-signing-snap>@noble/curves>@noble/hashes",
+      "app/beta:@metamask/name-controller>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/beta:@metamask/network-controller>@metamask/utils",
+      "app/beta:@metamask/notification-controller>@metamask/utils",
+      "app/beta:@metamask/notification-services-controller>@metamask/utils",
+      "app/beta:@metamask/permission-controller>@metamask/json-rpc-engine>@metamask/utils",
+      "app/beta:@metamask/permission-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/permission-controller>@metamask/utils",
+      "app/beta:@metamask/permission-log-controller>@metamask/utils",
+      "app/beta:@metamask/phishing-controller",
+      "app/beta:@metamask/post-message-stream>@metamask/utils",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/rate-limit-controller>@metamask/utils",
+      "app/beta:@metamask/scure-bip39",
+      "app/beta:@metamask/scure-bip39>@noble/hashes",
+      "app/beta:@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller>@ethereumjs/tx>@ethereumjs/rlp",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/utils",
+      "app/beta:@metamask/snaps-controllers>tar-stream>b4a",
+      "app/beta:@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:@metamask/user-operation-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/beta:@metamask/user-operation-controller>@metamask/utils",
+      "app/beta:@metamask/utils",
+      "app/beta:@metamask/utils>@scure/base",
+      "app/beta:@noble/hashes",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/utils",
+      "app/beta:@solana/addresses",
+      "app/beta:@solana/addresses>@solana/codecs-strings",
+      "app/beta:@zxing/library",
+      "app/beta:eth-lattice-keyring>rlp",
+      "app/mmi:@ensdomains/content-hash>cids>multibase",
+      "app/mmi:@ensdomains/content-hash>cids>uint8arrays",
+      "app/mmi:@ensdomains/content-hash>js-base64",
+      "app/mmi:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/mmi:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/mmi:@ensdomains/content-hash>multihashes>web-encoding",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/rlp",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp",
+      "app/mmi:@ethereumjs/tx>ethereum-cryptography>@noble/hashes",
+      "app/mmi:@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes",
+      "app/mmi:@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp",
+      "app/mmi:@metamask/abi-utils>@metamask/utils",
+      "app/mmi:@metamask/accounts-controller>@metamask/utils",
+      "app/mmi:@metamask/browser-passworder>@metamask/utils",
+      "app/mmi:@metamask/ens-controller>@metamask/utils",
+      "app/mmi:@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp",
+      "app/mmi:@metamask/eth-sig-util>@metamask/utils",
+      "app/mmi:@metamask/eth-snap-keyring>@metamask/utils",
+      "app/mmi:@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils",
+      "app/mmi:@metamask/keyring-api>@metamask/utils",
+      "app/mmi:@metamask/keyring-controller>@metamask/eth-hd-keyring",
+      "app/mmi:@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils",
+      "app/mmi:@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils",
+      "app/mmi:@metamask/keyring-controller>@metamask/utils",
+      "app/mmi:@metamask/message-manager>@metamask/utils",
+      "app/mmi:@metamask/message-signing-snap>@noble/ciphers",
+      "app/mmi:@metamask/message-signing-snap>@noble/curves",
+      "app/mmi:@metamask/message-signing-snap>@noble/curves>@noble/hashes",
+      "app/mmi:@metamask/name-controller>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-middleware>@metamask/utils",
+      "app/mmi:@metamask/network-controller>@metamask/utils",
+      "app/mmi:@metamask/notification-controller>@metamask/utils",
+      "app/mmi:@metamask/notification-services-controller>@metamask/utils",
+      "app/mmi:@metamask/permission-controller>@metamask/json-rpc-engine>@metamask/utils",
+      "app/mmi:@metamask/permission-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/permission-controller>@metamask/utils",
+      "app/mmi:@metamask/permission-log-controller>@metamask/utils",
+      "app/mmi:@metamask/phishing-controller",
+      "app/mmi:@metamask/post-message-stream>@metamask/utils",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/rate-limit-controller>@metamask/utils",
+      "app/mmi:@metamask/scure-bip39",
+      "app/mmi:@metamask/scure-bip39>@noble/hashes",
+      "app/mmi:@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller>@ethereumjs/tx>@ethereumjs/rlp",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/utils",
+      "app/mmi:@metamask/snaps-controllers>tar-stream>b4a",
+      "app/mmi:@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:@metamask/user-operation-controller>@metamask/rpc-errors>@metamask/utils",
+      "app/mmi:@metamask/user-operation-controller>@metamask/utils",
+      "app/mmi:@metamask/utils",
+      "app/mmi:@metamask/utils>@scure/base",
+      "app/mmi:@noble/hashes",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@solana/addresses",
+      "app/mmi:@solana/addresses>@solana/codecs-strings",
+      "app/mmi:@zxing/library",
+      "app/mmi:eth-lattice-keyring>rlp",
+      "build/main:@metamask/build-utils>@metamask/utils",
+      "build/main:@metamask/utils>@scure/base",
+      "build/main:@noble/hashes",
+      "build/main:sass-embedded>@bufbuild/protobuf"
+    ],
+    "Base64": [
+      "app/main:@ensdomains/content-hash>js-base64",
+      "app/flask:@ensdomains/content-hash>js-base64",
+      "app/beta:@ensdomains/content-hash>js-base64",
+      "app/mmi:@ensdomains/content-hash>js-base64",
+      "build/main:postcss-discard-font-face>postcss>js-base64"
+    ],
+    "atob": [
+      "app/main:@ensdomains/content-hash>js-base64",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@solana/addresses>@solana/codecs-strings",
+      "app/main:ethers>@ethersproject/base64",
+      "app/main:localforage",
+      "app/flask:@ensdomains/content-hash>js-base64",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@solana/addresses>@solana/codecs-strings",
+      "app/flask:ethers>@ethersproject/base64",
+      "app/flask:localforage",
+      "app/beta:@ensdomains/content-hash>js-base64",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@solana/addresses>@solana/codecs-strings",
+      "app/beta:ethers>@ethersproject/base64",
+      "app/beta:localforage",
+      "app/mmi:@ensdomains/content-hash>js-base64",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@solana/addresses>@solana/codecs-strings",
+      "app/mmi:ethers>@ethersproject/base64",
+      "app/mmi:localforage",
+      "build/main:@babel/core>convert-source-map",
+      "build/main:@lavamoat/lavapack>convert-source-map",
+      "build/main:gulp-postcss>postcss-load-config>yaml",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss",
+      "build/main:postcss",
+      "build/main:prettier",
+      "build/main:stylelint>cosmiconfig>yaml",
+      "build/main:stylelint>postcss",
+      "build/main:stylelint>postcss-less>postcss",
+      "build/main:stylelint>postcss-safe-parser>postcss",
+      "build/main:stylelint>postcss-sass>postcss",
+      "build/main:stylelint>postcss-scss>postcss",
+      "build/main:stylelint>sugarss>postcss",
+      "build/main:terser",
+      "build/main:yaml"
+    ],
+    "btoa": [
+      "app/main:@ensdomains/content-hash>js-base64",
+      "app/main:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/main:@metamask/browser-passworder",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@metamask/network-controller",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@solana/addresses>@solana/codecs-strings",
+      "app/main:@solana/addresses>@solana/errors",
+      "app/main:@trezor/connect-web",
+      "app/main:@zxing/library",
+      "app/main:blo",
+      "app/main:ethers>@ethersproject/base64",
+      "app/main:localforage",
+      "app/flask:@ensdomains/content-hash>js-base64",
+      "app/flask:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/flask:@metamask/browser-passworder",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@metamask/network-controller",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@solana/addresses>@solana/codecs-strings",
+      "app/flask:@solana/addresses>@solana/errors",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@zxing/library",
+      "app/flask:blo",
+      "app/flask:ethers>@ethersproject/base64",
+      "app/flask:localforage",
+      "app/beta:@ensdomains/content-hash>js-base64",
+      "app/beta:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/beta:@metamask/browser-passworder",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@metamask/network-controller",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@solana/addresses>@solana/codecs-strings",
+      "app/beta:@solana/addresses>@solana/errors",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@zxing/library",
+      "app/beta:blo",
+      "app/beta:ethers>@ethersproject/base64",
+      "app/beta:localforage",
+      "app/mmi:@ensdomains/content-hash>js-base64",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/mmi:@metamask/browser-passworder",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@metamask/network-controller",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@solana/addresses>@solana/codecs-strings",
+      "app/mmi:@solana/addresses>@solana/errors",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@zxing/library",
+      "app/mmi:blo",
+      "app/mmi:ethers>@ethersproject/base64",
+      "app/mmi:localforage",
+      "build/main:@babel/core>convert-source-map",
+      "build/main:@lavamoat/lavapack>convert-source-map",
+      "build/main:gulp-postcss>postcss-load-config>yaml",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss",
+      "build/main:postcss",
+      "build/main:prettier",
+      "build/main:stylelint>cosmiconfig>yaml",
+      "build/main:stylelint>postcss",
+      "build/main:stylelint>postcss-less>postcss",
+      "build/main:stylelint>postcss-safe-parser>postcss",
+      "build/main:stylelint>postcss-sass>postcss",
+      "build/main:stylelint>postcss-scss>postcss",
+      "build/main:stylelint>sugarss>postcss",
+      "build/main:terser",
+      "build/main:yaml"
+    ],
+    "define": [
+      "app/main:@ensdomains/content-hash>js-base64",
+      "app/main:@ethereumjs/tx>@ethereumjs/common>crc-32",
+      "app/main:@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js",
+      "app/main:@metamask/ethjs>js-sha3",
+      "app/main:@metamask/ppom-validator>crypto-js",
+      "app/main:@metamask/smart-transactions-controller>bignumber.js",
+      "app/main:@metamask/snaps-utils>marked",
+      "app/main:@ngraveio/bc-ur>bignumber.js",
+      "app/main:@ngraveio/bc-ur>cbor-sync",
+      "app/main:@ngraveio/bc-ur>jsbi",
+      "app/main:@swc/helpers>tslib",
+      "app/main:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js",
+      "app/main:@trezor/connect-web>@trezor/utils>bignumber.js",
+      "app/main:@welldone-software/why-did-you-render",
+      "app/main:bignumber.js",
+      "app/main:bowser",
+      "app/main:browserify>punycode",
+      "app/main:chart.js>@kurkle/color",
+      "app/main:classnames",
+      "app/main:currency-formatter>accounting",
+      "app/main:eth-ens-namehash>idna-uts46-hx",
+      "app/main:eth-lattice-keyring>gridplus-sdk>aes-js",
+      "app/main:eth-lattice-keyring>gridplus-sdk>bignumber.js",
+      "app/main:eth-lattice-keyring>gridplus-sdk>borc>bignumber.js",
+      "app/main:ethers>@ethersproject/json-wallets>aes-js",
+      "app/main:ethers>@ethersproject/json-wallets>scrypt-js",
+      "app/main:fuse.js",
+      "app/main:he",
+      "app/main:history",
+      "app/main:localforage",
+      "app/main:lodash",
+      "app/main:loglevel",
+      "app/main:lottie-web",
+      "app/main:qrcode-generator",
+      "app/main:react-responsive-carousel>react-easy-swipe",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom-v5-compat>react-router",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/main:react-toggle-button",
+      "app/main:superstruct",
+      "app/main:uri-js",
+      "app/main:webextension-polyfill",
+      "app/flask:@ensdomains/content-hash>js-base64",
+      "app/flask:@ethereumjs/tx>@ethereumjs/common>crc-32",
+      "app/flask:@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js",
+      "app/flask:@metamask/ethjs>js-sha3",
+      "app/flask:@metamask/ppom-validator>crypto-js",
+      "app/flask:@metamask/smart-transactions-controller>bignumber.js",
+      "app/flask:@metamask/snaps-utils>marked",
+      "app/flask:@ngraveio/bc-ur>bignumber.js",
+      "app/flask:@ngraveio/bc-ur>cbor-sync",
+      "app/flask:@ngraveio/bc-ur>jsbi",
+      "app/flask:@swc/helpers>tslib",
+      "app/flask:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js",
+      "app/flask:@trezor/connect-web>@trezor/utils>bignumber.js",
+      "app/flask:@welldone-software/why-did-you-render",
+      "app/flask:bignumber.js",
+      "app/flask:bowser",
+      "app/flask:browserify>punycode",
+      "app/flask:chart.js>@kurkle/color",
+      "app/flask:classnames",
+      "app/flask:currency-formatter>accounting",
+      "app/flask:eth-ens-namehash>idna-uts46-hx",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>aes-js",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>bignumber.js",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>borc>bignumber.js",
+      "app/flask:ethers>@ethersproject/json-wallets>aes-js",
+      "app/flask:ethers>@ethersproject/json-wallets>scrypt-js",
+      "app/flask:fuse.js",
+      "app/flask:he",
+      "app/flask:history",
+      "app/flask:localforage",
+      "app/flask:lodash",
+      "app/flask:loglevel",
+      "app/flask:lottie-web",
+      "app/flask:qrcode-generator",
+      "app/flask:react-responsive-carousel>react-easy-swipe",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat>react-router",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/flask:react-toggle-button",
+      "app/flask:superstruct",
+      "app/flask:uri-js",
+      "app/flask:webextension-polyfill",
+      "app/beta:@ensdomains/content-hash>js-base64",
+      "app/beta:@ethereumjs/tx>@ethereumjs/common>crc-32",
+      "app/beta:@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js",
+      "app/beta:@metamask/ethjs>js-sha3",
+      "app/beta:@metamask/ppom-validator>crypto-js",
+      "app/beta:@metamask/smart-transactions-controller>bignumber.js",
+      "app/beta:@metamask/snaps-utils>marked",
+      "app/beta:@ngraveio/bc-ur>bignumber.js",
+      "app/beta:@ngraveio/bc-ur>cbor-sync",
+      "app/beta:@ngraveio/bc-ur>jsbi",
+      "app/beta:@swc/helpers>tslib",
+      "app/beta:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js",
+      "app/beta:@trezor/connect-web>@trezor/utils>bignumber.js",
+      "app/beta:@welldone-software/why-did-you-render",
+      "app/beta:bignumber.js",
+      "app/beta:bowser",
+      "app/beta:browserify>punycode",
+      "app/beta:chart.js>@kurkle/color",
+      "app/beta:classnames",
+      "app/beta:currency-formatter>accounting",
+      "app/beta:eth-ens-namehash>idna-uts46-hx",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>aes-js",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>bignumber.js",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>borc>bignumber.js",
+      "app/beta:ethers>@ethersproject/json-wallets>aes-js",
+      "app/beta:ethers>@ethersproject/json-wallets>scrypt-js",
+      "app/beta:fuse.js",
+      "app/beta:he",
+      "app/beta:history",
+      "app/beta:localforage",
+      "app/beta:lodash",
+      "app/beta:loglevel",
+      "app/beta:lottie-web",
+      "app/beta:qrcode-generator",
+      "app/beta:react-responsive-carousel>react-easy-swipe",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat>react-router",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/beta:react-toggle-button",
+      "app/beta:superstruct",
+      "app/beta:uri-js",
+      "app/beta:webextension-polyfill",
+      "app/mmi:@ensdomains/content-hash>js-base64",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/common>crc-32",
+      "app/mmi:@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js",
+      "app/mmi:@metamask/ethjs>js-sha3",
+      "app/mmi:@metamask/ppom-validator>crypto-js",
+      "app/mmi:@metamask/smart-transactions-controller>bignumber.js",
+      "app/mmi:@metamask/snaps-utils>marked",
+      "app/mmi:@ngraveio/bc-ur>bignumber.js",
+      "app/mmi:@ngraveio/bc-ur>cbor-sync",
+      "app/mmi:@ngraveio/bc-ur>jsbi",
+      "app/mmi:@swc/helpers>tslib",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js",
+      "app/mmi:@trezor/connect-web>@trezor/utils>bignumber.js",
+      "app/mmi:@welldone-software/why-did-you-render",
+      "app/mmi:bignumber.js",
+      "app/mmi:bowser",
+      "app/mmi:browserify>punycode",
+      "app/mmi:chart.js>@kurkle/color",
+      "app/mmi:classnames",
+      "app/mmi:currency-formatter>accounting",
+      "app/mmi:eth-ens-namehash>idna-uts46-hx",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>aes-js",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>bignumber.js",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>borc>bignumber.js",
+      "app/mmi:ethers>@ethersproject/json-wallets>aes-js",
+      "app/mmi:ethers>@ethersproject/json-wallets>scrypt-js",
+      "app/mmi:fuse.js",
+      "app/mmi:he",
+      "app/mmi:history",
+      "app/mmi:localforage",
+      "app/mmi:lodash",
+      "app/mmi:loglevel",
+      "app/mmi:lottie-web",
+      "app/mmi:qrcode-generator",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat>react-router",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js",
+      "app/mmi:react-toggle-button",
+      "app/mmi:superstruct",
+      "app/mmi:uri-js",
+      "app/mmi:webextension-polyfill",
+      "build/main:@babel/core>@ampproject/remapping",
+      "build/main:@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regenerate",
+      "build/main:@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsgen",
+      "build/main:@storybook/react>acorn-walk",
+      "build/main:browserify>syntax-error>acorn-node>acorn",
+      "build/main:eslint-plugin-jsdoc>@es-joy/jsdoccomment>jsdoc-type-pratt-parser",
+      "build/main:eslint>esquery",
+      "build/main:eta",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/identity-map>acorn",
+      "build/main:gulp-sourcemaps>acorn",
+      "build/main:jsdom>acorn",
+      "build/main:lavamoat-viz>lavamoat-core",
+      "build/main:lodash",
+      "build/main:nyc>spawn-wrap>is-windows",
+      "build/main:postcss-discard-font-face>postcss>js-base64",
+      "build/main:prettier",
+      "build/main:randomcolor",
+      "build/main:resolve-url-loader>rework>css>source-map-resolve>source-map-url",
+      "build/main:sass-embedded>immutable",
+      "build/main:stylelint>normalize-selector",
+      "build/main:stylelint>postcss-sass>gonzales-pe",
+      "build/main:stylelint>specificity",
+      "build/main:superstruct",
+      "build/main:terser",
+      "build/main:terser-webpack-plugin>@jridgewell/trace-mapping",
+      "build/main:terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri",
+      "build/main:terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec",
+      "build/main:terser>@jridgewell/source-map>@jridgewell/gen-mapping",
+      "build/main:terser>@jridgewell/source-map>@jridgewell/gen-mapping>@jridgewell/set-array",
+      "build/main:ts-node>@cspotcode/source-map-support>@jridgewell/trace-mapping",
+      "build/main:ts-node>acorn-walk",
+      "build/main:uri-js"
+    ],
+    "Buffer": [
+      "app/main:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/main:bn.js",
+      "app/main:browserify>assert",
+      "app/flask:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/flask:bn.js",
+      "app/flask:browserify>assert",
+      "app/beta:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/beta:bn.js",
+      "app/beta:browserify>assert",
+      "app/mmi:@ensdomains/content-hash>multicodec>uint8arrays",
+      "app/mmi:bn.js",
+      "app/mmi:browserify>assert",
+      "build/main:@babel/core>@babel/generator>jsesc",
+      "build/main:@babel/core>convert-source-map",
+      "build/main:@lavamoat/lavapack>combine-source-map>inline-source-map",
+      "build/main:@lavamoat/lavapack>convert-source-map",
+      "build/main:@metamask/build-utils>@metamask/utils",
+      "build/main:@metamask/jazzicon>color>clone",
+      "build/main:babelify",
+      "build/main:browserify>JSONStream",
+      "build/main:browserify>JSONStream>jsonparse",
+      "build/main:browserify>concat-stream",
+      "build/main:browserify>insert-module-globals",
+      "build/main:browserify>shasum-object",
+      "build/main:cross-spawn",
+      "build/main:duplexify",
+      "build/main:fs-extra",
+      "build/main:fs-extra>jsonfile",
+      "build/main:gulp-livereload>event-stream",
+      "build/main:gulp-livereload>tiny-lr>body>raw-body",
+      "build/main:gulp-livereload>tiny-lr>faye-websocket",
+      "build/main:gulp-postcss",
+      "build/main:gulp-postcss>postcss-load-config>yaml",
+      "build/main:gulp-sourcemaps",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss",
+      "build/main:gulp-sourcemaps>css>source-map-resolve>atob",
+      "build/main:gulp-stylelint",
+      "build/main:gulp-watch>vinyl-file>strip-bom",
+      "build/main:gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream",
+      "build/main:gulp-zip>get-stream",
+      "build/main:gulp-zip>yazl",
+      "build/main:gulp>vinyl-fs",
+      "build/main:gulp>vinyl-fs>glob-stream>pumpify>duplexify",
+      "build/main:gulp>vinyl-fs>lead>flush-write-stream",
+      "build/main:gulp>vinyl-fs>pumpify>duplexify",
+      "build/main:gulp>vinyl-fs>vinyl-sourcemap",
+      "build/main:gulp>vinyl-fs>vinyl-sourcemap>append-buffer",
+      "build/main:lavamoat-browserify>concat-stream",
+      "build/main:lavamoat-browserify>duplexify",
+      "build/main:lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>kind-of",
+      "build/main:nyc>convert-source-map",
+      "build/main:postcss",
+      "build/main:prettier",
+      "build/main:readable-stream-2>core-util-is",
+      "build/main:sass",
+      "build/main:sass-embedded",
+      "build/main:sass-embedded>buffer-builder",
+      "build/main:stylelint>cosmiconfig>yaml",
+      "build/main:stylelint>postcss",
+      "build/main:stylelint>postcss-less>postcss",
+      "build/main:stylelint>postcss-safe-parser>postcss",
+      "build/main:stylelint>postcss-sass>postcss",
+      "build/main:stylelint>postcss-scss>postcss",
+      "build/main:stylelint>sugarss>postcss",
+      "build/main:stylelint>write-file-atomic",
+      "build/main:stylelint>write-file-atomic>typedarray-to-buffer",
+      "build/main:terser",
+      "build/main:terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec",
+      "build/main:terser>source-map-support>buffer-from",
+      "build/main:ts-node",
+      "build/main:ts-node>@cspotcode/source-map-support",
+      "build/main:ts-node>v8-compile-cache-lib",
+      "build/main:vinyl>clone",
+      "build/main:webpack>json-parse-even-better-errors",
+      "build/main:yaml",
+      "build/override:sass"
+    ],
+    "crypto": [
+      "app/main:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/main:@ethereumjs/tx>ethereum-cryptography",
+      "app/main:@ethereumjs/tx>ethereum-cryptography>@noble/hashes",
+      "app/main:@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes",
+      "app/main:@ethersproject/providers>@ethersproject/random",
+      "app/main:@metamask/approval-controller>nanoid",
+      "app/main:@metamask/browser-passworder",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js",
+      "app/main:@metamask/eth-sig-util>tweetnacl",
+      "app/main:@metamask/eth-snap-keyring>uuid",
+      "app/main:@metamask/keyring-api>uuid",
+      "app/main:@metamask/message-signing-snap>@noble/ciphers",
+      "app/main:@metamask/message-signing-snap>@noble/curves>@noble/hashes",
+      "app/main:@metamask/notification-controller>nanoid",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/main:@metamask/permission-controller>nanoid",
+      "app/main:@metamask/ppom-validator",
+      "app/main:@metamask/ppom-validator>crypto-js",
+      "app/main:@metamask/ppom-validator>elliptic>brorand",
+      "app/main:@metamask/profile-sync-controller>siwe>@stablelib/random",
+      "app/main:@metamask/rpc-methods-flask>nanoid",
+      "app/main:@metamask/rpc-methods>nanoid",
+      "app/main:@metamask/scure-bip39>@noble/hashes",
+      "app/main:@metamask/smart-transactions-controller>@metamask/controllers>nanoid",
+      "app/main:@metamask/smart-transactions-controller>bignumber.js",
+      "app/main:@metamask/snaps-controllers-flask>nanoid",
+      "app/main:@metamask/snaps-controllers>nanoid",
+      "app/main:@metamask/snaps-rpc-methods>@metamask/permission-controller>nanoid",
+      "app/main:@metamask/snaps-utils",
+      "app/main:@metamask/snaps-utils>@metamask/permission-controller>nanoid",
+      "app/main:@ngraveio/bc-ur>bignumber.js",
+      "app/main:@noble/hashes",
+      "app/main:@solana/addresses",
+      "app/main:@solana/addresses>@solana/assertions",
+      "app/main:@trezor/connect-web>@trezor/utils>bignumber.js",
+      "app/main:bignumber.js",
+      "app/main:crypto-browserify>pbkdf2",
+      "app/main:crypto-browserify>randombytes",
+      "app/main:crypto-browserify>randomfill",
+      "app/main:depcheck>@vue/compiler-sfc>postcss>nanoid",
+      "app/main:dependency-tree>precinct>detective-postcss>postcss>nanoid",
+      "app/main:eth-keyring-controller>@metamask/browser-passworder",
+      "app/main:eth-lattice-keyring>gridplus-sdk>bignumber.js",
+      "app/main:eth-lattice-keyring>gridplus-sdk>borc>bignumber.js",
+      "app/main:eth-lattice-keyring>gridplus-sdk>uuid",
+      "app/main:ethereumjs-wallet>randombytes",
+      "app/main:nanoid",
+      "app/main:uuid",
+      "app/main:web3-stream-provider>uuid",
+      "app/flask:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/flask:@ethereumjs/tx>ethereum-cryptography",
+      "app/flask:@ethereumjs/tx>ethereum-cryptography>@noble/hashes",
+      "app/flask:@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes",
+      "app/flask:@ethersproject/providers>@ethersproject/random",
+      "app/flask:@metamask/approval-controller>nanoid",
+      "app/flask:@metamask/browser-passworder",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js",
+      "app/flask:@metamask/eth-sig-util>tweetnacl",
+      "app/flask:@metamask/eth-snap-keyring>uuid",
+      "app/flask:@metamask/keyring-api>uuid",
+      "app/flask:@metamask/message-signing-snap>@noble/ciphers",
+      "app/flask:@metamask/message-signing-snap>@noble/curves>@noble/hashes",
+      "app/flask:@metamask/notification-controller>nanoid",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/permission-controller>nanoid",
+      "app/flask:@metamask/ppom-validator",
+      "app/flask:@metamask/ppom-validator>crypto-js",
+      "app/flask:@metamask/ppom-validator>elliptic>brorand",
+      "app/flask:@metamask/profile-sync-controller>siwe>@stablelib/random",
+      "app/flask:@metamask/rpc-methods-flask>nanoid",
+      "app/flask:@metamask/rpc-methods>nanoid",
+      "app/flask:@metamask/scure-bip39>@noble/hashes",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/controllers>nanoid",
+      "app/flask:@metamask/smart-transactions-controller>bignumber.js",
+      "app/flask:@metamask/snaps-controllers-flask>nanoid",
+      "app/flask:@metamask/snaps-controllers>nanoid",
+      "app/flask:@metamask/snaps-rpc-methods>@metamask/permission-controller>nanoid",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:@metamask/snaps-utils>@metamask/permission-controller>nanoid",
+      "app/flask:@ngraveio/bc-ur>bignumber.js",
+      "app/flask:@noble/hashes",
+      "app/flask:@solana/addresses",
+      "app/flask:@solana/addresses>@solana/assertions",
+      "app/flask:@trezor/connect-web>@trezor/utils>bignumber.js",
+      "app/flask:bignumber.js",
+      "app/flask:crypto-browserify>pbkdf2",
+      "app/flask:crypto-browserify>randombytes",
+      "app/flask:crypto-browserify>randomfill",
+      "app/flask:depcheck>@vue/compiler-sfc>postcss>nanoid",
+      "app/flask:dependency-tree>precinct>detective-postcss>postcss>nanoid",
+      "app/flask:eth-keyring-controller>@metamask/browser-passworder",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>bignumber.js",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>borc>bignumber.js",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>uuid",
+      "app/flask:ethereumjs-wallet>randombytes",
+      "app/flask:nanoid",
+      "app/flask:uuid",
+      "app/flask:web3-stream-provider>uuid",
+      "app/beta:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/beta:@ethereumjs/tx>ethereum-cryptography",
+      "app/beta:@ethereumjs/tx>ethereum-cryptography>@noble/hashes",
+      "app/beta:@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes",
+      "app/beta:@ethersproject/providers>@ethersproject/random",
+      "app/beta:@metamask/approval-controller>nanoid",
+      "app/beta:@metamask/browser-passworder",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js",
+      "app/beta:@metamask/eth-sig-util>tweetnacl",
+      "app/beta:@metamask/eth-snap-keyring>uuid",
+      "app/beta:@metamask/keyring-api>uuid",
+      "app/beta:@metamask/message-signing-snap>@noble/ciphers",
+      "app/beta:@metamask/message-signing-snap>@noble/curves>@noble/hashes",
+      "app/beta:@metamask/notification-controller>nanoid",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/permission-controller>nanoid",
+      "app/beta:@metamask/ppom-validator",
+      "app/beta:@metamask/ppom-validator>crypto-js",
+      "app/beta:@metamask/ppom-validator>elliptic>brorand",
+      "app/beta:@metamask/profile-sync-controller>siwe>@stablelib/random",
+      "app/beta:@metamask/rpc-methods-flask>nanoid",
+      "app/beta:@metamask/rpc-methods>nanoid",
+      "app/beta:@metamask/scure-bip39>@noble/hashes",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/controllers>nanoid",
+      "app/beta:@metamask/smart-transactions-controller>bignumber.js",
+      "app/beta:@metamask/snaps-controllers-flask>nanoid",
+      "app/beta:@metamask/snaps-controllers>nanoid",
+      "app/beta:@metamask/snaps-rpc-methods>@metamask/permission-controller>nanoid",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:@metamask/snaps-utils>@metamask/permission-controller>nanoid",
+      "app/beta:@ngraveio/bc-ur>bignumber.js",
+      "app/beta:@noble/hashes",
+      "app/beta:@solana/addresses",
+      "app/beta:@solana/addresses>@solana/assertions",
+      "app/beta:@trezor/connect-web>@trezor/utils>bignumber.js",
+      "app/beta:bignumber.js",
+      "app/beta:crypto-browserify>pbkdf2",
+      "app/beta:crypto-browserify>randombytes",
+      "app/beta:crypto-browserify>randomfill",
+      "app/beta:depcheck>@vue/compiler-sfc>postcss>nanoid",
+      "app/beta:dependency-tree>precinct>detective-postcss>postcss>nanoid",
+      "app/beta:eth-keyring-controller>@metamask/browser-passworder",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>bignumber.js",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>borc>bignumber.js",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>uuid",
+      "app/beta:ethereumjs-wallet>randombytes",
+      "app/beta:nanoid",
+      "app/beta:uuid",
+      "app/beta:web3-stream-provider>uuid",
+      "app/mmi:@ensdomains/content-hash>multicodec>uint8arrays>multiformats",
+      "app/mmi:@ethereumjs/tx>ethereum-cryptography",
+      "app/mmi:@ethereumjs/tx>ethereum-cryptography>@noble/hashes",
+      "app/mmi:@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes",
+      "app/mmi:@ethersproject/providers>@ethersproject/random",
+      "app/mmi:@metamask/approval-controller>nanoid",
+      "app/mmi:@metamask/browser-passworder",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js",
+      "app/mmi:@metamask/eth-sig-util>tweetnacl",
+      "app/mmi:@metamask/eth-snap-keyring>uuid",
+      "app/mmi:@metamask/keyring-api>uuid",
+      "app/mmi:@metamask/message-signing-snap>@noble/ciphers",
+      "app/mmi:@metamask/message-signing-snap>@noble/curves>@noble/hashes",
+      "app/mmi:@metamask/notification-controller>nanoid",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/permission-controller>nanoid",
+      "app/mmi:@metamask/ppom-validator",
+      "app/mmi:@metamask/ppom-validator>crypto-js",
+      "app/mmi:@metamask/ppom-validator>elliptic>brorand",
+      "app/mmi:@metamask/profile-sync-controller>siwe>@stablelib/random",
+      "app/mmi:@metamask/rpc-methods-flask>nanoid",
+      "app/mmi:@metamask/rpc-methods>nanoid",
+      "app/mmi:@metamask/scure-bip39>@noble/hashes",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/controllers>nanoid",
+      "app/mmi:@metamask/smart-transactions-controller>bignumber.js",
+      "app/mmi:@metamask/snaps-controllers-flask>nanoid",
+      "app/mmi:@metamask/snaps-controllers>nanoid",
+      "app/mmi:@metamask/snaps-rpc-methods>@metamask/permission-controller>nanoid",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:@metamask/snaps-utils>@metamask/permission-controller>nanoid",
+      "app/mmi:@ngraveio/bc-ur>bignumber.js",
+      "app/mmi:@noble/hashes",
+      "app/mmi:@solana/addresses",
+      "app/mmi:@solana/addresses>@solana/assertions",
+      "app/mmi:@trezor/connect-web>@trezor/utils>bignumber.js",
+      "app/mmi:bignumber.js",
+      "app/mmi:crypto-browserify>pbkdf2",
+      "app/mmi:crypto-browserify>randombytes",
+      "app/mmi:crypto-browserify>randomfill",
+      "app/mmi:depcheck>@vue/compiler-sfc>postcss>nanoid",
+      "app/mmi:dependency-tree>precinct>detective-postcss>postcss>nanoid",
+      "app/mmi:eth-keyring-controller>@metamask/browser-passworder",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>bignumber.js",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>borc>bignumber.js",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>uuid",
+      "app/mmi:ethereumjs-wallet>randombytes",
+      "app/mmi:nanoid",
+      "app/mmi:uuid",
+      "app/mmi:web3-stream-provider>uuid",
+      "app/override:@ethersproject/providers>@ethersproject/random",
+      "app/override:eth-keyring-controller>@metamask/browser-passworder",
+      "app/override:eth-lattice-keyring>gridplus-sdk>uuid",
+      "app/override:ethereumjs-wallet>randombytes",
+      "app/override:nanoid",
+      "app/override:@metamask/approval-controller>nanoid",
+      "app/override:@metamask/permission-controller>nanoid",
+      "app/override:@metamask/notification-controller>nanoid",
+      "app/override:@metamask/snaps-controllers>nanoid",
+      "app/override:@metamask/snaps-controllers-flask>nanoid",
+      "app/override:@metamask/rpc-methods>nanoid",
+      "app/override:@metamask/rpc-methods-flask>nanoid",
+      "app/override:@metamask/smart-transactions-controller>@metamask/controllers>nanoid",
+      "app/override:depcheck>@vue/compiler-sfc>postcss>nanoid",
+      "app/override:dependency-tree>precinct>detective-postcss>postcss>nanoid",
+      "build/main:@noble/hashes"
+    ],
+    "DO_NOT_EXPORT_CRC": [
+      "app/main:@ethereumjs/tx>@ethereumjs/common>crc-32",
+      "app/flask:@ethereumjs/tx>@ethereumjs/common>crc-32",
+      "app/beta:@ethereumjs/tx>@ethereumjs/common>crc-32",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/common>crc-32"
+    ],
+    "Headers": [
+      "app/main:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/main:@metamask/assets-controllers",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@sentry/utils",
+      "app/main:node-fetch",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/utils",
+      "app/flask:node-fetch",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/utils",
+      "app/beta:node-fetch",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/utils",
+      "app/mmi:node-fetch",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router",
+      "app/override:node-fetch"
+    ],
+    "URL": [
+      "app/main:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/main:@metamask/assets-controllers",
+      "app/main:@metamask/controller-utils",
+      "app/main:@metamask/eth-json-rpc-middleware",
+      "app/main:@metamask/eth-snap-keyring",
+      "app/main:@metamask/etherscan-link",
+      "app/main:@metamask/keyring-api",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/phishing-controller",
+      "app/main:@metamask/ppom-validator",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@metamask/snaps-controllers",
+      "app/main:@metamask/snaps-utils",
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@sentry/utils",
+      "app/main:@zxing/library",
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/main:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/main:lottie-web",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@metamask/controller-utils",
+      "app/flask:@metamask/eth-json-rpc-middleware",
+      "app/flask:@metamask/eth-snap-keyring",
+      "app/flask:@metamask/etherscan-link",
+      "app/flask:@metamask/keyring-api",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/phishing-controller",
+      "app/flask:@metamask/ppom-validator",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@metamask/snaps-controllers",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/utils",
+      "app/flask:@zxing/library",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/flask:lottie-web",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@metamask/controller-utils",
+      "app/beta:@metamask/eth-json-rpc-middleware",
+      "app/beta:@metamask/eth-snap-keyring",
+      "app/beta:@metamask/etherscan-link",
+      "app/beta:@metamask/keyring-api",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/phishing-controller",
+      "app/beta:@metamask/ppom-validator",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@metamask/snaps-controllers",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/utils",
+      "app/beta:@zxing/library",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/beta:lottie-web",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/mmi:@metamask-institutional/rpc-allowlist",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@metamask/controller-utils",
+      "app/mmi:@metamask/eth-json-rpc-middleware",
+      "app/mmi:@metamask/eth-snap-keyring",
+      "app/mmi:@metamask/etherscan-link",
+      "app/mmi:@metamask/keyring-api",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/phishing-controller",
+      "app/mmi:@metamask/ppom-validator",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@metamask/snaps-controllers",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@zxing/library",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/mmi:lottie-web",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router",
+      "build/main:@babel/core",
+      "build/main:postcss",
+      "build/main:sass-embedded",
+      "build/main:ts-node>@cspotcode/source-map-support"
+    ],
+    "fetch": [
+      "app/main:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/main:@ethersproject/providers>@ethersproject/web",
+      "app/main:@metamask/controller-utils",
+      "app/main:@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch",
+      "app/main:@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch",
+      "app/main:@metamask/eth-ledger-bridge-keyring",
+      "app/main:@metamask/name-controller",
+      "app/main:@metamask/network-controller",
+      "app/main:@metamask/notification-services-controller",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/phishing-controller",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@metamask/signature-controller",
+      "app/main:@metamask/smart-transactions-controller",
+      "app/main:@metamask/smart-transactions-controller>@ethereumjs/util",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/main:@metamask/snaps-controllers",
+      "app/main:@metamask/snaps-sdk",
+      "app/main:@metamask/snaps-utils",
+      "app/main:@metamask/transaction-controller",
+      "app/main:@metamask/user-operation-controller",
+      "app/main:eth-lattice-keyring",
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/main:eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util",
+      "app/main:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/main:ethers>@ethersproject/web",
+      "app/main:localforage",
+      "app/main:node-fetch",
+      "app/main:stream-http",
+      "app/flask:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/flask:@ethersproject/providers>@ethersproject/web",
+      "app/flask:@metamask/controller-utils",
+      "app/flask:@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch",
+      "app/flask:@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch",
+      "app/flask:@metamask/eth-ledger-bridge-keyring",
+      "app/flask:@metamask/name-controller",
+      "app/flask:@metamask/network-controller",
+      "app/flask:@metamask/notification-services-controller",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/phishing-controller",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@metamask/signature-controller",
+      "app/flask:@metamask/smart-transactions-controller",
+      "app/flask:@metamask/smart-transactions-controller>@ethereumjs/util",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/flask:@metamask/snaps-controllers",
+      "app/flask:@metamask/snaps-sdk",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:@metamask/transaction-controller",
+      "app/flask:@metamask/user-operation-controller",
+      "app/flask:eth-lattice-keyring",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util",
+      "app/flask:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/flask:ethers>@ethersproject/web",
+      "app/flask:localforage",
+      "app/flask:node-fetch",
+      "app/flask:stream-http",
+      "app/beta:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/beta:@ethersproject/providers>@ethersproject/web",
+      "app/beta:@metamask/controller-utils",
+      "app/beta:@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch",
+      "app/beta:@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch",
+      "app/beta:@metamask/eth-ledger-bridge-keyring",
+      "app/beta:@metamask/name-controller",
+      "app/beta:@metamask/network-controller",
+      "app/beta:@metamask/notification-services-controller",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/phishing-controller",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@metamask/signature-controller",
+      "app/beta:@metamask/smart-transactions-controller",
+      "app/beta:@metamask/smart-transactions-controller>@ethereumjs/util",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/beta:@metamask/snaps-controllers",
+      "app/beta:@metamask/snaps-sdk",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:@metamask/transaction-controller",
+      "app/beta:@metamask/user-operation-controller",
+      "app/beta:eth-lattice-keyring",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util",
+      "app/beta:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/beta:ethers>@ethersproject/web",
+      "app/beta:localforage",
+      "app/beta:node-fetch",
+      "app/beta:stream-http",
+      "app/mmi:@ethereumjs/tx>@ethereumjs/util>micro-ftch",
+      "app/mmi:@ethersproject/providers>@ethersproject/web",
+      "app/mmi:@metamask-institutional/custody-keyring>@metamask-institutional/configuration-client",
+      "app/mmi:@metamask-institutional/sdk",
+      "app/mmi:@metamask/controller-utils",
+      "app/mmi:@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch",
+      "app/mmi:@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring",
+      "app/mmi:@metamask/name-controller",
+      "app/mmi:@metamask/network-controller",
+      "app/mmi:@metamask/notification-services-controller",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/phishing-controller",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@metamask/signature-controller",
+      "app/mmi:@metamask/smart-transactions-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@ethereumjs/util",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/mmi:@metamask/snaps-controllers",
+      "app/mmi:@metamask/snaps-sdk",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:@metamask/transaction-controller",
+      "app/mmi:@metamask/user-operation-controller",
+      "app/mmi:eth-lattice-keyring",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util",
+      "app/mmi:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/mmi:ethers>@ethersproject/web",
+      "app/mmi:localforage",
+      "app/mmi:node-fetch",
+      "app/mmi:stream-http",
+      "app/override:@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch",
+      "app/override:@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch",
+      "app/override:node-fetch",
+      "build/main:source-map"
+    ],
+    "setTimeout": [
+      "app/main:@ethersproject/contracts",
+      "app/main:@ethersproject/providers",
+      "app/main:@ethersproject/providers>@ethersproject/web",
+      "app/main:@material-ui/core",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@material-ui/core>react-transition-group",
+      "app/main:@metamask/announcement-controller>@metamask/base-controller",
+      "app/main:@metamask/assets-controllers",
+      "app/main:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/main:@metamask/base-controller",
+      "app/main:@metamask/controller-utils",
+      "app/main:@metamask/ens-controller>@metamask/base-controller",
+      "app/main:@metamask/eth-json-rpc-middleware",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/main:@metamask/eth-trezor-keyring",
+      "app/main:@metamask/gas-fee-controller>@metamask/base-controller",
+      "app/main:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/main:@metamask/json-rpc-middleware-stream",
+      "app/main:@metamask/name-controller>@metamask/base-controller",
+      "app/main:@metamask/name-controller>async-mutex",
+      "app/main:@metamask/network-controller",
+      "app/main:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-infura",
+      "app/main:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/main:@metamask/notification-controller>@metamask/base-controller",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@metamask/permission-controller>@metamask/base-controller",
+      "app/main:@metamask/permission-log-controller>@metamask/base-controller",
+      "app/main:@metamask/polling-controller",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@metamask/rate-limit-controller",
+      "app/main:@metamask/rate-limit-controller>@metamask/base-controller",
+      "app/main:@metamask/safe-event-emitter",
+      "app/main:@metamask/smart-transactions-controller>@metamask/base-controller",
+      "app/main:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/main:@metamask/snaps-controllers",
+      "app/main:@metamask/transaction-controller",
+      "app/main:@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/main:@metamask/user-operation-controller>@metamask/base-controller",
+      "app/main:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/main:@reduxjs/toolkit",
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@sentry/utils",
+      "app/main:@trezor/connect-web",
+      "app/main:@trezor/connect-web>@trezor/connect-common",
+      "app/main:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs",
+      "app/main:@trezor/connect-web>@trezor/utils",
+      "app/main:@welldone-software/why-did-you-render",
+      "app/main:@zxing/browser",
+      "app/main:@zxing/library",
+      "app/main:browserify>timers-browserify",
+      "app/main:chart.js",
+      "app/main:cockatiel",
+      "app/main:crypto-browserify>pbkdf2",
+      "app/main:debounce-stream>debounce",
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/main:ethers>@ethersproject/json-wallets>scrypt-js",
+      "app/main:ethers>@ethersproject/providers",
+      "app/main:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/main:ethers>@ethersproject/web",
+      "app/main:fast-json-patch",
+      "app/main:localforage",
+      "app/main:lodash",
+      "app/main:lottie-web",
+      "app/main:process",
+      "app/main:promise-to-callback>set-immediate-shim",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-chartjs-2",
+      "app/main:react-devtools>react-devtools-core",
+      "app/main:react-dom",
+      "app/main:react-dom>scheduler",
+      "app/main:react-focus-lock",
+      "app/main:react-focus-lock>focus-lock",
+      "app/main:react-idle-timer",
+      "app/main:react-responsive-carousel",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/main:react-toggle-button",
+      "app/main:stream-http",
+      "app/main:wait-on>rxjs",
+      "app/main:web3-stream-provider",
+      "app/flask:@ethersproject/contracts",
+      "app/flask:@ethersproject/providers",
+      "app/flask:@ethersproject/providers>@ethersproject/web",
+      "app/flask:@material-ui/core",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@material-ui/core>react-transition-group",
+      "app/flask:@metamask/announcement-controller>@metamask/base-controller",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/flask:@metamask/base-controller",
+      "app/flask:@metamask/controller-utils",
+      "app/flask:@metamask/ens-controller>@metamask/base-controller",
+      "app/flask:@metamask/eth-json-rpc-middleware",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/flask:@metamask/eth-trezor-keyring",
+      "app/flask:@metamask/gas-fee-controller>@metamask/base-controller",
+      "app/flask:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/flask:@metamask/json-rpc-middleware-stream",
+      "app/flask:@metamask/name-controller>@metamask/base-controller",
+      "app/flask:@metamask/name-controller>async-mutex",
+      "app/flask:@metamask/network-controller",
+      "app/flask:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-infura",
+      "app/flask:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/flask:@metamask/notification-controller>@metamask/base-controller",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@metamask/permission-controller>@metamask/base-controller",
+      "app/flask:@metamask/permission-log-controller>@metamask/base-controller",
+      "app/flask:@metamask/polling-controller",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@metamask/rate-limit-controller",
+      "app/flask:@metamask/rate-limit-controller>@metamask/base-controller",
+      "app/flask:@metamask/safe-event-emitter",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/base-controller",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/flask:@metamask/snaps-controllers",
+      "app/flask:@metamask/transaction-controller",
+      "app/flask:@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/flask:@metamask/user-operation-controller>@metamask/base-controller",
+      "app/flask:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/flask:@reduxjs/toolkit",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/utils",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@trezor/connect-web>@trezor/connect-common",
+      "app/flask:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs",
+      "app/flask:@trezor/connect-web>@trezor/utils",
+      "app/flask:@welldone-software/why-did-you-render",
+      "app/flask:@zxing/browser",
+      "app/flask:@zxing/library",
+      "app/flask:browserify>timers-browserify",
+      "app/flask:chart.js",
+      "app/flask:cockatiel",
+      "app/flask:crypto-browserify>pbkdf2",
+      "app/flask:debounce-stream>debounce",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:ethers>@ethersproject/json-wallets>scrypt-js",
+      "app/flask:ethers>@ethersproject/providers",
+      "app/flask:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/flask:ethers>@ethersproject/web",
+      "app/flask:fast-json-patch",
+      "app/flask:localforage",
+      "app/flask:lodash",
+      "app/flask:lottie-web",
+      "app/flask:process",
+      "app/flask:promise-to-callback>set-immediate-shim",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-chartjs-2",
+      "app/flask:react-devtools>react-devtools-core",
+      "app/flask:react-dom",
+      "app/flask:react-dom>scheduler",
+      "app/flask:react-focus-lock",
+      "app/flask:react-focus-lock>focus-lock",
+      "app/flask:react-idle-timer",
+      "app/flask:react-responsive-carousel",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/flask:react-toggle-button",
+      "app/flask:stream-http",
+      "app/flask:wait-on>rxjs",
+      "app/flask:web3-stream-provider",
+      "app/beta:@ethersproject/contracts",
+      "app/beta:@ethersproject/providers",
+      "app/beta:@ethersproject/providers>@ethersproject/web",
+      "app/beta:@material-ui/core",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@material-ui/core>react-transition-group",
+      "app/beta:@metamask/announcement-controller>@metamask/base-controller",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/beta:@metamask/base-controller",
+      "app/beta:@metamask/controller-utils",
+      "app/beta:@metamask/ens-controller>@metamask/base-controller",
+      "app/beta:@metamask/eth-json-rpc-middleware",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/beta:@metamask/eth-trezor-keyring",
+      "app/beta:@metamask/gas-fee-controller>@metamask/base-controller",
+      "app/beta:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/beta:@metamask/json-rpc-middleware-stream",
+      "app/beta:@metamask/name-controller>@metamask/base-controller",
+      "app/beta:@metamask/name-controller>async-mutex",
+      "app/beta:@metamask/network-controller",
+      "app/beta:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-infura",
+      "app/beta:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/beta:@metamask/notification-controller>@metamask/base-controller",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@metamask/permission-controller>@metamask/base-controller",
+      "app/beta:@metamask/permission-log-controller>@metamask/base-controller",
+      "app/beta:@metamask/polling-controller",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@metamask/rate-limit-controller",
+      "app/beta:@metamask/rate-limit-controller>@metamask/base-controller",
+      "app/beta:@metamask/safe-event-emitter",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/base-controller",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/beta:@metamask/snaps-controllers",
+      "app/beta:@metamask/transaction-controller",
+      "app/beta:@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/beta:@metamask/user-operation-controller>@metamask/base-controller",
+      "app/beta:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/beta:@reduxjs/toolkit",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/utils",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@trezor/connect-web>@trezor/connect-common",
+      "app/beta:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs",
+      "app/beta:@trezor/connect-web>@trezor/utils",
+      "app/beta:@welldone-software/why-did-you-render",
+      "app/beta:@zxing/browser",
+      "app/beta:@zxing/library",
+      "app/beta:browserify>timers-browserify",
+      "app/beta:chart.js",
+      "app/beta:cockatiel",
+      "app/beta:crypto-browserify>pbkdf2",
+      "app/beta:debounce-stream>debounce",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:ethers>@ethersproject/json-wallets>scrypt-js",
+      "app/beta:ethers>@ethersproject/providers",
+      "app/beta:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/beta:ethers>@ethersproject/web",
+      "app/beta:fast-json-patch",
+      "app/beta:localforage",
+      "app/beta:lodash",
+      "app/beta:lottie-web",
+      "app/beta:process",
+      "app/beta:promise-to-callback>set-immediate-shim",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-chartjs-2",
+      "app/beta:react-devtools>react-devtools-core",
+      "app/beta:react-dom",
+      "app/beta:react-dom>scheduler",
+      "app/beta:react-focus-lock",
+      "app/beta:react-focus-lock>focus-lock",
+      "app/beta:react-idle-timer",
+      "app/beta:react-responsive-carousel",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/beta:react-toggle-button",
+      "app/beta:stream-http",
+      "app/beta:wait-on>rxjs",
+      "app/beta:web3-stream-provider",
+      "app/mmi:@ethersproject/contracts",
+      "app/mmi:@ethersproject/providers",
+      "app/mmi:@ethersproject/providers>@ethersproject/web",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@material-ui/core>react-transition-group",
+      "app/mmi:@metamask-institutional/transaction-update>@metamask-institutional/websocket-client",
+      "app/mmi:@metamask/announcement-controller>@metamask/base-controller",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/mmi:@metamask/base-controller",
+      "app/mmi:@metamask/controller-utils",
+      "app/mmi:@metamask/ens-controller>@metamask/base-controller",
+      "app/mmi:@metamask/eth-json-rpc-middleware",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/mmi:@metamask/eth-trezor-keyring",
+      "app/mmi:@metamask/gas-fee-controller>@metamask/base-controller",
+      "app/mmi:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/mmi:@metamask/json-rpc-middleware-stream",
+      "app/mmi:@metamask/name-controller>@metamask/base-controller",
+      "app/mmi:@metamask/name-controller>async-mutex",
+      "app/mmi:@metamask/network-controller",
+      "app/mmi:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-infura",
+      "app/mmi:@metamask/network-controller>@metamask/eth-json-rpc-middleware",
+      "app/mmi:@metamask/notification-controller>@metamask/base-controller",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@metamask/permission-controller>@metamask/base-controller",
+      "app/mmi:@metamask/permission-log-controller>@metamask/base-controller",
+      "app/mmi:@metamask/polling-controller",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@metamask/rate-limit-controller",
+      "app/mmi:@metamask/rate-limit-controller>@metamask/base-controller",
+      "app/mmi:@metamask/safe-event-emitter",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/base-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/mmi:@metamask/snaps-controllers",
+      "app/mmi:@metamask/transaction-controller",
+      "app/mmi:@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/mmi:@metamask/user-operation-controller>@metamask/base-controller",
+      "app/mmi:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/mmi:@reduxjs/toolkit",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common",
+      "app/mmi:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs",
+      "app/mmi:@trezor/connect-web>@trezor/utils",
+      "app/mmi:@welldone-software/why-did-you-render",
+      "app/mmi:@zxing/browser",
+      "app/mmi:@zxing/library",
+      "app/mmi:browserify>timers-browserify",
+      "app/mmi:chart.js",
+      "app/mmi:cockatiel",
+      "app/mmi:crypto-browserify>pbkdf2",
+      "app/mmi:debounce-stream>debounce",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:ethers>@ethersproject/json-wallets>scrypt-js",
+      "app/mmi:ethers>@ethersproject/providers",
+      "app/mmi:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/mmi:ethers>@ethersproject/web",
+      "app/mmi:fast-json-patch",
+      "app/mmi:localforage",
+      "app/mmi:lodash",
+      "app/mmi:lottie-web",
+      "app/mmi:process",
+      "app/mmi:promise-to-callback>set-immediate-shim",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-chartjs-2",
+      "app/mmi:react-devtools>react-devtools-core",
+      "app/mmi:react-dom",
+      "app/mmi:react-dom>scheduler",
+      "app/mmi:react-focus-lock",
+      "app/mmi:react-focus-lock>focus-lock",
+      "app/mmi:react-idle-timer",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js",
+      "app/mmi:react-toggle-button",
+      "app/mmi:stream-http",
+      "app/mmi:wait-on>rxjs",
+      "app/mmi:web3-stream-provider",
+      "app/override:lodash",
+      "app/override:react-devtools>react-devtools-core",
+      "app/override:@metamask/announcement-controller>@metamask/base-controller",
+      "build/main:@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>lodash.debounce",
+      "build/main:@lavamoat/lavapack",
+      "build/main:browserify>module-deps",
+      "build/main:chokidar",
+      "build/main:del>graceful-fs",
+      "build/main:del>rimraf",
+      "build/main:fs-extra",
+      "build/main:gh-pages>globby>pinkie-promise>pinkie",
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee",
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee>next-tick",
+      "build/main:gulp-watch",
+      "build/main:gulp-watch>chokidar",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf",
+      "build/main:gulp>glob-watcher>just-debounce",
+      "build/main:lavamoat-browserify",
+      "build/main:prettier",
+      "build/main:stylelint>file-entry-cache>flat-cache>rimraf",
+      "build/main:ts-node>diff",
+      "build/main:typescript",
+      "build/main:wait-on>rxjs",
+      "build/main:watchify",
+      "build/override:gulp-watch>chokidar",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf"
+    ],
+    "WebSocket": [
+      "app/main:@ethersproject/providers",
+      "app/main:ethers>@ethersproject/providers",
+      "app/main:react-devtools>react-devtools-core",
+      "app/flask:@ethersproject/providers",
+      "app/flask:ethers>@ethersproject/providers",
+      "app/flask:react-devtools>react-devtools-core",
+      "app/beta:@ethersproject/providers",
+      "app/beta:ethers>@ethersproject/providers",
+      "app/beta:react-devtools>react-devtools-core",
+      "app/mmi:@ethersproject/providers",
+      "app/mmi:@metamask-institutional/transaction-update>@metamask-institutional/websocket-client",
+      "app/mmi:ethers>@ethersproject/providers",
+      "app/mmi:react-devtools>react-devtools-core",
+      "app/override:react-devtools>react-devtools-core"
+    ],
+    "clearInterval": [
+      "app/main:@ethersproject/providers",
+      "app/main:@material-ui/core",
+      "app/main:@metamask/assets-controllers",
+      "app/main:@metamask/ethjs",
+      "app/main:@metamask/ethjs>@metamask/ethjs-filter",
+      "app/main:@metamask/gas-fee-controller",
+      "app/main:@metamask/smart-transactions-controller",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@trezor/connect-web",
+      "app/main:@trezor/connect-web>@trezor/utils",
+      "app/main:browserify>timers-browserify",
+      "app/main:eth-lattice-keyring",
+      "app/main:ethers>@ethersproject/providers",
+      "app/main:lottie-web",
+      "app/main:wait-on>rxjs",
+      "app/flask:@ethersproject/providers",
+      "app/flask:@material-ui/core",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@metamask/ethjs",
+      "app/flask:@metamask/ethjs>@metamask/ethjs-filter",
+      "app/flask:@metamask/gas-fee-controller",
+      "app/flask:@metamask/smart-transactions-controller",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@trezor/connect-web>@trezor/utils",
+      "app/flask:browserify>timers-browserify",
+      "app/flask:eth-lattice-keyring",
+      "app/flask:ethers>@ethersproject/providers",
+      "app/flask:lottie-web",
+      "app/flask:wait-on>rxjs",
+      "app/beta:@ethersproject/providers",
+      "app/beta:@material-ui/core",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@metamask/ethjs",
+      "app/beta:@metamask/ethjs>@metamask/ethjs-filter",
+      "app/beta:@metamask/gas-fee-controller",
+      "app/beta:@metamask/smart-transactions-controller",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@trezor/connect-web>@trezor/utils",
+      "app/beta:browserify>timers-browserify",
+      "app/beta:eth-lattice-keyring",
+      "app/beta:ethers>@ethersproject/providers",
+      "app/beta:lottie-web",
+      "app/beta:wait-on>rxjs",
+      "app/mmi:@ethersproject/providers",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@metamask-institutional/transaction-update",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@metamask/ethjs",
+      "app/mmi:@metamask/ethjs>@metamask/ethjs-filter",
+      "app/mmi:@metamask/gas-fee-controller",
+      "app/mmi:@metamask/smart-transactions-controller",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@trezor/connect-web>@trezor/utils",
+      "app/mmi:browserify>timers-browserify",
+      "app/mmi:eth-lattice-keyring",
+      "app/mmi:ethers>@ethersproject/providers",
+      "app/mmi:lottie-web",
+      "app/mmi:wait-on>rxjs",
+      "build/main:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge",
+      "build/main:gulp-livereload>tiny-lr>faye-websocket",
+      "build/main:wait-on>rxjs",
+      "build/override:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge"
+    ],
+    "clearTimeout": [
+      "app/main:@ethersproject/providers",
+      "app/main:@ethersproject/providers>@ethersproject/web",
+      "app/main:@material-ui/core",
+      "app/main:@metamask/assets-controllers",
+      "app/main:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/main:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/main:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/main:@metamask/name-controller>async-mutex",
+      "app/main:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/main:@metamask/polling-controller",
+      "app/main:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/main:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/main:@metamask/snaps-controllers",
+      "app/main:@metamask/transaction-controller",
+      "app/main:@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/main:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@sentry/utils",
+      "app/main:@trezor/connect-web",
+      "app/main:@trezor/connect-web>@trezor/utils",
+      "app/main:@zxing/browser",
+      "app/main:browserify>timers-browserify",
+      "app/main:chart.js",
+      "app/main:cockatiel",
+      "app/main:debounce-stream>debounce",
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/main:ethers>@ethersproject/providers",
+      "app/main:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/main:ethers>@ethersproject/web",
+      "app/main:fast-json-patch",
+      "app/main:lodash",
+      "app/main:process",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-dnd-html5-backend",
+      "app/main:react-dom",
+      "app/main:react-dom>scheduler",
+      "app/main:react-idle-timer",
+      "app/main:react-responsive-carousel",
+      "app/main:react-tippy",
+      "app/main:react-toggle-button",
+      "app/main:stream-http",
+      "app/main:wait-on>rxjs",
+      "app/flask:@ethersproject/providers",
+      "app/flask:@ethersproject/providers>@ethersproject/web",
+      "app/flask:@material-ui/core",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/flask:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/flask:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/flask:@metamask/name-controller>async-mutex",
+      "app/flask:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/flask:@metamask/polling-controller",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/flask:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/flask:@metamask/snaps-controllers",
+      "app/flask:@metamask/transaction-controller",
+      "app/flask:@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/flask:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/utils",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@trezor/connect-web>@trezor/utils",
+      "app/flask:@zxing/browser",
+      "app/flask:browserify>timers-browserify",
+      "app/flask:chart.js",
+      "app/flask:cockatiel",
+      "app/flask:debounce-stream>debounce",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:ethers>@ethersproject/providers",
+      "app/flask:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/flask:ethers>@ethersproject/web",
+      "app/flask:fast-json-patch",
+      "app/flask:lodash",
+      "app/flask:process",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-dnd-html5-backend",
+      "app/flask:react-dom",
+      "app/flask:react-dom>scheduler",
+      "app/flask:react-idle-timer",
+      "app/flask:react-responsive-carousel",
+      "app/flask:react-tippy",
+      "app/flask:react-toggle-button",
+      "app/flask:stream-http",
+      "app/flask:wait-on>rxjs",
+      "app/beta:@ethersproject/providers",
+      "app/beta:@ethersproject/providers>@ethersproject/web",
+      "app/beta:@material-ui/core",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/beta:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/beta:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/beta:@metamask/name-controller>async-mutex",
+      "app/beta:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/beta:@metamask/polling-controller",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/beta:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/beta:@metamask/snaps-controllers",
+      "app/beta:@metamask/transaction-controller",
+      "app/beta:@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/beta:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/utils",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@trezor/connect-web>@trezor/utils",
+      "app/beta:@zxing/browser",
+      "app/beta:browserify>timers-browserify",
+      "app/beta:chart.js",
+      "app/beta:cockatiel",
+      "app/beta:debounce-stream>debounce",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:ethers>@ethersproject/providers",
+      "app/beta:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/beta:ethers>@ethersproject/web",
+      "app/beta:fast-json-patch",
+      "app/beta:lodash",
+      "app/beta:process",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-dnd-html5-backend",
+      "app/beta:react-dom",
+      "app/beta:react-dom>scheduler",
+      "app/beta:react-idle-timer",
+      "app/beta:react-responsive-carousel",
+      "app/beta:react-tippy",
+      "app/beta:react-toggle-button",
+      "app/beta:stream-http",
+      "app/beta:wait-on>rxjs",
+      "app/mmi:@ethersproject/providers",
+      "app/mmi:@ethersproject/providers>@ethersproject/web",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@metamask-institutional/transaction-update>@metamask-institutional/websocket-client",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@metamask/assets-controllers>@metamask/polling-controller",
+      "app/mmi:@metamask/eth-token-tracker>@metamask/eth-block-tracker",
+      "app/mmi:@metamask/gas-fee-controller>@metamask/polling-controller",
+      "app/mmi:@metamask/name-controller>async-mutex",
+      "app/mmi:@metamask/network-controller>@metamask/eth-block-tracker",
+      "app/mmi:@metamask/polling-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/polling-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller",
+      "app/mmi:@metamask/smart-transactions-controller>@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/mmi:@metamask/snaps-controllers",
+      "app/mmi:@metamask/transaction-controller",
+      "app/mmi:@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex",
+      "app/mmi:@metamask/user-operation-controller>@metamask/polling-controller",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@trezor/connect-web>@trezor/utils",
+      "app/mmi:@zxing/browser",
+      "app/mmi:browserify>timers-browserify",
+      "app/mmi:chart.js",
+      "app/mmi:cockatiel",
+      "app/mmi:debounce-stream>debounce",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:ethers>@ethersproject/providers",
+      "app/mmi:ethers>@ethersproject/providers>@ethersproject/web",
+      "app/mmi:ethers>@ethersproject/web",
+      "app/mmi:fast-json-patch",
+      "app/mmi:lodash",
+      "app/mmi:process",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-dnd-html5-backend",
+      "app/mmi:react-dom",
+      "app/mmi:react-dom>scheduler",
+      "app/mmi:react-idle-timer",
+      "app/mmi:react-tippy",
+      "app/mmi:react-toggle-button",
+      "app/mmi:stream-http",
+      "app/mmi:wait-on>rxjs",
+      "app/override:lodash",
+      "app/override:react-dnd-html5-backend",
+      "build/main:@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>lodash.debounce",
+      "build/main:chokidar",
+      "build/main:del>graceful-fs",
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee",
+      "build/main:gulp-watch>chokidar",
+      "build/main:gulp>glob-watcher>just-debounce",
+      "build/main:prettier",
+      "build/main:typescript",
+      "build/main:wait-on>rxjs",
+      "build/main:watchify",
+      "build/override:gulp-watch>chokidar"
+    ],
+    "setInterval": [
+      "app/main:@ethersproject/providers",
+      "app/main:@material-ui/core",
+      "app/main:@metamask/assets-controllers",
+      "app/main:@metamask/ethjs",
+      "app/main:@metamask/ethjs>@metamask/ethjs-filter",
+      "app/main:@metamask/gas-fee-controller",
+      "app/main:@metamask/smart-transactions-controller",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@sentry/utils",
+      "app/main:@trezor/connect-web",
+      "app/main:@trezor/connect-web>@trezor/utils",
+      "app/main:browserify>timers-browserify",
+      "app/main:eth-lattice-keyring",
+      "app/main:ethers>@ethersproject/providers",
+      "app/main:lottie-web",
+      "app/main:wait-on>rxjs",
+      "app/flask:@ethersproject/providers",
+      "app/flask:@material-ui/core",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@metamask/ethjs",
+      "app/flask:@metamask/ethjs>@metamask/ethjs-filter",
+      "app/flask:@metamask/gas-fee-controller",
+      "app/flask:@metamask/smart-transactions-controller",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/utils",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@trezor/connect-web>@trezor/utils",
+      "app/flask:browserify>timers-browserify",
+      "app/flask:eth-lattice-keyring",
+      "app/flask:ethers>@ethersproject/providers",
+      "app/flask:lottie-web",
+      "app/flask:wait-on>rxjs",
+      "app/beta:@ethersproject/providers",
+      "app/beta:@material-ui/core",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@metamask/ethjs",
+      "app/beta:@metamask/ethjs>@metamask/ethjs-filter",
+      "app/beta:@metamask/gas-fee-controller",
+      "app/beta:@metamask/smart-transactions-controller",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/utils",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@trezor/connect-web>@trezor/utils",
+      "app/beta:browserify>timers-browserify",
+      "app/beta:eth-lattice-keyring",
+      "app/beta:ethers>@ethersproject/providers",
+      "app/beta:lottie-web",
+      "app/beta:wait-on>rxjs",
+      "app/mmi:@ethersproject/providers",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@metamask-institutional/transaction-update",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@metamask/ethjs",
+      "app/mmi:@metamask/ethjs>@metamask/ethjs-filter",
+      "app/mmi:@metamask/gas-fee-controller",
+      "app/mmi:@metamask/smart-transactions-controller",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@trezor/connect-web>@trezor/utils",
+      "app/mmi:browserify>timers-browserify",
+      "app/mmi:eth-lattice-keyring",
+      "app/mmi:ethers>@ethersproject/providers",
+      "app/mmi:lottie-web",
+      "app/mmi:wait-on>rxjs",
+      "build/main:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge",
+      "build/main:gulp-livereload>tiny-lr>faye-websocket",
+      "build/main:wait-on>rxjs",
+      "build/override:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge"
+    ],
+    "Document": [
+      "app/main:@lavamoat/lavadome-react",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@lavamoat/lavadome-react",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@lavamoat/lavadome-react",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@lavamoat/lavadome-react",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "DocumentFragment": [
+      "app/main:@lavamoat/lavadome-react",
+      "app/flask:@lavamoat/lavadome-react",
+      "app/beta:@lavamoat/lavadome-react",
+      "app/mmi:@lavamoat/lavadome-react"
+    ],
+    "Element": [
+      "app/main:@lavamoat/lavadome-react",
+      "app/main:@material-ui/core>react-transition-group",
+      "app/main:@popperjs/core",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/utils",
+      "app/main:@welldone-software/why-did-you-render",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-popper>react-fast-compare",
+      "app/main:react-tippy",
+      "app/flask:@lavamoat/lavadome-react",
+      "app/flask:@material-ui/core>react-transition-group",
+      "app/flask:@popperjs/core",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/utils",
+      "app/flask:@welldone-software/why-did-you-render",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-popper>react-fast-compare",
+      "app/flask:react-tippy",
+      "app/beta:@lavamoat/lavadome-react",
+      "app/beta:@material-ui/core>react-transition-group",
+      "app/beta:@popperjs/core",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/utils",
+      "app/beta:@welldone-software/why-did-you-render",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-popper>react-fast-compare",
+      "app/beta:react-tippy",
+      "app/mmi:@lavamoat/lavadome-react",
+      "app/mmi:@material-ui/core>react-transition-group",
+      "app/mmi:@popperjs/core",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@welldone-software/why-did-you-render",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-popper>react-fast-compare",
+      "app/mmi:react-tippy",
+      "build/main:prettier"
+    ],
+    "Node": [
+      "app/main:@lavamoat/lavadome-react",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:react-focus-lock>focus-lock",
+      "app/main:react-inspector",
+      "app/main:react-tippy>popper.js",
+      "app/flask:@lavamoat/lavadome-react",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:react-focus-lock>focus-lock",
+      "app/flask:react-inspector",
+      "app/flask:react-tippy>popper.js",
+      "app/beta:@lavamoat/lavadome-react",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:react-focus-lock>focus-lock",
+      "app/beta:react-inspector",
+      "app/beta:react-tippy>popper.js",
+      "app/mmi:@lavamoat/lavadome-react",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:react-focus-lock>focus-lock",
+      "app/mmi:react-inspector",
+      "app/mmi:react-tippy>popper.js"
+    ],
+    "document": [
+      "app/main:@lavamoat/lavadome-react",
+      "app/main:@material-ui/core",
+      "app/main:@material-ui/core>@material-ui/styles",
+      "app/main:@material-ui/core>@material-ui/styles>jss",
+      "app/main:@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor",
+      "app/main:@material-ui/core>@material-ui/styles>jss>is-in-browser",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@metamask/eth-ledger-bridge-keyring",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@metamask/jazzicon",
+      "app/main:@metamask/logo",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@metamask/snaps-controllers",
+      "app/main:@metamask/snaps-execution-environments",
+      "app/main:@metamask/snaps-utils",
+      "app/main:@popperjs/core",
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/main:@sentry/utils",
+      "app/main:@trezor/connect-web",
+      "app/main:@zxing/browser",
+      "app/main:@zxing/library",
+      "app/main:browserify>vm-browserify",
+      "app/main:chart.js",
+      "app/main:copy-to-clipboard",
+      "app/main:copy-to-clipboard>toggle-selection",
+      "app/main:history",
+      "app/main:loglevel",
+      "app/main:lottie-web",
+      "app/main:nock>debug",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-dom",
+      "app/main:react-focus-lock",
+      "app/main:react-focus-lock>focus-lock",
+      "app/main:react-idle-timer",
+      "app/main:react-popper",
+      "app/main:react-redux",
+      "app/main:react-responsive-carousel",
+      "app/main:react-responsive-carousel>react-easy-swipe",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/main:react-router-dom>history",
+      "app/main:react-syntax-highlighter>refractor>parse-entities",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/main:string.prototype.matchall>es-abstract>is-callable",
+      "app/flask:@lavamoat/lavadome-react",
+      "app/flask:@material-ui/core",
+      "app/flask:@material-ui/core>@material-ui/styles",
+      "app/flask:@material-ui/core>@material-ui/styles>jss",
+      "app/flask:@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor",
+      "app/flask:@material-ui/core>@material-ui/styles>jss>is-in-browser",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@metamask/eth-ledger-bridge-keyring",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@metamask/jazzicon",
+      "app/flask:@metamask/logo",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@metamask/snaps-controllers",
+      "app/flask:@metamask/snaps-execution-environments",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:@popperjs/core",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:@sentry/utils",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@zxing/browser",
+      "app/flask:@zxing/library",
+      "app/flask:browserify>vm-browserify",
+      "app/flask:chart.js",
+      "app/flask:copy-to-clipboard",
+      "app/flask:copy-to-clipboard>toggle-selection",
+      "app/flask:history",
+      "app/flask:loglevel",
+      "app/flask:lottie-web",
+      "app/flask:nock>debug",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-dom",
+      "app/flask:react-focus-lock",
+      "app/flask:react-focus-lock>focus-lock",
+      "app/flask:react-idle-timer",
+      "app/flask:react-popper",
+      "app/flask:react-redux",
+      "app/flask:react-responsive-carousel",
+      "app/flask:react-responsive-carousel>react-easy-swipe",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:react-router-dom>history",
+      "app/flask:react-syntax-highlighter>refractor>parse-entities",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/flask:string.prototype.matchall>es-abstract>is-callable",
+      "app/beta:@lavamoat/lavadome-react",
+      "app/beta:@material-ui/core",
+      "app/beta:@material-ui/core>@material-ui/styles",
+      "app/beta:@material-ui/core>@material-ui/styles>jss",
+      "app/beta:@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor",
+      "app/beta:@material-ui/core>@material-ui/styles>jss>is-in-browser",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@metamask/eth-ledger-bridge-keyring",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@metamask/jazzicon",
+      "app/beta:@metamask/logo",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@metamask/snaps-controllers",
+      "app/beta:@metamask/snaps-execution-environments",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:@popperjs/core",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:@sentry/utils",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@zxing/browser",
+      "app/beta:@zxing/library",
+      "app/beta:browserify>vm-browserify",
+      "app/beta:chart.js",
+      "app/beta:copy-to-clipboard",
+      "app/beta:copy-to-clipboard>toggle-selection",
+      "app/beta:history",
+      "app/beta:loglevel",
+      "app/beta:lottie-web",
+      "app/beta:nock>debug",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-dom",
+      "app/beta:react-focus-lock",
+      "app/beta:react-focus-lock>focus-lock",
+      "app/beta:react-idle-timer",
+      "app/beta:react-popper",
+      "app/beta:react-redux",
+      "app/beta:react-responsive-carousel",
+      "app/beta:react-responsive-carousel>react-easy-swipe",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:react-router-dom>history",
+      "app/beta:react-syntax-highlighter>refractor>parse-entities",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/beta:string.prototype.matchall>es-abstract>is-callable",
+      "app/mmi:@lavamoat/lavadome-react",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@material-ui/core>@material-ui/styles",
+      "app/mmi:@material-ui/core>@material-ui/styles>jss",
+      "app/mmi:@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor",
+      "app/mmi:@material-ui/core>@material-ui/styles>jss>is-in-browser",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@metamask/jazzicon",
+      "app/mmi:@metamask/logo",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@metamask/snaps-controllers",
+      "app/mmi:@metamask/snaps-execution-environments",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:@popperjs/core",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@zxing/browser",
+      "app/mmi:@zxing/library",
+      "app/mmi:browserify>vm-browserify",
+      "app/mmi:chart.js",
+      "app/mmi:copy-to-clipboard",
+      "app/mmi:copy-to-clipboard>toggle-selection",
+      "app/mmi:history",
+      "app/mmi:loglevel",
+      "app/mmi:lottie-web",
+      "app/mmi:nock>debug",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-dom",
+      "app/mmi:react-focus-lock",
+      "app/mmi:react-focus-lock>focus-lock",
+      "app/mmi:react-idle-timer",
+      "app/mmi:react-popper",
+      "app/mmi:react-redux",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:react-router-dom>history",
+      "app/mmi:react-syntax-highlighter>refractor>parse-entities",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js",
+      "app/mmi:string.prototype.matchall>es-abstract>is-callable",
+      "build/main:eslint-import-resolver-node>debug",
+      "build/main:eslint-plugin-import>debug",
+      "build/main:eslint-plugin-import>eslint-module-utils>debug",
+      "build/main:gulp-livereload>debug",
+      "build/main:gulp-livereload>tiny-lr>debug",
+      "build/main:gulp-sourcemaps>debug-fabulous>debug",
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee>next-tick",
+      "build/main:gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug",
+      "build/main:gulp>gulp-cli>matchdep>micromatch>snapdragon>debug",
+      "build/main:nock>debug",
+      "build/main:prettier",
+      "build/main:string.prototype.matchall>es-abstract>is-callable"
+    ],
+    "Image": [
+      "app/main:@material-ui/core",
+      "app/flask:@material-ui/core",
+      "app/beta:@material-ui/core",
+      "app/mmi:@material-ui/core"
+    ],
+    "_formatMuiErrorMessage": [
+      "app/main:@material-ui/core",
+      "app/flask:@material-ui/core",
+      "app/beta:@material-ui/core",
+      "app/mmi:@material-ui/core"
+    ],
+    "addEventListener": [
+      "app/main:@material-ui/core",
+      "app/main:@metamask/eth-ledger-bridge-keyring",
+      "app/main:@metamask/logo",
+      "app/main:@metamask/notification-services-controller",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/post-message-stream",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@trezor/connect-web",
+      "app/main:chart.js",
+      "app/main:eth-lattice-keyring",
+      "app/main:fast-json-patch",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-dnd-html5-backend",
+      "app/main:react-dom",
+      "app/main:react-focus-lock",
+      "app/main:react-responsive-carousel",
+      "app/main:react-responsive-carousel>react-easy-swipe",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom>history",
+      "app/main:react-tippy",
+      "app/flask:@material-ui/core",
+      "app/flask:@metamask/eth-ledger-bridge-keyring",
+      "app/flask:@metamask/logo",
+      "app/flask:@metamask/notification-services-controller",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/post-message-stream",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@trezor/connect-web",
+      "app/flask:chart.js",
+      "app/flask:eth-lattice-keyring",
+      "app/flask:fast-json-patch",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-dnd-html5-backend",
+      "app/flask:react-dom",
+      "app/flask:react-focus-lock",
+      "app/flask:react-responsive-carousel",
+      "app/flask:react-responsive-carousel>react-easy-swipe",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom>history",
+      "app/flask:react-tippy",
+      "app/beta:@material-ui/core",
+      "app/beta:@metamask/eth-ledger-bridge-keyring",
+      "app/beta:@metamask/logo",
+      "app/beta:@metamask/notification-services-controller",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/post-message-stream",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@trezor/connect-web",
+      "app/beta:chart.js",
+      "app/beta:eth-lattice-keyring",
+      "app/beta:fast-json-patch",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-dnd-html5-backend",
+      "app/beta:react-dom",
+      "app/beta:react-focus-lock",
+      "app/beta:react-responsive-carousel",
+      "app/beta:react-responsive-carousel>react-easy-swipe",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom>history",
+      "app/beta:react-tippy",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring",
+      "app/mmi:@metamask/logo",
+      "app/mmi:@metamask/notification-services-controller",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/post-message-stream",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:chart.js",
+      "app/mmi:eth-lattice-keyring",
+      "app/mmi:fast-json-patch",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-dnd-html5-backend",
+      "app/mmi:react-dom",
+      "app/mmi:react-focus-lock",
+      "app/mmi:react-responsive-carousel",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom>history",
+      "app/mmi:react-tippy",
+      "app/override:react-responsive-carousel",
+      "app/override:react-beautiful-dnd",
+      "app/override:react-dnd-html5-backend"
+    ],
+    "getComputedStyle": [
+      "app/main:@material-ui/core",
+      "app/main:@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-beautiful-dnd>css-box-model",
+      "app/main:react-focus-lock>focus-lock",
+      "app/main:react-responsive-carousel",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/flask:@material-ui/core",
+      "app/flask:@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-beautiful-dnd>css-box-model",
+      "app/flask:react-focus-lock>focus-lock",
+      "app/flask:react-responsive-carousel",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/beta:@material-ui/core",
+      "app/beta:@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-beautiful-dnd>css-box-model",
+      "app/beta:react-focus-lock>focus-lock",
+      "app/beta:react-responsive-carousel",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-beautiful-dnd>css-box-model",
+      "app/mmi:react-focus-lock>focus-lock",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js"
+    ],
+    "getSelection": [
+      "app/main:@material-ui/core",
+      "app/flask:@material-ui/core",
+      "app/beta:@material-ui/core",
+      "app/mmi:@material-ui/core"
+    ],
+    "innerHeight": [
+      "app/main:@material-ui/core",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@metamask/logo",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/flask:@material-ui/core",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@metamask/logo",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/beta:@material-ui/core",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@metamask/logo",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@metamask/logo",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js"
+    ],
+    "innerWidth": [
+      "app/main:@material-ui/core",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@metamask/logo",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/flask:@material-ui/core",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@metamask/logo",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/beta:@material-ui/core",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@metamask/logo",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@metamask/logo",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js"
+    ],
+    "matchMedia": [
+      "app/main:@material-ui/core",
+      "app/flask:@material-ui/core",
+      "app/beta:@material-ui/core",
+      "app/mmi:@material-ui/core"
+    ],
+    "navigator": [
+      "app/main:@material-ui/core",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@popperjs/core",
+      "app/main:@trezor/connect-web",
+      "app/main:@trezor/connect-web>@trezor/connect-common",
+      "app/main:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/main:@zxing/browser",
+      "app/main:@zxing/library",
+      "app/main:copy-to-clipboard",
+      "app/main:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/main:localforage",
+      "app/main:loglevel",
+      "app/main:lottie-web",
+      "app/main:nanoid",
+      "app/main:nock>debug",
+      "app/main:react-dom",
+      "app/main:react-dom>scheduler",
+      "app/main:react-router-dom>history",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/flask:@material-ui/core",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@popperjs/core",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@trezor/connect-web>@trezor/connect-common",
+      "app/flask:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/flask:@zxing/browser",
+      "app/flask:@zxing/library",
+      "app/flask:copy-to-clipboard",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/flask:localforage",
+      "app/flask:loglevel",
+      "app/flask:lottie-web",
+      "app/flask:nanoid",
+      "app/flask:nock>debug",
+      "app/flask:react-dom",
+      "app/flask:react-dom>scheduler",
+      "app/flask:react-router-dom>history",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/beta:@material-ui/core",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@popperjs/core",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@trezor/connect-web>@trezor/connect-common",
+      "app/beta:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/beta:@zxing/browser",
+      "app/beta:@zxing/library",
+      "app/beta:copy-to-clipboard",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/beta:localforage",
+      "app/beta:loglevel",
+      "app/beta:lottie-web",
+      "app/beta:nanoid",
+      "app/beta:nock>debug",
+      "app/beta:react-dom",
+      "app/beta:react-dom>scheduler",
+      "app/beta:react-router-dom>history",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@popperjs/core",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/mmi:@zxing/browser",
+      "app/mmi:@zxing/library",
+      "app/mmi:copy-to-clipboard",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/mmi:localforage",
+      "app/mmi:loglevel",
+      "app/mmi:lottie-web",
+      "app/mmi:nanoid",
+      "app/mmi:nock>debug",
+      "app/mmi:react-dom",
+      "app/mmi:react-dom>scheduler",
+      "app/mmi:react-router-dom>history",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js",
+      "build/main:eslint-import-resolver-node>debug",
+      "build/main:eslint-plugin-import>debug",
+      "build/main:eslint-plugin-import>eslint-module-utils>debug",
+      "build/main:gulp-livereload>debug",
+      "build/main:gulp-livereload>tiny-lr>debug",
+      "build/main:gulp-sourcemaps>debug-fabulous>debug",
+      "build/main:gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug",
+      "build/main:gulp>gulp-cli>matchdep>micromatch>snapdragon>debug",
+      "build/main:nock>debug",
+      "build/main:prettier"
+    ],
+    "performance": [
+      "app/main:@material-ui/core",
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/main:cockatiel",
+      "app/main:react-dom",
+      "app/main:react-dom>scheduler",
+      "app/main:react-tippy",
+      "app/main:react-toggle-button",
+      "app/main:wait-on>rxjs",
+      "app/flask:@material-ui/core",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:cockatiel",
+      "app/flask:react-dom",
+      "app/flask:react-dom>scheduler",
+      "app/flask:react-tippy",
+      "app/flask:react-toggle-button",
+      "app/flask:wait-on>rxjs",
+      "app/beta:@material-ui/core",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:cockatiel",
+      "app/beta:react-dom",
+      "app/beta:react-dom>scheduler",
+      "app/beta:react-tippy",
+      "app/beta:react-toggle-button",
+      "app/beta:wait-on>rxjs",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:cockatiel",
+      "app/mmi:react-dom",
+      "app/mmi:react-dom>scheduler",
+      "app/mmi:react-tippy",
+      "app/mmi:react-toggle-button",
+      "app/mmi:wait-on>rxjs",
+      "build/main:prettier",
+      "build/main:typescript",
+      "build/main:wait-on>rxjs"
+    ],
+    "removeEventListener": [
+      "app/main:@material-ui/core",
+      "app/main:@metamask/eth-ledger-bridge-keyring",
+      "app/main:@metamask/notification-services-controller",
+      "app/main:@metamask/post-message-stream",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/main:@trezor/connect-web",
+      "app/main:chart.js",
+      "app/main:fast-json-patch",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-dnd-html5-backend",
+      "app/main:react-dom",
+      "app/main:react-focus-lock",
+      "app/main:react-responsive-carousel",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom>history",
+      "app/flask:@material-ui/core",
+      "app/flask:@metamask/eth-ledger-bridge-keyring",
+      "app/flask:@metamask/notification-services-controller",
+      "app/flask:@metamask/post-message-stream",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:@trezor/connect-web",
+      "app/flask:chart.js",
+      "app/flask:fast-json-patch",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-dnd-html5-backend",
+      "app/flask:react-dom",
+      "app/flask:react-focus-lock",
+      "app/flask:react-responsive-carousel",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom>history",
+      "app/beta:@material-ui/core",
+      "app/beta:@metamask/eth-ledger-bridge-keyring",
+      "app/beta:@metamask/notification-services-controller",
+      "app/beta:@metamask/post-message-stream",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:@trezor/connect-web",
+      "app/beta:chart.js",
+      "app/beta:fast-json-patch",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-dnd-html5-backend",
+      "app/beta:react-dom",
+      "app/beta:react-focus-lock",
+      "app/beta:react-responsive-carousel",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom>history",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring",
+      "app/mmi:@metamask/notification-services-controller",
+      "app/mmi:@metamask/post-message-stream",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:chart.js",
+      "app/mmi:fast-json-patch",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-dnd-html5-backend",
+      "app/mmi:react-dom",
+      "app/mmi:react-focus-lock",
+      "app/mmi:react-responsive-carousel",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom>history",
+      "app/override:react-responsive-carousel",
+      "app/override:react-beautiful-dnd",
+      "app/override:react-dnd-html5-backend"
+    ],
+    "requestAnimationFrame": [
+      "app/main:@material-ui/core",
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@metamask/logo",
+      "app/main:@reduxjs/toolkit",
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:chart.js",
+      "app/main:lottie-web",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-beautiful-dnd>raf-schd",
+      "app/main:react-dom>scheduler",
+      "app/main:react-tippy",
+      "app/main:react-tippy>popper.js",
+      "app/main:wait-on>rxjs",
+      "app/flask:@material-ui/core",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@metamask/logo",
+      "app/flask:@reduxjs/toolkit",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:chart.js",
+      "app/flask:lottie-web",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-beautiful-dnd>raf-schd",
+      "app/flask:react-dom>scheduler",
+      "app/flask:react-tippy",
+      "app/flask:react-tippy>popper.js",
+      "app/flask:wait-on>rxjs",
+      "app/beta:@material-ui/core",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@metamask/logo",
+      "app/beta:@reduxjs/toolkit",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:chart.js",
+      "app/beta:lottie-web",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-beautiful-dnd>raf-schd",
+      "app/beta:react-dom>scheduler",
+      "app/beta:react-tippy",
+      "app/beta:react-tippy>popper.js",
+      "app/beta:wait-on>rxjs",
+      "app/mmi:@material-ui/core",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@metamask/logo",
+      "app/mmi:@reduxjs/toolkit",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:chart.js",
+      "app/mmi:lottie-web",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-beautiful-dnd>raf-schd",
+      "app/mmi:react-dom>scheduler",
+      "app/mmi:react-tippy",
+      "app/mmi:react-tippy>popper.js",
+      "app/mmi:wait-on>rxjs",
+      "build/main:wait-on>rxjs"
+    ],
+    "CSS": [
+      "app/main:@material-ui/core>@material-ui/styles>jss",
+      "app/main:@material-ui/core>@material-ui/styles>jss-plugin-default-unit",
+      "app/flask:@material-ui/core>@material-ui/styles>jss",
+      "app/flask:@material-ui/core>@material-ui/styles>jss-plugin-default-unit",
+      "app/beta:@material-ui/core>@material-ui/styles>jss",
+      "app/beta:@material-ui/core>@material-ui/styles>jss-plugin-default-unit",
+      "app/mmi:@material-ui/core>@material-ui/styles>jss",
+      "app/mmi:@material-ui/core>@material-ui/styles>jss-plugin-default-unit"
+    ],
+    "MSInputMethodContext": [
+      "app/main:@material-ui/core>popper.js",
+      "app/main:react-tippy>popper.js",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:react-tippy>popper.js",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:react-tippy>popper.js",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:react-tippy>popper.js"
+    ],
+    "cancelAnimationFrame": [
+      "app/main:@material-ui/core>popper.js",
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/main:react-beautiful-dnd",
+      "app/main:react-beautiful-dnd>raf-schd",
+      "app/main:react-dom>scheduler",
+      "app/main:react-tippy>popper.js",
+      "app/main:wait-on>rxjs",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-beautiful-dnd>raf-schd",
+      "app/flask:react-dom>scheduler",
+      "app/flask:react-tippy>popper.js",
+      "app/flask:wait-on>rxjs",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-beautiful-dnd>raf-schd",
+      "app/beta:react-dom>scheduler",
+      "app/beta:react-tippy>popper.js",
+      "app/beta:wait-on>rxjs",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-beautiful-dnd>raf-schd",
+      "app/mmi:react-dom>scheduler",
+      "app/mmi:react-tippy>popper.js",
+      "app/mmi:wait-on>rxjs",
+      "build/main:wait-on>rxjs"
+    ],
+    "devicePixelRatio": [
+      "app/main:@material-ui/core>popper.js",
+      "app/main:chart.js",
+      "app/main:qrcode.react",
+      "app/main:react-tippy>popper.js",
+      "app/flask:@material-ui/core>popper.js",
+      "app/flask:chart.js",
+      "app/flask:qrcode.react",
+      "app/flask:react-tippy>popper.js",
+      "app/beta:@material-ui/core>popper.js",
+      "app/beta:chart.js",
+      "app/beta:qrcode.react",
+      "app/beta:react-tippy>popper.js",
+      "app/mmi:@material-ui/core>popper.js",
+      "app/mmi:chart.js",
+      "app/mmi:qrcode.react",
+      "app/mmi:react-tippy>popper.js"
+    ],
+    "AbortController": [
+      "app/main:@metamask/assets-controllers",
+      "app/main:@reduxjs/toolkit",
+      "app/main:@trezor/connect-web>@trezor/utils",
+      "app/main:cockatiel",
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/main:extension-port-stream>readable-stream",
+      "app/main:extension-port-stream>readable-stream>abort-controller",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/main:stream-http",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@reduxjs/toolkit",
+      "app/flask:@trezor/connect-web>@trezor/utils",
+      "app/flask:cockatiel",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:extension-port-stream>readable-stream",
+      "app/flask:extension-port-stream>readable-stream>abort-controller",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:stream-http",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@reduxjs/toolkit",
+      "app/beta:@trezor/connect-web>@trezor/utils",
+      "app/beta:cockatiel",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:extension-port-stream>readable-stream",
+      "app/beta:extension-port-stream>readable-stream>abort-controller",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:stream-http",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@reduxjs/toolkit",
+      "app/mmi:@trezor/connect-web>@trezor/utils",
+      "app/mmi:cockatiel",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:extension-port-stream>readable-stream",
+      "app/mmi:extension-port-stream>readable-stream>abort-controller",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:stream-http"
+    ],
+    "URLSearchParams": [
+      "app/main:@metamask/assets-controllers",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@metamask/smart-transactions-controller",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@trezor/connect-web",
+      "app/main:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:@metamask/assets-controllers",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@metamask/smart-transactions-controller",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@trezor/connect-web",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:@metamask/assets-controllers",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@metamask/smart-transactions-controller",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@trezor/connect-web",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:@metamask-institutional/sdk",
+      "app/mmi:@metamask/assets-controllers",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@metamask/smart-transactions-controller",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router"
+    ],
+    "CryptoKey": [
+      "app/main:@metamask/browser-passworder",
+      "app/flask:@metamask/browser-passworder",
+      "app/beta:@metamask/browser-passworder",
+      "app/mmi:@metamask/browser-passworder"
+    ],
+    "XMLHttpRequest": [
+      "app/main:@metamask/controllers>web3",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@metamask/ethjs>@metamask/ethjs-provider-http>xhr2",
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/main:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch",
+      "app/main:lottie-web",
+      "app/main:stream-http",
+      "app/main:web3",
+      "app/flask:@metamask/controllers>web3",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@metamask/ethjs>@metamask/ethjs-provider-http>xhr2",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch",
+      "app/flask:lottie-web",
+      "app/flask:stream-http",
+      "app/flask:web3",
+      "app/beta:@metamask/controllers>web3",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@metamask/ethjs>@metamask/ethjs-provider-http>xhr2",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch",
+      "app/beta:lottie-web",
+      "app/beta:stream-http",
+      "app/beta:web3",
+      "app/mmi:@metamask/controllers>web3",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@metamask/ethjs>@metamask/ethjs-provider-http>xhr2",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch",
+      "app/mmi:lottie-web",
+      "app/mmi:stream-http",
+      "app/mmi:web3",
+      "app/override:web3",
+      "app/override:@metamask/controllers>web3",
+      "build/main:terser>source-map-support",
+      "build/main:ts-node>@cspotcode/source-map-support"
+    ],
+    "Blob": [
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/main:extension-port-stream>readable-stream",
+      "app/main:localforage",
+      "app/main:lottie-web",
+      "app/main:stream-http",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:extension-port-stream>readable-stream",
+      "app/flask:localforage",
+      "app/flask:lottie-web",
+      "app/flask:stream-http",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:extension-port-stream>readable-stream",
+      "app/beta:localforage",
+      "app/beta:lottie-web",
+      "app/beta:stream-http",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:extension-port-stream>readable-stream",
+      "app/mmi:localforage",
+      "app/mmi:lottie-web",
+      "app/mmi:stream-http"
+    ],
+    "FormData": [
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:axios>form-data",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:axios>form-data",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:axios>form-data",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:axios>form-data",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router"
+    ],
+    "location": [
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/post-message-stream",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@trezor/connect-web",
+      "app/main:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/main:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/main:lottie-web",
+      "app/main:react-dom",
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom>history",
+      "app/main:stream-http",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/post-message-stream",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@trezor/connect-web",
+      "app/flask:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/flask:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/flask:lottie-web",
+      "app/flask:react-dom",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom>history",
+      "app/flask:stream-http",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/post-message-stream",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@trezor/connect-web",
+      "app/beta:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/beta:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/beta:lottie-web",
+      "app/beta:react-dom",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom>history",
+      "app/beta:stream-http",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/post-message-stream",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk>borc>iso-url",
+      "app/mmi:lottie-web",
+      "app/mmi:react-dom",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom>history",
+      "app/mmi:stream-http",
+      "build/main:prettier"
+    ],
+    "__ledgerLogsListen": [
+      "app/main:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs",
+      "app/flask:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs",
+      "app/beta:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs",
+      "app/mmi:@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs"
+    ],
+    "msCrypto": [
+      "app/main:@metamask/eth-sig-util>tweetnacl",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/main:@metamask/ppom-validator>crypto-js",
+      "app/main:@metamask/ppom-validator>elliptic>brorand",
+      "app/main:@metamask/profile-sync-controller>siwe>@stablelib/random",
+      "app/main:crypto-browserify>randombytes",
+      "app/main:crypto-browserify>randomfill",
+      "app/main:nanoid",
+      "app/main:uuid",
+      "app/flask:@metamask/eth-sig-util>tweetnacl",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/ppom-validator>crypto-js",
+      "app/flask:@metamask/ppom-validator>elliptic>brorand",
+      "app/flask:@metamask/profile-sync-controller>siwe>@stablelib/random",
+      "app/flask:crypto-browserify>randombytes",
+      "app/flask:crypto-browserify>randomfill",
+      "app/flask:nanoid",
+      "app/flask:uuid",
+      "app/beta:@metamask/eth-sig-util>tweetnacl",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/ppom-validator>crypto-js",
+      "app/beta:@metamask/ppom-validator>elliptic>brorand",
+      "app/beta:@metamask/profile-sync-controller>siwe>@stablelib/random",
+      "app/beta:crypto-browserify>randombytes",
+      "app/beta:crypto-browserify>randomfill",
+      "app/beta:nanoid",
+      "app/beta:uuid",
+      "app/mmi:@metamask/eth-sig-util>tweetnacl",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/ppom-validator>crypto-js",
+      "app/mmi:@metamask/ppom-validator>elliptic>brorand",
+      "app/mmi:@metamask/profile-sync-controller>siwe>@stablelib/random",
+      "app/mmi:crypto-browserify>randombytes",
+      "app/mmi:crypto-browserify>randomfill",
+      "app/mmi:nanoid",
+      "app/mmi:uuid"
+    ],
+    "nacl": [
+      "app/main:@metamask/eth-sig-util>tweetnacl",
+      "app/flask:@metamask/eth-sig-util>tweetnacl",
+      "app/beta:@metamask/eth-sig-util>tweetnacl",
+      "app/mmi:@metamask/eth-sig-util>tweetnacl"
+    ],
+    "StopIteration": [
+      "app/main:@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator",
+      "app/flask:@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator",
+      "app/beta:@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator",
+      "app/mmi:@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator"
+    ],
+    "WeakRef": [
+      "app/main:@metamask/network-controller>reselect",
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/main:cockatiel",
+      "app/main:string.prototype.matchall>es-abstract>object-inspect",
+      "app/main:string.prototype.matchall>get-intrinsic",
+      "app/flask:@metamask/network-controller>reselect",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:cockatiel",
+      "app/flask:string.prototype.matchall>es-abstract>object-inspect",
+      "app/flask:string.prototype.matchall>get-intrinsic",
+      "app/beta:@metamask/network-controller>reselect",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:cockatiel",
+      "app/beta:string.prototype.matchall>es-abstract>object-inspect",
+      "app/beta:string.prototype.matchall>get-intrinsic",
+      "app/mmi:@metamask/network-controller>reselect",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:cockatiel",
+      "app/mmi:string.prototype.matchall>es-abstract>object-inspect",
+      "app/mmi:string.prototype.matchall>get-intrinsic",
+      "build/main:string.prototype.matchall>es-abstract>object-inspect",
+      "build/main:string.prototype.matchall>get-intrinsic"
+    ],
+    "unstable_autotrackMemoize": [
+      "app/main:@metamask/network-controller>reselect",
+      "app/flask:@metamask/network-controller>reselect",
+      "app/beta:@metamask/network-controller>reselect",
+      "app/mmi:@metamask/network-controller>reselect"
+    ],
+    "Intl": [
+      "app/main:@metamask/notification-services-controller",
+      "app/main:@solana/addresses",
+      "app/main:@trezor/connect-web>@trezor/utils",
+      "app/main:chart.js",
+      "app/main:luxon",
+      "app/flask:@metamask/notification-services-controller",
+      "app/flask:@solana/addresses",
+      "app/flask:@trezor/connect-web>@trezor/utils",
+      "app/flask:chart.js",
+      "app/flask:luxon",
+      "app/beta:@metamask/notification-services-controller",
+      "app/beta:@solana/addresses",
+      "app/beta:@trezor/connect-web>@trezor/utils",
+      "app/beta:chart.js",
+      "app/beta:luxon",
+      "app/mmi:@metamask/notification-services-controller",
+      "app/mmi:@solana/addresses",
+      "app/mmi:@trezor/connect-web>@trezor/utils",
+      "app/mmi:chart.js",
+      "app/mmi:luxon",
+      "build/main:prettier",
+      "build/main:typescript"
+    ],
+    "registration": [
+      "app/main:@metamask/notification-services-controller",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging"
+    ],
+    "SuppressedError": [
+      "app/main:@metamask/notification-services-controller>@contentful/rich-text-html-renderer",
+      "app/main:@swc/helpers>tslib",
+      "app/flask:@metamask/notification-services-controller>@contentful/rich-text-html-renderer",
+      "app/flask:@swc/helpers>tslib",
+      "app/beta:@metamask/notification-services-controller>@contentful/rich-text-html-renderer",
+      "app/beta:@swc/helpers>tslib",
+      "app/mmi:@metamask/notification-services-controller>@contentful/rich-text-html-renderer",
+      "app/mmi:@swc/helpers>tslib",
+      "build/main:postcss-rtlcss"
+    ],
+    "FinalizationRegistry": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app",
+      "app/main:string.prototype.matchall>get-intrinsic",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app",
+      "app/flask:string.prototype.matchall>get-intrinsic",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app",
+      "app/beta:string.prototype.matchall>get-intrinsic",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app",
+      "app/mmi:string.prototype.matchall>get-intrinsic",
+      "build/main:string.prototype.matchall>get-intrinsic"
+    ],
+    "DOMException": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/main:@sentry/utils",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/flask:@sentry/utils",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/beta:@sentry/utils",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/mmi:@sentry/utils",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router"
+    ],
+    "IDBCursor": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>idb"
+    ],
+    "IDBDatabase": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>idb"
+    ],
+    "IDBIndex": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>idb"
+    ],
+    "IDBObjectStore": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>idb"
+    ],
+    "IDBRequest": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>idb"
+    ],
+    "IDBTransaction": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>idb"
+    ],
+    "indexedDB": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@sentry/browser",
+      "app/main:localforage",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@sentry/browser",
+      "app/flask:localforage",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@sentry/browser",
+      "app/beta:localforage",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/app>idb",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@sentry/browser",
+      "app/mmi:localforage"
+    ],
+    "BroadcastChannel": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/installations",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/installations"
+    ],
+    "Notification": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging"
+    ],
+    "PushSubscription": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging"
+    ],
+    "ServiceWorkerRegistration": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging"
+    ],
+    "clients": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging"
+    ],
+    "origin": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/main:@trezor/connect-web",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/flask:@trezor/connect-web",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/beta:@trezor/connect-web",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/messaging",
+      "app/mmi:@trezor/connect-web"
+    ],
+    "browser": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@metamask/post-message-stream",
+      "app/main:eth-lattice-keyring",
+      "app/main:webextension-polyfill",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@metamask/post-message-stream",
+      "app/flask:eth-lattice-keyring",
+      "app/flask:webextension-polyfill",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@metamask/post-message-stream",
+      "app/beta:eth-lattice-keyring",
+      "app/beta:webextension-polyfill",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@metamask/post-message-stream",
+      "app/mmi:eth-lattice-keyring",
+      "app/mmi:webextension-polyfill"
+    ],
+    "chrome": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@metamask/post-message-stream",
+      "app/main:@trezor/connect-web",
+      "app/main:webextension-polyfill",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@metamask/post-message-stream",
+      "app/flask:@trezor/connect-web",
+      "app/flask:webextension-polyfill",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@metamask/post-message-stream",
+      "app/beta:@trezor/connect-web",
+      "app/beta:webextension-polyfill",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@metamask/post-message-stream",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:webextension-polyfill",
+      "build/main:eslint-plugin-import>debug",
+      "build/main:gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug",
+      "build/main:gulp>gulp-cli>matchdep>micromatch>snapdragon>debug"
+    ],
+    "process": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs",
+      "app/main:browserify>assert>util",
+      "app/main:crypto-browserify>pbkdf2",
+      "app/main:nock>debug",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs",
+      "app/flask:browserify>assert>util",
+      "app/flask:crypto-browserify>pbkdf2",
+      "app/flask:nock>debug",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs",
+      "app/beta:browserify>assert>util",
+      "app/beta:crypto-browserify>pbkdf2",
+      "app/beta:nock>debug",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs",
+      "app/mmi:browserify>assert>util",
+      "app/mmi:crypto-browserify>pbkdf2",
+      "app/mmi:nock>debug",
+      "build/main:@babel/code-frame",
+      "build/main:@babel/code-frame>@babel/highlight",
+      "build/main:@babel/code-frame>@babel/highlight>chalk",
+      "build/main:@babel/code-frame>@babel/highlight>chalk>supports-color",
+      "build/main:@babel/core",
+      "build/main:@babel/core>@babel/helper-compilation-targets",
+      "build/main:@babel/core>@babel/helper-compilation-targets>semver",
+      "build/main:@babel/core>@babel/types",
+      "build/main:@babel/core>semver",
+      "build/main:@babel/eslint-parser",
+      "build/main:@babel/eslint-parser>semver",
+      "build/main:@babel/preset-env",
+      "build/main:@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>semver",
+      "build/main:@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin>semver",
+      "build/main:@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider",
+      "build/main:@babel/preset-env>babel-plugin-polyfill-corejs2>semver",
+      "build/main:@babel/preset-env>semver",
+      "build/main:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog",
+      "build/main:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge",
+      "build/main:@lavamoat/lavapack",
+      "build/main:@lavamoat/lavapack>combine-source-map",
+      "build/main:@sentry/cli>which>isexe",
+      "build/main:@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir",
+      "build/main:@storybook/react>@storybook/node-logger>npmlog>gauge>has-unicode",
+      "build/main:autoprefixer",
+      "build/main:bify-module-groups>through2",
+      "build/main:browserify",
+      "build/main:browserify>browser-pack",
+      "build/main:browserify>browser-pack>through2",
+      "build/main:browserify>browser-pack>through2>readable-stream",
+      "build/main:browserify>browser-resolve",
+      "build/main:browserify>cached-path-relative",
+      "build/main:browserify>concat-stream>readable-stream",
+      "build/main:browserify>deps-sort>through2",
+      "build/main:browserify>deps-sort>through2>readable-stream",
+      "build/main:browserify>duplexer2>readable-stream",
+      "build/main:browserify>insert-module-globals>through2",
+      "build/main:browserify>insert-module-globals>through2>readable-stream",
+      "build/main:browserify>module-deps",
+      "build/main:browserify>module-deps>readable-stream",
+      "build/main:browserify>module-deps>stream-combiner2>readable-stream",
+      "build/main:browserify>module-deps>through2",
+      "build/main:browserify>parents",
+      "build/main:browserify>parents>path-platform",
+      "build/main:browserify>read-only-stream>readable-stream",
+      "build/main:browserify>readable-stream",
+      "build/main:browserify>through2",
+      "build/main:browserslist",
+      "build/main:chalk>supports-color",
+      "build/main:chalk>supports-color>has-flag",
+      "build/main:chokidar",
+      "build/main:chokidar>anymatch>picomatch",
+      "build/main:chokidar>fsevents",
+      "build/main:chokidar>readdirp",
+      "build/main:cross-spawn",
+      "build/main:cross-spawn>path-key",
+      "build/main:cross-spawn>which",
+      "build/main:debounce-stream>through",
+      "build/main:del",
+      "build/main:del>graceful-fs",
+      "build/main:del>is-path-cwd",
+      "build/main:del>rimraf",
+      "build/main:depcheck>is-core-module",
+      "build/main:depcheck>resolve",
+      "build/main:depcheck>resolve>path-parse",
+      "build/main:duplexify",
+      "build/main:duplexify>end-of-stream",
+      "build/main:eslint",
+      "build/main:eslint-config-prettier",
+      "build/main:eslint-import-resolver-node>debug",
+      "build/main:eslint-import-resolver-typescript",
+      "build/main:eslint-plugin-import",
+      "build/main:eslint-plugin-import>debug",
+      "build/main:eslint-plugin-import>eslint-module-utils",
+      "build/main:eslint-plugin-import>eslint-module-utils>debug",
+      "build/main:eslint-plugin-import>eslint-module-utils>find-up>locate-path",
+      "build/main:eslint-plugin-import>tsconfig-paths",
+      "build/main:eslint-plugin-node",
+      "build/main:eslint-plugin-node>semver",
+      "build/main:eslint-plugin-react",
+      "build/main:eslint-plugin-react-hooks",
+      "build/main:eslint-plugin-react>resolve",
+      "build/main:eslint-plugin-react>semver",
+      "build/main:eslint>@eslint/eslintrc",
+      "build/main:eslint>@nodelib/fs.walk>@nodelib/fs.scandir",
+      "build/main:eslint>@nodelib/fs.walk>@nodelib/fs.scandir>run-parallel",
+      "build/main:eslint>ignore",
+      "build/main:fancy-log",
+      "build/main:fancy-log>color-support",
+      "build/main:fast-glob",
+      "build/main:fs-extra",
+      "build/main:gh-pages>globby>pinkie-promise>pinkie",
+      "build/main:globby",
+      "build/main:globby>dir-glob",
+      "build/main:globby>merge2",
+      "build/main:gulp-livereload>chalk",
+      "build/main:gulp-livereload>chalk>supports-color",
+      "build/main:gulp-livereload>chalk>supports-color>has-flag",
+      "build/main:gulp-livereload>debug",
+      "build/main:gulp-livereload>event-stream",
+      "build/main:gulp-livereload>event-stream>from",
+      "build/main:gulp-livereload>event-stream>map-stream",
+      "build/main:gulp-livereload>tiny-lr>body>raw-body",
+      "build/main:gulp-livereload>tiny-lr>debug",
+      "build/main:gulp-livereload>tiny-lr>faye-websocket",
+      "build/main:gulp-postcss>postcss-load-config",
+      "build/main:gulp-postcss>postcss-load-config>lilconfig",
+      "build/main:gulp-postcss>postcss-load-config>yaml",
+      "build/main:gulp-sass",
+      "build/main:gulp-sort>through2",
+      "build/main:gulp-sort>through2>readable-stream",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss>picocolors",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/identity-map>through2",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream",
+      "build/main:gulp-sourcemaps>debug-fabulous>debug",
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee>next-tick",
+      "build/main:gulp-sourcemaps>through2",
+      "build/main:gulp-sourcemaps>through2>readable-stream",
+      "build/main:gulp-stylelint",
+      "build/main:gulp-stylelint>through2",
+      "build/main:gulp-watch",
+      "build/main:gulp-watch>anymatch>micromatch",
+      "build/main:gulp-watch>chokidar",
+      "build/main:gulp-watch>chokidar>fsevents",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>nopt",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp>semver",
+      "build/main:gulp-watch>fancy-log",
+      "build/main:gulp-watch>path-is-absolute",
+      "build/main:gulp-watch>readable-stream",
+      "build/main:gulp-watch>vinyl-file",
+      "build/main:gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream",
+      "build/main:gulp-watch>vinyl-file>vinyl",
+      "build/main:gulp-zip>through2",
+      "build/main:gulp>glob-watcher>anymatch>micromatch",
+      "build/main:gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug",
+      "build/main:gulp>glob-watcher>async-done",
+      "build/main:gulp>glob-watcher>chokidar>fsevents",
+      "build/main:gulp>gulp-cli>matchdep>micromatch>snapdragon>debug",
+      "build/main:gulp>undertaker",
+      "build/main:gulp>undertaker>last-run>default-resolution",
+      "build/main:gulp>vinyl-fs",
+      "build/main:gulp>vinyl-fs>fs-mkdirp-stream",
+      "build/main:gulp>vinyl-fs>fs-mkdirp-stream>through2",
+      "build/main:gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream",
+      "build/main:gulp>vinyl-fs>glob-stream",
+      "build/main:gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream",
+      "build/main:gulp>vinyl-fs>glob-stream>pumpify>duplexify",
+      "build/main:gulp>vinyl-fs>glob-stream>readable-stream",
+      "build/main:gulp>vinyl-fs>glob-stream>to-absolute-glob",
+      "build/main:gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2",
+      "build/main:gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream",
+      "build/main:gulp>vinyl-fs>lazystream>readable-stream",
+      "build/main:gulp>vinyl-fs>lead",
+      "build/main:gulp>vinyl-fs>lead>flush-write-stream>readable-stream",
+      "build/main:gulp>vinyl-fs>pumpify>duplexify",
+      "build/main:gulp>vinyl-fs>readable-stream",
+      "build/main:gulp>vinyl-fs>remove-bom-stream>through2",
+      "build/main:gulp>vinyl-fs>remove-bom-stream>through2>readable-stream",
+      "build/main:gulp>vinyl-fs>through2",
+      "build/main:gulp>vinyl-fs>to-through>through2",
+      "build/main:gulp>vinyl-fs>to-through>through2>readable-stream",
+      "build/main:ini",
+      "build/main:labeled-stream-splicer>stream-splicer",
+      "build/main:labeled-stream-splicer>stream-splicer>readable-stream",
+      "build/main:lavamoat-browserify",
+      "build/main:lavamoat-browserify>duplexify",
+      "build/main:lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/types",
+      "build/main:lavamoat>lavamoat-core>merge-deep>clone-deep>lazy-cache",
+      "build/main:lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>lazy-cache",
+      "build/main:loose-envify",
+      "build/main:mocha>find-up>locate-path",
+      "build/main:mocha>log-symbols>is-unicode-supported",
+      "build/main:mocha>supports-color",
+      "build/main:mocha>supports-color>has-flag",
+      "build/main:nock>debug",
+      "build/main:nyc>glob",
+      "build/main:nyc>glob>fs.realpath",
+      "build/main:nyc>glob>inflight",
+      "build/main:nyc>signal-exit",
+      "build/main:nyc>spawn-wrap>is-windows",
+      "build/main:nyc>yargs>set-blocking",
+      "build/main:postcss",
+      "build/main:postcss-discard-font-face>postcss>chalk",
+      "build/main:postcss-discard-font-face>postcss>chalk>supports-color",
+      "build/main:postcss-discard-font-face>postcss>supports-color",
+      "build/main:postcss-discard-font-face>postcss>supports-color>has-flag",
+      "build/main:postcss>picocolors",
+      "build/main:prettier",
+      "build/main:prop-types",
+      "build/main:prop-types>react-is",
+      "build/main:pumpify>pump",
+      "build/main:react-markdown>vfile",
+      "build/main:readable-stream",
+      "build/main:readable-stream-2>process-nextick-args",
+      "build/main:sass-embedded",
+      "build/main:sass-embedded>@bufbuild/protobuf",
+      "build/main:semver",
+      "build/main:stylelint",
+      "build/main:stylelint>autoprefixer",
+      "build/main:stylelint>cosmiconfig",
+      "build/main:stylelint>cosmiconfig>yaml",
+      "build/main:stylelint>file-entry-cache>flat-cache>rimraf",
+      "build/main:stylelint>global-modules",
+      "build/main:stylelint>global-modules>global-prefix",
+      "build/main:stylelint>global-modules>global-prefix>ini",
+      "build/main:stylelint>global-modules>global-prefix>which",
+      "build/main:stylelint>postcss",
+      "build/main:stylelint>postcss-less>postcss",
+      "build/main:stylelint>postcss-less>postcss>picocolors",
+      "build/main:stylelint>postcss-safe-parser>postcss",
+      "build/main:stylelint>postcss-safe-parser>postcss>picocolors",
+      "build/main:stylelint>postcss-sass>postcss",
+      "build/main:stylelint>postcss-sass>postcss>picocolors",
+      "build/main:stylelint>postcss-scss>postcss",
+      "build/main:stylelint>postcss-scss>postcss>picocolors",
+      "build/main:stylelint>postcss>picocolors",
+      "build/main:stylelint>sugarss>postcss",
+      "build/main:stylelint>sugarss>postcss>picocolors",
+      "build/main:stylelint>table",
+      "build/main:stylelint>write-file-atomic",
+      "build/main:terser",
+      "build/main:terser>source-map-support",
+      "build/main:ts-node",
+      "build/main:ts-node>@cspotcode/source-map-support",
+      "build/main:ts-node>arg",
+      "build/main:ts-node>create-require",
+      "build/main:ts-node>v8-compile-cache-lib",
+      "build/main:typescript",
+      "build/main:vinyl",
+      "build/main:vinyl-buffer>bl>readable-stream",
+      "build/main:vinyl-buffer>through2",
+      "build/main:vinyl-source-stream",
+      "build/main:vinyl-source-stream>through2",
+      "build/main:vinyl-source-stream>through2>readable-stream",
+      "build/main:vinyl>cloneable-readable>process-nextick-args",
+      "build/main:vinyl>cloneable-readable>through2",
+      "build/main:vinyl>cloneable-readable>through2>readable-stream",
+      "build/main:vinyl>cloneable-readable>through2>readable-stream>process-nextick-args",
+      "build/main:vinyl>remove-trailing-separator",
+      "build/main:webpack-dev-server>sockjs>websocket-driver",
+      "build/main:yaml",
+      "build/main:yargs",
+      "build/main:yargs-parser",
+      "build/main:yargs>cliui",
+      "build/main:yargs>yargs-parser",
+      "build/override:@babel/eslint-parser",
+      "build/override:eslint>@eslint/eslintrc",
+      "build/override:yargs",
+      "build/override:yargs>yargs-parser",
+      "build/override:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog",
+      "build/override:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge",
+      "build/override:@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir",
+      "build/override:@storybook/react>@storybook/node-logger>npmlog>gauge>has-unicode",
+      "build/override:gulp-watch>chokidar",
+      "build/override:gulp-watch>chokidar>fsevents",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>nopt",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp>semver",
+      "build/override:chokidar>fsevents",
+      "build/override:gulp>glob-watcher>chokidar>fsevents",
+      "build/override:nyc>yargs>set-blocking"
+    ],
+    "self": [
+      "app/main:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/main:react-dom",
+      "app/flask:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/flask:react-dom",
+      "app/beta:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/beta:react-dom",
+      "app/mmi:@metamask/notification-services-controller>firebase>@firebase/util",
+      "app/mmi:react-dom"
+    ],
+    "MessageEvent": [
+      "app/main:@metamask/post-message-stream",
+      "app/flask:@metamask/post-message-stream",
+      "app/beta:@metamask/post-message-stream",
+      "app/mmi:@metamask/post-message-stream"
+    ],
+    "WorkerGlobalScope": [
+      "app/main:@metamask/post-message-stream",
+      "app/flask:@metamask/post-message-stream",
+      "app/beta:@metamask/post-message-stream",
+      "app/mmi:@metamask/post-message-stream",
+      "build/main:prettier"
+    ],
+    "postMessage": [
+      "app/main:@metamask/post-message-stream",
+      "app/flask:@metamask/post-message-stream",
+      "app/beta:@metamask/post-message-stream",
+      "app/mmi:@metamask/post-message-stream"
+    ],
+    "Event": [
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:@sentry/utils",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:@sentry/utils",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:@sentry/utils",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:@sentry/utils"
+    ],
+    "dispatchEvent": [
+      "app/main:@metamask/profile-sync-controller",
+      "app/main:react-dom",
+      "app/flask:@metamask/profile-sync-controller",
+      "app/flask:react-dom",
+      "app/beta:@metamask/profile-sync-controller",
+      "app/beta:react-dom",
+      "app/mmi:@metamask/profile-sync-controller",
+      "app/mmi:react-dom"
+    ],
+    "DecompressionStream": [
+      "app/main:@metamask/snaps-controllers",
+      "app/flask:@metamask/snaps-controllers",
+      "app/beta:@metamask/snaps-controllers",
+      "app/mmi:@metamask/snaps-controllers"
+    ],
+    "queueMicrotask": [
+      "app/main:@metamask/snaps-controllers>tar-stream>streamx>queue-tick",
+      "app/main:@reduxjs/toolkit",
+      "app/main:crypto-browserify>pbkdf2",
+      "app/flask:@metamask/snaps-controllers>tar-stream>streamx>queue-tick",
+      "app/flask:@reduxjs/toolkit",
+      "app/flask:crypto-browserify>pbkdf2",
+      "app/beta:@metamask/snaps-controllers>tar-stream>streamx>queue-tick",
+      "app/beta:@reduxjs/toolkit",
+      "app/beta:crypto-browserify>pbkdf2",
+      "app/mmi:@metamask/snaps-controllers>tar-stream>streamx>queue-tick",
+      "app/mmi:@reduxjs/toolkit",
+      "app/mmi:crypto-browserify>pbkdf2",
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee>next-tick",
+      "build/main:prettier"
+    ],
+    "File": [
+      "app/main:@metamask/snaps-utils",
+      "app/main:react-simple-file-input",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:react-simple-file-input",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:react-simple-file-input",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:react-simple-file-input"
+    ],
+    "FileReader": [
+      "app/main:@metamask/snaps-utils",
+      "app/main:localforage",
+      "app/main:react-simple-file-input",
+      "app/flask:@metamask/snaps-utils",
+      "app/flask:localforage",
+      "app/flask:react-simple-file-input",
+      "app/beta:@metamask/snaps-utils",
+      "app/beta:localforage",
+      "app/beta:react-simple-file-input",
+      "app/mmi:@metamask/snaps-utils",
+      "app/mmi:localforage",
+      "app/mmi:react-simple-file-input"
+    ],
+    "entityName": [
+      "app/main:@metamask/snaps-utils>fast-xml-parser",
+      "app/flask:@metamask/snaps-utils>fast-xml-parser",
+      "app/beta:@metamask/snaps-utils>fast-xml-parser",
+      "app/mmi:@metamask/snaps-utils>fast-xml-parser"
+    ],
+    "val": [
+      "app/main:@metamask/snaps-utils>fast-xml-parser",
+      "app/flask:@metamask/snaps-utils>fast-xml-parser",
+      "app/beta:@metamask/snaps-utils>fast-xml-parser",
+      "app/mmi:@metamask/snaps-utils>fast-xml-parser"
+    ],
+    "HTMLElement": [
+      "app/main:@popperjs/core",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/utils",
+      "app/main:@zxing/browser",
+      "app/main:react-responsive-carousel",
+      "app/main:string.prototype.matchall>es-abstract>object-inspect",
+      "app/flask:@popperjs/core",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/utils",
+      "app/flask:@zxing/browser",
+      "app/flask:react-responsive-carousel",
+      "app/flask:string.prototype.matchall>es-abstract>object-inspect",
+      "app/beta:@popperjs/core",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/utils",
+      "app/beta:@zxing/browser",
+      "app/beta:react-responsive-carousel",
+      "app/beta:string.prototype.matchall>es-abstract>object-inspect",
+      "app/mmi:@popperjs/core",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/utils",
+      "app/mmi:@zxing/browser",
+      "app/mmi:string.prototype.matchall>es-abstract>object-inspect",
+      "build/main:prettier",
+      "build/main:string.prototype.matchall>es-abstract>object-inspect"
+    ],
+    "ShadowRoot": [
+      "app/main:@popperjs/core",
+      "app/flask:@popperjs/core",
+      "app/beta:@popperjs/core",
+      "app/mmi:@popperjs/core"
+    ],
+    "__REDUX_DEVTOOLS_EXTENSION_COMPOSE__": [
+      "app/main:@reduxjs/toolkit",
+      "app/main:react-beautiful-dnd",
+      "app/flask:@reduxjs/toolkit",
+      "app/flask:react-beautiful-dnd",
+      "app/beta:@reduxjs/toolkit",
+      "app/beta:react-beautiful-dnd",
+      "app/mmi:@reduxjs/toolkit",
+      "app/mmi:react-beautiful-dnd"
+    ],
+    "__REDUX_DEVTOOLS_EXTENSION__": [
+      "app/main:@reduxjs/toolkit",
+      "app/flask:@reduxjs/toolkit",
+      "app/beta:@reduxjs/toolkit",
+      "app/mmi:@reduxjs/toolkit"
+    ],
+    "PerformanceObserver": [
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils",
+      "build/main:typescript"
+    ],
+    "Request": [
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@sentry/utils",
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/main:node-fetch",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/utils",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:node-fetch",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/utils",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:node-fetch",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/utils",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:node-fetch",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router",
+      "app/override:node-fetch"
+    ],
+    "__SENTRY_DEBUG__": [
+      "app/main:@sentry/browser",
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry/core",
+      "app/main:@sentry/utils",
+      "app/flask:@sentry/browser",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/utils",
+      "app/beta:@sentry/browser",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/utils",
+      "app/mmi:@sentry/browser",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/utils"
+    ],
+    "__SENTRY_RELEASE__": [
+      "app/main:@sentry/browser",
+      "app/flask:@sentry/browser",
+      "app/beta:@sentry/browser",
+      "app/mmi:@sentry/browser"
+    ],
+    "PerformanceEventTiming": [
+      "app/main:@sentry/browser>@sentry-internal/browser-utils",
+      "app/flask:@sentry/browser>@sentry-internal/browser-utils",
+      "app/beta:@sentry/browser>@sentry-internal/browser-utils",
+      "app/mmi:@sentry/browser>@sentry-internal/browser-utils"
+    ],
+    "HTMLFormElement": [
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "isSecureContext": [
+      "app/main:@sentry/browser>@sentry-internal/feedback",
+      "app/main:@solana/addresses>@solana/assertions",
+      "app/flask:@sentry/browser>@sentry-internal/feedback",
+      "app/flask:@solana/addresses>@solana/assertions",
+      "app/beta:@sentry/browser>@sentry-internal/feedback",
+      "app/beta:@solana/addresses>@solana/assertions",
+      "app/mmi:@sentry/browser>@sentry-internal/feedback",
+      "app/mmi:@solana/addresses>@solana/assertions"
+    ],
+    "CSSConditionRule": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "CSSGroupingRule": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "CSSMediaRule": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "CSSRule": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "CSSSupportsRule": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "DragEvent": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "MouseEvent": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "MutationObserver": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:chart.js",
+      "app/main:react-tippy",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:chart.js",
+      "app/flask:react-tippy",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:chart.js",
+      "app/beta:react-tippy",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:chart.js",
+      "app/mmi:react-tippy",
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee>next-tick"
+    ],
+    "PointerEvent": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "Worker": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/main:lottie-web",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:lottie-web",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:lottie-web",
+      "app/mmi:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:lottie-web"
+    ],
+    "__RRWEB_EXCLUDE_IFRAME__": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "__RRWEB_EXCLUDE_SHADOW_DOM__": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "__SENTRY_EXCLUDE_REPLAY_WORKER__": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "__rrMutationObserver": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "customElements": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "parent": [
+      "app/main:@sentry/browser>@sentry-internal/replay",
+      "app/flask:@sentry/browser>@sentry-internal/replay",
+      "app/beta:@sentry/browser>@sentry-internal/replay",
+      "app/mmi:@sentry/browser>@sentry-internal/replay"
+    ],
+    "HTMLCanvasElement": [
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas"
+    ],
+    "HTMLImageElement": [
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/main:@zxing/browser",
+      "app/main:@zxing/library",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:@zxing/browser",
+      "app/flask:@zxing/library",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:@zxing/browser",
+      "app/beta:@zxing/library",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:@zxing/browser",
+      "app/mmi:@zxing/library"
+    ],
+    "ImageData": [
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas"
+    ],
+    "createImageBitmap": [
+      "app/main:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/flask:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/beta:@sentry/browser>@sentry-internal/replay-canvas",
+      "app/mmi:@sentry/browser>@sentry-internal/replay-canvas"
+    ],
+    "__SENTRY_TRACING__": [
+      "app/main:@sentry/browser>@sentry/core",
+      "app/flask:@sentry/browser>@sentry/core",
+      "app/beta:@sentry/browser>@sentry/core",
+      "app/mmi:@sentry/browser>@sentry/core"
+    ],
+    "CustomEvent": [
+      "app/main:@sentry/utils",
+      "app/flask:@sentry/utils",
+      "app/beta:@sentry/utils",
+      "app/mmi:@sentry/utils"
+    ],
+    "DOMError": [
+      "app/main:@sentry/utils",
+      "app/flask:@sentry/utils",
+      "app/beta:@sentry/utils",
+      "app/mmi:@sentry/utils"
+    ],
+    "EdgeRuntime": [
+      "app/main:@sentry/utils",
+      "app/flask:@sentry/utils",
+      "app/beta:@sentry/utils",
+      "app/mmi:@sentry/utils"
+    ],
+    "ErrorEvent": [
+      "app/main:@sentry/utils",
+      "app/flask:@sentry/utils",
+      "app/beta:@sentry/utils",
+      "app/mmi:@sentry/utils"
+    ],
+    "Response": [
+      "app/main:@sentry/utils",
+      "app/main:node-fetch",
+      "app/main:react-router-dom-v5-compat>@remix-run/router",
+      "app/flask:@sentry/utils",
+      "app/flask:node-fetch",
+      "app/flask:react-router-dom-v5-compat>@remix-run/router",
+      "app/beta:@sentry/utils",
+      "app/beta:node-fetch",
+      "app/beta:react-router-dom-v5-compat>@remix-run/router",
+      "app/mmi:@sentry/utils",
+      "app/mmi:node-fetch",
+      "app/mmi:react-router-dom-v5-compat>@remix-run/router",
+      "app/override:node-fetch"
+    ],
+    "__SENTRY_BROWSER_BUNDLE__": [
+      "app/main:@sentry/utils",
+      "app/flask:@sentry/utils",
+      "app/beta:@sentry/utils",
+      "app/mmi:@sentry/utils"
+    ],
+    "__TREZOR_CONNECT_SRC": [
+      "app/main:@trezor/connect-web",
+      "app/flask:@trezor/connect-web",
+      "app/beta:@trezor/connect-web",
+      "app/mmi:@trezor/connect-web"
+    ],
+    "open": [
+      "app/main:@trezor/connect-web",
+      "app/main:eth-lattice-keyring",
+      "app/flask:@trezor/connect-web",
+      "app/flask:eth-lattice-keyring",
+      "app/beta:@trezor/connect-web",
+      "app/beta:eth-lattice-keyring",
+      "app/mmi:@trezor/connect-web",
+      "app/mmi:eth-lattice-keyring"
+    ],
+    "localStorage": [
+      "app/main:@trezor/connect-web>@trezor/connect-common",
+      "app/main:localforage",
+      "app/main:loglevel",
+      "app/main:nock>debug",
+      "app/main:readable-stream>util-deprecate",
+      "app/flask:@trezor/connect-web>@trezor/connect-common",
+      "app/flask:localforage",
+      "app/flask:loglevel",
+      "app/flask:nock>debug",
+      "app/flask:readable-stream>util-deprecate",
+      "app/beta:@trezor/connect-web>@trezor/connect-common",
+      "app/beta:localforage",
+      "app/beta:loglevel",
+      "app/beta:nock>debug",
+      "app/beta:readable-stream>util-deprecate",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common",
+      "app/mmi:localforage",
+      "app/mmi:loglevel",
+      "app/mmi:nock>debug",
+      "app/mmi:readable-stream>util-deprecate",
+      "build/main:eslint-import-resolver-node>debug",
+      "build/main:eslint-plugin-import>debug",
+      "build/main:eslint-plugin-import>eslint-module-utils>debug",
+      "build/main:gulp-livereload>debug",
+      "build/main:gulp-livereload>tiny-lr>debug",
+      "build/main:gulp-sourcemaps>debug-fabulous>debug",
+      "build/main:gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug",
+      "build/main:gulp>gulp-cli>matchdep>micromatch>snapdragon>debug",
+      "build/main:nock>debug"
+    ],
+    "window": [
+      "app/main:@trezor/connect-web>@trezor/connect-common",
+      "app/flask:@trezor/connect-web>@trezor/connect-common",
+      "app/beta:@trezor/connect-web>@trezor/connect-common",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common"
+    ],
+    "screen": [
+      "app/main:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/flask:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/beta:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils",
+      "app/mmi:@trezor/connect-web>@trezor/connect-common>@trezor/env-utils"
+    ],
+    "HTMLVideoElement": [
+      "app/main:@zxing/browser",
+      "app/main:@zxing/library",
+      "app/flask:@zxing/browser",
+      "app/flask:@zxing/library",
+      "app/beta:@zxing/browser",
+      "app/beta:@zxing/library",
+      "app/mmi:@zxing/browser",
+      "app/mmi:@zxing/library"
+    ],
+    "OffscreenCanvas": [
+      "app/main:chart.js",
+      "app/main:lottie-web",
+      "app/flask:chart.js",
+      "app/flask:lottie-web",
+      "app/beta:chart.js",
+      "app/beta:lottie-web",
+      "app/mmi:chart.js",
+      "app/mmi:lottie-web"
+    ],
+    "Path2D": [
+      "app/main:chart.js",
+      "app/main:qrcode.react",
+      "app/flask:chart.js",
+      "app/flask:qrcode.react",
+      "app/beta:chart.js",
+      "app/beta:qrcode.react",
+      "app/mmi:chart.js",
+      "app/mmi:qrcode.react"
+    ],
+    "ResizeObserver": [
+      "app/main:chart.js",
+      "app/flask:chart.js",
+      "app/beta:chart.js",
+      "app/mmi:chart.js"
+    ],
+    "classNames": [
+      "app/main:classnames",
+      "app/flask:classnames",
+      "app/beta:classnames",
+      "app/mmi:classnames"
+    ],
+    "AbortSignal": [
+      "app/main:cockatiel",
+      "app/flask:cockatiel",
+      "app/beta:cockatiel",
+      "app/mmi:cockatiel"
+    ],
+    "clipboardData": [
+      "app/main:copy-to-clipboard",
+      "app/main:react-dom",
+      "app/flask:copy-to-clipboard",
+      "app/flask:react-dom",
+      "app/beta:copy-to-clipboard",
+      "app/beta:react-dom",
+      "app/mmi:copy-to-clipboard",
+      "app/mmi:react-dom"
+    ],
+    "prompt": [
+      "app/main:copy-to-clipboard",
+      "app/flask:copy-to-clipboard",
+      "app/beta:copy-to-clipboard",
+      "app/mmi:copy-to-clipboard"
+    ],
+    "setImmediate": [
+      "app/main:crypto-browserify>pbkdf2",
+      "app/flask:crypto-browserify>pbkdf2",
+      "app/beta:crypto-browserify>pbkdf2",
+      "app/mmi:crypto-browserify>pbkdf2",
+      "build/main:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge",
+      "build/main:browserify>browser-pack>through2>readable-stream",
+      "build/main:browserify>concat-stream>readable-stream",
+      "build/main:browserify>deps-sort>through2>readable-stream",
+      "build/main:browserify>duplexer2>readable-stream",
+      "build/main:browserify>insert-module-globals>through2>readable-stream",
+      "build/main:browserify>module-deps>readable-stream",
+      "build/main:browserify>module-deps>stream-combiner2>readable-stream",
+      "build/main:browserify>read-only-stream>readable-stream",
+      "build/main:browserify>readable-stream",
+      "build/main:eslint>@nodelib/fs.walk",
+      "build/main:gh-pages>globby>pinkie-promise>pinkie",
+      "build/main:gulp-livereload>event-stream",
+      "build/main:gulp-postcss",
+      "build/main:gulp-sort>through2>readable-stream",
+      "build/main:gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream",
+      "build/main:gulp-sourcemaps>css>source-map-resolve",
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee>next-tick",
+      "build/main:gulp-sourcemaps>through2>readable-stream",
+      "build/main:gulp-watch>chokidar>fsevents",
+      "build/main:gulp-watch>readable-stream",
+      "build/main:gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream",
+      "build/main:gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream",
+      "build/main:gulp-zip>yazl",
+      "build/main:gulp>glob-watcher>async-done>stream-exhaust",
+      "build/main:gulp>glob-watcher>chokidar>fsevents",
+      "build/main:gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream",
+      "build/main:gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream",
+      "build/main:gulp>vinyl-fs>glob-stream>readable-stream",
+      "build/main:gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream",
+      "build/main:gulp>vinyl-fs>lazystream>readable-stream",
+      "build/main:gulp>vinyl-fs>lead>flush-write-stream>readable-stream",
+      "build/main:gulp>vinyl-fs>readable-stream",
+      "build/main:gulp>vinyl-fs>remove-bom-stream>through2>readable-stream",
+      "build/main:gulp>vinyl-fs>to-through>through2>readable-stream",
+      "build/main:labeled-stream-splicer>stream-splicer",
+      "build/main:labeled-stream-splicer>stream-splicer>readable-stream",
+      "build/main:prettier",
+      "build/main:resolve-url-loader>rework>css>source-map-resolve",
+      "build/main:vinyl-buffer>bl>readable-stream",
+      "build/main:vinyl-source-stream>through2>readable-stream",
+      "build/main:vinyl>cloneable-readable>through2>readable-stream",
+      "build/override:@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge",
+      "build/override:gulp-watch>chokidar>fsevents",
+      "build/override:gulp>glob-watcher>chokidar>fsevents"
+    ],
+    "countryCode": [
+      "app/main:currency-formatter>locale-currency",
+      "app/flask:currency-formatter>locale-currency",
+      "app/beta:currency-formatter>locale-currency",
+      "app/mmi:currency-formatter>locale-currency"
+    ],
+    "name": [
+      "app/main:eth-ens-namehash",
+      "app/flask:eth-ens-namehash",
+      "app/beta:eth-ens-namehash",
+      "app/mmi:eth-ens-namehash"
+    ],
+    "__values": [
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk",
+      "build/main:sass-embedded>@bufbuild/protobuf"
+    ],
+    "caches": [
+      "app/main:eth-lattice-keyring>gridplus-sdk",
+      "app/flask:eth-lattice-keyring>gridplus-sdk",
+      "app/beta:eth-lattice-keyring>gridplus-sdk",
+      "app/mmi:eth-lattice-keyring>gridplus-sdk"
+    ],
+    "AggregateError": [
+      "app/main:extension-port-stream>readable-stream",
+      "app/main:string.prototype.matchall>get-intrinsic",
+      "app/flask:extension-port-stream>readable-stream",
+      "app/flask:string.prototype.matchall>get-intrinsic",
+      "app/beta:extension-port-stream>readable-stream",
+      "app/beta:string.prototype.matchall>get-intrinsic",
+      "app/mmi:extension-port-stream>readable-stream",
+      "app/mmi:string.prototype.matchall>get-intrinsic",
+      "build/main:string.prototype.matchall>get-intrinsic"
+    ],
+    "BlobBuilder": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "IDBKeyRange": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "MSBlobBuilder": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "MozBlobBuilder": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "OIndexedDB": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "WebKitBlobBuilder": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "mozIndexedDB": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "msIndexedDB": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "openDatabase": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "webkitIndexedDB": [
+      "app/main:localforage",
+      "app/flask:localforage",
+      "app/beta:localforage",
+      "app/mmi:localforage"
+    ],
+    "log": [
+      "app/main:loglevel",
+      "app/flask:loglevel",
+      "app/beta:loglevel",
+      "app/mmi:loglevel"
+    ],
+    "Howl": [
+      "app/main:lottie-web",
+      "app/flask:lottie-web",
+      "app/beta:lottie-web",
+      "app/mmi:lottie-web"
+    ],
+    "bodymovin": [
+      "app/main:lottie-web",
+      "app/flask:lottie-web",
+      "app/beta:lottie-web",
+      "app/mmi:lottie-web"
+    ],
+    "pageXOffset": [
+      "app/main:react-beautiful-dnd",
+      "app/main:react-beautiful-dnd>css-box-model",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-beautiful-dnd>css-box-model",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-beautiful-dnd>css-box-model",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-beautiful-dnd>css-box-model"
+    ],
+    "pageYOffset": [
+      "app/main:react-beautiful-dnd",
+      "app/main:react-beautiful-dnd>css-box-model",
+      "app/flask:react-beautiful-dnd",
+      "app/flask:react-beautiful-dnd>css-box-model",
+      "app/beta:react-beautiful-dnd",
+      "app/beta:react-beautiful-dnd>css-box-model",
+      "app/mmi:react-beautiful-dnd",
+      "app/mmi:react-beautiful-dnd>css-box-model"
+    ],
+    "scrollBy": [
+      "app/main:react-beautiful-dnd",
+      "app/flask:react-beautiful-dnd",
+      "app/beta:react-beautiful-dnd",
+      "app/mmi:react-beautiful-dnd"
+    ],
+    "HTMLIFrameElement": [
+      "app/main:react-dom",
+      "app/main:react-focus-lock>focus-lock",
+      "app/flask:react-dom",
+      "app/flask:react-focus-lock>focus-lock",
+      "app/beta:react-dom",
+      "app/beta:react-focus-lock>focus-lock",
+      "app/mmi:react-dom",
+      "app/mmi:react-focus-lock>focus-lock",
+      "app/override:react-dom"
+    ],
+    "MSApp": [
+      "app/main:react-dom",
+      "app/flask:react-dom",
+      "app/beta:react-dom",
+      "app/mmi:react-dom"
+    ],
+    "__REACT_DEVTOOLS_GLOBAL_HOOK__": [
+      "app/main:react-dom",
+      "app/flask:react-dom",
+      "app/beta:react-dom",
+      "app/mmi:react-dom"
+    ],
+    "event": [
+      "app/main:react-dom",
+      "app/flask:react-dom",
+      "app/beta:react-dom",
+      "app/mmi:react-dom"
+    ],
+    "jest": [
+      "app/main:react-dom",
+      "app/flask:react-dom",
+      "app/beta:react-dom",
+      "app/mmi:react-dom"
+    ],
+    "top": [
+      "app/main:react-dom",
+      "app/flask:react-dom",
+      "app/beta:react-dom",
+      "app/mmi:react-dom"
+    ],
+    "trustedTypes": [
+      "app/main:react-dom",
+      "app/flask:react-dom",
+      "app/beta:react-dom",
+      "app/mmi:react-dom"
+    ],
+    "MessageChannel": [
+      "app/main:react-dom>scheduler",
+      "app/flask:react-dom>scheduler",
+      "app/beta:react-dom>scheduler",
+      "app/mmi:react-dom>scheduler"
+    ],
+    "chromeDark": [
+      "app/main:react-inspector",
+      "app/flask:react-inspector",
+      "app/beta:react-inspector",
+      "app/mmi:react-inspector"
+    ],
+    "chromeLight": [
+      "app/main:react-inspector",
+      "app/flask:react-inspector",
+      "app/beta:react-inspector",
+      "app/mmi:react-inspector"
+    ],
+    "__reactRouterVersion": [
+      "app/main:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat"
+    ],
+    "confirm": [
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom>history",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom>history",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom>history",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom>history"
+    ],
+    "history": [
+      "app/main:react-router-dom-v5-compat",
+      "app/main:react-router-dom>history",
+      "app/flask:react-router-dom-v5-compat",
+      "app/flask:react-router-dom>history",
+      "app/beta:react-router-dom-v5-compat",
+      "app/beta:react-router-dom>history",
+      "app/mmi:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom>history"
+    ],
+    "scrollTo": [
+      "app/main:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat"
+    ],
+    "scrollY": [
+      "app/main:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat"
+    ],
+    "sessionStorage": [
+      "app/main:react-router-dom-v5-compat",
+      "app/flask:react-router-dom-v5-compat",
+      "app/beta:react-router-dom-v5-compat",
+      "app/mmi:react-router-dom-v5-compat"
+    ],
+    "MSStream": [
+      "app/main:react-tippy",
+      "app/flask:react-tippy",
+      "app/beta:react-tippy",
+      "app/mmi:react-tippy"
+    ],
+    "MSStreamReader": [
+      "app/main:stream-http",
+      "app/flask:stream-http",
+      "app/beta:stream-http",
+      "app/mmi:stream-http"
+    ],
+    "ReadableStream": [
+      "app/main:stream-http",
+      "app/flask:stream-http",
+      "app/beta:stream-http",
+      "app/mmi:stream-http"
+    ],
+    "WritableStream": [
+      "app/main:stream-http",
+      "app/flask:stream-http",
+      "app/beta:stream-http",
+      "app/mmi:stream-http"
+    ],
+    "XDomainRequest": [
+      "app/main:stream-http",
+      "app/flask:stream-http",
+      "app/beta:stream-http",
+      "app/mmi:stream-http"
+    ],
+    "value": [
+      "build/main:@babel/core>convert-source-map",
+      "build/main:@lavamoat/lavapack>convert-source-map",
+      "build/main:ts-node"
+    ],
+    "__dirname": [
+      "build/main:@babel/eslint-parser",
+      "build/main:@lavamoat/lavapack",
+      "build/main:browserify",
+      "build/main:browserify>browser-pack",
+      "build/main:browserify>browser-resolve",
+      "build/main:eslint",
+      "build/main:eslint-plugin-import>eslint-module-utils",
+      "build/main:eslint-plugin-jest",
+      "build/main:eslint>@eslint/eslintrc>import-fresh",
+      "build/main:eslint>file-entry-cache>flat-cache",
+      "build/main:gulp-watch>chokidar>fsevents",
+      "build/main:gulp-watch>chokidar>fsevents>node-pre-gyp",
+      "build/main:gulp>glob-watcher>chokidar>fsevents",
+      "build/main:lavamoat-viz>lavamoat-core",
+      "build/main:prettier",
+      "build/main:sass-embedded",
+      "build/main:source-map",
+      "build/main:stylelint",
+      "build/main:stylelint>@stylelint/postcss-css-in-js",
+      "build/main:stylelint>file-entry-cache>flat-cache",
+      "build/main:stylelint>postcss-html",
+      "build/main:ts-node",
+      "build/main:typescript",
+      "build/main:yargs",
+      "build/override:gulp-watch>chokidar>fsevents",
+      "build/override:gulp-watch>chokidar>fsevents>node-pre-gyp",
+      "build/override:gulp>glob-watcher>chokidar>fsevents"
+    ],
+    "characterClassItem": [
+      "build/main:@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core"
+    ],
+    "regjsparser": [
+      "build/main:@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsparser"
+    ],
+    "__filename": [
+      "build/main:@lavamoat/lavapack",
+      "build/main:eslint>@eslint/eslintrc",
+      "build/main:eslint>@eslint/eslintrc>import-fresh",
+      "build/main:gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets",
+      "build/main:gulp>gulp-cli>matchdep>micromatch>snapdragon",
+      "build/main:prettier",
+      "build/main:sass-embedded",
+      "build/main:stylelint>write-file-atomic",
+      "build/main:typescript"
+    ],
+    "TESTING_WINDOWS": [
+      "build/main:@sentry/cli>which>isexe"
+    ],
+    "tr": [
+      "build/main:browserify>module-deps"
+    ],
+    "describe": [
+      "build/main:eslint"
+    ],
+    "it": [
+      "build/main:eslint"
+    ],
+    "structuredClone": [
+      "build/main:eslint>@ungap/structured-clone"
+    ],
+    "YAML_SILENCE_DEPRECATION_WARNINGS": [
+      "build/main:gulp-postcss>postcss-load-config>yaml",
+      "build/main:prettier",
+      "build/main:stylelint>cosmiconfig>yaml"
+    ],
+    "YAML_SILENCE_WARNINGS": [
+      "build/main:gulp-postcss>postcss-load-config>yaml",
+      "build/main:prettier",
+      "build/main:stylelint>cosmiconfig>yaml"
+    ],
+    "WebKitMutationObserver": [
+      "build/main:gulp-sourcemaps>debug-fabulous>memoizee>next-tick"
+    ],
+    "utf8FileName": [
+      "build/main:gulp-zip>yazl"
+    ],
+    "isWindows": [
+      "build/main:nyc>spawn-wrap>is-windows"
+    ],
+    "ANONYMOUS": [
+      "build/main:prettier"
+    ],
+    "BuilderFileEmit": [
+      "build/main:prettier"
+    ],
+    "BuilderProgramKind": [
+      "build/main:prettier"
+    ],
+    "BuilderState": [
+      "build/main:prettier"
+    ],
+    "CheckMode": [
+      "build/main:prettier"
+    ],
+    "ClassificationType": [
+      "build/main:prettier"
+    ],
+    "ClassificationTypeNames": [
+      "build/main:prettier"
+    ],
+    "CompletionInfoFlags": [
+      "build/main:prettier"
+    ],
+    "CompletionTriggerKind": [
+      "build/main:prettier"
+    ],
+    "ConfigFileProgramReloadLevel": [
+      "build/main:prettier"
+    ],
+    "CoreServicesShimHostAdapter": [
+      "build/main:prettier"
+    ],
+    "DocumentHighlights": [
+      "build/main:prettier"
+    ],
+    "EndOfLineState": [
+      "build/main:prettier"
+    ],
+    "ExportKind": [
+      "build/main:prettier"
+    ],
+    "FileSystemEntryKind": [
+      "build/main:prettier"
+    ],
+    "FileWatcherEventKind": [
+      "build/main:prettier"
+    ],
+    "FlattenLevel": [
+      "build/main:prettier"
+    ],
+    "ForegroundColorEscapeSequences": [
+      "build/main:prettier"
+    ],
+    "HighlightSpanKind": [
+      "build/main:prettier"
+    ],
+    "ImportKind": [
+      "build/main:prettier"
+    ],
+    "IndentStyle": [
+      "build/main:prettier"
+    ],
+    "InlayHintKind": [
+      "build/main:prettier"
+    ],
+    "InvalidatedProjectKind": [
+      "build/main:prettier"
+    ],
+    "LanguageServiceMode": [
+      "build/main:prettier"
+    ],
+    "LanguageServiceShimHostAdapter": [
+      "build/main:prettier"
+    ],
+    "ModuleInstanceState": [
+      "build/main:prettier"
+    ],
+    "NodeResolutionFeatures": [
+      "build/main:prettier"
+    ],
+    "OrganizeImportsMode": [
+      "build/main:prettier"
+    ],
+    "OutliningSpanKind": [
+      "build/main:prettier"
+    ],
+    "OutputFileType": [
+      "build/main:prettier"
+    ],
+    "PackageJsonAutoImportPreference": [
+      "build/main:prettier"
+    ],
+    "PackageJsonDependencyGroup": [
+      "build/main:prettier"
+    ],
+    "PatternMatchKind": [
+      "build/main:prettier"
+    ],
+    "PollingInterval": [
+      "build/main:prettier"
+    ],
+    "PrivateIdentifierKind": [
+      "build/main:prettier"
+    ],
+    "ProcessLevel": [
+      "build/main:prettier"
+    ],
+    "QuotePreference": [
+      "build/main:prettier"
+    ],
+    "SVGElement": [
+      "build/main:prettier"
+    ],
+    "ScriptElementKind": [
+      "build/main:prettier"
+    ],
+    "ScriptElementKindModifier": [
+      "build/main:prettier"
+    ],
+    "ScriptSnapshot": [
+      "build/main:prettier"
+    ],
+    "SemanticClassificationFormat": [
+      "build/main:prettier"
+    ],
+    "SemanticMeaning": [
+      "build/main:prettier"
+    ],
+    "SemicolonPreference": [
+      "build/main:prettier"
+    ],
+    "SignatureCheckMode": [
+      "build/main:prettier"
+    ],
+    "SymbolDisplayPartKind": [
+      "build/main:prettier"
+    ],
+    "TokenClass": [
+      "build/main:prettier"
+    ],
+    "TypeFacts": [
+      "build/main:prettier"
+    ],
+    "TypeScriptServicesFactory": [
+      "build/main:prettier"
+    ],
+    "UpToDateStatusType": [
+      "build/main:prettier"
+    ],
+    "Version": [
+      "build/main:prettier"
+    ],
+    "VersionRange": [
+      "build/main:prettier"
+    ],
+    "WatchLogLevel": [
+      "build/main:prettier"
+    ],
+    "WatchType": [
+      "build/main:prettier"
+    ],
+    "accessPrivateIdentifier": [
+      "build/main:prettier"
+    ],
+    "addEmitFlags": [
+      "build/main:prettier"
+    ],
+    "addEmitHelper": [
+      "build/main:prettier"
+    ],
+    "addEmitHelpers": [
+      "build/main:prettier"
+    ],
+    "addInternalEmitFlags": [
+      "build/main:prettier"
+    ],
+    "addSyntheticLeadingComment": [
+      "build/main:prettier"
+    ],
+    "addSyntheticTrailingComment": [
+      "build/main:prettier"
+    ],
+    "advancedAsyncSuperHelper": [
+      "build/main:prettier"
+    ],
+    "affectsDeclarationPathOptionDeclarations": [
+      "build/main:prettier"
+    ],
+    "affectsEmitOptionDeclarations": [
+      "build/main:prettier"
+    ],
+    "allKeysStartWithDot": [
+      "build/main:prettier"
+    ],
+    "assertDoc": [
+      "build/main:prettier"
+    ],
+    "assignHelper": [
+      "build/main:prettier"
+    ],
+    "asyncDelegator": [
+      "build/main:prettier"
+    ],
+    "asyncGeneratorHelper": [
+      "build/main:prettier"
+    ],
+    "asyncSuperHelper": [
+      "build/main:prettier"
+    ],
+    "asyncValues": [
+      "build/main:prettier"
+    ],
+    "awaitHelper": [
+      "build/main:prettier"
+    ],
+    "awaiterHelper": [
+      "build/main:prettier"
+    ],
+    "bindSourceFile": [
+      "build/main:prettier"
+    ],
+    "breakIntoCharacterSpans": [
+      "build/main:prettier"
+    ],
+    "breakIntoWordSpans": [
+      "build/main:prettier"
+    ],
+    "buildLinkParts": [
+      "build/main:prettier"
+    ],
+    "buildOpts": [
+      "build/main:prettier"
+    ],
+    "buildOverload": [
+      "build/main:prettier"
+    ],
+    "bundlerModuleNameResolver": [
+      "build/main:prettier"
+    ],
+    "canBeConvertedToAsync": [
+      "build/main:prettier"
+    ],
+    "canJsonReportNoInputFiles": [
+      "build/main:prettier"
+    ],
+    "canProduceDiagnostics": [
+      "build/main:prettier"
+    ],
+    "canWatchDirectoryOrFile": [
+      "build/main:prettier"
+    ],
+    "chainBundle": [
+      "build/main:prettier"
+    ],
+    "changeCompilerHostLikeToUseCache": [
+      "build/main:prettier"
+    ],
+    "classPrivateFieldGetHelper": [
+      "build/main:prettier"
+    ],
+    "classPrivateFieldInHelper": [
+      "build/main:prettier"
+    ],
+    "classPrivateFieldSetHelper": [
+      "build/main:prettier"
+    ],
+    "classicNameResolver": [
+      "build/main:prettier"
+    ],
+    "cleanExtendedConfigCache": [
+      "build/main:prettier"
+    ],
+    "clearSharedExtendedConfigFileWatcher": [
+      "build/main:prettier"
+    ],
+    "climbPastPropertyAccess": [
+      "build/main:prettier"
+    ],
+    "climbPastPropertyOrElementAccess": [
+      "build/main:prettier"
+    ],
+    "cloneCompilerOptions": [
+      "build/main:prettier"
+    ],
+    "closeFileWatcherOf": [
+      "build/main:prettier"
+    ],
+    "collectExternalModuleInfo": [
+      "build/main:prettier"
+    ],
+    "commonOptionsWithBuild": [
+      "build/main:prettier"
+    ],
+    "compareEmitHelpers": [
+      "build/main:prettier"
+    ],
+    "comparePatternKeys": [
+      "build/main:prettier"
+    ],
+    "compileOnSaveCommandLineOption": [
+      "build/main:prettier"
+    ],
+    "compilerOptionsDidYouMeanDiagnostics": [
+      "build/main:prettier"
+    ],
+    "compilerOptionsIndicateEsModules": [
+      "build/main:prettier"
+    ],
+    "computeCommonSourceDirectoryOfFilenames": [
+      "build/main:prettier"
+    ],
+    "computeSignature": [
+      "build/main:prettier"
+    ],
+    "computeSignatureWithDiagnostics": [
+      "build/main:prettier"
+    ],
+    "computeSuggestionDiagnostics": [
+      "build/main:prettier"
+    ],
+    "consumesNodeCoreModules": [
+      "build/main:prettier"
+    ],
+    "convertCompilerOptionsForTelemetry": [
+      "build/main:prettier"
+    ],
+    "convertCompilerOptionsFromJson": [
+      "build/main:prettier"
+    ],
+    "convertJsonOption": [
+      "build/main:prettier"
+    ],
+    "convertToObject": [
+      "build/main:prettier"
+    ],
+    "convertToObjectWorker": [
+      "build/main:prettier"
+    ],
+    "convertToOptionsWithAbsolutePaths": [
+      "build/main:prettier"
+    ],
+    "convertToTSConfig": [
+      "build/main:prettier"
+    ],
+    "convertTypeAcquisitionFromJson": [
+      "build/main:prettier"
+    ],
+    "copyComments": [
+      "build/main:prettier"
+    ],
+    "copyLeadingComments": [
+      "build/main:prettier"
+    ],
+    "copyTrailingAsLeadingComments": [
+      "build/main:prettier"
+    ],
+    "copyTrailingComments": [
+      "build/main:prettier"
+    ],
+    "createAbstractBuilder": [
+      "build/main:prettier"
+    ],
+    "createBindingHelper": [
+      "build/main:prettier"
+    ],
+    "createBuildInfo": [
+      "build/main:prettier"
+    ],
+    "createBuilderProgram": [
+      "build/main:prettier"
+    ],
+    "createBuilderProgramUsingProgramBuildInfo": [
+      "build/main:prettier"
+    ],
+    "createBuilderStatusReporter": [
+      "build/main:prettier"
+    ],
+    "createCacheWithRedirects": [
+      "build/main:prettier"
+    ],
+    "createCacheableExportInfoMap": [
+      "build/main:prettier"
+    ],
+    "createCachedDirectoryStructureHost": [
+      "build/main:prettier"
+    ],
+    "createClassifier": [
+      "build/main:prettier"
+    ],
+    "createCompilerDiagnosticForInvalidCustomType": [
+      "build/main:prettier"
+    ],
+    "createCompilerHost": [
+      "build/main:prettier"
+    ],
+    "createCompilerHostFromProgramHost": [
+      "build/main:prettier"
+    ],
+    "createCompilerHostWorker": [
+      "build/main:prettier"
+    ],
+    "createDiagnosticReporter": [
+      "build/main:prettier"
+    ],
+    "createDocumentPositionMapper": [
+      "build/main:prettier"
+    ],
+    "createDocumentRegistry": [
+      "build/main:prettier"
+    ],
+    "createDocumentRegistryInternal": [
+      "build/main:prettier"
+    ],
+    "createEmitAndSemanticDiagnosticsBuilderProgram": [
+      "build/main:prettier"
+    ],
+    "createEmitHelperFactory": [
+      "build/main:prettier"
+    ],
+    "createGetSourceFile": [
+      "build/main:prettier"
+    ],
+    "createGetSymbolAccessibilityDiagnosticForNode": [
+      "build/main:prettier"
+    ],
+    "createGetSymbolAccessibilityDiagnosticForNodeName": [
+      "build/main:prettier"
+    ],
+    "createGetSymbolWalker": [
+      "build/main:prettier"
+    ],
+    "createIncrementalCompilerHost": [
+      "build/main:prettier"
+    ],
+    "createIncrementalProgram": [
+      "build/main:prettier"
+    ],
+    "createModeAwareCache": [
+      "build/main:prettier"
+    ],
+    "createModeAwareCacheKey": [
+      "build/main:prettier"
+    ],
+    "createModuleResolutionCache": [
+      "build/main:prettier"
+    ],
+    "createModuleResolutionLoader": [
+      "build/main:prettier"
+    ],
+    "createModuleSpecifierResolutionHost": [
+      "build/main:prettier"
+    ],
+    "createOptionNameMap": [
+      "build/main:prettier"
+    ],
+    "createOverload": [
+      "build/main:prettier"
+    ],
+    "createPackageJsonImportFilter": [
+      "build/main:prettier"
+    ],
+    "createPackageJsonInfo": [
+      "build/main:prettier"
+    ],
+    "createParenthesizerRules": [
+      "build/main:prettier"
+    ],
+    "createPatternMatcher": [
+      "build/main:prettier"
+    ],
+    "createPrependNodes": [
+      "build/main:prettier"
+    ],
+    "createPrinter": [
+      "build/main:prettier"
+    ],
+    "createPrinterWithDefaults": [
+      "build/main:prettier"
+    ],
+    "createPrinterWithRemoveComments": [
+      "build/main:prettier"
+    ],
+    "createPrinterWithRemoveCommentsNeverAsciiEscape": [
+      "build/main:prettier"
+    ],
+    "createPrinterWithRemoveCommentsOmitTrailingSemicolon": [
+      "build/main:prettier"
+    ],
+    "createProgram": [
+      "build/main:prettier"
+    ],
+    "createProgramHost": [
+      "build/main:prettier"
+    ],
+    "createRedirectedBuilderProgram": [
+      "build/main:prettier"
+    ],
+    "createResolutionCache": [
+      "build/main:prettier"
+    ],
+    "createRuntimeTypeSerializer": [
+      "build/main:prettier"
+    ],
+    "createSemanticDiagnosticsBuilderProgram": [
+      "build/main:prettier"
+    ],
+    "createSolutionBuilder": [
+      "build/main:prettier"
+    ],
+    "createSolutionBuilderHost": [
+      "build/main:prettier"
+    ],
+    "createSolutionBuilderWithWatch": [
+      "build/main:prettier"
+    ],
+    "createSolutionBuilderWithWatchHost": [
+      "build/main:prettier"
+    ],
+    "createSourceMapGenerator": [
+      "build/main:prettier"
+    ],
+    "createSuperAccessVariableStatement": [
+      "build/main:prettier"
+    ],
+    "createSystemWatchFunctions": [
+      "build/main:prettier"
+    ],
+    "createTextChange": [
+      "build/main:prettier"
+    ],
+    "createTextChangeFromStartLength": [
+      "build/main:prettier"
+    ],
+    "createTextRangeFromNode": [
+      "build/main:prettier"
+    ],
+    "createTextRangeFromSpan": [
+      "build/main:prettier"
+    ],
+    "createTextSpanFromNode": [
+      "build/main:prettier"
+    ],
+    "createTextSpanFromRange": [
+      "build/main:prettier"
+    ],
+    "createTextSpanFromStringLiteralLikeContent": [
+      "build/main:prettier"
+    ],
+    "createTypeChecker": [
+      "build/main:prettier"
+    ],
+    "createTypeReferenceDirectiveResolutionCache": [
+      "build/main:prettier"
+    ],
+    "createTypeReferenceResolutionLoader": [
+      "build/main:prettier"
+    ],
+    "createWatchCompilerHost2": [
+      "build/main:prettier"
+    ],
+    "createWatchCompilerHostOfConfigFile": [
+      "build/main:prettier"
+    ],
+    "createWatchCompilerHostOfFilesAndCompilerOptions": [
+      "build/main:prettier"
+    ],
+    "createWatchFactory": [
+      "build/main:prettier"
+    ],
+    "createWatchHost": [
+      "build/main:prettier"
+    ],
+    "createWatchProgram": [
+      "build/main:prettier"
+    ],
+    "createWatchStatusReporter": [
+      "build/main:prettier"
+    ],
+    "createWriteFileMeasuringIO": [
+      "build/main:prettier"
+    ],
+    "decodeMappings": [
+      "build/main:prettier"
+    ],
+    "decorateHelper": [
+      "build/main:prettier"
+    ],
+    "defaultIncludeSpec": [
+      "build/main:prettier"
+    ],
+    "defaultInitCompilerOptions": [
+      "build/main:prettier"
+    ],
+    "diagnosticToString": [
+      "build/main:prettier"
+    ],
+    "displayPart": [
+      "build/main:prettier"
+    ],
+    "disposeEmitNodes": [
+      "build/main:prettier"
+    ],
+    "documentSpansEqual": [
+      "build/main:prettier"
+    ],
+    "dumpTracingLegend": [
+      "build/main:prettier"
+    ],
+    "emitFiles": [
+      "build/main:prettier"
+    ],
+    "emitFilesAndReportErrors": [
+      "build/main:prettier"
+    ],
+    "emitFilesAndReportErrorsAndGetExitStatus": [
+      "build/main:prettier"
+    ],
+    "emitSkippedWithNoDiagnostics": [
+      "build/main:prettier"
+    ],
+    "emitUsingBuildInfo": [
+      "build/main:prettier"
+    ],
+    "emptyOptions": [
+      "build/main:prettier"
+    ],
+    "esDecorateHelper": [
+      "build/main:prettier"
+    ],
+    "explainFiles": [
+      "build/main:prettier"
+    ],
+    "explainIfFileIsRedirectAndImpliedFormat": [
+      "build/main:prettier"
+    ],
+    "exportStarHelper": [
+      "build/main:prettier"
+    ],
+    "extendsHelper": [
+      "build/main:prettier"
+    ],
+    "fileIncludeReasonToDiagnostics": [
+      "build/main:prettier"
+    ],
+    "filterSemanticDiagnostics": [
+      "build/main:prettier"
+    ],
+    "findChildOfKind": [
+      "build/main:prettier"
+    ],
+    "findConfigFile": [
+      "build/main:prettier"
+    ],
+    "findContainingList": [
+      "build/main:prettier"
+    ],
+    "findDiagnosticForNode": [
+      "build/main:prettier"
+    ],
+    "findFirstNonJsxWhitespaceToken": [
+      "build/main:prettier"
+    ],
+    "findListItemInfo": [
+      "build/main:prettier"
+    ],
+    "findModifier": [
+      "build/main:prettier"
+    ],
+    "findNextToken": [
+      "build/main:prettier"
+    ],
+    "findPackageJson": [
+      "build/main:prettier"
+    ],
+    "findPackageJsons": [
+      "build/main:prettier"
+    ],
+    "findPrecedingMatchingToken": [
+      "build/main:prettier"
+    ],
+    "findPrecedingToken": [
+      "build/main:prettier"
+    ],
+    "findSuperStatementIndex": [
+      "build/main:prettier"
+    ],
+    "findTokenOnLeftOfPosition": [
+      "build/main:prettier"
+    ],
+    "firstOrOnly": [
+      "build/main:prettier"
+    ],
+    "fixupCompilerOptions": [
+      "build/main:prettier"
+    ],
+    "flattenDestructuringAssignment": [
+      "build/main:prettier"
+    ],
+    "flattenDestructuringBinding": [
+      "build/main:prettier"
+    ],
+    "flattenDiagnosticMessageText": [
+      "build/main:prettier"
+    ],
+    "forEachEmittedFile": [
+      "build/main:prettier"
+    ],
+    "forEachExternalModuleToImportFrom": [
+      "build/main:prettier"
+    ],
+    "forEachResolvedProjectReference": [
+      "build/main:prettier"
+    ],
+    "forEachUnique": [
+      "build/main:prettier"
+    ],
+    "formatColorAndReset": [
+      "build/main:prettier"
+    ],
+    "formatDiagnostic": [
+      "build/main:prettier"
+    ],
+    "formatDiagnostics": [
+      "build/main:prettier"
+    ],
+    "formatDiagnosticsWithColorAndContext": [
+      "build/main:prettier"
+    ],
+    "formatLocation": [
+      "build/main:prettier"
+    ],
+    "generateDjb2Hash": [
+      "build/main:prettier"
+    ],
+    "generateTSConfig": [
+      "build/main:prettier"
+    ],
+    "generatorHelper": [
+      "build/main:prettier"
+    ],
+    "getAdjustedReferenceLocation": [
+      "build/main:prettier"
+    ],
+    "getAdjustedRenameLocation": [
+      "build/main:prettier"
+    ],
+    "getAllDecoratorsOfClass": [
+      "build/main:prettier"
+    ],
+    "getAllDecoratorsOfClassElement": [
+      "build/main:prettier"
+    ],
+    "getAllProjectOutputs": [
+      "build/main:prettier"
+    ],
+    "getAllUnscopedEmitHelpers": [
+      "build/main:prettier"
+    ],
+    "getAutomaticTypeDirectiveNames": [
+      "build/main:prettier"
+    ],
+    "getBuildInfo": [
+      "build/main:prettier"
+    ],
+    "getBuildInfoFileVersionMap": [
+      "build/main:prettier"
+    ],
+    "getBuildInfoText": [
+      "build/main:prettier"
+    ],
+    "getBuildOrderFromAnyBuildOrder": [
+      "build/main:prettier"
+    ],
+    "getBuilderCreationParameters": [
+      "build/main:prettier"
+    ],
+    "getBuilderFileEmit": [
+      "build/main:prettier"
+    ],
+    "getCommentRange": [
+      "build/main:prettier"
+    ],
+    "getCommonSourceDirectory": [
+      "build/main:prettier"
+    ],
+    "getCommonSourceDirectoryOfConfig": [
+      "build/main:prettier"
+    ],
+    "getCompilerOptionsDiffValue": [
+      "build/main:prettier"
+    ],
+    "getConditions": [
+      "build/main:prettier"
+    ],
+    "getConfigFileParsingDiagnostics": [
+      "build/main:prettier"
+    ],
+    "getConstantValue": [
+      "build/main:prettier"
+    ],
+    "getContainerNode": [
+      "build/main:prettier"
+    ],
+    "getContextualTypeFromParent": [
+      "build/main:prettier"
+    ],
+    "getContextualTypeFromParentOrAncestorTypeNode": [
+      "build/main:prettier"
+    ],
+    "getCurrentTime": [
+      "build/main:prettier"
+    ],
+    "getDeclarationDiagnostics": [
+      "build/main:prettier"
+    ],
+    "getDefaultExportInfoWorker": [
+      "build/main:prettier"
+    ],
+    "getDefaultFormatCodeSettings": [
+      "build/main:prettier"
+    ],
+    "getDefaultLikeExportInfo": [
+      "build/main:prettier"
+    ],
+    "getDiagnosticText": [
+      "build/main:prettier"
+    ],
+    "getDiagnosticsWithinSpan": [
+      "build/main:prettier"
+    ],
+    "getDocumentPositionMapper": [
+      "build/main:prettier"
+    ],
+    "getEditsForFileRename": [
+      "build/main:prettier"
+    ],
+    "getEffectiveTypeRoots": [
+      "build/main:prettier"
+    ],
+    "getEmitHelpers": [
+      "build/main:prettier"
+    ],
+    "getEncodedSemanticClassifications": [
+      "build/main:prettier"
+    ],
+    "getEncodedSyntacticClassifications": [
+      "build/main:prettier"
+    ],
+    "getEntrypointsFromPackageJsonInfo": [
+      "build/main:prettier"
+    ],
+    "getErrorCountForSummary": [
+      "build/main:prettier"
+    ],
+    "getErrorSummaryText": [
+      "build/main:prettier"
+    ],
+    "getExportInfoMap": [
+      "build/main:prettier"
+    ],
+    "getExportNeedsImportStarHelper": [
+      "build/main:prettier"
+    ],
+    "getFallbackOptions": [
+      "build/main:prettier"
+    ],
+    "getFileEmitOutput": [
+      "build/main:prettier"
+    ],
+    "getFileNamesFromConfigSpecs": [
+      "build/main:prettier"
+    ],
+    "getFileWatcherEventKind": [
+      "build/main:prettier"
+    ],
+    "getFilesInErrorForSummary": [
+      "build/main:prettier"
+    ],
+    "getFirstNonSpaceCharacterPosition": [
+      "build/main:prettier"
+    ],
+    "getFirstProjectOutput": [
+      "build/main:prettier"
+    ],
+    "getFixableErrorSpanExpression": [
+      "build/main:prettier"
+    ],
+    "getFormatCodeSettingsForWriting": [
+      "build/main:prettier"
+    ],
+    "getIdentifierAutoGenerate": [
+      "build/main:prettier"
+    ],
+    "getIdentifierGeneratedImportReference": [
+      "build/main:prettier"
+    ],
+    "getIdentifierTypeArguments": [
+      "build/main:prettier"
+    ],
+    "getImpliedNodeFormatForFile": [
+      "build/main:prettier"
+    ],
+    "getImpliedNodeFormatForFileWorker": [
+      "build/main:prettier"
+    ],
+    "getImportNeedsImportDefaultHelper": [
+      "build/main:prettier"
+    ],
+    "getImportNeedsImportStarHelper": [
+      "build/main:prettier"
+    ],
+    "getKeyForCompilerOptions": [
+      "build/main:prettier"
+    ],
+    "getLineInfo": [
+      "build/main:prettier"
+    ],
+    "getLineStartPositionForPosition": [
+      "build/main:prettier"
+    ],
+    "getLocaleTimeString": [
+      "build/main:prettier"
+    ],
+    "getMappedContextSpan": [
+      "build/main:prettier"
+    ],
+    "getMappedDocumentSpan": [
+      "build/main:prettier"
+    ],
+    "getMappedLocation": [
+      "build/main:prettier"
+    ],
+    "getMatchedFileSpec": [
+      "build/main:prettier"
+    ],
+    "getMatchedIncludeSpec": [
+      "build/main:prettier"
+    ],
+    "getMeaningFromDeclaration": [
+      "build/main:prettier"
+    ],
+    "getMeaningFromLocation": [
+      "build/main:prettier"
+    ],
+    "getModeForFileReference": [
+      "build/main:prettier"
+    ],
+    "getModeForResolutionAtIndex": [
+      "build/main:prettier"
+    ],
+    "getModeForUsageLocation": [
+      "build/main:prettier"
+    ],
+    "getModifiedTime": [
+      "build/main:prettier"
+    ],
+    "getModuleInstanceState": [
+      "build/main:prettier"
+    ],
+    "getModuleNameStringLiteralAt": [
+      "build/main:prettier"
+    ],
+    "getModuleSpecifierResolverHost": [
+      "build/main:prettier"
+    ],
+    "getNameForExportedSymbol": [
+      "build/main:prettier"
+    ],
+    "getNameFromPropertyName": [
+      "build/main:prettier"
+    ],
+    "getNameOfCompilerOptionValue": [
+      "build/main:prettier"
+    ],
+    "getNamesForExportedSymbol": [
+      "build/main:prettier"
+    ],
+    "getNavigateToItems": [
+      "build/main:prettier"
+    ],
+    "getNavigationBarItems": [
+      "build/main:prettier"
+    ],
+    "getNavigationTree": [
+      "build/main:prettier"
+    ],
+    "getNewLineKind": [
+      "build/main:prettier"
+    ],
+    "getNewLineOrDefaultFromHost": [
+      "build/main:prettier"
+    ],
+    "getNodeId": [
+      "build/main:prettier"
+    ],
+    "getNodeKind": [
+      "build/main:prettier"
+    ],
+    "getNodeModifiers": [
+      "build/main:prettier"
+    ],
+    "getNonAssignmentOperatorForCompoundAssignment": [
+      "build/main:prettier"
+    ],
+    "getOptionFromName": [
+      "build/main:prettier"
+    ],
+    "getOptionsNameMap": [
+      "build/main:prettier"
+    ],
+    "getOrCreateEmitNode": [
+      "build/main:prettier"
+    ],
+    "getOriginalNodeId": [
+      "build/main:prettier"
+    ],
+    "getOutputDeclarationFileName": [
+      "build/main:prettier"
+    ],
+    "getOutputExtension": [
+      "build/main:prettier"
+    ],
+    "getOutputFileNames": [
+      "build/main:prettier"
+    ],
+    "getOutputPathsFor": [
+      "build/main:prettier"
+    ],
+    "getOutputPathsForBundle": [
+      "build/main:prettier"
+    ],
+    "getPackageJsonInfo": [
+      "build/main:prettier"
+    ],
+    "getPackageJsonTypesVersionsPaths": [
+      "build/main:prettier"
+    ],
+    "getPackageJsonsVisibleToFile": [
+      "build/main:prettier"
+    ],
+    "getPackageNameFromTypesPackageName": [
+      "build/main:prettier"
+    ],
+    "getPackageScopeForPath": [
+      "build/main:prettier"
+    ],
+    "getParentNodeInSpan": [
+      "build/main:prettier"
+    ],
+    "getParsedCommandLineOfConfigFile": [
+      "build/main:prettier"
+    ],
+    "getPathUpdater": [
+      "build/main:prettier"
+    ],
+    "getPendingEmitKind": [
+      "build/main:prettier"
+    ],
+    "getPossibleGenericSignatures": [
+      "build/main:prettier"
+    ],
+    "getPossibleTypeArgumentsInfo": [
+      "build/main:prettier"
+    ],
+    "getPreEmitDiagnostics": [
+      "build/main:prettier"
+    ],
+    "getPrecedingNonSpaceCharacterPosition": [
+      "build/main:prettier"
+    ],
+    "getPrivateIdentifier": [
+      "build/main:prettier"
+    ],
+    "getProperties": [
+      "build/main:prettier"
+    ],
+    "getPropertySymbolFromBindingElement": [
+      "build/main:prettier"
+    ],
+    "getQuoteFromPreference": [
+      "build/main:prettier"
+    ],
+    "getQuotePreference": [
+      "build/main:prettier"
+    ],
+    "getRefactorContextSpan": [
+      "build/main:prettier"
+    ],
+    "getReferencedFileLocation": [
+      "build/main:prettier"
+    ],
+    "getRenameLocation": [
+      "build/main:prettier"
+    ],
+    "getReplacementSpanForContextToken": [
+      "build/main:prettier"
+    ],
+    "getResolutionDiagnostic": [
+      "build/main:prettier"
+    ],
+    "getResolutionModeOverrideForClause": [
+      "build/main:prettier"
+    ],
+    "getScriptKind": [
+      "build/main:prettier"
+    ],
+    "getScriptTargetFeatures": [
+      "build/main:prettier"
+    ],
+    "getSemanticClassifications": [
+      "build/main:prettier"
+    ],
+    "getSnapshotText": [
+      "build/main:prettier"
+    ],
+    "getSnippetElement": [
+      "build/main:prettier"
+    ],
+    "getSourceFileVersionAsHashFromText": [
+      "build/main:prettier"
+    ],
+    "getSourceMapRange": [
+      "build/main:prettier"
+    ],
+    "getSourceMapper": [
+      "build/main:prettier"
+    ],
+    "getStartsOnNewLine": [
+      "build/main:prettier"
+    ],
+    "getStaticPropertiesAndClassStaticBlock": [
+      "build/main:prettier"
+    ],
+    "getSuperCallFromStatement": [
+      "build/main:prettier"
+    ],
+    "getSwitchedType": [
+      "build/main:prettier"
+    ],
+    "getSymbolId": [
+      "build/main:prettier"
+    ],
+    "getSymbolTarget": [
+      "build/main:prettier"
+    ],
+    "getSyntacticClassifications": [
+      "build/main:prettier"
+    ],
+    "getSynthesizedDeepClone": [
+      "build/main:prettier"
+    ],
+    "getSynthesizedDeepCloneWithReplacements": [
+      "build/main:prettier"
+    ],
+    "getSynthesizedDeepClones": [
+      "build/main:prettier"
+    ],
+    "getSynthesizedDeepClonesWithReplacements": [
+      "build/main:prettier"
+    ],
+    "getSyntheticLeadingComments": [
+      "build/main:prettier"
+    ],
+    "getSyntheticTrailingComments": [
+      "build/main:prettier"
+    ],
+    "getTargetLabel": [
+      "build/main:prettier"
+    ],
+    "getTemporaryModuleResolutionState": [
+      "build/main:prettier"
+    ],
+    "getTokenAtPosition": [
+      "build/main:prettier"
+    ],
+    "getTokenSourceMapRange": [
+      "build/main:prettier"
+    ],
+    "getTouchingPropertyName": [
+      "build/main:prettier"
+    ],
+    "getTouchingToken": [
+      "build/main:prettier"
+    ],
+    "getTransformers": [
+      "build/main:prettier"
+    ],
+    "getTsBuildInfoEmitOutputFilePath": [
+      "build/main:prettier"
+    ],
+    "getTypeArgumentOrTypeParameterList": [
+      "build/main:prettier"
+    ],
+    "getTypeKeywordOfTypeOnlyImport": [
+      "build/main:prettier"
+    ],
+    "getTypeNode": [
+      "build/main:prettier"
+    ],
+    "getTypeNodeIfAccessible": [
+      "build/main:prettier"
+    ],
+    "getTypesPackageName": [
+      "build/main:prettier"
+    ],
+    "getUniqueName": [
+      "build/main:prettier"
+    ],
+    "getUniqueSymbolId": [
+      "build/main:prettier"
+    ],
+    "getWatchErrorSummaryDiagnosticMessage": [
+      "build/main:prettier"
+    ],
+    "getWatchFactory": [
+      "build/main:prettier"
+    ],
+    "handleNoEmitOptions": [
+      "build/main:prettier"
+    ],
+    "hasChildOfKind": [
+      "build/main:prettier"
+    ],
+    "hasDocComment": [
+      "build/main:prettier"
+    ],
+    "hasIndexSignature": [
+      "build/main:prettier"
+    ],
+    "hasPropertyAccessExpressionWithName": [
+      "build/main:prettier"
+    ],
+    "helperString": [
+      "build/main:prettier"
+    ],
+    "identitySourceMapConsumer": [
+      "build/main:prettier"
+    ],
+    "ignoreSourceNewlines": [
+      "build/main:prettier"
+    ],
+    "ignoredPaths": [
+      "build/main:prettier"
+    ],
+    "importDefaultHelper": [
+      "build/main:prettier"
+    ],
+    "importStarHelper": [
+      "build/main:prettier"
+    ],
+    "inferredTypesContainingFile": [
+      "build/main:prettier"
+    ],
+    "insertImports": [
+      "build/main:prettier"
+    ],
+    "inverseJsxOptionMap": [
+      "build/main:prettier"
+    ],
+    "isAccessibilityModifier": [
+      "build/main:prettier"
+    ],
+    "isApplicableVersionedTypesKey": [
+      "build/main:prettier"
+    ],
+    "isArgumentExpressionOfElementAccess": [
+      "build/main:prettier"
+    ],
+    "isArrayLiteralOrObjectLiteralDestructuringPattern": [
+      "build/main:prettier"
+    ],
+    "isBuildInfoFile": [
+      "build/main:prettier"
+    ],
+    "isBuilderProgram2": [
+      "build/main:prettier"
+    ],
+    "isCallExpressionTarget": [
+      "build/main:prettier"
+    ],
+    "isCallOrNewExpressionTarget": [
+      "build/main:prettier"
+    ],
+    "isCallToHelper": [
+      "build/main:prettier"
+    ],
+    "isCircularBuildOrder": [
+      "build/main:prettier"
+    ],
+    "isComment": [
+      "build/main:prettier"
+    ],
+    "isCompoundAssignment": [
+      "build/main:prettier"
+    ],
+    "isDecoratorTarget": [
+      "build/main:prettier"
+    ],
+    "isDeprecatedDeclaration": [
+      "build/main:prettier"
+    ],
+    "isDiagnosticWithLocation": [
+      "build/main:prettier"
+    ],
+    "isEmittedFileOfProgram": [
+      "build/main:prettier"
+    ],
+    "isEqualityOperatorKind": [
+      "build/main:prettier"
+    ],
+    "isExcludedFile": [
+      "build/main:prettier"
+    ],
+    "isExclusivelyTypeOnlyImportOrExport": [
+      "build/main:prettier"
+    ],
+    "isExportsOrModuleExportsOrAlias": [
+      "build/main:prettier"
+    ],
+    "isExpressionOfExternalModuleImportEqualsDeclaration": [
+      "build/main:prettier"
+    ],
+    "isExternalModuleSymbol": [
+      "build/main:prettier"
+    ],
+    "isFirstDeclarationOfSymbolParameter": [
+      "build/main:prettier"
+    ],
+    "isFixablePromiseHandler": [
+      "build/main:prettier"
+    ],
+    "isGlobalDeclaration": [
+      "build/main:prettier"
+    ],
+    "isIgnoredFileFromWildCardWatching": [
+      "build/main:prettier"
+    ],
+    "isImportOrExportSpecifierName": [
+      "build/main:prettier"
+    ],
+    "isImportableFile": [
+      "build/main:prettier"
+    ],
+    "isInComment": [
+      "build/main:prettier"
+    ],
+    "isInJSXText": [
+      "build/main:prettier"
+    ],
+    "isInNonReferenceComment": [
+      "build/main:prettier"
+    ],
+    "isInReferenceComment": [
+      "build/main:prettier"
+    ],
+    "isInRightSideOfInternalImportEqualsDeclaration": [
+      "build/main:prettier"
+    ],
+    "isInString": [
+      "build/main:prettier"
+    ],
+    "isInTemplateString": [
+      "build/main:prettier"
+    ],
+    "isInitializedProperty": [
+      "build/main:prettier"
+    ],
+    "isInsideJsxElement": [
+      "build/main:prettier"
+    ],
+    "isInsideJsxElementOrAttribute": [
+      "build/main:prettier"
+    ],
+    "isInsideNodeModules": [
+      "build/main:prettier"
+    ],
+    "isInsideTemplateLiteral": [
+      "build/main:prettier"
+    ],
+    "isInstantiatedModule": [
+      "build/main:prettier"
+    ],
+    "isInternalDeclaration": [
+      "build/main:prettier"
+    ],
+    "isJsxOpeningLikeElementTagName": [
+      "build/main:prettier"
+    ],
+    "isJumpStatementTarget": [
+      "build/main:prettier"
+    ],
+    "isLabelName": [
+      "build/main:prettier"
+    ],
+    "isLabelOfLabeledStatement": [
+      "build/main:prettier"
+    ],
+    "isLiteralNameOfPropertyDeclarationOrIndexAccess": [
+      "build/main:prettier"
+    ],
+    "isModuleSpecifierLike": [
+      "build/main:prettier"
+    ],
+    "isNameOfFunctionDeclaration": [
+      "build/main:prettier"
+    ],
+    "isNameOfModuleDeclaration": [
+      "build/main:prettier"
+    ],
+    "isNewExpressionTarget": [
+      "build/main:prettier"
+    ],
+    "isNonGlobalDeclaration": [
+      "build/main:prettier"
+    ],
+    "isNonStaticMethodOrAccessorWithPrivateName": [
+      "build/main:prettier"
+    ],
+    "isObjectBindingElementWithoutPropertyName": [
+      "build/main:prettier"
+    ],
+    "isPossiblyTypeArgumentPosition": [
+      "build/main:prettier"
+    ],
+    "isProgramBundleEmitBuildInfo": [
+      "build/main:prettier"
+    ],
+    "isProgramUptoDate": [
+      "build/main:prettier"
+    ],
+    "isPunctuation": [
+      "build/main:prettier"
+    ],
+    "isRawSourceMap": [
+      "build/main:prettier"
+    ],
+    "isReferenceFileLocation": [
+      "build/main:prettier"
+    ],
+    "isReferencedFile": [
+      "build/main:prettier"
+    ],
+    "isReturnStatementWithFixablePromiseHandler": [
+      "build/main:prettier"
+    ],
+    "isRightSideOfPropertyAccess": [
+      "build/main:prettier"
+    ],
+    "isRightSideOfQualifiedName": [
+      "build/main:prettier"
+    ],
+    "isSimpleCopiableExpression": [
+      "build/main:prettier"
+    ],
+    "isSimpleInlineableExpression": [
+      "build/main:prettier"
+    ],
+    "isSourceFileFromLibrary": [
+      "build/main:prettier"
+    ],
+    "isSourceMapping": [
+      "build/main:prettier"
+    ],
+    "isStringAndEmptyAnonymousObjectIntersection": [
+      "build/main:prettier"
+    ],
+    "isStringLiteralOrTemplate": [
+      "build/main:prettier"
+    ],
+    "isStringOrRegularExpressionOrTemplateLiteral": [
+      "build/main:prettier"
+    ],
+    "isTagName": [
+      "build/main:prettier"
+    ],
+    "isTaggedTemplateTag": [
+      "build/main:prettier"
+    ],
+    "isTextWhiteSpaceLike": [
+      "build/main:prettier"
+    ],
+    "isThis": [
+      "build/main:prettier"
+    ],
+    "isTraceEnabled": [
+      "build/main:prettier"
+    ],
+    "isTypeKeyword": [
+      "build/main:prettier"
+    ],
+    "isTypeKeywordToken": [
+      "build/main:prettier"
+    ],
+    "isTypeKeywordTokenOrIdentifier": [
+      "build/main:prettier"
+    ],
+    "jsxModeNeedsExplicitImport": [
+      "build/main:prettier"
+    ],
+    "keywordPart": [
+      "build/main:prettier"
+    ],
+    "libMap": [
+      "build/main:prettier"
+    ],
+    "libs": [
+      "build/main:prettier"
+    ],
+    "lineBreakPart": [
+      "build/main:prettier"
+    ],
+    "linkNamePart": [
+      "build/main:prettier"
+    ],
+    "linkPart": [
+      "build/main:prettier"
+    ],
+    "linkTextPart": [
+      "build/main:prettier"
+    ],
+    "listFiles": [
+      "build/main:prettier"
+    ],
+    "loadModuleFromGlobalCache": [
+      "build/main:prettier"
+    ],
+    "loadWithModeAwareCache": [
+      "build/main:prettier"
+    ],
+    "makeImport": [
+      "build/main:prettier"
+    ],
+    "makeImportIfNecessary": [
+      "build/main:prettier"
+    ],
+    "makeStringLiteral": [
+      "build/main:prettier"
+    ],
+    "mangleScopedPackageName": [
+      "build/main:prettier"
+    ],
+    "mapOneOrMany": [
+      "build/main:prettier"
+    ],
+    "mapToDisplayParts": [
+      "build/main:prettier"
+    ],
+    "matchesExclude": [
+      "build/main:prettier"
+    ],
+    "metadataHelper": [
+      "build/main:prettier"
+    ],
+    "missingFileModifiedTime": [
+      "build/main:prettier"
+    ],
+    "moduleOptionDeclaration": [
+      "build/main:prettier"
+    ],
+    "moduleResolutionNameAndModeGetter": [
+      "build/main:prettier"
+    ],
+    "moduleResolutionOptionDeclarations": [
+      "build/main:prettier"
+    ],
+    "moduleResolutionUsesNodeModules": [
+      "build/main:prettier"
+    ],
+    "moveEmitHelpers": [
+      "build/main:prettier"
+    ],
+    "moveSyntheticComments": [
+      "build/main:prettier"
+    ],
+    "needsParentheses": [
+      "build/main:prettier"
+    ],
+    "newCaseClauseTracker": [
+      "build/main:prettier"
+    ],
+    "newPrivateEnvironment": [
+      "build/main:prettier"
+    ],
+    "noEmitNotification": [
+      "build/main:prettier"
+    ],
+    "noEmitSubstitution": [
+      "build/main:prettier"
+    ],
+    "noTransformers": [
+      "build/main:prettier"
+    ],
+    "nodeModuleNameResolver": [
+      "build/main:prettier"
+    ],
+    "nodeModulesPathPart": [
+      "build/main:prettier"
+    ],
+    "nodeNextJsonConfigResolver": [
+      "build/main:prettier"
+    ],
+    "nodeOverlapsWithStartEnd": [
+      "build/main:prettier"
+    ],
+    "nodeSeenTracker": [
+      "build/main:prettier"
+    ],
+    "nodeToDisplayParts": [
+      "build/main:prettier"
+    ],
+    "noopFileWatcher": [
+      "build/main:prettier"
+    ],
+    "notImplementedResolver": [
+      "build/main:prettier"
+    ],
+    "nullNodeConverters": [
+      "build/main:prettier"
+    ],
+    "nullTransformationContext": [
+      "build/main:prettier"
+    ],
+    "onProfilerEvent": [
+      "build/main:prettier",
+      "build/main:typescript"
+    ],
+    "operatorPart": [
+      "build/main:prettier"
+    ],
+    "optionDeclarations": [
+      "build/main:prettier"
+    ],
+    "optionMapToObject": [
+      "build/main:prettier"
+    ],
+    "optionsAffectingProgramStructure": [
+      "build/main:prettier"
+    ],
+    "optionsForBuild": [
+      "build/main:prettier"
+    ],
+    "optionsForWatch": [
+      "build/main:prettier"
+    ],
+    "paramHelper": [
+      "build/main:prettier"
+    ],
+    "parameterNamePart": [
+      "build/main:prettier"
+    ],
+    "parseBuildCommand": [
+      "build/main:prettier"
+    ],
+    "parseCommandLine": [
+      "build/main:prettier"
+    ],
+    "parseCommandLineWorker": [
+      "build/main:prettier"
+    ],
+    "parseConfigFileTextToJson": [
+      "build/main:prettier"
+    ],
+    "parseConfigFileWithSystem": [
+      "build/main:prettier"
+    ],
+    "parseConfigHostFromCompilerHostLike": [
+      "build/main:prettier"
+    ],
+    "parseCustomTypeOption": [
+      "build/main:prettier"
+    ],
+    "parseJsonConfigFileContent": [
+      "build/main:prettier"
+    ],
+    "parseJsonSourceFileConfigFileContent": [
+      "build/main:prettier"
+    ],
+    "parseListTypeOption": [
+      "build/main:prettier"
+    ],
+    "parseNodeModuleFromPath": [
+      "build/main:prettier"
+    ],
+    "parsePackageName": [
+      "build/main:prettier"
+    ],
+    "patchWriteFileEnsuringDirectory": [
+      "build/main:prettier"
+    ],
+    "pathContainsNodeModules": [
+      "build/main:prettier"
+    ],
+    "performIncrementalCompilation": [
+      "build/main:prettier"
+    ],
+    "plainJSErrors": [
+      "build/main:prettier"
+    ],
+    "positionBelongsToNode": [
+      "build/main:prettier"
+    ],
+    "positionIsASICandidate": [
+      "build/main:prettier"
+    ],
+    "preProcessFile": [
+      "build/main:prettier"
+    ],
+    "probablyUsesSemicolons": [
+      "build/main:prettier"
+    ],
+    "processTaggedTemplateExpression": [
+      "build/main:prettier"
+    ],
+    "programContainsEsModules": [
+      "build/main:prettier"
+    ],
+    "programContainsModules": [
+      "build/main:prettier"
+    ],
+    "propKeyHelper": [
+      "build/main:prettier"
+    ],
+    "propertyNamePart": [
+      "build/main:prettier"
+    ],
+    "punctuationPart": [
+      "build/main:prettier"
+    ],
+    "quote": [
+      "build/main:prettier"
+    ],
+    "quotePreferenceFromString": [
+      "build/main:prettier"
+    ],
+    "rangeContainsPosition": [
+      "build/main:prettier"
+    ],
+    "rangeContainsPositionExclusive": [
+      "build/main:prettier"
+    ],
+    "rangeContainsRange": [
+      "build/main:prettier"
+    ],
+    "rangeContainsRangeExclusive": [
+      "build/main:prettier"
+    ],
+    "rangeContainsStartEnd": [
+      "build/main:prettier"
+    ],
+    "rangeOverlapsWithStartEnd": [
+      "build/main:prettier"
+    ],
+    "readBuilderProgram": [
+      "build/main:prettier"
+    ],
+    "readConfigFile": [
+      "build/main:prettier"
+    ],
+    "readHelper": [
+      "build/main:prettier"
+    ],
+    "readJsonConfigFile": [
+      "build/main:prettier"
+    ],
+    "realizeDiagnostics": [
+      "build/main:prettier"
+    ],
+    "removeAllComments": [
+      "build/main:prettier"
+    ],
+    "removeEmitHelper": [
+      "build/main:prettier"
+    ],
+    "removeIgnoredPath": [
+      "build/main:prettier"
+    ],
+    "removeOptionality": [
+      "build/main:prettier"
+    ],
+    "repeatString": [
+      "build/main:prettier"
+    ],
+    "resolveConfigFileProjectName": [
+      "build/main:prettier"
+    ],
+    "resolveJSModule": [
+      "build/main:prettier"
+    ],
+    "resolveModuleName": [
+      "build/main:prettier"
+    ],
+    "resolveModuleNameFromCache": [
+      "build/main:prettier"
+    ],
+    "resolvePackageNameToPackageJson": [
+      "build/main:prettier"
+    ],
+    "resolveProjectReferencePath": [
+      "build/main:prettier"
+    ],
+    "resolveTripleslashReference": [
+      "build/main:prettier"
+    ],
+    "resolveTypeReferenceDirective": [
+      "build/main:prettier"
+    ],
+    "restHelper": [
+      "build/main:prettier"
+    ],
+    "returnNoopFileWatcher": [
+      "build/main:prettier"
+    ],
+    "returnsPromise": [
+      "build/main:prettier"
+    ],
+    "runInitializersHelper": [
+      "build/main:prettier"
+    ],
+    "sameMapping": [
+      "build/main:prettier"
+    ],
+    "screenStartingMessageCodes": [
+      "build/main:prettier"
+    ],
+    "semanticDiagnosticsOptionDeclarations": [
+      "build/main:prettier"
+    ],
+    "serializeCompilerOptions": [
+      "build/main:prettier"
+    ],
+    "setCommentRange": [
+      "build/main:prettier"
+    ],
+    "setConfigFileInOptions": [
+      "build/main:prettier"
+    ],
+    "setConstantValue": [
+      "build/main:prettier"
+    ],
+    "setEmitFlags": [
+      "build/main:prettier"
+    ],
+    "setFunctionNameHelper": [
+      "build/main:prettier"
+    ],
+    "setGetSourceFileAsHashVersioned": [
+      "build/main:prettier"
+    ],
+    "setIdentifierAutoGenerate": [
+      "build/main:prettier"
+    ],
+    "setIdentifierGeneratedImportReference": [
+      "build/main:prettier"
+    ],
+    "setIdentifierTypeArguments": [
+      "build/main:prettier"
+    ],
+    "setInternalEmitFlags": [
+      "build/main:prettier"
+    ],
+    "setModuleDefaultHelper": [
+      "build/main:prettier"
+    ],
+    "setPrivateIdentifier": [
+      "build/main:prettier"
+    ],
+    "setSnippetElement": [
+      "build/main:prettier"
+    ],
+    "setSourceMapRange": [
+      "build/main:prettier"
+    ],
+    "setStackTraceLimit": [
+      "build/main:prettier"
+    ],
+    "setStartsOnNewLine": [
+      "build/main:prettier"
+    ],
+    "setSyntheticLeadingComments": [
+      "build/main:prettier"
+    ],
+    "setSyntheticTrailingComments": [
+      "build/main:prettier"
+    ],
+    "setSys": [
+      "build/main:prettier"
+    ],
+    "setSysLog": [
+      "build/main:prettier"
+    ],
+    "setTokenSourceMapRange": [
+      "build/main:prettier"
+    ],
+    "setTypeNode": [
+      "build/main:prettier"
+    ],
+    "shouldAllowImportingTsExtension": [
+      "build/main:prettier"
+    ],
+    "shouldUseUriStyleNodeCoreModules": [
+      "build/main:prettier"
+    ],
+    "signatureHasLiteralTypes": [
+      "build/main:prettier"
+    ],
+    "signatureHasRestParameter": [
+      "build/main:prettier"
+    ],
+    "signatureToDisplayParts": [
+      "build/main:prettier"
+    ],
+    "skipConstraint": [
+      "build/main:prettier"
+    ],
+    "sourceFileAffectingCompilerOptions": [
+      "build/main:prettier"
+    ],
+    "sourceMapCommentRegExp": [
+      "build/main:prettier"
+    ],
+    "sourceMapCommentRegExpDontCareLineStart": [
+      "build/main:prettier"
+    ],
+    "spacePart": [
+      "build/main:prettier"
+    ],
+    "spreadArrayHelper": [
+      "build/main:prettier"
+    ],
+    "startEndContainsRange": [
+      "build/main:prettier"
+    ],
+    "startEndOverlapsWithStartEnd": [
+      "build/main:prettier"
+    ],
+    "startTracing": [
+      "build/main:prettier"
+    ],
+    "startsWithUnderscore": [
+      "build/main:prettier"
+    ],
+    "stringContainsAt": [
+      "build/main:prettier"
+    ],
+    "suppressLeadingAndTrailingTrivia": [
+      "build/main:prettier"
+    ],
+    "suppressLeadingTrivia": [
+      "build/main:prettier"
+    ],
+    "suppressTrailingTrivia": [
+      "build/main:prettier"
+    ],
+    "symbolEscapedNameNoDefault": [
+      "build/main:prettier"
+    ],
+    "symbolNameNoDefault": [
+      "build/main:prettier"
+    ],
+    "symbolPart": [
+      "build/main:prettier"
+    ],
+    "symbolToDisplayParts": [
+      "build/main:prettier"
+    ],
+    "syntaxMayBeASICandidate": [
+      "build/main:prettier"
+    ],
+    "syntaxRequiresTrailingSemicolonOrASI": [
+      "build/main:prettier"
+    ],
+    "sysLog": [
+      "build/main:prettier"
+    ],
+    "targetOptionDeclaration": [
+      "build/main:prettier"
+    ],
+    "templateObjectHelper": [
+      "build/main:prettier"
+    ],
+    "testFormatSettings": [
+      "build/main:prettier"
+    ],
+    "textOrKeywordPart": [
+      "build/main:prettier"
+    ],
+    "textPart": [
+      "build/main:prettier"
+    ],
+    "textSpansEqual": [
+      "build/main:prettier"
+    ],
+    "toBuilderFileEmit": [
+      "build/main:prettier"
+    ],
+    "toBuilderStateFileInfoForMultiEmit": [
+      "build/main:prettier"
+    ],
+    "toProgramEmitPending": [
+      "build/main:prettier"
+    ],
+    "trace": [
+      "build/main:prettier"
+    ],
+    "tracingEnabled": [
+      "build/main:prettier"
+    ],
+    "transform": [
+      "build/main:prettier"
+    ],
+    "transformClassFields": [
+      "build/main:prettier"
+    ],
+    "transformDeclarations": [
+      "build/main:prettier"
+    ],
+    "transformECMAScriptModule": [
+      "build/main:prettier"
+    ],
+    "transformES2015": [
+      "build/main:prettier"
+    ],
+    "transformES2016": [
+      "build/main:prettier"
+    ],
+    "transformES2017": [
+      "build/main:prettier"
+    ],
+    "transformES2018": [
+      "build/main:prettier"
+    ],
+    "transformES2019": [
+      "build/main:prettier"
+    ],
+    "transformES2020": [
+      "build/main:prettier"
+    ],
+    "transformES2021": [
+      "build/main:prettier"
+    ],
+    "transformES5": [
+      "build/main:prettier"
+    ],
+    "transformESDecorators": [
+      "build/main:prettier"
+    ],
+    "transformESNext": [
+      "build/main:prettier"
+    ],
+    "transformGenerators": [
+      "build/main:prettier"
+    ],
+    "transformJsx": [
+      "build/main:prettier"
+    ],
+    "transformLegacyDecorators": [
+      "build/main:prettier"
+    ],
+    "transformModule": [
+      "build/main:prettier"
+    ],
+    "transformNodeModule": [
+      "build/main:prettier"
+    ],
+    "transformNodes": [
+      "build/main:prettier"
+    ],
+    "transformSystemModule": [
+      "build/main:prettier"
+    ],
+    "transformTypeScript": [
+      "build/main:prettier"
+    ],
+    "transpile": [
+      "build/main:prettier"
+    ],
+    "transpileModule": [
+      "build/main:prettier"
+    ],
+    "transpileOptionValueCompilerOptions": [
+      "build/main:prettier"
+    ],
+    "tryAndIgnoreErrors": [
+      "build/main:prettier"
+    ],
+    "tryDirectoryExists": [
+      "build/main:prettier"
+    ],
+    "tryFileExists": [
+      "build/main:prettier"
+    ],
+    "tryGetDirectories": [
+      "build/main:prettier"
+    ],
+    "tryGetSourceMappingURL": [
+      "build/main:prettier"
+    ],
+    "tryIOAndConsumeErrors": [
+      "build/main:prettier"
+    ],
+    "tryParseRawSourceMap": [
+      "build/main:prettier"
+    ],
+    "tryReadDirectory": [
+      "build/main:prettier"
+    ],
+    "tryReadFile": [
+      "build/main:prettier"
+    ],
+    "ts_BreakpointResolver_exports": [
+      "build/main:prettier"
+    ],
+    "ts_CallHierarchy_exports": [
+      "build/main:prettier"
+    ],
+    "ts_Completions_exports": [
+      "build/main:prettier"
+    ],
+    "ts_FindAllReferences_exports": [
+      "build/main:prettier"
+    ],
+    "ts_GoToDefinition_exports": [
+      "build/main:prettier"
+    ],
+    "ts_InlayHints_exports": [
+      "build/main:prettier"
+    ],
+    "ts_JsDoc_exports": [
+      "build/main:prettier"
+    ],
+    "ts_JsTyping_exports": [
+      "build/main:prettier"
+    ],
+    "ts_NavigateTo_exports": [
+      "build/main:prettier"
+    ],
+    "ts_NavigationBar_exports": [
+      "build/main:prettier"
+    ],
+    "ts_OrganizeImports_exports": [
+      "build/main:prettier"
+    ],
+    "ts_OutliningElementsCollector_exports": [
+      "build/main:prettier"
+    ],
+    "ts_Rename_exports": [
+      "build/main:prettier"
+    ],
+    "ts_SignatureHelp_exports": [
+      "build/main:prettier"
+    ],
+    "ts_SmartSelectionRange_exports": [
+      "build/main:prettier"
+    ],
+    "ts_SymbolDisplay_exports": [
+      "build/main:prettier"
+    ],
+    "ts_classifier_exports": [
+      "build/main:prettier"
+    ],
+    "ts_codefix_exports": [
+      "build/main:prettier"
+    ],
+    "ts_formatting_exports": [
+      "build/main:prettier"
+    ],
+    "ts_moduleSpecifiers_exports": [
+      "build/main:prettier"
+    ],
+    "ts_performance_exports": [
+      "build/main:prettier"
+    ],
+    "ts_refactor_exports": [
+      "build/main:prettier"
+    ],
+    "ts_server_exports": [
+      "build/main:prettier"
+    ],
+    "ts_textChanges_exports": [
+      "build/main:prettier"
+    ],
+    "typeAcquisitionDeclarations": [
+      "build/main:prettier"
+    ],
+    "typeAliasNamePart": [
+      "build/main:prettier"
+    ],
+    "typeKeywords": [
+      "build/main:prettier"
+    ],
+    "typeParameterNamePart": [
+      "build/main:prettier"
+    ],
+    "typeReferenceResolutionNameAndModeGetter": [
+      "build/main:prettier"
+    ],
+    "typeToDisplayParts": [
+      "build/main:prettier"
+    ],
+    "unchangedPollThresholds": [
+      "build/main:prettier"
+    ],
+    "unmangleScopedPackageName": [
+      "build/main:prettier"
+    ],
+    "updateErrorForNoInputFiles": [
+      "build/main:prettier"
+    ],
+    "updateMissingFilePathsWatch": [
+      "build/main:prettier"
+    ],
+    "updatePackageJsonWatch": [
+      "build/main:prettier"
+    ],
+    "updateResolutionField": [
+      "build/main:prettier"
+    ],
+    "updateSharedExtendedConfigFileWatcher": [
+      "build/main:prettier"
+    ],
+    "updateWatchingWildcardDirectories": [
+      "build/main:prettier"
+    ],
+    "valuesHelper": [
+      "build/main:prettier"
+    ],
+    "visitArray": [
+      "build/main:prettier"
+    ],
+    "visitCommaListElements": [
+      "build/main:prettier"
+    ],
+    "visitEachChild": [
+      "build/main:prettier"
+    ],
+    "visitFunctionBody": [
+      "build/main:prettier"
+    ],
+    "visitIterationBody": [
+      "build/main:prettier"
+    ],
+    "visitLexicalEnvironment": [
+      "build/main:prettier"
+    ],
+    "visitNode": [
+      "build/main:prettier"
+    ],
+    "visitNodes2": [
+      "build/main:prettier"
+    ],
+    "visitParameterList": [
+      "build/main:prettier"
+    ],
+    "walkUpLexicalEnvironments": [
+      "build/main:prettier"
+    ],
+    "whitespaceOrMapCommentRegExp": [
+      "build/main:prettier"
+    ],
+    "zipToModeAwareCache": [
+      "build/main:prettier"
+    ],
+    "__global__": [
+      "build/main:resolve-url-loader>es6-iterator>es6-symbol>ext"
+    ],
+    "WebAssembly": [
+      "build/main:source-map"
+    ],
+    "assert": [
+      "build/main:stylelint"
+    ],
+    "ERR_INVALID_ARG_VALUE": [
+      "build/main:ts-node"
+    ],
+    "gc": [
+      "build/main:typescript"
+    ],
+    "globalThis": [
+      "build/main:typescript",
+      "build/override:typescript"
+    ],
+    "Error": [
+      "build/main:yargs",
+      "build/override:yargs"
+    ]
+  }
+}

--- a/lavamoat/stats.js
+++ b/lavamoat/stats.js
@@ -1,0 +1,97 @@
+const globalToPackage = {};
+
+const suggestedDefaults = [
+  // ecmascript
+  'globalThis',
+  'WeakRef',
+  'FinalizationRegistry',
+  'Error',
+  'AggregateError',
+  // common (nodejs + browser)
+  'console',
+  'TextEncoder',
+  'TextDecoder',
+  'atob',
+  'btoa',
+  'URL',
+  'URLSearchParams',
+  'Headers',
+  'FormData',
+  'Response',
+  'setTimeout',
+  'clearTimeout',
+  'setInterval',
+  'clearInterval',
+  'setImmediate',
+  'clearImmediate',
+  'queueMicrotask',
+  'AbortController',
+  'AbortSignal',
+  // browser
+  'self',
+  'window',
+  // cjs
+  '__dirname',
+  '__filename',
+  // amd/umd
+  'define',
+]
+
+const stats = {
+  savedEntries: 0,
+  totalEntries: 0,
+}
+
+
+analyzePolicy('app/main', require('./browserify/main/policy.json'));
+analyzePolicy('app/flask', require('./browserify/flask/policy.json'));
+analyzePolicy('app/beta', require('./browserify/beta/policy.json'));
+analyzePolicy('app/mmi', require('./browserify/mmi/policy.json'));
+analyzePolicy('app/override', require('./browserify/policy-override.json'));
+
+analyzePolicy('build/main', require('./build-system/policy.json'));
+analyzePolicy('build/override', require('./build-system/policy-override.json'));
+
+const ouput = {
+  stats,
+  suggestedDefaults,
+  globalToPackage,
+}
+console.log(JSON.stringify(ouput, null, 2))
+Object.entries(globalToPackage)
+  .sort(([_,a], [_2,b]) => b.length - a.length)
+  .forEach(([key, packages]) => {
+    console.error(`${key}: ${packages.length}`);
+  }
+);
+
+
+function analyzePolicy(label, policy) {
+  for (const [packageName, packagePolicy] of Object.entries(policy.resources)) {
+    const globals = packagePolicy.globals || {};
+    const globalKeys = Object.keys(globals);
+    for (const keyPath of globalKeys) {
+      const key = keyPathToTopLevel(keyPath);
+      if (suggestedDefaults.includes(key)) {
+        stats.savedEntries++;
+      }
+      stats.totalEntries++;
+    }
+    const topLevelGlobalKeys = unique(globalKeys.map(keyPathToTopLevel));
+    for (const key of topLevelGlobalKeys) {
+      const packageLabel = `${label}:${packageName}`;
+      const packagesForGlobal = globalToPackage[key] || [];
+      packagesForGlobal.push(packageLabel);
+      globalToPackage[key] = packagesForGlobal;
+    }
+  }
+  stats.savedEntriesPercent = (100 * stats.savedEntries / stats.totalEntries).toFixed(2);
+}
+
+function keyPathToTopLevel(keyPath) {
+  return keyPath.split('.')[0];
+}
+
+function unique(arr) {
+  return Array.from(new Set(arr));
+}


### PR DESCRIPTION
Not intended for merge, but could evolve into a tool / CI process

Looks like we could remove ~41% of policy global entries by setting some better defaults

776 policy lines are dedicated to `prettier`'s weird usage of globals (~8% of policy) [fixed in `prettier@^3`]