### PR TITLE
fix: wiping txHistory on both source and dest chains

### DIFF
--- a/app/scripts/controllers/bridge-status/bridge-status-controller.ts
+++ b/app/scripts/controllers/bridge-status/bridge-status-controller.ts
@@ -313,7 +313,7 @@ export default class BridgeStatusController extends StaticIntervalPollingControl
   };
 
   // Wipes the bridge status for the given address and chainId
-  // Will match either source or destination chainId to the selectedChainId
+  // Will match only source chainId to the selectedChainId
   #wipeBridgeStatusByChainId = (address: string, selectedChainId: Hex) => {
     const sourceTxMetaIdsToDelete = Object.keys(
       this.state.bridgeStatusState.txHistory,
@@ -324,14 +324,10 @@ export default class BridgeStatusController extends StaticIntervalPollingControl
       const hexSourceChainId = decimalToPrefixedHex(
         bridgeHistoryItem.quote.srcChainId,
       );
-      const hexDestChainId = decimalToPrefixedHex(
-        bridgeHistoryItem.quote.destChainId,
-      );
 
       return (
         bridgeHistoryItem.account === address &&
-        (hexSourceChainId === selectedChainId ||
-          hexDestChainId === selectedChainId)
+        hexSourceChainId === selectedChainId
       );
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29000?quickstart=1)

This PR fixes an issue for Bridge txs where both the source chain AND destination chain txHistory get wiped when the user clears their Activity tab data.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Add `BRIDGE_USE_DEV_APIS=1` to `.metamaskrc`
1. Do a bridge from chain 1 to chain 2
2. Switch to chain 2
3. Do a bridge from chain 2 to another chain
4. Go into Settings > Advanced > Click Clear activity 
5. Observe that chain 2's tx are gone
6. Switch to chain 1
7. Observe that chain 1's bridge tx has the proper values

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/247a061e-84ac-4757-bede-edeeecff7c4a



### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/ce872b63-e31c-47ea-8d78-d59555864a6b



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
