### PR TITLE
ci: Add optional CircleCI job trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,6 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
-          <<: *develop_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -208,7 +207,6 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
-          <<: *develop_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff
@@ -1074,6 +1072,8 @@ jobs:
       - run: sudo corepack enable
       - attach_workspace:
           at: .
+      # Stop job unless 'test-e2e-chrome-webpack' manifest run flag is set
+      - run: yarn tsx .circleci/scripts/check-optional-e2e-trigger.ts test-e2e-chrome-webpack
       - run:
           name: Move test build to dist
           command: mv ./dist-test-webpack ./dist
@@ -1381,6 +1381,8 @@ jobs:
       - run: sudo corepack enable
       - attach_workspace:
           at: .
+      # Stop job unless 'test-e2e-firefox' manifest run flag is set
+      - run: yarn tsx .circleci/scripts/check-optional-e2e-trigger.ts test-e2e-firefox
       - run:
           name: Move test build to dist
           command: mv ./dist-test-mv2 ./dist

--- a/.circleci/scripts/check-optional-e2e-trigger.ts
+++ b/.circleci/scripts/check-optional-e2e-trigger.ts
@@ -1,0 +1,40 @@
+const path = require('path');
+const fs = require('node:fs/promises');
+const { promisify } = require('node:util');
+const { exec: callbackExec } = require('node:child_process');
+
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+const { getManifestFlags } = require('../../development/lib/get-manifest-flag');
+
+const exec = promisify(callbackExec);
+
+/**
+ * Stop the current CircleCI job unless it is listed among the manifest run flags.
+ */
+async function main() {
+  const { argv } = yargs(hideBin(process.argv)).usage(
+    '$0 <job>',
+    'Check whether the given optional job should be triggered',
+    (_yargs) =>
+      _yargs.positional('job', {
+        description:
+          'The name of the job to check',
+        type: 'string',
+      })
+      .strict(),
+  );
+
+  const manifestFlags = await getManifestFlags();
+
+  if (!manifestFlags?.run || !manifestFlags.run.includes(argv.job)) {
+    await exec('circleci step halt');
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/app/scripts/lib/manifestFlags.ts
+++ b/app/scripts/lib/manifestFlags.ts
@@ -1,17 +1,59 @@
 import browser from 'webextension-polyfill';
 
+/**
+ * Flags that we use to control runtime behavior of the extension. Typically
+ * used for E2E tests.
+ *
+ * These flags are added to `manifest.json` for runtime querying.
+ */
 export type ManifestFlags = {
+  /**
+   * CircleCI metadata for the current run
+   */
   circleci?: {
+    /**
+     * Whether CircleCI manifest flags are enabled.
+     */
     enabled: boolean;
+    /**
+     * The name of the branch that triggered the current run on CircleCI
+     */
     branch?: string;
+    /**
+     * The current CircleCI build number
+     */
     buildNum?: number;
+    /**
+     * The name of the CircleCI job currently running
+     */
     job?: string;
+    /**
+     * For jobs with CircleCI parallelism enabled, this is the index of the current machine.
+     */
     nodeIndex?: number;
+    /**
+     * The pull request number of the pull request the current run was triggered by
+     */
     prNumber?: number;
   };
+  /**
+   * Sentry flags
+   */
   sentry?: {
+    /**
+     * Override the performance trace sample rate
+     */
     tracesSampleRate?: number;
-    lazyLoadSubSampleRate?: number; // multiply by tracesSampleRate to get the actual probability
+    /**
+     * Sub-sample rate for lazy-loaded components.
+     *
+     * Multiply this rate by tracesSampleRate to get the actual probability of sampling the load
+     * time of for a lazy-loaded component.
+     */
+    lazyLoadSubSampleRate?: number;
+    /**
+     * Force enable Sentry
+     */
     forceEnable?: boolean;
   };
 };

--- a/app/scripts/lib/manifestFlags.ts
+++ b/app/scripts/lib/manifestFlags.ts
@@ -37,6 +37,10 @@ export type ManifestFlags = {
     prNumber?: number;
   };
   /**
+   * Optional CircleCI jobs that we want to explicitly trigger to run.
+   */
+  run?: string[];
+  /**
    * Sentry flags
    */
   sentry?: {

--- a/development/lib/get-manifest-flag.ts
+++ b/development/lib/get-manifest-flag.ts
@@ -1,0 +1,103 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { exec as callbackExec } from 'node:child_process';
+
+import { hasProperty } from '@metamask/utils';
+import { merge } from 'lodash';
+
+import type { ManifestFlags } from '../../app/scripts/lib/manifestFlags';
+
+const exec = promisify(callbackExec);
+const PR_BODY_FILEPATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'changed-files',
+  'pr-body.txt',
+);
+
+/**
+ * Search a string for `flags = {...}` and return ManifestFlags if it exists
+ *
+ * @param str - The string to search
+ * @param errorType - The type of error to log if parsing fails
+ * @returns The ManifestFlags object if valid, otherwise undefined
+ */
+function regexSearchForFlags(str: string, errorType: string): ManifestFlags {
+  // Search str for `flags = {...}`
+  const flagsMatch = str.match(/flags\s*=\s*(\{.*\})/u);
+
+  if (flagsMatch) {
+    try {
+      // Get 1st capturing group from regex
+      return JSON.parse(flagsMatch[1]);
+    } catch (error) {
+      console.error(
+        `Error parsing flags from ${errorType}, ignoring flags\n`,
+        error,
+      );
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Get flags from the GitHub PR body if they are set
+ *
+ * To use this feature, add a line to your PR body like:
+ * `flags = {"sentry": {"tracesSampleRate": 0.1}}`
+ * (must be valid JSON)
+ *
+ * @returns Any manifest flags found in the PR body
+ */
+async function getFlagsFromPrBody(): Promise<ManifestFlags> {
+  let body: string;
+  try {
+    body = await fs.readFile(PR_BODY_FILEPATH, 'utf8');
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      hasProperty(error, 'code') &&
+      error.code === 'ENOENT'
+    ) {
+      console.debug('No pr-body.txt, ignoring flags');
+      return {};
+    }
+    throw error;
+  }
+
+  return regexSearchForFlags(body, 'PR body');
+}
+
+/**
+ * Get flags from the Git message if they are set
+ *
+ * To use this feature, add a line to your commit message like:
+ * `flags = {"sentry": {"tracesSampleRate": 0.1}}`
+ * (must be valid JSON)
+ *
+ * @returns Any manifest flags found in the commit message
+ */
+async function getFlagsFromGitMessage(): Promise<ManifestFlags> {
+  const gitMessage = (
+    await exec(`git show --format='%B' --no-patch "HEAD"`)
+  ).toString();
+
+  return regexSearchForFlags(gitMessage, 'git message');
+}
+
+/**
+ * Get any manifest flags found in the PR body and git message.
+ *
+ * @returns Any manifest flags found
+ */
+export async function getManifestFlags(): Promise<ManifestFlags> {
+  const [prBodyFlags, gitMessageFlags] = await Promise.all([
+    getFlagsFromPrBody(),
+    getFlagsFromGitMessage(),
+  ]);
+
+  return merge(prBodyFlags, gitMessageFlags);
+}

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -185,7 +185,7 @@ async function withFixtures(options, testSuite) {
     }
     await mockServer.start(8000);
 
-    setManifestFlags(manifestFlags);
+    await setManifestFlags(manifestFlags);
 
     driver = (await buildWebDriver(driverOptions)).driver;
     webDriver = driver.driver;

--- a/test/e2e/set-manifest-flags.ts
+++ b/test/e2e/set-manifest-flags.ts
@@ -1,7 +1,7 @@
-import { execSync } from 'child_process';
 import fs from 'fs';
 import { merge } from 'lodash';
 import { ManifestFlags } from '../../app/scripts/lib/manifestFlags';
+import { getManifestFlags } from '../../development/lib/get-manifest-flag';
 
 export const folder = `dist/${process.env.SELENIUM_BROWSER}`;
 
@@ -12,86 +12,8 @@ function parseIntOrUndefined(value: string | undefined): number | undefined {
   return value ? parseInt(value, 10) : undefined;
 }
 
-/**
- * Search a string for `flags = {...}` and return ManifestFlags if it exists
- *
- * @param str - The string to search
- * @param errorType - The type of error to log if parsing fails
- * @returns The ManifestFlags object if valid, otherwise undefined
- */
-function regexSearchForFlags(
-  str: string,
-  errorType: string,
-): ManifestFlags | undefined {
-  // Search str for `flags = {...}`
-  const flagsMatch = str.match(/flags\s*=\s*(\{.*\})/u);
-
-  if (flagsMatch) {
-    try {
-      // Get 1st capturing group from regex
-      return JSON.parse(flagsMatch[1]);
-    } catch (error) {
-      console.error(
-        `Error parsing flags from ${errorType}, ignoring flags\n`,
-        error,
-      );
-    }
-  }
-
-  return undefined;
-}
-
-/**
- * Add flags from the GitHub PR body if they are set
- *
- * To use this feature, add a line to your PR body like:
- * `flags = {"sentry": {"tracesSampleRate": 0.1}}`
- * (must be valid JSON)
- *
- * @param flags - The flags object to add to
- */
-function addFlagsFromPrBody(flags: ManifestFlags) {
-  let body;
-
-  try {
-    body = fs.readFileSync('changed-files/pr-body.txt', 'utf8');
-  } catch (error) {
-    console.debug('No pr-body.txt, ignoring flags');
-    return;
-  }
-
-  const newFlags = regexSearchForFlags(body, 'PR body');
-
-  if (newFlags) {
-    // Use lodash merge to do a deep merge (spread operator is shallow)
-    merge(flags, newFlags);
-  }
-}
-
-/**
- * Add flags from the Git message if they are set
- *
- * To use this feature, add a line to your commit message like:
- * `flags = {"sentry": {"tracesSampleRate": 0.1}}`
- * (must be valid JSON)
- *
- * @param flags - The flags object to add to
- */
-function addFlagsFromGitMessage(flags: ManifestFlags) {
-  const gitMessage = execSync(
-    `git show --format='%B' --no-patch "HEAD"`,
-  ).toString();
-
-  const newFlags = regexSearchForFlags(gitMessage, 'git message');
-
-  if (newFlags) {
-    // Use lodash merge to do a deep merge (spread operator is shallow)
-    merge(flags, newFlags);
-  }
-}
-
 // Alter the manifest with CircleCI environment variables and custom flags
-export function setManifestFlags(flags: ManifestFlags = {}) {
+export async function setManifestFlags(flags: ManifestFlags = {}) {
   if (process.env.CIRCLECI) {
     flags.circleci = {
       enabled: true,
@@ -104,8 +26,8 @@ export function setManifestFlags(flags: ManifestFlags = {}) {
       ),
     };
 
-    addFlagsFromPrBody(flags);
-    addFlagsFromGitMessage(flags);
+    const additionalManifestFlags = await getManifestFlags();
+    merge(flags, additionalManifestFlags);
 
     // Set `flags.sentry.forceEnable` to true by default
     if (flags.sentry === undefined) {


### PR DESCRIPTION
## **Description**

Add a way to manually trigger an optional CircleCI job to run. For now it has been configured to allow running `test-e2e-firefox` and `test-e2e-chrome-webpack`, which have recently been made optional.

The optional jobs can be triggered by putting this in the PR description:

```
flags = { "run": ["test-e2e-firefox", "test-e2e-chrome-webpack"] }
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28687?quickstart=1)

## **Related issues**

Resolves #28685

## **Manual testing steps**

See that the optional jobs are run on this PR.

Create PRs branching from here to test other scenarios.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
