### PR TITLE
fix: updated analytics preferences to be logged during onboarding

### DIFF
--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -17,7 +17,6 @@ import {
   setDataCollectionForMarketing,
 } from '../../../store/actions';
 import {
-  getParticipateInMetaMetrics,
   getDataCollectionForMarketing,
   getFirstTimeFlowType,
   getFirstTimeFlowTypeRouteAfterMetaMetricsOptIn,
@@ -53,7 +52,6 @@ export default function OnboardingMetametrics() {
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
 
   const dataCollectionForMarketing = useSelector(getDataCollectionForMarketing);
-  const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
 
   const trackEvent = useContext(MetaMetricsContext);
 
@@ -82,22 +80,20 @@ export default function OnboardingMetametrics() {
         },
       );
 
-      if (participateInMetaMetrics) {
-        trackEvent({
-          category: MetaMetricsEventCategory.Onboarding,
-          event: MetaMetricsEventName.AppInstalled,
-        });
+      trackEvent({
+        category: MetaMetricsEventCategory.Onboarding,
+        event: MetaMetricsEventName.AppInstalled,
+      });
 
-        trackEvent({
-          category: MetaMetricsEventCategory.Onboarding,
-          event: MetaMetricsEventName.AnalyticsPreferenceSelected,
-          properties: {
-            is_metrics_opted_in: true,
-            has_marketing_consent: Boolean(dataCollectionForMarketing),
-            location: 'onboarding_metametrics',
-          },
-        });
-      }
+      trackEvent({
+        category: MetaMetricsEventCategory.Onboarding,
+        event: MetaMetricsEventName.AnalyticsPreferenceSelected,
+        properties: {
+          is_metrics_opted_in: true,
+          has_marketing_consent: Boolean(dataCollectionForMarketing),
+          location: 'onboarding_metametrics',
+        },
+      });
     } finally {
       history.push(nextRoute);
     }


### PR DESCRIPTION
During onboarding while clicking on I agree button, the analytics preferences event was not being triggered. This PR is to ensure analytics preferences are logged when user click on `I agree` button in Onboarding Page

## **Related issues**

Fixes: [https://github.com/MetaMask/MetaMask-planning/issues/3723](https://github.com/MetaMask/MetaMask-planning/issues/3723)

## **Manual testing steps**

1. Run extension with yarn start
2. Add console.log in trackEvent in ui/contexts/metametrics.js to see the payload
3. Do a fresh install and go on onboading flow
4. Click on I agree button on onboarding screen, check analytics preferences selected are being logged in console

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


### **After**

https://github.com/user-attachments/assets/35e156a1-ea81-4dd6-a037-87cfcd581773
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
