### PR TITLE
fix: Add default value to custom nonce modal

### DIFF
--- a/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
+++ b/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
@@ -86,7 +86,7 @@ exports[`Customize Nonce should match snapshot 1`] = `
                   min="0"
                   placeholder="1"
                   type="number"
-                  value=""
+                  value="1"
                 />
               </div>
             </div>

--- a/ui/components/app/modals/customize-nonce/customize-nonce.component.js
+++ b/ui/components/app/modals/customize-nonce/customize-nonce.component.js
@@ -27,7 +27,9 @@ const CustomizeNonce = ({
   updateCustomNonce,
   getNextNonce,
 }) => {
-  const [customNonce, setCustomNonce] = useState('');
+  const defaultNonce =
+    customNonceValue || (typeof nextNonce === 'number' && nextNonce.toString());
+  const [customNonce, setCustomNonce] = useState(defaultNonce);
   const t = useI18nContext();
 
   return (
@@ -107,10 +109,7 @@ const CustomizeNonce = ({
               type="number"
               data-testid="custom-nonce-input"
               min="0"
-              placeholder={
-                customNonceValue ||
-                (typeof nextNonce === 'number' && nextNonce.toString())
-              }
+              placeholder={defaultNonce}
               onChange={(e) => {
                 setCustomNonce(e.target.value);
               }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

See original bug ticket.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28659?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/28033

## **Manual testing steps**

See original bug ticket.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
