### PR TITLE
chore: update CODEOWNERS for bridge related code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,7 +102,7 @@ app/scripts/controllers/swaps                         @MetaMask/swaps-engineers
 
 # Swaps-Bridge team to own code for the bridge folder
 **/bridge/**                                          @MetaMask/swaps-engineers
-**/bridge-status/**                                    @MetaMask/swaps-engineers
+**/bridge-status/**                                   @MetaMask/swaps-engineers
 
 # Ramps team to own code for the ramps folder
 **/ramps/**                                           @MetaMask/ramp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,9 +96,13 @@ ui/pages/settings/security-tab/profile-sync-toggle      @MetaMask/identity
 
 app/scripts/lib/snap-keyring         @MetaMask/accounts-engineers
 
-# Swaps team to own code for the swaps folder
+# Swaps-Bridge team to own code for the swaps folder
 ui/pages/swaps                                        @MetaMask/swaps-engineers
 app/scripts/controllers/swaps                         @MetaMask/swaps-engineers
+
+# Swaps-Bridge team to own code for the bridge folder
+**/bridge/**                                          @MetaMask/swaps-engineers
+**/bridge-status/**                                    @MetaMask/swaps-engineers
 
 # Ramps team to own code for the ramps folder
 **/ramps/**                                           @MetaMask/ramp


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29029?quickstart=1)

This PR updates `CODEOWNERS` for all Bridge related code.

## **Related issues**

n/a

## **Manual testing steps**

n/a
## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

n/a

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
