### PR TITLE
fix: send up requestId for squid

### DIFF
--- a/app/scripts/controllers/bridge-status/utils.ts
+++ b/app/scripts/controllers/bridge-status/utils.ts
@@ -6,6 +6,7 @@ import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
 import {
   StatusResponse,
   StatusRequestWithSrcTxHash,
+  StatusRequestDto,
 } from '../../../../shared/types/bridge-status';
 // TODO fix this
 // eslint-disable-next-line import/no-restricted-paths
@@ -16,18 +17,32 @@ const CLIENT_ID_HEADER = { 'X-Client-Id': BRIDGE_CLIENT_ID };
 
 export const BRIDGE_STATUS_BASE_URL = `${BRIDGE_API_BASE_URL}/getTxStatus`;
 
-export const fetchBridgeTxStatus = async (
+export const getStatusRequestDto = (
   statusRequest: StatusRequestWithSrcTxHash,
-) => {
-  // Assemble params
+): StatusRequestDto => {
   const { quote, ...statusRequestNoQuote } = statusRequest;
+
   const statusRequestNoQuoteFormatted = Object.fromEntries(
     Object.entries(statusRequestNoQuote).map(([key, value]) => [
       key,
       value.toString(),
     ]),
-  );
-  const params = new URLSearchParams(statusRequestNoQuoteFormatted);
+  ) as unknown as Omit<StatusRequestDto, 'requestId'>;
+
+  const requestId: { requestId: string } | Record<string, never> =
+    quote?.requestId ? { requestId: quote.requestId } : {};
+
+  return {
+    ...statusRequestNoQuoteFormatted,
+    ...requestId,
+  };
+};
+
+export const fetchBridgeTxStatus = async (
+  statusRequest: StatusRequestWithSrcTxHash,
+) => {
+  const statusRequestDto = getStatusRequestDto(statusRequest);
+  const params = new URLSearchParams(statusRequestDto);
 
   // Fetch
   const url = `${BRIDGE_STATUS_BASE_URL}?${params.toString()}`;

--- a/shared/types/bridge-status.ts
+++ b/shared/types/bridge-status.ts
@@ -28,6 +28,16 @@ export type StatusRequest = {
   refuel?: boolean; // lifi
 };
 
+export type StatusRequestDto = Omit<
+  StatusRequest,
+  'quote' | 'srcChainId' | 'destChainId' | 'refuel'
+> & {
+  srcChainId: string; // lifi, socket, squid
+  destChainId: string; // lifi, socket, squid
+  requestId?: string;
+  refuel?: string; // lifi
+};
+
 export type StatusRequestWithSrcTxHash = StatusRequest & {
   srcTxHash: string;
 };


### PR DESCRIPTION



<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29042?quickstart=1)

This PR fixes issues with calling the Bridge API for `getTxStatus` for bridges that expect a `requestId`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Get a bridge quote
2. Select Axelar/Squid
3. Execute the bridge
4. See your status update correctly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
