### PR TITLE
fix: Support decimal point on advanced gas modal on mac

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -511,7 +511,6 @@ const generateGanacheOptions = ({
 
 // Edit priority gas fee form
 const editGasFeeForm = async (driver, gasLimit, gasPrice) => {
-  await driver.delay(veryLargeDelayMs);
   const inputs = await driver.findElements('input[type="number"]');
   const gasLimitInput = inputs[0];
   const gasPriceInput = inputs[1];

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -511,6 +511,7 @@ const generateGanacheOptions = ({
 
 // Edit priority gas fee form
 const editGasFeeForm = async (driver, gasLimit, gasPrice) => {
+  await driver.delay(veryLargeDelayMs);
   const inputs = await driver.findElements('input[type="number"]');
   const gasLimitInput = inputs[0];
   const gasPriceInput = inputs[1];

--- a/ui/components/app/modals/customize-nonce/customize-nonce.component.js
+++ b/ui/components/app/modals/customize-nonce/customize-nonce.component.js
@@ -111,7 +111,9 @@ const CustomizeNonce = ({
               min="0"
               placeholder={defaultNonce}
               onChange={(e) => {
-                setCustomNonce(e.target.value);
+                // Prevent decimal nonce values
+                const sanitizedValue = e.target.value.replace(/[.,]/gu, '');
+                setCustomNonce(sanitizedValue);
               }}
               fullWidth
               margin="dense"

--- a/ui/components/ui/numeric-input/numeric-input.component.js
+++ b/ui/components/ui/numeric-input/numeric-input.component.js
@@ -40,7 +40,7 @@ export default function NumericInput({
           if (match?.[1]?.length >= 15) {
             return;
           }
-          onChange?.(parseFloat(newValue || 0, 10));
+          onChange?.(newValue);
         }}
         min="0"
         autoFocus={autoFocus}

--- a/ui/components/ui/numeric-input/numeric-input.component.js
+++ b/ui/components/ui/numeric-input/numeric-input.component.js
@@ -30,7 +30,7 @@ export default function NumericInput({
         type="number"
         value={value}
         onKeyDown={(e) => {
-          if (!allowDecimals && e.key === '.') {
+          if (!allowDecimals && (e.key === '.' || e.key === ',')) {
             e.preventDefault();
           }
         }}

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-gas-limit/advanced-gas-fee-gas-limit.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-gas-limit/advanced-gas-fee-gas-limit.js
@@ -39,7 +39,7 @@ const AdvancedGasFeeGasLimit = () => {
   const [gasLimitError, setGasLimitError] = useState();
 
   const updateGasLimit = (value) => {
-    setGasLimit(value);
+    setGasLimit(value || 0);
   };
 
   useEffect(() => {

--- a/ui/pages/confirmations/components/edit-gas-display/edit-gas-display.component.js
+++ b/ui/pages/confirmations/components/edit-gas-display/edit-gas-display.component.js
@@ -54,7 +54,7 @@ export default function EditGasDisplay({
   if (
     gasLimit !== undefined &&
     properGasLimit !== undefined &&
-    new BigNumber(gasLimit).lessThan(new BigNumber(properGasLimit))
+    new BigNumber(gasLimit || 0).lessThan(new BigNumber(properGasLimit))
   ) {
     warningMessage = t('gasLimitRecommended', [properGasLimit]);
   }

--- a/ui/pages/confirmations/hooks/useGasFeeErrors.js
+++ b/ui/pages/confirmations/hooks/useGasFeeErrors.js
@@ -59,9 +59,10 @@ const validateGasPrice = (
   if (supportsEIP1559 && isFeeMarketGasEstimate) {
     return undefined;
   }
+
   if (
     (!supportsEIP1559 || transaction?.txParams?.gasPrice) &&
-    bnLessThan(gasPrice, 0)
+    bnLessThan(gasPrice || 0, 0)
   ) {
     return GAS_FORM_ERRORS.GAS_PRICE_TOO_LOW;
   }

--- a/ui/pages/confirmations/hooks/useGasFeeErrors.js
+++ b/ui/pages/confirmations/hooks/useGasFeeErrors.js
@@ -59,7 +59,6 @@ const validateGasPrice = (
   if (supportsEIP1559 && isFeeMarketGasEstimate) {
     return undefined;
   }
-
   if (
     (!supportsEIP1559 || transaction?.txParams?.gasPrice) &&
     bnLessThan(gasPrice || 0, 0)


### PR DESCRIPTION
## **Description**

The main bug this PR fixes only happens on mac, not linux. It is the following: when a user pressed `.` on the advanced gas modal and a number after it, a zero would appear instead the `.` and any numbers before it. This is because in the `onChange` in `NumericInput`, when the user presses `.`, `e.target.value` is `""`, and the code was defaulting the value that got passed to the on change handler to `0`. To fix the bug, this PR removes that default, and necessarily the `parseInt` that wrapped it.

The PR also adds the `0` default to a few places where the newly possible `""` value would otherwise break execution.

This PR also prevents the user from setting decimal custom nonce values.

Finally, it prevents `,` to be registered when `allowDecimals` is set on `<FormField />`, most notably for the gas limit input.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28869?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/28843

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
