### PR TITLE
chore: Reduce MMI trigger machine size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1749,7 +1749,7 @@ jobs:
           command: echo 'whew - everything passed!'
 
   check-mmi-trigger:
-    executor: node-browsers-medium
+    executor: node-browsers-small
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## **Description**

The `check-mmi-trigger` job was using a medium machine, but the work performed during this job is trivial and doesn't require a medium machine. It has been reduced to small.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28689?quickstart=1)

## **Related issues**

No related issue, just a minor CircleCI credit usage reduction.

## **Manual testing steps**

See that the trigger MMI job still passes.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
