### PR TITLE
fix(snap-keyring): do not block empty url

### DIFF
--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -141,20 +141,24 @@ export const snapKeyringBuilder = (
       redirectUser: async (snapId: string, url: string, message: string) => {
         // Either url or message must be defined
         if (url.length > 0 || message.length > 0) {
-          const isBlocked = await isBlockedUrl(
-            url,
-            async () => {
-              return await controllerMessenger.call(
-                'PhishingController:maybeUpdateState',
-              );
-            },
-            (urlToTest: string) => {
-              return controllerMessenger.call(
-                'PhishingController:testOrigin',
-                urlToTest,
-              );
-            },
-          );
+          // If the url is empty, we don't need to check if it's blocked
+          const isBlocked =
+            url.length === 0
+              ? false
+              : await isBlockedUrl(
+                  url,
+                  async () => {
+                    return await controllerMessenger.call(
+                      'PhishingController:maybeUpdateState',
+                    );
+                  },
+                  (urlToTest: string) => {
+                    return controllerMessenger.call(
+                      'PhishingController:testOrigin',
+                      urlToTest,
+                    );
+                  },
+                );
 
           const confirmationResult = await controllerMessenger.call(
             'ApprovalController:addRequest',


### PR DESCRIPTION
## **Description**
When a Snap developer attempts to display the redirect modal with only a message, without specifying a URL to redirect to, an error is displayed.

This PR allows user to pass empty url, so only a message is displayed.

## **Manual testing steps**

1. Trigger snap keyring redirectUser function with empty url
2. Error will be shown in the modal

## **Screenshots/Recordings**

### **Before**

![image](https://github.com/user-attachments/assets/a7b19f67-a7d2-46d2-bec9-e52cbc8d1cfd)

### **After**

![Screenshot 2024-11-26 at 15 13 21](https://github.com/user-attachments/assets/1acf6efb-7e8f-40ed-941e-7cecf2016b5f)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
