### PR TITLE
ci: Only check attributions on release candidates

### DIFF
--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -3,13 +3,6 @@ name: Check Attributions
 on:
   push:
     branches: Version-v*
-  pull_request:
-    branches: Version-v*
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 jobs:
   check-attributions:


### PR DESCRIPTION
## **Description**

The `check-attributions` workflow has been updated to only check on release candidates, as was initially intended.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29043?quickstart=1)

## **Related issues**

Fixes #29037

## **Manual testing steps**

We could test this by creating a pretend release candidate, but that would mess up some of our other metrics/release automation. In this case it seems easier to test this by merging it, there are no significant negative consequences if it doesn't work as intended. 

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
