### PR TITLE
fix:updated account name and length for dapp connections

### DIFF
--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell-tooltip.js
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell-tooltip.js
@@ -79,7 +79,7 @@ export const SiteCellTooltip = ({ accounts, networks }) => {
                     data-testid="accounts-list-item-connected-account-name"
                     ellipsis
                   >
-                    {acc.label || acc.metadata.name}
+                    {acc.metadata.name || acc.label}
                   </Text>
                 </Box>
               );

--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
@@ -72,13 +72,13 @@ export const SiteCell: React.FC<SiteCellProps> = ({
   const accountMessageConnectedState =
     selectedAccounts.length === 1
       ? t('connectedWithAccountName', [
-          selectedAccounts[0].label || selectedAccounts[0].metadata.name,
+          selectedAccounts[0].metadata.name || selectedAccounts[0].label,
         ])
-      : t('connectedWithAccount', [accounts.length]);
+      : t('connectedWithAccount', [selectedAccounts.length]);
   const accountMessageNotConnectedState =
     selectedAccounts.length === 1
       ? t('requestingForAccount', [
-          selectedAccounts[0].label || selectedAccounts[0].metadata.name,
+          selectedAccounts[0].metadata.name || selectedAccounts[0].label,
         ])
       : t('requestingFor');
 


### PR DESCRIPTION
This PR is to:
1. Show correct account names when dapp tries to connect with MM and account is imported
2. Show correct length of accounts when more than one account is connected

## **Related issues**

Fixes: [3685-planning](https://github.com/MetaMask/MetaMask-planning/issues/3685
)
#28312 
## **Manual testing steps**

1. Import an account in MM
2. Initiate connection request from Dapp, check correct name of account is shown on connections page
3. After connecting, select more than account, check length of accounts shown is correct

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/bb7281c6-0f92-4160-a09b-9a69fe69d671


### **After**

https://github.com/user-attachments/assets/96d45514-74b1-451c-a136-889821b31e22
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
