### PR TITLE
fix: swaps approval checking for approvals between 0 and unlimited

### DIFF
--- a/app/scripts/controllers/swaps/index.ts
+++ b/app/scripts/controllers/swaps/index.ts
@@ -383,12 +383,11 @@ export default class SwapsController extends BaseController<
       const [firstQuote] = Object.values(newQuotes);
 
       // For a user to be able to swap a token, they need to have approved the MetaSwap contract to withdraw that token.
-      // _getERC20Allowance() returns the amount of the token they have approved for withdrawal. If that amount is greater
-      // than 0, it means that approval has already occurred and is not needed. Otherwise, for tokens to be swapped, a new
-      // call of the ERC-20 approve method is required.
+      // _getERC20Allowance() returns the amount of the token they have approved for withdrawal. If that amount is either
+      // zero or less than the soucreAmount of the swap, a new call of the ERC-20 approve method is required.333
       approvalRequired =
         firstQuote.approvalNeeded &&
-        allowance.eq(0) &&
+        (allowance.eq(0) || allowance.lt(firstQuote.sourceAmount)) &&
         firstQuote.aggregator !== 'wrappedNative';
       if (!approvalRequired) {
         newQuotes = mapValues(newQuotes, (quote) => ({

--- a/app/scripts/controllers/swaps/index.ts
+++ b/app/scripts/controllers/swaps/index.ts
@@ -384,7 +384,7 @@ export default class SwapsController extends BaseController<
 
       // For a user to be able to swap a token, they need to have approved the MetaSwap contract to withdraw that token.
       // _getERC20Allowance() returns the amount of the token they have approved for withdrawal. If that amount is either
-      // zero or less than the soucreAmount of the swap, a new call of the ERC-20 approve method is required.333
+      // zero or less than the soucreAmount of the swap, a new call of the ERC-20 approve method is required.
       approvalRequired =
         firstQuote.approvalNeeded &&
         (allowance.eq(0) || allowance.lt(firstQuote.sourceAmount)) &&


### PR DESCRIPTION
## **Description**
For approval amounts that were greater than 0, but less than the amount the user was trying to swap. The swaps controller was filtering out quotes for users. This PR fixes a longstanding bug in the swaps controller, where we only checked if the approval amount was 0. Instead of when the approval is 0 OR approval amount is less than swap amount. This PR updates the logic to correctly reflect this case

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28680?quickstart=1)

## **Related issues**

Fixes issue reported in Slack here https://consensys.slack.com/archives/C0220SURQ3E/p1732474780474849

## **Manual testing steps**

**Testing wallet with seeded state:**
1. Load [this wallet](https://share.1password.com/s#fZ0NxJ-NZWOMxhbKHBTIgE_0tkMir4wY2KdZI-iZu4Y) into your MetaMask
2. Try and Swap 1 USDC for Polygon on Polygon
3. Quotes should be returned

New Testing Wallet
1. Create a swaps approval for some small amount
2. Try and swap a larger amount
3. Swaps quotes should be returned

## **Screenshots/Recordings**

### **Before**
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/2b592e19-8b37-4e8c-bf41-a76e8ecec498">


### **After**
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/46d1167f-d13c-4c57-86a6-5245ea98e6da">


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
