### PR TITLE
chore: accept regex expression for rerun-from-failed trigger from circle ci UI, so we can add multiple triggers following the name convention

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,9 @@ workflows:
           - matches:
               pattern: /^l10n_crowdin_action$/
               value: << pipeline.git.branch >>
-          - equal: [rerun-from-failed, << pipeline.schedule.name >>]
+          - matches:
+              pattern: /^rerun-from-failed.*/
+              value: << pipeline.schedule.name >>
     jobs:
       - create_release_pull_request:
           <<: *rc_branch_only
@@ -361,7 +363,9 @@ workflows:
 
   rerun-from-failed:
     when:
-      equal: [rerun-from-failed, << pipeline.schedule.name >>]
+      matches:
+        pattern: /^rerun-from-failed.*/
+        value: << pipeline.schedule.name >>
     jobs:
       - prep-deps
       - rerun-workflows-from-failed:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In circle ci UI, there is no way to schedule a trigger for different times in a day. Instead you can only scheduled a trigger to run once a day (or multiple times within that scheduled hour).
Given that we want to trigger the rerun from failed job, different times within a day, we are now accepting a regex in the trigger name, so we can add as many triggers as we want in the UI, following that pattern (see screenshot below).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28804?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. We can only test this from the UI side, once the PR is merged - I already created different triggers on circle ci

## **Screenshots/Recordings**

![Screenshot from 2024-11-29 11-10-44](https://github.com/user-attachments/assets/0c71c6f9-8673-42d2-a5fd-6d7790be95ac)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
