### PR TITLE
fix: SonarCloud branch information

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,7 +19,7 @@ jobs:
   sonarcloud:
     # Only scan code from non-forked repositories that have passed the tests
     # This will skip scanning the code for forks, but will run for the main repository on PRs from forks
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.repository.fork == false }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && !github.event.workflow_run.repository.fork }}
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +53,10 @@ jobs:
       - name: SonarCloud Scan
         # This is SonarSource/sonarcloud-github-action@v2.0.0
         uses: SonarSource/sonarcloud-github-action@4b4d7634dab97dcee0b75763a54a6dc92a9e6bc1
+        # Override the branch name to the branch that triggered the workflow
+        with:
+          args: >
+            -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -62,9 +62,11 @@ jobs:
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
         run: |
           if [ "$EVENT" == "pull_request" ]; then
-            echo "sonar.pullrequest.branch=$HEAD_BRANCH" >> sonar-project.properties
-            echo "sonar.pullrequest.base=$BASE_BRANCH" >> sonar-project.properties
-            echo "sonar.pullrequest.key=$PR_NUMBER" >> sonar-project.properties
+            {
+              echo "sonar.pullrequest.branch=$HEAD_BRANCH"
+              echo "sonar.pullrequest.base=$BASE_BRANCH"
+              echo "sonar.pullrequest.key=$PR_NUMBER"
+            } >> sonar-project.properties
           else
             echo "sonar.branch.name=$HEAD_BRANCH" >> sonar-project.properties
           fi

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,9 +3,8 @@
 # actions that may result in code from that branch being executed
 # such as installing dependencies or running build scripts.
 
-# Updating this file on feature branches or forks will not reflect changes.
-# For security reasons, always the latest version from the default branch is used.
-# This means any changes made to this file in a feature branch will not be considered until they are merged.
+# For security reasons, this file always uses the latest version from the default branch.
+# Changes made in feature branches or forks will not take effect until they are merged.
 
 name: SonarCloud
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,10 @@
 # actions that may result in code from that branch being executed
 # such as installing dependencies or running build scripts.
 
+# Updating this file on feature branches or forks will not reflect changes.
+# For security reasons, always the latest version from the default branch is used.
+# This means any changes made to this file in a feature branch will not be considered until they are merged.
+
 name: SonarCloud
 
 on:
@@ -17,9 +21,9 @@ permissions:
 
 jobs:
   sonarcloud:
-    # Only scan code from non-forked repositories that have passed the tests
+    # Only scan code from non-forked repositories that have completed successfully using the push and pull_request events
     # This will skip scanning the code for forks, but will run for the main repository on PRs from forks
-    if: ${{ github.event.workflow_run.conclusion == 'success' && !github.event.workflow_run.repository.fork }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(fromJSON('["push", "pull_request"]'), github.event.workflow_run.event) && !github.event.workflow_run.repository.fork }}
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
@@ -50,13 +54,24 @@ jobs:
           fi
           echo "$sonar_project_properties" > sonar-project.properties
 
+      - name: Update sonar-project.properties with branch information
+        env:
+          EVENT: ${{ github.event.workflow_run.event }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BASE_BRANCH: ${{ github.event.workflow_run.pull_requests[0].base.ref || '' }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
+        run: |
+          if [ "$EVENT" == "pull_request" ]; then
+            echo "sonar.pullrequest.branch=$HEAD_BRANCH" >> sonar-project.properties
+            echo "sonar.pullrequest.base=$BASE_BRANCH" >> sonar-project.properties
+            echo "sonar.pullrequest.key=$PR_NUMBER" >> sonar-project.properties
+          else
+            echo "sonar.branch.name=$HEAD_BRANCH" >> sonar-project.properties
+          fi
+
       - name: SonarCloud Scan
         # This is SonarSource/sonarcloud-github-action@v2.0.0
         uses: SonarSource/sonarcloud-github-action@4b4d7634dab97dcee0b75763a54a6dc92a9e6bc1
-        # Override the branch name to the branch that triggered the workflow
-        with:
-          args: >
-            -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29072?quickstart=1)

In this [slack thread](https://consensys.slack.com/archives/CTQAGKY5V/p1733397151519159?thread_ts=1732116793.123109&cid=CTQAGKY5V) it was reported that SonarCloud is only executed on "main". Following some investigation, we discovered that it is executed on other branches too, but the SonarCloud UI displays the branch always as "main" due to a problem with the wrong branch name being reported by the workflow. We identified that this issue was introduced by the https://github.com/MetaMask/metamask-extension/pull/27700 that updated the SonarCloud workflow to enable execution on forks. Enabling execution on forks required some security measures to avoid arbitrary code execution by malicious actors, which seems to have confused the SonarCloud GitHub Action.

In order to solve this problem, the workflow now overrides the analysis parameters, according to the documentation [here](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/analysis-parameters/).

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3774

## **Manual testing steps**

1. Run SonarCloud scan (after merging, as the workflow only executes from main), and see PRs and branches correctly displayed on the SonarCloud UI.

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
