### PR TITLE
chore: cleanup on some names and scripts in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,7 +491,7 @@ jobs:
           at: .
       - run:
           name: Get changed files with git diff
-          command: yarn git-diff-default-branch
+          command: npx tsx .circleci/scripts/git-diff-default-branch.ts
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,7 +491,7 @@ jobs:
           at: .
       - run:
           name: Get changed files with git diff
-          command: npx tsx .circleci/scripts/git-diff-develop.ts
+          command: yarn git-diff-default-branch
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,8 @@ workflows:
             branches:
               ignore:
                 - master
+          requires:
+            - prep-deps
       - test-deps-audit:
           requires:
             - prep-deps
@@ -491,7 +493,7 @@ jobs:
           at: .
       - run:
           name: Get changed files with git diff
-          command: npx tsx .circleci/scripts/git-diff-default-branch.ts
+          command: yarn git-diff-default-branch
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/scripts/git-diff-default-branch.ts
+++ b/.circleci/scripts/git-diff-default-branch.ts
@@ -10,7 +10,7 @@ const PR_NUMBER =
   process.env.CIRCLE_PR_NUMBER ||
   process.env.CIRCLE_PULL_REQUEST?.split('/').pop();
 
-const MAIN_BRANCH = 'main';
+const GITHUB_DEFAULT_BRANCH = 'main';
 const SOURCE_BRANCH = `refs/pull/${PR_NUMBER}/head`;
 
 const CHANGED_FILES_DIR = 'changed-files';
@@ -48,7 +48,7 @@ async function getPrInfo(): Promise<PRInfo | null> {
  */
 async function fetchWithDepth(depth: number): Promise<boolean> {
   try {
-    await exec(`git fetch --depth ${depth} origin "${MAIN_BRANCH}"`);
+    await exec(`git fetch --depth ${depth} origin "${GITHUB_DEFAULT_BRANCH}"`);
     await exec(
       `git fetch --depth ${depth} origin "${SOURCE_BRANCH}:${SOURCE_BRANCH}"`,
     );
@@ -84,7 +84,7 @@ async function fetchUntilMergeBaseFound() {
       }
     }
   }
-  await exec(`git fetch --unshallow origin "${MAIN_BRANCH}"`);
+  await exec(`git fetch --unshallow origin "${GITHUB_DEFAULT_BRANCH}"`);
 }
 
 /**
@@ -137,7 +137,7 @@ async function storeGitDiffOutputAndPrBody() {
     if (!baseRef) {
       console.log('Not a PR, skipping git diff');
       return;
-    } else if (baseRef !== MAIN_BRANCH) {
+    } else if (baseRef !== GITHUB_DEFAULT_BRANCH) {
       console.log(`This is for a PR targeting '${baseRef}', skipping git diff`);
       writePrBodyToFile(prInfo.body);
       return;

--- a/.circleci/scripts/rerun-ci-workflow-from-failed.ts
+++ b/.circleci/scripts/rerun-ci-workflow-from-failed.ts
@@ -1,4 +1,5 @@
 const CIRCLE_TOKEN = process.env.API_V2_TOKEN;
+const GITHUB_DEFAULT_BRANCH = 'main';
 
 interface Actor {
   login: string;
@@ -177,7 +178,7 @@ async function rerunWorkflowById(workflowId: string) {
 }
 
 /**
- * Re-runs failed CircleCI workflows from main branch.
+ * Re-runs failed CircleCI workflows from default branch.
  * The workflow will only be re-runed if:
  *   1. It has the status of 'failed'
  *   2. It has only been run once
@@ -186,9 +187,9 @@ async function rerunWorkflowById(workflowId: string) {
  *
  * @throws Will throw an error if fetching the workflows or re-running a workflow fails.
  */
-async function rerunFailedWorkflowsFromDevelop() {
+async function rerunFailedWorkflowsFromDefaultBranch() {
   console.log('Getting Circle Ci workflows from main branch...');
-  const workflows = await getCircleCiWorkflowsByBranch('main');
+  const workflows = await getCircleCiWorkflowsByBranch(GITHUB_DEFAULT_BRANCH);
 
   console.log('Assessing if any of the workflows needs to be rerun...');
   for (const item of workflows) {
@@ -204,7 +205,7 @@ async function rerunFailedWorkflowsFromDevelop() {
   console.log('Task completed successfully!');
 }
 
-rerunFailedWorkflowsFromDevelop()
+rerunFailedWorkflowsFromDefaultBranch()
   .catch((error) => {
     console.error(error);
     process.exitCode = 1;

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "update-mock-cdn": "node test/e2e/mock-cdn/update-mock-cdn-files.js",
     "attributions:check": "./development/attributions-check.sh",
     "attributions:generate": "./development/generate-attributions.sh",
-    "ci-rerun-from-failed": "tsx .circleci/scripts/rerun-ci-workflow-from-failed.ts"
+    "ci-rerun-from-failed": "tsx .circleci/scripts/rerun-ci-workflow-from-failed.ts",
+    "git-diff-default-branch": "tsx .circleci/scripts/git-diff-default-branch.ts"
   },
   "resolutions": {
     "chokidar": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -129,8 +129,7 @@
     "update-mock-cdn": "node test/e2e/mock-cdn/update-mock-cdn-files.js",
     "attributions:check": "./development/attributions-check.sh",
     "attributions:generate": "./development/generate-attributions.sh",
-    "ci-rerun-from-failed": "tsx .circleci/scripts/rerun-ci-workflow-from-failed.ts",
-    "git-diff-default-branch": "tsx .circleci/scripts/git-diff-default-branch.ts"
+    "ci-rerun-from-failed": "tsx .circleci/scripts/rerun-ci-workflow-from-failed.ts"
   },
   "resolutions": {
     "chokidar": "^3.6.0",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

After the default branch has been renamed from develop to main, there were some names that could improve on some ci scripts/files.
This Pr updates them
It also updates how the git diff was run, to use yarn as a better practice (pointed by Mark on another PR for the rerun-from-failed)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28844?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. All jobs should continue to work

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
