### PR TITLE
fix: decoding data display for ERC-1155 tokens

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.test.tsx
@@ -41,6 +41,23 @@ const decodingDataListing: DecodingDataStateChanges = [
   },
 ];
 
+const decodingDataListingERC1155: DecodingDataStateChanges = [
+  {
+    assetType: 'NATIVE',
+    changeType: DecodingDataChangeType.Receive,
+    address: '',
+    amount: '900000000000000000',
+    contractAddress: '',
+  },
+  {
+    assetType: 'ERC1155',
+    changeType: DecodingDataChangeType.Listing,
+    address: '',
+    amount: '',
+    contractAddress: '0xafd4896984CA60d2feF66136e57f958dCe9482d5',
+    tokenID: '2233',
+  },
+];
 const decodingDataBidding: DecodingDataStateChanges = [
   {
     assetType: 'ERC721',
@@ -76,6 +93,44 @@ describe('DecodedSimulation', () => {
     expect(await findByText('Estimated changes')).toBeInTheDocument();
     expect(await findByText('Spending cap')).toBeInTheDocument();
     expect(await findByText('1,461,501,637,3...')).toBeInTheDocument();
+  });
+
+  it('render correctly for ERC712 token', async () => {
+    const state = getMockTypedSignConfirmStateForRequest({
+      ...permitSignatureMsg,
+      decodingLoading: false,
+      decodingData: { stateChanges: decodingDataListing },
+    });
+    const mockStore = configureMockStore([])(state);
+
+    const { findByText } = renderWithConfirmContextProvider(
+      <PermitSimulation />,
+      mockStore,
+    );
+
+    expect(await findByText('Estimated changes')).toBeInTheDocument();
+    expect(await findByText('You receive')).toBeInTheDocument();
+    expect(await findByText('You list')).toBeInTheDocument();
+    expect(await findByText('#2101')).toBeInTheDocument();
+  });
+
+  it('render correctly for ERC1155 token', async () => {
+    const state = getMockTypedSignConfirmStateForRequest({
+      ...permitSignatureMsg,
+      decodingLoading: false,
+      decodingData: { stateChanges: decodingDataListingERC1155 },
+    });
+    const mockStore = configureMockStore([])(state);
+
+    const { findByText } = renderWithConfirmContextProvider(
+      <PermitSimulation />,
+      mockStore,
+    );
+
+    expect(await findByText('Estimated changes')).toBeInTheDocument();
+    expect(await findByText('You receive')).toBeInTheDocument();
+    expect(await findByText('You list')).toBeInTheDocument();
+    expect(await findByText('#2233')).toBeInTheDocument();
   });
 
   it('renders unavailable message if no state change is returned', async () => {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx
@@ -75,7 +75,8 @@ const StateChangeRow = ({
       tooltip={tooltip}
     >
       {(assetType === TokenStandard.ERC20 ||
-        assetType === TokenStandard.ERC721) && (
+        assetType === TokenStandard.ERC721 ||
+        assetType === TokenStandard.ERC1155) && (
         <TokenValueDisplay
           tokenContract={contractAddress}
           value={amount}


### PR DESCRIPTION
## **Description**

Signatuare decoding data was not being displayed for ERC-1155 tokens, this PR fixes it.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/28903

## **Manual testing steps**
Detailed [here](https://www.notion.so/metamask-consensys/Signature-Decoding-v12-9-QA-151f86d67d68802baddfebf3e44aea5e?pvs=4#151f86d67d6880f5a69aff17d227329d)

## **Screenshots/Recordings**
<img width="359" alt="Screenshot 2024-12-04 at 4 01 53 PM" src="https://github.com/user-attachments/assets/b6e5096e-7b39-49cd-b012-f96c231dc7f1">

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
