### PR TITLE
[cherry-pick] fix: Correct preferences controller usage for `isOnPhishingList` hook

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2897,8 +2897,7 @@ export default class MetamaskController extends EventEmitter {
             );
           },
           isOnPhishingList: (url) => {
-            const { usePhishDetect } =
-              this.preferencesController.store.getState();
+            const { usePhishDetect } = this.preferencesController.state;
 
             if (!usePhishDetect) {
               return false;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**

This is a cherry-pick to the RC for the following commit: https://github.com/MetaMask/metamask-extension/commit/db4386f6e25c8a96bd2510588c9ba462a51d9ca1

In [this commit](https://github.com/MetaMask/metamask-extension/commit/cedabc62e45601c77871689425320c54d717275e) the preferences controller was converted to `BaseControllerV2`, however the `isOnPhishingList` hook was not corrected to reference the state properly. The hook will currently always throw which means that link validation fails for Snaps notifications, making them unable to display. This PR corrects that mistake.

Note: This is an edge-case of the Snaps API that doesn't have good E2E coverage yet. We should prioritize that.

[![Open in GitHub
Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28803?quickstart=1)

## **Manual testing steps**

The following Snap should work correctly and display a notification:
```
export const onRpcRequest: OnRpcRequestHandler = async ({
  origin,
  request,
}) => {
  switch (request.method) {
    case 'hello':
      return snap.request({
        method: 'snap_notify',
        params: {
          type: 'inApp',
          message: 'Hello! [metamask.io](https://metamask.io)',
        },
      });
    default:
      throw new Error('Method not found.');
  }
};

```
