### PR TITLE
chore: Bump `@metamask/providers` to v18

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -34,7 +34,7 @@ cleanContextForImports();
 import log from 'loglevel';
 import { v4 as uuid } from 'uuid';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
-import { initializeProvider } from '@metamask/providers/dist/initializeInpageProvider';
+import { initializeProvider } from '@metamask/providers';
 import shouldInjectProvider from '../../shared/modules/provider-injection';
 
 // contexts

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -34,7 +34,7 @@ cleanContextForImports();
 import log from 'loglevel';
 import { v4 as uuid } from 'uuid';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
-import { initializeProvider } from '@metamask/providers/dist/initializeInpageProvider.cjs';
+import { initializeProvider } from '@metamask/providers/initializeInpageProvider';
 import shouldInjectProvider from '../../shared/modules/provider-injection';
 
 // contexts

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -34,7 +34,7 @@ cleanContextForImports();
 import log from 'loglevel';
 import { v4 as uuid } from 'uuid';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
-import { initializeProvider } from '@metamask/providers';
+import { initializeProvider } from '@metamask/providers/dist/initializeInpageProvider.cjs';
 import shouldInjectProvider from '../../shared/modules/provider-injection';
 
 // contexts

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "@metamask/ppom-validator": "0.35.1",
     "@metamask/preinstalled-example-snap": "^0.2.0",
     "@metamask/profile-sync-controller": "^2.0.0",
-    "@metamask/providers": "^18.1.1",
+    "@metamask/providers": "^18.2.0",
     "@metamask/queued-request-controller": "^7.0.1",
     "@metamask/rate-limit-controller": "^6.0.0",
     "@metamask/rpc-errors": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "@metamask/ppom-validator": "0.35.1",
     "@metamask/preinstalled-example-snap": "^0.2.0",
     "@metamask/profile-sync-controller": "^2.0.0",
-    "@metamask/providers": "^14.0.2",
+    "@metamask/providers": "^18.1.1",
     "@metamask/queued-request-controller": "^7.0.1",
     "@metamask/rate-limit-controller": "^6.0.0",
     "@metamask/rpc-errors": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6269,26 +6269,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/providers@npm:^14.0.2":
-  version: 14.0.2
-  resolution: "@metamask/providers@npm:14.0.2"
-  dependencies:
-    "@metamask/json-rpc-engine": "npm:^7.1.1"
-    "@metamask/object-multiplex": "npm:^2.0.0"
-    "@metamask/rpc-errors": "npm:^6.0.0"
-    "@metamask/safe-event-emitter": "npm:^3.0.0"
-    "@metamask/utils": "npm:^8.1.0"
-    detect-browser: "npm:^5.2.0"
-    extension-port-stream: "npm:^3.0.0"
-    fast-deep-equal: "npm:^3.1.3"
-    is-stream: "npm:^2.0.0"
-    json-rpc-middleware-stream: "npm:^5.0.1"
-    readable-stream: "npm:^3.6.2"
-    webextension-polyfill: "npm:^0.10.0"
-  checksum: 10/e5ad5d4261f7629df0fd2a7a60e5fbd5a0d39b54ab5b5917ddfc16f741e122625769d65d323c5a97d7dbe95be987e3d5cf1c2ca4fc28ed9f68dc369c9e3209f1
-  languageName: node
-  linkType: hard
-
 "@metamask/providers@npm:^18.1.1":
   version: 18.1.1
   resolution: "@metamask/providers@npm:18.1.1"
@@ -24832,18 +24812,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-rpc-middleware-stream@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "json-rpc-middleware-stream@npm:5.0.1"
-  dependencies:
-    "@metamask/json-rpc-engine": "npm:^7.1.1"
-    "@metamask/safe-event-emitter": "npm:^3.0.0"
-    "@metamask/utils": "npm:^8.1.0"
-    readable-stream: "npm:^3.6.2"
-  checksum: 10/b5e9b2ae21cc93586f1f4d8c6543634406575bf9cb6e909a4b5d47359b44519f37192a0262279291e5cde0876a67928d26d7e420d9e2aaf7992083e2c1f97a37
-  languageName: node
-  linkType: hard
-
 "json-rpc-random-id@npm:^1.0.0, json-rpc-random-id@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-rpc-random-id@npm:1.0.1"
