### PR TITLE
chore: Skip flaky smart-transactions.spec.ts until we determine the root cau…

### DIFF
--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -64,7 +64,7 @@ export const waitForTransactionToComplete = async (
 };
 
 describe('smart transactions @no-mmi', function () {
-  it('Completes a Swap', async function () {
+  it.skip('Completes a Swap', async function () {
     await withFixturesForSmartTransactions(
       {
         title: this.test?.fullTitle(),


### PR DESCRIPTION
…se of the flakiness


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We are seeing fairly consistent failures of this test: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/113978/workflows/8fa39e5f-3b57-4124-9af1-30e9bf63fad0/jobs/4272132/tests

This PR skips it so that we can unblock merges while we investigate the root cause of the flakiness

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28943?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
