### PR TITLE
chore: Update CODEOWNERS to remove ownership from most

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,10 @@ CHANGELOG.md
 coverage.json
 package.json
 yarn.lock
+app/_locales
 app/scripts/metamask-controller.js
+app/scripts/metamask-controller.test.js
+app/scripts/metamask-controller.actions.test.js
 
 # LavaMoat policy changes can highlight security risks. Teams are encouraged to
 # audit these changes on their own, and leave their analysis in a comment.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,24 +9,6 @@
 # follows all policies or without full understanding of the impact of
 # those changes on build, release and publishing outcomes.
 
-# All files are owned by extension platform by default.
-*                                    @MetaMask/extension-platform
-
-# These files/directories are intentionally left unassigned because they are
-# reviewed/validated during the release process:
-attribution.txt
-CHANGELOG.md
-
-# These files/directories are intentionally left unassigned because they are
-# changed frequently by many teams:
-coverage.json
-package.json
-yarn.lock
-app/_locales
-app/scripts/metamask-controller.js
-app/scripts/metamask-controller.test.js
-app/scripts/metamask-controller.actions.test.js
-
 # LavaMoat policy changes can highlight security risks. Teams are encouraged to
 # audit these changes on their own, and leave their analysis in a comment.
 # These codeowners will review this analysis, and review the policy changes in

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,8 +24,10 @@ package.json
 yarn.lock
 app/scripts/metamask-controller.js
 
-# LavaMoat policy changes are reviewed by either the extension platform team or
-# the supply chain team.
+# LavaMoat policy changes can highlight security risks. Teams are encouraged to
+# audit these changes on their own, and leave their analysis in a comment.
+# These codeowners will review this analysis, and review the policy changes in
+# further detail if warranted.
 lavamoat/                            @MetaMask/extension-platform @MetaMask/supply-chain
 
 # The offscreen.ts script file that is included in the offscreen document html

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 # Lines starting with '#' are comments.
+
+# GUIDELINES:
 # Each line is a file pattern followed by one or more owners.
 # Owners bear a responsibility to the organization and the users of this
 # application. Repository administrators have the ability to merge pull
@@ -7,8 +9,23 @@
 # follows all policies or without full understanding of the impact of
 # those changes on build, release and publishing outcomes.
 
+# All files are owned by extension platform by default.
 *                                    @MetaMask/extension-platform
-development/                         @MetaMask/extension-platform
+
+# These files/directories are intentionally left unassigned because they are
+# reviewed/checked during the release process:
+attribution.txt
+CHANGELOG.md
+
+# These files/directories are intentionally left unassigned because they are
+# changed frequently by many teams:
+coverage.json
+package.json
+yarn.lock
+app/scripts/metamask-controller.js
+
+# LavaMoat policy changes are reviewed by either the extension platform team or
+# the supply chain team.
 lavamoat/                            @MetaMask/extension-platform @MetaMask/supply-chain
 
 # The offscreen.ts script file that is included in the offscreen document html
@@ -45,7 +62,7 @@ privacy-snapshot.json                @MetaMask/extension-privacy-reviewers
 # of contributors. Modifications to this file result in a modification of
 # that agreement and can only be approved by those with the knowledge
 # and responsibility to publish libraries under the MetaMask name.
-.github/CODEOWNERS                   @MetaMask/extension-privacy-reviewers
+.github/CODEOWNERS                   @MetaMask/extension-security-team
 
 # For now, restricting approvals inside the .devcontainer folder to devs
 # who were involved with the Codespaces project.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 *                                    @MetaMask/extension-platform
 
 # These files/directories are intentionally left unassigned because they are
-# reviewed/checked during the release process:
+# reviewed/validated during the release process:
 attribution.txt
 CHANGELOG.md
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,7 @@ app/scripts/metamask-controller.actions.test.js
 # audit these changes on their own, and leave their analysis in a comment.
 # These codeowners will review this analysis, and review the policy changes in
 # further detail if warranted.
-lavamoat/                            @MetaMask/extension-platform @MetaMask/supply-chain
+lavamoat/                            @MetaMask/extension-devs @MetaMask/supply-chain
 
 # The offscreen.ts script file that is included in the offscreen document html
 # file is responsible, at present, for loading the snaps execution environment


### PR DESCRIPTION
## **Description**

The CODEOWNERS file has been updated to remove ownership from most files, to give us more time to plan which files the platform should own, and to give teams more time to consolidate their features.

Also, ownership of the CODEOWNERS file itself was moved to the extension security team (it was accidentally set to privacy reviewers).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28941?quickstart=1)

## **Related issues**

This is an adjustment to recent changes made in #28851

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
