### PR TITLE
fix: add missing filter for scheduled job rerun-from-failed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,9 +364,6 @@ workflows:
     jobs:
       - prep-deps
       - rerun-workflows-from-failed:
-          filters:
-            branches:
-              only: develop
           requires:
             - prep-deps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,6 +364,9 @@ workflows:
     jobs:
       - prep-deps
       - rerun-workflows-from-failed:
+          filters:
+            branches:
+              only: develop
           requires:
             - prep-deps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,9 +103,11 @@ workflows:
   test_and_release:
     when:
       not:
-        matches:
-          pattern: /^l10n_crowdin_action$/
-          value: << pipeline.git.branch >>
+        or:
+          matches:
+            pattern: /^l10n_crowdin_action$/
+            value: << pipeline.git.branch >>
+          equal: [rerun-from-failed, << pipeline.schedule.name >>]
     jobs:
       - create_release_pull_request:
           <<: *rc_branch_only
@@ -358,8 +360,7 @@ workflows:
 
   rerun-from-failed:
     when:
-      condition:
-        equal: ["<< pipeline.schedule.name >>", "rerun-from-failed"]
+      equal: [rerun-from-failed, << pipeline.schedule.name >>]
     jobs:
       - prep-deps
       - rerun-workflows-from-failed:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,10 @@ workflows:
     when:
       not:
         or:
-          matches:
-            pattern: /^l10n_crowdin_action$/
-            value: << pipeline.git.branch >>
-          equal: [rerun-from-failed, << pipeline.schedule.name >>]
+          - matches:
+              pattern: /^l10n_crowdin_action$/
+              value: << pipeline.git.branch >>
+          - equal: [rerun-from-failed, << pipeline.schedule.name >>]
     jobs:
       - create_release_pull_request:
           <<: *rc_branch_only


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

After [the rerun from failed PR ](https://github.com/MetaMask/metamask-extension/pull/28143) was merged there was one remaining filter to tweak, related to the scheduled trigger that will be done in the UI:
- In the Circle ci UI panel, there is no way to tell to trigger a specific workflow, rather all the config file will be checked, which means both the test_and_release and the rerun_from_failed workflows would run. For that, we need to add a filter in the `test_and_release` flow, so that is not run when we schedule the automatic runs using the name rerun-from-failed. Unfortunately there is no way to do this from the UI, so we need this filter in the config file

- I saw, that the rerun-failed workflow was run once the PR was merged, which shouldn't be the case. I've tweaked that following this example in circle [ci docs](https://circleci.com/docs/schedule-pipelines-with-multiple-workflows/#schedule-using-built-in-pipeline-values))

![Screenshot from 2024-11-22 11-06-07](https://github.com/user-attachments/assets/ef82e9e0-4da9-42e6-bb24-6fb97b55034e)

Why this was missed: on the testing for the previous PR, I removed ALL the filters, to make the rerun-from-failed workflow run and check that it works (it worked). However, I didn't test leaving the filter of the `[rerun-from-failed, << pipeline.schedule.name >>]` and checking that it is not run

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28644?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**
How to test this: instead of removing ALL the filters (like it was done for testing the previous PR), just remove the filter for develop. This way, we can see if the job rerun-from-failed is run --> it shouldn't be, as it's not a scheduled run with that name.

It can be checked [here](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension?branch=rerun-failed-missing-filter): see only the test and release is run

![Screenshot from 2024-11-22 11-12-15](https://github.com/user-attachments/assets/d33761b2-beec-4d01-914a-c559815578d5)

For testing the scheduled run, it needs to be done in the UI once this PR is merged, but if the filter has been proven to work here, it should then also work there, for when it needs to be run

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
