### PR TITLE
chore: Run MMI tests on long-running branches

### DIFF
--- a/.circleci/scripts/check_mmi_trigger.sh
+++ b/.circleci/scripts/check_mmi_trigger.sh
@@ -9,6 +9,12 @@ if [ -z "$CIRCLE_PULL_REQUEST" ] || [ -z "$GITHUB_TOKEN" ]; then
   exit 0
 fi
 
+if [[ $CIRCLE_BRANCH = 'develop' || $CIRCLE_BRANCH = 'master' || $CIRCLE_BRANCH =~ ^Version-v[0-9.]* ]]; then
+  echo "Long-running branch detected, running MMI tests."
+  echo "run_mmi_tests=true" > mmi_trigger.env
+  exit 0
+fi
+
 # Extract PR number from the pull request URL
 PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | awk -F'/' '{print $NF}')
 


### PR DESCRIPTION
## **Description**

The `check_mmi_trigger.sh` script has been updated to run MMI-related tests on long-running branches (`develop`, `master`, and RCs). This is intended to make it easier for us to detect these regressions sooner, so that we don't waste time tracking down the commit that caused any given breakage.
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28651?quickstart=1)

## **Related issues**

No linked issue. This is intended to make it safer to extend the use of this MMI filter to other jobs, which will help us save CircleCI credits

## **Manual testing steps**

I tested this locally by running the script with the `CIRCLE_PULL_REQUEST`, `GITHUB_TOKEN`, and `CIRCLE_BRANCH` environment variables set. e.g.

```
> CIRCLE_PULL_REQUEST=foo GITHUB_TOKEN=foo CIRCLE_BRANCH=Version-v12.0.0 ./.circleci/scripts/check_mmi_trigger.sh
Long-running branch detected, running MMI tests.
```

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
