### PR TITLE
style: Update typography, spacing and content of network confirmations modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -231,6 +231,26 @@
   "addCustomNetwork": {
     "message": "Add custom network"
   },
+<<<<<<< HEAD
+=======
+  "addEthereumChainConfirmationDescription": {
+    "message": "This allows this network to be used in MetaMask."
+  },
+  "addEthereumChainConfirmationRisks": {
+    "message": "MetaMask does not verify custom networks."
+  },
+  "addEthereumChainConfirmationRisksLearnMore": {
+    "message": "Learn about $1.",
+    "description": "$1 is a link with text that is provided by the 'addEthereumChainConfirmationRisksLearnMoreLink' key"
+  },
+  "addEthereumChainConfirmationRisksLearnMoreLink": {
+    "message": "scams and network security risks",
+    "description": "Link text for the 'addEthereumChainConfirmationRisksLearnMore' translation key"
+  },
+  "addEthereumChainConfirmationTitle": {
+    "message": "Allow this site to add a network?"
+  },
+>>>>>>> d79fe55339 (fix: banner margin and confirmation page ui)
   "addEthereumChainWarningModalHeader": {
     "message": "Only add this RPC provider if you’re sure you can trust it. $1",
     "description": "$1 is addEthereumChainWarningModalHeaderPartTwo passed separately so that it can be bolded"
@@ -6604,7 +6624,7 @@
     "description": "$1 is the menu path to be shown with font weight bold"
   },
   "wantToAddThisNetwork": {
-    "message": "Want to add this network?"
+    "message": "Add this network?"
   },
   "wantsToAddThisAsset": {
     "message": "This allows the following asset to be added to your wallet."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -214,7 +214,7 @@
     "message": "Add custom network"
   },
   "addEthereumChainConfirmationDescription": {
-    "message": "This will allow this network to be used within MetaMask."
+    "message": "This allows this network to be used in MetaMask."
   },
   "addEthereumChainConfirmationRisks": {
     "message": "MetaMask does not verify custom networks."

--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -374,7 +374,6 @@ export const NetworkListMenu = ({ onClose }: { onClose: () => void }) => {
                   marginRight={4}
                   borderRadius={BorderRadius.LG}
                   padding={4}
-                  marginBottom={4}
                   marginTop={2}
                   backgroundColor={BackgroundColor.backgroundAlternative}
                   startAccessory={

--- a/ui/components/ui/chip/chip.js
+++ b/ui/components/ui/chip/chip.js
@@ -24,7 +24,7 @@ export default function Chip({
   dataTestId,
   className,
   children,
-  borderColor = BorderColor.borderDefault,
+  borderColor = BorderColor.borderMuted,
   backgroundColor,
   label,
   labelProps = {},
@@ -70,7 +70,7 @@ export default function Chip({
           className="chip__label"
           variant={TextVariant.bodySm}
           as="span"
-          color={TextColor.textAlternative}
+          color={TextColor.textDefault}
           {...labelProps}
         >
           {label}

--- a/ui/components/ui/definition-list/definition-list.js
+++ b/ui/components/ui/definition-list/definition-list.js
@@ -35,7 +35,6 @@ export default function DefinitionList({
             variant={TextVariant.bodyMdMedium}
             {...termTypography}
             marginTop={0}
-            marginBottom={1}
             className="definition-list__term"
             as="dt"
           >

--- a/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.js
@@ -244,6 +244,109 @@ function getValues(pendingApproval, t, actions, history, data) {
   return {
     content: [
       {
+<<<<<<< HEAD
+=======
+        hide: !originIsMetaMask,
+        element: 'Box',
+        key: 'network-box',
+        props: {
+          textAlign: TextAlign.Center,
+          display: Display.Flex,
+          justifyContent: JustifyContent.center,
+          marginTop: 4,
+          marginBottom: 2,
+        },
+        children: [
+          {
+            element: 'Chip',
+            key: 'network-chip',
+            props: {
+              label: pendingApproval.requestData.chainName,
+              backgroundColor: BackgroundColor.backgroundDefault,
+              leftIconUrl: pendingApproval.requestData.imageUrl,
+            },
+          },
+        ],
+      },
+      multichainFlag && {
+        element: 'BannerAlert',
+        key: 'only-add-networks-you-trust',
+        children: [
+          {
+            element: 'Typography',
+            key: 'description',
+            props: {
+              style: { display: originIsMetaMask && '-webkit-box' },
+            },
+            children: [
+              `${t('unknownChainWarning')} `,
+              {
+                hide: !originIsMetaMask,
+                element: 'Tooltip',
+                key: 'tooltip-info',
+                props: {
+                  position: 'bottom',
+                  interactive: true,
+                  trigger: 'mouseenter',
+                  html: (
+                    <div
+                      style={{
+                        width: '180px',
+                        margin: '16px',
+                        textAlign: 'left',
+                      }}
+                    >
+                      <a
+                        key="zendesk_page_link"
+                        href={ZENDESK_URLS.UNKNOWN_NETWORK}
+                        rel="noreferrer"
+                        target="_blank"
+                        style={{ color: 'var(--color-primary-default)' }}
+                      >
+                        {t('learnMoreUpperCase')}
+                      </a>
+                    </div>
+                  ),
+                },
+                children: [
+                  {
+                    element: 'i',
+                    key: 'info-circle',
+                    props: {
+                      className: 'fas fa-info-circle',
+                      style: {
+                        marginLeft: '4px',
+                        color: 'var(--color-icon-default)',
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            element: 'a',
+            children: t('learnMoreUpperCase'),
+            key: 'learnMoreUpperCase',
+            props: {
+              href: ZENDESK_URLS.USER_GUIDE_CUSTOM_NETWORKS,
+              target: '__blank',
+            },
+          },
+        ],
+        props: {
+          severity: BannerAlertSeverity.Warning,
+          boxProps: {
+            margin: [0, 4],
+            display: Display.Flex,
+            flexDirection: FlexDirection.Column,
+            alignItems: AlignItems.center,
+          },
+        },
+      },
+
+      {
+>>>>>>> d79fe55339 (fix: banner margin and confirmation page ui)
         element: 'Typography',
         key: 'title',
         children: title,


### PR DESCRIPTION
## **Description**

This PR resolves styling inconsistencies in the Confirmation Modal that appears when a user adds a network. The updates refine the UI for a more polished look and incorporate several copy adjustments.

## **Manual testing steps**

1. Run `yarn webpack --watch`
2. Open MetaMask
3. Click on network selector
4. Add a network

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
