### PR TITLE
fix: remove network modal

### DIFF
--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
-import { matchPath, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import IdleTimer from 'react-idle-timer';
 
 import Authenticated from '../../helpers/higher-order-components/authenticated';
@@ -75,7 +75,6 @@ import {
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import QRHardwarePopover from '../../components/app/qr-hardware-popover';
 import DeprecatedNetworks from '../../components/ui/deprecated-networks/deprecated-networks';
-import NewNetworkInfo from '../../components/ui/new-network-info/new-network-info';
 import { Box } from '../../components/component-library';
 import { ToggleIpfsModal } from '../../components/app/assets/nfts/nft-default-image/toggle-ipfs-modal';
 import { BasicConfigurationModal } from '../../components/app/basic-configuration-modal';
@@ -88,8 +87,6 @@ import { MultichainMetaFoxLogo } from '../../components/multichain/app-header/mu
 import NetworkConfirmationPopover from '../../components/multichain/network-list-menu/network-confirmation-popover/network-confirmation-popover';
 import { ToastMaster } from '../../components/app/toast-master/toast-master';
 import { mmLazy } from '../../helpers/utils/mm-lazy';
-import { InternalAccountPropType } from '../../selectors/multichain';
-import { isCurrentChainCompatibleWithAccount } from '../../../shared/lib/multichain';
 import {
   isCorrectDeveloperTransactionType,
   isCorrectSignatureApprovalType,
@@ -154,7 +151,6 @@ export default class Routes extends Component {
   static propTypes = {
     currentCurrency: PropTypes.string,
     activeTabOrigin: PropTypes.string,
-    account: InternalAccountPropType,
     setCurrentCurrencyToUSD: PropTypes.func,
     isLoading: PropTypes.bool,
     loadingMessage: PropTypes.string,
@@ -172,14 +168,9 @@ export default class Routes extends Component {
     browserEnvironmentOs: PropTypes.string,
     browserEnvironmentBrowser: PropTypes.string,
     theme: PropTypes.string,
-    isNetworkUsed: PropTypes.bool,
-    allAccountsOnNetworkAreEmpty: PropTypes.bool,
-    isTestNet: PropTypes.bool,
     showExtensionInFullSizeView: PropTypes.bool,
-    currentChainId: PropTypes.string,
     shouldShowSeedPhraseReminder: PropTypes.bool,
     forgottenPassword: PropTypes.bool,
-    isCurrentProviderCustom: PropTypes.bool,
     completedOnboarding: PropTypes.bool,
     isAccountMenuOpen: PropTypes.bool,
     toggleAccountMenu: PropTypes.func,
@@ -195,7 +186,6 @@ export default class Routes extends Component {
     hideImportTokensModal: PropTypes.func.isRequired,
     isDeprecatedNetworkModalOpen: PropTypes.bool.isRequired,
     hideDeprecatedNetworkModal: PropTypes.func.isRequired,
-    switchedNetworkDetails: PropTypes.object,
     clearSwitchedNetworkDetails: PropTypes.func.isRequired,
     networkToAutomaticallySwitchTo: PropTypes.object,
     automaticallySwitchNetwork: PropTypes.func.isRequired,
@@ -437,13 +427,7 @@ export default class Routes extends Component {
       isNetworkLoading,
       browserEnvironmentOs: os,
       browserEnvironmentBrowser: browser,
-      isNetworkUsed,
-      allAccountsOnNetworkAreEmpty,
-      isTestNet,
-      account,
-      currentChainId,
       shouldShowSeedPhraseReminder,
-      isCurrentProviderCustom,
       completedOnboarding,
       isAccountMenuOpen,
       toggleAccountMenu,
@@ -460,7 +444,6 @@ export default class Routes extends Component {
       hideIpfsModal,
       hideImportTokensModal,
       hideDeprecatedNetworkModal,
-      switchedNetworkDetails,
       clearSwitchedNetworkDetails,
       clearEditedNetwork,
       privacyMode,
@@ -478,23 +461,6 @@ export default class Routes extends Component {
       loadingMessage || isNetworkLoading
         ? getConnectingLabel(loadingMessage, this.props, this.context)
         : null;
-
-    // Conditions for displaying the Send route
-    const isSendRoute = matchPath(location.pathname, {
-      path: SEND_ROUTE,
-      exact: false,
-    });
-    const shouldShowNetworkInfo =
-      isUnlocked &&
-      account &&
-      isCurrentChainCompatibleWithAccount(currentChainId, account) &&
-      !isTestNet &&
-      !isSendRoute &&
-      !isNetworkUsed &&
-      !isCurrentProviderCustom &&
-      completedOnboarding &&
-      allAccountsOnNetworkAreEmpty &&
-      switchedNetworkDetails === null;
 
     const windowType = getEnvironmentType();
 
@@ -554,9 +520,6 @@ export default class Routes extends Component {
         }
       >
         {shouldShowNetworkDeprecationWarning ? <DeprecatedNetworks /> : null}
-        {location.pathname === DEFAULT_ROUTE && shouldShowNetworkInfo ? (
-          <NewNetworkInfo />
-        ) : null}
         <QRHardwarePopover />
         <Modal />
         <Alert visible={this.props.alertOpen} msg={alertMessage} />

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -268,15 +268,15 @@ describe('Routes Component', () => {
     };
 
     it('displays new EVM network popup for EVM accounts', async () => {
-      const { getAllByText, getByTestId } = await renderPopup(mockEvmAccount);
-
-      const networkInfo = getByTestId('new-network-info__bullet-paragraph');
+      const { getAllByText, queryByTestId } = await renderPopup(mockEvmAccount);
 
       await waitFor(() => {
         expect(getAllByText(mockNewlyAddedNetwork.name).length).toBeGreaterThan(
           0,
         );
-        expect(networkInfo).toBeInTheDocument();
+        expect(
+          queryByTestId('new-network-info__bullet-paragraph'),
+        ).not.toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
## **Description**

PR to remove network modal

![image](https://github.com/user-attachments/assets/86c355d1-0cbe-4fdc-a47c-1ae1d00c48fc)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28765?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to home page and click Network selector and go to 'Additional networks' section
2. Click on "Add" and then click on "approve"
3. You should not see another network modal "You're now using.."


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
