### PR TITLE
fix(snaps): Migration to remove `snap_ManageAccounts` from the snaps permissions.

### DIFF
--- a/app/scripts/migrations/132.test.ts
+++ b/app/scripts/migrations/132.test.ts
@@ -1,0 +1,182 @@
+import { AccountsControllerState } from '@metamask/accounts-controller';
+import { cloneDeep } from 'lodash';
+import { createMockInternalAccount } from '../../../test/jest/mocks';
+import { migrate, version } from './132';
+
+const oldVersion = 131;
+
+const mockSnapControllerState = {
+  snaps: {
+    foobar: {
+      id: 'foobar',
+    },
+  },
+};
+
+const mockPermissionControllerState = {
+  subjects: {
+    foobar: {
+      permissions: {
+        snap_manageAccounts: {},
+      },
+    },
+  },
+};
+
+describe(`migration #${version}`, () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        SnapController: mockSnapControllerState,
+        PermissionController: mockPermissionControllerState,
+      },
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('does nothing if SnapController is not present', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        PermissionController: mockPermissionControllerState,
+      },
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('does nothing if PermissionController is not present', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        SnapController: mockSnapControllerState,
+      },
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('does nothing if there is no snaps', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        SnapController: {},
+        PermissionController: mockPermissionControllerState,
+      },
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('does nothing if there are no permission subjects', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        SnapController: mockSnapControllerState,
+        PermissionController: {},
+      },
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('does nothing if the snap does not have a corresponding permission subject', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        SnapController: {
+          snaps: {
+            foobar: {
+              id: 'foobar',
+            },
+          },
+        },
+        PermissionController: {
+          subjects: {},
+        },
+      },
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('does nothing if the snap does not have a snap_manageAccounts permission', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        SnapController: {
+          snaps: {
+            foobar: {
+              id: 'foobar',
+            },
+          },
+        },
+        PermissionController: {
+          subjects: {
+            foobar: {
+              permissions: {
+                snap_notify: {},
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('removes the snap_manageAccounts permission from the snap', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        SnapController: mockSnapControllerState,
+        PermissionController: {
+          subjects: {
+            foobar: {
+              permissions: {
+                snap_notify: {},
+                snap_manageAccounts: {},
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedData = {
+      SnapController: mockSnapControllerState,
+      PermissionController: {
+        subjects: {
+          foobar: {
+            permissions: {
+              snap_notify: {},
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.data).toStrictEqual(expectedData);
+  });
+});

--- a/app/scripts/migrations/132.ts
+++ b/app/scripts/migrations/132.ts
@@ -5,10 +5,8 @@ import {
   PermissionSpecificationConstraint,
 } from '@metamask/permission-controller';
 import { SnapControllerState } from '@metamask/snaps-controllers';
-import { filterRemovedPermissions } from '@metamask/snaps-rpc-methods';
 import { hasProperty, isObject } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
-import log from 'loglevel';
 
 type VersionedData = {
   meta: { version: number };
@@ -93,4 +91,6 @@ function transformState(state: Record<string, unknown>): void {
       ].permissions = newSnapPermissions;
     }
   });
+
+  console.log(state);
 }

--- a/app/scripts/migrations/132.ts
+++ b/app/scripts/migrations/132.ts
@@ -75,8 +75,8 @@ function transformState(state: Record<string, unknown>): void {
     return;
   }
 
-  const snaps = snapControllerState.snaps;
-  const subjects = permissionControllerState.subjects;
+  const { snaps } = snapControllerState;
+  const { subjects } = permissionControllerState;
 
   Object.keys(snaps).forEach((snapId) => {
     if (subjects[snapId]) {

--- a/app/scripts/migrations/132.ts
+++ b/app/scripts/migrations/132.ts
@@ -1,0 +1,96 @@
+import {
+  CaveatSpecificationConstraint,
+  ExtractPermission,
+  PermissionControllerState,
+  PermissionSpecificationConstraint,
+} from '@metamask/permission-controller';
+import { SnapControllerState } from '@metamask/snaps-controllers';
+import { filterRemovedPermissions } from '@metamask/snaps-rpc-methods';
+import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+import log from 'loglevel';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+type ActualPermissionControllerState = PermissionControllerState<
+  ExtractPermission<
+    PermissionSpecificationConstraint,
+    CaveatSpecificationConstraint
+  >
+>;
+
+export const version = 132;
+
+/**
+ * Handle the `snap_manageAccounts` removal from the restricted methods of snap.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly
+ * what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by
+ * controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>): void {
+  if (
+    !hasProperty(state, 'SnapController') ||
+    !isObject(state.SnapController)
+  ) {
+    return;
+  }
+
+  if (
+    !hasProperty(state, 'PermissionController') ||
+    !isObject(state.PermissionController)
+  ) {
+    return;
+  }
+
+  const snapControllerState = state.SnapController as SnapControllerState;
+  const permissionControllerState =
+    state.PermissionController as ActualPermissionControllerState;
+
+  if (
+    !isObject(snapControllerState) ||
+    !hasProperty(snapControllerState, 'snaps')
+  ) {
+    return;
+  }
+
+  if (
+    !isObject(permissionControllerState) ||
+    !hasProperty(permissionControllerState, 'subjects')
+  ) {
+    return;
+  }
+
+  const snaps = snapControllerState.snaps;
+  const subjects = permissionControllerState.subjects;
+
+  Object.keys(snaps).forEach((snapId) => {
+    if (subjects[snapId]) {
+      const newSnapPermissions = Object.fromEntries(
+        Object.entries(subjects[snapId].permissions).filter(
+          ([permissionName]) => permissionName !== 'snap_manageAccounts',
+        ),
+      );
+
+      (state.PermissionController as ActualPermissionControllerState).subjects[
+        snapId
+      ].permissions = newSnapPermissions;
+    }
+  });
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -152,6 +152,7 @@ const migrations = [
   require('./129'),
   require('./130'),
   require('./131'),
+  require('./132'),
 ];
 
 export default migrations;


### PR DESCRIPTION
## **Description**

This PR creates a migration to remove the `snap_manageAccounts` permission of any snap from the `PermissionController`.

The `snap_manageAccouts` permission was moved to a gated permitted method and it does not require anymore to be requested by the snap.

Mandatory for: https://github.com/MetaMask/snaps/pull/2869

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28656?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
