### PR TITLE
Add offscreen localStorage solution so that localStorage can still be…

### DIFF
--- a/app/scripts/lib/stores/local-storage-with-offscreen-store.test.ts
+++ b/app/scripts/lib/stores/local-storage-with-offscreen-store.test.ts
@@ -1,0 +1,153 @@
+import browser from 'webextension-polyfill';
+import { awaitOffscreenDocumentCreation } from '../../offscreen';
+import { OffscreenCommunicationTarget } from '../../../../shared/constants/offscreen-communication';
+
+jest.mock('../../offscreen', () => ({
+  awaitOffscreenDocumentCreation: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../../shared/modules/mv3.utils', () => ({
+  isOffscreenAvailable: true,
+}));
+
+jest.mock('webextension-polyfill', () => ({
+  runtime: {
+    sendMessage: jest
+      .fn()
+      .mockResolvedValue({ value: { testKey: 'testValue' } }),
+  },
+}));
+
+describe('LocalStorageWithOffScreenStore', () => {
+  let LocalStorageWithOffScreenStore;
+  let localStorageMock: Record<string, string>;
+
+  beforeEach(() => {
+    localStorageMock = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: jest.fn((key) => localStorageMock[key] || null),
+        setItem: jest.fn((key, value) => {
+          localStorageMock[key] = value;
+        }),
+        removeItem: jest.fn((key) => {
+          delete localStorageMock[key];
+        }),
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+  });
+
+  describe('get', () => {
+    it('retrieves data from offscreen when offscreen is available', async () => {
+      jest.doMock('../../../../shared/modules/mv3.utils', () => ({
+        isOffscreenAvailable: true,
+      }));
+
+      const module = await import('./local-storage-with-offscreen-store');
+      LocalStorageWithOffScreenStore = module.default;
+
+      const store = new LocalStorageWithOffScreenStore();
+      const result = await store.get();
+
+      expect(awaitOffscreenDocumentCreation).toHaveBeenCalled();
+      expect(browser.runtime.sendMessage).toHaveBeenCalledWith(undefined, {
+        target: OffscreenCommunicationTarget.localStorageOffScreen,
+        action: 'getItem',
+      });
+      expect(result).toEqual({ testKey: 'testValue' });
+    });
+
+    it('retrieves data from localStorage when offscreen is unavailable', async () => {
+      jest.doMock('../../../../shared/modules/mv3.utils', () => ({
+        isOffscreenAvailable: false,
+      }));
+
+      const module = await import('./local-storage-with-offscreen-store');
+      LocalStorageWithOffScreenStore = module.default;
+
+      localStorageMock.state = JSON.stringify({ testKey: 'testValue' });
+
+      const store = new LocalStorageWithOffScreenStore();
+      const result = await store.get();
+
+      expect(window.localStorage.getItem).toHaveBeenCalledWith('state');
+      expect(result).toEqual({ testKey: 'testValue' });
+    });
+
+    it('returns null if no data is found in localStorage', async () => {
+      jest.doMock('../../../../shared/modules/mv3.utils', () => ({
+        isOffscreenAvailable: false,
+      }));
+
+      const module = await import('./local-storage-with-offscreen-store');
+      LocalStorageWithOffScreenStore = module.default;
+
+      const store = new LocalStorageWithOffScreenStore();
+      const result = await store.get();
+
+      expect(window.localStorage.getItem).toHaveBeenCalledWith('state');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    it('stores data using offscreen when offscreen is available', async () => {
+      jest.resetModules();
+
+      jest.doMock('webextension-polyfill', () => ({
+        runtime: {
+          sendMessage: jest
+            .fn()
+            .mockResolvedValue({ value: { testKey: 'testValue' } }),
+        },
+      }));
+
+      jest.doMock('../../../../shared/modules/mv3.utils', () => ({
+        isOffscreenAvailable: true,
+      }));
+
+      const module = await import('./local-storage-with-offscreen-store');
+      LocalStorageWithOffScreenStore = module.default;
+
+      const { runtime } = await import('webextension-polyfill');
+
+      const store = new LocalStorageWithOffScreenStore();
+      const state = { data: { testKey: 'testValue' } };
+
+      await store.set(state);
+
+      expect(runtime.sendMessage).toHaveBeenCalledTimes(1);
+      expect(runtime.sendMessage).toHaveBeenCalledWith(undefined, {
+        target: OffscreenCommunicationTarget.localStorageOffScreen,
+        action: 'setItem',
+        key: 'state',
+        value: JSON.stringify(state),
+      });
+    });
+
+    it('stores data in localStorage when offscreen is unavailable', async () => {
+      jest.doMock('../../../../shared/modules/mv3.utils', () => ({
+        isOffscreenAvailable: false,
+      }));
+
+      const module = await import('./local-storage-with-offscreen-store');
+      LocalStorageWithOffScreenStore = module.default;
+
+      const state = { data: { testKey: 'testValue' } };
+
+      const store = new LocalStorageWithOffScreenStore();
+      await store.set(state);
+
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        'state',
+        JSON.stringify(state),
+      );
+    });
+  });
+});

--- a/app/scripts/lib/stores/local-storage-with-offscreen-store.ts
+++ b/app/scripts/lib/stores/local-storage-with-offscreen-store.ts
@@ -1,0 +1,67 @@
+import browser from 'webextension-polyfill';
+import { awaitOffscreenDocumentCreation } from '../../offscreen';
+import { OffscreenCommunicationTarget } from '../../../../shared/constants/offscreen-communication';
+import { isOffscreenAvailable } from '../../../../shared/modules/mv3.utils';
+import { BaseStore, MetaMaskStorageStructure } from './base-store';
+
+const isLocalStorageAvailable = window.localStorage;
+
+const browserRuntimeSendMessageToAwait = async (params: {
+  target: string;
+  action: string;
+  key?: string;
+  value?: string;
+}): Promise<Record<string, unknown>> => {
+  await awaitOffscreenDocumentCreation();
+  console.log('browser.runtime.sendMessage', browser.runtime.sendMessage);
+  return new Promise((resolve, reject) => {
+    browser.runtime
+      .sendMessage(undefined, params)
+      .then((response: { error?: Error; value: Record<string, unknown> }) => {
+        if (response.error) {
+          reject(response.error);
+        }
+        resolve(response.value);
+      });
+  });
+};
+
+export default class LocalStorageWithOffScreenStore extends BaseStore {
+  isSupported: boolean;
+
+  constructor() {
+    super();
+
+    this.isSupported = Boolean(isOffscreenAvailable || isLocalStorageAvailable);
+    if (!this.isSupported) {
+      throw new Error('Local storage and offscreen are not supported');
+    }
+  }
+
+  async get(): Promise<MetaMaskStorageStructure | null> {
+    if (isOffscreenAvailable) {
+      await awaitOffscreenDocumentCreation();
+      return (await browserRuntimeSendMessageToAwait({
+        target: OffscreenCommunicationTarget.localStorageOffScreen,
+        action: 'getItem',
+      })) as MetaMaskStorageStructure;
+    } else if (isLocalStorageAvailable) {
+      const value = window.localStorage.getItem('state');
+      return value ? JSON.parse(value) : null;
+    }
+    return null;
+  }
+
+  async set(state: MetaMaskStorageStructure): Promise<void> {
+    if (isOffscreenAvailable) {
+      await browserRuntimeSendMessageToAwait({
+        target: OffscreenCommunicationTarget.localStorageOffScreen,
+        action: 'setItem',
+        key: 'state',
+        value: JSON.stringify(state),
+      });
+    } else {
+      window.localStorage.setItem('state', JSON.stringify(state));
+    }
+  }
+}

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -26,6 +26,15 @@ async function hasOffscreenDocument() {
   return matchedClients.some((client) => client.url === url);
 }
 
+export async function awaitOffscreenDocumentCreation() {
+  const offscreenExists = await hasOffscreenDocument();
+  if (!offscreenExists) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return await awaitOffscreenDocumentCreation();
+  }
+  return undefined;
+}
+
 /**
  * Creates an offscreen document that can be used to load additional scripts
  * and iframes that can communicate with the extension through the chrome

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
   testMatch: [
     '<rootDir>/app/scripts/**/*.test.(js|ts|tsx)',
     '<rootDir>/shared/**/*.test.(js|ts|tsx)',
