### PR TITLE
fix: Provide selector that enables cross-chain polling, regardless of network filter state

### DIFF
--- a/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
+++ b/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
@@ -5,9 +5,9 @@ import {
   getCurrentChainId,
   getCurrentNetwork,
   getPreferences,
-  getChainIdsToPoll,
   getShouldHideZeroBalanceTokens,
   getSelectedAccount,
+  getAllChainsToPoll,
 } from '../../../../../selectors';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
@@ -49,7 +49,7 @@ const NetworkFilter = ({ handleClose }: SortControlProps) => {
   const shouldHideZeroBalanceTokens = useSelector(
     getShouldHideZeroBalanceTokens,
   );
-  const allChainIDs = useSelector(getChainIdsToPoll);
+  const allChainIDs = useSelector(getAllChainsToPoll);
   const { formattedTokensWithBalancesPerChain } = useGetFormattedTokensPerChain(
     selectedAccount,
     shouldHideZeroBalanceTokens,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2371,11 +2371,12 @@ export const getChainIdsToPoll = createDeepEqualSelector(
   (
     networkConfigurations,
     currentChainId,
-    isTokenNetworkFilterEqualCurrentNetwork,
+    // isTokenNetworkFilterEqualCurrentNetwork,
   ) => {
     if (
-      !process.env.PORTFOLIO_VIEW ||
-      isTokenNetworkFilterEqualCurrentNetwork
+      !process.env.PORTFOLIO_VIEW
+      // !process.env.PORTFOLIO_VIEW ||
+      // isTokenNetworkFilterEqualCurrentNetwork
     ) {
       return [currentChainId];
     }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2364,15 +2364,31 @@ export const getAllEnabledNetworks = createDeepEqualSelector(
     ),
 );
 
-// USE THIS WITH CAUTION
-// Only use this selector if you are absolutely sure that your UI component needs data from _all chains_ to compute a value. Else, use getChainsIdsToPoll
-// An example of a component that should _not_ use this selector: the token list only needs to poll for chains based on the network filter, (potentially only one chain). In this case you would want to use getChainIdsToPoll
-// An example of a component that should _need_ to use this selector: Aggregated balance that needs to display regardless of network filter selection (always needs to display aggregated balance regardless of chains that are selected)
-// Leveraging this hook can cause expensive computation that is not needed in all cases, and should be optimized, where possible, to use getChainIdsToPoll instead
+/*
+ * USE THIS WITH CAUTION
+ *
+ * Only use this selector if you are absolutely sure that your UI component needs
+ * data from _all chains_ to compute a value. Else, use `getChainIdsToPoll`.
+ *
+ * Examples:
+ * - Components that should NOT use this selector:
+ *   - Token list: This only needs to poll for chains based on the network filter
+ *     (potentially only one chain). In this case, use `getChainIdsToPoll`.
+ * - Components that SHOULD use this selector:
+ *   - Aggregated balance: This needs to display data regardless of network filter
+ *     selection (always showing aggregated balances across all chains).
+ *
+ * Key Considerations:
+ * - This selector can cause expensive computations. It should only be used when
+ *   necessary, and where possible, optimized to use `getChainIdsToPoll` instead.
+ * - Logic Overview:
+ *   - If `PORTFOLIO_VIEW` is not enabled, the selector returns only the `currentChainId`.
+ *   - Otherwise, it includes all chains from `networkConfigurations`, excluding
+ *     `TEST_CHAINS`, while ensuring the `currentChainId` is included.
+ */
 export const getAllChainsToPoll = createDeepEqualSelector(
   getNetworkConfigurationsByChainId,
   getCurrentChainId,
-  getIsTokenNetworkFilterEqualCurrentNetwork,
   (networkConfigurations, currentChainId) => {
     if (!process.env.PORTFOLIO_VIEW) {
       return [currentChainId];

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1082,6 +1082,7 @@ export function getIsTokenNetworkFilterEqualCurrentNetwork(state) {
   const chainId = getCurrentChainId(state);
   const { tokenNetworkFilter: tokenNetworkFilterValue } = getPreferences(state);
   const tokenNetworkFilter = tokenNetworkFilterValue || {};
+  console.log(chainId, tokenNetworkFilterValue, tokenNetworkFilter);
   if (
     Object.keys(tokenNetworkFilter).length === 1 &&
     Object.keys(tokenNetworkFilter)[0] === chainId
@@ -2375,6 +2376,8 @@ export const getChainIdsToPoll = createDeepEqualSelector(
   ) => {
     if (
       !process.env.PORTFOLIO_VIEW
+      // TODO: We need to poll across allchains in order to calculate the aggregate balances in the main balance as well as in all networks
+      // If we scope this to the currently filtered chain, we won't be able to compute the balances for the chains outside of the filtered one
       // !process.env.PORTFOLIO_VIEW ||
       // isTokenNetworkFilterEqualCurrentNetwork
     ) {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1082,7 +1082,6 @@ export function getIsTokenNetworkFilterEqualCurrentNetwork(state) {
   const chainId = getCurrentChainId(state);
   const { tokenNetworkFilter: tokenNetworkFilterValue } = getPreferences(state);
   const tokenNetworkFilter = tokenNetworkFilterValue || {};
-  console.log(chainId, tokenNetworkFilterValue, tokenNetworkFilter);
   if (
     Object.keys(tokenNetworkFilter).length === 1 &&
     Object.keys(tokenNetworkFilter)[0] === chainId


### PR DESCRIPTION
## **Description**

We cannot rely on the same selector for all cases, as not all UI is tightly coupled to the tokenNetworkFilter, else we will not be able to compute aggregated balances across chains, when filtered by current network. Since polling for balances is UI based, we can use a different selector on the network-filter, which should execute polling loops only when the dropdown is toggled open.

With the current behavior, the aggregated balance will only display when "All Networks" filter is selected, and when the "Current Network" is selected, it will aggregate balances only for that chain.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28662?quickstart=1)

## **Related issues**

Fixes: Current chain aggregated balance showing up in cross chain aggregated balance when current network is filterd.

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