@@ -26829,7 +26797,7 @@ __metadata:
     "@metamask/preferences-controller": "npm:^13.0.2"
     "@metamask/preinstalled-example-snap": "npm:^0.2.0"
     "@metamask/profile-sync-controller": "npm:^2.0.0"
-    "@metamask/providers": "npm:^14.0.2"
+    "@metamask/providers": "npm:^18.1.1"
     "@metamask/queued-request-controller": "npm:^7.0.1"
     "@metamask/rate-limit-controller": "npm:^6.0.0"
     "@metamask/rpc-errors": "npm:^7.0.0"
@@ -37573,13 +37541,6 @@ __metadata:
   version: 0.12.0
   resolution: "webextension-polyfill@npm:0.12.0"
   checksum: 10/77e648b958b573ef075e75a0c180e2bbd74dee17b3145e86d21fcbb168c4999e4a311654fe634b8178997bee9b35ea5808d8d3d3e5ff2ad138f197f4f0ea75d9
-  languageName: node
-  linkType: hard
-
-"webextension-polyfill@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "webextension-polyfill@npm:0.10.0"
-  checksum: 10/51ff30ebed4b1aa802b7f0347f05021b2fe492078bb1a597223d43995fcee96e2da8f914a2f6e36f988c1877ed5ab36ca7077f2f3ab828955151a59e4c01bf7e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6269,9 +6269,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/providers@npm:^18.1.1":
-  version: 18.1.1
-  resolution: "@metamask/providers@npm:18.1.1"
+"@metamask/providers@npm:^18.1.1, @metamask/providers@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "@metamask/providers@npm:18.2.0"
   dependencies:
     "@metamask/json-rpc-engine": "npm:^10.0.1"
     "@metamask/json-rpc-middleware-stream": "npm:^8.0.5"
@@ -6286,7 +6286,7 @@ __metadata:
     readable-stream: "npm:^3.6.2"
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/dca428d84e490343d85921d4fb09216a0b64be59a036d7b4f7b5ca4e2581c29a4106d58ff9dfe0650dc2b9387dd2adad508fc61073a9fda8ebde8ee3a5137abe
+  checksum: 10/d808f14fc5cf6e240abec61c6b0cb93c0a1d883078ee3d005b9cd49c44e65767a4227d828b19c31500da8e94d85c3632d6957ab35da20b250f6f3a52746ed6b3
   languageName: node
   linkType: hard
 
@@ -26797,7 +26797,7 @@ __metadata:
     "@metamask/preferences-controller": "npm:^13.0.2"
     "@metamask/preinstalled-example-snap": "npm:^0.2.0"
     "@metamask/profile-sync-controller": "npm:^2.0.0"
-    "@metamask/providers": "npm:^18.1.1"
+    "@metamask/providers": "npm:^18.2.0"
     "@metamask/queued-request-controller": "npm:^7.0.1"
     "@metamask/rate-limit-controller": "npm:^6.0.0"
     "@metamask/rpc-errors": "npm:^7.0.0"


### PR DESCRIPTION
## **Description**

The `@metamask/providers` package has been updated from v14 to v18. The breaking changes do not require any changes to the extension. They include:
* Removal of certain provider features, which were later restored
* Updates to JSON-RPC packages that used to impact error serialization in a breaking way, but no longer do (as of rpc-errors v7.0.1)
* `webextension-polyfill` added as a peer dependency
* Sub-path exports no longer work due to addition of exports and ESM build.

Altogether this should result in no functional changes, aside from eliminating some redundant older copies of libraries (reducing bundle size).

This update was difficult because of the need for a subpath export in `inpage.js`. We want to import just the `initializeInpageProvider` module without the rest of the package, which means we need to use a subpath export (because browserify doesn't support tree shaking). But this was challenging because the export maps added in v17 prevent the use of any subpath exports not defined in the export map. There was no entry that worked correctly across webpack and browserify. This was resolved by a new entry added in https://github.com/MetaMask/providers/pull/391 (as part of v18.2.0)

Changelog: https://github.com/MetaMask/providers/blob/main/CHANGELOG.md#1820

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28757?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