+    '<rootDir>/offscreen/**/*.test.(js|ts|tsx)',
     '<rootDir>/ui/**/*.test.(js|ts|tsx)',
     '<rootDir>/development/**/*.test.(js|ts|tsx)',
     '<rootDir>/test/unit-global/**/*.test.(js|ts|tsx)',

--- a/offscreen/scripts/localStorage.test.ts
+++ b/offscreen/scripts/localStorage.test.ts
@@ -1,0 +1,131 @@
+import { beforeAll } from '@jest/globals';
+import { OffscreenCommunicationTarget } from '../../shared/constants/offscreen-communication';
+import setupLocalStorageMessageListeners from './localStorage';
+
+const originalGetItem = Storage.prototype.getItem;
+const originalSetItem = Storage.prototype.setItem;
+const originalRemoveItem = Storage.prototype.removeItem;
+
+describe('setupLocalStorageMessageListeners', () => {
+  let mockAddListener: jest.Mock;
+  let mockSendMessage: jest.Mock;
+
+  beforeAll(() => {
+    Storage.prototype.getItem = jest.fn().mockReturnValue('testValue');
+    Storage.prototype.setItem = jest.fn();
+    Storage.prototype.removeItem = jest.fn();
+  });
+
+  afterAll(() => {
+    Storage.prototype.getItem = originalGetItem;
+    Storage.prototype.setItem = originalSetItem;
+    Storage.prototype.removeItem = originalRemoveItem;
+  });
+
+  beforeEach(() => {
+    mockAddListener = jest.fn();
+    mockSendMessage = jest.fn();
+
+    Object.defineProperty(chrome.runtime, 'onMessage', {
+      value: { addListener: mockAddListener },
+    });
+
+    Object.defineProperty(chrome.runtime, 'sendMessage', {
+      value: mockSendMessage,
+    });
+
+    setupLocalStorageMessageListeners();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds a listener to chrome.runtime.onMessage', () => {
+    expect(mockAddListener).toHaveBeenCalledTimes(1);
+  });
+
+  describe('onMessage listener', () => {
+    let messageListener: (message: {
+      target: string;
+      action: string;
+      key?: string;
+      value?: string;
+    }) => void;
+
+    beforeEach(() => {
+      messageListener = mockAddListener.mock.calls[0][0];
+    });
+
+    it('handles getItem action correctly', () => {
+      const mockMessage = {
+        target: OffscreenCommunicationTarget.localStorageOffScreen,
+        action: 'getItem',
+        key: 'testKey',
+      };
+
+      const mockStoredValue = 'testValue';
+
+      messageListener(mockMessage);
+
+      expect(window.localStorage.getItem).toHaveBeenCalledWith('testKey');
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+        target: OffscreenCommunicationTarget.extensionLocalStorage,
+        value: mockStoredValue,
+      });
+    });
+
+    it('handles setItem action correctly', () => {
+      const mockMessage = {
+        target: OffscreenCommunicationTarget.localStorageOffScreen,
+        action: 'setItem',
+        key: 'testKey',
+        value: 'testValue',
+      };
+
+      messageListener(mockMessage);
+
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        'testKey',
+        'testValue',
+      );
+    });
+
+    it('handles removeItem action correctly', () => {
+      const mockMessage = {
+        target: OffscreenCommunicationTarget.localStorageOffScreen,
+        action: 'removeItem',
+        key: 'testKey',
+      };
+
+      messageListener(mockMessage);
+
+      expect(window.localStorage.removeItem).toHaveBeenCalledWith('testKey');
+    });
+
+    it('does not process messages with an invalid target', () => {
+      const mockMessage = {
+        target: 'invalidTarget',
+        action: 'getItem',
+        key: 'testKey',
+      };
+
+      messageListener(mockMessage);
+
+      expect(window.localStorage.getItem).not.toHaveBeenCalled();
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not process messages with missing fields', () => {
+      const mockMessage = {
+        target: OffscreenCommunicationTarget.localStorageOffScreen,
+        action: 'getItem',
+      };
+
+      messageListener(mockMessage);
+
+      expect(window.localStorage.getItem).not.toHaveBeenCalled();
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/offscreen/scripts/localStorage.ts
+++ b/offscreen/scripts/localStorage.ts
@@ -1,0 +1,36 @@
+import { isObject } from '@metamask/utils';
+import { OffscreenCommunicationTarget } from '../../shared/constants/offscreen-communication';
+
+export default function setupLocalStorageMessageListeners() {
+  chrome.runtime.onMessage.addListener(
+    (
+      message: {
+        target: string;
+        action: string;
+        key: string;
+        value: string;
+      },
+      _sender,
+    ) => {
+      if (
+        message &&
+        isObject(message) &&
+        message.action &&
+        message.key &&
+        message.target === OffscreenCommunicationTarget.localStorageOffScreen
+      ) {
+        if (message.action === 'getItem') {
+          const storedValue = window.localStorage.getItem(message.key);
+          chrome.runtime.sendMessage({
+            target: OffscreenCommunicationTarget.extensionLocalStorage,
+            value: storedValue,
+          });
+        } else if (message.action === 'setItem') {
+          window.localStorage.setItem(message.key, message.value);
+        } else if (message.action === 'removeItem') {
+          window.localStorage.removeItem(message.key);
+        }
+      }
+    },
+  );
+}

--- a/offscreen/scripts/offscreen.ts
+++ b/offscreen/scripts/offscreen.ts
@@ -10,6 +10,7 @@ import {
 import initLedger from './ledger';
 import initTrezor from './trezor';
 import initLattice from './lattice';
+import setupLocalStorageMessageListeners from './localStorage';
 
 /**
  * Initialize a post message stream with the parent window that is initialized
@@ -34,6 +35,7 @@ async function init(): Promise<void> {
   initializePostMessageStream();
   initTrezor();
   initLattice();
+  setupLocalStorageMessageListeners();
 
   try {
     const ledgerInitTimeout = new Promise((_, reject) => {

--- a/shared/constants/offscreen-communication.ts
+++ b/shared/constants/offscreen-communication.ts
@@ -10,6 +10,8 @@ export enum OffscreenCommunicationTarget {
   ledgerOffscreen = 'ledger-offscreen',
   latticeOffscreen = 'lattice-offscreen',
   extension = 'extension-offscreen',
+  localStorageOffScreen = 'local-storage-offscreen',
+  extensionLocalStorage = 'extension-local-storage',
   extensionMain = 'extension',
 }
 


### PR DESCRIPTION
… used even when global.localStorage does not exists


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28652?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
