### PR TITLE
chore: Restrict MMI test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1198,6 +1198,7 @@ jobs:
       - run: sudo corepack enable
       - attach_workspace:
           at: .
+      - run: *check-mmi-trigger
       - run:
           name: Move test build to dist
           command: mv ./dist-test-mmi ./dist
@@ -1287,6 +1288,7 @@ jobs:
       - run: sudo corepack enable
       - attach_workspace:
           at: .
+      - run: *check-mmi-trigger
       - run:
           name: Move test build to dist
           command: mv ./dist-test-mmi ./dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,7 @@ workflows:
       - prep-build-test-mmi:
           requires:
             - prep-deps
+            - check-mmi-trigger
       - prep-build-test-mmi-playwright:
           requires:
             - prep-deps
@@ -802,6 +803,7 @@ jobs:
       - run: corepack enable
       - attach_workspace:
           at: .
+      - run: *check-mmi-trigger
       - run:
           name: Build extension for testing
           command: yarn build:test:mmi


### PR DESCRIPTION
## **Description**

The standard MMI e2e test suite now only runs on long-running branches, and for MMI-related changes. This should reduce CircleCI credit usage substantially.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28655?quickstart=1)

## **Related issues**

No issue. This is just to reduce credit usage.

## **Manual testing steps**

We should see in the logs for the `test-e2e-mmi` job on this PR that the tests were skipped.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
