### PR TITLE
fix: add unit test for assets polling loops

### DIFF
--- a/ui/hooks/useAccountTrackerPolling.test.ts
+++ b/ui/hooks/useAccountTrackerPolling.test.ts
@@ -1,0 +1,118 @@
+import { renderHookWithProvider } from '../../test/lib/render-helpers';
+import {
+  accountTrackerStartPolling,
+  accountTrackerStopPollingByPollingToken,
+} from '../store/actions';
+import useAccountTrackerPolling from './useAccountTrackerPolling';
+
+let mockPromises: Promise<string>[];
+
+jest.mock('../store/actions', () => ({
+  accountTrackerStartPolling: jest.fn().mockImplementation((input) => {
+    const promise = Promise.resolve(`${input}_tracking`);
+    mockPromises.push(promise);
+    return promise;
+  }),
+  accountTrackerStopPollingByPollingToken: jest.fn(),
+}));
+
+describe('useAccountTrackerPolling', () => {
+  beforeEach(() => {
+    mockPromises = [];
+    jest.clearAllMocks();
+  });
+
+  it('should poll account trackers for network client IDs when enabled and stop on dismount', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        selectedNetworkClientId: 'selectedNetworkClientId',
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            defaultRpcEndpointIndex: 0,
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { unmount } = renderHookWithProvider(
+      () => useAccountTrackerPolling(),
+      state,
+    );
+
+    // Should poll each client ID
+    await Promise.all(mockPromises);
+    expect(accountTrackerStartPolling).toHaveBeenCalledTimes(1);
+    expect(accountTrackerStartPolling).toHaveBeenCalledWith(
+      'selectedNetworkClientId',
+    );
+
+    // Stop polling on dismount
+    unmount();
+    expect(accountTrackerStopPollingByPollingToken).toHaveBeenCalledTimes(1);
+    expect(accountTrackerStopPollingByPollingToken).toHaveBeenCalledWith(
+      'selectedNetworkClientId_tracking',
+    );
+  });
+
+  it('should not poll if onboarding is not completed', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: false,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useAccountTrackerPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(accountTrackerStartPolling).toHaveBeenCalledTimes(0);
+    expect(accountTrackerStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when locked', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: false,
+        completedOnboarding: true,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useAccountTrackerPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(accountTrackerStartPolling).toHaveBeenCalledTimes(0);
+    expect(accountTrackerStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when no network client IDs are provided', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useAccountTrackerPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(accountTrackerStartPolling).toHaveBeenCalledTimes(0);
+    expect(accountTrackerStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+});

--- a/ui/hooks/useCurrencyRatePolling.test.ts
+++ b/ui/hooks/useCurrencyRatePolling.test.ts
@@ -1,0 +1,119 @@
+import { renderHookWithProvider } from '../../test/lib/render-helpers';
+import {
+  currencyRateStartPolling,
+  currencyRateStopPollingByPollingToken,
+} from '../store/actions';
+import useCurrencyRatePolling from './useCurrencyRatePolling';
+
+let mockPromises: Promise<string>[];
+
+jest.mock('../store/actions', () => ({
+  currencyRateStartPolling: jest.fn().mockImplementation((input) => {
+    const promise = Promise.resolve(`${input}_rates`);
+    mockPromises.push(promise);
+    return promise;
+  }),
+  currencyRateStopPollingByPollingToken: jest.fn(),
+}));
+
+describe('useCurrencyRatePolling', () => {
+  beforeEach(() => {
+    mockPromises = [];
+    jest.clearAllMocks();
+  });
+
+  it('should poll currency rates for native currencies when enabled and stop on dismount', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        useCurrencyRateCheck: true,
+        selectedNetworkClientId: 'selectedNetworkClientId',
+        networkConfigurationsByChainId: {
+          '0x1': {
+            nativeCurrency: 'ETH',
+            defaultRpcEndpointIndex: 0,
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { unmount } = renderHookWithProvider(
+      () => useCurrencyRatePolling(),
+      state,
+    );
+
+    await Promise.all(mockPromises);
+    expect(currencyRateStartPolling).toHaveBeenCalledTimes(1);
+    expect(currencyRateStartPolling).toHaveBeenCalledWith(['ETH']);
+
+    // Stop polling on dismount
+    unmount();
+    expect(currencyRateStopPollingByPollingToken).toHaveBeenCalledTimes(1);
+    expect(currencyRateStopPollingByPollingToken).toHaveBeenCalledWith(
+      'ETH_rates',
+    );
+  });
+
+  it('should not poll if onboarding is not completed', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: false,
+        useCurrencyRateCheck: true,
+        networkConfigurationsByChainId: {
+          '0x1': { nativeCurrency: 'ETH' },
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useCurrencyRatePolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(currencyRateStartPolling).toHaveBeenCalledTimes(0);
+    expect(currencyRateStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when locked', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: false,
+        completedOnboarding: true,
+        useCurrencyRateCheck: true,
+        networkConfigurationsByChainId: {
+          '0x1': { nativeCurrency: 'ETH' },
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useCurrencyRatePolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(currencyRateStartPolling).toHaveBeenCalledTimes(0);
+    expect(currencyRateStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when currency rate checking is disabled', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        useCurrencyRateCheck: false,
+        networkConfigurationsByChainId: {
+          '0x1': { nativeCurrency: 'ETH' },
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useCurrencyRatePolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(currencyRateStartPolling).toHaveBeenCalledTimes(0);
+    expect(currencyRateStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+});

--- a/ui/hooks/useCurrencyRatePolling.test.ts
+++ b/ui/hooks/useCurrencyRatePolling.test.ts
@@ -39,6 +39,15 @@ describe('useCurrencyRatePolling', () => {
               },
             ],
           },
+          '0x89': {
+            nativeCurrency: 'BNB',
+            defaultRpcEndpointIndex: 0,
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId2',
+              },
+            ],
+          },
         },
       },
     };
@@ -50,13 +59,13 @@ describe('useCurrencyRatePolling', () => {
 
     await Promise.all(mockPromises);
     expect(currencyRateStartPolling).toHaveBeenCalledTimes(1);
-    expect(currencyRateStartPolling).toHaveBeenCalledWith(['ETH']);
+    expect(currencyRateStartPolling).toHaveBeenCalledWith(['ETH', 'BNB']);
 
     // Stop polling on dismount
     unmount();
     expect(currencyRateStopPollingByPollingToken).toHaveBeenCalledTimes(1);
     expect(currencyRateStopPollingByPollingToken).toHaveBeenCalledWith(
-      'ETH_rates',
+      'ETH,BNB_rates',
     );
   });
 

--- a/ui/hooks/useTokenDetectionPolling.test.ts
+++ b/ui/hooks/useTokenDetectionPolling.test.ts
@@ -9,21 +9,31 @@ let mockPromises: Promise<string>[];
 
 jest.mock('../store/actions', () => ({
   tokenDetectionStartPolling: jest.fn().mockImplementation((input) => {
-    console.log('PASSING HERE ....', input);
     const promise = Promise.resolve(`${input}_detection`);
     mockPromises.push(promise);
     return promise;
   }),
   tokenDetectionStopPollingByPollingToken: jest.fn(),
 }));
+let originalPortfolioView: string | undefined;
 
 describe('useTokenDetectionPolling', () => {
   beforeEach(() => {
+    // Mock process.env.PORTFOLIO_VIEW
+    originalPortfolioView = process.env.PORTFOLIO_VIEW;
+    process.env.PORTFOLIO_VIEW = 'true'; // Set your desired mock value here
+
     mockPromises = [];
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    // Restore the original value
+    process.env.PORTFOLIO_VIEW = originalPortfolioView;
+  });
+
   it('should poll token detection for chain IDs when enabled and stop on dismount', async () => {
+    process.env.PORTFOLIO_VIEW = 'true';
     const state = {
       metamask: {
         isUnlocked: true,
@@ -39,6 +49,14 @@ describe('useTokenDetectionPolling', () => {
               },
             ],
           },
+          '0x89': {
+            chainId: '0x89',
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId2',
+              },
+            ],
+          },
         },
       },
     };
@@ -51,13 +69,13 @@ describe('useTokenDetectionPolling', () => {
     // Should poll each chain
     await Promise.all(mockPromises);
     expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(1);
-    expect(tokenDetectionStartPolling).toHaveBeenCalledWith(['0x1']);
+    expect(tokenDetectionStartPolling).toHaveBeenCalledWith(['0x1', '0x89']);
 
     // Stop polling on dismount
     unmount();
     expect(tokenDetectionStopPollingByPollingToken).toHaveBeenCalledTimes(1);
     expect(tokenDetectionStopPollingByPollingToken).toHaveBeenCalledWith(
-      '0x1_detection',
+      '0x1,0x89_detection',
     );
   });
 

--- a/ui/hooks/useTokenDetectionPolling.test.ts
+++ b/ui/hooks/useTokenDetectionPolling.test.ts
@@ -1,0 +1,139 @@
+import { renderHookWithProvider } from '../../test/lib/render-helpers';
+import {
+  tokenDetectionStartPolling,
+  tokenDetectionStopPollingByPollingToken,
+} from '../store/actions';
+import useTokenDetectionPolling from './useTokenDetectionPolling';
+
+let mockPromises: Promise<string>[];
+
+jest.mock('../store/actions', () => ({
+  tokenDetectionStartPolling: jest.fn().mockImplementation((input) => {
+    console.log('PASSING HERE ....', input);
+    const promise = Promise.resolve(`${input}_detection`);
+    mockPromises.push(promise);
+    return promise;
+  }),
+  tokenDetectionStopPollingByPollingToken: jest.fn(),
+}));
+
+describe('useTokenDetectionPolling', () => {
+  beforeEach(() => {
+    mockPromises = [];
+    jest.clearAllMocks();
+  });
+
+  it('should poll token detection for chain IDs when enabled and stop on dismount', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        useTokenDetection: true,
+        selectedNetworkClientId: 'selectedNetworkClientId',
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { unmount } = renderHookWithProvider(
+      () => useTokenDetectionPolling(),
+      state,
+    );
+
+    // Should poll each chain
+    await Promise.all(mockPromises);
+    expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(1);
+    expect(tokenDetectionStartPolling).toHaveBeenCalledWith(['0x1']);
+
+    // Stop polling on dismount
+    unmount();
+    expect(tokenDetectionStopPollingByPollingToken).toHaveBeenCalledTimes(1);
+    expect(tokenDetectionStopPollingByPollingToken).toHaveBeenCalledWith(
+      '0x1_detection',
+    );
+  });
+
+  it('should not poll if onboarding is not completed', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: false,
+        useTokenDetection: true,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useTokenDetectionPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(0);
+    expect(tokenDetectionStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when locked', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: false,
+        completedOnboarding: true,
+        useTokenDetection: true,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useTokenDetectionPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(0);
+    expect(tokenDetectionStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when token detection is disabled', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        useTokenDetection: false,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useTokenDetectionPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(0);
+    expect(tokenDetectionStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when no chains are provided', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        useTokenDetection: true,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useTokenDetectionPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(tokenDetectionStartPolling).toHaveBeenCalledTimes(0);
+    expect(tokenDetectionStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+});

--- a/ui/hooks/useTokenRatesPolling.test.ts
+++ b/ui/hooks/useTokenRatesPolling.test.ts
@@ -16,10 +16,20 @@ jest.mock('../store/actions', () => ({
   tokenRatesStopPollingByPollingToken: jest.fn(),
 }));
 
+let originalPortfolioView: string | undefined;
 describe('useTokenRatesPolling', () => {
   beforeEach(() => {
+    // Mock process.env.PORTFOLIO_VIEW
+    originalPortfolioView = process.env.PORTFOLIO_VIEW;
+    process.env.PORTFOLIO_VIEW = 'true'; // Set your desired mock value here
+
     mockPromises = [];
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore the original value
+    process.env.PORTFOLIO_VIEW = originalPortfolioView;
   });
 
   it('should poll token rates when enabled and stop on dismount', async () => {
@@ -38,6 +48,14 @@ describe('useTokenRatesPolling', () => {
               },
             ],
           },
+          '0x89': {
+            chainId: '0x89',
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId2',
+              },
+            ],
+          },
         },
       },
     };
@@ -49,14 +67,17 @@ describe('useTokenRatesPolling', () => {
 
     // Should poll each chain
     await Promise.all(mockPromises);
-    expect(tokenRatesStartPolling).toHaveBeenCalledTimes(1);
+    expect(tokenRatesStartPolling).toHaveBeenCalledTimes(2);
     expect(tokenRatesStartPolling).toHaveBeenCalledWith('0x1');
-
+    expect(tokenRatesStartPolling).toHaveBeenCalledWith('0x89');
     // Stop polling on dismount
     unmount();
-    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledTimes(1);
+    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledTimes(2);
     expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledWith(
       '0x1_rates',
+    );
+    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledWith(
+      '0x89_rates',
     );
   });
 

--- a/ui/hooks/useTokenRatesPolling.test.ts
+++ b/ui/hooks/useTokenRatesPolling.test.ts
@@ -1,0 +1,139 @@
+import { renderHookWithProvider } from '../../test/lib/render-helpers';
+import {
+  tokenRatesStartPolling,
+  tokenRatesStopPollingByPollingToken,
+} from '../store/actions';
+import useTokenRatesPolling from './useTokenRatesPolling';
+
+let mockPromises: Promise<string>[];
+
+jest.mock('../store/actions', () => ({
+  tokenRatesStartPolling: jest.fn().mockImplementation((input) => {
+    const promise = Promise.resolve(`${input}_rates`);
+    mockPromises.push(promise);
+    return promise;
+  }),
+  tokenRatesStopPollingByPollingToken: jest.fn(),
+}));
+
+describe('useTokenRatesPolling', () => {
+  beforeEach(() => {
+    mockPromises = [];
+    jest.clearAllMocks();
+  });
+
+  it('should poll token rates when enabled and stop on dismount', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        useCurrencyRateCheck: true,
+        selectedNetworkClientId: 'selectedNetworkClientId',
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { unmount } = renderHookWithProvider(
+      () => useTokenRatesPolling(),
+      state,
+    );
+
+    // Should poll each chain
+    await Promise.all(mockPromises);
+    expect(tokenRatesStartPolling).toHaveBeenCalledTimes(1);
+    expect(tokenRatesStartPolling).toHaveBeenCalledWith('0x1');
+
+    // Stop polling on dismount
+    unmount();
+    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledTimes(1);
+    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledWith(
+      '0x1_rates',
+    );
+  });
+
+  it('should not poll if onboarding is not completed', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: false,
+        useCurrencyRateCheck: true,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+          '0x89': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useTokenRatesPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(tokenRatesStartPolling).toHaveBeenCalledTimes(0);
+    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when locked', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: false,
+        completedOnboarding: true,
+        useCurrencyRateCheck: true,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+          '0x89': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useTokenRatesPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(tokenRatesStartPolling).toHaveBeenCalledTimes(0);
+    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when rate checking is disabled', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        useCurrencyRateCheck: false,
+        networkConfigurationsByChainId: {
+          '0x1': {},
+          '0x89': {},
+        },
+      },
+    };
+
+    renderHookWithProvider(() => useTokenRatesPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(tokenRatesStartPolling).toHaveBeenCalledTimes(0);
+    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not poll when no chains are provided', async () => {
+    const state = {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+        useCurrencyRateCheck: true,
+        networkConfigurationsByChainId: {},
+      },
+    };
+
+    renderHookWithProvider(() => useTokenRatesPolling(), state);
+
+    await Promise.all(mockPromises);
+    expect(tokenRatesStartPolling).toHaveBeenCalledTimes(0);
+    expect(tokenRatesStopPollingByPollingToken).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
the goal of this PR is to add unit tests for all multichain assets polling loops

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28646?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
