### PR TITLE
feat: Migrate signature e2e tests for redesigned screens

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -691,6 +691,29 @@ async function clickSignOnSignatureConfirmation({
 }
 
 /**
+ * This method handles clicking the sign button on signature confirmation
+ * screen.
+ *
+ * @param {object} options - Options for the function.
+ * @param {WebDriver} options.driver - The WebDriver instance controlling the browser.
+ * @param {boolean} [options.snapSigInsights] - Whether to wait for the insights snap to be ready before clicking the sign button.
+ */
+async function clickSignOnRedesignedSignatureConfirmation({
+  driver,
+  snapSigInsights = false,
+}) {
+  await driver.clickElementSafe('.confirm-scroll-to-bottom__button');
+
+  if (snapSigInsights) {
+    // there is no condition we can wait for to know the snap is ready,
+    // so we have to add a small delay as the last alternative to avoid flakiness.
+    await driver.delay(regularDelayMs);
+  }
+
+  await driver.clickElement({ text: 'Confirm', tag: 'button' });
+}
+
+/**
  * Some signing methods have extra security that requires the user to click a
  * button to validate that they have verified the details. This method handles
  * performing the necessary steps to click that button.
@@ -962,6 +985,7 @@ module.exports = {
   roundToXDecimalPlaces,
   generateRandNumBetween,
   clickSignOnSignatureConfirmation,
+  clickSignOnRedesignedSignatureConfirmation,
   validateContractDetails,
   switchToNotificationWindow,
   getEventPayloads,

--- a/test/e2e/snaps/test-snap-siginsights.spec.js
+++ b/test/e2e/snaps/test-snap-siginsights.spec.js
@@ -1,6 +1,7 @@
 const {
   withFixtures,
   clickSignOnSignatureConfirmation,
+  clickSignOnRedesignedSignatureConfirmation,
   defaultGanacheOptions,
   openDapp,
   unlockWallet,
@@ -11,494 +12,723 @@ const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
 describe('Test Snap Signature Insights', function () {
-  it('tests Signature Insights functionality (New)', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        failOnConsoleError: false,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await unlockWallet(driver);
+  describe('Old confirmation screens', function () {
+    it('tests Signature Insights functionality (Legacy)', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          failOnConsoleError: false,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
 
-        // navigate to test snaps page and connect
-        await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+          // navigate to test snaps page and connect
+          await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
 
-        // wait for page to load
-        await driver.waitForSelector({
-          text: 'Installed Snaps',
-          tag: 'h2',
-        });
+          // delay added for page render (deflake)
+          await driver.delay(1000);
 
-        // find and scroll to the transaction-insights snap
-        const snapButton1 = await driver.findElement(
-          '#connectsignature-insights',
-        );
-        await driver.scrollToElement(snapButton1);
+          // find and scroll to the transaction-insights test snap
+          const snapButton1 = await driver.findElement(
+            '#connectsignature-insights',
+          );
+          await driver.scrollToElement(snapButton1);
 
-        // added delay for firefox (deflake)
-        await driver.delayFirefox(1000);
+          // added delay for firefox (deflake)
+          await driver.delayFirefox(1000);
 
-        // wait for and click connect
-        await driver.waitForSelector('#connectsignature-insights');
-        await driver.clickElement('#connectsignature-insights');
+          // wait for and click connect
+          await driver.waitForSelector('#connectsignature-insights');
+          await driver.clickElement('#connectsignature-insights');
 
-        // switch to metamask extension
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // switch to metamask extension
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // wait for and click connect
-        await driver.waitForSelector({
-          text: 'Connect',
-          tag: 'button',
-        });
-        await driver.clickElement({
-          text: 'Connect',
-          tag: 'button',
-        });
+          // wait for and click connect
+          await driver.waitForSelector({
+            text: 'Connect',
+            tag: 'button',
+          });
+          await driver.clickElement({
+            text: 'Connect',
+            tag: 'button',
+          });
 
-        // wait for and click confirm
-        await driver.waitForSelector({ text: 'Confirm' });
-        await driver.clickElement({
-          text: 'Confirm',
-          tag: 'button',
-        });
+          // wait for and click confirm
+          await driver.waitForSelector({ text: 'Confirm' });
+          await driver.clickElement({
+            text: 'Confirm',
+            tag: 'button',
+          });
 
-        // wait for and click ok and wait for window to close
-        await driver.waitForSelector({ text: 'OK' });
-        await driver.clickElementAndWaitForWindowToClose({
-          text: 'OK',
-          tag: 'button',
-        });
+          // wait for and click ok and wait for window to close
+          await driver.waitForSelector({ text: 'OK' });
+          await driver.clickElementAndWaitForWindowToClose({
+            text: 'OK',
+            tag: 'button',
+          });
 
-        // switch to test-snaps page
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
+          // switch to test-snaps page
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
 
-        // open the test-dapp page
-        await openDapp(driver);
+          // open the test-dapp page
+          await openDapp(driver);
 
-        // TEST ONE: personal sign
-        // find and scroll to personal sign and click sign
-        const personalSignButton1 = await driver.findElement('#personalSign');
-        await driver.scrollToElement(personalSignButton1);
-        await driver.clickElement('#personalSign');
+          // TEST ONE: personal sign
+          // find and scroll to personal sign and click sign
+          const personalSignButton1 = await driver.findElement('#personalSign');
+          await driver.scrollToElement(personalSignButton1);
+          await driver.clickElement('#personalSign');
 
-        // switch back to MetaMask window and switch to tx insights pane
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // wait for information from signature request screen
-        await driver.waitForSelector({
-          text: 'Example `personal_sign` message',
-          tag: 'p',
-        });
+          // wait for and click sign
+          await clickSignOnSignatureConfirmation({
+            driver,
+            snapSigInsights: true,
+          });
 
-        // look for returned signature insights data
-        await driver.waitForSelector({
-          text: '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765',
-          tag: 'p',
-        });
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765',
+            tag: 'p',
+          });
 
-        // Click down arrow
-        await driver.clickElementSafe('[aria-label="Scroll down"]');
+          // wait for host to render and click checkbox to authorize signing
+          await driver.waitForSelector({
+            text: '127.0.0.1:8080',
+            tag: 'span',
+          });
+          await driver.clickElement('.mm-checkbox__input-wrapper');
 
-        // click sign button
-        await driver.clickElementAndWaitForWindowToClose(
-          '[data-testid="confirm-footer-button"]',
-        );
+          // click sign button and wait for window to close
+          await driver.clickElementAndWaitForWindowToClose(
+            '[data-testid="snapInsightsButtonConfirm"]',
+          );
 
-        // switch back to test-dapp window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
-        // check result of test
-        await driver.waitForSelector({
-          text: '0xa10b6707dd79e2f1f91ba243ab7abe15a46f58b052ad9cec170c5366ef5667c447a87eba2c0a9d4c9fbfa0a23e9db1fb55865d0568c32bd7cc681b8d0860e7af1b',
-          tag: 'span',
-        });
+          // check result of test
+          await driver.waitForSelector({
+            text: '0xa10b6707dd79e2f1f91ba243ab7abe15a46f58b052ad9cec170c5366ef5667c447a87eba2c0a9d4c9fbfa0a23e9db1fb55865d0568c32bd7cc681b8d0860e7af1b',
+            tag: 'span',
+          });
 
-        // TEST TWO: sign typed data
-        // find and scroll to sign typed data and click sign
-        const signTypedButton1 = await driver.findElement('#signTypedData');
-        await driver.scrollToElement(signTypedButton1);
-        await driver.clickElement('#signTypedData');
+          // TEST TWO: sign typed data
+          // find and scroll to sign typed data and click sign
+          const signTypedButton1 = await driver.findElement('#signTypedData');
+          await driver.scrollToElement(signTypedButton1);
+          await driver.clickElement('#signTypedData');
 
-        // switch back to MetaMask window and switch to tx insights pane
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // wait for information from signature request screen
-        await driver.waitForSelector({
-          text: 'Hi, Alice!',
-          tag: 'p',
-        });
+          // wait for and click sign
+          await clickSignOnSignatureConfirmation({
+            driver,
+            snapSigInsights: true,
+          });
 
-        // click down arrow
-        await driver.clickElementSafe('[aria-label="Scroll down"]');
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '1',
+            tag: 'p',
+          });
 
-        // required: delay for scroll to render
-        await driver.delay(500);
+          // wait for host to render and click checkbox to authorize signing
+          await driver.waitForSelector({
+            text: '127.0.0.1:8080',
+            tag: 'span',
+          });
+          await driver.clickElement('.mm-checkbox__input-wrapper');
 
-        // look for returned signature insights data
-        await driver.waitForSelector({
-          text: '1',
-          tag: 'p',
-        });
+          // click sign button and wait for window to close
+          await driver.clickElementAndWaitForWindowToClose(
+            '[data-testid="snapInsightsButtonConfirm"]',
+          );
 
-        // click sign button and wait for window to close
-        await driver.clickElementAndWaitForWindowToClose(
-          '[data-testid="confirm-footer-button"]',
-        );
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
-        // switch back to test-dapp window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          // check result of test
+          await driver.waitForSelector({
+            text: '0x32791e3c41d40dd5bbfb42e66cf80ca354b0869ae503ad61cd19ba68e11d4f0d2e42a5835b0bfd633596b6a7834ef7d36033633a2479dacfdb96bda360d51f451b',
+            tag: 'span',
+          });
 
-        // check result of test
-        await driver.waitForSelector({
-          text: '0x32791e3c41d40dd5bbfb42e66cf80ca354b0869ae503ad61cd19ba68e11d4f0d2e42a5835b0bfd633596b6a7834ef7d36033633a2479dacfdb96bda360d51f451b',
-          tag: 'span',
-        });
+          // TEST THREE: sign typed data v3
+          // find and scroll to sign typed data v3 and click sign
+          const signTypedV3Button1 = await driver.findElement(
+            '#signTypedDataV3',
+          );
+          await driver.scrollToElement(signTypedV3Button1);
+          await driver.clickElement('#signTypedDataV3');
 
-        // TEST THREE: sign typed data v3
-        // find and scroll to sign typed data v3 and click sign
-        const signTypedV3Button1 = await driver.findElement('#signTypedDataV3');
-        await driver.scrollToElement(signTypedV3Button1);
-        await driver.clickElement('#signTypedDataV3');
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // switch back to MetaMask window and switch to tx insights pane
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // click down arrow
+          await driver.waitForSelector('.fa-arrow-down');
+          await driver.clickElement('.fa-arrow-down');
 
-        // click down arrow
-        await driver.clickElementSafe('[aria-label="Scroll down"]');
+          // wait for and click sign
+          await clickSignOnSignatureConfirmation({
+            driver,
+            snapSigInsights: true,
+          });
 
-        // required: delay for scroll to render
-        await driver.delay(500);
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
+            tag: 'p',
+          });
 
-        // wait for information from signature request screen
-        await driver.waitForSelector({
-          text: 'Hello, Bob!',
-          tag: 'p',
-        });
+          // wait for host to render and click checkbox to authorize signing
+          await driver.waitForSelector({
+            text: '127.0.0.1:8080',
+            tag: 'span',
+          });
+          await driver.clickElement('.mm-checkbox__input-wrapper');
 
-        // click down arrow
-        await driver.clickElementSafe('[aria-label="Scroll down"]');
+          // click sign button and wait for window to close
+          await driver.clickElementAndWaitForWindowToClose(
+            '[data-testid="snapInsightsButtonConfirm"]',
+          );
 
-        // required: delay for scroll to render
-        await driver.delay(500);
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
-        // look for returned signature insights data
-        await driver.waitForSelector({
-          text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
-          tag: 'p',
-        });
+          // check result of test
+          await driver.waitForSelector({
+            text: '0x0a22f7796a2a70c8dc918e7e6eb8452c8f2999d1a1eb5ad714473d36270a40d6724472e5609948c778a07216bd082b60b6f6853d6354c731fd8ccdd3a2f4af261b',
+            tag: 'span',
+          });
 
-        // click sign button
-        await driver.clickElementAndWaitForWindowToClose(
-          '[data-testid="confirm-footer-button"]',
-        );
+          // TEST FOUR: sign typed data v4
+          // find and scroll to sign typed data v4 and click sign
+          const signTypedV4Button1 = await driver.findElement(
+            '#signTypedDataV4',
+          );
+          await driver.scrollToElement(signTypedV4Button1);
+          await driver.clickElement('#signTypedDataV4');
 
-        // switch back to test-dapp window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // check result of test
-        await driver.waitForSelector({
-          text: '0x0a22f7796a2a70c8dc918e7e6eb8452c8f2999d1a1eb5ad714473d36270a40d6724472e5609948c778a07216bd082b60b6f6853d6354c731fd8ccdd3a2f4af261b',
-          tag: 'span',
-        });
+          // click down arrow
+          await driver.waitForSelector('.fa-arrow-down');
+          await driver.clickElement('.fa-arrow-down');
 
-        // TEST FOUR: sign typed data v4
-        // find and scroll to sign typed data v4 and click sign
-        const signTypedV4Button1 = await driver.findElement('#signTypedDataV4');
-        await driver.scrollToElement(signTypedV4Button1);
-        await driver.clickElement('#signTypedDataV4');
+          // wait for and click sign
+          await clickSignOnSignatureConfirmation({
+            driver,
+            snapSigInsights: true,
+          });
 
-        // switch back to MetaMask window and switch to tx insights pane
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
+            tag: 'p',
+          });
 
-        // click down arrow
-        await driver.clickElementSafe('[aria-label="Scroll down"]');
+          // wait for host to render and click checkbox to authorize signing
+          await driver.waitForSelector({
+            text: '127.0.0.1:8080',
+            tag: 'span',
+          });
+          await driver.clickElement('.mm-checkbox__input-wrapper');
 
-        // required: delay for scroll to render
-        await driver.delay(500);
+          // click sign button and wait for window to close
+          await driver.clickElementAndWaitForWindowToClose(
+            '[data-testid="snapInsightsButtonConfirm"]',
+          );
 
-        // wait for information from signature request screen
-        await driver.waitForSelector({
-          text: 'Hello, Bob!',
-          tag: 'p',
-        });
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
-        // click down arrow
-        await driver.clickElementSafe('[aria-label="Scroll down"]');
-
-        // required: delay for scroll to render
-        await driver.delay(500);
-
-        // look for returned signature insights data
-        await driver.waitForSelector({
-          text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
-          tag: 'p',
-        });
-
-        // click sign button and wait for window to close
-        await driver.clickElementAndWaitForWindowToClose(
-          '[data-testid="confirm-footer-button"]',
-        );
-
-        // switch back to test-dapp window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-
-        // check results of test
-        await driver.waitForSelector({
-          text: '0xcd2f9c55840f5e1bcf61812e93c1932485b524ca673b36355482a4fbdf52f692684f92b4f4ab6f6c8572dacce46bd107da154be1c06939b855ecce57a1616ba71b',
-          tag: 'span',
-        });
-      },
-    );
+          // check results of test
+          await driver.waitForSelector({
+            text: '0xcd2f9c55840f5e1bcf61812e93c1932485b524ca673b36355482a4fbdf52f692684f92b4f4ab6f6c8572dacce46bd107da154be1c06939b855ecce57a1616ba71b',
+            tag: 'span',
+          });
+        },
+      );
+    });
   });
 
-  it('tests Signature Insights functionality (Legacy)', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        failOnConsoleError: false,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
+  describe('Redesigned confirmation screens', function () {
+    it('tests Signature Insights functionality (New)', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          failOnConsoleError: false,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
 
-        // navigate to test snaps page and connect
-        await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+          // navigate to test snaps page and connect
+          await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
 
-        // delay added for page render (deflake)
-        await driver.delay(1000);
+          // wait for page to load
+          await driver.waitForSelector({
+            text: 'Installed Snaps',
+            tag: 'h2',
+          });
 
-        // find and scroll to the transaction-insights test snap
-        const snapButton1 = await driver.findElement(
-          '#connectsignature-insights',
-        );
-        await driver.scrollToElement(snapButton1);
+          // find and scroll to the transaction-insights snap
+          const snapButton1 = await driver.findElement(
+            '#connectsignature-insights',
+          );
+          await driver.scrollToElement(snapButton1);
 
-        // added delay for firefox (deflake)
-        await driver.delayFirefox(1000);
+          // added delay for firefox (deflake)
+          await driver.delayFirefox(1000);
 
-        // wait for and click connect
-        await driver.waitForSelector('#connectsignature-insights');
-        await driver.clickElement('#connectsignature-insights');
+          // wait for and click connect
+          await driver.waitForSelector('#connectsignature-insights');
+          await driver.clickElement('#connectsignature-insights');
 
-        // switch to metamask extension
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // switch to metamask extension
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // wait for and click connect
-        await driver.waitForSelector({
-          text: 'Connect',
-          tag: 'button',
-        });
-        await driver.clickElement({
-          text: 'Connect',
-          tag: 'button',
-        });
+          // wait for and click connect
+          await driver.waitForSelector({
+            text: 'Connect',
+            tag: 'button',
+          });
+          await driver.clickElement({
+            text: 'Connect',
+            tag: 'button',
+          });
 
-        // wait for and click confirm
-        await driver.waitForSelector({ text: 'Confirm' });
-        await driver.clickElement({
-          text: 'Confirm',
-          tag: 'button',
-        });
+          // wait for and click confirm
+          await driver.waitForSelector({ text: 'Confirm' });
+          await driver.clickElement({
+            text: 'Confirm',
+            tag: 'button',
+          });
 
-        // wait for and click ok and wait for window to close
-        await driver.waitForSelector({ text: 'OK' });
-        await driver.clickElementAndWaitForWindowToClose({
-          text: 'OK',
-          tag: 'button',
-        });
+          // wait for and click ok and wait for window to close
+          await driver.waitForSelector({ text: 'OK' });
+          await driver.clickElementAndWaitForWindowToClose({
+            text: 'OK',
+            tag: 'button',
+          });
 
-        // switch to test-snaps page
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
+          // switch to test-snaps page
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
 
-        // open the test-dapp page
-        await openDapp(driver);
+          // open the test-dapp page
+          await openDapp(driver);
 
-        // TEST ONE: personal sign
-        // find and scroll to personal sign and click sign
-        const personalSignButton1 = await driver.findElement('#personalSign');
-        await driver.scrollToElement(personalSignButton1);
-        await driver.clickElement('#personalSign');
+          // TEST ONE: personal sign
+          // find and scroll to personal sign and click sign
+          const personalSignButton1 = await driver.findElement('#personalSign');
+          await driver.scrollToElement(personalSignButton1);
+          await driver.clickElement('#personalSign');
 
-        // switch back to MetaMask window and switch to tx insights pane
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // wait for and click sign
-        await clickSignOnSignatureConfirmation({
-          driver,
-          snapSigInsights: true,
-        });
+          // wait for information from signature request screen
+          await driver.waitForSelector({
+            text: 'Example `personal_sign` message',
+            tag: 'p',
+          });
 
-        // look for returned signature insights data
-        await driver.waitForSelector({
-          text: '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765',
-          tag: 'p',
-        });
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765',
+            tag: 'p',
+          });
 
-        // wait for host to render and click checkbox to authorize signing
-        await driver.waitForSelector({
-          text: '127.0.0.1:8080',
-          tag: 'span',
-        });
-        await driver.clickElement('.mm-checkbox__input-wrapper');
+          // Click down arrow
+          await driver.clickElementSafe('[aria-label="Scroll down"]');
 
-        // click sign button and wait for window to close
-        await driver.clickElementAndWaitForWindowToClose(
-          '[data-testid="snapInsightsButtonConfirm"]',
-        );
+          // click sign button
+          await driver.clickElementAndWaitForWindowToClose(
+            '[data-testid="confirm-footer-button"]',
+          );
 
-        // switch back to test-dapp window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
-        // check result of test
-        await driver.waitForSelector({
-          text: '0xa10b6707dd79e2f1f91ba243ab7abe15a46f58b052ad9cec170c5366ef5667c447a87eba2c0a9d4c9fbfa0a23e9db1fb55865d0568c32bd7cc681b8d0860e7af1b',
-          tag: 'span',
-        });
+          // check result of test
+          await driver.waitForSelector({
+            text: '0xa10b6707dd79e2f1f91ba243ab7abe15a46f58b052ad9cec170c5366ef5667c447a87eba2c0a9d4c9fbfa0a23e9db1fb55865d0568c32bd7cc681b8d0860e7af1b',
+            tag: 'span',
+          });
 
-        // TEST TWO: sign typed data
-        // find and scroll to sign typed data and click sign
-        const signTypedButton1 = await driver.findElement('#signTypedData');
-        await driver.scrollToElement(signTypedButton1);
-        await driver.clickElement('#signTypedData');
+          // TEST TWO: sign typed data
+          // find and scroll to sign typed data and click sign
+          const signTypedButton1 = await driver.findElement('#signTypedData');
+          await driver.scrollToElement(signTypedButton1);
+          await driver.clickElement('#signTypedData');
 
-        // switch back to MetaMask window and switch to tx insights pane
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // wait for and click sign
-        await clickSignOnSignatureConfirmation({
-          driver,
-          snapSigInsights: true,
-        });
+          // wait for information from signature request screen
+          await driver.waitForSelector({
+            text: 'Hi, Alice!',
+            tag: 'p',
+          });
 
-        // look for returned signature insights data
-        await driver.waitForSelector({
-          text: '1',
-          tag: 'p',
-        });
+          // click down arrow
+          await driver.clickElementSafe('[aria-label="Scroll down"]');
 
-        // wait for host to render and click checkbox to authorize signing
-        await driver.waitForSelector({
-          text: '127.0.0.1:8080',
-          tag: 'span',
-        });
-        await driver.clickElement('.mm-checkbox__input-wrapper');
+          // required: delay for scroll to render
+          await driver.delay(500);
 
-        // click sign button and wait for window to close
-        await driver.clickElementAndWaitForWindowToClose(
-          '[data-testid="snapInsightsButtonConfirm"]',
-        );
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '1',
+            tag: 'p',
+          });
 
-        // switch back to test-dapp window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          // click sign button and wait for window to close
+          await driver.clickElementAndWaitForWindowToClose(
+            '[data-testid="confirm-footer-button"]',
+          );
 
-        // check result of test
-        await driver.waitForSelector({
-          text: '0x32791e3c41d40dd5bbfb42e66cf80ca354b0869ae503ad61cd19ba68e11d4f0d2e42a5835b0bfd633596b6a7834ef7d36033633a2479dacfdb96bda360d51f451b',
-          tag: 'span',
-        });
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
-        // TEST THREE: sign typed data v3
-        // find and scroll to sign typed data v3 and click sign
-        const signTypedV3Button1 = await driver.findElement('#signTypedDataV3');
-        await driver.scrollToElement(signTypedV3Button1);
-        await driver.clickElement('#signTypedDataV3');
+          // check result of test
+          await driver.waitForSelector({
+            text: '0x32791e3c41d40dd5bbfb42e66cf80ca354b0869ae503ad61cd19ba68e11d4f0d2e42a5835b0bfd633596b6a7834ef7d36033633a2479dacfdb96bda360d51f451b',
+            tag: 'span',
+          });
 
-        // switch back to MetaMask window and switch to tx insights pane
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // TEST THREE: sign typed data v3
+          // find and scroll to sign typed data v3 and click sign
+          const signTypedV3Button1 = await driver.findElement(
+            '#signTypedDataV3',
+          );
+          await driver.scrollToElement(signTypedV3Button1);
+          await driver.clickElement('#signTypedDataV3');
 
-        // click down arrow
-        await driver.waitForSelector('.fa-arrow-down');
-        await driver.clickElement('.fa-arrow-down');
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // wait for and click sign
-        await clickSignOnSignatureConfirmation({
-          driver,
-          snapSigInsights: true,
-        });
+          // click down arrow
+          await driver.clickElementSafe('[aria-label="Scroll down"]');
 
-        // look for returned signature insights data
-        await driver.waitForSelector({
-          text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
-          tag: 'p',
-        });
+          // required: delay for scroll to render
+          await driver.delay(500);
 
-        // wait for host to render and click checkbox to authorize signing
-        await driver.waitForSelector({
-          text: '127.0.0.1:8080',
-          tag: 'span',
-        });
-        await driver.clickElement('.mm-checkbox__input-wrapper');
+          // wait for information from signature request screen
+          await driver.waitForSelector({
+            text: 'Hello, Bob!',
+            tag: 'p',
+          });
 
-        // click sign button and wait for window to close
-        await driver.clickElementAndWaitForWindowToClose(
-          '[data-testid="snapInsightsButtonConfirm"]',
-        );
+          // click down arrow
+          await driver.clickElementSafe('[aria-label="Scroll down"]');
 
-        // switch back to test-dapp window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          // required: delay for scroll to render
+          await driver.delay(500);
 
-        // check result of test
-        await driver.waitForSelector({
-          text: '0x0a22f7796a2a70c8dc918e7e6eb8452c8f2999d1a1eb5ad714473d36270a40d6724472e5609948c778a07216bd082b60b6f6853d6354c731fd8ccdd3a2f4af261b',
-          tag: 'span',
-        });
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
+            tag: 'p',
+          });
 
-        // TEST FOUR: sign typed data v4
-        // find and scroll to sign typed data v4 and click sign
-        const signTypedV4Button1 = await driver.findElement('#signTypedDataV4');
-        await driver.scrollToElement(signTypedV4Button1);
-        await driver.clickElement('#signTypedDataV4');
+          // click sign button
+          await driver.clickElementAndWaitForWindowToClose(
+            '[data-testid="confirm-footer-button"]',
+          );
 
-        // switch back to MetaMask window and switch to tx insights pane
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
-        // click down arrow
-        await driver.waitForSelector('.fa-arrow-down');
-        await driver.clickElement('.fa-arrow-down');
+          // check result of test
+          await driver.waitForSelector({
+            text: '0x0a22f7796a2a70c8dc918e7e6eb8452c8f2999d1a1eb5ad714473d36270a40d6724472e5609948c778a07216bd082b60b6f6853d6354c731fd8ccdd3a2f4af261b',
+            tag: 'span',
+          });
 
-        // wait for and click sign
-        await clickSignOnSignatureConfirmation({
-          driver,
-          snapSigInsights: true,
-        });
+          // TEST FOUR: sign typed data v4
+          // find and scroll to sign typed data v4 and click sign
+          const signTypedV4Button1 = await driver.findElement(
+            '#signTypedDataV4',
+          );
+          await driver.scrollToElement(signTypedV4Button1);
+          await driver.clickElement('#signTypedDataV4');
 
-        // look for returned signature insights data
-        await driver.waitForSelector({
-          text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
-          tag: 'p',
-        });
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        // wait for host to render and click checkbox to authorize signing
-        await driver.waitForSelector({
-          text: '127.0.0.1:8080',
-          tag: 'span',
-        });
-        await driver.clickElement('.mm-checkbox__input-wrapper');
+          // click down arrow
+          await driver.clickElementSafe('[aria-label="Scroll down"]');
 
-        // click sign button and wait for window to close
-        await driver.clickElementAndWaitForWindowToClose(
-          '[data-testid="snapInsightsButtonConfirm"]',
-        );
+          // required: delay for scroll to render
+          await driver.delay(500);
 
-        // switch back to test-dapp window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          // wait for information from signature request screen
+          await driver.waitForSelector({
+            text: 'Hello, Bob!',
+            tag: 'p',
+          });
 
-        // check results of test
-        await driver.waitForSelector({
-          text: '0xcd2f9c55840f5e1bcf61812e93c1932485b524ca673b36355482a4fbdf52f692684f92b4f4ab6f6c8572dacce46bd107da154be1c06939b855ecce57a1616ba71b',
-          tag: 'span',
-        });
-      },
-    );
+          // click down arrow
+          await driver.clickElementSafe('[aria-label="Scroll down"]');
+
+          // required: delay for scroll to render
+          await driver.delay(500);
+
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
+            tag: 'p',
+          });
+
+          // click sign button and wait for window to close
+          await driver.clickElementAndWaitForWindowToClose(
+            '[data-testid="confirm-footer-button"]',
+          );
+
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+
+          // check results of test
+          await driver.waitForSelector({
+            text: '0xcd2f9c55840f5e1bcf61812e93c1932485b524ca673b36355482a4fbdf52f692684f92b4f4ab6f6c8572dacce46bd107da154be1c06939b855ecce57a1616ba71b',
+            tag: 'span',
+          });
+        },
+      );
+    });
+
+    it('tests Signature Insights functionality (Legacy)', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          failOnConsoleError: false,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+
+          // navigate to test snaps page and connect
+          await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+
+          // delay added for page render (deflake)
+          await driver.delay(1000);
+
+          // find and scroll to the transaction-insights test snap
+          const snapButton1 = await driver.findElement(
+            '#connectsignature-insights',
+          );
+          await driver.scrollToElement(snapButton1);
+
+          // added delay for firefox (deflake)
+          await driver.delayFirefox(1000);
+
+          // wait for and click connect
+          await driver.waitForSelector('#connectsignature-insights');
+          await driver.clickElement('#connectsignature-insights');
+
+          // switch to metamask extension
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+          // wait for and click connect
+          await driver.waitForSelector({
+            text: 'Connect',
+            tag: 'button',
+          });
+          await driver.clickElement({
+            text: 'Connect',
+            tag: 'button',
+          });
+
+          // wait for and click confirm
+          await driver.waitForSelector({ text: 'Confirm' });
+          await driver.clickElement({
+            text: 'Confirm',
+            tag: 'button',
+          });
+
+          // wait for and click ok and wait for window to close
+          await driver.waitForSelector({ text: 'OK' });
+          await driver.clickElementAndWaitForWindowToClose({
+            text: 'OK',
+            tag: 'button',
+          });
+
+          // switch to test-snaps page
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
+
+          // open the test-dapp page
+          await openDapp(driver);
+
+          // TEST ONE: personal sign
+          // find and scroll to personal sign and click sign
+          const personalSignButton1 = await driver.findElement('#personalSign');
+          await driver.scrollToElement(personalSignButton1);
+          await driver.clickElement('#personalSign');
+
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765',
+            tag: 'p',
+          });
+
+          // wait for host to render and click checkbox to authorize signing
+          await driver.waitForSelector({
+            text: '127.0.0.1:8080',
+            tag: 'p',
+          });
+
+          // wait for and click sign
+          await clickSignOnRedesignedSignatureConfirmation({
+            driver,
+            snapSigInsights: true,
+          });
+
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+
+          // check result of test
+          await driver.waitForSelector({
+            text: '0xa10b6707dd79e2f1f91ba243ab7abe15a46f58b052ad9cec170c5366ef5667c447a87eba2c0a9d4c9fbfa0a23e9db1fb55865d0568c32bd7cc681b8d0860e7af1b',
+            tag: 'span',
+          });
+
+          // TEST TWO: sign typed data
+          // find and scroll to sign typed data and click sign
+          const signTypedButton1 = await driver.findElement('#signTypedData');
+          await driver.scrollToElement(signTypedButton1);
+          await driver.clickElement('#signTypedData');
+
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '1',
+            tag: 'p',
+          });
+
+          // wait for host to render and click checkbox to authorize signing
+          await driver.waitForSelector({
+            text: '127.0.0.1:8080',
+            tag: 'p',
+          });
+
+          // wait for and click sign
+          await clickSignOnRedesignedSignatureConfirmation({
+            driver,
+            snapSigInsights: true,
+          });
+
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+
+          // check result of test
+          await driver.waitForSelector({
+            text: '0x32791e3c41d40dd5bbfb42e66cf80ca354b0869ae503ad61cd19ba68e11d4f0d2e42a5835b0bfd633596b6a7834ef7d36033633a2479dacfdb96bda360d51f451b',
+            tag: 'span',
+          });
+
+          // TEST THREE: sign typed data v3
+          // find and scroll to sign typed data v3 and click sign
+          const signTypedV3Button1 = await driver.findElement(
+            '#signTypedDataV3',
+          );
+          await driver.scrollToElement(signTypedV3Button1);
+          await driver.clickElement('#signTypedDataV3');
+
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
+            tag: 'p',
+          });
+
+          // wait for host to render and click checkbox to authorize signing
+          await driver.waitForSelector({
+            text: '127.0.0.1:8080',
+            tag: 'p',
+          });
+
+          // wait for and click sign
+          await clickSignOnRedesignedSignatureConfirmation({
+            driver,
+            snapSigInsights: true,
+          });
+
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+
+          // check result of test
+          await driver.waitForSelector({
+            text: '0x0a22f7796a2a70c8dc918e7e6eb8452c8f2999d1a1eb5ad714473d36270a40d6724472e5609948c778a07216bd082b60b6f6853d6354c731fd8ccdd3a2f4af261b',
+            tag: 'span',
+          });
+
+          // TEST FOUR: sign typed data v4
+          // find and scroll to sign typed data v4 and click sign
+          const signTypedV4Button1 = await driver.findElement(
+            '#signTypedDataV4',
+          );
+          await driver.scrollToElement(signTypedV4Button1);
+          await driver.clickElement('#signTypedDataV4');
+
+          // switch back to MetaMask window and switch to tx insights pane
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+          // look for returned signature insights data
+          await driver.waitForSelector({
+            text: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC has been identified as a malicious verifying contract.',
+            tag: 'p',
+          });
+
+          // wait for host to render and click checkbox to authorize signing
+          await driver.waitForSelector({
+            text: '127.0.0.1:8080',
+            tag: 'p',
+          });
+
+          // wait for and click sign
+          await clickSignOnRedesignedSignatureConfirmation({
+            driver,
+            snapSigInsights: true,
+          });
+
+          // switch back to test-dapp window
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+
+          // check results of test
+          await driver.waitForSelector({
+            text: '0xcd2f9c55840f5e1bcf61812e93c1932485b524ca673b36355482a4fbdf52f692684f92b4f4ab6f6c8572dacce46bd107da154be1c06939b855ecce57a1616ba71b',
+            tag: 'span',
+          });
+        },
+      );
+    });
   });
 });

--- a/test/e2e/snaps/test-snap-siginsights.spec.js
+++ b/test/e2e/snaps/test-snap-siginsights.spec.js
@@ -176,8 +176,7 @@ describe('Test Snap Signature Insights', function () {
           await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
           // click down arrow
-          await driver.waitForSelector('.fa-arrow-down');
-          await driver.clickElement('.fa-arrow-down');
+          await driver.clickElementSafe('.fa-arrow-down');
 
           // wait for and click sign
           await clickSignOnSignatureConfirmation({
@@ -224,8 +223,7 @@ describe('Test Snap Signature Insights', function () {
           await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
           // click down arrow
-          await driver.waitForSelector('.fa-arrow-down');
-          await driver.clickElement('.fa-arrow-down');
+          await driver.clickElementSafe('.fa-arrow-down');
 
           // wait for and click sign
           await clickSignOnSignatureConfirmation({

--- a/test/e2e/tests/dapp-interactions/signin-with-ethereum.spec.js
+++ b/test/e2e/tests/dapp-interactions/signin-with-ethereum.spec.js
@@ -11,74 +11,157 @@ const {
 const FixtureBuilder = require('../../fixture-builder');
 
 describe('Sign in with ethereum', function () {
-  it('user should be able to confirm sign in with ethereum', async function () {
-    const expectedSigninMessageTitle =
-      'This site is requesting to sign in with Account 1';
-    const expectedSigninMessage =
-      'I accept the MetaMask Terms of Service: https://community.metamask.io/tos';
-    const expectedSignInResult =
-      '0xef8674a92d62a1876624547bdccaef6c67014ae821de18fa910fbff56577a65830f68848585b33d1f4b9ea1c3da1c1b11553b6aabe8446717daf7cd1e38a68271c';
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
+  describe('Old confirmation screens', function () {
+    it('user should be able to confirm sign in with ethereum', async function () {
+      const expectedSigninMessageTitle =
+        'This site is requesting to sign in with Account 1';
+      const expectedSigninMessage =
+        'I accept the MetaMask Terms of Service: https://community.metamask.io/tos';
+      const expectedSignInResult =
+        '0xef8674a92d62a1876624547bdccaef6c67014ae821de18fa910fbff56577a65830f68848585b33d1f4b9ea1c3da1c1b11553b6aabe8446717daf7cd1e38a68271c';
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
 
-        // Create a signin with ethereum request in test dapp
-        await openDapp(driver);
-        await driver.clickElement('#siwe');
+          // Create a signin with ethereum request in test dapp
+          await openDapp(driver);
+          await driver.clickElement('#siwe');
 
-        // Wait for signature request popup and check the message title
-        await driver.waitUntilXWindowHandles(3);
-        let windowHandles = await driver.getAllWindowHandles();
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.Dialog,
-          windowHandles,
-        );
-        const title = await driver.findElement(
-          '.permissions-connect-header__title',
-        );
-        const origin = await driver.findElement('.site-origin');
-        assert.equal(await title.getText(), 'Sign-in request');
-        assert.equal(await origin.getText(), DAPP_URL);
+          // Wait for signature request popup and check the message title
+          await driver.waitUntilXWindowHandles(3);
+          let windowHandles = await driver.getAllWindowHandles();
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.Dialog,
+            windowHandles,
+          );
+          const title = await driver.findElement(
+            '.permissions-connect-header__title',
+          );
+          const origin = await driver.findElement('.site-origin');
+          assert.equal(await title.getText(), 'Sign-in request');
+          assert.equal(await origin.getText(), DAPP_URL);
 
-        const displayedMessageTitle = await driver.findElement(
-          '.permissions-connect-header__subtitle',
-        );
-        const account = await driver.findElement(
-          '.account-list-item__account-name',
-        );
-        assert.equal(
-          `${await displayedMessageTitle.getText()} ${await account.getText()}`,
-          expectedSigninMessageTitle,
-        );
+          const displayedMessageTitle = await driver.findElement(
+            '.permissions-connect-header__subtitle',
+          );
+          const account = await driver.findElement(
+            '.account-list-item__account-name',
+          );
+          assert.equal(
+            `${await displayedMessageTitle.getText()} ${await account.getText()}`,
+            expectedSigninMessageTitle,
+          );
 
-        // Check the displayed information in popup content
-        const [message, url, version, chainId] = await driver.findElements(
-          '.signature-request-siwe-message__sub-text',
-        );
-        assert.equal(await message.getText(), expectedSigninMessage);
-        assert.equal(await url.getText(), 'https://127.0.0.1:8080');
-        assert.equal(await version.getText(), '1');
-        assert.equal(await chainId.getText(), '1');
+          // Check the displayed information in popup content
+          const [message, url, version, chainId] = await driver.findElements(
+            '.signature-request-siwe-message__sub-text',
+          );
+          assert.equal(await message.getText(), expectedSigninMessage);
+          assert.equal(await url.getText(), 'https://127.0.0.1:8080');
+          assert.equal(await version.getText(), '1');
+          assert.equal(await chainId.getText(), '1');
 
-        // Click on extension popup to approve signin with ethereum
-        await driver.clickElement('[data-testid="page-container-footer-next"]');
-        await driver.waitUntilXWindowHandles(2);
+          // Click on extension popup to approve signin with ethereum
+          await driver.clickElement(
+            '[data-testid="page-container-footer-next"]',
+          );
+          await driver.waitUntilXWindowHandles(2);
 
-        // Switch back to the dapp and verify the signed result
-        windowHandles = await driver.getAllWindowHandles();
-        await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
-        const result = await driver.findElement('#siweResult');
-        assert.equal(await result.getText(), expectedSignInResult);
-      },
-    );
+          // Switch back to the dapp and verify the signed result
+          windowHandles = await driver.getAllWindowHandles();
+          await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
+          const result = await driver.findElement('#siweResult');
+          assert.equal(await result.getText(), expectedSignInResult);
+        },
+      );
+    });
+  });
+
+  describe('Redesigned confirmation screens', function () {
+    it('user should be able to confirm sign in with ethereum', async function () {
+      const expectedSigninMessageTitle =
+        'A site wants you to sign in to prove you own this account.';
+      const expectedSigninMessage =
+        'I accept the MetaMask Terms of Service: https://community.metamask.io/tos';
+      const expectedSignInResult =
+        '0xef8674a92d62a1876624547bdccaef6c67014ae821de18fa910fbff56577a65830f68848585b33d1f4b9ea1c3da1c1b11553b6aabe8446717daf7cd1e38a68271c';
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+
+          // Create a signin with ethereum request in test dapp
+          await openDapp(driver);
+          await driver.clickElement('#siwe');
+
+          // Wait for signature request popup and check the message title
+          await driver.waitUntilXWindowHandles(3);
+          let windowHandles = await driver.getAllWindowHandles();
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.Dialog,
+            windowHandles,
+          );
+          await driver.findElement({
+            css: 'h2',
+            text: 'Sign-in request',
+          });
+          await driver.findElement({
+            css: 'p',
+            text: expectedSigninMessageTitle,
+          });
+          await driver.findElement({
+            css: 'p',
+            text: '127.0.0.1:8080',
+          });
+
+          await driver.clickElement('[data-testid="sectionCollapseButton"]');
+
+          // Check the displayed information in popup content
+          await driver.findElement({
+            css: 'p',
+            text: expectedSigninMessage,
+          });
+          await driver.findElement({
+            css: 'p',
+            text: 'https://127.0.0.1:8080',
+          });
+          await driver.findElement({
+            css: 'p',
+            text: '1',
+          });
+          await driver.findElement({
+            css: 'p',
+            text: '1',
+          });
+
+          await driver.clickElement({
+            css: 'button',
+            text: 'Confirm',
+          });
+
+          // Switch back to the dapp and verify the signed result
+          windowHandles = await driver.getAllWindowHandles();
+          await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
+          const result = await driver.findElement('#siweResult');
+          assert.equal(await result.getText(), expectedSignInResult);
+        },
+      );
+    });
   });
 });

--- a/test/e2e/tests/metrics/signature-approved.spec.js
+++ b/test/e2e/tests/metrics/signature-approved.spec.js
@@ -10,6 +10,8 @@ const {
   clickSignOnSignatureConfirmation,
   tempToggleSettingRedesignedConfirmations,
   validateContractDetails,
+  clickSignOnRedesignedSignatureConfirmation,
+  WINDOW_TITLES,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 
@@ -58,168 +60,342 @@ const expectedEventPropertiesBase = {
   security_alert_response: 'loading',
 };
 
+const additionalRedesignEventProperties = {
+  ui_customizations: ['redesigned_confirmation'],
+};
+
 describe('Signature Approved Event @no-mmi', function () {
-  it('Successfully tracked for signTypedData_v4', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
-            participateInMetaMetrics: true,
-          })
-          .build(),
-        defaultGanacheOptions,
-        title: this.test.fullTitle(),
-        testSpecificMock: mockSegment,
-      },
-      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
-        await openDapp(driver);
+  describe('Old confirmation screens', function () {
+    it('Successfully tracked for signTypedData_v4', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withMetaMetricsController({
+              metaMetricsId: 'fake-metrics-id',
+              participateInMetaMetrics: true,
+            })
+            .build(),
+          defaultGanacheOptions,
+          title: this.test.fullTitle(),
+          testSpecificMock: mockSegment,
+        },
+        async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
+          await openDapp(driver);
 
-        // creates a sign typed data signature request
-        await driver.clickElement('#signTypedDataV4');
-        await switchToNotificationWindow(driver);
-        await validateContractDetails(driver);
-        await clickSignOnSignatureConfirmation({ driver });
-        const events = await getEventPayloads(driver, mockedEndpoints);
+          // creates a sign typed data signature request
+          await driver.clickElement('#signTypedDataV4');
+          await switchToNotificationWindow(driver);
+          await validateContractDetails(driver);
+          await clickSignOnSignatureConfirmation({ driver });
+          const events = await getEventPayloads(driver, mockedEndpoints);
 
-        assert.deepStrictEqual(events[0].properties, {
-          ...expectedEventPropertiesBase,
-          signature_type: 'eth_signTypedData_v4',
-          eip712_primary_type: 'Mail',
-        });
+          assert.deepStrictEqual(events[0].properties, {
+            ...expectedEventPropertiesBase,
+            signature_type: 'eth_signTypedData_v4',
+            eip712_primary_type: 'Mail',
+          });
 
-        assert.deepStrictEqual(events[1].properties, {
-          ...expectedEventPropertiesBase,
-          signature_type: 'eth_signTypedData_v4',
-          eip712_primary_type: 'Mail',
-          security_alert_response: 'Benign',
-        });
-      },
-    );
+          assert.deepStrictEqual(events[1].properties, {
+            ...expectedEventPropertiesBase,
+            signature_type: 'eth_signTypedData_v4',
+            eip712_primary_type: 'Mail',
+            security_alert_response: 'Benign',
+          });
+        },
+      );
+    });
+
+    it('Successfully tracked for signTypedData_v3', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withMetaMetricsController({
+              metaMetricsId: 'fake-metrics-id',
+              participateInMetaMetrics: true,
+            })
+            .build(),
+          defaultGanacheOptions,
+          title: this.test.fullTitle(),
+          testSpecificMock: mockSegment,
+        },
+        async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
+          await openDapp(driver);
+
+          // creates a sign typed data signature request
+          await driver.clickElement('#signTypedDataV3');
+          await switchToNotificationWindow(driver);
+          await validateContractDetails(driver);
+          await clickSignOnSignatureConfirmation({ driver });
+          const events = await getEventPayloads(driver, mockedEndpoints);
+
+          assert.deepStrictEqual(events[0].properties, {
+            ...expectedEventPropertiesBase,
+            signature_type: 'eth_signTypedData_v3',
+          });
+
+          assert.deepStrictEqual(events[1].properties, {
+            ...expectedEventPropertiesBase,
+            signature_type: 'eth_signTypedData_v3',
+            security_alert_response: 'Benign',
+          });
+        },
+      );
+    });
+
+    it('Successfully tracked for signTypedData', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withMetaMetricsController({
+              metaMetricsId: 'fake-metrics-id',
+              participateInMetaMetrics: true,
+            })
+            .build(),
+          defaultGanacheOptions,
+          title: this.test.fullTitle(),
+          testSpecificMock: mockSegment,
+        },
+        async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
+          await openDapp(driver);
+
+          // creates a sign typed data signature request
+          await driver.clickElement('#signTypedData');
+          await switchToNotificationWindow(driver);
+          await clickSignOnSignatureConfirmation({ driver });
+          const events = await getEventPayloads(driver, mockedEndpoints);
+
+          assert.deepStrictEqual(events[0].properties, {
+            ...expectedEventPropertiesBase,
+            signature_type: 'eth_signTypedData',
+          });
+
+          assert.deepStrictEqual(events[1].properties, {
+            ...expectedEventPropertiesBase,
+            signature_type: 'eth_signTypedData',
+            security_alert_response: 'Benign',
+          });
+        },
+      );
+    });
+
+    it('Successfully tracked for personalSign', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withMetaMetricsController({
+              metaMetricsId: 'fake-metrics-id',
+              participateInMetaMetrics: true,
+            })
+            .build(),
+          defaultGanacheOptions,
+          title: this.test.fullTitle(),
+          testSpecificMock: mockSegment,
+        },
+        async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
+          await openDapp(driver);
+
+          // creates a sign typed data signature request
+          await driver.clickElement('#personalSign');
+          await switchToNotificationWindow(driver);
+          await clickSignOnSignatureConfirmation({ driver });
+          const events = await getEventPayloads(driver, mockedEndpoints);
+
+          assert.deepStrictEqual(events[0].properties, {
+            ...expectedEventPropertiesBase,
+            signature_type: 'personal_sign',
+          });
+
+          assert.deepStrictEqual(events[1].properties, {
+            ...expectedEventPropertiesBase,
+            signature_type: 'personal_sign',
+            security_alert_response: 'Benign',
+          });
+        },
+      );
+    });
   });
 
-  it('Successfully tracked for signTypedData_v3', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
-            participateInMetaMetrics: true,
-          })
-          .build(),
-        defaultGanacheOptions,
-        title: this.test.fullTitle(),
-        testSpecificMock: mockSegment,
-      },
-      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
-        await openDapp(driver);
+  describe('Redesigned confirmation screens', function () {
+    it('Successfully tracked for signTypedData_v4', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withMetaMetricsController({
+              metaMetricsId: 'fake-metrics-id',
+              participateInMetaMetrics: true,
+            })
+            .build(),
+          defaultGanacheOptions,
+          title: this.test.fullTitle(),
+          testSpecificMock: mockSegment,
+        },
+        async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+          await unlockWallet(driver);
+          await openDapp(driver);
 
-        // creates a sign typed data signature request
-        await driver.clickElement('#signTypedDataV3');
-        await switchToNotificationWindow(driver);
-        await validateContractDetails(driver);
-        await clickSignOnSignatureConfirmation({ driver });
-        const events = await getEventPayloads(driver, mockedEndpoints);
+          // creates a sign typed data signature request
+          await driver.clickElement('#signTypedDataV4');
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await clickSignOnRedesignedSignatureConfirmation({ driver });
+          const events = await getEventPayloads(driver, mockedEndpoints);
 
-        assert.deepStrictEqual(events[0].properties, {
-          ...expectedEventPropertiesBase,
-          signature_type: 'eth_signTypedData_v3',
-        });
+          assert.deepStrictEqual(events[0].properties, {
+            ...expectedEventPropertiesBase,
+            ...additionalRedesignEventProperties,
+            signature_type: 'eth_signTypedData_v4',
+            eip712_primary_type: 'Mail',
+          });
 
-        assert.deepStrictEqual(events[1].properties, {
-          ...expectedEventPropertiesBase,
-          signature_type: 'eth_signTypedData_v3',
-          security_alert_response: 'Benign',
-        });
-      },
-    );
-  });
+          assert.deepStrictEqual(events[1].properties, {
+            ...expectedEventPropertiesBase,
+            ...additionalRedesignEventProperties,
+            signature_type: 'eth_signTypedData_v4',
+            eip712_primary_type: 'Mail',
+            security_alert_response: 'Benign',
+          });
+        },
+      );
+    });
 
-  it('Successfully tracked for signTypedData', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
-            participateInMetaMetrics: true,
-          })
-          .build(),
-        defaultGanacheOptions,
-        title: this.test.fullTitle(),
-        testSpecificMock: mockSegment,
-      },
-      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
-        await openDapp(driver);
+    it('Successfully tracked for signTypedData_v3', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withMetaMetricsController({
+              metaMetricsId: 'fake-metrics-id',
+              participateInMetaMetrics: true,
+            })
+            .build(),
+          defaultGanacheOptions,
+          title: this.test.fullTitle(),
+          testSpecificMock: mockSegment,
+        },
+        async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+          await unlockWallet(driver);
+          await openDapp(driver);
 
-        // creates a sign typed data signature request
-        await driver.clickElement('#signTypedData');
-        await switchToNotificationWindow(driver);
-        await clickSignOnSignatureConfirmation({ driver });
-        const events = await getEventPayloads(driver, mockedEndpoints);
+          // creates a sign typed data signature request
+          await driver.clickElement('#signTypedDataV3');
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await clickSignOnRedesignedSignatureConfirmation({ driver });
+          const events = await getEventPayloads(driver, mockedEndpoints);
 
-        assert.deepStrictEqual(events[0].properties, {
-          ...expectedEventPropertiesBase,
-          signature_type: 'eth_signTypedData',
-        });
+          assert.deepStrictEqual(events[0].properties, {
+            ...expectedEventPropertiesBase,
+            ...additionalRedesignEventProperties,
+            signature_type: 'eth_signTypedData_v3',
+          });
 
-        assert.deepStrictEqual(events[1].properties, {
-          ...expectedEventPropertiesBase,
-          signature_type: 'eth_signTypedData',
-          security_alert_response: 'Benign',
-        });
-      },
-    );
-  });
+          assert.deepStrictEqual(events[1].properties, {
+            ...expectedEventPropertiesBase,
+            ...additionalRedesignEventProperties,
+            signature_type: 'eth_signTypedData_v3',
+            security_alert_response: 'Benign',
+          });
+        },
+      );
+    });
 
-  it('Successfully tracked for personalSign', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
-            participateInMetaMetrics: true,
-          })
-          .build(),
-        defaultGanacheOptions,
-        title: this.test.fullTitle(),
-        testSpecificMock: mockSegment,
-      },
-      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
-        await openDapp(driver);
+    it('Successfully tracked for signTypedData', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withMetaMetricsController({
+              metaMetricsId: 'fake-metrics-id',
+              participateInMetaMetrics: true,
+            })
+            .build(),
+          defaultGanacheOptions,
+          title: this.test.fullTitle(),
+          testSpecificMock: mockSegment,
+        },
+        async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+          await unlockWallet(driver);
+          await openDapp(driver);
 
-        // creates a sign typed data signature request
-        await driver.clickElement('#personalSign');
-        await switchToNotificationWindow(driver);
-        await clickSignOnSignatureConfirmation({ driver });
-        const events = await getEventPayloads(driver, mockedEndpoints);
+          // creates a sign typed data signature request
+          await driver.clickElement('#signTypedData');
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await clickSignOnRedesignedSignatureConfirmation({ driver });
+          const events = await getEventPayloads(driver, mockedEndpoints);
 
-        assert.deepStrictEqual(events[0].properties, {
-          ...expectedEventPropertiesBase,
-          signature_type: 'personal_sign',
-        });
+          assert.deepStrictEqual(events[0].properties, {
+            ...expectedEventPropertiesBase,
+            ...additionalRedesignEventProperties,
+            signature_type: 'eth_signTypedData',
+          });
 
-        assert.deepStrictEqual(events[1].properties, {
-          ...expectedEventPropertiesBase,
-          signature_type: 'personal_sign',
-          security_alert_response: 'Benign',
-        });
-      },
-    );
+          assert.deepStrictEqual(events[1].properties, {
+            ...expectedEventPropertiesBase,
+            ...additionalRedesignEventProperties,
+            signature_type: 'eth_signTypedData',
+            security_alert_response: 'Benign',
+          });
+        },
+      );
+    });
+
+    it('Successfully tracked for personalSign', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withMetaMetricsController({
+              metaMetricsId: 'fake-metrics-id',
+              participateInMetaMetrics: true,
+            })
+            .build(),
+          defaultGanacheOptions,
+          title: this.test.fullTitle(),
+          testSpecificMock: mockSegment,
+        },
+        async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+          await unlockWallet(driver);
+          await openDapp(driver);
+
+          // creates a sign typed data signature request
+          await driver.clickElement('#personalSign');
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await clickSignOnRedesignedSignatureConfirmation({ driver });
+          const events = await getEventPayloads(driver, mockedEndpoints);
+
+          assert.deepStrictEqual(events[0].properties, {
+            ...expectedEventPropertiesBase,
+            ...additionalRedesignEventProperties,
+            signature_type: 'personal_sign',
+          });
+
+          assert.deepStrictEqual(events[1].properties, {
+            ...expectedEventPropertiesBase,
+            ...additionalRedesignEventProperties,
+            signature_type: 'personal_sign',
+            security_alert_response: 'Benign',
+          });
+        },
+      );
+    });
   });
 });

--- a/test/e2e/tests/petnames/petnames-signatures.spec.js
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.js
@@ -5,6 +5,7 @@ const {
   tempToggleSettingRedesignedConfirmations,
   unlockWallet,
   defaultGanacheOptions,
+  WINDOW_TITLES,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('../../snaps/enums');
@@ -14,6 +15,7 @@ const {
   rejectSignatureOrTransactionRequest,
   saveName,
   clickName,
+  rejectRedesignedSignatureOrTransactionRequest,
 } = require('./petnames-helpers');
 
 const SIGNATURE_TYPE = {
@@ -95,109 +97,209 @@ async function expectProposedNames(driver, value, options) {
   }
 }
 
-describe('Petnames - Signatures', function () {
-  it('can save names for addresses in type 3 signatures', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withNoNames()
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
-        await openDapp(driver);
-        await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V3);
-        await switchToNotificationWindow(driver, 3);
-        await expectName(driver, '0xCD2a3...DD826', false);
-        await expectName(driver, '0xbBbBB...bBBbB', false);
-        await saveName(driver, '0xCD2a3...DD826', undefined, 'test.lens');
-        await saveName(driver, '0xbBbBB...bBBbB', undefined, 'test2.lens');
-        await showThirdPartyDetails(driver);
-        await expectName(driver, '0xCcCCc...ccccC', false);
-        await saveName(driver, '0xCcCCc...ccccC', 'Custom Name');
-        await closeThirdPartyDetails(driver);
-        await rejectSignatureOrTransactionRequest(driver);
-        await focusTestDapp(driver);
-        await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V3);
-        await switchToNotificationWindow(driver, 3);
-        await expectName(driver, 'test.lens', true);
-        await expectName(driver, 'test2.lens', true);
-        await showThirdPartyDetails(driver);
-        await expectName(driver, 'Custom Name', true);
-      },
-    );
+describe('Petnames - Signatures', function () {
+  describe('Old confirmation screens', function () {
+    it('can save names for addresses in type 3 signatures', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withNoNames()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
+          await openDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V3);
+          await switchToNotificationWindow(driver, 3);
+          await expectName(driver, '0xCD2a3...DD826', false);
+          await expectName(driver, '0xbBbBB...bBBbB', false);
+          await saveName(driver, '0xCD2a3...DD826', undefined, 'test.lens');
+          await saveName(driver, '0xbBbBB...bBBbB', undefined, 'test2.lens');
+          await showThirdPartyDetails(driver);
+          await expectName(driver, '0xCcCCc...ccccC', false);
+          await saveName(driver, '0xCcCCc...ccccC', 'Custom Name');
+          await closeThirdPartyDetails(driver);
+          await rejectSignatureOrTransactionRequest(driver);
+          await focusTestDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V3);
+          await switchToNotificationWindow(driver, 3);
+          await expectName(driver, 'test.lens', true);
+          await expectName(driver, 'test2.lens', true);
+          await showThirdPartyDetails(driver);
+          await expectName(driver, 'Custom Name', true);
+        },
+      );
+    });
+
+    it('can save names for addresses in type 4 signatures', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withNoNames()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
+          await openDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
+          await switchToNotificationWindow(driver, 3);
+          await expectName(driver, '0xCD2a3...DD826', false);
+          await expectName(driver, '0xDeaDb...DbeeF', false);
+          await expectName(driver, '0xbBbBB...bBBbB', false);
+          await expectName(driver, '0xB0Bda...bEa57', false);
+          await expectName(driver, '0xB0B0b...00000', false);
+          await saveName(driver, '0xCD2a3...DD826', undefined, 'test.lens');
+          await saveName(driver, '0xB0Bda...bEa57', undefined, 'Test Token 2');
+          await showThirdPartyDetails(driver);
+          await expectName(driver, '0xCcCCc...ccccC', false);
+          await saveName(driver, '0xCcCCc...ccccC', 'Custom Name');
+          await closeThirdPartyDetails(driver);
+          await rejectSignatureOrTransactionRequest(driver);
+          await focusTestDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
+          await switchToNotificationWindow(driver, 3);
+          await expectName(driver, 'test.lens', true);
+          await expectName(driver, 'Test Token 2', true);
+          await showThirdPartyDetails(driver);
+          await expectName(driver, 'Custom Name', true);
+        },
+      );
+    });
+
+    it('can propose names using installed snaps', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withNoNames()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+          await tempToggleSettingRedesignedConfirmations(driver);
+          await openDapp(driver);
+          await openTestSnaps(driver);
+          await installNameLookupSnap(driver);
+          await focusTestDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
+          await switchToNotificationWindow(driver, 4);
+          await expectProposedNames(driver, '0xCD2a3...DD826', [
+            ['test.lens', 'Lens Protocol'],
+            ['cd2.1337.test.domain', 'Name Lookup Example Snap'],
+          ]);
+        },
+      );
+    });
   });
 
-  it('can save names for addresses in type 4 signatures', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withNoNames()
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
-        await openDapp(driver);
-        await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
-        await switchToNotificationWindow(driver, 3);
-        await expectName(driver, '0xCD2a3...DD826', false);
-        await expectName(driver, '0xDeaDb...DbeeF', false);
-        await expectName(driver, '0xbBbBB...bBBbB', false);
-        await expectName(driver, '0xB0Bda...bEa57', false);
-        await expectName(driver, '0xB0B0b...00000', false);
-        await saveName(driver, '0xCD2a3...DD826', undefined, 'test.lens');
-        await saveName(driver, '0xB0Bda...bEa57', undefined, 'Test Token 2');
-        await showThirdPartyDetails(driver);
-        await expectName(driver, '0xCcCCc...ccccC', false);
-        await saveName(driver, '0xCcCCc...ccccC', 'Custom Name');
-        await closeThirdPartyDetails(driver);
-        await rejectSignatureOrTransactionRequest(driver);
-        await focusTestDapp(driver);
-        await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
-        await switchToNotificationWindow(driver, 3);
-        await expectName(driver, 'test.lens', true);
-        await expectName(driver, 'Test Token 2', true);
-        await showThirdPartyDetails(driver);
-        await expectName(driver, 'Custom Name', true);
-      },
-    );
-  });
+  describe('Redesigned confirmation screens', function () {
+    it('can save names for addresses in type 3 signatures', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withNoNames()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+          await openDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V3);
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await expectName(driver, '0xCD2a3...DD826', false);
+          await expectName(driver, '0xbBbBB...bBBbB', false);
+          await saveName(driver, '0xCD2a3...DD826', undefined, 'test.lens');
+          await saveName(driver, '0xbBbBB...bBBbB', undefined, 'test2.lens');
+          await expectName(driver, '0xCcCCc...ccccC', false);
+          await saveName(driver, '0xCcCCc...ccccC', 'Custom Name');
+          await rejectRedesignedSignatureOrTransactionRequest(driver);
+          await focusTestDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V3);
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await expectName(driver, 'test.lens', true);
+          await expectName(driver, 'test2.lens', true);
+          await expectName(driver, 'Custom Name', true);
+        },
+      );
+    });
 
-  it('can propose names using installed snaps', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withNoNames()
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await unlockWallet(driver);
-        await tempToggleSettingRedesignedConfirmations(driver);
-        await openDapp(driver);
-        await openTestSnaps(driver);
-        await installNameLookupSnap(driver);
-        await focusTestDapp(driver);
-        await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
-        await switchToNotificationWindow(driver, 4);
-        await expectProposedNames(driver, '0xCD2a3...DD826', [
-          ['test.lens', 'Lens Protocol'],
-          ['cd2.1337.test.domain', 'Name Lookup Example Snap'],
-        ]);
-      },
-    );
+    it('can save names for addresses in type 4 signatures', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withNoNames()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+          await openDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await expectName(driver, '0xCD2a3...DD826', false);
+          await expectName(driver, '0xDeaDb...DbeeF', false);
+          await expectName(driver, '0xbBbBB...bBBbB', false);
+          await expectName(driver, '0xB0Bda...bEa57', false);
+          await expectName(driver, '0xB0B0b...00000', false);
+          await saveName(driver, '0xCD2a3...DD826', undefined, 'test.lens');
+          await saveName(driver, '0xB0Bda...bEa57', undefined, 'Test Token 2');
+          await expectName(driver, '0xCcCCc...ccccC', false);
+          await saveName(driver, '0xCcCCc...ccccC', 'Custom Name');
+          await rejectRedesignedSignatureOrTransactionRequest(driver);
+          await focusTestDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await expectName(driver, 'test.lens', true);
+          await expectName(driver, 'Test Token 2', true);
+          await expectName(driver, 'Custom Name', true);
+        },
+      );
+    });
+
+    it('can propose names using installed snaps', async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPermissionControllerConnectedToTestDapp()
+            .withNoNames()
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await unlockWallet(driver);
+          await openDapp(driver);
+          await openTestSnaps(driver);
+          await installNameLookupSnap(driver);
+          await focusTestDapp(driver);
+          await createSignatureRequest(driver, SIGNATURE_TYPE.TYPED_V4);
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await expectProposedNames(driver, '0xCD2a3...DD826', [
+            ['test.lens', 'Lens Protocol'],
+            ['cd2.1337.test.domain', 'Name Lookup Example Snap'],
+          ]);
+        },
+      );
+    });
   });
 });

--- a/test/e2e/tests/signature/signature-request.spec.js
+++ b/test/e2e/tests/signature/signature-request.spec.js
@@ -1,4 +1,5 @@
 const { strict: assert } = require('assert');
+const { By } = require('selenium-webdriver');
 const {
   withFixtures,
   regularDelayMs,
@@ -63,267 +64,543 @@ const testData = [
 ];
 
 describe('Sign Typed Data Signature Request', function () {
-  testData.forEach((data) => {
-    it(`can initiate and confirm a Signature Request of ${data.type}`, async function () {
-      await withFixtures(
-        {
-          dapp: true,
-          fixtures: new FixtureBuilder()
-            .withPermissionControllerConnectedToTestDapp()
-            .build(),
-          ganacheOptions: defaultGanacheOptions,
-          title: this.test.fullTitle(),
-        },
-        async ({ driver, ganacheServer }) => {
-          const addresses = await ganacheServer.getAccounts();
-          const publicAddress = addresses[0];
-          await unlockWallet(driver);
-          await tempToggleSettingRedesignedConfirmations(driver);
+  describe('Old confirmation screens', function () {
+    testData.forEach((data) => {
+      it(`can initiate and confirm a Signature Request of ${data.type}`, async function () {
+        await withFixtures(
+          {
+            dapp: true,
+            fixtures: new FixtureBuilder()
+              .withPermissionControllerConnectedToTestDapp()
+              .build(),
+            ganacheOptions: defaultGanacheOptions,
+            title: this.test.fullTitle(),
+          },
+          async ({ driver, ganacheServer }) => {
+            const addresses = await ganacheServer.getAccounts();
+            const publicAddress = addresses[0];
+            await unlockWallet(driver);
+            await tempToggleSettingRedesignedConfirmations(driver);
 
-          await openDapp(driver);
+            await openDapp(driver);
 
-          // creates a sign typed data signature request
-          await driver.clickElement(data.buttonId);
+            // creates a sign typed data signature request
+            await driver.clickElement(data.buttonId);
 
-          await driver.waitUntilXWindowHandles(3);
-          let windowHandles = await driver.getAllWindowHandles();
-          await driver.switchToWindowWithTitle(
-            WINDOW_TITLES.Dialog,
-            windowHandles,
-          );
+            await driver.waitUntilXWindowHandles(3);
+            let windowHandles = await driver.getAllWindowHandles();
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.Dialog,
+              windowHandles,
+            );
 
-          await verifyAndAssertSignTypedData(
-            driver,
-            data.type,
-            data.verifyAndAssertMessage.titleClass,
-            data.verifyAndAssertMessage.originClass,
-            data.verifyAndAssertMessage.messageClass,
-            data.expectedMessage,
-          );
+            await verifyAndAssertSignTypedData(
+              driver,
+              data.type,
+              data.verifyAndAssertMessage.titleClass,
+              data.verifyAndAssertMessage.originClass,
+              data.verifyAndAssertMessage.messageClass,
+              data.expectedMessage,
+            );
 
-          // Approve signing typed data
-          await finalizeSignatureRequest(
-            driver,
-            data.type,
-            '[data-testid="signature-request-scroll-button"]',
-            'Sign',
-          );
-          await driver.waitUntilXWindowHandles(2);
-          windowHandles = await driver.getAllWindowHandles();
+            // Approve signing typed data
+            await finalizeSignatureRequest(
+              driver,
+              '[data-testid="signature-request-scroll-button"]',
+              'Sign',
+            );
+            await driver.waitUntilXWindowHandles(2);
+            windowHandles = await driver.getAllWindowHandles();
 
-          // switch to the Dapp and verify the signed address
-          await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
-          await driver.clickElement(data.verifyId);
-          const recoveredAddress = await driver.findElement(
-            data.verifyResultId,
-          );
+            // switch to the Dapp and verify the signed address
+            await driver.switchToWindowWithTitle(
+              'E2E Test Dapp',
+              windowHandles,
+            );
+            await driver.clickElement(data.verifyId);
+            const recoveredAddress = await driver.findElement(
+              data.verifyResultId,
+            );
 
-          assert.equal(await recoveredAddress.getText(), publicAddress);
-        },
-      );
+            assert.equal(await recoveredAddress.getText(), publicAddress);
+          },
+        );
+      });
+    });
+
+    testData.forEach((data) => {
+      it(`can queue multiple Signature Requests of ${data.type} and confirm`, async function () {
+        await withFixtures(
+          {
+            dapp: true,
+            fixtures: new FixtureBuilder()
+              .withPermissionControllerConnectedToTestDapp()
+              .build(),
+            ganacheOptions: defaultGanacheOptions,
+            title: this.test.fullTitle(),
+          },
+          async ({ driver, ganacheServer }) => {
+            const addresses = await ganacheServer.getAccounts();
+            const publicAddress = addresses[0];
+            await unlockWallet(driver);
+            await tempToggleSettingRedesignedConfirmations(driver);
+
+            await openDapp(driver);
+
+            // creates multiple sign typed data signature requests
+            await driver.clickElement(data.buttonId);
+
+            await driver.waitUntilXWindowHandles(3);
+            const windowHandles = await driver.getAllWindowHandles();
+            // switches to Dapp
+            await driver.switchToWindowWithTitle(
+              'E2E Test Dapp',
+              windowHandles,
+            );
+            // creates second sign typed data signature request
+            await driver.clickElement(data.buttonId);
+
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.Dialog,
+              windowHandles,
+            );
+
+            await driver.waitForSelector({
+              text: 'Reject 2 requests',
+              tag: 'button',
+            });
+
+            await verifyAndAssertSignTypedData(
+              driver,
+              data.type,
+              data.verifyAndAssertMessage.titleClass,
+              data.verifyAndAssertMessage.originClass,
+              data.verifyAndAssertMessage.messageClass,
+              data.expectedMessage,
+            );
+
+            // approve first signature request
+            await finalizeSignatureRequest(
+              driver,
+              '[data-testid="signature-request-scroll-button"]',
+              'Sign',
+            );
+            await driver.waitUntilXWindowHandles(3);
+
+            // approve second signature request
+            await finalizeSignatureRequest(
+              driver,
+              '[data-testid="signature-request-scroll-button"]',
+              'Sign',
+            );
+            await driver.waitUntilXWindowHandles(2);
+
+            // switch to the Dapp and verify the signed address for each request
+            await driver.switchToWindowWithTitle('E2E Test Dapp');
+            await driver.clickElement(data.verifyId);
+            const recoveredAddress = await driver.findElement(
+              data.verifyResultId,
+            );
+            assert.equal(await recoveredAddress.getText(), publicAddress);
+          },
+        );
+      });
+    });
+
+    testData.forEach((data) => {
+      it(`can initiate and reject a Signature Request of ${data.type}`, async function () {
+        await withFixtures(
+          {
+            dapp: true,
+            fixtures: new FixtureBuilder()
+              .withPermissionControllerConnectedToTestDapp()
+              .build(),
+            ganacheOptions: defaultGanacheOptions,
+            title: this.test.fullTitle(),
+          },
+          async ({ driver }) => {
+            await unlockWallet(driver);
+            await tempToggleSettingRedesignedConfirmations(driver);
+
+            await openDapp(driver);
+
+            // creates a sign typed data signature request
+            await driver.clickElement(data.buttonId);
+
+            await driver.waitUntilXWindowHandles(3);
+            let windowHandles = await driver.getAllWindowHandles();
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.Dialog,
+              windowHandles,
+            );
+
+            // Reject signing typed data
+            await finalizeSignatureRequest(
+              driver,
+              '[data-testid="signature-request-scroll-button"]',
+              'Reject',
+            );
+            await driver.waitUntilXWindowHandles(2);
+            windowHandles = await driver.getAllWindowHandles();
+
+            // switch to the Dapp and verify the rejection was successful
+            await driver.switchToWindowWithTitle(
+              'E2E Test Dapp',
+              windowHandles,
+            );
+
+            await driver.waitForSelector(data.verifyRejectionResultId);
+            const rejectionResult = await driver.findElement(
+              data.verifyRejectionResultId,
+            );
+
+            assert.equal(
+              await rejectionResult.getText(),
+              data.rejectSignatureMessage,
+            );
+          },
+        );
+      });
+    });
+
+    testData.forEach((data) => {
+      it(`can queue multiple Signature Requests of ${data.type} and reject`, async function () {
+        await withFixtures(
+          {
+            dapp: true,
+            fixtures: new FixtureBuilder()
+              .withPermissionControllerConnectedToTestDapp()
+              .build(),
+            ganacheOptions: defaultGanacheOptions,
+            title: this.test.fullTitle(),
+          },
+          async ({ driver }) => {
+            await unlockWallet(driver);
+            await tempToggleSettingRedesignedConfirmations(driver);
+
+            await openDapp(driver);
+
+            // creates multiple sign typed data signature requests
+            await driver.clickElement(data.buttonId);
+
+            await driver.waitUntilXWindowHandles(3);
+            const windowHandles = await driver.getAllWindowHandles();
+            // switches to Dapp
+            await driver.switchToWindowWithTitle(
+              'E2E Test Dapp',
+              windowHandles,
+            );
+            // creates second sign typed data signature request
+            await driver.clickElement(data.buttonId);
+
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.Dialog,
+              windowHandles,
+            );
+
+            await driver.waitForSelector({
+              text: 'Reject 2 requests',
+              tag: 'button',
+            });
+
+            // reject first signature request
+            await finalizeSignatureRequest(
+              driver,
+              '[data-testid="signature-request-scroll-button"]',
+              'Reject',
+            );
+            await driver.waitUntilXWindowHandles(3);
+
+            // reject second signature request
+            await finalizeSignatureRequest(
+              driver,
+              '[data-testid="signature-request-scroll-button"]',
+              'Reject',
+            );
+            await driver.waitUntilXWindowHandles(2);
+
+            // switch to the Dapp and verify the rejection was successful
+            await driver.switchToWindowWithTitle('E2E Test Dapp');
+
+            await driver.waitForSelector(data.verifyRejectionResultId);
+            const rejectionResult = await driver.findElement(
+              data.verifyRejectionResultId,
+            );
+            assert.equal(
+              await rejectionResult.getText(),
+              data.rejectSignatureMessage,
+            );
+          },
+        );
+      });
     });
   });
 
-  testData.forEach((data) => {
-    it(`can queue multiple Signature Requests of ${data.type} and confirm`, async function () {
-      await withFixtures(
-        {
-          dapp: true,
-          fixtures: new FixtureBuilder()
-            .withPermissionControllerConnectedToTestDapp()
-            .build(),
-          ganacheOptions: defaultGanacheOptions,
-          title: this.test.fullTitle(),
-        },
-        async ({ driver, ganacheServer }) => {
-          const addresses = await ganacheServer.getAccounts();
-          const publicAddress = addresses[0];
-          await unlockWallet(driver);
-          await tempToggleSettingRedesignedConfirmations(driver);
+  describe('Redesigned confirmation screens', function () {
+    testData.forEach((data) => {
+      it(`can initiate and confirm a Signature Request of ${data.type}`, async function () {
+        await withFixtures(
+          {
+            dapp: true,
+            fixtures: new FixtureBuilder()
+              .withPermissionControllerConnectedToTestDapp()
+              .build(),
+            ganacheOptions: defaultGanacheOptions,
+            title: this.test.fullTitle(),
+          },
+          async ({ driver, ganacheServer }) => {
+            const addresses = await ganacheServer.getAccounts();
+            const publicAddress = addresses[0];
+            await unlockWallet(driver);
 
-          await openDapp(driver);
+            await openDapp(driver);
 
-          // creates multiple sign typed data signature requests
-          await driver.clickElement(data.buttonId);
+            // creates a sign typed data signature request
+            await driver.clickElement(data.buttonId);
 
-          await driver.waitUntilXWindowHandles(3);
-          const windowHandles = await driver.getAllWindowHandles();
-          // switches to Dapp
-          await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
-          // creates second sign typed data signature request
-          await driver.clickElement(data.buttonId);
+            await driver.waitUntilXWindowHandles(3);
+            let windowHandles = await driver.getAllWindowHandles();
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.Dialog,
+              windowHandles,
+            );
 
-          await driver.switchToWindowWithTitle(
-            WINDOW_TITLES.Dialog,
-            windowHandles,
-          );
+            await verifyAndAssertRedesignedSignTypedData(
+              driver,
+              data.expectedMessage,
+            );
 
-          await driver.waitForSelector({
-            text: 'Reject 2 requests',
-            tag: 'button',
-          });
+            // Approve signing typed data
+            await finalizeSignatureRequest(
+              driver,
+              '.confirm-scroll-to-bottom__button',
+              'Confirm',
+            );
+            await driver.waitUntilXWindowHandles(2);
+            windowHandles = await driver.getAllWindowHandles();
 
-          await verifyAndAssertSignTypedData(
-            driver,
-            data.type,
-            data.verifyAndAssertMessage.titleClass,
-            data.verifyAndAssertMessage.originClass,
-            data.verifyAndAssertMessage.messageClass,
-            data.expectedMessage,
-          );
+            // switch to the Dapp and verify the signed address
+            await driver.switchToWindowWithTitle(
+              'E2E Test Dapp',
+              windowHandles,
+            );
+            await driver.clickElement(data.verifyId);
+            const recoveredAddress = await driver.findElement(
+              data.verifyResultId,
+            );
 
-          // approve first signature request
-          await finalizeSignatureRequest(
-            driver,
-            data.type,
-            '[data-testid="signature-request-scroll-button"]',
-            'Sign',
-          );
-          await driver.waitUntilXWindowHandles(3);
-
-          // approve second signature request
-          await finalizeSignatureRequest(
-            driver,
-            data.type,
-            '[data-testid="signature-request-scroll-button"]',
-            'Sign',
-          );
-          await driver.waitUntilXWindowHandles(2);
-
-          // switch to the Dapp and verify the signed address for each request
-          await driver.switchToWindowWithTitle('E2E Test Dapp');
-          await driver.clickElement(data.verifyId);
-          const recoveredAddress = await driver.findElement(
-            data.verifyResultId,
-          );
-          assert.equal(await recoveredAddress.getText(), publicAddress);
-        },
-      );
+            assert.equal(await recoveredAddress.getText(), publicAddress);
+          },
+        );
+      });
     });
-  });
 
-  testData.forEach((data) => {
-    it(`can initiate and reject a Signature Request of ${data.type}`, async function () {
-      await withFixtures(
-        {
-          dapp: true,
-          fixtures: new FixtureBuilder()
-            .withPermissionControllerConnectedToTestDapp()
-            .build(),
-          ganacheOptions: defaultGanacheOptions,
-          title: this.test.fullTitle(),
-        },
-        async ({ driver }) => {
-          await unlockWallet(driver);
-          await tempToggleSettingRedesignedConfirmations(driver);
+    testData.forEach((data) => {
+      it(`can queue multiple Signature Requests of ${data.type} and confirm`, async function () {
+        await withFixtures(
+          {
+            dapp: true,
+            fixtures: new FixtureBuilder()
+              .withPermissionControllerConnectedToTestDapp()
+              .build(),
+            ganacheOptions: defaultGanacheOptions,
+            title: this.test.fullTitle(),
+          },
+          async ({ driver, ganacheServer }) => {
+            const addresses = await ganacheServer.getAccounts();
+            const publicAddress = addresses[0];
+            await unlockWallet(driver);
 
-          await openDapp(driver);
+            await openDapp(driver);
 
-          // creates a sign typed data signature request
-          await driver.clickElement(data.buttonId);
+            // creates multiple sign typed data signature requests
+            await driver.clickElement(data.buttonId);
 
-          await driver.waitUntilXWindowHandles(3);
-          let windowHandles = await driver.getAllWindowHandles();
-          await driver.switchToWindowWithTitle(
-            WINDOW_TITLES.Dialog,
-            windowHandles,
-          );
+            await driver.waitUntilXWindowHandles(3);
+            const windowHandles = await driver.getAllWindowHandles();
+            // switches to Dapp
+            await driver.switchToWindowWithTitle(
+              'E2E Test Dapp',
+              windowHandles,
+            );
+            // creates second sign typed data signature request
+            await driver.clickElement(data.buttonId);
 
-          // Reject signing typed data
-          await finalizeSignatureRequest(
-            driver,
-            data.type,
-            '[data-testid="signature-request-scroll-button"]',
-            'Reject',
-          );
-          await driver.waitUntilXWindowHandles(2);
-          windowHandles = await driver.getAllWindowHandles();
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.Dialog,
+              windowHandles,
+            );
 
-          // switch to the Dapp and verify the rejection was successful
-          await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
+            await driver.waitForSelector(
+              By.xpath("//div[normalize-space(.)='1 of 2']"),
+            );
 
-          await driver.waitForSelector(data.verifyRejectionResultId);
-          const rejectionResult = await driver.findElement(
-            data.verifyRejectionResultId,
-          );
+            await driver.waitForSelector({
+              text: 'Reject all',
+              tag: 'button',
+            });
 
-          assert.equal(
-            await rejectionResult.getText(),
-            data.rejectSignatureMessage,
-          );
-        },
-      );
+            await verifyAndAssertRedesignedSignTypedData(
+              driver,
+              data.expectedMessage,
+            );
+
+            // Approve signing typed data
+            await finalizeSignatureRequest(
+              driver,
+              '.confirm-scroll-to-bottom__button',
+              'Confirm',
+            );
+            await driver.waitUntilXWindowHandles(3);
+
+            // Approve signing typed data
+            await finalizeSignatureRequest(
+              driver,
+              '.confirm-scroll-to-bottom__button',
+              'Confirm',
+            );
+            await driver.waitUntilXWindowHandles(2);
+
+            // switch to the Dapp and verify the signed address for each request
+            await driver.switchToWindowWithTitle('E2E Test Dapp');
+            await driver.clickElement(data.verifyId);
+            const recoveredAddress = await driver.findElement(
+              data.verifyResultId,
+            );
+            assert.equal(await recoveredAddress.getText(), publicAddress);
+          },
+        );
+      });
     });
-  });
 
-  testData.forEach((data) => {
-    it(`can queue multiple Signature Requests of ${data.type} and reject`, async function () {
-      await withFixtures(
-        {
-          dapp: true,
-          fixtures: new FixtureBuilder()
-            .withPermissionControllerConnectedToTestDapp()
-            .build(),
-          ganacheOptions: defaultGanacheOptions,
-          title: this.test.fullTitle(),
-        },
-        async ({ driver }) => {
-          await unlockWallet(driver);
-          await tempToggleSettingRedesignedConfirmations(driver);
+    testData.forEach((data) => {
+      it(`can initiate and reject a Signature Request of ${data.type}`, async function () {
+        await withFixtures(
+          {
+            dapp: true,
+            fixtures: new FixtureBuilder()
+              .withPermissionControllerConnectedToTestDapp()
+              .build(),
+            ganacheOptions: defaultGanacheOptions,
+            title: this.test.fullTitle(),
+          },
+          async ({ driver }) => {
+            await unlockWallet(driver);
 
-          await openDapp(driver);
+            await openDapp(driver);
 
-          // creates multiple sign typed data signature requests
-          await driver.clickElement(data.buttonId);
+            // creates a sign typed data signature request
+            await driver.clickElement(data.buttonId);
 
-          await driver.waitUntilXWindowHandles(3);
-          const windowHandles = await driver.getAllWindowHandles();
-          // switches to Dapp
-          await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
-          // creates second sign typed data signature request
-          await driver.clickElement(data.buttonId);
+            await driver.waitUntilXWindowHandles(3);
+            let windowHandles = await driver.getAllWindowHandles();
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.Dialog,
+              windowHandles,
+            );
 
-          await driver.switchToWindowWithTitle(
-            WINDOW_TITLES.Dialog,
-            windowHandles,
-          );
+            // Reject signing typed data
+            await finalizeSignatureRequest(
+              driver,
+              '.confirm-scroll-to-bottom__button',
+              'Cancel',
+            );
+            await driver.waitUntilXWindowHandles(2);
+            windowHandles = await driver.getAllWindowHandles();
 
-          await driver.waitForSelector({
-            text: 'Reject 2 requests',
-            tag: 'button',
-          });
+            // switch to the Dapp and verify the rejection was successful
+            await driver.switchToWindowWithTitle(
+              'E2E Test Dapp',
+              windowHandles,
+            );
 
-          // reject first signature request
-          await finalizeSignatureRequest(
-            driver,
-            data.type,
-            '[data-testid="signature-request-scroll-button"]',
-            'Reject',
-          );
-          await driver.waitUntilXWindowHandles(3);
+            await driver.waitForSelector(data.verifyRejectionResultId);
+            const rejectionResult = await driver.findElement(
+              data.verifyRejectionResultId,
+            );
 
-          // reject second signature request
-          await finalizeSignatureRequest(
-            driver,
-            data.type,
-            '[data-testid="signature-request-scroll-button"]',
-            'Reject',
-          );
-          await driver.waitUntilXWindowHandles(2);
+            assert.equal(
+              await rejectionResult.getText(),
+              data.rejectSignatureMessage,
+            );
+          },
+        );
+      });
+    });
 
-          // switch to the Dapp and verify the rejection was successful
-          await driver.switchToWindowWithTitle('E2E Test Dapp');
+    testData.forEach((data) => {
+      it(`can queue multiple Signature Requests of ${data.type} and reject`, async function () {
+        await withFixtures(
+          {
+            dapp: true,
+            fixtures: new FixtureBuilder()
+              .withPermissionControllerConnectedToTestDapp()
+              .build(),
+            ganacheOptions: defaultGanacheOptions,
+            title: this.test.fullTitle(),
+          },
+          async ({ driver }) => {
+            await unlockWallet(driver);
 
-          await driver.waitForSelector(data.verifyRejectionResultId);
-          const rejectionResult = await driver.findElement(
-            data.verifyRejectionResultId,
-          );
-          assert.equal(
-            await rejectionResult.getText(),
-            data.rejectSignatureMessage,
-          );
-        },
-      );
+            await openDapp(driver);
+
+            // creates multiple sign typed data signature requests
+            await driver.clickElement(data.buttonId);
+
+            await driver.waitUntilXWindowHandles(3);
+            const windowHandles = await driver.getAllWindowHandles();
+            // switches to Dapp
+            await driver.switchToWindowWithTitle(
+              'E2E Test Dapp',
+              windowHandles,
+            );
+            // creates second sign typed data signature request
+            await driver.clickElement(data.buttonId);
+
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.Dialog,
+              windowHandles,
+            );
+
+            await driver.waitForSelector(
+              By.xpath("//div[normalize-space(.)='1 of 2']"),
+            );
+
+            await driver.waitForSelector({
+              text: 'Reject all',
+              tag: 'button',
+            });
+
+            // reject first signature request
+            await finalizeSignatureRequest(
+              driver,
+              '.confirm-scroll-to-bottom__button',
+              'Cancel',
+            );
+            await driver.waitUntilXWindowHandles(3);
+
+            // reject second signature request
+            await finalizeSignatureRequest(
+              driver,
+              '.confirm-scroll-to-bottom__button',
+              'Cancel',
+            );
+            await driver.waitUntilXWindowHandles(2);
+
+            // switch to the Dapp and verify the rejection was successful
+            await driver.switchToWindowWithTitle('E2E Test Dapp');
+
+            await driver.waitForSelector(data.verifyRejectionResultId);
+            const rejectionResult = await driver.findElement(
+              data.verifyRejectionResultId,
+            );
+            assert.equal(
+              await rejectionResult.getText(),
+              data.rejectSignatureMessage,
+            );
+          },
+        );
+      });
     });
   });
 });
@@ -359,11 +636,27 @@ async function verifyAndAssertSignTypedData(
   assert.equal(await messages[messageNumber].getText(), expectedMessage);
 }
 
-async function finalizeSignatureRequest(driver, type, buttonElementId, action) {
-  if (type !== signatureRequestType.signTypedData) {
-    await driver.delay(regularDelayMs);
-    await driver.clickElement(buttonElementId);
-  }
+async function verifyAndAssertRedesignedSignTypedData(driver, expectedMessage) {
+  await driver.findElement({
+    css: 'h2',
+    text: 'Signature request',
+  });
+
+  await driver.findElement({
+    css: 'p',
+    text: '127.0.0.1:8080',
+  });
+
+  await driver.findElement({
+    css: 'p',
+    text: expectedMessage,
+  });
+}
+
+async function finalizeSignatureRequest(driver, buttonElementId, action) {
+  await driver.delay(regularDelayMs);
+  await driver.clickElementSafe(buttonElementId);
+
   await driver.delay(regularDelayMs);
   await driver.clickElement({ text: action, tag: 'button' });
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

A number of e2e tests uses `tempToggleSettingRedesignedConfirmations` to programatically disable the redesigned signature confirmations.

This PR duplicates those tests and tucks them under an "Old confirmation screens" describe block. All original tests are correspondingly moved to under a "Redesigned confirmation screens" describe block, and the helper method is removed. Then each test is modified enough so its assertions can pass again.

The "old confirmation screens" tests will be removed in https://github.com/MetaMask/MetaMask-planning/issues/3029.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29023?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3718

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
