### PR TITLE
feat(snaps): Add loading variant to Snap UI button

### DIFF
--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -1,7 +1,12 @@
 import React, { FunctionComponent, MouseEvent as ReactMouseEvent } from 'react';
 import classnames from 'classnames';
 import { ButtonType, UserInputEventType } from '@metamask/snaps-sdk';
-import { ButtonLinkProps, Text } from '../../../component-library';
+import {
+  ButtonLinkProps,
+  Icon,
+  IconName,
+  Text,
+} from '../../../component-library';
 import {
   FontWeight,
   TextColor,
@@ -17,6 +22,7 @@ const COLORS = {
   primary: TextColor.infoDefault,
   destructive: TextColor.errorDefault,
   disabled: TextColor.textMuted,
+  loading: TextColor.primaryDefault,
 };
 
 export const SnapUIButton: FunctionComponent<
@@ -63,7 +69,14 @@ export const SnapUIButton: FunctionComponent<
       variant={textVariant}
       {...props}
     >
-      {children}
+      {variant === 'loading' ? (
+        <Icon
+          name={IconName.Loading}
+          style={{ animation: 'spin 2s linear infinite' }}
+        />
+      ) : (
+        children
+      )}
     </Text>
   );
 };

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -73,7 +73,7 @@ export const SnapUIButton: FunctionComponent<
       {loading ? (
         <Icon
           name={IconName.Loading}
-          style={{ animation: 'spin 2s linear infinite' }}
+          style={{ animation: 'spin 1.2s linear infinite' }}
         />
       ) : (
         children

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -16,13 +16,13 @@ import { useSnapInterfaceContext } from '../../../../contexts/snaps';
 export type SnapUIButtonProps = {
   name?: string;
   textVariant: ButtonLinkProps<'button'>['variant'];
+  loading?: boolean;
 };
 
 const COLORS = {
   primary: TextColor.infoDefault,
   destructive: TextColor.errorDefault,
   disabled: TextColor.textMuted,
-  loading: TextColor.primaryDefault,
 };
 
 export const SnapUIButton: FunctionComponent<
@@ -33,6 +33,7 @@ export const SnapUIButton: FunctionComponent<
   type = ButtonType.Button,
   variant = 'primary',
   disabled = false,
+  loading = false,
   className = '',
   textVariant,
   ...props
@@ -69,7 +70,7 @@ export const SnapUIButton: FunctionComponent<
       variant={textVariant}
       {...props}
     >
-      {variant === 'loading' ? (
+      {loading ? (
         <Icon
           name={IconName.Loading}
           style={{ animation: 'spin 2s linear infinite' }}

--- a/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
+++ b/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
@@ -10,7 +10,10 @@ import {
   Button,
   ButtonProps,
   ButtonSize,
+  Icon,
+  IconName,
   IconSize,
+  ButtonVariant as ExtensionButtonVariant,
 } from '../../../component-library';
 import {
   AlignItems,
@@ -64,6 +67,8 @@ export const SnapUIFooterButton: FunctionComponent<
     : ButtonVariant.Secondary;
 
   const buttonVariant = hideSnapBranding ? variant : brandedButtonVariant;
+  const finalButtonVariant =
+    buttonVariant === 'loading' ? ButtonVariant.Primary : buttonVariant;
 
   return (
     <Button
@@ -77,7 +82,7 @@ export const SnapUIFooterButton: FunctionComponent<
       size={ButtonSize.Lg}
       block
       disabled={disabled}
-      variant={buttonVariant}
+      variant={finalButtonVariant as unknown as ExtensionButtonVariant}
       onClick={handleClick}
       textProps={{
         display: Display.Flex,
@@ -85,10 +90,17 @@ export const SnapUIFooterButton: FunctionComponent<
         flexDirection: FlexDirection.Row,
       }}
     >
-      {isSnapAction && !hideSnapBranding && (
+      {isSnapAction && !hideSnapBranding && variant !== 'loading' && (
         <SnapIcon snapId={snapId} avatarSize={IconSize.Sm} marginRight={2} />
       )}
-      {children}
+      {variant === 'loading' ? (
+        <Icon
+          name={IconName.Loading}
+          style={{ animation: 'spin 2s linear infinite' }}
+        />
+      ) : (
+        children
+      )}
     </Button>
   );
 };

--- a/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
+++ b/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
@@ -94,7 +94,7 @@ export const SnapUIFooterButton: FunctionComponent<
       {loading ? (
         <Icon
           name={IconName.Loading}
-          style={{ animation: 'spin 2s linear infinite' }}
+          style={{ animation: 'spin 1.2s linear infinite' }}
         />
       ) : (
         children

--- a/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
+++ b/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
@@ -13,7 +13,6 @@ import {
   Icon,
   IconName,
   IconSize,
-  ButtonVariant as ExtensionButtonVariant,
 } from '../../../component-library';
 import {
   AlignItems,
@@ -38,6 +37,7 @@ export const SnapUIFooterButton: FunctionComponent<
   name,
   children,
   disabled = false,
+  loading = false,
   isSnapAction = false,
   type,
   variant = ButtonVariant.Primary,
@@ -67,8 +67,6 @@ export const SnapUIFooterButton: FunctionComponent<
     : ButtonVariant.Secondary;
 
   const buttonVariant = hideSnapBranding ? variant : brandedButtonVariant;
-  const finalButtonVariant =
-    buttonVariant === 'loading' ? ButtonVariant.Primary : buttonVariant;
 
   return (
     <Button
@@ -82,7 +80,7 @@ export const SnapUIFooterButton: FunctionComponent<
       size={ButtonSize.Lg}
       block
       disabled={disabled}
-      variant={finalButtonVariant as unknown as ExtensionButtonVariant}
+      variant={buttonVariant}
       onClick={handleClick}
       textProps={{
         display: Display.Flex,
@@ -90,10 +88,10 @@ export const SnapUIFooterButton: FunctionComponent<
         flexDirection: FlexDirection.Row,
       }}
     >
-      {isSnapAction && !hideSnapBranding && variant !== 'loading' && (
+      {isSnapAction && !hideSnapBranding && !loading && (
         <SnapIcon snapId={snapId} avatarSize={IconSize.Sm} marginRight={2} />
       )}
-      {variant === 'loading' ? (
+      {loading ? (
         <Icon
           name={IconName.Loading}
           style={{ animation: 'spin 2s linear infinite' }}

--- a/ui/components/app/snaps/snap-ui-renderer/components/button.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/button.ts
@@ -16,6 +16,7 @@ export const button: UIComponentFactory<ButtonElement> = ({
     variant: element.props.variant,
     name: element.props.name,
     disabled: element.props.disabled,
+    loading: element.props.loading,
     textVariant:
       element.props.size === 'sm' ? TextVariant.bodySm : TextVariant.bodyMd,
   },

--- a/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
@@ -71,15 +71,19 @@ export const footer: UIComponentFactory<FooterElement> = ({
       ...params,
       element: children,
     } as UIComponentParams<ButtonElement>);
+
+    const variant =
+      buttonMapped.props?.variant ??
+      (providedChildren.length === 2 && index === 0
+        ? ButtonVariant.Secondary
+        : ButtonVariant.Primary);
+
     return {
       element: 'SnapUIFooterButton',
       key: `snap-footer-button-${buttonMapped.props?.name ?? index}`,
       props: {
         ...buttonMapped.props,
-        variant:
-          providedChildren.length === 2 && index === 0
-            ? ButtonVariant.Secondary
-            : ButtonVariant.Primary,
+        variant,
         isSnapAction: true,
       },
       children: buttonMapped.children,

--- a/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/footer.ts
@@ -71,19 +71,15 @@ export const footer: UIComponentFactory<FooterElement> = ({
       ...params,
       element: children,
     } as UIComponentParams<ButtonElement>);
-
-    const variant =
-      buttonMapped.props?.variant ??
-      (providedChildren.length === 2 && index === 0
-        ? ButtonVariant.Secondary
-        : ButtonVariant.Primary);
-
     return {
       element: 'SnapUIFooterButton',
       key: `snap-footer-button-${buttonMapped.props?.name ?? index}`,
       props: {
         ...buttonMapped.props,
-        variant,
+        variant:
+          providedChildren.length === 2 && index === 0
+            ? ButtonVariant.Secondary
+            : ButtonVariant.Primary,
         isSnapAction: true,
       },
       children: buttonMapped.children,


### PR DESCRIPTION
## **Description**
This PR enables loading button variant for Snaps UI.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/28997?quickstart=1)

#### Notes
- Targets Snaps release integration PR: https://github.com/MetaMask/metamask-extension/pull/29275

## **Related issues**
Fixes: https://github.com/MetaMask/snaps/issues/2694

## **Related PR dependencies**
Snaps monorepo: https://github.com/MetaMask/snaps/pull/2930

## **Manual testing steps**
1. Create some example Snap for testing and add Snap UI Button with `loading` variant.
Example: 
```TypeScript
<Button loading={true} variant="primary">
    Example Button
</Button>
<Button loading={true} variant="destructive">
    Example Button
</Button>
```

## **Screenshots/Recordings**
### **Before**
Loading button variant was not available before.

### **After**
https://github.com/user-attachments/assets/5afea22c-1951-4475-a908-aa5b97eafb6b


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
