### PR TITLE
fix: add dispatch detect Nfts on network switch

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.test.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.js
@@ -22,6 +22,7 @@ const mockSetActiveNetwork = jest.fn();
 const mockUpdateCustomNonce = jest.fn();
 const mockSetNextNonce = jest.fn();
 const mockSetTokenNetworkFilter = jest.fn();
+const mockDetectNfts = jest.fn();
 
 jest.mock('../../../store/actions.ts', () => ({
   setShowTestNetworks: () => mockSetShowTestNetworks,
@@ -32,6 +33,7 @@ jest.mock('../../../store/actions.ts', () => ({
   setNetworkClientIdForDomain: (network, id) =>
     mockSetNetworkClientIdForDomain(network, id),
   setTokenNetworkFilter: () => mockSetTokenNetworkFilter,
+  detectNfts: () => mockDetectNfts,
 }));
 
 const MOCK_ORIGIN = 'https://portfolio.metamask.io';
@@ -218,6 +220,7 @@ describe('NetworkListMenu', () => {
     expect(mockSetActiveNetwork).toHaveBeenCalled();
     expect(mockUpdateCustomNonce).toHaveBeenCalled();
     expect(mockSetNextNonce).toHaveBeenCalled();
+    expect(mockDetectNfts).toHaveBeenCalled();
   });
 
   it('shows the correct selected network when networks share the same chain ID', () => {

--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -29,6 +29,7 @@ import {
   updateCustomNonce,
   setNextNonce,
   setTokenNetworkFilter,
+  detectNfts,
 } from '../../../store/actions';
 import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
@@ -287,6 +288,7 @@ export const NetworkListMenu = ({ onClose }: { onClose: () => void }) => {
           dispatch(toggleNetworkMenu());
           dispatch(updateCustomNonce(''));
           dispatch(setNextNonce(''));
+          dispatch(detectNfts());
 
           // as a user, I don't want my network selection to force update my filter when I have "All Networks" toggled on
           // however, if I am already filtered on "Current Network", we'll want to filter by the selected network when the network changes


### PR DESCRIPTION
## **Description**

PR to fix detecting NFTs when a user switches networks while on the NFT tab

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28769?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/bea181c6-b252-4c0c-bc16-dd48abaeae13


<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/4c674e18-09c7-4b9f-81d3-fc42e59f2bc2



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.


## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
