### PR TITLE
fix: Fix create metric fragment

### DIFF
--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -309,6 +309,7 @@ describe('MetaMetricsController', function () {
           });
 
           const expectedFragment = merge(
+            {},
             SAMPLE_TX_SUBMITTED_PARTIAL_FRAGMENT,
             SAMPLE_PERSISTED_EVENT_NO_ID,
             {

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -584,7 +584,7 @@ export default class MetaMetricsController extends BaseController<
       : {};
 
     this.update((state) => {
-      state.fragments[id] = merge(additionalFragmentProps, fragment);
+      state.fragments[id] = merge({}, additionalFragmentProps, fragment);
     });
 
     if (fragment.initialEvent) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The function `createEventFragment`  of the `MetaMetricsController` was broken recently in the migration to BaseControllerV2 (#28113). We ended up trying to mutate a piece of Immer state, resulting in an error.

The affected line was updated to use `cloneDeep` prior to mutating, so that we're no longer attempting to mutate a frozen object.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28970?quickstart=1)

## **Related issues**

Fixes #28599

## **Manual testing steps**

I'm not sure exactly how to reproduce the error using a real build. But the problem is easy to demonstrate in the "should update existing fragment state with new fragment props" unit test. The problem is that we didn't catch this before because Lodash doesn't have strict mode enabled, so in unit tests the attempt to mutate a frozen object will silently fail. In a production build, [strict mode is enabled by LavaMoat](https://github.com/LavaMoat/LavaMoat/blob/7a3896a08b45f667649c46a56f27fe7bf20f4207/packages/lavapack/src/pack.js#L333).

You can reproduce the problem by adding `"use strict"` to the top of the file `node_modules/lodash/lodash.js` and running the test with the `{}, ` removed. Then you can test that adding back `{}` as the initial parameter fixes the problem.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
