### PR TITLE
chore: Don't pop modal if All Networks filter is selected

### DIFF
--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -152,6 +152,7 @@ const Home = mmLazy(() => import('../home'));
 
 export default class Routes extends Component {
   static propTypes = {
+    allNetworksFilterShown: PropTypes.bool,
     currentCurrency: PropTypes.string,
     activeTabOrigin: PropTypes.string,
     account: InternalAccountPropType,

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -429,6 +429,7 @@ export default class Routes extends Component {
 
   render() {
     const {
+      allNetworksFilterShown,
       isLoading,
       isUnlocked,
       alertMessage,
@@ -494,7 +495,8 @@ export default class Routes extends Component {
       !isCurrentProviderCustom &&
       completedOnboarding &&
       allAccountsOnNetworkAreEmpty &&
-      switchedNetworkDetails === null;
+      switchedNetworkDetails === null &&
+      !allNetworksFilterShown;
 
     const windowType = getEnvironmentType();
 

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -248,6 +248,13 @@ describe('Routes Component', () => {
           swapsState: { swapsFeatureIsLive: false },
           announcements: {},
           pendingApprovals: {},
+          preferences: {
+            ...mockState.metamask.preferences,
+            tokenNetworkFilter: {
+              '0x1': true,
+              '0x5': true,
+            },
+          },
           termsOfUseLastAgreed: new Date('2999-03-25'),
           shouldShowSeedPhraseReminder: false,
           useExternalServices: true,

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -87,7 +87,7 @@ function mapStateToProps(state) {
   });
 
   const allNetworksFilterShown =
-    Object.keys(tokenNetworkFilter || {}).length !==
+    Object.keys(tokenNetworkFilter || {}).length ===
     Object.keys(allNetworkOpts || {}).length;
 
   return {

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -28,6 +28,7 @@ import {
 import {
   isNetworkLoading,
   getProviderConfig,
+  getNetworkConfigurationsByChainId,
 } from '../../../shared/modules/selectors/networks';
 import {
   lockMetamask,
@@ -58,8 +59,11 @@ import Routes from './routes.component';
 function mapStateToProps(state) {
   const { activeTab, appState } = state;
   const { alertOpen, alertMessage, isLoading, loadingMessage } = appState;
-  const { autoLockTimeLimit = DEFAULT_AUTO_LOCK_TIME_LIMIT, privacyMode } =
-    getPreferences(state);
+  const {
+    autoLockTimeLimit = DEFAULT_AUTO_LOCK_TIME_LIMIT,
+    privacyMode,
+    tokenNetworkFilter,
+  } = getPreferences(state);
   const { completedOnboarding } = state.metamask;
 
   // If there is more than one connected account to activeTabOrigin,
@@ -75,10 +79,21 @@ function mapStateToProps(state) {
   const oldestPendingApproval = oldestPendingConfirmationSelector(state);
   const pendingApprovals = getPendingApprovals(state);
   const transactionsMetadata = getUnapprovedTransactions(state);
+  const allNetworks = getNetworkConfigurationsByChainId(state);
+
+  const allNetworkOpts = {};
+  Object.keys(allNetworks || {}).forEach((chainId) => {
+    allNetworkOpts[chainId] = true;
+  });
+
+  const allNetworksFilterShown =
+    Object.keys(tokenNetworkFilter || {}).length !==
+    Object.keys(allNetworkOpts || {}).length;
 
   return {
     alertOpen,
     alertMessage,
+    allNetworksFilterShown,
     account,
     activeTabOrigin,
     textDirection: state.metamask.textDirection,


### PR DESCRIPTION
## **Description**

https://consensys.slack.com/archives/C06FXU326RL/p1732658056010989?thread_ts=1732582292.738099&cid=C06FXU326RL
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28752?quickstart=1)

## **Related issues**

Fixes: Issue where "You are now using" modal pops up inconsistently. Here we are hiding it if "All Networks" filter is selected.

Eventually this modal will be completely removed. But that scope needs more refinement before we implement it.

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
