### PR TITLE
fix: hide first time interaction alert if internal account

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
@@ -1,22 +1,32 @@
 import { useMemo } from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 
+import { useSelector } from 'react-redux';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { useConfirmContext } from '../../../context/confirm';
+import { getInternalAccounts } from '../../../../../selectors';
 
 export function useFirstTimeInteractionAlert(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const internalAccounts = useSelector(getInternalAccounts);
 
-  const { isFirstTimeInteraction } = currentConfirmation ?? {};
+  const { txParams, isFirstTimeInteraction } = currentConfirmation ?? {};
+  const { to } = txParams ?? {};
+
+  const isInternalAccount = internalAccounts.some(
+    (account) => account.address?.toLowerCase() === to?.toLowerCase(),
+  );
+
+  const showAlert = !isInternalAccount && isFirstTimeInteraction;
 
   return useMemo(() => {
     // If isFirstTimeInteraction is undefined that means it's either disabled or error in accounts API
     // If it's false that means account relationship found
-    if (!isFirstTimeInteraction) {
+    if (!showAlert) {
       return [];
     }
 
@@ -31,5 +41,5 @@ export function useFirstTimeInteractionAlert(): Alert[] {
         severity: Severity.Warning,
       },
     ];
-  }, [isFirstTimeInteraction, t]);
+  }, [showAlert, t]);
 }


### PR DESCRIPTION
## **Description**

Hide the first time interaction alert if the transaction `to` is an internal account.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28990?quickstart=1)

## **Related issues**

Fixes: #28942 

## **Manual testing steps**

See issue.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
