### PR TITLE
chore: Update lavamoat to a version with more diff-friendly policy ordering

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -5,115 +5,70 @@
         "regeneratorRuntime": "write"
       }
     },
+    "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": {
+      "globals": {
+        "SuppressedError": true
+      }
+    },
     "@ensdomains/content-hash": {
       "globals": {
         "console.warn": true
       },
       "packages": {
+        "browserify>buffer": true,
         "@ensdomains/content-hash>cids": true,
         "@ensdomains/content-hash>js-base64": true,
         "@ensdomains/content-hash>multicodec": true,
-        "@ensdomains/content-hash>multihashes": true,
-        "browserify>buffer": true
+        "@ensdomains/content-hash>multihashes": true
       }
     },
-    "@ensdomains/content-hash>cids": {
+    "@ethereumjs/tx>@ethereumjs/common": {
       "packages": {
-        "@ensdomains/content-hash>cids>multibase": true,
-        "@ensdomains/content-hash>cids>multihashes": true,
-        "@ensdomains/content-hash>cids>uint8arrays": true,
-        "@ensdomains/content-hash>multicodec": true
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "webpack>events": true
       }
     },
-    "@ensdomains/content-hash>cids>multibase": {
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "@metamask/transaction-controller>@ethereumjs/common": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "webpack>events": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@ethereumjs/common": {
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "@ethereumjs/tx>@ethereumjs/rlp": {
       "globals": {
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase>@multiformats/base-x": true
       }
     },
-    "@ensdomains/content-hash>cids>multihashes": {
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase": true,
-        "@ensdomains/content-hash>cids>multihashes>varint": true,
-        "@ensdomains/content-hash>cids>uint8arrays": true
-      }
-    },
-    "@ensdomains/content-hash>cids>uint8arrays": {
+    "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": {
       "globals": {
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase": true
       }
     },
-    "@ensdomains/content-hash>js-base64": {
+    "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": {
       "globals": {
-        "Base64": "write",
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "atob": true,
-        "btoa": true,
-        "define": true
-      },
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec": {
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays": true,
-        "sass-embedded>varint": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec>uint8arrays": {
-      "globals": {
-        "Buffer": true,
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "console.warn": true,
-        "crypto.subtle.digest": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase": true,
-        "@ensdomains/content-hash>multihashes>varint": true,
-        "@ensdomains/content-hash>multihashes>web-encoding": true,
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>multibase": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase>base-x": true,
-        "@ensdomains/content-hash>multihashes>web-encoding": true,
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>multibase>base-x": {
-      "packages": {
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>web-encoding": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "browserify>util": true
       }
     },
     "@ethereumjs/tx": {
@@ -121,28 +76,36 @@
         "@ethereumjs/tx>@ethereumjs/common": true,
         "@ethereumjs/tx>@ethereumjs/rlp": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>insert-module-globals>is-buffer": true
       }
     },
-    "@ethereumjs/tx>@ethereumjs/common": {
+    "@metamask/smart-transactions-controller>@ethereumjs/tx": {
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "browserify>buffer": true,
+        "@trezor/connect-web>@trezor/connect>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": {
+      "globals": {
+        "console.warn": true,
+        "fetch": true
+      },
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "webpack>events": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/common>crc-32": {
-      "globals": {
-        "DO_NOT_EXPORT_CRC": true,
-        "define": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/rlp": {
-      "globals": {
-        "TextEncoder": true
       }
     },
     "@ethereumjs/tx>@ethereumjs/util": {
@@ -151,78 +114,33 @@
       },
       "packages": {
         "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": true,
-        "@ethereumjs/tx>@ethereumjs/util>micro-ftch": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true,
         "browserify>insert-module-globals>is-buffer": true,
-        "webpack>events": true
+        "@ethereumjs/tx>@ethereumjs/util>micro-ftch": true
       }
     },
-    "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": {
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": {
       "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/util>micro-ftch": {
-      "globals": {
-        "Headers": true,
-        "TextDecoder": true,
-        "URL": true,
-        "btoa": true,
+        "console.warn": true,
         "fetch": true
       },
       "packages": {
-        "browserify>browserify-zlib": true,
-        "browserify>buffer": true,
-        "browserify>url": true,
-        "browserify>util": true,
-        "https-browserify": true,
-        "process": true,
-        "stream-http": true
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true
       }
     },
-    "@ethereumjs/tx>ethereum-cryptography": {
+    "@metamask/smart-transactions-controller>@ethereumjs/util": {
       "globals": {
-        "TextDecoder": true,
-        "crypto": true
+        "console.warn": true,
+        "fetch": true
       },
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": true,
-        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/curves": {
-      "globals": {
-        "TextEncoder": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true
       }
     },
     "@ethersproject/abi": {
@@ -230,27 +148,70 @@
         "console.log": true
       },
       "packages": {
+        "ethers>@ethersproject/address": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/strings": true
       }
     },
+    "ethers>@ethersproject/abstract-provider": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
+    "ethers>@ethersproject/abstract-signer": {
+      "packages": {
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
+    "ethers>@ethersproject/address": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/rlp": true
+      }
+    },
+    "ethers>@ethersproject/base64": {
+      "globals": {
+        "atob": true,
+        "btoa": true
+      },
+      "packages": {
+        "@ethersproject/bytes": true
+      }
+    },
+    "ethers>@ethersproject/basex": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
     "@ethersproject/bignumber": {
       "packages": {
         "@ethersproject/bytes": true,
-        "bn.js": true,
-        "ethers>@ethersproject/logger": true
+        "ethers>@ethersproject/logger": true,
+        "bn.js": true
       }
     },
     "@ethersproject/bytes": {
       "packages": {
         "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/constants": {
+      "packages": {
+        "@ethersproject/bignumber": true
       }
     },
     "@ethersproject/contracts": {
@@ -259,11 +220,11 @@
       },
       "packages": {
         "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/transactions": true
@@ -271,10 +232,10 @@
     },
     "@ethersproject/hash": {
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
@@ -283,9 +244,9 @@
     },
     "@ethersproject/hdnode": {
       "packages": {
+        "ethers>@ethersproject/basex": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/bytes": true,
-        "ethers>@ethersproject/basex": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/pbkdf2": true,
         "ethers>@ethersproject/properties": true,
@@ -294,6 +255,54 @@
         "ethers>@ethersproject/strings": true,
         "ethers>@ethersproject/transactions": true,
         "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets": {
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bytes": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/pbkdf2": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/json-wallets>aes-js": true,
+        "ethers>@ethersproject/json-wallets>scrypt-js": true
+      }
+    },
+    "ethers>@ethersproject/keccak256": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "@metamask/ethjs>js-sha3": true
+      }
+    },
+    "ethers>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "ethers>@ethersproject/providers>@ethersproject/networks": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "@metamask/test-bundler>@ethersproject/networks": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/pbkdf2": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/sha2": true
+      }
+    },
+    "ethers>@ethersproject/properties": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
       }
     },
     "@ethersproject/providers": {
@@ -307,29 +316,140 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/providers>@ethersproject/web": true,
-        "@ethersproject/providers>bech32": true,
-        "@metamask/test-bundler>@ethersproject/networks": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
         "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
         "ethers>@ethersproject/logger": true,
+        "@metamask/test-bundler>@ethersproject/networks": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/random": true,
         "ethers>@ethersproject/sha2": true,
         "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
+        "ethers>@ethersproject/transactions": true,
+        "@ethersproject/providers>@ethersproject/web": true,
+        "@ethersproject/providers>bech32": true
+      }
+    },
+    "ethers>@ethersproject/providers": {
+      "globals": {
+        "WebSocket": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "console.warn": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethers>@ethersproject/abstract-provider": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/providers>@ethersproject/networks": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/providers>bech32": true
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
+      }
+    },
+    "ethers>@ethersproject/random": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/rlp": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/sha2": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/sha2>hash.js": true
+      }
+    },
+    "ethers>@ethersproject/signing-key": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "ethers>@ethersproject/solidity": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/strings": true
+      }
+    },
+    "ethers>@ethersproject/strings": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/transactions": {
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/signing-key": true
+      }
+    },
+    "ethers>@ethersproject/units": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "@ethersproject/wallet": {
+      "packages": {
+        "ethers>@ethersproject/abstract-provider": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bytes": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/transactions": true
       }
     },
     "@ethersproject/providers>@ethersproject/web": {
@@ -339,1486 +459,48 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/strings": true
       }
     },
-    "@ethersproject/wallet": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "ethers>@ethersproject/abstract-provider": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "@keystonehq/bc-ur-registry-eth": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "uuid": true
-      }
-    },
-    "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": {
+    "ethers>@ethersproject/providers>@ethersproject/web": {
       "globals": {
-        "define": true
-      },
-      "packages": {
-        "@ngraveio/bc-ur": true,
-        "@swc/helpers>tslib": true,
-        "browserify>buffer": true,
-        "buffer": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring": {
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@keystonehq/bc-ur-registry-eth": true,
-        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": true,
-        "@metamask/obs-store": true,
-        "browserify>buffer": true,
-        "ethereumjs-util>rlp": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": {
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@keystonehq/bc-ur-registry-eth": true,
-        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "uuid": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@lavamoat/lavadome-react": {
-      "globals": {
-        "Document.prototype": true,
-        "DocumentFragment.prototype": true,
-        "Element.prototype": true,
-        "Node.prototype": true,
-        "console.warn": true,
-        "document": true
-      },
-      "packages": {
-        "react": true
-      }
-    },
-    "@material-ui/core": {
-      "globals": {
-        "Image": true,
-        "_formatMuiErrorMessage": true,
-        "addEventListener": true,
-        "clearInterval": true,
         "clearTimeout": true,
-        "console.error": true,
-        "console.warn": true,
-        "document": true,
-        "getComputedStyle": true,
-        "getSelection": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "matchMedia": true,
-        "navigator": true,
-        "performance.now": true,
-        "removeEventListener": true,
-        "requestAnimationFrame": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles": true,
-        "@material-ui/core>@material-ui/system": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "@material-ui/core>clsx": true,
-        "@material-ui/core>popper.js": true,
-        "@material-ui/core>react-transition-group": true,
-        "prop-types": true,
-        "prop-types>react-is": true,
-        "react": true,
-        "react-dom": true,
-        "react-redux>hoist-non-react-statics": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true,
-        "document.createComment": true,
-        "document.head": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-global": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-nested": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-props-sort": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "@material-ui/core>clsx": true,
-        "prop-types": true,
-        "react": true,
-        "react-redux>hoist-non-react-statics": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss": {
-      "globals": {
-        "CSS": true,
-        "document.createElement": true,
-        "document.querySelector": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case>hyphenate-style-name": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": {
-      "globals": {
-        "CSS": true
-      },
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-global": {
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-nested": {
-      "packages": {
-        "@babel/runtime": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": {
-      "globals": {
-        "document.createElement": true,
-        "document.documentElement": true,
-        "getComputedStyle": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss>is-in-browser": {
-      "globals": {
-        "document": true
-      }
-    },
-    "@material-ui/core>@material-ui/system": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "prop-types": true
-      }
-    },
-    "@material-ui/core>@material-ui/utils": {
-      "packages": {
-        "@babel/runtime": true,
-        "prop-types": true,
-        "prop-types>react-is": true
-      }
-    },
-    "@material-ui/core>popper.js": {
-      "globals": {
-        "MSInputMethodContext": true,
-        "Node.DOCUMENT_POSITION_FOLLOWING": true,
-        "cancelAnimationFrame": true,
-        "console.warn": true,
-        "define": true,
-        "devicePixelRatio": true,
-        "document": true,
-        "getComputedStyle": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "navigator": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
-      }
-    },
-    "@material-ui/core>react-transition-group": {
-      "globals": {
-        "Element": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@material-ui/core>react-transition-group>dom-helpers": true,
-        "prop-types": true,
-        "react": true,
-        "react-dom": true
-      }
-    },
-    "@material-ui/core>react-transition-group>dom-helpers": {
-      "packages": {
-        "@babel/runtime": true
-      }
-    },
-    "@metamask/abi-utils": {
-      "packages": {
-        "@metamask/abi-utils>@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/abi-utils>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/accounts-controller": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/base-controller": true,
-        "@metamask/eth-snap-keyring": true,
-        "@metamask/keyring-api": true,
-        "@metamask/keyring-controller": true,
-        "@metamask/utils": true,
-        "uuid": true
-      }
-    },
-    "@metamask/address-book-controller": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true
-      }
-    },
-    "@metamask/announcement-controller": {
-      "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/approval-controller": {
-      "globals": {
-        "console.info": true
-      },
-      "packages": {
-        "@metamask/approval-controller>nanoid": true,
-        "@metamask/base-controller": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/approval-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/assets-controllers": {
-      "globals": {
-        "AbortController": true,
-        "Headers": true,
-        "URL": true,
-        "URLSearchParams": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "console.log": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/providers": true,
-        "@metamask/abi-utils": true,
-        "@metamask/base-controller": true,
-        "@metamask/contract-metadata": true,
-        "@metamask/controller-utils": true,
-        "@metamask/eth-query": true,
-        "@metamask/metamask-eth-abis": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/polling-controller": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "bn.js": true,
-        "cockatiel": true,
-        "ethers>@ethersproject/address": true,
-        "lodash": true,
-        "single-call-balance-checker-abi": true,
-        "uuid": true
-      }
-    },
-    "@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/browser-passworder": {
-      "globals": {
-        "CryptoKey": true,
-        "btoa": true,
-        "crypto.getRandomValues": true,
-        "crypto.subtle.decrypt": true,
-        "crypto.subtle.deriveKey": true,
-        "crypto.subtle.encrypt": true,
-        "crypto.subtle.exportKey": true,
-        "crypto.subtle.importKey": true
-      },
-      "packages": {
-        "@metamask/browser-passworder>@metamask/utils": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/browser-passworder>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/controller-utils": {
-      "globals": {
-        "URL": true,
-        "console.error": true,
         "fetch": true,
         "setTimeout": true
       },
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/controller-utils>@spruceid/siwe-parser": true,
-        "@metamask/ethjs>@metamask/ethjs-unit": true,
-        "@metamask/utils": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "eslint>fast-deep-equal": true,
-        "eth-ens-namehash": true
-      }
-    },
-    "@metamask/controller-utils>@spruceid/siwe-parser": {
-      "globals": {
-        "console.error": true,
-        "console.log": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/controllers>web3": {
-      "globals": {
-        "XMLHttpRequest": true
-      }
-    },
-    "@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch": {
-      "globals": {
-        "fetch": true
-      }
-    },
-    "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
-      "globals": {
-        "fetch": true
-      }
-    },
-    "@metamask/ens-controller": {
-      "packages": {
-        "@ethersproject/providers": true,
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/utils": true,
-        "punycode": true
-      }
-    },
-    "@metamask/eth-json-rpc-filters": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/safe-event-emitter": true,
-        "pify": true
-      }
-    },
-    "@metamask/eth-json-rpc-middleware": {
-      "globals": {
-        "URL": true,
-        "console.error": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-json-rpc-middleware>@metamask/utils": true,
-        "@metamask/eth-json-rpc-middleware>klona": true,
-        "@metamask/eth-json-rpc-middleware>safe-stable-stringify": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/eth-json-rpc-middleware>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-json-rpc-provider": {
-      "packages": {
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/safe-event-emitter": true,
-        "uuid": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring": {
-      "globals": {
-        "addEventListener": true,
-        "console.error": true,
-        "document.createElement": true,
-        "document.head.appendChild": true,
-        "fetch": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@ethersproject/abi": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": true,
-        "browserify>buffer": true,
-        "ethers>@ethersproject/rlp": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
-      "packages": {
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": {
-      "globals": {
-        "console.warn": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
-      "packages": {
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": true,
-        "@metamask/ppom-validator>crypto-js": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "wait-on>rxjs": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": {
-      "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "@ethersproject/providers": true,
-        "@ethersproject/providers>@ethersproject/web": true,
-        "@ethersproject/wallet": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/solidity": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true,
-        "ethers>@ethersproject/units": true,
-        "ethers>@ethersproject/wordlists": true
+        "ethers>@ethersproject/strings": true
       }
     },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": {
-      "globals": {
-        "__ledgerLogsListen": "write",
-        "console.error": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "@metamask/eth-query": {
-      "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "watchify>xtend": true
-      }
-    },
-    "@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-sig-util>tweetnacl": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true,
-        "nacl": "write"
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/eth-snap-keyring": {
-      "globals": {
-        "URL": true,
-        "console.error": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@metamask/eth-snap-keyring>@metamask/eth-sig-util": true,
-        "@metamask/eth-snap-keyring>@metamask/utils": true,
-        "@metamask/eth-snap-keyring>uuid": true,
-        "@metamask/keyring-api": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-snap-keyring>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/eth-snap-keyring>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/eth-snap-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-snap-keyring>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "@metamask/eth-token-tracker": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@metamask/eth-token-tracker>@metamask/eth-block-tracker": true,
-        "@metamask/eth-token-tracker>deep-equal": true,
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true,
-        "@metamask/safe-event-emitter": true,
-        "bn.js": true,
-        "human-standard-token-abi": true
-      }
-    },
-    "@metamask/eth-token-tracker>@metamask/eth-block-tracker": {
+    "ethers>@ethersproject/web": {
       "globals": {
         "clearTimeout": true,
-        "console.error": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": true,
-        "@metamask/safe-event-emitter": true,
-        "pify": true
-      }
-    },
-    "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator": true,
-        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection": true,
-        "@ngraveio/bc-ur>assert>object-is": true,
-        "browserify>util>is-arguments": true,
-        "browserify>util>which-typed-array": true,
-        "gulp>vinyl-fs>object.assign": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>array-buffer-byte-length": true,
-        "string.prototype.matchall>es-abstract>is-array-buffer": true,
-        "string.prototype.matchall>es-abstract>is-regex": true,
-        "string.prototype.matchall>es-abstract>is-shared-array-buffer": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>regexp.prototype.flags": true,
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>es-get-iterator": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": true,
-        "browserify>util>is-arguments": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "process": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": {
-      "globals": {
-        "StopIteration": true
-      },
-      "packages": {
-        "string.prototype.matchall>internal-slot": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>unbox-primitive>has-bigints": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-collection": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakmap": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "@metamask/eth-trezor-keyring": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "@trezor/connect-web": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": {
-      "packages": {
-        "@metamask/eth-sig-util": true,
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/eth-trezor-keyring>hdkey": {
-      "packages": {
-        "browserify>assert": true,
-        "crypto-browserify": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ganache>secp256k1": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@metamask/etherscan-link": {
-      "globals": {
-        "URL": true
-      }
-    },
-    "@metamask/ethjs": {
-      "globals": {
-        "clearInterval": true,
-        "setInterval": true
-      },
-      "packages": {
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true,
-        "@metamask/ethjs>@metamask/ethjs-filter": true,
-        "@metamask/ethjs>@metamask/ethjs-provider-http": true,
-        "@metamask/ethjs>@metamask/ethjs-unit": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>@metamask/number-to-bn": true,
-        "@metamask/ethjs>ethjs-abi": true,
-        "@metamask/ethjs>js-sha3": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs-contract": {
-      "packages": {
-        "@babel/runtime": true,
-        "@metamask/ethjs>@metamask/ethjs-filter": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>ethjs-abi": true,
-        "@metamask/ethjs>js-sha3": true,
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs-query": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@metamask/ethjs-query>@metamask/ethjs-format": true,
-        "@metamask/ethjs-query>@metamask/ethjs-rpc": true,
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs-query>@metamask/ethjs-format": {
-      "packages": {
-        "@metamask/ethjs-query>@metamask/ethjs-format>ethjs-schema": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "@metamask/ethjs>@metamask/number-to-bn": true
-      }
-    },
-    "@metamask/ethjs-query>@metamask/ethjs-rpc": {
-      "packages": {
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-filter": {
-      "globals": {
-        "clearInterval": true,
-        "setInterval": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-provider-http": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": {
-      "globals": {
-        "XMLHttpRequest": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-unit": {
-      "packages": {
-        "@metamask/ethjs>@metamask/number-to-bn": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-util": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true,
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true
-      }
-    },
-    "@metamask/ethjs>@metamask/number-to-bn": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>ethjs-abi": {
-      "packages": {
-        "@metamask/ethjs>ethjs-abi>number-to-bn": true,
-        "@metamask/ethjs>js-sha3": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs>ethjs-abi>number-to-bn": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>js-sha3": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "process": true
-      }
-    },
-    "@metamask/gas-fee-controller": {
-      "globals": {
-        "clearInterval": true,
-        "console.error": true,
-        "setInterval": true
-      },
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/eth-query": true,
-        "@metamask/polling-controller": true,
-        "bn.js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/jazzicon": {
-      "globals": {
-        "document.createElement": true,
-        "document.createElementNS": true
-      },
-      "packages": {
-        "@metamask/jazzicon>color": true,
-        "@metamask/jazzicon>mersenne-twister": true
-      }
-    },
-    "@metamask/jazzicon>color": {
-      "packages": {
-        "@metamask/jazzicon>color>clone": true,
-        "@metamask/jazzicon>color>color-convert": true,
-        "@metamask/jazzicon>color>color-string": true
-      }
-    },
-    "@metamask/jazzicon>color>clone": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/jazzicon>color>color-convert": {
-      "packages": {
-        "@metamask/jazzicon>color>color-convert>color-name": true
-      }
-    },
-    "@metamask/jazzicon>color>color-string": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
-      }
-    },
-    "@metamask/json-rpc-engine": {
-      "packages": {
-        "@metamask/rpc-errors": true,
-        "@metamask/safe-event-emitter": true,
-        "@metamask/utils": true
-      }
-    },
-    "@metamask/json-rpc-middleware-stream": {
-      "globals": {
-        "console.warn": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/safe-event-emitter": true,
-        "@metamask/utils": true,
-        "readable-stream": true
-      }
-    },
-    "@metamask/keyring-api": {
-      "globals": {
-        "URL": true
-      },
-      "packages": {
-        "@metamask/keyring-api>@metamask/utils": true,
-        "@metamask/keyring-api>bech32": true,
-        "@metamask/keyring-api>uuid": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/keyring-api>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-api>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "@metamask/keyring-controller": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/base-controller": true,
-        "@metamask/browser-passworder": true,
-        "@metamask/keyring-controller>@metamask/eth-hd-keyring": true,
-        "@metamask/keyring-controller>@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
-        "@metamask/keyring-controller>ethereumjs-wallet": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/utils": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-hd-keyring": {
-      "globals": {
-        "TextEncoder": true
-      },
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": true,
-        "@metamask/scure-bip39": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-simple-keyring": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": true,
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet": {
-      "packages": {
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": true,
-        "@metamask/keyring-controller>ethereumjs-wallet>utf8": true,
-        "browserify>buffer": true,
-        "crypto-browserify": true,
-        "crypto-browserify>randombytes": true,
-        "eth-lattice-keyring>gridplus-sdk>aes-js": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ethers>@ethersproject/json-wallets>scrypt-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": {
-      "packages": {
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "crypto-browserify>create-hmac": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ethereumjs-util>ethereum-cryptography>keccak": true,
-        "ethers>@ethersproject/sha2>hash.js": true,
-        "ganache>secp256k1": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": {
-      "packages": {
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
-        "bn.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>rlp": true
-      }
-    },
-    "@metamask/logging-controller": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "uuid": true
-      }
-    },
-    "@metamask/logo": {
-      "globals": {
-        "addEventListener": true,
-        "document.body.appendChild": true,
-        "document.createElementNS": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "requestAnimationFrame": true
-      },
-      "packages": {
-        "@metamask/logo>gl-mat4": true,
-        "@metamask/logo>gl-vec3": true
-      }
-    },
-    "@metamask/message-manager": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/utils": true,
-        "browserify>buffer": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/message-manager>jsonschema": {
-      "packages": {
-        "browserify>url": true
-      }
-    },
-    "@metamask/name-controller": {
-      "globals": {
-        "fetch": true
-      },
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/name-controller>@metamask/base-controller": true,
-        "@metamask/name-controller>@metamask/utils": true,
-        "@metamask/name-controller>async-mutex": true
-      }
-    },
-    "@metamask/name-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/name-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/name-controller>async-mutex": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/network-controller": {
-      "globals": {
-        "btoa": true,
         "fetch": true,
         "setTimeout": true
       },
       "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/network-controller>reselect": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "eslint>fast-deep-equal": true,
-        "uri-js": true,
-        "uuid": true
+        "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
       }
     },
-    "@metamask/network-controller>@metamask/eth-block-tracker": {
-      "globals": {
-        "clearTimeout": true,
-        "console.error": true,
-        "setTimeout": true
-      },
+    "ethers>@ethersproject/wordlists": {
       "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": true,
-        "@metamask/safe-event-emitter": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-json-rpc-infura": {
-      "globals": {
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/network-controller>reselect": {
-      "globals": {
-        "WeakRef": true,
-        "console.warn": true,
-        "unstable_autotrackMemoize": true
-      }
-    },
-    "@metamask/notification-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/notification-services-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "addEventListener": true,
-        "fetch": true,
-        "registration": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": true,
-        "@metamask/notification-services-controller>bignumber.js": true,
-        "@metamask/notification-services-controller>firebase": true,
-        "@metamask/profile-sync-controller": true,
-        "@metamask/utils": true,
-        "loglevel": true,
-        "uuid": true
-      }
-    },
-    "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": {
-      "globals": {
-        "SuppressedError": true
-      }
-    },
-    "@metamask/notification-services-controller>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase": {
-      "packages": {
-        "@metamask/notification-services-controller>firebase>@firebase/app": true,
-        "@metamask/notification-services-controller>firebase>@firebase/messaging": true
+        "@ethersproject/bytes": true,
+        "@ethersproject/hash": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/app": {
@@ -1829,34 +511,13 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": {
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/util": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>idb": {
-      "globals": {
-        "DOMException": true,
-        "IDBCursor": true,
-        "IDBDatabase": true,
-        "IDBIndex": true,
-        "IDBObjectStore": true,
-        "IDBRequest": true,
-        "IDBTransaction": true,
-        "indexedDB.deleteDatabase": true,
-        "indexedDB.open": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/installations": {
@@ -1874,8 +535,16 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/messaging": {
@@ -1906,9 +575,9 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
         "@metamask/notification-services-controller>firebase>@firebase/installations": true,
         "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
         "@swc/helpers>tslib": true
       }
     },
@@ -1930,6 +599,820 @@
         "process": true
       }
     },
+    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@keystonehq/bc-ur-registry-eth": true,
+        "browserify>buffer": true,
+        "@metamask/eth-trezor-keyring>hdkey": true,
+        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": true,
+        "uuid": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": true,
+        "browserify>buffer": true,
+        "@metamask/eth-trezor-keyring>hdkey": true,
+        "uuid": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "@ngraveio/bc-ur": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "buffer": true,
+        "browserify>buffer": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@keystonehq/metamask-airgapped-keyring": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": true,
+        "@keystonehq/bc-ur-registry-eth": true,
+        "@metamask/obs-store": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "ethereumjs-util>rlp": true,
+        "uuid": true
+      }
+    },
+    "chart.js>@kurkle/color": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@lavamoat/lavadome-react": {
+      "globals": {
+        "Document.prototype": true,
+        "DocumentFragment.prototype": true,
+        "Element.prototype": true,
+        "Node.prototype": true,
+        "console.warn": true,
+        "document": true
+      },
+      "packages": {
+        "react": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": true,
+        "@metamask/ppom-validator>crypto-js": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/rlp": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": true,
+        "browserify>buffer": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "wait-on>rxjs": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": {
+      "globals": {
+        "__ledgerLogsListen": "write",
+        "console.error": true
+      }
+    },
+    "@material-ui/core": {
+      "globals": {
+        "Image": true,
+        "_formatMuiErrorMessage": true,
+        "addEventListener": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "getSelection": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "matchMedia": true,
+        "navigator": true,
+        "performance.now": true,
+        "removeEventListener": true,
+        "requestAnimationFrame": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles": true,
+        "@material-ui/core>@material-ui/system": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
+        "@material-ui/core>popper.js": true,
+        "prop-types": true,
+        "react": true,
+        "react-dom": true,
+        "prop-types>react-is": true,
+        "@material-ui/core>react-transition-group": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true,
+        "document.createComment": true,
+        "document.head": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-global": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-nested": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-props-sort": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": true,
+        "@material-ui/core>@material-ui/styles>jss": true,
+        "prop-types": true,
+        "react": true
+      }
+    },
+    "@material-ui/core>@material-ui/system": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "prop-types": true
+      }
+    },
+    "@material-ui/core>@material-ui/utils": {
+      "packages": {
+        "@babel/runtime": true,
+        "prop-types": true,
+        "prop-types>react-is": true
+      }
+    },
+    "@metamask/abi-utils": {
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/abi-utils>@metamask/utils": true
+      }
+    },
+    "@metamask/accounts-controller": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-snap-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "uuid": true
+      }
+    },
+    "@metamask/address-book-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
+    "@metamask/announcement-controller": {
+      "packages": {
+        "@metamask/announcement-controller>@metamask/base-controller": true
+      }
+    },
+    "@metamask/approval-controller": {
+      "globals": {
+        "console.info": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/approval-controller>nanoid": true
+      }
+    },
+    "@metamask/assets-controllers": {
+      "globals": {
+        "AbortController": true,
+        "Headers": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "console.log": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/abi-utils": true,
+        "@metamask/base-controller": true,
+        "@metamask/contract-metadata": true,
+        "@metamask/controller-utils": true,
+        "@metamask/eth-query": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/polling-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
+        "bn.js": true,
+        "cockatiel": true,
+        "lodash": true,
+        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true,
+        "single-call-balance-checker-abi": true,
+        "uuid": true
+      }
+    },
+    "@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/announcement-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/name-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/browser-passworder": {
+      "globals": {
+        "CryptoKey": true,
+        "btoa": true,
+        "crypto.getRandomValues": true,
+        "crypto.subtle.decrypt": true,
+        "crypto.subtle.deriveKey": true,
+        "crypto.subtle.encrypt": true,
+        "crypto.subtle.exportKey": true,
+        "crypto.subtle.importKey": true
+      },
+      "packages": {
+        "@metamask/browser-passworder>@metamask/utils": true,
+        "browserify>buffer": true
+      }
+    },
+    "eth-keyring-controller>@metamask/browser-passworder": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/controller-utils": {
+      "globals": {
+        "URL": true,
+        "console.error": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/ethjs>@metamask/ethjs-unit": true,
+        "@metamask/utils": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "eth-ens-namehash": true,
+        "eslint>fast-deep-equal": true
+      }
+    },
+    "@metamask/ens-controller": {
+      "packages": {
+        "@ethersproject/providers": true,
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/utils": true,
+        "punycode": true
+      }
+    },
+    "@metamask/eth-token-tracker>@metamask/eth-block-tracker": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": true,
+        "@metamask/eth-query>json-rpc-random-id": true,
+        "pify": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-block-tracker": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": true,
+        "@metamask/eth-query>json-rpc-random-id": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-hd-keyring": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "@metamask/eth-json-rpc-filters": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/safe-event-emitter": true,
+        "@metamask/name-controller>async-mutex": true,
+        "pify": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-json-rpc-infura": {
+      "globals": {
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": true
+      }
+    },
+    "@metamask/eth-json-rpc-middleware": {
+      "globals": {
+        "URL": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/eth-sig-util": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/eth-json-rpc-middleware>@metamask/utils": true,
+        "@metamask/eth-json-rpc-middleware>klona": true,
+        "@metamask/eth-json-rpc-middleware>safe-stable-stringify": true
+      }
+    },
+    "@metamask/eth-json-rpc-provider": {
+      "packages": {
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/safe-event-emitter": true,
+        "uuid": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring": {
+      "globals": {
+        "addEventListener": true,
+        "console.error": true,
+        "document.createElement": true,
+        "document.head.appendChild": true,
+        "fetch": true,
+        "removeEventListener": true
+      },
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": true,
+        "@metamask/eth-sig-util": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "@metamask/eth-trezor-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-query": {
+      "packages": {
+        "@metamask/eth-query>json-rpc-random-id": true,
+        "watchify>xtend": true
+      }
+    },
+    "@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/eth-snap-keyring>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/eth-snap-keyring>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/signature-controller>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-simple-keyring": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "@metamask/eth-snap-keyring": {
+      "globals": {
+        "URL": true,
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-snap-keyring>@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/eth-snap-keyring>@metamask/utils": true,
+        "webpack>events": true,
+        "@metamask/eth-snap-keyring>uuid": true
+      }
+    },
+    "@metamask/eth-token-tracker": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@metamask/eth-token-tracker>@metamask/eth-block-tracker": true,
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs-query": true,
+        "@metamask/safe-event-emitter": true,
+        "bn.js": true,
+        "@metamask/eth-token-tracker>deep-equal": true,
+        "human-standard-token-abi": true
+      }
+    },
+    "@metamask/eth-trezor-keyring": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": true,
+        "@trezor/connect-web": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "@metamask/eth-trezor-keyring>hdkey": true
+      }
+    },
+    "@metamask/etherscan-link": {
+      "globals": {
+        "URL": true
+      }
+    },
+    "@metamask/ethjs": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs>@metamask/ethjs-filter": true,
+        "@metamask/ethjs>@metamask/ethjs-provider-http": true,
+        "@metamask/ethjs-query": true,
+        "@metamask/ethjs>@metamask/ethjs-unit": true,
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ethjs>ethjs-abi": true,
+        "@metamask/ethjs>js-sha3": true
+      }
+    },
+    "@metamask/ethjs-contract": {
+      "packages": {
+        "@babel/runtime": true,
+        "@metamask/ethjs>@metamask/ethjs-filter": true,
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>ethjs-abi": true,
+        "@metamask/ethjs>js-sha3": true,
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-filter": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      }
+    },
+    "@metamask/ethjs-query>@metamask/ethjs-format": {
+      "packages": {
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "@metamask/ethjs-query>@metamask/ethjs-format>ethjs-schema": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-provider-http": {
+      "packages": {
+        "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": true
+      }
+    },
+    "@metamask/ethjs-query": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@metamask/ethjs-query>@metamask/ethjs-format": true,
+        "@metamask/ethjs-query>@metamask/ethjs-rpc": true,
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs-query>@metamask/ethjs-rpc": {
+      "packages": {
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-unit": {
+      "packages": {
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "bn.js": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-util": {
+      "packages": {
+        "browserify>buffer": true,
+        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "@metamask/gas-fee-controller": {
+      "globals": {
+        "clearInterval": true,
+        "console.error": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@metamask/controller-utils": true,
+        "@metamask/eth-query": true,
+        "@metamask/polling-controller": true,
+        "bn.js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/jazzicon": {
+      "globals": {
+        "document.createElement": true,
+        "document.createElementNS": true
+      },
+      "packages": {
+        "@metamask/jazzicon>color": true,
+        "@metamask/jazzicon>mersenne-twister": true
+      }
+    },
+    "@metamask/json-rpc-engine": {
+      "packages": {
+        "@metamask/rpc-errors": true,
+        "@metamask/safe-event-emitter": true,
+        "@metamask/utils": true
+      }
+    },
+    "@metamask/json-rpc-middleware-stream": {
+      "globals": {
+        "console.warn": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/utils": true,
+        "readable-stream": true
+      }
+    },
+    "@metamask/snaps-sdk>@metamask/key-tree": {
+      "globals": {
+        "crypto.subtle": true
+      },
+      "packages": {
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true
+      }
+    },
+    "@metamask/keyring-api": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/keyring-api>@metamask/utils": true,
+        "@metamask/keyring-api>bech32": true,
+        "@metamask/keyring-api>uuid": true
+      }
+    },
+    "@metamask/keyring-controller": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/browser-passworder": true,
+        "@metamask/keyring-controller>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-controller>@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true
+      }
+    },
+    "@metamask/logging-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "uuid": true
+      }
+    },
+    "@metamask/logo": {
+      "globals": {
+        "addEventListener": true,
+        "document.body.appendChild": true,
+        "document.createElementNS": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "requestAnimationFrame": true
+      },
+      "packages": {
+        "@metamask/logo>gl-mat4": true,
+        "@metamask/logo>gl-vec3": true
+      }
+    },
+    "@metamask/message-manager": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/utils": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "uuid": true
+      }
+    },
+    "@metamask/name-controller": {
+      "globals": {
+        "fetch": true
+      },
+      "packages": {
+        "@metamask/name-controller>@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/name-controller>@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true
+      }
+    },
+    "@metamask/network-controller": {
+      "globals": {
+        "btoa": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "eslint>fast-deep-equal": true,
+        "@metamask/network-controller>reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/nonce-tracker": {
+      "packages": {
+        "@ethersproject/providers": true,
+        "browserify>assert": true,
+        "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": true
+      }
+    },
+    "@metamask/notification-services-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "addEventListener": true,
+        "fetch": true,
+        "registration": true,
+        "removeEventListener": true
+      },
+      "packages": {
+        "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": true,
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/profile-sync-controller": true,
+        "@metamask/utils": true,
+        "@metamask/notification-services-controller>bignumber.js": true,
+        "@metamask/notification-services-controller>firebase": true,
+        "loglevel": true,
+        "uuid": true
+      }
+    },
+    "@metamask/ethjs>@metamask/number-to-bn": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
     "@metamask/object-multiplex": {
       "globals": {
         "console.warn": true
@@ -1937,11 +1420,6 @@
       "packages": {
         "@metamask/object-multiplex>once": true,
         "readable-stream": true
-      }
-    },
-    "@metamask/object-multiplex>once": {
-      "packages": {
-        "@metamask/object-multiplex>once>wrappy": true
       }
     },
     "@metamask/obs-store": {
@@ -1958,37 +1436,17 @@
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/json-rpc-engine": true,
-        "@metamask/permission-controller>nanoid": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "deep-freeze-strict": true,
-        "immer": true
-      }
-    },
-    "@metamask/permission-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+        "immer": true,
+        "@metamask/permission-controller>nanoid": true
       }
     },
     "@metamask/permission-log-controller": {
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/permission-log-controller>@metamask/utils": true
-      }
-    },
-    "@metamask/permission-log-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
       }
     },
     "@metamask/phishing-controller": {
@@ -1999,12 +1457,12 @@
         "fetch": true
       },
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
         "@noble/hashes": true,
-        "punycode": true,
-        "webpack-cli>fastest-levenshtein": true
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack-cli>fastest-levenshtein": true,
+        "punycode": true
       }
     },
     "@metamask/polling-controller": {
@@ -2035,21 +1493,6 @@
         "readable-stream": true
       }
     },
-    "@metamask/post-message-stream>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
     "@metamask/ppom-validator": {
       "globals": {
         "URL": true,
@@ -2059,48 +1502,11 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
-        "@metamask/eth-query>json-rpc-random-id": true,
+        "await-semaphore": true,
+        "browserify>buffer": true,
         "@metamask/ppom-validator>crypto-js": true,
         "@metamask/ppom-validator>elliptic": true,
-        "await-semaphore": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ppom-validator>crypto-js": {
-      "globals": {
-        "crypto": true,
-        "define": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>brorand": true,
-        "@metamask/ppom-validator>elliptic>hmac-drbg": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true,
-        "bn.js": true,
-        "ethers>@ethersproject/sha2>hash.js": true,
-        "pumpify>inherits": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic>brorand": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic>hmac-drbg": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true,
-        "ethers>@ethersproject/sha2>hash.js": true
+        "@metamask/eth-query>json-rpc-random-id": true
       }
     },
     "@metamask/preferences-controller": {
@@ -2129,55 +1535,10 @@
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
         "@metamask/profile-sync-controller>@noble/ciphers": true,
-        "@metamask/profile-sync-controller>siwe": true,
         "@noble/hashes": true,
         "browserify>buffer": true,
-        "loglevel": true
-      }
-    },
-    "@metamask/profile-sync-controller>@noble/ciphers": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>valid-url": true,
-        "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": true,
-        "@metamask/profile-sync-controller>siwe>@stablelib/random": true,
-        "ethers": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": {
-      "globals": {
-        "console.error": true,
-        "console.log": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@stablelib/random": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": true,
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true,
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": {
-      "packages": {
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary>@stablelib/int": true
+        "loglevel": true,
+        "@metamask/profile-sync-controller>siwe": true
       }
     },
     "@metamask/queued-request-controller": {
@@ -2199,50 +1560,6 @@
         "@metamask/rate-limit-controller>@metamask/utils": true
       }
     },
-    "@metamask/rate-limit-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/rpc-errors": {
-      "packages": {
-        "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": true,
-        "@metamask/rpc-errors>fast-safe-stringify": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
     "@metamask/remote-feature-flag-controller": {
       "packages": {
         "@metamask/base-controller": true,
@@ -2251,18 +1568,14 @@
     },
     "@metamask/rpc-errors": {
       "packages": {
-        "@metamask/rpc-errors>fast-safe-stringify": true,
-        "@metamask/utils": true
+        "@metamask/utils": true,
+        "@metamask/rpc-errors>fast-safe-stringify": true
       }
     },
-    "@metamask/rpc-methods-flask>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/rpc-methods>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+    "@metamask/rate-limit-controller>@metamask/rpc-errors": {
+      "packages": {
+        "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": true,
+        "@metamask/rpc-errors>fast-safe-stringify": true
       }
     },
     "@metamask/safe-event-emitter": {
@@ -2282,12 +1595,6 @@
         "@metamask/utils>@scure/base": true
       }
     },
-    "@metamask/scure-bip39>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
     "@metamask/selected-network-controller": {
       "packages": {
         "@metamask/base-controller": true,
@@ -2301,40 +1608,14 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/signature-controller>@metamask/eth-sig-util": true,
         "@metamask/keyring-controller": true,
         "@metamask/logging-controller": true,
-        "@metamask/message-manager>jsonschema": true,
-        "@metamask/signature-controller>@metamask/eth-sig-util": true,
         "@metamask/utils": true,
         "browserify>buffer": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/signature-controller>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
+        "webpack>events": true,
+        "@metamask/message-manager>jsonschema": true,
+        "uuid": true
       }
     },
     "@metamask/smart-transactions-controller": {
@@ -2347,47 +1628,17 @@
         "setInterval": true
       },
       "packages": {
+        "@metamask/smart-transactions-controller>@ethereumjs/tx": true,
+        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
         "@ethersproject/bytes": true,
         "@metamask/controller-utils": true,
         "@metamask/eth-query": true,
         "@metamask/polling-controller": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/tx": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
-        "@metamask/smart-transactions-controller>bignumber.js": true,
         "@metamask/transaction-controller": true,
+        "@metamask/smart-transactions-controller>bignumber.js": true,
         "browserify>buffer": true,
         "fast-json-patch": true,
         "lodash": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@ethereumjs/tx": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
-        "@trezor/connect-web>@trezor/connect>@ethereumjs/common": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@metamask/controllers>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/smart-transactions-controller>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
       }
     },
     "@metamask/snaps-controllers": {
@@ -2407,72 +1658,22 @@
         "@metamask/permission-controller": true,
         "@metamask/post-message-stream": true,
         "@metamask/rpc-errors": true,
-        "@metamask/snaps-controllers>@xstate/fsm": true,
-        "@metamask/snaps-controllers>concat-stream": true,
-        "@metamask/snaps-controllers>get-npm-tarball-url": true,
-        "@metamask/snaps-controllers>nanoid": true,
-        "@metamask/snaps-controllers>readable-web-to-node-stream": true,
-        "@metamask/snaps-controllers>tar-stream": true,
+        "@metamask/snaps-utils>@metamask/snaps-registry": true,
         "@metamask/snaps-rpc-methods": true,
         "@metamask/snaps-sdk": true,
         "@metamask/snaps-utils": true,
-        "@metamask/snaps-utils>@metamask/snaps-registry": true,
         "@metamask/utils": true,
+        "@metamask/snaps-controllers>@xstate/fsm": true,
         "browserify>browserify-zlib": true,
+        "@metamask/snaps-controllers>concat-stream": true,
         "eslint>fast-deep-equal": true,
+        "@metamask/snaps-controllers>get-npm-tarball-url": true,
         "immer": true,
+        "@metamask/snaps-controllers>nanoid": true,
         "readable-stream": true,
-        "semver": true
-      }
-    },
-    "@metamask/snaps-controllers-flask>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/snaps-controllers>concat-stream": {
-      "packages": {
-        "browserify>buffer": true,
-        "browserify>concat-stream>typedarray": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
-        "terser>source-map-support>buffer-from": true
-      }
-    },
-    "@metamask/snaps-controllers>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/snaps-controllers>readable-web-to-node-stream": {
-      "packages": {
-        "readable-stream": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream": {
-      "packages": {
-        "@metamask/snaps-controllers>tar-stream>b4a": true,
-        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
-        "@metamask/snaps-controllers>tar-stream>streamx": true,
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>b4a": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>streamx": {
-      "packages": {
-        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
-        "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
-      "globals": {
-        "queueMicrotask": true
+        "@metamask/snaps-controllers>readable-web-to-node-stream": true,
+        "semver": true,
+        "@metamask/snaps-controllers>tar-stream": true
       }
     },
     "@metamask/snaps-execution-environments": {
@@ -2485,15 +1686,23 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/snaps-utils>@metamask/snaps-registry": {
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@noble/hashes": true
+      }
+    },
     "@metamask/snaps-rpc-methods": {
       "packages": {
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/permission-controller": true,
         "@metamask/rpc-errors": true,
         "@metamask/snaps-sdk": true,
-        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
-        "@metamask/utils": true,
         "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
         "@noble/hashes": true
       }
     },
@@ -2503,20 +1712,8 @@
       },
       "packages": {
         "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/snaps-sdk>@metamask/key-tree": {
-      "globals": {
-        "crypto.subtle": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/scure-bip39": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "@noble/hashes": true
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true
       }
     },
     "@metamask/snaps-utils": {
@@ -2535,74 +1732,23 @@
         "fetch": true
       },
       "packages": {
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/permission-controller": true,
         "@metamask/rpc-errors": true,
-        "@metamask/snaps-sdk": true,
-        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils>@metamask/slip44": true,
+        "@metamask/snaps-sdk": true,
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "chalk": true,
         "@metamask/snaps-utils>cron-parser": true,
         "@metamask/snaps-utils>fast-json-stable-stringify": true,
         "@metamask/snaps-utils>fast-xml-parser": true,
         "@metamask/snaps-utils>marked": true,
         "@metamask/snaps-utils>rfdc": true,
-        "@metamask/snaps-utils>validate-npm-package-name": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@noble/hashes": true,
-        "chalk": true,
-        "semver": true
-      }
-    },
-    "@metamask/snaps-utils>@metamask/snaps-registry": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/snaps-utils>cron-parser": {
-      "packages": {
-        "browserify>browser-resolve": true,
-        "luxon": true
-      }
-    },
-    "@metamask/snaps-utils>fast-xml-parser": {
-      "globals": {
-        "entityName": true,
-        "val": true
-      },
-      "packages": {
-        "@metamask/snaps-utils>fast-xml-parser>strnum": true
-      }
-    },
-    "@metamask/snaps-utils>marked": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true,
-        "define": true
-      }
-    },
-    "@metamask/snaps-utils>rfdc": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/snaps-utils>validate-npm-package-name": {
-      "packages": {
-        "@metamask/snaps-utils>validate-npm-package-name>builtins": true
-      }
-    },
-    "@metamask/snaps-utils>validate-npm-package-name>builtins": {
-      "packages": {
-        "process": true,
-        "semver": true
-      }
-    },
-    "@metamask/test-bundler>@ethersproject/networks": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
+        "semver": true,
+        "@metamask/snaps-utils>validate-npm-package-name": true
       }
     },
     "@metamask/transaction-controller": {
@@ -2613,6 +1759,7 @@
         "setTimeout": true
       },
       "packages": {
+        "@metamask/transaction-controller>@ethereumjs/common": true,
         "@ethereumjs/tx": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
         "@ethersproject/abi": true,
@@ -2623,43 +1770,18 @@
         "@metamask/eth-query": true,
         "@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/name-controller>async-mutex": true,
         "@metamask/network-controller": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/transaction-controller>@ethereumjs/common": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
         "bn.js": true,
         "browserify>buffer": true,
         "eth-method-registry": true,
+        "webpack>events": true,
         "fast-json-patch": true,
         "lodash": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/transaction-controller>@ethereumjs/common": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/nonce-tracker": {
-      "packages": {
-        "@ethersproject/providers": true,
-        "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": true,
-        "browserify>assert": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
+        "uuid": true
       }
     },
     "@metamask/user-operation-controller": {
@@ -2673,13 +1795,13 @@
         "@metamask/gas-fee-controller": true,
         "@metamask/polling-controller": true,
         "@metamask/rpc-errors": true,
+        "@metamask/utils>@metamask/superstruct": true,
         "@metamask/transaction-controller": true,
         "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
         "bn.js": true,
+        "webpack>events": true,
         "lodash": true,
-        "uuid": true,
-        "webpack>events": true
+        "uuid": true
       }
     },
     "@metamask/utils": {
@@ -2689,63 +1811,336 @@
       },
       "packages": {
         "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
         "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
         "browserify>buffer": true,
         "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
         "semver": true
       }
     },
-    "@metamask/utils>@scure/base": {
+    "@metamask/abi-utils>@metamask/utils": {
       "globals": {
         "TextDecoder": true,
         "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/browser-passworder>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-json-rpc-middleware>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-snap-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-api>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/name-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/permission-log-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
       }
     },
     "@ngraveio/bc-ur": {
       "packages": {
         "@ngraveio/bc-ur>@keystonehq/alias-sampling": true,
+        "browserify>assert": true,
         "@ngraveio/bc-ur>bignumber.js": true,
+        "browserify>buffer": true,
         "@ngraveio/bc-ur>cbor-sync": true,
         "@ngraveio/bc-ur>crc": true,
         "@ngraveio/bc-ur>jsbi": true,
-        "addons-linter>sha.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true
+        "addons-linter>sha.js": true
       }
     },
-    "@ngraveio/bc-ur>assert>object-is": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true
-      }
-    },
-    "@ngraveio/bc-ur>bignumber.js": {
+    "@metamask/profile-sync-controller>@noble/ciphers": {
       "globals": {
-        "crypto": true,
-        "define": true
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "crypto": true
       }
     },
-    "@ngraveio/bc-ur>cbor-sync": {
+    "@ethereumjs/tx>ethereum-cryptography>@noble/curves": {
       "globals": {
-        "define": true
+        "TextEncoder": true
       },
       "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ngraveio/bc-ur>crc": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ngraveio/bc-ur>jsbi": {
-      "globals": {
-        "define": true
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": true
       }
     },
     "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/scure-bip39>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -2762,6 +2157,20 @@
         "navigator.userAgent": true
       }
     },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": {
+      "globals": {
+        "console.log": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": {
+      "globals": {
+        "XMLHttpRequest": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true
+      }
+    },
     "@reduxjs/toolkit": {
       "globals": {
         "AbortController": true,
@@ -2773,42 +2182,46 @@
         "setTimeout": true
       },
       "packages": {
-        "@reduxjs/toolkit>reselect": true,
         "immer": true,
         "process": true,
         "redux": true,
-        "redux-thunk": true
+        "redux-thunk": true,
+        "@reduxjs/toolkit>reselect": true
+      }
+    },
+    "react-router-dom-v5-compat>@remix-run/router": {
+      "globals": {
+        "AbortController": true,
+        "DOMException": true,
+        "FormData": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "console": true,
+        "document.defaultView": true
+      }
+    },
+    "@metamask/utils>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": true,
+        "@metamask/utils>@scure/base": true
       }
     },
     "@segment/loosely-validate-event": {
       "packages": {
-        "@segment/loosely-validate-event>component-type": true,
-        "@segment/loosely-validate-event>join-component": true,
         "browserify>assert": true,
-        "browserify>buffer": true
-      }
-    },
-    "@sentry/browser": {
-      "globals": {
-        "PerformanceObserver.supportedEntryTypes": true,
-        "Request": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_DEBUG__": true,
-        "__SENTRY_RELEASE__": true,
-        "addEventListener": true,
-        "console.error": true,
-        "indexedDB.open": true,
-        "performance.timeOrigin": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@sentry/browser>@sentry-internal/browser-utils": true,
-        "@sentry/browser>@sentry-internal/feedback": true,
-        "@sentry/browser>@sentry-internal/replay": true,
-        "@sentry/browser>@sentry-internal/replay-canvas": true,
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "browserify>buffer": true,
+        "@segment/loosely-validate-event>component-type": true,
+        "@segment/loosely-validate-event>join-component": true
       }
     },
     "@sentry/browser>@sentry-internal/browser-utils": {
@@ -2841,6 +2254,25 @@
         "isSecureContext": true,
         "requestAnimationFrame": true,
         "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/replay-canvas": {
+      "globals": {
+        "Blob": true,
+        "HTMLCanvasElement": true,
+        "HTMLImageElement": true,
+        "ImageData": true,
+        "URL.createObjectURL": true,
+        "WeakRef": true,
+        "Worker": true,
+        "cancelAnimationFrame": true,
+        "console.error": true,
+        "createImageBitmap": true,
+        "document": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2896,21 +2328,25 @@
         "@sentry/utils": true
       }
     },
-    "@sentry/browser>@sentry-internal/replay-canvas": {
+    "@sentry/browser": {
       "globals": {
-        "Blob": true,
-        "HTMLCanvasElement": true,
-        "HTMLImageElement": true,
-        "ImageData": true,
-        "URL.createObjectURL": true,
-        "WeakRef": true,
-        "Worker": true,
-        "cancelAnimationFrame": true,
+        "PerformanceObserver.supportedEntryTypes": true,
+        "Request": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_RELEASE__": true,
+        "addEventListener": true,
         "console.error": true,
-        "createImageBitmap": true,
-        "document": true
+        "indexedDB.open": true,
+        "performance.timeOrigin": true,
+        "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/browser-utils": true,
+        "@sentry/browser>@sentry-internal/feedback": true,
+        "@sentry/browser>@sentry-internal/replay-canvas": true,
+        "@sentry/browser>@sentry-internal/replay": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
@@ -3006,20 +2442,61 @@
         "btoa": true
       }
     },
-    "@storybook/addon-docs>remark-external-links>mdast-util-definitions": {
-      "packages": {
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "@storybook/addon-knobs>qs": {
-      "packages": {
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "@swc/helpers>tslib": {
+    "@metamask/controller-utils>@spruceid/siwe-parser": {
       "globals": {
-        "SuppressedError": true,
-        "define": true
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": {
+      "globals": {
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": {
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary>@stablelib/int": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@stablelib/random": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": true,
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true,
+        "browserify>browser-resolve": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect-common": {
+      "globals": {
+        "console.warn": true,
+        "localStorage.getItem": true,
+        "localStorage.setItem": true,
+        "navigator": true,
+        "setTimeout": true,
+        "window": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": true,
+        "@trezor/connect-web>@trezor/utils": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": {
+      "packages": {
+        "@metamask/eth-sig-util": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web": {
@@ -3046,35 +2523,20 @@
         "setTimeout": true
       },
       "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect": true,
         "@trezor/connect-web>@trezor/connect-common": true,
+        "@trezor/connect-web>@trezor/connect": true,
         "@trezor/connect-web>@trezor/utils": true,
-        "webpack>events": true
+        "webpack>events": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect": {
       "packages": {
-        "@swc/helpers>tslib": true,
         "@trezor/connect-web>@trezor/connect>@trezor/protobuf": true,
         "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": true,
         "@trezor/connect-web>@trezor/connect>@trezor/transport": true,
-        "@trezor/connect-web>@trezor/utils": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect-common": {
-      "globals": {
-        "console.warn": true,
-        "localStorage.getItem": true,
-        "localStorage.setItem": true,
-        "navigator": true,
-        "setTimeout": true,
-        "window": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": true,
-        "@trezor/connect-web>@trezor/utils": true
+        "@trezor/connect-web>@trezor/utils": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": {
@@ -3090,71 +2552,17 @@
         "screen.width": true
       },
       "packages": {
+        "process": true,
         "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": true,
-        "process": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@ethereumjs/common": {
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": true,
-        "webpack>events": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
+        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": true
       }
     },
     "@trezor/connect-web>@trezor/connect>@trezor/protobuf": {
       "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": true,
         "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": true,
-        "browserify>buffer": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": {
-      "globals": {
-        "process": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/base64": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/eventemitter": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/float": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/path": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/pool": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/utf8": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": {
-      "globals": {
-        "console.log": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": {
-      "globals": {
-        "XMLHttpRequest": true
-      },
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true
+        "browserify>buffer": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": {
@@ -3181,16 +2589,10 @@
         "setTimeout": true
       },
       "packages": {
-        "@swc/helpers>tslib": true,
         "@trezor/connect-web>@trezor/utils>bignumber.js": true,
         "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@trezor/connect-web>@trezor/utils>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
+        "webpack>events": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@welldone-software/why-did-you-render": {
@@ -3243,21 +2645,155 @@
         "@zxing/library>ts-custom-error": true
       }
     },
-    "addons-linter>sha.js": {
+    "extension-port-stream>readable-stream>abort-controller": {
+      "globals": {
+        "AbortController": true
+      }
+    },
+    "currency-formatter>accounting": {
+      "globals": {
+        "define": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets>aes-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>aes-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "chalk>ansi-styles": {
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
+        "chalk>ansi-styles>color-convert": true
+      }
+    },
+    "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>array-buffer-byte-length": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>es-abstract>is-array-buffer": true
+      }
+    },
+    "crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "browserify>vm-browserify": true
+      }
+    },
+    "browserify>assert": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "react>object-assign": true,
+        "browserify>assert>util": true
+      }
+    },
+    "@metamask/name-controller>async-mutex": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>available-typed-arrays": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>typed-array-length>possible-typed-array-names": true
       }
     },
     "await-semaphore": {
       "packages": {
-        "browserify>timers-browserify": true,
+        "process": true,
+        "browserify>timers-browserify": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": {
+      "globals": {
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
         "process": true
       }
     },
-    "axios>form-data": {
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": {
       "globals": {
-        "FormData": true
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
+        "process": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": {
+      "globals": {
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
+        "process": true
+      }
+    },
+    "@metamask/snaps-controllers>tar-stream>b4a": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>multibase>base-x": {
+      "packages": {
+        "koa>content-disposition>safe-buffer": true
       }
     },
     "base32-encode": {
@@ -3266,6 +2802,48 @@
       }
     },
     "bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/notification-services-controller>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/smart-transactions-controller>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@ngraveio/bc-ur>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@trezor/connect-web>@trezor/utils>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>bignumber.js": {
       "globals": {
         "crypto": true,
         "define": true
@@ -3284,123 +2862,107 @@
         "browserify>browser-resolve": true
       }
     },
+    "eth-lattice-keyring>gridplus-sdk>borc": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": true,
+        "browserify>buffer": true,
+        "buffer>ieee754": true,
+        "eth-lattice-keyring>gridplus-sdk>borc>iso-url": true
+      }
+    },
     "bowser": {
       "globals": {
         "define": true
       }
     },
-    "browserify>assert": {
+    "@metamask/ppom-validator>elliptic>brorand": {
       "globals": {
-        "Buffer": true
+        "crypto": true,
+        "msCrypto": true
       },
       "packages": {
-        "browserify>assert>util": true,
-        "react>object-assign": true
+        "browserify>browser-resolve": true
       }
     },
-    "browserify>assert>util": {
-      "globals": {
-        "console.error": true,
-        "console.log": true,
-        "console.trace": true,
-        "process": true
-      },
+    "ethereumjs-util>ethereum-cryptography>browserify-aes": {
       "packages": {
-        "browserify>assert>util>inherits": true,
-        "process": true
+        "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "crypto-browserify>browserify-cipher": {
+      "packages": {
+        "ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "crypto-browserify>browserify-cipher>browserify-des": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>browserify-des": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "crypto-browserify>browserify-cipher>browserify-des>des.js": true,
+        "pumpify>inherits": true
+      }
+    },
+    "crypto-browserify>public-encrypt>browserify-rsa": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "crypto-browserify>browserify-sign": {
+      "packages": {
+        "bn.js": true,
+        "crypto-browserify>public-encrypt>browserify-rsa": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "crypto-browserify>create-hmac": true,
+        "@metamask/ppom-validator>elliptic": true,
+        "pumpify>inherits": true,
+        "crypto-browserify>public-encrypt>parse-asn1": true,
+        "stream-browserify": true
       }
     },
     "browserify>browserify-zlib": {
       "packages": {
         "browserify>assert": true,
-        "browserify>browserify-zlib>pako": true,
         "browserify>buffer": true,
-        "browserify>util": true,
+        "browserify>browserify-zlib>pako": true,
         "process": true,
-        "stream-browserify": true
+        "stream-browserify": true,
+        "browserify>util": true
       }
     },
-    "browserify>buffer": {
-      "globals": {
-        "console": true
-      },
+    "ethereumjs-util>ethereum-cryptography>bs58check>bs58": {
       "packages": {
-        "base64-js": true,
-        "buffer>ieee754": true
+        "@ensdomains/content-hash>multihashes>multibase>base-x": true
       }
     },
-    "browserify>punycode": {
-      "globals": {
-        "define": true
-      }
-    },
-    "browserify>string_decoder": {
+    "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": {
       "packages": {
+        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58>base-x": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>bs58check": {
+      "packages": {
+        "ethereumjs-util>ethereum-cryptography>bs58check>bs58": true,
+        "ethereumjs-util>create-hash": true,
         "koa>content-disposition>safe-buffer": true
       }
     },
-    "browserify>timers-browserify": {
-      "globals": {
-        "clearInterval": true,
-        "clearTimeout": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
+    "eth-lattice-keyring>gridplus-sdk>bs58check": {
       "packages": {
-        "process": true
-      }
-    },
-    "browserify>url": {
-      "packages": {
-        "@storybook/addon-knobs>qs": true,
-        "browserify>punycode": true
-      }
-    },
-    "browserify>util": {
-      "globals": {
-        "console.error": true,
-        "console.log": true,
-        "console.trace": true
-      },
-      "packages": {
-        "browserify>util>is-arguments": true,
-        "browserify>util>is-typed-array": true,
-        "browserify>util>which-typed-array": true,
-        "koa>is-generator-function": true,
-        "process": true,
-        "pumpify>inherits": true
-      }
-    },
-    "browserify>util>is-arguments": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "browserify>util>is-typed-array": {
-      "packages": {
-        "browserify>util>which-typed-array": true
-      }
-    },
-    "browserify>util>which-typed-array": {
-      "packages": {
-        "browserify>util>which-typed-array>for-each": true,
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>available-typed-arrays": true,
-        "string.prototype.matchall>es-abstract>gopd": true
-      }
-    },
-    "browserify>util>which-typed-array>for-each": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>is-callable": true
-      }
-    },
-    "browserify>vm-browserify": {
-      "globals": {
-        "document.body.appendChild": true,
-        "document.body.removeChild": true,
-        "document.createElement": true
+        "@noble/hashes": true,
+        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": true
       }
     },
     "buffer": {
@@ -3412,20 +2974,52 @@
         "buffer>ieee754": true
       }
     },
+    "terser>source-map-support>buffer-from": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "browserify>buffer": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "base64-js": true,
+        "buffer>ieee754": true
+      }
+    },
+    "@metamask/snaps-utils>validate-npm-package-name>builtins": {
+      "packages": {
+        "process": true,
+        "semver": true
+      }
+    },
+    "string.prototype.matchall>call-bind": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>call-bind>set-function-length": true
+      }
+    },
+    "@ngraveio/bc-ur>cbor-sync": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
     "chalk": {
       "packages": {
         "chalk>ansi-styles": true,
         "chalk>supports-color": true
-      }
-    },
-    "chalk>ansi-styles": {
-      "packages": {
-        "chalk>ansi-styles>color-convert": true
-      }
-    },
-    "chalk>ansi-styles>color-convert": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
       }
     },
     "chart.js": {
@@ -3449,15 +3043,31 @@
         "chart.js>@kurkle/color": true
       }
     },
-    "chart.js>@kurkle/color": {
-      "globals": {
-        "define": true
+    "@ensdomains/content-hash>cids": {
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase": true,
+        "@ensdomains/content-hash>multicodec": true,
+        "@ensdomains/content-hash>cids>multihashes": true,
+        "@ensdomains/content-hash>cids>uint8arrays": true
+      }
+    },
+    "ethereumjs-util>create-hash>cipher-base": {
+      "packages": {
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true,
+        "stream-browserify": true,
+        "browserify>string_decoder": true
       }
     },
     "classnames": {
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "@metamask/jazzicon>color>clone": {
+      "packages": {
+        "browserify>buffer": true
       }
     },
     "cockatiel": {
@@ -3471,6 +3081,37 @@
       },
       "packages": {
         "process": true
+      }
+    },
+    "chalk>ansi-styles>color-convert": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-convert": {
+      "packages": {
+        "@metamask/jazzicon>color>color-convert>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-string": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color": {
+      "packages": {
+        "@metamask/jazzicon>color>clone": true,
+        "@metamask/jazzicon>color>color-convert": true,
+        "@metamask/jazzicon>color>color-string": true
+      }
+    },
+    "@metamask/snaps-controllers>concat-stream": {
+      "packages": {
+        "terser>source-map-support>buffer-from": true,
+        "browserify>buffer": true,
+        "pumpify>inherits": true,
+        "readable-stream": true,
+        "browserify>concat-stream>typedarray": true
       }
     },
     "copy-to-clipboard": {
@@ -3491,10 +3132,47 @@
         "copy-to-clipboard>toggle-selection": true
       }
     },
-    "copy-to-clipboard>toggle-selection": {
+    "@ethereumjs/tx>@ethereumjs/common>crc-32": {
       "globals": {
-        "document.activeElement": true,
-        "document.getSelection": true
+        "DO_NOT_EXPORT_CRC": true,
+        "define": true
+      }
+    },
+    "@ngraveio/bc-ur>crc": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "crypto-browserify>create-ecdh": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "ethereumjs-util>create-hash": {
+      "packages": {
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "pumpify>inherits": true,
+        "ethereumjs-util>create-hash>md5.js": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "crypto-browserify>create-hmac": {
+      "packages": {
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "ethereumjs-util>create-hash": true,
+        "pumpify>inherits": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "@metamask/snaps-utils>cron-parser": {
+      "packages": {
+        "browserify>browser-resolve": true,
+        "luxon": true
       }
     },
     "crypto-browserify": {
@@ -3502,156 +3180,44 @@
         "crypto-browserify>browserify-cipher": true,
         "crypto-browserify>browserify-sign": true,
         "crypto-browserify>create-ecdh": true,
+        "ethereumjs-util>create-hash": true,
         "crypto-browserify>create-hmac": true,
         "crypto-browserify>diffie-hellman": true,
         "crypto-browserify>pbkdf2": true,
         "crypto-browserify>public-encrypt": true,
         "crypto-browserify>randombytes": true,
-        "crypto-browserify>randomfill": true,
-        "ethereumjs-util>create-hash": true
+        "crypto-browserify>randomfill": true
       }
     },
-    "crypto-browserify>browserify-cipher": {
-      "packages": {
-        "crypto-browserify>browserify-cipher>browserify-des": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>browserify-des": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>browserify-des>des.js": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>browserify-des>des.js": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>evp_bytestokey": {
-      "packages": {
-        "ethereumjs-util>create-hash>md5.js": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "crypto-browserify>browserify-sign": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>create-hmac": true,
-        "crypto-browserify>public-encrypt>browserify-rsa": true,
-        "crypto-browserify>public-encrypt>parse-asn1": true,
-        "ethereumjs-util>create-hash": true,
-        "pumpify>inherits": true,
-        "stream-browserify": true
-      }
-    },
-    "crypto-browserify>create-ecdh": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "crypto-browserify>create-hmac": {
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>diffie-hellman": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>diffie-hellman>miller-rabin": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "crypto-browserify>diffie-hellman>miller-rabin": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>brorand": true,
-        "bn.js": true
-      }
-    },
-    "crypto-browserify>pbkdf2": {
+    "@metamask/ppom-validator>crypto-js": {
       "globals": {
         "crypto": true,
-        "process": true,
-        "queueMicrotask": true,
-        "setImmediate": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
-      }
-    },
-    "crypto-browserify>public-encrypt": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>public-encrypt>browserify-rsa": true,
-        "crypto-browserify>public-encrypt>parse-asn1": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>create-hash": true
-      }
-    },
-    "crypto-browserify>public-encrypt>browserify-rsa": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "crypto-browserify>public-encrypt>parse-asn1": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "crypto-browserify>pbkdf2": true,
-        "crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes": true
-      }
-    },
-    "crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "browserify>vm-browserify": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>randombytes": {
-      "globals": {
-        "crypto": true,
+        "define": true,
         "msCrypto": true
       },
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
+        "browserify>browser-resolve": true
       }
     },
-    "crypto-browserify>randomfill": {
+    "react-beautiful-dnd>css-box-model": {
       "globals": {
-        "crypto": true,
-        "msCrypto": true
+        "getComputedStyle": true,
+        "pageXOffset": true,
+        "pageYOffset": true
       },
       "packages": {
-        "crypto-browserify>randombytes": true,
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
+        "react-router-dom>tiny-invariant": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": {
+      "globals": {
+        "document.createElement": true,
+        "document.documentElement": true,
+        "getComputedStyle": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true
       }
     },
     "currency-formatter": {
@@ -3659,16 +3225,6 @@
         "currency-formatter>accounting": true,
         "currency-formatter>locale-currency": true,
         "react>object-assign": true
-      }
-    },
-    "currency-formatter>accounting": {
-      "globals": {
-        "define": true
-      }
-    },
-    "currency-formatter>locale-currency": {
-      "globals": {
-        "countryCode": true
       }
     },
     "debounce-stream": {
@@ -3684,35 +3240,107 @@
         "setTimeout": true
       }
     },
+    "nock>debug": {
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "nock>debug>ms": true,
+        "process": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>array-buffer-byte-length": true,
+        "string.prototype.matchall>call-bind": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "browserify>util>is-arguments": true,
+        "string.prototype.matchall>es-abstract>is-array-buffer": true,
+        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
+        "string.prototype.matchall>es-abstract>is-regex": true,
+        "string.prototype.matchall>es-abstract>is-shared-array-buffer": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
+        "@ngraveio/bc-ur>assert>object-is": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
+        "gulp>vinyl-fs>object.assign": true,
+        "string.prototype.matchall>regexp.prototype.flags": true,
+        "string.prototype.matchall>side-channel": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection": true,
+        "browserify>util>which-typed-array": true
+      }
+    },
+    "string.prototype.matchall>define-properties>define-data-property": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>gopd": true
+      }
+    },
+    "string.prototype.matchall>define-properties": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>browserify-des>des.js": {
+      "packages": {
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true
+      }
+    },
+    "crypto-browserify>diffie-hellman": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "crypto-browserify>diffie-hellman>miller-rabin": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "@material-ui/core>react-transition-group>dom-helpers": {
+      "packages": {
+        "@babel/runtime": true
+      }
+    },
     "debounce-stream>duplexer": {
       "packages": {
         "stream-browserify": true
       }
     },
-    "debounce-stream>through": {
+    "@metamask/ppom-validator>elliptic": {
       "packages": {
+        "bn.js": true,
+        "@metamask/ppom-validator>elliptic>brorand": true,
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "@metamask/ppom-validator>elliptic>hmac-drbg": true,
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "string.prototype.matchall>call-bind>es-define-property": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>es-get-iterator": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>has-symbols": true,
+        "browserify>util>is-arguments": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
         "process": true,
-        "stream-browserify": true
-      }
-    },
-    "depcheck>@vue/compiler-sfc>postcss>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "depcheck>is-core-module>hasown": {
-      "packages": {
-        "browserify>has>function-bind": true
-      }
-    },
-    "dependency-tree>precinct>detective-postcss>postcss>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "eslint-plugin-react>array-includes>is-string": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": true
       }
     },
     "eth-ens-namehash": {
@@ -3720,22 +3348,9 @@
         "name": "write"
       },
       "packages": {
-        "@metamask/ethjs>js-sha3": true,
         "browserify>buffer": true,
-        "eth-ens-namehash>idna-uts46-hx": true
-      }
-    },
-    "eth-ens-namehash>idna-uts46-hx": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "browserify>punycode": true
-      }
-    },
-    "eth-keyring-controller>@metamask/browser-passworder": {
-      "globals": {
-        "crypto": true
+        "eth-ens-namehash>idna-uts46-hx": true,
+        "@metamask/ethjs>js-sha3": true
       }
     },
     "eth-lattice-keyring": {
@@ -3753,9 +3368,246 @@
         "bn.js": true,
         "browserify>buffer": true,
         "crypto-browserify": true,
+        "webpack>events": true,
         "eth-lattice-keyring>gridplus-sdk": true,
-        "eth-lattice-keyring>rlp": true,
-        "webpack>events": true
+        "eth-lattice-keyring>rlp": true
+      }
+    },
+    "eth-method-registry": {
+      "packages": {
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs-query": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true
+      },
+      "packages": {
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": true,
+        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>ethereum-cryptography>keccak": true,
+        "crypto-browserify>randombytes": true,
+        "ganache>secp256k1": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": {
+      "packages": {
+        "browserify>assert": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "browserify>buffer": true,
+        "crypto-browserify>create-hmac": true,
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "ethereumjs-util>ethereum-cryptography>keccak": true,
+        "crypto-browserify>randombytes": true,
+        "koa>content-disposition>safe-buffer": true,
+        "ganache>secp256k1": true
+      }
+    },
+    "ethereumjs-util": {
+      "packages": {
+        "browserify>assert": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "ethereumjs-util>ethereum-cryptography": true,
+        "browserify>insert-module-globals>is-buffer": true,
+        "ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": {
+      "packages": {
+        "browserify>assert": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
+        "browserify>insert-module-globals>is-buffer": true,
+        "ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>aes-js": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "browserify>buffer": true,
+        "crypto-browserify": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": true,
+        "crypto-browserify>randombytes": true,
+        "ethers>@ethersproject/json-wallets>scrypt-js": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>utf8": true,
+        "uuid": true
+      }
+    },
+    "ethers": {
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/providers": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/solidity": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/units": true,
+        "@ethersproject/wallet": true,
+        "ethers>@ethersproject/web": true,
+        "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": {
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "@ethersproject/providers": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/solidity": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/units": true,
+        "@ethersproject/wallet": true,
+        "@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "@metamask/ethjs>ethjs-abi": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ethjs>js-sha3": true,
+        "@metamask/ethjs>ethjs-abi>number-to-bn": true
+      }
+    },
+    "webpack>events": {
+      "globals": {
+        "console": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>evp_bytestokey": {
+      "packages": {
+        "ethereumjs-util>create-hash>md5.js": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "extension-port-stream": {
+      "packages": {
+        "browserify>buffer": true,
+        "extension-port-stream>readable-stream": true
+      }
+    },
+    "fast-json-patch": {
+      "globals": {
+        "addEventListener": true,
+        "clearTimeout": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      }
+    },
+    "@metamask/snaps-utils>fast-xml-parser": {
+      "globals": {
+        "entityName": true,
+        "val": true
+      },
+      "packages": {
+        "@metamask/snaps-utils>fast-xml-parser>strnum": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase": {
+      "packages": {
+        "@metamask/notification-services-controller>firebase>@firebase/app": true,
+        "@metamask/notification-services-controller>firebase>@firebase/messaging": true
+      }
+    },
+    "react-focus-lock>focus-lock": {
+      "globals": {
+        "HTMLIFrameElement": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.DOCUMENT_NODE": true,
+        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
+        "Node.DOCUMENT_POSITION_CONTAINS": true,
+        "Node.ELEMENT_NODE": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "browserify>util>which-typed-array>for-each": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>is-callable": true
+      }
+    },
+    "axios>form-data": {
+      "globals": {
+        "FormData": true
+      }
+    },
+    "fuse.js": {
+      "globals": {
+        "console": true,
+        "define": true
+      }
+    },
+    "string.prototype.matchall>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>es-abstract>has-proto": true,
+        "string.prototype.matchall>has-symbols": true,
+        "depcheck>is-core-module>hasown": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>gopd": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk": {
@@ -3773,545 +3625,63 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethersproject/abi": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/ethjs>js-sha3": true,
-        "@metamask/keyring-api>bech32": true,
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": true,
+        "@ethersproject/abi": true,
+        "@metamask/eth-sig-util": true,
         "eth-lattice-keyring>gridplus-sdk>aes-js": true,
+        "@metamask/keyring-api>bech32": true,
         "eth-lattice-keyring>gridplus-sdk>bignumber.js": true,
+        "bn.js": true,
         "eth-lattice-keyring>gridplus-sdk>borc": true,
         "eth-lattice-keyring>gridplus-sdk>bs58check": true,
-        "eth-lattice-keyring>gridplus-sdk>secp256k1": true,
-        "eth-lattice-keyring>gridplus-sdk>uuid": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "@metamask/ppom-validator>elliptic": true,
         "ethers>@ethersproject/sha2>hash.js": true,
-        "lodash": true
+        "@metamask/ethjs>js-sha3": true,
+        "lodash": true,
+        "eth-lattice-keyring>gridplus-sdk>secp256k1": true,
+        "eth-lattice-keyring>gridplus-sdk>uuid": true
       }
     },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
+    "string.prototype.matchall>es-abstract>has-property-descriptors": {
       "packages": {
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
-        "webpack>events": true
+        "string.prototype.matchall>call-bind>es-define-property": true
       }
     },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": {
+    "koa>is-generator-function>has-tostringtag": {
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": true,
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": {
-      "packages": {
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
-        "webpack>events": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>aes-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "browserify>buffer": true,
-        "buffer>ieee754": true,
-        "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": true,
-        "eth-lattice-keyring>gridplus-sdk>borc>iso-url": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc>iso-url": {
-      "globals": {
-        "URL": true,
-        "URLSearchParams": true,
-        "location": true,
-        "navigator": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bs58check": {
-      "packages": {
-        "@noble/hashes": true,
-        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": {
-      "packages": {
-        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58>base-x": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>secp256k1": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "eth-lattice-keyring>rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "eth-method-registry": {
-      "packages": {
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true
-      }
-    },
-    "ethereumjs-util": {
-      "packages": {
-        "bn.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>ethereum-cryptography": true,
-        "ethereumjs-util>rlp": true
-      }
-    },
-    "ethereumjs-util>create-hash": {
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>create-hash>md5.js": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>create-hash>cipher-base": {
-      "packages": {
-        "browserify>string_decoder": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true,
-        "stream-browserify": true
-      }
-    },
-    "ethereumjs-util>create-hash>md5.js": {
-      "packages": {
-        "ethereumjs-util>create-hash>md5.js>hash-base": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
+        "string.prototype.matchall>has-symbols": true
       }
     },
     "ethereumjs-util>create-hash>md5.js>hash-base": {
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
         "pumpify>inherits": true,
-        "readable-stream": true
-      }
-    },
-    "ethereumjs-util>create-hash>ripemd160": {
-      "packages": {
-        "browserify>buffer": true,
-        "ethereumjs-util>create-hash>md5.js>hash-base": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>ethereum-cryptography>keccak": true,
-        "ganache>secp256k1": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>browserify-aes": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>bs58check": {
-      "packages": {
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check>bs58": true,
+        "readable-stream": true,
         "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>bs58check>bs58": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase>base-x": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>keccak": {
-      "packages": {
-        "browserify>buffer": true,
-        "readable-stream": true
-      }
-    },
-    "ethereumjs-util>rlp": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers": {
-      "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "@ethersproject/wallet": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/solidity": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true,
-        "ethers>@ethersproject/units": true,
-        "ethers>@ethersproject/web": true,
-        "ethers>@ethersproject/wordlists": true
-      }
-    },
-    "ethers>@ethersproject/abstract-provider": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/abstract-signer": {
-      "packages": {
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/address": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/rlp": true
-      }
-    },
-    "ethers>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true
-      }
-    },
-    "ethers>@ethersproject/basex": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/constants": {
-      "packages": {
-        "@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hdnode": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/json-wallets>aes-js": true,
-        "ethers>@ethersproject/json-wallets>scrypt-js": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/pbkdf2": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets>aes-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets>scrypt-js": {
-      "globals": {
-        "define": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>timers-browserify": true
-      }
-    },
-    "ethers>@ethersproject/keccak256": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@metamask/ethjs>js-sha3": true
-      }
-    },
-    "ethers>@ethersproject/logger": {
-      "globals": {
-        "console": true
-      }
-    },
-    "ethers>@ethersproject/pbkdf2": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/sha2": true
-      }
-    },
-    "ethers>@ethersproject/properties": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers": {
-      "globals": {
-        "WebSocket": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "console.log": true,
-        "console.warn": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/abstract-provider": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers>@ethersproject/networks": true,
-        "ethers>@ethersproject/providers>@ethersproject/web": true,
-        "ethers>@ethersproject/providers>bech32": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/networks": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/random": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/rlp": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/sha2": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/sha2>hash.js": true
       }
     },
     "ethers>@ethersproject/sha2>hash.js": {
       "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "pumpify>inherits": true
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true
       }
     },
-    "ethers>@ethersproject/signing-key": {
+    "depcheck>is-core-module>hasown": {
       "packages": {
-        "@ethersproject/bytes": true,
-        "@metamask/ppom-validator>elliptic": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
+        "browserify>has>function-bind": true
       }
     },
-    "ethers>@ethersproject/solidity": {
+    "@metamask/eth-trezor-keyring>hdkey": {
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/strings": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/transactions": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/signing-key": true
-      }
-    },
-    "ethers>@ethersproject/units": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/wordlists": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "extension-port-stream": {
-      "packages": {
-        "browserify>buffer": true,
-        "extension-port-stream>readable-stream": true
-      }
-    },
-    "extension-port-stream>readable-stream": {
-      "globals": {
-        "AbortController": true,
-        "AggregateError": true,
-        "Blob": true
-      },
-      "packages": {
-        "browserify>buffer": true,
-        "browserify>string_decoder": true,
-        "extension-port-stream>readable-stream>abort-controller": true,
-        "process": true,
-        "webpack>events": true
-      }
-    },
-    "extension-port-stream>readable-stream>abort-controller": {
-      "globals": {
-        "AbortController": true
-      }
-    },
-    "fast-json-patch": {
-      "globals": {
-        "addEventListener": true,
-        "clearTimeout": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
-    "fuse.js": {
-      "globals": {
-        "console": true,
-        "define": true
-      }
-    },
-    "ganache>secp256k1": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true
-      }
-    },
-    "gulp>vinyl-fs>object.assign": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>has-symbols": true
+        "browserify>assert": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "crypto-browserify": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "ganache>secp256k1": true
       }
     },
     "he": {
@@ -4327,15 +3697,100 @@
         "document.querySelector": true
       }
     },
-    "https-browserify": {
+    "react-router-dom>history": {
+      "globals": {
+        "addEventListener": true,
+        "confirm": true,
+        "document": true,
+        "history": true,
+        "location": true,
+        "navigator.userAgent": true,
+        "removeEventListener": true
+      },
       "packages": {
-        "browserify>url": true,
-        "stream-http": true
+        "react-router-dom>history>resolve-pathname": true,
+        "react-router-dom>tiny-invariant": true,
+        "react-router-dom>tiny-warning": true,
+        "react-router-dom>history>value-equal": true
       }
     },
-    "koa>content-disposition>safe-buffer": {
+    "@metamask/ppom-validator>elliptic>hmac-drbg": {
       "packages": {
-        "browserify>buffer": true
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "react-redux>hoist-non-react-statics": {
+      "packages": {
+        "prop-types>react-is": true
+      }
+    },
+    "https-browserify": {
+      "packages": {
+        "stream-http": true,
+        "browserify>url": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>idb": {
+      "globals": {
+        "DOMException": true,
+        "IDBCursor": true,
+        "IDBDatabase": true,
+        "IDBIndex": true,
+        "IDBObjectStore": true,
+        "IDBRequest": true,
+        "IDBTransaction": true,
+        "indexedDB.deleteDatabase": true,
+        "indexedDB.open": true
+      }
+    },
+    "eth-ens-namehash>idna-uts46-hx": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "browserify>punycode": true
+      }
+    },
+    "string.prototype.matchall>internal-slot": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "depcheck>is-core-module>hasown": true,
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "browserify>util>is-arguments": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-array-buffer": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>unbox-primitive>has-bigints": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
       }
     },
     "koa>is-generator-function": {
@@ -4343,9 +3798,145 @@
         "koa>is-generator-function>has-tostringtag": true
       }
     },
-    "koa>is-generator-function>has-tostringtag": {
+    "@material-ui/core>@material-ui/styles>jss>is-in-browser": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-regex": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-shared-array-buffer": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true
+      }
+    },
+    "eslint-plugin-react>array-includes>is-string": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
       "packages": {
         "string.prototype.matchall>has-symbols": true
+      }
+    },
+    "browserify>util>is-typed-array": {
+      "packages": {
+        "browserify>util>which-typed-array": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>borc>iso-url": {
+      "globals": {
+        "URL": true,
+        "URLSearchParams": true,
+        "location": true,
+        "navigator": true
+      }
+    },
+    "@ensdomains/content-hash>js-base64": {
+      "globals": {
+        "Base64": "write",
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true,
+        "define": true
+      },
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "@metamask/ethjs>js-sha3": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "process": true
+      }
+    },
+    "@ngraveio/bc-ur>jsbi": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@metamask/message-manager>jsonschema": {
+      "packages": {
+        "browserify>url": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case>hyphenate-style-name": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": {
+      "globals": {
+        "CSS": true
+      },
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-global": {
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-nested": {
+      "packages": {
+        "@babel/runtime": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": true,
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss": {
+      "globals": {
+        "CSS": true,
+        "document.createElement": true,
+        "document.querySelector": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>keccak": {
+      "packages": {
+        "browserify>buffer": true,
+        "readable-stream": true
+      }
+    },
+    "currency-formatter>locale-currency": {
+      "globals": {
+        "countryCode": true
       }
     },
     "localforage": {
@@ -4425,6 +4016,120 @@
         "Intl": true
       }
     },
+    "@metamask/snaps-utils>marked": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true,
+        "define": true
+      }
+    },
+    "ethereumjs-util>create-hash>md5.js": {
+      "packages": {
+        "ethereumjs-util>create-hash>md5.js>hash-base": true,
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "@storybook/addon-docs>remark-external-links>mdast-util-definitions": {
+      "packages": {
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
+        "react-syntax-highlighter>refractor>parse-entities": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>remark-rehype>mdast-util-to-hast": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@storybook/addon-docs>remark-external-links>mdast-util-definitions": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "@ethereumjs/tx>@ethereumjs/util>micro-ftch": {
+      "globals": {
+        "Headers": true,
+        "TextDecoder": true,
+        "URL": true,
+        "btoa": true,
+        "fetch": true
+      },
+      "packages": {
+        "browserify>browserify-zlib": true,
+        "browserify>buffer": true,
+        "https-browserify": true,
+        "process": true,
+        "stream-http": true,
+        "browserify>url": true,
+        "browserify>util": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
+      "packages": {
+        "react-syntax-highlighter>refractor>parse-entities": true
+      }
+    },
+    "crypto-browserify>diffie-hellman>miller-rabin": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ppom-validator>elliptic>brorand": true
+      }
+    },
+    "@ensdomains/content-hash>cids>multibase": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase>@multiformats/base-x": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>multibase": {
+      "packages": {
+        "@ensdomains/content-hash>multihashes>multibase>base-x": true,
+        "browserify>buffer": true,
+        "@ensdomains/content-hash>multihashes>web-encoding": true
+      }
+    },
+    "@ensdomains/content-hash>multicodec": {
+      "packages": {
+        "@ensdomains/content-hash>multicodec>uint8arrays": true,
+        "sass-embedded>varint": true
+      }
+    },
+    "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "console.warn": true,
+        "crypto.subtle.digest": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes": {
+      "packages": {
+        "browserify>buffer": true,
+        "@ensdomains/content-hash>multihashes>multibase": true,
+        "@ensdomains/content-hash>multihashes>varint": true,
+        "@ensdomains/content-hash>multihashes>web-encoding": true
+      }
+    },
+    "@ensdomains/content-hash>cids>multihashes": {
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase": true,
+        "@ensdomains/content-hash>cids>uint8arrays": true,
+        "@ensdomains/content-hash>cids>multihashes>varint": true
+      }
+    },
     "nanoid": {
       "globals": {
         "crypto": true,
@@ -4432,17 +4137,54 @@
         "navigator": true
       }
     },
-    "nock>debug": {
+    "@metamask/approval-controller>nanoid": {
       "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "nock>debug>ms": true,
-        "process": true
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/smart-transactions-controller>@metamask/controllers>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/notification-controller>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/permission-controller>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/rpc-methods>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/rpc-methods-flask>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/snaps-controllers>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/snaps-controllers-flask>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "depcheck>@vue/compiler-sfc>postcss>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "dependency-tree>precinct>detective-postcss>postcss>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
       }
     },
     "node-fetch": {
@@ -4453,9 +4195,122 @@
         "fetch": true
       }
     },
+    "@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "@metamask/ethjs>ethjs-abi>number-to-bn": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>object-inspect": {
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "browserify>browser-resolve": true
+      }
+    },
+    "@ngraveio/bc-ur>assert>object-is": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true
+      }
+    },
+    "gulp>vinyl-fs>object.assign": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>has-symbols": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "@metamask/object-multiplex>once": {
+      "packages": {
+        "@metamask/object-multiplex>once>wrappy": true
+      }
+    },
+    "crypto-browserify>public-encrypt>parse-asn1": {
+      "packages": {
+        "crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
+        "ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "browserify>buffer": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "crypto-browserify>pbkdf2": true
+      }
+    },
+    "react-syntax-highlighter>refractor>parse-entities": {
+      "globals": {
+        "document.createElement": true
+      }
+    },
     "path-browserify": {
       "packages": {
         "process": true
+      }
+    },
+    "serve-handler>path-to-regexp": {
+      "packages": {
+        "serve-handler>path-to-regexp>isarray": true
+      }
+    },
+    "crypto-browserify>pbkdf2": {
+      "globals": {
+        "crypto": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethereumjs-util>create-hash": true,
+        "process": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "@material-ui/core>popper.js": {
+      "globals": {
+        "MSInputMethodContext": true,
+        "Node.DOCUMENT_POSITION_FOLLOWING": true,
+        "cancelAnimationFrame": true,
+        "console.warn": true,
+        "define": true,
+        "devicePixelRatio": true,
+        "document": true,
+        "getComputedStyle": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "navigator": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      }
+    },
+    "react-tippy>popper.js": {
+      "globals": {
+        "MSInputMethodContext": true,
+        "Node.DOCUMENT_POSITION_FOLLOWING": true,
+        "cancelAnimationFrame": true,
+        "console.warn": true,
+        "define": true,
+        "devicePixelRatio": true,
+        "document": true,
+        "getComputedStyle": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "navigator.userAgent": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
       }
     },
     "process": {
@@ -4470,26 +4325,51 @@
         "promise-to-callback>set-immediate-shim": true
       }
     },
-    "promise-to-callback>set-immediate-shim": {
-      "globals": {
-        "setTimeout.apply": true
-      },
-      "packages": {
-        "browserify>timers-browserify": true
-      }
-    },
     "prop-types": {
       "globals": {
         "console": true
       },
       "packages": {
-        "prop-types>react-is": true,
-        "react>object-assign": true
+        "react>object-assign": true,
+        "prop-types>react-is": true
       }
     },
-    "prop-types>react-is": {
+    "react-markdown>property-information": {
+      "packages": {
+        "watchify>xtend": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": {
       "globals": {
-        "console": true
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/base64": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/eventemitter": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/float": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/path": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/pool": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/utf8": true
+      }
+    },
+    "crypto-browserify>public-encrypt": {
+      "packages": {
+        "bn.js": true,
+        "crypto-browserify>public-encrypt>browserify-rsa": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "crypto-browserify>public-encrypt>parse-asn1": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "browserify>punycode": {
+      "globals": {
+        "define": true
       }
     },
     "qrcode-generator": {
@@ -4506,13 +4386,55 @@
         "react": true
       }
     },
+    "@storybook/addon-knobs>qs": {
+      "packages": {
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
+      "globals": {
+        "queueMicrotask": true
+      }
+    },
+    "react-beautiful-dnd>raf-schd": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "requestAnimationFrame": true
+      }
+    },
+    "crypto-browserify>randombytes": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "process": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "ethereumjs-wallet>randombytes": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "crypto-browserify>randomfill": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "process": true,
+        "crypto-browserify>randombytes": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
     "react": {
       "globals": {
         "console": true
       },
       "packages": {
-        "prop-types": true,
-        "react>object-assign": true
+        "react>object-assign": true,
+        "prop-types": true
       }
     },
     "react-beautiful-dnd": {
@@ -4534,35 +4456,14 @@
       },
       "packages": {
         "@babel/runtime": true,
-        "react": true,
         "react-beautiful-dnd>css-box-model": true,
         "react-beautiful-dnd>memoize-one": true,
         "react-beautiful-dnd>raf-schd": true,
-        "react-beautiful-dnd>use-memo-one": true,
+        "react": true,
         "react-dom": true,
         "react-redux": true,
-        "redux": true
-      }
-    },
-    "react-beautiful-dnd>css-box-model": {
-      "globals": {
-        "getComputedStyle": true,
-        "pageXOffset": true,
-        "pageYOffset": true
-      },
-      "packages": {
-        "react-router-dom>tiny-invariant": true
-      }
-    },
-    "react-beautiful-dnd>raf-schd": {
-      "globals": {
-        "cancelAnimationFrame": true,
-        "requestAnimationFrame": true
-      }
-    },
-    "react-beautiful-dnd>use-memo-one": {
-      "packages": {
-        "react": true
+        "redux": true,
+        "react-beautiful-dnd>use-memo-one": true
       }
     },
     "react-chartjs-2": {
@@ -4571,6 +4472,12 @@
       },
       "packages": {
         "chart.js": true,
+        "react": true
+      }
+    },
+    "react-focus-lock>react-clientside-effect": {
+      "packages": {
+        "@babel/runtime": true,
         "react": true
       }
     },
@@ -4615,22 +4522,28 @@
         "trustedTypes": true
       },
       "packages": {
+        "react>object-assign": true,
         "prop-types": true,
         "react": true,
-        "react-dom>scheduler": true,
-        "react>object-assign": true
+        "react-dom>scheduler": true
       }
     },
-    "react-dom>scheduler": {
+    "react-responsive-carousel>react-easy-swipe": {
       "globals": {
-        "MessageChannel": true,
-        "cancelAnimationFrame": true,
-        "clearTimeout": true,
-        "console": true,
-        "navigator": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
+        "addEventListener": true,
+        "define": true,
+        "document.addEventListener": true,
+        "document.removeEventListener": true
+      },
+      "packages": {
+        "prop-types": true,
+        "react": true
+      }
+    },
+    "react-popper>react-fast-compare": {
+      "globals": {
+        "Element": true,
+        "console.warn": true
       }
     },
     "react-focus-lock": {
@@ -4644,51 +4557,12 @@
       },
       "packages": {
         "@babel/runtime": true,
+        "react-focus-lock>focus-lock": true,
         "prop-types": true,
         "react": true,
-        "react-focus-lock>focus-lock": true,
         "react-focus-lock>react-clientside-effect": true,
         "react-focus-lock>use-callback-ref": true,
         "react-focus-lock>use-sidecar": true
-      }
-    },
-    "react-focus-lock>focus-lock": {
-      "globals": {
-        "HTMLIFrameElement": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
-        "Node.DOCUMENT_NODE": true,
-        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
-        "Node.DOCUMENT_POSITION_CONTAINS": true,
-        "Node.ELEMENT_NODE": true,
-        "console.error": true,
-        "console.warn": true,
-        "document": true,
-        "getComputedStyle": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "react-focus-lock>react-clientside-effect": {
-      "packages": {
-        "@babel/runtime": true,
-        "react": true
-      }
-    },
-    "react-focus-lock>use-callback-ref": {
-      "packages": {
-        "react": true
-      }
-    },
-    "react-focus-lock>use-sidecar": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true,
-        "react": true,
-        "react-focus-lock>use-sidecar>detect-node-es": true
       }
     },
     "react-idle-timer": {
@@ -4712,15 +4586,30 @@
         "react": true
       }
     },
+    "prop-types>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-markdown>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-redux>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
     "react-markdown": {
       "globals": {
         "console.warn": true
       },
       "packages": {
-        "prop-types": true,
-        "react": true,
         "react-markdown>comma-separated-tokens": true,
+        "prop-types": true,
         "react-markdown>property-information": true,
+        "react": true,
         "react-markdown>react-is": true,
         "react-markdown>remark-parse": true,
         "react-markdown>remark-rehype": true,
@@ -4729,96 +4618,6 @@
         "react-markdown>unified": true,
         "react-markdown>unist-util-visit": true,
         "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>property-information": {
-      "packages": {
-        "watchify>xtend": true
-      }
-    },
-    "react-markdown>react-is": {
-      "globals": {
-        "console": true
-      }
-    },
-    "react-markdown>remark-parse": {
-      "packages": {
-        "react-markdown>remark-parse>mdast-util-from-markdown": true
-      }
-    },
-    "react-markdown>remark-parse>mdast-util-from-markdown": {
-      "packages": {
-        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
-        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
-        "react-markdown>remark-parse>mdast-util-from-markdown>unist-util-stringify-position": true,
-        "react-syntax-highlighter>refractor>parse-entities": true
-      }
-    },
-    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
-      "packages": {
-        "react-syntax-highlighter>refractor>parse-entities": true
-      }
-    },
-    "react-markdown>remark-rehype": {
-      "packages": {
-        "react-markdown>remark-rehype>mdast-util-to-hast": true
-      }
-    },
-    "react-markdown>remark-rehype>mdast-util-to-hast": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@storybook/addon-docs>remark-external-links>mdast-util-definitions": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "react-markdown>style-to-object": {
-      "packages": {
-        "react-markdown>style-to-object>inline-style-parser": true
-      }
-    },
-    "react-markdown>unified": {
-      "packages": {
-        "mocha>yargs-unparser>is-plain-obj": true,
-        "react-markdown>unified>bail": true,
-        "react-markdown>unified>extend": true,
-        "react-markdown>unified>is-buffer": true,
-        "react-markdown>unified>trough": true,
-        "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>unist-util-visit": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-visit-parents": true
-      }
-    },
-    "react-markdown>unist-util-visit>unist-util-visit-parents": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-is": true
-      }
-    },
-    "react-markdown>vfile": {
-      "packages": {
-        "path-browserify": true,
-        "process": true,
-        "react-markdown>vfile>is-buffer": true,
-        "react-markdown>vfile>replace-ext": true,
-        "react-markdown>vfile>vfile-message": true
-      }
-    },
-    "react-markdown>vfile>replace-ext": {
-      "packages": {
-        "path-browserify": true
-      }
-    },
-    "react-markdown>vfile>vfile-message": {
-      "packages": {
-        "react-markdown>vfile>unist-util-stringify-position": true
       }
     },
     "react-popper": {
@@ -4832,17 +4631,6 @@
         "react-popper>warning": true
       }
     },
-    "react-popper>react-fast-compare": {
-      "globals": {
-        "Element": true,
-        "console.warn": true
-      }
-    },
-    "react-popper>warning": {
-      "globals": {
-        "console": true
-      }
-    },
     "react-redux": {
       "globals": {
         "console": true,
@@ -4850,21 +4638,11 @@
       },
       "packages": {
         "@babel/runtime": true,
+        "react-redux>hoist-non-react-statics": true,
         "prop-types": true,
         "react": true,
         "react-dom": true,
-        "react-redux>hoist-non-react-statics": true,
         "react-redux>react-is": true
-      }
-    },
-    "react-redux>hoist-non-react-statics": {
-      "packages": {
-        "prop-types>react-is": true
-      }
-    },
-    "react-redux>react-is": {
-      "globals": {
-        "console": true
       }
     },
     "react-responsive-carousel": {
@@ -4885,23 +4663,11 @@
         "react-responsive-carousel>react-easy-swipe": true
       }
     },
-    "react-responsive-carousel>react-easy-swipe": {
-      "globals": {
-        "addEventListener": true,
-        "define": true,
-        "document.addEventListener": true,
-        "document.removeEventListener": true
-      },
-      "packages": {
-        "prop-types": true,
-        "react": true
-      }
-    },
     "react-router-dom": {
       "packages": {
+        "react-router-dom>history": true,
         "prop-types": true,
         "react": true,
-        "react-router-dom>history": true,
         "react-router-dom>react-router": true,
         "react-router-dom>tiny-invariant": true,
         "react-router-dom>tiny-warning": true
@@ -4927,26 +4693,24 @@
         "setTimeout": true
       },
       "packages": {
+        "react-router-dom-v5-compat>@remix-run/router": true,
         "history": true,
         "react": true,
         "react-dom": true,
         "react-router-dom": true,
-        "react-router-dom-v5-compat>@remix-run/router": true,
         "react-router-dom-v5-compat>react-router": true
       }
     },
-    "react-router-dom-v5-compat>@remix-run/router": {
-      "globals": {
-        "AbortController": true,
-        "DOMException": true,
-        "FormData": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "URL": true,
-        "URLSearchParams": true,
-        "console": true,
-        "document.defaultView": true
+    "react-router-dom>react-router": {
+      "packages": {
+        "react-router-dom>history": true,
+        "react-redux>hoist-non-react-statics": true,
+        "serve-handler>path-to-regexp": true,
+        "prop-types": true,
+        "react": true,
+        "prop-types>react-is": true,
+        "react-router-dom>tiny-invariant": true,
+        "react-router-dom>tiny-warning": true
       }
     },
     "react-router-dom-v5-compat>react-router": {
@@ -4955,42 +4719,8 @@
         "define": true
       },
       "packages": {
-        "react": true,
-        "react-router-dom-v5-compat>@remix-run/router": true
-      }
-    },
-    "react-router-dom>history": {
-      "globals": {
-        "addEventListener": true,
-        "confirm": true,
-        "document": true,
-        "history": true,
-        "location": true,
-        "navigator.userAgent": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "react-router-dom>history>resolve-pathname": true,
-        "react-router-dom>history>value-equal": true,
-        "react-router-dom>tiny-invariant": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "react-router-dom>react-router": {
-      "packages": {
-        "prop-types": true,
-        "prop-types>react-is": true,
-        "react": true,
-        "react-redux>hoist-non-react-statics": true,
-        "react-router-dom>history": true,
-        "react-router-dom>tiny-invariant": true,
-        "react-router-dom>tiny-warning": true,
-        "serve-handler>path-to-regexp": true
-      }
-    },
-    "react-router-dom>tiny-warning": {
-      "globals": {
-        "console": true
+        "react-router-dom-v5-compat>@remix-run/router": true,
+        "react": true
       }
     },
     "react-simple-file-input": {
@@ -5002,11 +4732,6 @@
       "packages": {
         "prop-types": true,
         "react": true
-      }
-    },
-    "react-syntax-highlighter>refractor>parse-entities": {
-      "globals": {
-        "document.createElement": true
       }
     },
     "react-tippy": {
@@ -5031,26 +4756,9 @@
         "setTimeout": true
       },
       "packages": {
+        "react-tippy>popper.js": true,
         "react": true,
-        "react-dom": true,
-        "react-tippy>popper.js": true
-      }
-    },
-    "react-tippy>popper.js": {
-      "globals": {
-        "MSInputMethodContext": true,
-        "Node.DOCUMENT_POSITION_FOLLOWING": true,
-        "cancelAnimationFrame": true,
-        "console.warn": true,
-        "define": true,
-        "devicePixelRatio": true,
-        "document": true,
-        "getComputedStyle": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "navigator.userAgent": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
+        "react-dom": true
       }
     },
     "react-toggle-button": {
@@ -5065,22 +4773,46 @@
         "react": true
       }
     },
+    "@material-ui/core>react-transition-group": {
+      "globals": {
+        "Element": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@material-ui/core>react-transition-group>dom-helpers": true,
+        "prop-types": true,
+        "react": true,
+        "react-dom": true
+      }
+    },
     "readable-stream": {
       "packages": {
         "browserify>browser-resolve": true,
         "browserify>buffer": true,
-        "browserify>string_decoder": true,
-        "process": true,
+        "webpack>events": true,
         "pumpify>inherits": true,
-        "readable-stream>util-deprecate": true,
-        "webpack>events": true
+        "process": true,
+        "browserify>string_decoder": true,
+        "readable-stream>util-deprecate": true
       }
     },
-    "readable-stream>util-deprecate": {
+    "extension-port-stream>readable-stream": {
       "globals": {
-        "console.trace": true,
-        "console.warn": true,
-        "localStorage": true
+        "AbortController": true,
+        "AggregateError": true,
+        "Blob": true
+      },
+      "packages": {
+        "extension-port-stream>readable-stream>abort-controller": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "process": true,
+        "browserify>string_decoder": true
+      }
+    },
+    "@metamask/snaps-controllers>readable-web-to-node-stream": {
+      "packages": {
+        "readable-stream": true
       }
     },
     "redux": {
@@ -5091,6 +4823,111 @@
         "@babel/runtime": true
       }
     },
+    "string.prototype.matchall>regexp.prototype.flags": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+      }
+    },
+    "react-markdown>remark-parse": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown": true
+      }
+    },
+    "react-markdown>remark-rehype": {
+      "packages": {
+        "react-markdown>remark-rehype>mdast-util-to-hast": true
+      }
+    },
+    "react-markdown>vfile>replace-ext": {
+      "packages": {
+        "path-browserify": true
+      }
+    },
+    "@metamask/network-controller>reselect": {
+      "globals": {
+        "WeakRef": true,
+        "console.warn": true,
+        "unstable_autotrackMemoize": true
+      }
+    },
+    "@metamask/snaps-utils>rfdc": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "ethereumjs-util>create-hash>ripemd160": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>md5.js>hash-base": true,
+        "pumpify>inherits": true
+      }
+    },
+    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "eth-lattice-keyring>rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "ethereumjs-util>rlp": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true
+      }
+    },
+    "wait-on>rxjs": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setInterval.apply": true,
+        "setTimeout.apply": true
+      }
+    },
+    "koa>content-disposition>safe-buffer": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "react-dom>scheduler": {
+      "globals": {
+        "MessageChannel": true,
+        "cancelAnimationFrame": true,
+        "clearTimeout": true,
+        "console": true,
+        "navigator": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets>scrypt-js": {
+      "globals": {
+        "define": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>timers-browserify": true
+      }
+    },
+    "ganache>secp256k1": {
+      "packages": {
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>secp256k1": {
+      "packages": {
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
     "semver": {
       "globals": {
         "console.error": true
@@ -5099,16 +4936,69 @@
         "process": true
       }
     },
-    "serve-handler>path-to-regexp": {
+    "string.prototype.matchall>call-bind>set-function-length": {
       "packages": {
-        "serve-handler>path-to-regexp>isarray": true
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "promise-to-callback>set-immediate-shim": {
+      "globals": {
+        "setTimeout.apply": true
+      },
+      "packages": {
+        "browserify>timers-browserify": true
+      }
+    },
+    "addons-linter>sha.js": {
+      "packages": {
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "string.prototype.matchall>side-channel": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>object-inspect": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": true,
+        "@metamask/profile-sync-controller>siwe>@stablelib/random": true,
+        "ethers": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>valid-url": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": {
+      "globals": {
+        "StopIteration": true
+      },
+      "packages": {
+        "string.prototype.matchall>internal-slot": true
       }
     },
     "stream-browserify": {
       "packages": {
+        "webpack>events": true,
         "pumpify>inherits": true,
-        "readable-stream": true,
-        "webpack>events": true
+        "readable-stream": true
       }
     },
     "stream-http": {
@@ -5127,160 +5017,195 @@
       },
       "packages": {
         "browserify>buffer": true,
-        "browserify>url": true,
-        "process": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
         "stream-http>builtin-status-codes": true,
+        "pumpify>inherits": true,
+        "process": true,
+        "readable-stream": true,
+        "browserify>url": true,
         "watchify>xtend": true
       }
     },
-    "string.prototype.matchall>call-bind": {
+    "@metamask/snaps-controllers>tar-stream>streamx": {
       "packages": {
-        "browserify>has>function-bind": true,
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>call-bind>set-function-length": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "webpack>events": true,
+        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
+        "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": true
       }
     },
-    "string.prototype.matchall>call-bind>es-define-property": {
+    "browserify>string_decoder": {
       "packages": {
-        "string.prototype.matchall>get-intrinsic": true
+        "koa>content-disposition>safe-buffer": true
       }
     },
-    "string.prototype.matchall>call-bind>set-function-length": {
+    "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>gopd": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true
       }
     },
-    "string.prototype.matchall>define-properties": {
+    "react-markdown>style-to-object": {
       "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+        "react-markdown>style-to-object>inline-style-parser": true
       }
     },
-    "string.prototype.matchall>define-properties>define-data-property": {
+    "@metamask/snaps-controllers>tar-stream": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>gopd": true
+        "@metamask/snaps-controllers>tar-stream>b4a": true,
+        "browserify>browser-resolve": true,
+        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
+        "@metamask/snaps-controllers>tar-stream>streamx": true
       }
     },
-    "string.prototype.matchall>es-abstract>array-buffer-byte-length": {
+    "debounce-stream>through": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>is-array-buffer": true
+        "process": true,
+        "stream-browserify": true
       }
     },
-    "string.prototype.matchall>es-abstract>available-typed-arrays": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>typed-array-length>possible-typed-array-names": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
-      "packages": {
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>gopd": {
-      "packages": {
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>has-property-descriptors": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-array-buffer": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-callable": {
+    "browserify>timers-browserify": {
       "globals": {
-        "document": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-regex": {
+        "clearInterval": true,
+        "clearTimeout": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
       "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
+        "process": true
       }
     },
-    "string.prototype.matchall>es-abstract>is-shared-array-buffer": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>object-inspect": {
+    "react-router-dom>tiny-warning": {
       "globals": {
-        "HTMLElement": true,
-        "WeakRef": true
+        "console": true
+      }
+    },
+    "copy-to-clipboard>toggle-selection": {
+      "globals": {
+        "document.activeElement": true,
+        "document.getSelection": true
+      }
+    },
+    "@swc/helpers>tslib": {
+      "globals": {
+        "SuppressedError": true,
+        "define": true
+      }
+    },
+    "@metamask/eth-sig-util>tweetnacl": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "nacl": "write"
       },
       "packages": {
         "browserify>browser-resolve": true
       }
     },
-    "string.prototype.matchall>get-intrinsic": {
+    "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": {
       "globals": {
-        "AggregateError": true,
-        "FinalizationRegistry": true,
-        "WeakRef": true
+        "define": true
+      }
+    },
+    "@ensdomains/content-hash>cids>uint8arrays": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
       },
       "packages": {
-        "browserify>has>function-bind": true,
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>has-proto": true,
-        "string.prototype.matchall>has-symbols": true
+        "@ensdomains/content-hash>cids>multibase": true
       }
     },
-    "string.prototype.matchall>internal-slot": {
+    "@ensdomains/content-hash>multicodec>uint8arrays": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
       "packages": {
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>side-channel": true
+        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true
       }
     },
-    "string.prototype.matchall>regexp.prototype.flags": {
+    "react-markdown>unified": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+        "react-markdown>unified>bail": true,
+        "react-markdown>unified>extend": true,
+        "react-markdown>unified>is-buffer": true,
+        "mocha>yargs-unparser>is-plain-obj": true,
+        "react-markdown>unified>trough": true,
+        "react-markdown>vfile": true
       }
     },
-    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+    "react-markdown>unist-util-visit>unist-util-visit-parents": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+        "react-markdown>unist-util-visit>unist-util-is": true
       }
     },
-    "string.prototype.matchall>side-channel": {
+    "react-markdown>unist-util-visit": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>object-inspect": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "terser>source-map-support>buffer-from": {
-      "packages": {
-        "browserify>buffer": true
+        "react-markdown>unist-util-visit>unist-util-visit-parents": true
       }
     },
     "uri-js": {
       "globals": {
         "define": true
+      }
+    },
+    "browserify>url": {
+      "packages": {
+        "browserify>punycode": true,
+        "@storybook/addon-knobs>qs": true
+      }
+    },
+    "react-focus-lock>use-callback-ref": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-beautiful-dnd>use-memo-one": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-focus-lock>use-sidecar": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "react-focus-lock>use-sidecar>detect-node-es": true,
+        "react": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "readable-stream>util-deprecate": {
+      "globals": {
+        "console.trace": true,
+        "console.warn": true,
+        "localStorage": true
+      }
+    },
+    "browserify>assert>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true,
+        "process": true
+      },
+      "packages": {
+        "browserify>assert>util>inherits": true,
+        "process": true
+      }
+    },
+    "browserify>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "browserify>util>is-arguments": true,
+        "koa>is-generator-function": true,
+        "browserify>util>is-typed-array": true,
+        "process": true,
+        "browserify>util>which-typed-array": true
       }
     },
     "uuid": {
@@ -5289,15 +5214,64 @@
         "msCrypto": true
       }
     },
-    "wait-on>rxjs": {
+    "@metamask/eth-snap-keyring>uuid": {
       "globals": {
-        "cancelAnimationFrame": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setInterval.apply": true,
-        "setTimeout.apply": true
+        "crypto": true
+      }
+    },
+    "@metamask/keyring-api>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "web3-stream-provider>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/snaps-utils>validate-npm-package-name": {
+      "packages": {
+        "@metamask/snaps-utils>validate-npm-package-name>builtins": true
+      }
+    },
+    "react-markdown>vfile>vfile-message": {
+      "packages": {
+        "react-markdown>vfile>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>vfile": {
+      "packages": {
+        "react-markdown>vfile>is-buffer": true,
+        "path-browserify": true,
+        "process": true,
+        "react-markdown>vfile>replace-ext": true,
+        "react-markdown>vfile>vfile-message": true
+      }
+    },
+    "browserify>vm-browserify": {
+      "globals": {
+        "document.body.appendChild": true,
+        "document.body.removeChild": true,
+        "document.createElement": true
+      }
+    },
+    "react-popper>warning": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>web-encoding": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "browserify>util": true
       }
     },
     "web3": {
@@ -5310,14 +5284,14 @@
         "setTimeout": true
       },
       "packages": {
-        "browserify>util": true,
         "readable-stream": true,
+        "browserify>util": true,
         "web3-stream-provider>uuid": true
       }
     },
-    "web3-stream-provider>uuid": {
+    "@metamask/controllers>web3": {
       "globals": {
-        "crypto": true
+        "XMLHttpRequest": true
       }
     },
     "webextension-polyfill": {
@@ -5329,9 +5303,35 @@
         "define": true
       }
     },
-    "webpack>events": {
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": {
+      "packages": {
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-collection": {
+      "packages": {
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakmap": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": true
+      }
+    },
+    "browserify>util>which-typed-array": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>available-typed-arrays": true,
+        "string.prototype.matchall>call-bind": true,
+        "browserify>util>which-typed-array>for-each": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": {
       "globals": {
-        "console": true
+        "XMLHttpRequest": true
       }
     }
   }

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2645,7 +2645,7 @@
         "@zxing/library>ts-custom-error": true
       }
     },
-    "extension-port-stream>readable-stream>abort-controller": {
+    "@lavamoat/lavapack>readable-stream>abort-controller": {
       "globals": {
         "AbortController": true
       }
@@ -4803,7 +4803,7 @@
         "Blob": true
       },
       "packages": {
-        "extension-port-stream>readable-stream>abort-controller": true,
+        "@lavamoat/lavapack>readable-stream>abort-controller": true,
         "browserify>buffer": true,
         "webpack>events": true,
         "process": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -5,115 +5,70 @@
         "regeneratorRuntime": "write"
       }
     },
+    "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": {
+      "globals": {
+        "SuppressedError": true
+      }
+    },
     "@ensdomains/content-hash": {
       "globals": {
         "console.warn": true
       },
       "packages": {
+        "browserify>buffer": true,
         "@ensdomains/content-hash>cids": true,
         "@ensdomains/content-hash>js-base64": true,
         "@ensdomains/content-hash>multicodec": true,
-        "@ensdomains/content-hash>multihashes": true,
-        "browserify>buffer": true
+        "@ensdomains/content-hash>multihashes": true
       }
     },
-    "@ensdomains/content-hash>cids": {
+    "@ethereumjs/tx>@ethereumjs/common": {
       "packages": {
-        "@ensdomains/content-hash>cids>multibase": true,
-        "@ensdomains/content-hash>cids>multihashes": true,
-        "@ensdomains/content-hash>cids>uint8arrays": true,
-        "@ensdomains/content-hash>multicodec": true
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "webpack>events": true
       }
     },
-    "@ensdomains/content-hash>cids>multibase": {
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "@metamask/transaction-controller>@ethereumjs/common": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "webpack>events": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@ethereumjs/common": {
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "@ethereumjs/tx>@ethereumjs/rlp": {
       "globals": {
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase>@multiformats/base-x": true
       }
     },
-    "@ensdomains/content-hash>cids>multihashes": {
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase": true,
-        "@ensdomains/content-hash>cids>multihashes>varint": true,
-        "@ensdomains/content-hash>cids>uint8arrays": true
-      }
-    },
-    "@ensdomains/content-hash>cids>uint8arrays": {
+    "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": {
       "globals": {
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase": true
       }
     },
-    "@ensdomains/content-hash>js-base64": {
+    "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": {
       "globals": {
-        "Base64": "write",
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "atob": true,
-        "btoa": true,
-        "define": true
-      },
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec": {
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays": true,
-        "sass-embedded>varint": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec>uint8arrays": {
-      "globals": {
-        "Buffer": true,
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "console.warn": true,
-        "crypto.subtle.digest": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase": true,
-        "@ensdomains/content-hash>multihashes>varint": true,
-        "@ensdomains/content-hash>multihashes>web-encoding": true,
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>multibase": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase>base-x": true,
-        "@ensdomains/content-hash>multihashes>web-encoding": true,
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>multibase>base-x": {
-      "packages": {
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>web-encoding": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "browserify>util": true
       }
     },
     "@ethereumjs/tx": {
@@ -121,28 +76,36 @@
         "@ethereumjs/tx>@ethereumjs/common": true,
         "@ethereumjs/tx>@ethereumjs/rlp": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>insert-module-globals>is-buffer": true
       }
     },
-    "@ethereumjs/tx>@ethereumjs/common": {
+    "@metamask/smart-transactions-controller>@ethereumjs/tx": {
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "browserify>buffer": true,
+        "@trezor/connect-web>@trezor/connect>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": {
+      "globals": {
+        "console.warn": true,
+        "fetch": true
+      },
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "webpack>events": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/common>crc-32": {
-      "globals": {
-        "DO_NOT_EXPORT_CRC": true,
-        "define": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/rlp": {
-      "globals": {
-        "TextEncoder": true
       }
     },
     "@ethereumjs/tx>@ethereumjs/util": {
@@ -151,78 +114,33 @@
       },
       "packages": {
         "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": true,
-        "@ethereumjs/tx>@ethereumjs/util>micro-ftch": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true,
         "browserify>insert-module-globals>is-buffer": true,
-        "webpack>events": true
+        "@ethereumjs/tx>@ethereumjs/util>micro-ftch": true
       }
     },
-    "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": {
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": {
       "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/util>micro-ftch": {
-      "globals": {
-        "Headers": true,
-        "TextDecoder": true,
-        "URL": true,
-        "btoa": true,
+        "console.warn": true,
         "fetch": true
       },
       "packages": {
-        "browserify>browserify-zlib": true,
-        "browserify>buffer": true,
-        "browserify>url": true,
-        "browserify>util": true,
-        "https-browserify": true,
-        "process": true,
-        "stream-http": true
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true
       }
     },
-    "@ethereumjs/tx>ethereum-cryptography": {
+    "@metamask/smart-transactions-controller>@ethereumjs/util": {
       "globals": {
-        "TextDecoder": true,
-        "crypto": true
+        "console.warn": true,
+        "fetch": true
       },
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": true,
-        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/curves": {
-      "globals": {
-        "TextEncoder": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true
       }
     },
     "@ethersproject/abi": {
@@ -230,27 +148,70 @@
         "console.log": true
       },
       "packages": {
+        "ethers>@ethersproject/address": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/strings": true
       }
     },
+    "ethers>@ethersproject/abstract-provider": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
+    "ethers>@ethersproject/abstract-signer": {
+      "packages": {
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
+    "ethers>@ethersproject/address": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/rlp": true
+      }
+    },
+    "ethers>@ethersproject/base64": {
+      "globals": {
+        "atob": true,
+        "btoa": true
+      },
+      "packages": {
+        "@ethersproject/bytes": true
+      }
+    },
+    "ethers>@ethersproject/basex": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
     "@ethersproject/bignumber": {
       "packages": {
         "@ethersproject/bytes": true,
-        "bn.js": true,
-        "ethers>@ethersproject/logger": true
+        "ethers>@ethersproject/logger": true,
+        "bn.js": true
       }
     },
     "@ethersproject/bytes": {
       "packages": {
         "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/constants": {
+      "packages": {
+        "@ethersproject/bignumber": true
       }
     },
     "@ethersproject/contracts": {
@@ -259,11 +220,11 @@
       },
       "packages": {
         "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/transactions": true
@@ -271,10 +232,10 @@
     },
     "@ethersproject/hash": {
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
@@ -283,9 +244,9 @@
     },
     "@ethersproject/hdnode": {
       "packages": {
+        "ethers>@ethersproject/basex": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/bytes": true,
-        "ethers>@ethersproject/basex": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/pbkdf2": true,
         "ethers>@ethersproject/properties": true,
@@ -294,6 +255,54 @@
         "ethers>@ethersproject/strings": true,
         "ethers>@ethersproject/transactions": true,
         "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets": {
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bytes": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/pbkdf2": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/json-wallets>aes-js": true,
+        "ethers>@ethersproject/json-wallets>scrypt-js": true
+      }
+    },
+    "ethers>@ethersproject/keccak256": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "@metamask/ethjs>js-sha3": true
+      }
+    },
+    "ethers>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "ethers>@ethersproject/providers>@ethersproject/networks": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "@metamask/test-bundler>@ethersproject/networks": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/pbkdf2": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/sha2": true
+      }
+    },
+    "ethers>@ethersproject/properties": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
       }
     },
     "@ethersproject/providers": {
@@ -307,29 +316,140 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/providers>@ethersproject/web": true,
-        "@ethersproject/providers>bech32": true,
-        "@metamask/test-bundler>@ethersproject/networks": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
         "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
         "ethers>@ethersproject/logger": true,
+        "@metamask/test-bundler>@ethersproject/networks": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/random": true,
         "ethers>@ethersproject/sha2": true,
         "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
+        "ethers>@ethersproject/transactions": true,
+        "@ethersproject/providers>@ethersproject/web": true,
+        "@ethersproject/providers>bech32": true
+      }
+    },
+    "ethers>@ethersproject/providers": {
+      "globals": {
+        "WebSocket": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "console.warn": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethers>@ethersproject/abstract-provider": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/providers>@ethersproject/networks": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/providers>bech32": true
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
+      }
+    },
+    "ethers>@ethersproject/random": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/rlp": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/sha2": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/sha2>hash.js": true
+      }
+    },
+    "ethers>@ethersproject/signing-key": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "ethers>@ethersproject/solidity": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/strings": true
+      }
+    },
+    "ethers>@ethersproject/strings": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/transactions": {
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/signing-key": true
+      }
+    },
+    "ethers>@ethersproject/units": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "@ethersproject/wallet": {
+      "packages": {
+        "ethers>@ethersproject/abstract-provider": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bytes": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/transactions": true
       }
     },
     "@ethersproject/providers>@ethersproject/web": {
@@ -339,1486 +459,48 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/strings": true
       }
     },
-    "@ethersproject/wallet": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "ethers>@ethersproject/abstract-provider": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "@keystonehq/bc-ur-registry-eth": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "uuid": true
-      }
-    },
-    "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": {
+    "ethers>@ethersproject/providers>@ethersproject/web": {
       "globals": {
-        "define": true
-      },
-      "packages": {
-        "@ngraveio/bc-ur": true,
-        "@swc/helpers>tslib": true,
-        "browserify>buffer": true,
-        "buffer": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring": {
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@keystonehq/bc-ur-registry-eth": true,
-        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": true,
-        "@metamask/obs-store": true,
-        "browserify>buffer": true,
-        "ethereumjs-util>rlp": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": {
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@keystonehq/bc-ur-registry-eth": true,
-        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "uuid": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@lavamoat/lavadome-react": {
-      "globals": {
-        "Document.prototype": true,
-        "DocumentFragment.prototype": true,
-        "Element.prototype": true,
-        "Node.prototype": true,
-        "console.warn": true,
-        "document": true
-      },
-      "packages": {
-        "react": true
-      }
-    },
-    "@material-ui/core": {
-      "globals": {
-        "Image": true,
-        "_formatMuiErrorMessage": true,
-        "addEventListener": true,
-        "clearInterval": true,
         "clearTimeout": true,
-        "console.error": true,
-        "console.warn": true,
-        "document": true,
-        "getComputedStyle": true,
-        "getSelection": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "matchMedia": true,
-        "navigator": true,
-        "performance.now": true,
-        "removeEventListener": true,
-        "requestAnimationFrame": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles": true,
-        "@material-ui/core>@material-ui/system": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "@material-ui/core>clsx": true,
-        "@material-ui/core>popper.js": true,
-        "@material-ui/core>react-transition-group": true,
-        "prop-types": true,
-        "prop-types>react-is": true,
-        "react": true,
-        "react-dom": true,
-        "react-redux>hoist-non-react-statics": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true,
-        "document.createComment": true,
-        "document.head": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-global": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-nested": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-props-sort": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "@material-ui/core>clsx": true,
-        "prop-types": true,
-        "react": true,
-        "react-redux>hoist-non-react-statics": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss": {
-      "globals": {
-        "CSS": true,
-        "document.createElement": true,
-        "document.querySelector": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case>hyphenate-style-name": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": {
-      "globals": {
-        "CSS": true
-      },
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-global": {
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-nested": {
-      "packages": {
-        "@babel/runtime": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": {
-      "globals": {
-        "document.createElement": true,
-        "document.documentElement": true,
-        "getComputedStyle": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss>is-in-browser": {
-      "globals": {
-        "document": true
-      }
-    },
-    "@material-ui/core>@material-ui/system": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "prop-types": true
-      }
-    },
-    "@material-ui/core>@material-ui/utils": {
-      "packages": {
-        "@babel/runtime": true,
-        "prop-types": true,
-        "prop-types>react-is": true
-      }
-    },
-    "@material-ui/core>popper.js": {
-      "globals": {
-        "MSInputMethodContext": true,
-        "Node.DOCUMENT_POSITION_FOLLOWING": true,
-        "cancelAnimationFrame": true,
-        "console.warn": true,
-        "define": true,
-        "devicePixelRatio": true,
-        "document": true,
-        "getComputedStyle": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "navigator": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
-      }
-    },
-    "@material-ui/core>react-transition-group": {
-      "globals": {
-        "Element": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@material-ui/core>react-transition-group>dom-helpers": true,
-        "prop-types": true,
-        "react": true,
-        "react-dom": true
-      }
-    },
-    "@material-ui/core>react-transition-group>dom-helpers": {
-      "packages": {
-        "@babel/runtime": true
-      }
-    },
-    "@metamask/abi-utils": {
-      "packages": {
-        "@metamask/abi-utils>@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/abi-utils>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/accounts-controller": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/base-controller": true,
-        "@metamask/eth-snap-keyring": true,
-        "@metamask/keyring-api": true,
-        "@metamask/keyring-controller": true,
-        "@metamask/utils": true,
-        "uuid": true
-      }
-    },
-    "@metamask/address-book-controller": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true
-      }
-    },
-    "@metamask/announcement-controller": {
-      "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/approval-controller": {
-      "globals": {
-        "console.info": true
-      },
-      "packages": {
-        "@metamask/approval-controller>nanoid": true,
-        "@metamask/base-controller": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/approval-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/assets-controllers": {
-      "globals": {
-        "AbortController": true,
-        "Headers": true,
-        "URL": true,
-        "URLSearchParams": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "console.log": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/providers": true,
-        "@metamask/abi-utils": true,
-        "@metamask/base-controller": true,
-        "@metamask/contract-metadata": true,
-        "@metamask/controller-utils": true,
-        "@metamask/eth-query": true,
-        "@metamask/metamask-eth-abis": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/polling-controller": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "bn.js": true,
-        "cockatiel": true,
-        "ethers>@ethersproject/address": true,
-        "lodash": true,
-        "single-call-balance-checker-abi": true,
-        "uuid": true
-      }
-    },
-    "@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/browser-passworder": {
-      "globals": {
-        "CryptoKey": true,
-        "btoa": true,
-        "crypto.getRandomValues": true,
-        "crypto.subtle.decrypt": true,
-        "crypto.subtle.deriveKey": true,
-        "crypto.subtle.encrypt": true,
-        "crypto.subtle.exportKey": true,
-        "crypto.subtle.importKey": true
-      },
-      "packages": {
-        "@metamask/browser-passworder>@metamask/utils": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/browser-passworder>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/controller-utils": {
-      "globals": {
-        "URL": true,
-        "console.error": true,
         "fetch": true,
         "setTimeout": true
       },
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/controller-utils>@spruceid/siwe-parser": true,
-        "@metamask/ethjs>@metamask/ethjs-unit": true,
-        "@metamask/utils": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "eslint>fast-deep-equal": true,
-        "eth-ens-namehash": true
-      }
-    },
-    "@metamask/controller-utils>@spruceid/siwe-parser": {
-      "globals": {
-        "console.error": true,
-        "console.log": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/controllers>web3": {
-      "globals": {
-        "XMLHttpRequest": true
-      }
-    },
-    "@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch": {
-      "globals": {
-        "fetch": true
-      }
-    },
-    "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
-      "globals": {
-        "fetch": true
-      }
-    },
-    "@metamask/ens-controller": {
-      "packages": {
-        "@ethersproject/providers": true,
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/utils": true,
-        "punycode": true
-      }
-    },
-    "@metamask/eth-json-rpc-filters": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/safe-event-emitter": true,
-        "pify": true
-      }
-    },
-    "@metamask/eth-json-rpc-middleware": {
-      "globals": {
-        "URL": true,
-        "console.error": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-json-rpc-middleware>@metamask/utils": true,
-        "@metamask/eth-json-rpc-middleware>klona": true,
-        "@metamask/eth-json-rpc-middleware>safe-stable-stringify": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/eth-json-rpc-middleware>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-json-rpc-provider": {
-      "packages": {
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/safe-event-emitter": true,
-        "uuid": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring": {
-      "globals": {
-        "addEventListener": true,
-        "console.error": true,
-        "document.createElement": true,
-        "document.head.appendChild": true,
-        "fetch": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@ethersproject/abi": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": true,
-        "browserify>buffer": true,
-        "ethers>@ethersproject/rlp": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
-      "packages": {
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": {
-      "globals": {
-        "console.warn": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
-      "packages": {
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": true,
-        "@metamask/ppom-validator>crypto-js": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "wait-on>rxjs": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": {
-      "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "@ethersproject/providers": true,
-        "@ethersproject/providers>@ethersproject/web": true,
-        "@ethersproject/wallet": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/solidity": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true,
-        "ethers>@ethersproject/units": true,
-        "ethers>@ethersproject/wordlists": true
+        "ethers>@ethersproject/strings": true
       }
     },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": {
-      "globals": {
-        "__ledgerLogsListen": "write",
-        "console.error": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "@metamask/eth-query": {
-      "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "watchify>xtend": true
-      }
-    },
-    "@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-sig-util>tweetnacl": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true,
-        "nacl": "write"
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/eth-snap-keyring": {
-      "globals": {
-        "URL": true,
-        "console.error": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@metamask/eth-snap-keyring>@metamask/eth-sig-util": true,
-        "@metamask/eth-snap-keyring>@metamask/utils": true,
-        "@metamask/eth-snap-keyring>uuid": true,
-        "@metamask/keyring-api": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-snap-keyring>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/eth-snap-keyring>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/eth-snap-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-snap-keyring>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "@metamask/eth-token-tracker": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@metamask/eth-token-tracker>@metamask/eth-block-tracker": true,
-        "@metamask/eth-token-tracker>deep-equal": true,
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true,
-        "@metamask/safe-event-emitter": true,
-        "bn.js": true,
-        "human-standard-token-abi": true
-      }
-    },
-    "@metamask/eth-token-tracker>@metamask/eth-block-tracker": {
+    "ethers>@ethersproject/web": {
       "globals": {
         "clearTimeout": true,
-        "console.error": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": true,
-        "@metamask/safe-event-emitter": true,
-        "pify": true
-      }
-    },
-    "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator": true,
-        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection": true,
-        "@ngraveio/bc-ur>assert>object-is": true,
-        "browserify>util>is-arguments": true,
-        "browserify>util>which-typed-array": true,
-        "gulp>vinyl-fs>object.assign": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>array-buffer-byte-length": true,
-        "string.prototype.matchall>es-abstract>is-array-buffer": true,
-        "string.prototype.matchall>es-abstract>is-regex": true,
-        "string.prototype.matchall>es-abstract>is-shared-array-buffer": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>regexp.prototype.flags": true,
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>es-get-iterator": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": true,
-        "browserify>util>is-arguments": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "process": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": {
-      "globals": {
-        "StopIteration": true
-      },
-      "packages": {
-        "string.prototype.matchall>internal-slot": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>unbox-primitive>has-bigints": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-collection": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakmap": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "@metamask/eth-trezor-keyring": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "@trezor/connect-web": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": {
-      "packages": {
-        "@metamask/eth-sig-util": true,
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/eth-trezor-keyring>hdkey": {
-      "packages": {
-        "browserify>assert": true,
-        "crypto-browserify": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ganache>secp256k1": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@metamask/etherscan-link": {
-      "globals": {
-        "URL": true
-      }
-    },
-    "@metamask/ethjs": {
-      "globals": {
-        "clearInterval": true,
-        "setInterval": true
-      },
-      "packages": {
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true,
-        "@metamask/ethjs>@metamask/ethjs-filter": true,
-        "@metamask/ethjs>@metamask/ethjs-provider-http": true,
-        "@metamask/ethjs>@metamask/ethjs-unit": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>@metamask/number-to-bn": true,
-        "@metamask/ethjs>ethjs-abi": true,
-        "@metamask/ethjs>js-sha3": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs-contract": {
-      "packages": {
-        "@babel/runtime": true,
-        "@metamask/ethjs>@metamask/ethjs-filter": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>ethjs-abi": true,
-        "@metamask/ethjs>js-sha3": true,
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs-query": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@metamask/ethjs-query>@metamask/ethjs-format": true,
-        "@metamask/ethjs-query>@metamask/ethjs-rpc": true,
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs-query>@metamask/ethjs-format": {
-      "packages": {
-        "@metamask/ethjs-query>@metamask/ethjs-format>ethjs-schema": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "@metamask/ethjs>@metamask/number-to-bn": true
-      }
-    },
-    "@metamask/ethjs-query>@metamask/ethjs-rpc": {
-      "packages": {
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-filter": {
-      "globals": {
-        "clearInterval": true,
-        "setInterval": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-provider-http": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": {
-      "globals": {
-        "XMLHttpRequest": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-unit": {
-      "packages": {
-        "@metamask/ethjs>@metamask/number-to-bn": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-util": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true,
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true
-      }
-    },
-    "@metamask/ethjs>@metamask/number-to-bn": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>ethjs-abi": {
-      "packages": {
-        "@metamask/ethjs>ethjs-abi>number-to-bn": true,
-        "@metamask/ethjs>js-sha3": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs>ethjs-abi>number-to-bn": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>js-sha3": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "process": true
-      }
-    },
-    "@metamask/gas-fee-controller": {
-      "globals": {
-        "clearInterval": true,
-        "console.error": true,
-        "setInterval": true
-      },
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/eth-query": true,
-        "@metamask/polling-controller": true,
-        "bn.js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/jazzicon": {
-      "globals": {
-        "document.createElement": true,
-        "document.createElementNS": true
-      },
-      "packages": {
-        "@metamask/jazzicon>color": true,
-        "@metamask/jazzicon>mersenne-twister": true
-      }
-    },
-    "@metamask/jazzicon>color": {
-      "packages": {
-        "@metamask/jazzicon>color>clone": true,
-        "@metamask/jazzicon>color>color-convert": true,
-        "@metamask/jazzicon>color>color-string": true
-      }
-    },
-    "@metamask/jazzicon>color>clone": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/jazzicon>color>color-convert": {
-      "packages": {
-        "@metamask/jazzicon>color>color-convert>color-name": true
-      }
-    },
-    "@metamask/jazzicon>color>color-string": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
-      }
-    },
-    "@metamask/json-rpc-engine": {
-      "packages": {
-        "@metamask/rpc-errors": true,
-        "@metamask/safe-event-emitter": true,
-        "@metamask/utils": true
-      }
-    },
-    "@metamask/json-rpc-middleware-stream": {
-      "globals": {
-        "console.warn": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/safe-event-emitter": true,
-        "@metamask/utils": true,
-        "readable-stream": true
-      }
-    },
-    "@metamask/keyring-api": {
-      "globals": {
-        "URL": true
-      },
-      "packages": {
-        "@metamask/keyring-api>@metamask/utils": true,
-        "@metamask/keyring-api>bech32": true,
-        "@metamask/keyring-api>uuid": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/keyring-api>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-api>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "@metamask/keyring-controller": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/base-controller": true,
-        "@metamask/browser-passworder": true,
-        "@metamask/keyring-controller>@metamask/eth-hd-keyring": true,
-        "@metamask/keyring-controller>@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
-        "@metamask/keyring-controller>ethereumjs-wallet": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/utils": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-hd-keyring": {
-      "globals": {
-        "TextEncoder": true
-      },
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": true,
-        "@metamask/scure-bip39": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-simple-keyring": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": true,
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet": {
-      "packages": {
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": true,
-        "@metamask/keyring-controller>ethereumjs-wallet>utf8": true,
-        "browserify>buffer": true,
-        "crypto-browserify": true,
-        "crypto-browserify>randombytes": true,
-        "eth-lattice-keyring>gridplus-sdk>aes-js": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ethers>@ethersproject/json-wallets>scrypt-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": {
-      "packages": {
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "crypto-browserify>create-hmac": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ethereumjs-util>ethereum-cryptography>keccak": true,
-        "ethers>@ethersproject/sha2>hash.js": true,
-        "ganache>secp256k1": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": {
-      "packages": {
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
-        "bn.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>rlp": true
-      }
-    },
-    "@metamask/logging-controller": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "uuid": true
-      }
-    },
-    "@metamask/logo": {
-      "globals": {
-        "addEventListener": true,
-        "document.body.appendChild": true,
-        "document.createElementNS": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "requestAnimationFrame": true
-      },
-      "packages": {
-        "@metamask/logo>gl-mat4": true,
-        "@metamask/logo>gl-vec3": true
-      }
-    },
-    "@metamask/message-manager": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/utils": true,
-        "browserify>buffer": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/message-manager>jsonschema": {
-      "packages": {
-        "browserify>url": true
-      }
-    },
-    "@metamask/name-controller": {
-      "globals": {
-        "fetch": true
-      },
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/name-controller>@metamask/base-controller": true,
-        "@metamask/name-controller>@metamask/utils": true,
-        "@metamask/name-controller>async-mutex": true
-      }
-    },
-    "@metamask/name-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/name-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/name-controller>async-mutex": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/network-controller": {
-      "globals": {
-        "btoa": true,
         "fetch": true,
         "setTimeout": true
       },
       "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/network-controller>reselect": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "eslint>fast-deep-equal": true,
-        "uri-js": true,
-        "uuid": true
+        "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
       }
     },
-    "@metamask/network-controller>@metamask/eth-block-tracker": {
-      "globals": {
-        "clearTimeout": true,
-        "console.error": true,
-        "setTimeout": true
-      },
+    "ethers>@ethersproject/wordlists": {
       "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": true,
-        "@metamask/safe-event-emitter": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-json-rpc-infura": {
-      "globals": {
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/network-controller>reselect": {
-      "globals": {
-        "WeakRef": true,
-        "console.warn": true,
-        "unstable_autotrackMemoize": true
-      }
-    },
-    "@metamask/notification-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/notification-services-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "addEventListener": true,
-        "fetch": true,
-        "registration": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": true,
-        "@metamask/notification-services-controller>bignumber.js": true,
-        "@metamask/notification-services-controller>firebase": true,
-        "@metamask/profile-sync-controller": true,
-        "@metamask/utils": true,
-        "loglevel": true,
-        "uuid": true
-      }
-    },
-    "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": {
-      "globals": {
-        "SuppressedError": true
-      }
-    },
-    "@metamask/notification-services-controller>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase": {
-      "packages": {
-        "@metamask/notification-services-controller>firebase>@firebase/app": true,
-        "@metamask/notification-services-controller>firebase>@firebase/messaging": true
+        "@ethersproject/bytes": true,
+        "@ethersproject/hash": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/app": {
@@ -1829,34 +511,13 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": {
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/util": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>idb": {
-      "globals": {
-        "DOMException": true,
-        "IDBCursor": true,
-        "IDBDatabase": true,
-        "IDBIndex": true,
-        "IDBObjectStore": true,
-        "IDBRequest": true,
-        "IDBTransaction": true,
-        "indexedDB.deleteDatabase": true,
-        "indexedDB.open": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/installations": {
@@ -1874,8 +535,16 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/messaging": {
@@ -1906,9 +575,9 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
         "@metamask/notification-services-controller>firebase>@firebase/installations": true,
         "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
         "@swc/helpers>tslib": true
       }
     },
@@ -1930,6 +599,820 @@
         "process": true
       }
     },
+    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@keystonehq/bc-ur-registry-eth": true,
+        "browserify>buffer": true,
+        "@metamask/eth-trezor-keyring>hdkey": true,
+        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": true,
+        "uuid": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": true,
+        "browserify>buffer": true,
+        "@metamask/eth-trezor-keyring>hdkey": true,
+        "uuid": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "@ngraveio/bc-ur": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "buffer": true,
+        "browserify>buffer": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@keystonehq/metamask-airgapped-keyring": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": true,
+        "@keystonehq/bc-ur-registry-eth": true,
+        "@metamask/obs-store": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "ethereumjs-util>rlp": true,
+        "uuid": true
+      }
+    },
+    "chart.js>@kurkle/color": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@lavamoat/lavadome-react": {
+      "globals": {
+        "Document.prototype": true,
+        "DocumentFragment.prototype": true,
+        "Element.prototype": true,
+        "Node.prototype": true,
+        "console.warn": true,
+        "document": true
+      },
+      "packages": {
+        "react": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": true,
+        "@metamask/ppom-validator>crypto-js": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/rlp": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": true,
+        "browserify>buffer": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "wait-on>rxjs": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": {
+      "globals": {
+        "__ledgerLogsListen": "write",
+        "console.error": true
+      }
+    },
+    "@material-ui/core": {
+      "globals": {
+        "Image": true,
+        "_formatMuiErrorMessage": true,
+        "addEventListener": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "getSelection": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "matchMedia": true,
+        "navigator": true,
+        "performance.now": true,
+        "removeEventListener": true,
+        "requestAnimationFrame": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles": true,
+        "@material-ui/core>@material-ui/system": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
+        "@material-ui/core>popper.js": true,
+        "prop-types": true,
+        "react": true,
+        "react-dom": true,
+        "prop-types>react-is": true,
+        "@material-ui/core>react-transition-group": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true,
+        "document.createComment": true,
+        "document.head": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-global": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-nested": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-props-sort": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": true,
+        "@material-ui/core>@material-ui/styles>jss": true,
+        "prop-types": true,
+        "react": true
+      }
+    },
+    "@material-ui/core>@material-ui/system": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "prop-types": true
+      }
+    },
+    "@material-ui/core>@material-ui/utils": {
+      "packages": {
+        "@babel/runtime": true,
+        "prop-types": true,
+        "prop-types>react-is": true
+      }
+    },
+    "@metamask/abi-utils": {
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/abi-utils>@metamask/utils": true
+      }
+    },
+    "@metamask/accounts-controller": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-snap-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "uuid": true
+      }
+    },
+    "@metamask/address-book-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
+    "@metamask/announcement-controller": {
+      "packages": {
+        "@metamask/announcement-controller>@metamask/base-controller": true
+      }
+    },
+    "@metamask/approval-controller": {
+      "globals": {
+        "console.info": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/approval-controller>nanoid": true
+      }
+    },
+    "@metamask/assets-controllers": {
+      "globals": {
+        "AbortController": true,
+        "Headers": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "console.log": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/abi-utils": true,
+        "@metamask/base-controller": true,
+        "@metamask/contract-metadata": true,
+        "@metamask/controller-utils": true,
+        "@metamask/eth-query": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/polling-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
+        "bn.js": true,
+        "cockatiel": true,
+        "lodash": true,
+        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true,
+        "single-call-balance-checker-abi": true,
+        "uuid": true
+      }
+    },
+    "@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/announcement-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/name-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/browser-passworder": {
+      "globals": {
+        "CryptoKey": true,
+        "btoa": true,
+        "crypto.getRandomValues": true,
+        "crypto.subtle.decrypt": true,
+        "crypto.subtle.deriveKey": true,
+        "crypto.subtle.encrypt": true,
+        "crypto.subtle.exportKey": true,
+        "crypto.subtle.importKey": true
+      },
+      "packages": {
+        "@metamask/browser-passworder>@metamask/utils": true,
+        "browserify>buffer": true
+      }
+    },
+    "eth-keyring-controller>@metamask/browser-passworder": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/controller-utils": {
+      "globals": {
+        "URL": true,
+        "console.error": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/ethjs>@metamask/ethjs-unit": true,
+        "@metamask/utils": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "eth-ens-namehash": true,
+        "eslint>fast-deep-equal": true
+      }
+    },
+    "@metamask/ens-controller": {
+      "packages": {
+        "@ethersproject/providers": true,
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/utils": true,
+        "punycode": true
+      }
+    },
+    "@metamask/eth-token-tracker>@metamask/eth-block-tracker": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": true,
+        "@metamask/eth-query>json-rpc-random-id": true,
+        "pify": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-block-tracker": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": true,
+        "@metamask/eth-query>json-rpc-random-id": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-hd-keyring": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "@metamask/eth-json-rpc-filters": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/safe-event-emitter": true,
+        "@metamask/name-controller>async-mutex": true,
+        "pify": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-json-rpc-infura": {
+      "globals": {
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": true
+      }
+    },
+    "@metamask/eth-json-rpc-middleware": {
+      "globals": {
+        "URL": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/eth-sig-util": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/eth-json-rpc-middleware>@metamask/utils": true,
+        "@metamask/eth-json-rpc-middleware>klona": true,
+        "@metamask/eth-json-rpc-middleware>safe-stable-stringify": true
+      }
+    },
+    "@metamask/eth-json-rpc-provider": {
+      "packages": {
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/safe-event-emitter": true,
+        "uuid": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring": {
+      "globals": {
+        "addEventListener": true,
+        "console.error": true,
+        "document.createElement": true,
+        "document.head.appendChild": true,
+        "fetch": true,
+        "removeEventListener": true
+      },
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": true,
+        "@metamask/eth-sig-util": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "@metamask/eth-trezor-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-query": {
+      "packages": {
+        "@metamask/eth-query>json-rpc-random-id": true,
+        "watchify>xtend": true
+      }
+    },
+    "@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/eth-snap-keyring>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/eth-snap-keyring>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/signature-controller>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-simple-keyring": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "@metamask/eth-snap-keyring": {
+      "globals": {
+        "URL": true,
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-snap-keyring>@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/eth-snap-keyring>@metamask/utils": true,
+        "webpack>events": true,
+        "@metamask/eth-snap-keyring>uuid": true
+      }
+    },
+    "@metamask/eth-token-tracker": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@metamask/eth-token-tracker>@metamask/eth-block-tracker": true,
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs-query": true,
+        "@metamask/safe-event-emitter": true,
+        "bn.js": true,
+        "@metamask/eth-token-tracker>deep-equal": true,
+        "human-standard-token-abi": true
+      }
+    },
+    "@metamask/eth-trezor-keyring": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": true,
+        "@trezor/connect-web": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "@metamask/eth-trezor-keyring>hdkey": true
+      }
+    },
+    "@metamask/etherscan-link": {
+      "globals": {
+        "URL": true
+      }
+    },
+    "@metamask/ethjs": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs>@metamask/ethjs-filter": true,
+        "@metamask/ethjs>@metamask/ethjs-provider-http": true,
+        "@metamask/ethjs-query": true,
+        "@metamask/ethjs>@metamask/ethjs-unit": true,
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ethjs>ethjs-abi": true,
+        "@metamask/ethjs>js-sha3": true
+      }
+    },
+    "@metamask/ethjs-contract": {
+      "packages": {
+        "@babel/runtime": true,
+        "@metamask/ethjs>@metamask/ethjs-filter": true,
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>ethjs-abi": true,
+        "@metamask/ethjs>js-sha3": true,
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-filter": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      }
+    },
+    "@metamask/ethjs-query>@metamask/ethjs-format": {
+      "packages": {
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "@metamask/ethjs-query>@metamask/ethjs-format>ethjs-schema": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-provider-http": {
+      "packages": {
+        "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": true
+      }
+    },
+    "@metamask/ethjs-query": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@metamask/ethjs-query>@metamask/ethjs-format": true,
+        "@metamask/ethjs-query>@metamask/ethjs-rpc": true,
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs-query>@metamask/ethjs-rpc": {
+      "packages": {
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-unit": {
+      "packages": {
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "bn.js": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-util": {
+      "packages": {
+        "browserify>buffer": true,
+        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "@metamask/gas-fee-controller": {
+      "globals": {
+        "clearInterval": true,
+        "console.error": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@metamask/controller-utils": true,
+        "@metamask/eth-query": true,
+        "@metamask/polling-controller": true,
+        "bn.js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/jazzicon": {
+      "globals": {
+        "document.createElement": true,
+        "document.createElementNS": true
+      },
+      "packages": {
+        "@metamask/jazzicon>color": true,
+        "@metamask/jazzicon>mersenne-twister": true
+      }
+    },
+    "@metamask/json-rpc-engine": {
+      "packages": {
+        "@metamask/rpc-errors": true,
+        "@metamask/safe-event-emitter": true,
+        "@metamask/utils": true
+      }
+    },
+    "@metamask/json-rpc-middleware-stream": {
+      "globals": {
+        "console.warn": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/utils": true,
+        "readable-stream": true
+      }
+    },
+    "@metamask/snaps-sdk>@metamask/key-tree": {
+      "globals": {
+        "crypto.subtle": true
+      },
+      "packages": {
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true
+      }
+    },
+    "@metamask/keyring-api": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/keyring-api>@metamask/utils": true,
+        "@metamask/keyring-api>bech32": true,
+        "@metamask/keyring-api>uuid": true
+      }
+    },
+    "@metamask/keyring-controller": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/browser-passworder": true,
+        "@metamask/keyring-controller>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-controller>@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true
+      }
+    },
+    "@metamask/logging-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "uuid": true
+      }
+    },
+    "@metamask/logo": {
+      "globals": {
+        "addEventListener": true,
+        "document.body.appendChild": true,
+        "document.createElementNS": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "requestAnimationFrame": true
+      },
+      "packages": {
+        "@metamask/logo>gl-mat4": true,
+        "@metamask/logo>gl-vec3": true
+      }
+    },
+    "@metamask/message-manager": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/utils": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "uuid": true
+      }
+    },
+    "@metamask/name-controller": {
+      "globals": {
+        "fetch": true
+      },
+      "packages": {
+        "@metamask/name-controller>@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/name-controller>@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true
+      }
+    },
+    "@metamask/network-controller": {
+      "globals": {
+        "btoa": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "eslint>fast-deep-equal": true,
+        "@metamask/network-controller>reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/nonce-tracker": {
+      "packages": {
+        "@ethersproject/providers": true,
+        "browserify>assert": true,
+        "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": true
+      }
+    },
+    "@metamask/notification-services-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "addEventListener": true,
+        "fetch": true,
+        "registration": true,
+        "removeEventListener": true
+      },
+      "packages": {
+        "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": true,
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/profile-sync-controller": true,
+        "@metamask/utils": true,
+        "@metamask/notification-services-controller>bignumber.js": true,
+        "@metamask/notification-services-controller>firebase": true,
+        "loglevel": true,
+        "uuid": true
+      }
+    },
+    "@metamask/ethjs>@metamask/number-to-bn": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
     "@metamask/object-multiplex": {
       "globals": {
         "console.warn": true
@@ -1937,11 +1420,6 @@
       "packages": {
         "@metamask/object-multiplex>once": true,
         "readable-stream": true
-      }
-    },
-    "@metamask/object-multiplex>once": {
-      "packages": {
-        "@metamask/object-multiplex>once>wrappy": true
       }
     },
     "@metamask/obs-store": {
@@ -1958,37 +1436,17 @@
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/json-rpc-engine": true,
-        "@metamask/permission-controller>nanoid": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "deep-freeze-strict": true,
-        "immer": true
-      }
-    },
-    "@metamask/permission-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+        "immer": true,
+        "@metamask/permission-controller>nanoid": true
       }
     },
     "@metamask/permission-log-controller": {
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/permission-log-controller>@metamask/utils": true
-      }
-    },
-    "@metamask/permission-log-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
       }
     },
     "@metamask/phishing-controller": {
@@ -1999,12 +1457,12 @@
         "fetch": true
       },
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
         "@noble/hashes": true,
-        "punycode": true,
-        "webpack-cli>fastest-levenshtein": true
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack-cli>fastest-levenshtein": true,
+        "punycode": true
       }
     },
     "@metamask/polling-controller": {
@@ -2035,21 +1493,6 @@
         "readable-stream": true
       }
     },
-    "@metamask/post-message-stream>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
     "@metamask/ppom-validator": {
       "globals": {
         "URL": true,
@@ -2059,48 +1502,11 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
-        "@metamask/eth-query>json-rpc-random-id": true,
+        "await-semaphore": true,
+        "browserify>buffer": true,
         "@metamask/ppom-validator>crypto-js": true,
         "@metamask/ppom-validator>elliptic": true,
-        "await-semaphore": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ppom-validator>crypto-js": {
-      "globals": {
-        "crypto": true,
-        "define": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>brorand": true,
-        "@metamask/ppom-validator>elliptic>hmac-drbg": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true,
-        "bn.js": true,
-        "ethers>@ethersproject/sha2>hash.js": true,
-        "pumpify>inherits": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic>brorand": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic>hmac-drbg": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true,
-        "ethers>@ethersproject/sha2>hash.js": true
+        "@metamask/eth-query>json-rpc-random-id": true
       }
     },
     "@metamask/preferences-controller": {
@@ -2129,55 +1535,10 @@
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
         "@metamask/profile-sync-controller>@noble/ciphers": true,
-        "@metamask/profile-sync-controller>siwe": true,
         "@noble/hashes": true,
         "browserify>buffer": true,
-        "loglevel": true
-      }
-    },
-    "@metamask/profile-sync-controller>@noble/ciphers": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>valid-url": true,
-        "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": true,
-        "@metamask/profile-sync-controller>siwe>@stablelib/random": true,
-        "ethers": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": {
-      "globals": {
-        "console.error": true,
-        "console.log": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@stablelib/random": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": true,
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true,
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": {
-      "packages": {
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary>@stablelib/int": true
+        "loglevel": true,
+        "@metamask/profile-sync-controller>siwe": true
       }
     },
     "@metamask/queued-request-controller": {
@@ -2199,50 +1560,6 @@
         "@metamask/rate-limit-controller>@metamask/utils": true
       }
     },
-    "@metamask/rate-limit-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/rpc-errors": {
-      "packages": {
-        "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": true,
-        "@metamask/rpc-errors>fast-safe-stringify": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
     "@metamask/remote-feature-flag-controller": {
       "packages": {
         "@metamask/base-controller": true,
@@ -2251,18 +1568,14 @@
     },
     "@metamask/rpc-errors": {
       "packages": {
-        "@metamask/rpc-errors>fast-safe-stringify": true,
-        "@metamask/utils": true
+        "@metamask/utils": true,
+        "@metamask/rpc-errors>fast-safe-stringify": true
       }
     },
-    "@metamask/rpc-methods-flask>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/rpc-methods>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+    "@metamask/rate-limit-controller>@metamask/rpc-errors": {
+      "packages": {
+        "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": true,
+        "@metamask/rpc-errors>fast-safe-stringify": true
       }
     },
     "@metamask/safe-event-emitter": {
@@ -2282,12 +1595,6 @@
         "@metamask/utils>@scure/base": true
       }
     },
-    "@metamask/scure-bip39>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
     "@metamask/selected-network-controller": {
       "packages": {
         "@metamask/base-controller": true,
@@ -2301,40 +1608,14 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/signature-controller>@metamask/eth-sig-util": true,
         "@metamask/keyring-controller": true,
         "@metamask/logging-controller": true,
-        "@metamask/message-manager>jsonschema": true,
-        "@metamask/signature-controller>@metamask/eth-sig-util": true,
         "@metamask/utils": true,
         "browserify>buffer": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/signature-controller>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
+        "webpack>events": true,
+        "@metamask/message-manager>jsonschema": true,
+        "uuid": true
       }
     },
     "@metamask/smart-transactions-controller": {
@@ -2347,47 +1628,17 @@
         "setInterval": true
       },
       "packages": {
+        "@metamask/smart-transactions-controller>@ethereumjs/tx": true,
+        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
         "@ethersproject/bytes": true,
         "@metamask/controller-utils": true,
         "@metamask/eth-query": true,
         "@metamask/polling-controller": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/tx": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
-        "@metamask/smart-transactions-controller>bignumber.js": true,
         "@metamask/transaction-controller": true,
+        "@metamask/smart-transactions-controller>bignumber.js": true,
         "browserify>buffer": true,
         "fast-json-patch": true,
         "lodash": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@ethereumjs/tx": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
-        "@trezor/connect-web>@trezor/connect>@ethereumjs/common": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@metamask/controllers>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/smart-transactions-controller>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
       }
     },
     "@metamask/snaps-controllers": {
@@ -2407,72 +1658,22 @@
         "@metamask/permission-controller": true,
         "@metamask/post-message-stream": true,
         "@metamask/rpc-errors": true,
-        "@metamask/snaps-controllers>@xstate/fsm": true,
-        "@metamask/snaps-controllers>concat-stream": true,
-        "@metamask/snaps-controllers>get-npm-tarball-url": true,
-        "@metamask/snaps-controllers>nanoid": true,
-        "@metamask/snaps-controllers>readable-web-to-node-stream": true,
-        "@metamask/snaps-controllers>tar-stream": true,
+        "@metamask/snaps-utils>@metamask/snaps-registry": true,
         "@metamask/snaps-rpc-methods": true,
         "@metamask/snaps-sdk": true,
         "@metamask/snaps-utils": true,
-        "@metamask/snaps-utils>@metamask/snaps-registry": true,
         "@metamask/utils": true,
+        "@metamask/snaps-controllers>@xstate/fsm": true,
         "browserify>browserify-zlib": true,
+        "@metamask/snaps-controllers>concat-stream": true,
         "eslint>fast-deep-equal": true,
+        "@metamask/snaps-controllers>get-npm-tarball-url": true,
         "immer": true,
+        "@metamask/snaps-controllers>nanoid": true,
         "readable-stream": true,
-        "semver": true
-      }
-    },
-    "@metamask/snaps-controllers-flask>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/snaps-controllers>concat-stream": {
-      "packages": {
-        "browserify>buffer": true,
-        "browserify>concat-stream>typedarray": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
-        "terser>source-map-support>buffer-from": true
-      }
-    },
-    "@metamask/snaps-controllers>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/snaps-controllers>readable-web-to-node-stream": {
-      "packages": {
-        "readable-stream": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream": {
-      "packages": {
-        "@metamask/snaps-controllers>tar-stream>b4a": true,
-        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
-        "@metamask/snaps-controllers>tar-stream>streamx": true,
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>b4a": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>streamx": {
-      "packages": {
-        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
-        "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
-      "globals": {
-        "queueMicrotask": true
+        "@metamask/snaps-controllers>readable-web-to-node-stream": true,
+        "semver": true,
+        "@metamask/snaps-controllers>tar-stream": true
       }
     },
     "@metamask/snaps-execution-environments": {
@@ -2485,15 +1686,23 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/snaps-utils>@metamask/snaps-registry": {
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@noble/hashes": true
+      }
+    },
     "@metamask/snaps-rpc-methods": {
       "packages": {
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/permission-controller": true,
         "@metamask/rpc-errors": true,
         "@metamask/snaps-sdk": true,
-        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
-        "@metamask/utils": true,
         "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
         "@noble/hashes": true
       }
     },
@@ -2503,20 +1712,8 @@
       },
       "packages": {
         "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/snaps-sdk>@metamask/key-tree": {
-      "globals": {
-        "crypto.subtle": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/scure-bip39": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "@noble/hashes": true
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true
       }
     },
     "@metamask/snaps-utils": {
@@ -2535,74 +1732,23 @@
         "fetch": true
       },
       "packages": {
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/permission-controller": true,
         "@metamask/rpc-errors": true,
-        "@metamask/snaps-sdk": true,
-        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils>@metamask/slip44": true,
+        "@metamask/snaps-sdk": true,
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "chalk": true,
         "@metamask/snaps-utils>cron-parser": true,
         "@metamask/snaps-utils>fast-json-stable-stringify": true,
         "@metamask/snaps-utils>fast-xml-parser": true,
         "@metamask/snaps-utils>marked": true,
         "@metamask/snaps-utils>rfdc": true,
-        "@metamask/snaps-utils>validate-npm-package-name": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@noble/hashes": true,
-        "chalk": true,
-        "semver": true
-      }
-    },
-    "@metamask/snaps-utils>@metamask/snaps-registry": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/snaps-utils>cron-parser": {
-      "packages": {
-        "browserify>browser-resolve": true,
-        "luxon": true
-      }
-    },
-    "@metamask/snaps-utils>fast-xml-parser": {
-      "globals": {
-        "entityName": true,
-        "val": true
-      },
-      "packages": {
-        "@metamask/snaps-utils>fast-xml-parser>strnum": true
-      }
-    },
-    "@metamask/snaps-utils>marked": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true,
-        "define": true
-      }
-    },
-    "@metamask/snaps-utils>rfdc": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/snaps-utils>validate-npm-package-name": {
-      "packages": {
-        "@metamask/snaps-utils>validate-npm-package-name>builtins": true
-      }
-    },
-    "@metamask/snaps-utils>validate-npm-package-name>builtins": {
-      "packages": {
-        "process": true,
-        "semver": true
-      }
-    },
-    "@metamask/test-bundler>@ethersproject/networks": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
+        "semver": true,
+        "@metamask/snaps-utils>validate-npm-package-name": true
       }
     },
     "@metamask/transaction-controller": {
@@ -2613,6 +1759,7 @@
         "setTimeout": true
       },
       "packages": {
+        "@metamask/transaction-controller>@ethereumjs/common": true,
         "@ethereumjs/tx": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
         "@ethersproject/abi": true,
@@ -2623,43 +1770,18 @@
         "@metamask/eth-query": true,
         "@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/name-controller>async-mutex": true,
         "@metamask/network-controller": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/transaction-controller>@ethereumjs/common": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
         "bn.js": true,
         "browserify>buffer": true,
         "eth-method-registry": true,
+        "webpack>events": true,
         "fast-json-patch": true,
         "lodash": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/transaction-controller>@ethereumjs/common": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/nonce-tracker": {
-      "packages": {
-        "@ethersproject/providers": true,
-        "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": true,
-        "browserify>assert": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
+        "uuid": true
       }
     },
     "@metamask/user-operation-controller": {
@@ -2673,13 +1795,13 @@
         "@metamask/gas-fee-controller": true,
         "@metamask/polling-controller": true,
         "@metamask/rpc-errors": true,
+        "@metamask/utils>@metamask/superstruct": true,
         "@metamask/transaction-controller": true,
         "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
         "bn.js": true,
+        "webpack>events": true,
         "lodash": true,
-        "uuid": true,
-        "webpack>events": true
+        "uuid": true
       }
     },
     "@metamask/utils": {
@@ -2689,63 +1811,336 @@
       },
       "packages": {
         "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
         "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
         "browserify>buffer": true,
         "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
         "semver": true
       }
     },
-    "@metamask/utils>@scure/base": {
+    "@metamask/abi-utils>@metamask/utils": {
       "globals": {
         "TextDecoder": true,
         "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/browser-passworder>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-json-rpc-middleware>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-snap-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-api>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/name-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/permission-log-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
       }
     },
     "@ngraveio/bc-ur": {
       "packages": {
         "@ngraveio/bc-ur>@keystonehq/alias-sampling": true,
+        "browserify>assert": true,
         "@ngraveio/bc-ur>bignumber.js": true,
+        "browserify>buffer": true,
         "@ngraveio/bc-ur>cbor-sync": true,
         "@ngraveio/bc-ur>crc": true,
         "@ngraveio/bc-ur>jsbi": true,
-        "addons-linter>sha.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true
+        "addons-linter>sha.js": true
       }
     },
-    "@ngraveio/bc-ur>assert>object-is": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true
-      }
-    },
-    "@ngraveio/bc-ur>bignumber.js": {
+    "@metamask/profile-sync-controller>@noble/ciphers": {
       "globals": {
-        "crypto": true,
-        "define": true
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "crypto": true
       }
     },
-    "@ngraveio/bc-ur>cbor-sync": {
+    "@ethereumjs/tx>ethereum-cryptography>@noble/curves": {
       "globals": {
-        "define": true
+        "TextEncoder": true
       },
       "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ngraveio/bc-ur>crc": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ngraveio/bc-ur>jsbi": {
-      "globals": {
-        "define": true
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": true
       }
     },
     "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/scure-bip39>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -2762,6 +2157,20 @@
         "navigator.userAgent": true
       }
     },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": {
+      "globals": {
+        "console.log": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": {
+      "globals": {
+        "XMLHttpRequest": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true
+      }
+    },
     "@reduxjs/toolkit": {
       "globals": {
         "AbortController": true,
@@ -2773,42 +2182,46 @@
         "setTimeout": true
       },
       "packages": {
-        "@reduxjs/toolkit>reselect": true,
         "immer": true,
         "process": true,
         "redux": true,
-        "redux-thunk": true
+        "redux-thunk": true,
+        "@reduxjs/toolkit>reselect": true
+      }
+    },
+    "react-router-dom-v5-compat>@remix-run/router": {
+      "globals": {
+        "AbortController": true,
+        "DOMException": true,
+        "FormData": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "console": true,
+        "document.defaultView": true
+      }
+    },
+    "@metamask/utils>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": true,
+        "@metamask/utils>@scure/base": true
       }
     },
     "@segment/loosely-validate-event": {
       "packages": {
-        "@segment/loosely-validate-event>component-type": true,
-        "@segment/loosely-validate-event>join-component": true,
         "browserify>assert": true,
-        "browserify>buffer": true
-      }
-    },
-    "@sentry/browser": {
-      "globals": {
-        "PerformanceObserver.supportedEntryTypes": true,
-        "Request": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_DEBUG__": true,
-        "__SENTRY_RELEASE__": true,
-        "addEventListener": true,
-        "console.error": true,
-        "indexedDB.open": true,
-        "performance.timeOrigin": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@sentry/browser>@sentry-internal/browser-utils": true,
-        "@sentry/browser>@sentry-internal/feedback": true,
-        "@sentry/browser>@sentry-internal/replay": true,
-        "@sentry/browser>@sentry-internal/replay-canvas": true,
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "browserify>buffer": true,
+        "@segment/loosely-validate-event>component-type": true,
+        "@segment/loosely-validate-event>join-component": true
       }
     },
     "@sentry/browser>@sentry-internal/browser-utils": {
@@ -2841,6 +2254,25 @@
         "isSecureContext": true,
         "requestAnimationFrame": true,
         "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/replay-canvas": {
+      "globals": {
+        "Blob": true,
+        "HTMLCanvasElement": true,
+        "HTMLImageElement": true,
+        "ImageData": true,
+        "URL.createObjectURL": true,
+        "WeakRef": true,
+        "Worker": true,
+        "cancelAnimationFrame": true,
+        "console.error": true,
+        "createImageBitmap": true,
+        "document": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2896,21 +2328,25 @@
         "@sentry/utils": true
       }
     },
-    "@sentry/browser>@sentry-internal/replay-canvas": {
+    "@sentry/browser": {
       "globals": {
-        "Blob": true,
-        "HTMLCanvasElement": true,
-        "HTMLImageElement": true,
-        "ImageData": true,
-        "URL.createObjectURL": true,
-        "WeakRef": true,
-        "Worker": true,
-        "cancelAnimationFrame": true,
+        "PerformanceObserver.supportedEntryTypes": true,
+        "Request": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_RELEASE__": true,
+        "addEventListener": true,
         "console.error": true,
-        "createImageBitmap": true,
-        "document": true
+        "indexedDB.open": true,
+        "performance.timeOrigin": true,
+        "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/browser-utils": true,
+        "@sentry/browser>@sentry-internal/feedback": true,
+        "@sentry/browser>@sentry-internal/replay-canvas": true,
+        "@sentry/browser>@sentry-internal/replay": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
@@ -3006,20 +2442,61 @@
         "btoa": true
       }
     },
-    "@storybook/addon-docs>remark-external-links>mdast-util-definitions": {
-      "packages": {
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "@storybook/addon-knobs>qs": {
-      "packages": {
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "@swc/helpers>tslib": {
+    "@metamask/controller-utils>@spruceid/siwe-parser": {
       "globals": {
-        "SuppressedError": true,
-        "define": true
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": {
+      "globals": {
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": {
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary>@stablelib/int": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@stablelib/random": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": true,
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true,
+        "browserify>browser-resolve": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect-common": {
+      "globals": {
+        "console.warn": true,
+        "localStorage.getItem": true,
+        "localStorage.setItem": true,
+        "navigator": true,
+        "setTimeout": true,
+        "window": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": true,
+        "@trezor/connect-web>@trezor/utils": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": {
+      "packages": {
+        "@metamask/eth-sig-util": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web": {
@@ -3046,35 +2523,20 @@
         "setTimeout": true
       },
       "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect": true,
         "@trezor/connect-web>@trezor/connect-common": true,
+        "@trezor/connect-web>@trezor/connect": true,
         "@trezor/connect-web>@trezor/utils": true,
-        "webpack>events": true
+        "webpack>events": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect": {
       "packages": {
-        "@swc/helpers>tslib": true,
         "@trezor/connect-web>@trezor/connect>@trezor/protobuf": true,
         "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": true,
         "@trezor/connect-web>@trezor/connect>@trezor/transport": true,
-        "@trezor/connect-web>@trezor/utils": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect-common": {
-      "globals": {
-        "console.warn": true,
-        "localStorage.getItem": true,
-        "localStorage.setItem": true,
-        "navigator": true,
-        "setTimeout": true,
-        "window": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": true,
-        "@trezor/connect-web>@trezor/utils": true
+        "@trezor/connect-web>@trezor/utils": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": {
@@ -3090,71 +2552,17 @@
         "screen.width": true
       },
       "packages": {
+        "process": true,
         "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": true,
-        "process": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@ethereumjs/common": {
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": true,
-        "webpack>events": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
+        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": true
       }
     },
     "@trezor/connect-web>@trezor/connect>@trezor/protobuf": {
       "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": true,
         "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": true,
-        "browserify>buffer": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": {
-      "globals": {
-        "process": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/base64": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/eventemitter": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/float": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/path": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/pool": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/utf8": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": {
-      "globals": {
-        "console.log": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": {
-      "globals": {
-        "XMLHttpRequest": true
-      },
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true
+        "browserify>buffer": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": {
@@ -3181,16 +2589,10 @@
         "setTimeout": true
       },
       "packages": {
-        "@swc/helpers>tslib": true,
         "@trezor/connect-web>@trezor/utils>bignumber.js": true,
         "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@trezor/connect-web>@trezor/utils>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
+        "webpack>events": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@welldone-software/why-did-you-render": {
@@ -3243,21 +2645,155 @@
         "@zxing/library>ts-custom-error": true
       }
     },
-    "addons-linter>sha.js": {
+    "extension-port-stream>readable-stream>abort-controller": {
+      "globals": {
+        "AbortController": true
+      }
+    },
+    "currency-formatter>accounting": {
+      "globals": {
+        "define": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets>aes-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>aes-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "chalk>ansi-styles": {
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
+        "chalk>ansi-styles>color-convert": true
+      }
+    },
+    "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>array-buffer-byte-length": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>es-abstract>is-array-buffer": true
+      }
+    },
+    "crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "browserify>vm-browserify": true
+      }
+    },
+    "browserify>assert": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "react>object-assign": true,
+        "browserify>assert>util": true
+      }
+    },
+    "@metamask/name-controller>async-mutex": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>available-typed-arrays": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>typed-array-length>possible-typed-array-names": true
       }
     },
     "await-semaphore": {
       "packages": {
-        "browserify>timers-browserify": true,
+        "process": true,
+        "browserify>timers-browserify": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": {
+      "globals": {
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
         "process": true
       }
     },
-    "axios>form-data": {
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": {
       "globals": {
-        "FormData": true
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
+        "process": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": {
+      "globals": {
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
+        "process": true
+      }
+    },
+    "@metamask/snaps-controllers>tar-stream>b4a": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>multibase>base-x": {
+      "packages": {
+        "koa>content-disposition>safe-buffer": true
       }
     },
     "base32-encode": {
@@ -3266,6 +2802,48 @@
       }
     },
     "bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/notification-services-controller>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/smart-transactions-controller>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@ngraveio/bc-ur>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@trezor/connect-web>@trezor/utils>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>bignumber.js": {
       "globals": {
         "crypto": true,
         "define": true
@@ -3284,123 +2862,107 @@
         "browserify>browser-resolve": true
       }
     },
+    "eth-lattice-keyring>gridplus-sdk>borc": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": true,
+        "browserify>buffer": true,
+        "buffer>ieee754": true,
+        "eth-lattice-keyring>gridplus-sdk>borc>iso-url": true
+      }
+    },
     "bowser": {
       "globals": {
         "define": true
       }
     },
-    "browserify>assert": {
+    "@metamask/ppom-validator>elliptic>brorand": {
       "globals": {
-        "Buffer": true
+        "crypto": true,
+        "msCrypto": true
       },
       "packages": {
-        "browserify>assert>util": true,
-        "react>object-assign": true
+        "browserify>browser-resolve": true
       }
     },
-    "browserify>assert>util": {
-      "globals": {
-        "console.error": true,
-        "console.log": true,
-        "console.trace": true,
-        "process": true
-      },
+    "ethereumjs-util>ethereum-cryptography>browserify-aes": {
       "packages": {
-        "browserify>assert>util>inherits": true,
-        "process": true
+        "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "crypto-browserify>browserify-cipher": {
+      "packages": {
+        "ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "crypto-browserify>browserify-cipher>browserify-des": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>browserify-des": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "crypto-browserify>browserify-cipher>browserify-des>des.js": true,
+        "pumpify>inherits": true
+      }
+    },
+    "crypto-browserify>public-encrypt>browserify-rsa": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "crypto-browserify>browserify-sign": {
+      "packages": {
+        "bn.js": true,
+        "crypto-browserify>public-encrypt>browserify-rsa": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "crypto-browserify>create-hmac": true,
+        "@metamask/ppom-validator>elliptic": true,
+        "pumpify>inherits": true,
+        "crypto-browserify>public-encrypt>parse-asn1": true,
+        "stream-browserify": true
       }
     },
     "browserify>browserify-zlib": {
       "packages": {
         "browserify>assert": true,
-        "browserify>browserify-zlib>pako": true,
         "browserify>buffer": true,
-        "browserify>util": true,
+        "browserify>browserify-zlib>pako": true,
         "process": true,
-        "stream-browserify": true
+        "stream-browserify": true,
+        "browserify>util": true
       }
     },
-    "browserify>buffer": {
-      "globals": {
-        "console": true
-      },
+    "ethereumjs-util>ethereum-cryptography>bs58check>bs58": {
       "packages": {
-        "base64-js": true,
-        "buffer>ieee754": true
+        "@ensdomains/content-hash>multihashes>multibase>base-x": true
       }
     },
-    "browserify>punycode": {
-      "globals": {
-        "define": true
-      }
-    },
-    "browserify>string_decoder": {
+    "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": {
       "packages": {
+        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58>base-x": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>bs58check": {
+      "packages": {
+        "ethereumjs-util>ethereum-cryptography>bs58check>bs58": true,
+        "ethereumjs-util>create-hash": true,
         "koa>content-disposition>safe-buffer": true
       }
     },
-    "browserify>timers-browserify": {
-      "globals": {
-        "clearInterval": true,
-        "clearTimeout": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
+    "eth-lattice-keyring>gridplus-sdk>bs58check": {
       "packages": {
-        "process": true
-      }
-    },
-    "browserify>url": {
-      "packages": {
-        "@storybook/addon-knobs>qs": true,
-        "browserify>punycode": true
-      }
-    },
-    "browserify>util": {
-      "globals": {
-        "console.error": true,
-        "console.log": true,
-        "console.trace": true
-      },
-      "packages": {
-        "browserify>util>is-arguments": true,
-        "browserify>util>is-typed-array": true,
-        "browserify>util>which-typed-array": true,
-        "koa>is-generator-function": true,
-        "process": true,
-        "pumpify>inherits": true
-      }
-    },
-    "browserify>util>is-arguments": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "browserify>util>is-typed-array": {
-      "packages": {
-        "browserify>util>which-typed-array": true
-      }
-    },
-    "browserify>util>which-typed-array": {
-      "packages": {
-        "browserify>util>which-typed-array>for-each": true,
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>available-typed-arrays": true,
-        "string.prototype.matchall>es-abstract>gopd": true
-      }
-    },
-    "browserify>util>which-typed-array>for-each": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>is-callable": true
-      }
-    },
-    "browserify>vm-browserify": {
-      "globals": {
-        "document.body.appendChild": true,
-        "document.body.removeChild": true,
-        "document.createElement": true
+        "@noble/hashes": true,
+        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": true
       }
     },
     "buffer": {
@@ -3412,20 +2974,52 @@
         "buffer>ieee754": true
       }
     },
+    "terser>source-map-support>buffer-from": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "browserify>buffer": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "base64-js": true,
+        "buffer>ieee754": true
+      }
+    },
+    "@metamask/snaps-utils>validate-npm-package-name>builtins": {
+      "packages": {
+        "process": true,
+        "semver": true
+      }
+    },
+    "string.prototype.matchall>call-bind": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>call-bind>set-function-length": true
+      }
+    },
+    "@ngraveio/bc-ur>cbor-sync": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
     "chalk": {
       "packages": {
         "chalk>ansi-styles": true,
         "chalk>supports-color": true
-      }
-    },
-    "chalk>ansi-styles": {
-      "packages": {
-        "chalk>ansi-styles>color-convert": true
-      }
-    },
-    "chalk>ansi-styles>color-convert": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
       }
     },
     "chart.js": {
@@ -3449,15 +3043,31 @@
         "chart.js>@kurkle/color": true
       }
     },
-    "chart.js>@kurkle/color": {
-      "globals": {
-        "define": true
+    "@ensdomains/content-hash>cids": {
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase": true,
+        "@ensdomains/content-hash>multicodec": true,
+        "@ensdomains/content-hash>cids>multihashes": true,
+        "@ensdomains/content-hash>cids>uint8arrays": true
+      }
+    },
+    "ethereumjs-util>create-hash>cipher-base": {
+      "packages": {
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true,
+        "stream-browserify": true,
+        "browserify>string_decoder": true
       }
     },
     "classnames": {
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "@metamask/jazzicon>color>clone": {
+      "packages": {
+        "browserify>buffer": true
       }
     },
     "cockatiel": {
@@ -3471,6 +3081,37 @@
       },
       "packages": {
         "process": true
+      }
+    },
+    "chalk>ansi-styles>color-convert": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-convert": {
+      "packages": {
+        "@metamask/jazzicon>color>color-convert>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-string": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color": {
+      "packages": {
+        "@metamask/jazzicon>color>clone": true,
+        "@metamask/jazzicon>color>color-convert": true,
+        "@metamask/jazzicon>color>color-string": true
+      }
+    },
+    "@metamask/snaps-controllers>concat-stream": {
+      "packages": {
+        "terser>source-map-support>buffer-from": true,
+        "browserify>buffer": true,
+        "pumpify>inherits": true,
+        "readable-stream": true,
+        "browserify>concat-stream>typedarray": true
       }
     },
     "copy-to-clipboard": {
@@ -3491,10 +3132,47 @@
         "copy-to-clipboard>toggle-selection": true
       }
     },
-    "copy-to-clipboard>toggle-selection": {
+    "@ethereumjs/tx>@ethereumjs/common>crc-32": {
       "globals": {
-        "document.activeElement": true,
-        "document.getSelection": true
+        "DO_NOT_EXPORT_CRC": true,
+        "define": true
+      }
+    },
+    "@ngraveio/bc-ur>crc": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "crypto-browserify>create-ecdh": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "ethereumjs-util>create-hash": {
+      "packages": {
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "pumpify>inherits": true,
+        "ethereumjs-util>create-hash>md5.js": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "crypto-browserify>create-hmac": {
+      "packages": {
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "ethereumjs-util>create-hash": true,
+        "pumpify>inherits": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "@metamask/snaps-utils>cron-parser": {
+      "packages": {
+        "browserify>browser-resolve": true,
+        "luxon": true
       }
     },
     "crypto-browserify": {
@@ -3502,156 +3180,44 @@
         "crypto-browserify>browserify-cipher": true,
         "crypto-browserify>browserify-sign": true,
         "crypto-browserify>create-ecdh": true,
+        "ethereumjs-util>create-hash": true,
         "crypto-browserify>create-hmac": true,
         "crypto-browserify>diffie-hellman": true,
         "crypto-browserify>pbkdf2": true,
         "crypto-browserify>public-encrypt": true,
         "crypto-browserify>randombytes": true,
-        "crypto-browserify>randomfill": true,
-        "ethereumjs-util>create-hash": true
+        "crypto-browserify>randomfill": true
       }
     },
-    "crypto-browserify>browserify-cipher": {
-      "packages": {
-        "crypto-browserify>browserify-cipher>browserify-des": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>browserify-des": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>browserify-des>des.js": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>browserify-des>des.js": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>evp_bytestokey": {
-      "packages": {
-        "ethereumjs-util>create-hash>md5.js": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "crypto-browserify>browserify-sign": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>create-hmac": true,
-        "crypto-browserify>public-encrypt>browserify-rsa": true,
-        "crypto-browserify>public-encrypt>parse-asn1": true,
-        "ethereumjs-util>create-hash": true,
-        "pumpify>inherits": true,
-        "stream-browserify": true
-      }
-    },
-    "crypto-browserify>create-ecdh": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "crypto-browserify>create-hmac": {
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>diffie-hellman": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>diffie-hellman>miller-rabin": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "crypto-browserify>diffie-hellman>miller-rabin": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>brorand": true,
-        "bn.js": true
-      }
-    },
-    "crypto-browserify>pbkdf2": {
+    "@metamask/ppom-validator>crypto-js": {
       "globals": {
         "crypto": true,
-        "process": true,
-        "queueMicrotask": true,
-        "setImmediate": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
-      }
-    },
-    "crypto-browserify>public-encrypt": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>public-encrypt>browserify-rsa": true,
-        "crypto-browserify>public-encrypt>parse-asn1": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>create-hash": true
-      }
-    },
-    "crypto-browserify>public-encrypt>browserify-rsa": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "crypto-browserify>public-encrypt>parse-asn1": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "crypto-browserify>pbkdf2": true,
-        "crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes": true
-      }
-    },
-    "crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "browserify>vm-browserify": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>randombytes": {
-      "globals": {
-        "crypto": true,
+        "define": true,
         "msCrypto": true
       },
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
+        "browserify>browser-resolve": true
       }
     },
-    "crypto-browserify>randomfill": {
+    "react-beautiful-dnd>css-box-model": {
       "globals": {
-        "crypto": true,
-        "msCrypto": true
+        "getComputedStyle": true,
+        "pageXOffset": true,
+        "pageYOffset": true
       },
       "packages": {
-        "crypto-browserify>randombytes": true,
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
+        "react-router-dom>tiny-invariant": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": {
+      "globals": {
+        "document.createElement": true,
+        "document.documentElement": true,
+        "getComputedStyle": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true
       }
     },
     "currency-formatter": {
@@ -3659,16 +3225,6 @@
         "currency-formatter>accounting": true,
         "currency-formatter>locale-currency": true,
         "react>object-assign": true
-      }
-    },
-    "currency-formatter>accounting": {
-      "globals": {
-        "define": true
-      }
-    },
-    "currency-formatter>locale-currency": {
-      "globals": {
-        "countryCode": true
       }
     },
     "debounce-stream": {
@@ -3684,35 +3240,107 @@
         "setTimeout": true
       }
     },
+    "nock>debug": {
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "nock>debug>ms": true,
+        "process": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>array-buffer-byte-length": true,
+        "string.prototype.matchall>call-bind": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "browserify>util>is-arguments": true,
+        "string.prototype.matchall>es-abstract>is-array-buffer": true,
+        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
+        "string.prototype.matchall>es-abstract>is-regex": true,
+        "string.prototype.matchall>es-abstract>is-shared-array-buffer": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
+        "@ngraveio/bc-ur>assert>object-is": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
+        "gulp>vinyl-fs>object.assign": true,
+        "string.prototype.matchall>regexp.prototype.flags": true,
+        "string.prototype.matchall>side-channel": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection": true,
+        "browserify>util>which-typed-array": true
+      }
+    },
+    "string.prototype.matchall>define-properties>define-data-property": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>gopd": true
+      }
+    },
+    "string.prototype.matchall>define-properties": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>browserify-des>des.js": {
+      "packages": {
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true
+      }
+    },
+    "crypto-browserify>diffie-hellman": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "crypto-browserify>diffie-hellman>miller-rabin": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "@material-ui/core>react-transition-group>dom-helpers": {
+      "packages": {
+        "@babel/runtime": true
+      }
+    },
     "debounce-stream>duplexer": {
       "packages": {
         "stream-browserify": true
       }
     },
-    "debounce-stream>through": {
+    "@metamask/ppom-validator>elliptic": {
       "packages": {
+        "bn.js": true,
+        "@metamask/ppom-validator>elliptic>brorand": true,
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "@metamask/ppom-validator>elliptic>hmac-drbg": true,
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "string.prototype.matchall>call-bind>es-define-property": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>es-get-iterator": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>has-symbols": true,
+        "browserify>util>is-arguments": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
         "process": true,
-        "stream-browserify": true
-      }
-    },
-    "depcheck>@vue/compiler-sfc>postcss>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "depcheck>is-core-module>hasown": {
-      "packages": {
-        "browserify>has>function-bind": true
-      }
-    },
-    "dependency-tree>precinct>detective-postcss>postcss>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "eslint-plugin-react>array-includes>is-string": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": true
       }
     },
     "eth-ens-namehash": {
@@ -3720,22 +3348,9 @@
         "name": "write"
       },
       "packages": {
-        "@metamask/ethjs>js-sha3": true,
         "browserify>buffer": true,
-        "eth-ens-namehash>idna-uts46-hx": true
-      }
-    },
-    "eth-ens-namehash>idna-uts46-hx": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "browserify>punycode": true
-      }
-    },
-    "eth-keyring-controller>@metamask/browser-passworder": {
-      "globals": {
-        "crypto": true
+        "eth-ens-namehash>idna-uts46-hx": true,
+        "@metamask/ethjs>js-sha3": true
       }
     },
     "eth-lattice-keyring": {
@@ -3753,9 +3368,246 @@
         "bn.js": true,
         "browserify>buffer": true,
         "crypto-browserify": true,
+        "webpack>events": true,
         "eth-lattice-keyring>gridplus-sdk": true,
-        "eth-lattice-keyring>rlp": true,
-        "webpack>events": true
+        "eth-lattice-keyring>rlp": true
+      }
+    },
+    "eth-method-registry": {
+      "packages": {
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs-query": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true
+      },
+      "packages": {
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": true,
+        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>ethereum-cryptography>keccak": true,
+        "crypto-browserify>randombytes": true,
+        "ganache>secp256k1": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": {
+      "packages": {
+        "browserify>assert": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "browserify>buffer": true,
+        "crypto-browserify>create-hmac": true,
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "ethereumjs-util>ethereum-cryptography>keccak": true,
+        "crypto-browserify>randombytes": true,
+        "koa>content-disposition>safe-buffer": true,
+        "ganache>secp256k1": true
+      }
+    },
+    "ethereumjs-util": {
+      "packages": {
+        "browserify>assert": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "ethereumjs-util>ethereum-cryptography": true,
+        "browserify>insert-module-globals>is-buffer": true,
+        "ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": {
+      "packages": {
+        "browserify>assert": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
+        "browserify>insert-module-globals>is-buffer": true,
+        "ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>aes-js": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "browserify>buffer": true,
+        "crypto-browserify": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": true,
+        "crypto-browserify>randombytes": true,
+        "ethers>@ethersproject/json-wallets>scrypt-js": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>utf8": true,
+        "uuid": true
+      }
+    },
+    "ethers": {
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/providers": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/solidity": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/units": true,
+        "@ethersproject/wallet": true,
+        "ethers>@ethersproject/web": true,
+        "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": {
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "@ethersproject/providers": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/solidity": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/units": true,
+        "@ethersproject/wallet": true,
+        "@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "@metamask/ethjs>ethjs-abi": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ethjs>js-sha3": true,
+        "@metamask/ethjs>ethjs-abi>number-to-bn": true
+      }
+    },
+    "webpack>events": {
+      "globals": {
+        "console": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>evp_bytestokey": {
+      "packages": {
+        "ethereumjs-util>create-hash>md5.js": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "extension-port-stream": {
+      "packages": {
+        "browserify>buffer": true,
+        "extension-port-stream>readable-stream": true
+      }
+    },
+    "fast-json-patch": {
+      "globals": {
+        "addEventListener": true,
+        "clearTimeout": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      }
+    },
+    "@metamask/snaps-utils>fast-xml-parser": {
+      "globals": {
+        "entityName": true,
+        "val": true
+      },
+      "packages": {
+        "@metamask/snaps-utils>fast-xml-parser>strnum": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase": {
+      "packages": {
+        "@metamask/notification-services-controller>firebase>@firebase/app": true,
+        "@metamask/notification-services-controller>firebase>@firebase/messaging": true
+      }
+    },
+    "react-focus-lock>focus-lock": {
+      "globals": {
+        "HTMLIFrameElement": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.DOCUMENT_NODE": true,
+        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
+        "Node.DOCUMENT_POSITION_CONTAINS": true,
+        "Node.ELEMENT_NODE": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "browserify>util>which-typed-array>for-each": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>is-callable": true
+      }
+    },
+    "axios>form-data": {
+      "globals": {
+        "FormData": true
+      }
+    },
+    "fuse.js": {
+      "globals": {
+        "console": true,
+        "define": true
+      }
+    },
+    "string.prototype.matchall>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>es-abstract>has-proto": true,
+        "string.prototype.matchall>has-symbols": true,
+        "depcheck>is-core-module>hasown": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>gopd": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk": {
@@ -3773,545 +3625,63 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethersproject/abi": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/ethjs>js-sha3": true,
-        "@metamask/keyring-api>bech32": true,
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": true,
+        "@ethersproject/abi": true,
+        "@metamask/eth-sig-util": true,
         "eth-lattice-keyring>gridplus-sdk>aes-js": true,
+        "@metamask/keyring-api>bech32": true,
         "eth-lattice-keyring>gridplus-sdk>bignumber.js": true,
+        "bn.js": true,
         "eth-lattice-keyring>gridplus-sdk>borc": true,
         "eth-lattice-keyring>gridplus-sdk>bs58check": true,
-        "eth-lattice-keyring>gridplus-sdk>secp256k1": true,
-        "eth-lattice-keyring>gridplus-sdk>uuid": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "@metamask/ppom-validator>elliptic": true,
         "ethers>@ethersproject/sha2>hash.js": true,
-        "lodash": true
+        "@metamask/ethjs>js-sha3": true,
+        "lodash": true,
+        "eth-lattice-keyring>gridplus-sdk>secp256k1": true,
+        "eth-lattice-keyring>gridplus-sdk>uuid": true
       }
     },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
+    "string.prototype.matchall>es-abstract>has-property-descriptors": {
       "packages": {
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
-        "webpack>events": true
+        "string.prototype.matchall>call-bind>es-define-property": true
       }
     },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": {
+    "koa>is-generator-function>has-tostringtag": {
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": true,
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": {
-      "packages": {
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
-        "webpack>events": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>aes-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "browserify>buffer": true,
-        "buffer>ieee754": true,
-        "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": true,
-        "eth-lattice-keyring>gridplus-sdk>borc>iso-url": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc>iso-url": {
-      "globals": {
-        "URL": true,
-        "URLSearchParams": true,
-        "location": true,
-        "navigator": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bs58check": {
-      "packages": {
-        "@noble/hashes": true,
-        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": {
-      "packages": {
-        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58>base-x": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>secp256k1": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "eth-lattice-keyring>rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "eth-method-registry": {
-      "packages": {
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true
-      }
-    },
-    "ethereumjs-util": {
-      "packages": {
-        "bn.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>ethereum-cryptography": true,
-        "ethereumjs-util>rlp": true
-      }
-    },
-    "ethereumjs-util>create-hash": {
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>create-hash>md5.js": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>create-hash>cipher-base": {
-      "packages": {
-        "browserify>string_decoder": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true,
-        "stream-browserify": true
-      }
-    },
-    "ethereumjs-util>create-hash>md5.js": {
-      "packages": {
-        "ethereumjs-util>create-hash>md5.js>hash-base": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
+        "string.prototype.matchall>has-symbols": true
       }
     },
     "ethereumjs-util>create-hash>md5.js>hash-base": {
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
         "pumpify>inherits": true,
-        "readable-stream": true
-      }
-    },
-    "ethereumjs-util>create-hash>ripemd160": {
-      "packages": {
-        "browserify>buffer": true,
-        "ethereumjs-util>create-hash>md5.js>hash-base": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>ethereum-cryptography>keccak": true,
-        "ganache>secp256k1": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>browserify-aes": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>bs58check": {
-      "packages": {
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check>bs58": true,
+        "readable-stream": true,
         "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>bs58check>bs58": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase>base-x": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>keccak": {
-      "packages": {
-        "browserify>buffer": true,
-        "readable-stream": true
-      }
-    },
-    "ethereumjs-util>rlp": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers": {
-      "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "@ethersproject/wallet": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/solidity": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true,
-        "ethers>@ethersproject/units": true,
-        "ethers>@ethersproject/web": true,
-        "ethers>@ethersproject/wordlists": true
-      }
-    },
-    "ethers>@ethersproject/abstract-provider": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/abstract-signer": {
-      "packages": {
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/address": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/rlp": true
-      }
-    },
-    "ethers>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true
-      }
-    },
-    "ethers>@ethersproject/basex": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/constants": {
-      "packages": {
-        "@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hdnode": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/json-wallets>aes-js": true,
-        "ethers>@ethersproject/json-wallets>scrypt-js": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/pbkdf2": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets>aes-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets>scrypt-js": {
-      "globals": {
-        "define": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>timers-browserify": true
-      }
-    },
-    "ethers>@ethersproject/keccak256": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@metamask/ethjs>js-sha3": true
-      }
-    },
-    "ethers>@ethersproject/logger": {
-      "globals": {
-        "console": true
-      }
-    },
-    "ethers>@ethersproject/pbkdf2": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/sha2": true
-      }
-    },
-    "ethers>@ethersproject/properties": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers": {
-      "globals": {
-        "WebSocket": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "console.log": true,
-        "console.warn": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/abstract-provider": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers>@ethersproject/networks": true,
-        "ethers>@ethersproject/providers>@ethersproject/web": true,
-        "ethers>@ethersproject/providers>bech32": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/networks": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/random": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/rlp": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/sha2": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/sha2>hash.js": true
       }
     },
     "ethers>@ethersproject/sha2>hash.js": {
       "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "pumpify>inherits": true
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true
       }
     },
-    "ethers>@ethersproject/signing-key": {
+    "depcheck>is-core-module>hasown": {
       "packages": {
-        "@ethersproject/bytes": true,
-        "@metamask/ppom-validator>elliptic": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
+        "browserify>has>function-bind": true
       }
     },
-    "ethers>@ethersproject/solidity": {
+    "@metamask/eth-trezor-keyring>hdkey": {
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/strings": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/transactions": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/signing-key": true
-      }
-    },
-    "ethers>@ethersproject/units": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/wordlists": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "extension-port-stream": {
-      "packages": {
-        "browserify>buffer": true,
-        "extension-port-stream>readable-stream": true
-      }
-    },
-    "extension-port-stream>readable-stream": {
-      "globals": {
-        "AbortController": true,
-        "AggregateError": true,
-        "Blob": true
-      },
-      "packages": {
-        "browserify>buffer": true,
-        "browserify>string_decoder": true,
-        "extension-port-stream>readable-stream>abort-controller": true,
-        "process": true,
-        "webpack>events": true
-      }
-    },
-    "extension-port-stream>readable-stream>abort-controller": {
-      "globals": {
-        "AbortController": true
-      }
-    },
-    "fast-json-patch": {
-      "globals": {
-        "addEventListener": true,
-        "clearTimeout": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
-    "fuse.js": {
-      "globals": {
-        "console": true,
-        "define": true
-      }
-    },
-    "ganache>secp256k1": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true
-      }
-    },
-    "gulp>vinyl-fs>object.assign": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>has-symbols": true
+        "browserify>assert": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "crypto-browserify": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "ganache>secp256k1": true
       }
     },
     "he": {
@@ -4327,15 +3697,100 @@
         "document.querySelector": true
       }
     },
-    "https-browserify": {
+    "react-router-dom>history": {
+      "globals": {
+        "addEventListener": true,
+        "confirm": true,
+        "document": true,
+        "history": true,
+        "location": true,
+        "navigator.userAgent": true,
+        "removeEventListener": true
+      },
       "packages": {
-        "browserify>url": true,
-        "stream-http": true
+        "react-router-dom>history>resolve-pathname": true,
+        "react-router-dom>tiny-invariant": true,
+        "react-router-dom>tiny-warning": true,
+        "react-router-dom>history>value-equal": true
       }
     },
-    "koa>content-disposition>safe-buffer": {
+    "@metamask/ppom-validator>elliptic>hmac-drbg": {
       "packages": {
-        "browserify>buffer": true
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "react-redux>hoist-non-react-statics": {
+      "packages": {
+        "prop-types>react-is": true
+      }
+    },
+    "https-browserify": {
+      "packages": {
+        "stream-http": true,
+        "browserify>url": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>idb": {
+      "globals": {
+        "DOMException": true,
+        "IDBCursor": true,
+        "IDBDatabase": true,
+        "IDBIndex": true,
+        "IDBObjectStore": true,
+        "IDBRequest": true,
+        "IDBTransaction": true,
+        "indexedDB.deleteDatabase": true,
+        "indexedDB.open": true
+      }
+    },
+    "eth-ens-namehash>idna-uts46-hx": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "browserify>punycode": true
+      }
+    },
+    "string.prototype.matchall>internal-slot": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "depcheck>is-core-module>hasown": true,
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "browserify>util>is-arguments": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-array-buffer": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>unbox-primitive>has-bigints": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
       }
     },
     "koa>is-generator-function": {
@@ -4343,9 +3798,145 @@
         "koa>is-generator-function>has-tostringtag": true
       }
     },
-    "koa>is-generator-function>has-tostringtag": {
+    "@material-ui/core>@material-ui/styles>jss>is-in-browser": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-regex": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-shared-array-buffer": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true
+      }
+    },
+    "eslint-plugin-react>array-includes>is-string": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
       "packages": {
         "string.prototype.matchall>has-symbols": true
+      }
+    },
+    "browserify>util>is-typed-array": {
+      "packages": {
+        "browserify>util>which-typed-array": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>borc>iso-url": {
+      "globals": {
+        "URL": true,
+        "URLSearchParams": true,
+        "location": true,
+        "navigator": true
+      }
+    },
+    "@ensdomains/content-hash>js-base64": {
+      "globals": {
+        "Base64": "write",
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true,
+        "define": true
+      },
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "@metamask/ethjs>js-sha3": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "process": true
+      }
+    },
+    "@ngraveio/bc-ur>jsbi": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@metamask/message-manager>jsonschema": {
+      "packages": {
+        "browserify>url": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case>hyphenate-style-name": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": {
+      "globals": {
+        "CSS": true
+      },
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-global": {
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-nested": {
+      "packages": {
+        "@babel/runtime": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": true,
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss": {
+      "globals": {
+        "CSS": true,
+        "document.createElement": true,
+        "document.querySelector": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>keccak": {
+      "packages": {
+        "browserify>buffer": true,
+        "readable-stream": true
+      }
+    },
+    "currency-formatter>locale-currency": {
+      "globals": {
+        "countryCode": true
       }
     },
     "localforage": {
@@ -4425,6 +4016,120 @@
         "Intl": true
       }
     },
+    "@metamask/snaps-utils>marked": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true,
+        "define": true
+      }
+    },
+    "ethereumjs-util>create-hash>md5.js": {
+      "packages": {
+        "ethereumjs-util>create-hash>md5.js>hash-base": true,
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "@storybook/addon-docs>remark-external-links>mdast-util-definitions": {
+      "packages": {
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
+        "react-syntax-highlighter>refractor>parse-entities": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>remark-rehype>mdast-util-to-hast": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@storybook/addon-docs>remark-external-links>mdast-util-definitions": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "@ethereumjs/tx>@ethereumjs/util>micro-ftch": {
+      "globals": {
+        "Headers": true,
+        "TextDecoder": true,
+        "URL": true,
+        "btoa": true,
+        "fetch": true
+      },
+      "packages": {
+        "browserify>browserify-zlib": true,
+        "browserify>buffer": true,
+        "https-browserify": true,
+        "process": true,
+        "stream-http": true,
+        "browserify>url": true,
+        "browserify>util": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
+      "packages": {
+        "react-syntax-highlighter>refractor>parse-entities": true
+      }
+    },
+    "crypto-browserify>diffie-hellman>miller-rabin": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ppom-validator>elliptic>brorand": true
+      }
+    },
+    "@ensdomains/content-hash>cids>multibase": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase>@multiformats/base-x": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>multibase": {
+      "packages": {
+        "@ensdomains/content-hash>multihashes>multibase>base-x": true,
+        "browserify>buffer": true,
+        "@ensdomains/content-hash>multihashes>web-encoding": true
+      }
+    },
+    "@ensdomains/content-hash>multicodec": {
+      "packages": {
+        "@ensdomains/content-hash>multicodec>uint8arrays": true,
+        "sass-embedded>varint": true
+      }
+    },
+    "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "console.warn": true,
+        "crypto.subtle.digest": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes": {
+      "packages": {
+        "browserify>buffer": true,
+        "@ensdomains/content-hash>multihashes>multibase": true,
+        "@ensdomains/content-hash>multihashes>varint": true,
+        "@ensdomains/content-hash>multihashes>web-encoding": true
+      }
+    },
+    "@ensdomains/content-hash>cids>multihashes": {
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase": true,
+        "@ensdomains/content-hash>cids>uint8arrays": true,
+        "@ensdomains/content-hash>cids>multihashes>varint": true
+      }
+    },
     "nanoid": {
       "globals": {
         "crypto": true,
@@ -4432,17 +4137,54 @@
         "navigator": true
       }
     },
-    "nock>debug": {
+    "@metamask/approval-controller>nanoid": {
       "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "nock>debug>ms": true,
-        "process": true
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/smart-transactions-controller>@metamask/controllers>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/notification-controller>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/permission-controller>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/rpc-methods>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/rpc-methods-flask>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/snaps-controllers>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/snaps-controllers-flask>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "depcheck>@vue/compiler-sfc>postcss>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "dependency-tree>precinct>detective-postcss>postcss>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
       }
     },
     "node-fetch": {
@@ -4453,9 +4195,122 @@
         "fetch": true
       }
     },
+    "@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "@metamask/ethjs>ethjs-abi>number-to-bn": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>object-inspect": {
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "browserify>browser-resolve": true
+      }
+    },
+    "@ngraveio/bc-ur>assert>object-is": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true
+      }
+    },
+    "gulp>vinyl-fs>object.assign": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>has-symbols": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "@metamask/object-multiplex>once": {
+      "packages": {
+        "@metamask/object-multiplex>once>wrappy": true
+      }
+    },
+    "crypto-browserify>public-encrypt>parse-asn1": {
+      "packages": {
+        "crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
+        "ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "browserify>buffer": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "crypto-browserify>pbkdf2": true
+      }
+    },
+    "react-syntax-highlighter>refractor>parse-entities": {
+      "globals": {
+        "document.createElement": true
+      }
+    },
     "path-browserify": {
       "packages": {
         "process": true
+      }
+    },
+    "serve-handler>path-to-regexp": {
+      "packages": {
+        "serve-handler>path-to-regexp>isarray": true
+      }
+    },
+    "crypto-browserify>pbkdf2": {
+      "globals": {
+        "crypto": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethereumjs-util>create-hash": true,
+        "process": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "@material-ui/core>popper.js": {
+      "globals": {
+        "MSInputMethodContext": true,
+        "Node.DOCUMENT_POSITION_FOLLOWING": true,
+        "cancelAnimationFrame": true,
+        "console.warn": true,
+        "define": true,
+        "devicePixelRatio": true,
+        "document": true,
+        "getComputedStyle": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "navigator": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      }
+    },
+    "react-tippy>popper.js": {
+      "globals": {
+        "MSInputMethodContext": true,
+        "Node.DOCUMENT_POSITION_FOLLOWING": true,
+        "cancelAnimationFrame": true,
+        "console.warn": true,
+        "define": true,
+        "devicePixelRatio": true,
+        "document": true,
+        "getComputedStyle": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "navigator.userAgent": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
       }
     },
     "process": {
@@ -4470,26 +4325,51 @@
         "promise-to-callback>set-immediate-shim": true
       }
     },
-    "promise-to-callback>set-immediate-shim": {
-      "globals": {
-        "setTimeout.apply": true
-      },
-      "packages": {
-        "browserify>timers-browserify": true
-      }
-    },
     "prop-types": {
       "globals": {
         "console": true
       },
       "packages": {
-        "prop-types>react-is": true,
-        "react>object-assign": true
+        "react>object-assign": true,
+        "prop-types>react-is": true
       }
     },
-    "prop-types>react-is": {
+    "react-markdown>property-information": {
+      "packages": {
+        "watchify>xtend": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": {
       "globals": {
-        "console": true
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/base64": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/eventemitter": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/float": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/path": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/pool": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/utf8": true
+      }
+    },
+    "crypto-browserify>public-encrypt": {
+      "packages": {
+        "bn.js": true,
+        "crypto-browserify>public-encrypt>browserify-rsa": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "crypto-browserify>public-encrypt>parse-asn1": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "browserify>punycode": {
+      "globals": {
+        "define": true
       }
     },
     "qrcode-generator": {
@@ -4506,13 +4386,55 @@
         "react": true
       }
     },
+    "@storybook/addon-knobs>qs": {
+      "packages": {
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
+      "globals": {
+        "queueMicrotask": true
+      }
+    },
+    "react-beautiful-dnd>raf-schd": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "requestAnimationFrame": true
+      }
+    },
+    "crypto-browserify>randombytes": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "process": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "ethereumjs-wallet>randombytes": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "crypto-browserify>randomfill": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "process": true,
+        "crypto-browserify>randombytes": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
     "react": {
       "globals": {
         "console": true
       },
       "packages": {
-        "prop-types": true,
-        "react>object-assign": true
+        "react>object-assign": true,
+        "prop-types": true
       }
     },
     "react-beautiful-dnd": {
@@ -4534,35 +4456,14 @@
       },
       "packages": {
         "@babel/runtime": true,
-        "react": true,
         "react-beautiful-dnd>css-box-model": true,
         "react-beautiful-dnd>memoize-one": true,
         "react-beautiful-dnd>raf-schd": true,
-        "react-beautiful-dnd>use-memo-one": true,
+        "react": true,
         "react-dom": true,
         "react-redux": true,
-        "redux": true
-      }
-    },
-    "react-beautiful-dnd>css-box-model": {
-      "globals": {
-        "getComputedStyle": true,
-        "pageXOffset": true,
-        "pageYOffset": true
-      },
-      "packages": {
-        "react-router-dom>tiny-invariant": true
-      }
-    },
-    "react-beautiful-dnd>raf-schd": {
-      "globals": {
-        "cancelAnimationFrame": true,
-        "requestAnimationFrame": true
-      }
-    },
-    "react-beautiful-dnd>use-memo-one": {
-      "packages": {
-        "react": true
+        "redux": true,
+        "react-beautiful-dnd>use-memo-one": true
       }
     },
     "react-chartjs-2": {
@@ -4571,6 +4472,12 @@
       },
       "packages": {
         "chart.js": true,
+        "react": true
+      }
+    },
+    "react-focus-lock>react-clientside-effect": {
+      "packages": {
+        "@babel/runtime": true,
         "react": true
       }
     },
@@ -4615,22 +4522,28 @@
         "trustedTypes": true
       },
       "packages": {
+        "react>object-assign": true,
         "prop-types": true,
         "react": true,
-        "react-dom>scheduler": true,
-        "react>object-assign": true
+        "react-dom>scheduler": true
       }
     },
-    "react-dom>scheduler": {
+    "react-responsive-carousel>react-easy-swipe": {
       "globals": {
-        "MessageChannel": true,
-        "cancelAnimationFrame": true,
-        "clearTimeout": true,
-        "console": true,
-        "navigator": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
+        "addEventListener": true,
+        "define": true,
+        "document.addEventListener": true,
+        "document.removeEventListener": true
+      },
+      "packages": {
+        "prop-types": true,
+        "react": true
+      }
+    },
+    "react-popper>react-fast-compare": {
+      "globals": {
+        "Element": true,
+        "console.warn": true
       }
     },
     "react-focus-lock": {
@@ -4644,51 +4557,12 @@
       },
       "packages": {
         "@babel/runtime": true,
+        "react-focus-lock>focus-lock": true,
         "prop-types": true,
         "react": true,
-        "react-focus-lock>focus-lock": true,
         "react-focus-lock>react-clientside-effect": true,
         "react-focus-lock>use-callback-ref": true,
         "react-focus-lock>use-sidecar": true
-      }
-    },
-    "react-focus-lock>focus-lock": {
-      "globals": {
-        "HTMLIFrameElement": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
-        "Node.DOCUMENT_NODE": true,
-        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
-        "Node.DOCUMENT_POSITION_CONTAINS": true,
-        "Node.ELEMENT_NODE": true,
-        "console.error": true,
-        "console.warn": true,
-        "document": true,
-        "getComputedStyle": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "react-focus-lock>react-clientside-effect": {
-      "packages": {
-        "@babel/runtime": true,
-        "react": true
-      }
-    },
-    "react-focus-lock>use-callback-ref": {
-      "packages": {
-        "react": true
-      }
-    },
-    "react-focus-lock>use-sidecar": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true,
-        "react": true,
-        "react-focus-lock>use-sidecar>detect-node-es": true
       }
     },
     "react-idle-timer": {
@@ -4712,15 +4586,30 @@
         "react": true
       }
     },
+    "prop-types>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-markdown>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-redux>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
     "react-markdown": {
       "globals": {
         "console.warn": true
       },
       "packages": {
-        "prop-types": true,
-        "react": true,
         "react-markdown>comma-separated-tokens": true,
+        "prop-types": true,
         "react-markdown>property-information": true,
+        "react": true,
         "react-markdown>react-is": true,
         "react-markdown>remark-parse": true,
         "react-markdown>remark-rehype": true,
@@ -4729,96 +4618,6 @@
         "react-markdown>unified": true,
         "react-markdown>unist-util-visit": true,
         "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>property-information": {
-      "packages": {
-        "watchify>xtend": true
-      }
-    },
-    "react-markdown>react-is": {
-      "globals": {
-        "console": true
-      }
-    },
-    "react-markdown>remark-parse": {
-      "packages": {
-        "react-markdown>remark-parse>mdast-util-from-markdown": true
-      }
-    },
-    "react-markdown>remark-parse>mdast-util-from-markdown": {
-      "packages": {
-        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
-        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
-        "react-markdown>remark-parse>mdast-util-from-markdown>unist-util-stringify-position": true,
-        "react-syntax-highlighter>refractor>parse-entities": true
-      }
-    },
-    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
-      "packages": {
-        "react-syntax-highlighter>refractor>parse-entities": true
-      }
-    },
-    "react-markdown>remark-rehype": {
-      "packages": {
-        "react-markdown>remark-rehype>mdast-util-to-hast": true
-      }
-    },
-    "react-markdown>remark-rehype>mdast-util-to-hast": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@storybook/addon-docs>remark-external-links>mdast-util-definitions": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "react-markdown>style-to-object": {
-      "packages": {
-        "react-markdown>style-to-object>inline-style-parser": true
-      }
-    },
-    "react-markdown>unified": {
-      "packages": {
-        "mocha>yargs-unparser>is-plain-obj": true,
-        "react-markdown>unified>bail": true,
-        "react-markdown>unified>extend": true,
-        "react-markdown>unified>is-buffer": true,
-        "react-markdown>unified>trough": true,
-        "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>unist-util-visit": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-visit-parents": true
-      }
-    },
-    "react-markdown>unist-util-visit>unist-util-visit-parents": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-is": true
-      }
-    },
-    "react-markdown>vfile": {
-      "packages": {
-        "path-browserify": true,
-        "process": true,
-        "react-markdown>vfile>is-buffer": true,
-        "react-markdown>vfile>replace-ext": true,
-        "react-markdown>vfile>vfile-message": true
-      }
-    },
-    "react-markdown>vfile>replace-ext": {
-      "packages": {
-        "path-browserify": true
-      }
-    },
-    "react-markdown>vfile>vfile-message": {
-      "packages": {
-        "react-markdown>vfile>unist-util-stringify-position": true
       }
     },
     "react-popper": {
@@ -4832,17 +4631,6 @@
         "react-popper>warning": true
       }
     },
-    "react-popper>react-fast-compare": {
-      "globals": {
-        "Element": true,
-        "console.warn": true
-      }
-    },
-    "react-popper>warning": {
-      "globals": {
-        "console": true
-      }
-    },
     "react-redux": {
       "globals": {
         "console": true,
@@ -4850,21 +4638,11 @@
       },
       "packages": {
         "@babel/runtime": true,
+        "react-redux>hoist-non-react-statics": true,
         "prop-types": true,
         "react": true,
         "react-dom": true,
-        "react-redux>hoist-non-react-statics": true,
         "react-redux>react-is": true
-      }
-    },
-    "react-redux>hoist-non-react-statics": {
-      "packages": {
-        "prop-types>react-is": true
-      }
-    },
-    "react-redux>react-is": {
-      "globals": {
-        "console": true
       }
     },
     "react-responsive-carousel": {
@@ -4885,23 +4663,11 @@
         "react-responsive-carousel>react-easy-swipe": true
       }
     },
-    "react-responsive-carousel>react-easy-swipe": {
-      "globals": {
-        "addEventListener": true,
-        "define": true,
-        "document.addEventListener": true,
-        "document.removeEventListener": true
-      },
-      "packages": {
-        "prop-types": true,
-        "react": true
-      }
-    },
     "react-router-dom": {
       "packages": {
+        "react-router-dom>history": true,
         "prop-types": true,
         "react": true,
-        "react-router-dom>history": true,
         "react-router-dom>react-router": true,
         "react-router-dom>tiny-invariant": true,
         "react-router-dom>tiny-warning": true
@@ -4927,26 +4693,24 @@
         "setTimeout": true
       },
       "packages": {
+        "react-router-dom-v5-compat>@remix-run/router": true,
         "history": true,
         "react": true,
         "react-dom": true,
         "react-router-dom": true,
-        "react-router-dom-v5-compat>@remix-run/router": true,
         "react-router-dom-v5-compat>react-router": true
       }
     },
-    "react-router-dom-v5-compat>@remix-run/router": {
-      "globals": {
-        "AbortController": true,
-        "DOMException": true,
-        "FormData": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "URL": true,
-        "URLSearchParams": true,
-        "console": true,
-        "document.defaultView": true
+    "react-router-dom>react-router": {
+      "packages": {
+        "react-router-dom>history": true,
+        "react-redux>hoist-non-react-statics": true,
+        "serve-handler>path-to-regexp": true,
+        "prop-types": true,
+        "react": true,
+        "prop-types>react-is": true,
+        "react-router-dom>tiny-invariant": true,
+        "react-router-dom>tiny-warning": true
       }
     },
     "react-router-dom-v5-compat>react-router": {
@@ -4955,42 +4719,8 @@
         "define": true
       },
       "packages": {
-        "react": true,
-        "react-router-dom-v5-compat>@remix-run/router": true
-      }
-    },
-    "react-router-dom>history": {
-      "globals": {
-        "addEventListener": true,
-        "confirm": true,
-        "document": true,
-        "history": true,
-        "location": true,
-        "navigator.userAgent": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "react-router-dom>history>resolve-pathname": true,
-        "react-router-dom>history>value-equal": true,
-        "react-router-dom>tiny-invariant": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "react-router-dom>react-router": {
-      "packages": {
-        "prop-types": true,
-        "prop-types>react-is": true,
-        "react": true,
-        "react-redux>hoist-non-react-statics": true,
-        "react-router-dom>history": true,
-        "react-router-dom>tiny-invariant": true,
-        "react-router-dom>tiny-warning": true,
-        "serve-handler>path-to-regexp": true
-      }
-    },
-    "react-router-dom>tiny-warning": {
-      "globals": {
-        "console": true
+        "react-router-dom-v5-compat>@remix-run/router": true,
+        "react": true
       }
     },
     "react-simple-file-input": {
@@ -5002,11 +4732,6 @@
       "packages": {
         "prop-types": true,
         "react": true
-      }
-    },
-    "react-syntax-highlighter>refractor>parse-entities": {
-      "globals": {
-        "document.createElement": true
       }
     },
     "react-tippy": {
@@ -5031,26 +4756,9 @@
         "setTimeout": true
       },
       "packages": {
+        "react-tippy>popper.js": true,
         "react": true,
-        "react-dom": true,
-        "react-tippy>popper.js": true
-      }
-    },
-    "react-tippy>popper.js": {
-      "globals": {
-        "MSInputMethodContext": true,
-        "Node.DOCUMENT_POSITION_FOLLOWING": true,
-        "cancelAnimationFrame": true,
-        "console.warn": true,
-        "define": true,
-        "devicePixelRatio": true,
-        "document": true,
-        "getComputedStyle": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "navigator.userAgent": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
+        "react-dom": true
       }
     },
     "react-toggle-button": {
@@ -5065,22 +4773,46 @@
         "react": true
       }
     },
+    "@material-ui/core>react-transition-group": {
+      "globals": {
+        "Element": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@material-ui/core>react-transition-group>dom-helpers": true,
+        "prop-types": true,
+        "react": true,
+        "react-dom": true
+      }
+    },
     "readable-stream": {
       "packages": {
         "browserify>browser-resolve": true,
         "browserify>buffer": true,
-        "browserify>string_decoder": true,
-        "process": true,
+        "webpack>events": true,
         "pumpify>inherits": true,
-        "readable-stream>util-deprecate": true,
-        "webpack>events": true
+        "process": true,
+        "browserify>string_decoder": true,
+        "readable-stream>util-deprecate": true
       }
     },
-    "readable-stream>util-deprecate": {
+    "extension-port-stream>readable-stream": {
       "globals": {
-        "console.trace": true,
-        "console.warn": true,
-        "localStorage": true
+        "AbortController": true,
+        "AggregateError": true,
+        "Blob": true
+      },
+      "packages": {
+        "extension-port-stream>readable-stream>abort-controller": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "process": true,
+        "browserify>string_decoder": true
+      }
+    },
+    "@metamask/snaps-controllers>readable-web-to-node-stream": {
+      "packages": {
+        "readable-stream": true
       }
     },
     "redux": {
@@ -5091,6 +4823,111 @@
         "@babel/runtime": true
       }
     },
+    "string.prototype.matchall>regexp.prototype.flags": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+      }
+    },
+    "react-markdown>remark-parse": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown": true
+      }
+    },
+    "react-markdown>remark-rehype": {
+      "packages": {
+        "react-markdown>remark-rehype>mdast-util-to-hast": true
+      }
+    },
+    "react-markdown>vfile>replace-ext": {
+      "packages": {
+        "path-browserify": true
+      }
+    },
+    "@metamask/network-controller>reselect": {
+      "globals": {
+        "WeakRef": true,
+        "console.warn": true,
+        "unstable_autotrackMemoize": true
+      }
+    },
+    "@metamask/snaps-utils>rfdc": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "ethereumjs-util>create-hash>ripemd160": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>md5.js>hash-base": true,
+        "pumpify>inherits": true
+      }
+    },
+    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "eth-lattice-keyring>rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "ethereumjs-util>rlp": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true
+      }
+    },
+    "wait-on>rxjs": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setInterval.apply": true,
+        "setTimeout.apply": true
+      }
+    },
+    "koa>content-disposition>safe-buffer": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "react-dom>scheduler": {
+      "globals": {
+        "MessageChannel": true,
+        "cancelAnimationFrame": true,
+        "clearTimeout": true,
+        "console": true,
+        "navigator": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets>scrypt-js": {
+      "globals": {
+        "define": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>timers-browserify": true
+      }
+    },
+    "ganache>secp256k1": {
+      "packages": {
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>secp256k1": {
+      "packages": {
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
     "semver": {
       "globals": {
         "console.error": true
@@ -5099,16 +4936,69 @@
         "process": true
       }
     },
-    "serve-handler>path-to-regexp": {
+    "string.prototype.matchall>call-bind>set-function-length": {
       "packages": {
-        "serve-handler>path-to-regexp>isarray": true
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "promise-to-callback>set-immediate-shim": {
+      "globals": {
+        "setTimeout.apply": true
+      },
+      "packages": {
+        "browserify>timers-browserify": true
+      }
+    },
+    "addons-linter>sha.js": {
+      "packages": {
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "string.prototype.matchall>side-channel": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>object-inspect": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": true,
+        "@metamask/profile-sync-controller>siwe>@stablelib/random": true,
+        "ethers": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>valid-url": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": {
+      "globals": {
+        "StopIteration": true
+      },
+      "packages": {
+        "string.prototype.matchall>internal-slot": true
       }
     },
     "stream-browserify": {
       "packages": {
+        "webpack>events": true,
         "pumpify>inherits": true,
-        "readable-stream": true,
-        "webpack>events": true
+        "readable-stream": true
       }
     },
     "stream-http": {
@@ -5127,160 +5017,195 @@
       },
       "packages": {
         "browserify>buffer": true,
-        "browserify>url": true,
-        "process": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
         "stream-http>builtin-status-codes": true,
+        "pumpify>inherits": true,
+        "process": true,
+        "readable-stream": true,
+        "browserify>url": true,
         "watchify>xtend": true
       }
     },
-    "string.prototype.matchall>call-bind": {
+    "@metamask/snaps-controllers>tar-stream>streamx": {
       "packages": {
-        "browserify>has>function-bind": true,
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>call-bind>set-function-length": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "webpack>events": true,
+        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
+        "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": true
       }
     },
-    "string.prototype.matchall>call-bind>es-define-property": {
+    "browserify>string_decoder": {
       "packages": {
-        "string.prototype.matchall>get-intrinsic": true
+        "koa>content-disposition>safe-buffer": true
       }
     },
-    "string.prototype.matchall>call-bind>set-function-length": {
+    "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>gopd": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true
       }
     },
-    "string.prototype.matchall>define-properties": {
+    "react-markdown>style-to-object": {
       "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+        "react-markdown>style-to-object>inline-style-parser": true
       }
     },
-    "string.prototype.matchall>define-properties>define-data-property": {
+    "@metamask/snaps-controllers>tar-stream": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>gopd": true
+        "@metamask/snaps-controllers>tar-stream>b4a": true,
+        "browserify>browser-resolve": true,
+        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
+        "@metamask/snaps-controllers>tar-stream>streamx": true
       }
     },
-    "string.prototype.matchall>es-abstract>array-buffer-byte-length": {
+    "debounce-stream>through": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>is-array-buffer": true
+        "process": true,
+        "stream-browserify": true
       }
     },
-    "string.prototype.matchall>es-abstract>available-typed-arrays": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>typed-array-length>possible-typed-array-names": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
-      "packages": {
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>gopd": {
-      "packages": {
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>has-property-descriptors": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-array-buffer": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-callable": {
+    "browserify>timers-browserify": {
       "globals": {
-        "document": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-regex": {
+        "clearInterval": true,
+        "clearTimeout": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
       "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
+        "process": true
       }
     },
-    "string.prototype.matchall>es-abstract>is-shared-array-buffer": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>object-inspect": {
+    "react-router-dom>tiny-warning": {
       "globals": {
-        "HTMLElement": true,
-        "WeakRef": true
+        "console": true
+      }
+    },
+    "copy-to-clipboard>toggle-selection": {
+      "globals": {
+        "document.activeElement": true,
+        "document.getSelection": true
+      }
+    },
+    "@swc/helpers>tslib": {
+      "globals": {
+        "SuppressedError": true,
+        "define": true
+      }
+    },
+    "@metamask/eth-sig-util>tweetnacl": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "nacl": "write"
       },
       "packages": {
         "browserify>browser-resolve": true
       }
     },
-    "string.prototype.matchall>get-intrinsic": {
+    "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": {
       "globals": {
-        "AggregateError": true,
-        "FinalizationRegistry": true,
-        "WeakRef": true
+        "define": true
+      }
+    },
+    "@ensdomains/content-hash>cids>uint8arrays": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
       },
       "packages": {
-        "browserify>has>function-bind": true,
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>has-proto": true,
-        "string.prototype.matchall>has-symbols": true
+        "@ensdomains/content-hash>cids>multibase": true
       }
     },
-    "string.prototype.matchall>internal-slot": {
+    "@ensdomains/content-hash>multicodec>uint8arrays": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
       "packages": {
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>side-channel": true
+        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true
       }
     },
-    "string.prototype.matchall>regexp.prototype.flags": {
+    "react-markdown>unified": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+        "react-markdown>unified>bail": true,
+        "react-markdown>unified>extend": true,
+        "react-markdown>unified>is-buffer": true,
+        "mocha>yargs-unparser>is-plain-obj": true,
+        "react-markdown>unified>trough": true,
+        "react-markdown>vfile": true
       }
     },
-    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+    "react-markdown>unist-util-visit>unist-util-visit-parents": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+        "react-markdown>unist-util-visit>unist-util-is": true
       }
     },
-    "string.prototype.matchall>side-channel": {
+    "react-markdown>unist-util-visit": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>object-inspect": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "terser>source-map-support>buffer-from": {
-      "packages": {
-        "browserify>buffer": true
+        "react-markdown>unist-util-visit>unist-util-visit-parents": true
       }
     },
     "uri-js": {
       "globals": {
         "define": true
+      }
+    },
+    "browserify>url": {
+      "packages": {
+        "browserify>punycode": true,
+        "@storybook/addon-knobs>qs": true
+      }
+    },
+    "react-focus-lock>use-callback-ref": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-beautiful-dnd>use-memo-one": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-focus-lock>use-sidecar": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "react-focus-lock>use-sidecar>detect-node-es": true,
+        "react": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "readable-stream>util-deprecate": {
+      "globals": {
+        "console.trace": true,
+        "console.warn": true,
+        "localStorage": true
+      }
+    },
+    "browserify>assert>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true,
+        "process": true
+      },
+      "packages": {
+        "browserify>assert>util>inherits": true,
+        "process": true
+      }
+    },
+    "browserify>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "browserify>util>is-arguments": true,
+        "koa>is-generator-function": true,
+        "browserify>util>is-typed-array": true,
+        "process": true,
+        "browserify>util>which-typed-array": true
       }
     },
     "uuid": {
@@ -5289,15 +5214,64 @@
         "msCrypto": true
       }
     },
-    "wait-on>rxjs": {
+    "@metamask/eth-snap-keyring>uuid": {
       "globals": {
-        "cancelAnimationFrame": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setInterval.apply": true,
-        "setTimeout.apply": true
+        "crypto": true
+      }
+    },
+    "@metamask/keyring-api>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "web3-stream-provider>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/snaps-utils>validate-npm-package-name": {
+      "packages": {
+        "@metamask/snaps-utils>validate-npm-package-name>builtins": true
+      }
+    },
+    "react-markdown>vfile>vfile-message": {
+      "packages": {
+        "react-markdown>vfile>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>vfile": {
+      "packages": {
+        "react-markdown>vfile>is-buffer": true,
+        "path-browserify": true,
+        "process": true,
+        "react-markdown>vfile>replace-ext": true,
+        "react-markdown>vfile>vfile-message": true
+      }
+    },
+    "browserify>vm-browserify": {
+      "globals": {
+        "document.body.appendChild": true,
+        "document.body.removeChild": true,
+        "document.createElement": true
+      }
+    },
+    "react-popper>warning": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>web-encoding": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "browserify>util": true
       }
     },
     "web3": {
@@ -5310,14 +5284,14 @@
         "setTimeout": true
       },
       "packages": {
-        "browserify>util": true,
         "readable-stream": true,
+        "browserify>util": true,
         "web3-stream-provider>uuid": true
       }
     },
-    "web3-stream-provider>uuid": {
+    "@metamask/controllers>web3": {
       "globals": {
-        "crypto": true
+        "XMLHttpRequest": true
       }
     },
     "webextension-polyfill": {
@@ -5329,9 +5303,35 @@
         "define": true
       }
     },
-    "webpack>events": {
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": {
+      "packages": {
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-collection": {
+      "packages": {
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakmap": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": true
+      }
+    },
+    "browserify>util>which-typed-array": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>available-typed-arrays": true,
+        "string.prototype.matchall>call-bind": true,
+        "browserify>util>which-typed-array>for-each": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": {
       "globals": {
-        "console": true
+        "XMLHttpRequest": true
       }
     }
   }

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2645,7 +2645,7 @@
         "@zxing/library>ts-custom-error": true
       }
     },
-    "extension-port-stream>readable-stream>abort-controller": {
+    "@lavamoat/lavapack>readable-stream>abort-controller": {
       "globals": {
         "AbortController": true
       }
@@ -4803,7 +4803,7 @@
         "Blob": true
       },
       "packages": {
-        "extension-port-stream>readable-stream>abort-controller": true,
+        "@lavamoat/lavapack>readable-stream>abort-controller": true,
         "browserify>buffer": true,
         "webpack>events": true,
         "process": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -5,115 +5,70 @@
         "regeneratorRuntime": "write"
       }
     },
+    "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": {
+      "globals": {
+        "SuppressedError": true
+      }
+    },
     "@ensdomains/content-hash": {
       "globals": {
         "console.warn": true
       },
       "packages": {
+        "browserify>buffer": true,
         "@ensdomains/content-hash>cids": true,
         "@ensdomains/content-hash>js-base64": true,
         "@ensdomains/content-hash>multicodec": true,
-        "@ensdomains/content-hash>multihashes": true,
-        "browserify>buffer": true
+        "@ensdomains/content-hash>multihashes": true
       }
     },
-    "@ensdomains/content-hash>cids": {
+    "@ethereumjs/tx>@ethereumjs/common": {
       "packages": {
-        "@ensdomains/content-hash>cids>multibase": true,
-        "@ensdomains/content-hash>cids>multihashes": true,
-        "@ensdomains/content-hash>cids>uint8arrays": true,
-        "@ensdomains/content-hash>multicodec": true
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "webpack>events": true
       }
     },
-    "@ensdomains/content-hash>cids>multibase": {
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "@metamask/transaction-controller>@ethereumjs/common": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "webpack>events": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@ethereumjs/common": {
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "@ethereumjs/tx>@ethereumjs/rlp": {
       "globals": {
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase>@multiformats/base-x": true
       }
     },
-    "@ensdomains/content-hash>cids>multihashes": {
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase": true,
-        "@ensdomains/content-hash>cids>multihashes>varint": true,
-        "@ensdomains/content-hash>cids>uint8arrays": true
-      }
-    },
-    "@ensdomains/content-hash>cids>uint8arrays": {
+    "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": {
       "globals": {
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase": true
       }
     },
-    "@ensdomains/content-hash>js-base64": {
+    "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": {
       "globals": {
-        "Base64": "write",
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "atob": true,
-        "btoa": true,
-        "define": true
-      },
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec": {
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays": true,
-        "sass-embedded>varint": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec>uint8arrays": {
-      "globals": {
-        "Buffer": true,
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "console.warn": true,
-        "crypto.subtle.digest": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase": true,
-        "@ensdomains/content-hash>multihashes>varint": true,
-        "@ensdomains/content-hash>multihashes>web-encoding": true,
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>multibase": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase>base-x": true,
-        "@ensdomains/content-hash>multihashes>web-encoding": true,
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>multibase>base-x": {
-      "packages": {
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>web-encoding": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "browserify>util": true
       }
     },
     "@ethereumjs/tx": {
@@ -121,28 +76,36 @@
         "@ethereumjs/tx>@ethereumjs/common": true,
         "@ethereumjs/tx>@ethereumjs/rlp": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>insert-module-globals>is-buffer": true
       }
     },
-    "@ethereumjs/tx>@ethereumjs/common": {
+    "@metamask/smart-transactions-controller>@ethereumjs/tx": {
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "browserify>buffer": true,
+        "@trezor/connect-web>@trezor/connect>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": {
+      "globals": {
+        "console.warn": true,
+        "fetch": true
+      },
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "webpack>events": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/common>crc-32": {
-      "globals": {
-        "DO_NOT_EXPORT_CRC": true,
-        "define": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/rlp": {
-      "globals": {
-        "TextEncoder": true
       }
     },
     "@ethereumjs/tx>@ethereumjs/util": {
@@ -151,78 +114,33 @@
       },
       "packages": {
         "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": true,
-        "@ethereumjs/tx>@ethereumjs/util>micro-ftch": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true,
         "browserify>insert-module-globals>is-buffer": true,
-        "webpack>events": true
+        "@ethereumjs/tx>@ethereumjs/util>micro-ftch": true
       }
     },
-    "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": {
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": {
       "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/util>micro-ftch": {
-      "globals": {
-        "Headers": true,
-        "TextDecoder": true,
-        "URL": true,
-        "btoa": true,
+        "console.warn": true,
         "fetch": true
       },
       "packages": {
-        "browserify>browserify-zlib": true,
-        "browserify>buffer": true,
-        "browserify>url": true,
-        "browserify>util": true,
-        "https-browserify": true,
-        "process": true,
-        "stream-http": true
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true
       }
     },
-    "@ethereumjs/tx>ethereum-cryptography": {
+    "@metamask/smart-transactions-controller>@ethereumjs/util": {
       "globals": {
-        "TextDecoder": true,
-        "crypto": true
+        "console.warn": true,
+        "fetch": true
       },
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": true,
-        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/curves": {
-      "globals": {
-        "TextEncoder": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true
       }
     },
     "@ethersproject/abi": {
@@ -230,27 +148,70 @@
         "console.log": true
       },
       "packages": {
+        "ethers>@ethersproject/address": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/strings": true
       }
     },
+    "ethers>@ethersproject/abstract-provider": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
+    "ethers>@ethersproject/abstract-signer": {
+      "packages": {
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
+    "ethers>@ethersproject/address": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/rlp": true
+      }
+    },
+    "ethers>@ethersproject/base64": {
+      "globals": {
+        "atob": true,
+        "btoa": true
+      },
+      "packages": {
+        "@ethersproject/bytes": true
+      }
+    },
+    "ethers>@ethersproject/basex": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
     "@ethersproject/bignumber": {
       "packages": {
         "@ethersproject/bytes": true,
-        "bn.js": true,
-        "ethers>@ethersproject/logger": true
+        "ethers>@ethersproject/logger": true,
+        "bn.js": true
       }
     },
     "@ethersproject/bytes": {
       "packages": {
         "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/constants": {
+      "packages": {
+        "@ethersproject/bignumber": true
       }
     },
     "@ethersproject/contracts": {
@@ -259,11 +220,11 @@
       },
       "packages": {
         "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/transactions": true
@@ -271,10 +232,10 @@
     },
     "@ethersproject/hash": {
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
@@ -283,9 +244,9 @@
     },
     "@ethersproject/hdnode": {
       "packages": {
+        "ethers>@ethersproject/basex": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/bytes": true,
-        "ethers>@ethersproject/basex": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/pbkdf2": true,
         "ethers>@ethersproject/properties": true,
@@ -294,6 +255,54 @@
         "ethers>@ethersproject/strings": true,
         "ethers>@ethersproject/transactions": true,
         "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets": {
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bytes": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/pbkdf2": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/json-wallets>aes-js": true,
+        "ethers>@ethersproject/json-wallets>scrypt-js": true
+      }
+    },
+    "ethers>@ethersproject/keccak256": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "@metamask/ethjs>js-sha3": true
+      }
+    },
+    "ethers>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "ethers>@ethersproject/providers>@ethersproject/networks": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "@metamask/test-bundler>@ethersproject/networks": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/pbkdf2": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/sha2": true
+      }
+    },
+    "ethers>@ethersproject/properties": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
       }
     },
     "@ethersproject/providers": {
@@ -307,29 +316,140 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/providers>@ethersproject/web": true,
-        "@ethersproject/providers>bech32": true,
-        "@metamask/test-bundler>@ethersproject/networks": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
         "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
         "ethers>@ethersproject/logger": true,
+        "@metamask/test-bundler>@ethersproject/networks": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/random": true,
         "ethers>@ethersproject/sha2": true,
         "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
+        "ethers>@ethersproject/transactions": true,
+        "@ethersproject/providers>@ethersproject/web": true,
+        "@ethersproject/providers>bech32": true
+      }
+    },
+    "ethers>@ethersproject/providers": {
+      "globals": {
+        "WebSocket": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "console.warn": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethers>@ethersproject/abstract-provider": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/providers>@ethersproject/networks": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/providers>bech32": true
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
+      }
+    },
+    "ethers>@ethersproject/random": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/rlp": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/sha2": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/sha2>hash.js": true
+      }
+    },
+    "ethers>@ethersproject/signing-key": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "ethers>@ethersproject/solidity": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/strings": true
+      }
+    },
+    "ethers>@ethersproject/strings": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/transactions": {
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/signing-key": true
+      }
+    },
+    "ethers>@ethersproject/units": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "@ethersproject/wallet": {
+      "packages": {
+        "ethers>@ethersproject/abstract-provider": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bytes": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/transactions": true
       }
     },
     "@ethersproject/providers>@ethersproject/web": {
@@ -339,1486 +459,48 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/strings": true
       }
     },
-    "@ethersproject/wallet": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "ethers>@ethersproject/abstract-provider": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "@keystonehq/bc-ur-registry-eth": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "uuid": true
-      }
-    },
-    "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": {
+    "ethers>@ethersproject/providers>@ethersproject/web": {
       "globals": {
-        "define": true
-      },
-      "packages": {
-        "@ngraveio/bc-ur": true,
-        "@swc/helpers>tslib": true,
-        "browserify>buffer": true,
-        "buffer": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring": {
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@keystonehq/bc-ur-registry-eth": true,
-        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": true,
-        "@metamask/obs-store": true,
-        "browserify>buffer": true,
-        "ethereumjs-util>rlp": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": {
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@keystonehq/bc-ur-registry-eth": true,
-        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "uuid": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@lavamoat/lavadome-react": {
-      "globals": {
-        "Document.prototype": true,
-        "DocumentFragment.prototype": true,
-        "Element.prototype": true,
-        "Node.prototype": true,
-        "console.warn": true,
-        "document": true
-      },
-      "packages": {
-        "react": true
-      }
-    },
-    "@material-ui/core": {
-      "globals": {
-        "Image": true,
-        "_formatMuiErrorMessage": true,
-        "addEventListener": true,
-        "clearInterval": true,
         "clearTimeout": true,
-        "console.error": true,
-        "console.warn": true,
-        "document": true,
-        "getComputedStyle": true,
-        "getSelection": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "matchMedia": true,
-        "navigator": true,
-        "performance.now": true,
-        "removeEventListener": true,
-        "requestAnimationFrame": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles": true,
-        "@material-ui/core>@material-ui/system": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "@material-ui/core>clsx": true,
-        "@material-ui/core>popper.js": true,
-        "@material-ui/core>react-transition-group": true,
-        "prop-types": true,
-        "prop-types>react-is": true,
-        "react": true,
-        "react-dom": true,
-        "react-redux>hoist-non-react-statics": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true,
-        "document.createComment": true,
-        "document.head": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-global": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-nested": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-props-sort": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "@material-ui/core>clsx": true,
-        "prop-types": true,
-        "react": true,
-        "react-redux>hoist-non-react-statics": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss": {
-      "globals": {
-        "CSS": true,
-        "document.createElement": true,
-        "document.querySelector": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case>hyphenate-style-name": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": {
-      "globals": {
-        "CSS": true
-      },
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-global": {
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-nested": {
-      "packages": {
-        "@babel/runtime": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": {
-      "globals": {
-        "document.createElement": true,
-        "document.documentElement": true,
-        "getComputedStyle": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss>is-in-browser": {
-      "globals": {
-        "document": true
-      }
-    },
-    "@material-ui/core>@material-ui/system": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "prop-types": true
-      }
-    },
-    "@material-ui/core>@material-ui/utils": {
-      "packages": {
-        "@babel/runtime": true,
-        "prop-types": true,
-        "prop-types>react-is": true
-      }
-    },
-    "@material-ui/core>popper.js": {
-      "globals": {
-        "MSInputMethodContext": true,
-        "Node.DOCUMENT_POSITION_FOLLOWING": true,
-        "cancelAnimationFrame": true,
-        "console.warn": true,
-        "define": true,
-        "devicePixelRatio": true,
-        "document": true,
-        "getComputedStyle": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "navigator": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
-      }
-    },
-    "@material-ui/core>react-transition-group": {
-      "globals": {
-        "Element": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@material-ui/core>react-transition-group>dom-helpers": true,
-        "prop-types": true,
-        "react": true,
-        "react-dom": true
-      }
-    },
-    "@material-ui/core>react-transition-group>dom-helpers": {
-      "packages": {
-        "@babel/runtime": true
-      }
-    },
-    "@metamask/abi-utils": {
-      "packages": {
-        "@metamask/abi-utils>@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/abi-utils>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/accounts-controller": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/base-controller": true,
-        "@metamask/eth-snap-keyring": true,
-        "@metamask/keyring-api": true,
-        "@metamask/keyring-controller": true,
-        "@metamask/utils": true,
-        "uuid": true
-      }
-    },
-    "@metamask/address-book-controller": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true
-      }
-    },
-    "@metamask/announcement-controller": {
-      "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/approval-controller": {
-      "globals": {
-        "console.info": true
-      },
-      "packages": {
-        "@metamask/approval-controller>nanoid": true,
-        "@metamask/base-controller": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/approval-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/assets-controllers": {
-      "globals": {
-        "AbortController": true,
-        "Headers": true,
-        "URL": true,
-        "URLSearchParams": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "console.log": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/providers": true,
-        "@metamask/abi-utils": true,
-        "@metamask/base-controller": true,
-        "@metamask/contract-metadata": true,
-        "@metamask/controller-utils": true,
-        "@metamask/eth-query": true,
-        "@metamask/metamask-eth-abis": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/polling-controller": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "bn.js": true,
-        "cockatiel": true,
-        "ethers>@ethersproject/address": true,
-        "lodash": true,
-        "single-call-balance-checker-abi": true,
-        "uuid": true
-      }
-    },
-    "@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/browser-passworder": {
-      "globals": {
-        "CryptoKey": true,
-        "btoa": true,
-        "crypto.getRandomValues": true,
-        "crypto.subtle.decrypt": true,
-        "crypto.subtle.deriveKey": true,
-        "crypto.subtle.encrypt": true,
-        "crypto.subtle.exportKey": true,
-        "crypto.subtle.importKey": true
-      },
-      "packages": {
-        "@metamask/browser-passworder>@metamask/utils": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/browser-passworder>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/controller-utils": {
-      "globals": {
-        "URL": true,
-        "console.error": true,
         "fetch": true,
         "setTimeout": true
       },
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/controller-utils>@spruceid/siwe-parser": true,
-        "@metamask/ethjs>@metamask/ethjs-unit": true,
-        "@metamask/utils": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "eslint>fast-deep-equal": true,
-        "eth-ens-namehash": true
-      }
-    },
-    "@metamask/controller-utils>@spruceid/siwe-parser": {
-      "globals": {
-        "console.error": true,
-        "console.log": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/controllers>web3": {
-      "globals": {
-        "XMLHttpRequest": true
-      }
-    },
-    "@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch": {
-      "globals": {
-        "fetch": true
-      }
-    },
-    "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
-      "globals": {
-        "fetch": true
-      }
-    },
-    "@metamask/ens-controller": {
-      "packages": {
-        "@ethersproject/providers": true,
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/utils": true,
-        "punycode": true
-      }
-    },
-    "@metamask/eth-json-rpc-filters": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/safe-event-emitter": true,
-        "pify": true
-      }
-    },
-    "@metamask/eth-json-rpc-middleware": {
-      "globals": {
-        "URL": true,
-        "console.error": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-json-rpc-middleware>@metamask/utils": true,
-        "@metamask/eth-json-rpc-middleware>klona": true,
-        "@metamask/eth-json-rpc-middleware>safe-stable-stringify": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/eth-json-rpc-middleware>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-json-rpc-provider": {
-      "packages": {
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/safe-event-emitter": true,
-        "uuid": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring": {
-      "globals": {
-        "addEventListener": true,
-        "console.error": true,
-        "document.createElement": true,
-        "document.head.appendChild": true,
-        "fetch": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@ethersproject/abi": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": true,
-        "browserify>buffer": true,
-        "ethers>@ethersproject/rlp": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
-      "packages": {
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": {
-      "globals": {
-        "console.warn": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
-      "packages": {
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": true,
-        "@metamask/ppom-validator>crypto-js": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "wait-on>rxjs": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": {
-      "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "@ethersproject/providers": true,
-        "@ethersproject/providers>@ethersproject/web": true,
-        "@ethersproject/wallet": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/solidity": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true,
-        "ethers>@ethersproject/units": true,
-        "ethers>@ethersproject/wordlists": true
+        "ethers>@ethersproject/strings": true
       }
     },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": {
-      "globals": {
-        "__ledgerLogsListen": "write",
-        "console.error": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "@metamask/eth-query": {
-      "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "watchify>xtend": true
-      }
-    },
-    "@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-sig-util>tweetnacl": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true,
-        "nacl": "write"
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/eth-snap-keyring": {
-      "globals": {
-        "URL": true,
-        "console.error": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@metamask/eth-snap-keyring>@metamask/eth-sig-util": true,
-        "@metamask/eth-snap-keyring>@metamask/utils": true,
-        "@metamask/eth-snap-keyring>uuid": true,
-        "@metamask/keyring-api": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-snap-keyring>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/eth-snap-keyring>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/eth-snap-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-snap-keyring>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "@metamask/eth-token-tracker": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@metamask/eth-token-tracker>@metamask/eth-block-tracker": true,
-        "@metamask/eth-token-tracker>deep-equal": true,
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true,
-        "@metamask/safe-event-emitter": true,
-        "bn.js": true,
-        "human-standard-token-abi": true
-      }
-    },
-    "@metamask/eth-token-tracker>@metamask/eth-block-tracker": {
+    "ethers>@ethersproject/web": {
       "globals": {
         "clearTimeout": true,
-        "console.error": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": true,
-        "@metamask/safe-event-emitter": true,
-        "pify": true
-      }
-    },
-    "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator": true,
-        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection": true,
-        "@ngraveio/bc-ur>assert>object-is": true,
-        "browserify>util>is-arguments": true,
-        "browserify>util>which-typed-array": true,
-        "gulp>vinyl-fs>object.assign": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>array-buffer-byte-length": true,
-        "string.prototype.matchall>es-abstract>is-array-buffer": true,
-        "string.prototype.matchall>es-abstract>is-regex": true,
-        "string.prototype.matchall>es-abstract>is-shared-array-buffer": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>regexp.prototype.flags": true,
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>es-get-iterator": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": true,
-        "browserify>util>is-arguments": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "process": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": {
-      "globals": {
-        "StopIteration": true
-      },
-      "packages": {
-        "string.prototype.matchall>internal-slot": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>unbox-primitive>has-bigints": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-collection": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakmap": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "@metamask/eth-trezor-keyring": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "@trezor/connect-web": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": {
-      "packages": {
-        "@metamask/eth-sig-util": true,
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/eth-trezor-keyring>hdkey": {
-      "packages": {
-        "browserify>assert": true,
-        "crypto-browserify": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ganache>secp256k1": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@metamask/etherscan-link": {
-      "globals": {
-        "URL": true
-      }
-    },
-    "@metamask/ethjs": {
-      "globals": {
-        "clearInterval": true,
-        "setInterval": true
-      },
-      "packages": {
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true,
-        "@metamask/ethjs>@metamask/ethjs-filter": true,
-        "@metamask/ethjs>@metamask/ethjs-provider-http": true,
-        "@metamask/ethjs>@metamask/ethjs-unit": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>@metamask/number-to-bn": true,
-        "@metamask/ethjs>ethjs-abi": true,
-        "@metamask/ethjs>js-sha3": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs-contract": {
-      "packages": {
-        "@babel/runtime": true,
-        "@metamask/ethjs>@metamask/ethjs-filter": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>ethjs-abi": true,
-        "@metamask/ethjs>js-sha3": true,
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs-query": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@metamask/ethjs-query>@metamask/ethjs-format": true,
-        "@metamask/ethjs-query>@metamask/ethjs-rpc": true,
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs-query>@metamask/ethjs-format": {
-      "packages": {
-        "@metamask/ethjs-query>@metamask/ethjs-format>ethjs-schema": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "@metamask/ethjs>@metamask/number-to-bn": true
-      }
-    },
-    "@metamask/ethjs-query>@metamask/ethjs-rpc": {
-      "packages": {
-        "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-filter": {
-      "globals": {
-        "clearInterval": true,
-        "setInterval": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-provider-http": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": {
-      "globals": {
-        "XMLHttpRequest": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-unit": {
-      "packages": {
-        "@metamask/ethjs>@metamask/number-to-bn": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-util": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true,
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true
-      }
-    },
-    "@metamask/ethjs>@metamask/number-to-bn": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>ethjs-abi": {
-      "packages": {
-        "@metamask/ethjs>ethjs-abi>number-to-bn": true,
-        "@metamask/ethjs>js-sha3": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs>ethjs-abi>number-to-bn": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>js-sha3": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "process": true
-      }
-    },
-    "@metamask/gas-fee-controller": {
-      "globals": {
-        "clearInterval": true,
-        "console.error": true,
-        "setInterval": true
-      },
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/eth-query": true,
-        "@metamask/polling-controller": true,
-        "bn.js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/jazzicon": {
-      "globals": {
-        "document.createElement": true,
-        "document.createElementNS": true
-      },
-      "packages": {
-        "@metamask/jazzicon>color": true,
-        "@metamask/jazzicon>mersenne-twister": true
-      }
-    },
-    "@metamask/jazzicon>color": {
-      "packages": {
-        "@metamask/jazzicon>color>clone": true,
-        "@metamask/jazzicon>color>color-convert": true,
-        "@metamask/jazzicon>color>color-string": true
-      }
-    },
-    "@metamask/jazzicon>color>clone": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/jazzicon>color>color-convert": {
-      "packages": {
-        "@metamask/jazzicon>color>color-convert>color-name": true
-      }
-    },
-    "@metamask/jazzicon>color>color-string": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
-      }
-    },
-    "@metamask/json-rpc-engine": {
-      "packages": {
-        "@metamask/rpc-errors": true,
-        "@metamask/safe-event-emitter": true,
-        "@metamask/utils": true
-      }
-    },
-    "@metamask/json-rpc-middleware-stream": {
-      "globals": {
-        "console.warn": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/safe-event-emitter": true,
-        "@metamask/utils": true,
-        "readable-stream": true
-      }
-    },
-    "@metamask/keyring-api": {
-      "globals": {
-        "URL": true
-      },
-      "packages": {
-        "@metamask/keyring-api>@metamask/utils": true,
-        "@metamask/keyring-api>bech32": true,
-        "@metamask/keyring-api>uuid": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/keyring-api>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-api>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "@metamask/keyring-controller": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/base-controller": true,
-        "@metamask/browser-passworder": true,
-        "@metamask/keyring-controller>@metamask/eth-hd-keyring": true,
-        "@metamask/keyring-controller>@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
-        "@metamask/keyring-controller>ethereumjs-wallet": true,
-        "@metamask/name-controller>async-mutex": true,
-        "@metamask/utils": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-hd-keyring": {
-      "globals": {
-        "TextEncoder": true
-      },
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": true,
-        "@metamask/scure-bip39": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-simple-keyring": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": true,
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet": {
-      "packages": {
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": true,
-        "@metamask/keyring-controller>ethereumjs-wallet>utf8": true,
-        "browserify>buffer": true,
-        "crypto-browserify": true,
-        "crypto-browserify>randombytes": true,
-        "eth-lattice-keyring>gridplus-sdk>aes-js": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ethers>@ethersproject/json-wallets>scrypt-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": {
-      "packages": {
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "crypto-browserify>create-hmac": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ethereumjs-util>ethereum-cryptography>keccak": true,
-        "ethers>@ethersproject/sha2>hash.js": true,
-        "ganache>secp256k1": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": {
-      "packages": {
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
-        "bn.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>rlp": true
-      }
-    },
-    "@metamask/logging-controller": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "uuid": true
-      }
-    },
-    "@metamask/logo": {
-      "globals": {
-        "addEventListener": true,
-        "document.body.appendChild": true,
-        "document.createElementNS": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "requestAnimationFrame": true
-      },
-      "packages": {
-        "@metamask/logo>gl-mat4": true,
-        "@metamask/logo>gl-vec3": true
-      }
-    },
-    "@metamask/message-manager": {
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/utils": true,
-        "browserify>buffer": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/message-manager>jsonschema": {
-      "packages": {
-        "browserify>url": true
-      }
-    },
-    "@metamask/name-controller": {
-      "globals": {
-        "fetch": true
-      },
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/name-controller>@metamask/base-controller": true,
-        "@metamask/name-controller>@metamask/utils": true,
-        "@metamask/name-controller>async-mutex": true
-      }
-    },
-    "@metamask/name-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/name-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/name-controller>async-mutex": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/network-controller": {
-      "globals": {
-        "btoa": true,
         "fetch": true,
         "setTimeout": true
       },
       "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/network-controller>reselect": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "eslint>fast-deep-equal": true,
-        "uri-js": true,
-        "uuid": true
+        "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
       }
     },
-    "@metamask/network-controller>@metamask/eth-block-tracker": {
-      "globals": {
-        "clearTimeout": true,
-        "console.error": true,
-        "setTimeout": true
-      },
+    "ethers>@ethersproject/wordlists": {
       "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": true,
-        "@metamask/safe-event-emitter": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-json-rpc-infura": {
-      "globals": {
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/network-controller>reselect": {
-      "globals": {
-        "WeakRef": true,
-        "console.warn": true,
-        "unstable_autotrackMemoize": true
-      }
-    },
-    "@metamask/notification-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/notification-services-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "addEventListener": true,
-        "fetch": true,
-        "registration": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": true,
-        "@metamask/notification-services-controller>bignumber.js": true,
-        "@metamask/notification-services-controller>firebase": true,
-        "@metamask/profile-sync-controller": true,
-        "@metamask/utils": true,
-        "loglevel": true,
-        "uuid": true
-      }
-    },
-    "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": {
-      "globals": {
-        "SuppressedError": true
-      }
-    },
-    "@metamask/notification-services-controller>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase": {
-      "packages": {
-        "@metamask/notification-services-controller>firebase>@firebase/app": true,
-        "@metamask/notification-services-controller>firebase>@firebase/messaging": true
+        "@ethersproject/bytes": true,
+        "@ethersproject/hash": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/app": {
@@ -1829,34 +511,13 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": {
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/util": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>idb": {
-      "globals": {
-        "DOMException": true,
-        "IDBCursor": true,
-        "IDBDatabase": true,
-        "IDBIndex": true,
-        "IDBObjectStore": true,
-        "IDBRequest": true,
-        "IDBTransaction": true,
-        "indexedDB.deleteDatabase": true,
-        "indexedDB.open": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/installations": {
@@ -1874,8 +535,16 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
       }
     },
     "@metamask/notification-services-controller>firebase>@firebase/messaging": {
@@ -1906,9 +575,9 @@
       "packages": {
         "@metamask/notification-services-controller>firebase>@firebase/app": true,
         "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
         "@metamask/notification-services-controller>firebase>@firebase/installations": true,
         "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
         "@swc/helpers>tslib": true
       }
     },
@@ -1930,6 +599,820 @@
         "process": true
       }
     },
+    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@keystonehq/bc-ur-registry-eth": true,
+        "browserify>buffer": true,
+        "@metamask/eth-trezor-keyring>hdkey": true,
+        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": true,
+        "uuid": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": true,
+        "browserify>buffer": true,
+        "@metamask/eth-trezor-keyring>hdkey": true,
+        "uuid": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "@ngraveio/bc-ur": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "buffer": true,
+        "browserify>buffer": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@keystonehq/metamask-airgapped-keyring": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": true,
+        "@keystonehq/bc-ur-registry-eth": true,
+        "@metamask/obs-store": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "ethereumjs-util>rlp": true,
+        "uuid": true
+      }
+    },
+    "chart.js>@kurkle/color": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@lavamoat/lavadome-react": {
+      "globals": {
+        "Document.prototype": true,
+        "DocumentFragment.prototype": true,
+        "Element.prototype": true,
+        "Node.prototype": true,
+        "console.warn": true,
+        "document": true
+      },
+      "packages": {
+        "react": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": true,
+        "@metamask/ppom-validator>crypto-js": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/rlp": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": true,
+        "browserify>buffer": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "wait-on>rxjs": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": {
+      "globals": {
+        "__ledgerLogsListen": "write",
+        "console.error": true
+      }
+    },
+    "@material-ui/core": {
+      "globals": {
+        "Image": true,
+        "_formatMuiErrorMessage": true,
+        "addEventListener": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "getSelection": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "matchMedia": true,
+        "navigator": true,
+        "performance.now": true,
+        "removeEventListener": true,
+        "requestAnimationFrame": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles": true,
+        "@material-ui/core>@material-ui/system": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
+        "@material-ui/core>popper.js": true,
+        "prop-types": true,
+        "react": true,
+        "react-dom": true,
+        "prop-types>react-is": true,
+        "@material-ui/core>react-transition-group": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true,
+        "document.createComment": true,
+        "document.head": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-global": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-nested": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-props-sort": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": true,
+        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": true,
+        "@material-ui/core>@material-ui/styles>jss": true,
+        "prop-types": true,
+        "react": true
+      }
+    },
+    "@material-ui/core>@material-ui/system": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "prop-types": true
+      }
+    },
+    "@material-ui/core>@material-ui/utils": {
+      "packages": {
+        "@babel/runtime": true,
+        "prop-types": true,
+        "prop-types>react-is": true
+      }
+    },
+    "@metamask/abi-utils": {
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/abi-utils>@metamask/utils": true
+      }
+    },
+    "@metamask/accounts-controller": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-snap-keyring": true,
+        "@metamask/keyring-api": true,
+        "@metamask/keyring-controller": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "uuid": true
+      }
+    },
+    "@metamask/address-book-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
+    "@metamask/announcement-controller": {
+      "packages": {
+        "@metamask/announcement-controller>@metamask/base-controller": true
+      }
+    },
+    "@metamask/approval-controller": {
+      "globals": {
+        "console.info": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/approval-controller>nanoid": true
+      }
+    },
+    "@metamask/assets-controllers": {
+      "globals": {
+        "AbortController": true,
+        "Headers": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "console.log": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/abi-utils": true,
+        "@metamask/base-controller": true,
+        "@metamask/contract-metadata": true,
+        "@metamask/controller-utils": true,
+        "@metamask/eth-query": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/polling-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
+        "bn.js": true,
+        "cockatiel": true,
+        "lodash": true,
+        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true,
+        "single-call-balance-checker-abi": true,
+        "uuid": true
+      }
+    },
+    "@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/announcement-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/name-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/browser-passworder": {
+      "globals": {
+        "CryptoKey": true,
+        "btoa": true,
+        "crypto.getRandomValues": true,
+        "crypto.subtle.decrypt": true,
+        "crypto.subtle.deriveKey": true,
+        "crypto.subtle.encrypt": true,
+        "crypto.subtle.exportKey": true,
+        "crypto.subtle.importKey": true
+      },
+      "packages": {
+        "@metamask/browser-passworder>@metamask/utils": true,
+        "browserify>buffer": true
+      }
+    },
+    "eth-keyring-controller>@metamask/browser-passworder": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/controller-utils": {
+      "globals": {
+        "URL": true,
+        "console.error": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/ethjs>@metamask/ethjs-unit": true,
+        "@metamask/utils": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "eth-ens-namehash": true,
+        "eslint>fast-deep-equal": true
+      }
+    },
+    "@metamask/ens-controller": {
+      "packages": {
+        "@ethersproject/providers": true,
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/utils": true,
+        "punycode": true
+      }
+    },
+    "@metamask/eth-token-tracker>@metamask/eth-block-tracker": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": true,
+        "@metamask/eth-query>json-rpc-random-id": true,
+        "pify": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-block-tracker": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": true,
+        "@metamask/eth-query>json-rpc-random-id": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-hd-keyring": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "@metamask/eth-json-rpc-filters": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/safe-event-emitter": true,
+        "@metamask/name-controller>async-mutex": true,
+        "pify": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-json-rpc-infura": {
+      "globals": {
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": true
+      }
+    },
+    "@metamask/eth-json-rpc-middleware": {
+      "globals": {
+        "URL": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/eth-sig-util": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/eth-json-rpc-middleware>@metamask/utils": true,
+        "@metamask/eth-json-rpc-middleware>klona": true,
+        "@metamask/eth-json-rpc-middleware>safe-stable-stringify": true
+      }
+    },
+    "@metamask/eth-json-rpc-provider": {
+      "packages": {
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/safe-event-emitter": true,
+        "uuid": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring": {
+      "globals": {
+        "addEventListener": true,
+        "console.error": true,
+        "document.createElement": true,
+        "document.head.appendChild": true,
+        "fetch": true,
+        "removeEventListener": true
+      },
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": true,
+        "@metamask/eth-sig-util": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "@metamask/eth-trezor-keyring>hdkey": true
+      }
+    },
+    "@metamask/eth-query": {
+      "packages": {
+        "@metamask/eth-query>json-rpc-random-id": true,
+        "watchify>xtend": true
+      }
+    },
+    "@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/eth-snap-keyring>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/eth-snap-keyring>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/signature-controller>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-simple-keyring": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "@metamask/eth-snap-keyring": {
+      "globals": {
+        "URL": true,
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@metamask/eth-snap-keyring>@metamask/eth-sig-util": true,
+        "@metamask/keyring-api": true,
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/eth-snap-keyring>@metamask/utils": true,
+        "webpack>events": true,
+        "@metamask/eth-snap-keyring>uuid": true
+      }
+    },
+    "@metamask/eth-token-tracker": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@metamask/eth-token-tracker>@metamask/eth-block-tracker": true,
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs-query": true,
+        "@metamask/safe-event-emitter": true,
+        "bn.js": true,
+        "@metamask/eth-token-tracker>deep-equal": true,
+        "human-standard-token-abi": true
+      }
+    },
+    "@metamask/eth-trezor-keyring": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": true,
+        "@trezor/connect-web": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "@metamask/eth-trezor-keyring>hdkey": true
+      }
+    },
+    "@metamask/etherscan-link": {
+      "globals": {
+        "URL": true
+      }
+    },
+    "@metamask/ethjs": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs>@metamask/ethjs-filter": true,
+        "@metamask/ethjs>@metamask/ethjs-provider-http": true,
+        "@metamask/ethjs-query": true,
+        "@metamask/ethjs>@metamask/ethjs-unit": true,
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ethjs>ethjs-abi": true,
+        "@metamask/ethjs>js-sha3": true
+      }
+    },
+    "@metamask/ethjs-contract": {
+      "packages": {
+        "@babel/runtime": true,
+        "@metamask/ethjs>@metamask/ethjs-filter": true,
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>ethjs-abi": true,
+        "@metamask/ethjs>js-sha3": true,
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-filter": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      }
+    },
+    "@metamask/ethjs-query>@metamask/ethjs-format": {
+      "packages": {
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "@metamask/ethjs-query>@metamask/ethjs-format>ethjs-schema": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-provider-http": {
+      "packages": {
+        "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": true
+      }
+    },
+    "@metamask/ethjs-query": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@metamask/ethjs-query>@metamask/ethjs-format": true,
+        "@metamask/ethjs-query>@metamask/ethjs-rpc": true,
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs-query>@metamask/ethjs-rpc": {
+      "packages": {
+        "promise-to-callback": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-unit": {
+      "packages": {
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "bn.js": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-util": {
+      "packages": {
+        "browserify>buffer": true,
+        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "@metamask/gas-fee-controller": {
+      "globals": {
+        "clearInterval": true,
+        "console.error": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@metamask/controller-utils": true,
+        "@metamask/eth-query": true,
+        "@metamask/polling-controller": true,
+        "bn.js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/jazzicon": {
+      "globals": {
+        "document.createElement": true,
+        "document.createElementNS": true
+      },
+      "packages": {
+        "@metamask/jazzicon>color": true,
+        "@metamask/jazzicon>mersenne-twister": true
+      }
+    },
+    "@metamask/json-rpc-engine": {
+      "packages": {
+        "@metamask/rpc-errors": true,
+        "@metamask/safe-event-emitter": true,
+        "@metamask/utils": true
+      }
+    },
+    "@metamask/json-rpc-middleware-stream": {
+      "globals": {
+        "console.warn": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/utils": true,
+        "readable-stream": true
+      }
+    },
+    "@metamask/snaps-sdk>@metamask/key-tree": {
+      "globals": {
+        "crypto.subtle": true
+      },
+      "packages": {
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true
+      }
+    },
+    "@metamask/keyring-api": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/keyring-api>@metamask/utils": true,
+        "@metamask/keyring-api>bech32": true,
+        "@metamask/keyring-api>uuid": true
+      }
+    },
+    "@metamask/keyring-controller": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/browser-passworder": true,
+        "@metamask/keyring-controller>@metamask/eth-hd-keyring": true,
+        "@metamask/keyring-controller>@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true
+      }
+    },
+    "@metamask/logging-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "uuid": true
+      }
+    },
+    "@metamask/logo": {
+      "globals": {
+        "addEventListener": true,
+        "document.body.appendChild": true,
+        "document.createElementNS": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "requestAnimationFrame": true
+      },
+      "packages": {
+        "@metamask/logo>gl-mat4": true,
+        "@metamask/logo>gl-vec3": true
+      }
+    },
+    "@metamask/message-manager": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/utils": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "uuid": true
+      }
+    },
+    "@metamask/name-controller": {
+      "globals": {
+        "fetch": true
+      },
+      "packages": {
+        "@metamask/name-controller>@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/name-controller>@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true
+      }
+    },
+    "@metamask/network-controller": {
+      "globals": {
+        "btoa": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "eslint>fast-deep-equal": true,
+        "@metamask/network-controller>reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/nonce-tracker": {
+      "packages": {
+        "@ethersproject/providers": true,
+        "browserify>assert": true,
+        "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": true
+      }
+    },
+    "@metamask/notification-services-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "addEventListener": true,
+        "fetch": true,
+        "registration": true,
+        "removeEventListener": true
+      },
+      "packages": {
+        "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": true,
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/profile-sync-controller": true,
+        "@metamask/utils": true,
+        "@metamask/notification-services-controller>bignumber.js": true,
+        "@metamask/notification-services-controller>firebase": true,
+        "loglevel": true,
+        "uuid": true
+      }
+    },
+    "@metamask/ethjs>@metamask/number-to-bn": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
     "@metamask/object-multiplex": {
       "globals": {
         "console.warn": true
@@ -1937,11 +1420,6 @@
       "packages": {
         "@metamask/object-multiplex>once": true,
         "readable-stream": true
-      }
-    },
-    "@metamask/object-multiplex>once": {
-      "packages": {
-        "@metamask/object-multiplex>once>wrappy": true
       }
     },
     "@metamask/obs-store": {
@@ -1958,37 +1436,17 @@
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/json-rpc-engine": true,
-        "@metamask/permission-controller>nanoid": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "deep-freeze-strict": true,
-        "immer": true
-      }
-    },
-    "@metamask/permission-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+        "immer": true,
+        "@metamask/permission-controller>nanoid": true
       }
     },
     "@metamask/permission-log-controller": {
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/permission-log-controller>@metamask/utils": true
-      }
-    },
-    "@metamask/permission-log-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
       }
     },
     "@metamask/phishing-controller": {
@@ -1999,12 +1457,12 @@
         "fetch": true
       },
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
         "@noble/hashes": true,
-        "punycode": true,
-        "webpack-cli>fastest-levenshtein": true
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack-cli>fastest-levenshtein": true,
+        "punycode": true
       }
     },
     "@metamask/polling-controller": {
@@ -2035,21 +1493,6 @@
         "readable-stream": true
       }
     },
-    "@metamask/post-message-stream>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
     "@metamask/ppom-validator": {
       "globals": {
         "URL": true,
@@ -2059,48 +1502,11 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
-        "@metamask/eth-query>json-rpc-random-id": true,
+        "await-semaphore": true,
+        "browserify>buffer": true,
         "@metamask/ppom-validator>crypto-js": true,
         "@metamask/ppom-validator>elliptic": true,
-        "await-semaphore": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ppom-validator>crypto-js": {
-      "globals": {
-        "crypto": true,
-        "define": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>brorand": true,
-        "@metamask/ppom-validator>elliptic>hmac-drbg": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true,
-        "bn.js": true,
-        "ethers>@ethersproject/sha2>hash.js": true,
-        "pumpify>inherits": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic>brorand": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic>hmac-drbg": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true,
-        "ethers>@ethersproject/sha2>hash.js": true
+        "@metamask/eth-query>json-rpc-random-id": true
       }
     },
     "@metamask/preferences-controller": {
@@ -2129,55 +1535,10 @@
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
         "@metamask/profile-sync-controller>@noble/ciphers": true,
-        "@metamask/profile-sync-controller>siwe": true,
         "@noble/hashes": true,
         "browserify>buffer": true,
-        "loglevel": true
-      }
-    },
-    "@metamask/profile-sync-controller>@noble/ciphers": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>valid-url": true,
-        "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": true,
-        "@metamask/profile-sync-controller>siwe>@stablelib/random": true,
-        "ethers": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": {
-      "globals": {
-        "console.error": true,
-        "console.log": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@stablelib/random": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": true,
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true,
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": {
-      "packages": {
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary>@stablelib/int": true
+        "loglevel": true,
+        "@metamask/profile-sync-controller>siwe": true
       }
     },
     "@metamask/queued-request-controller": {
@@ -2199,50 +1560,6 @@
         "@metamask/rate-limit-controller>@metamask/utils": true
       }
     },
-    "@metamask/rate-limit-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/rpc-errors": {
-      "packages": {
-        "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": true,
-        "@metamask/rpc-errors>fast-safe-stringify": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
     "@metamask/remote-feature-flag-controller": {
       "packages": {
         "@metamask/base-controller": true,
@@ -2251,18 +1568,14 @@
     },
     "@metamask/rpc-errors": {
       "packages": {
-        "@metamask/rpc-errors>fast-safe-stringify": true,
-        "@metamask/utils": true
+        "@metamask/utils": true,
+        "@metamask/rpc-errors>fast-safe-stringify": true
       }
     },
-    "@metamask/rpc-methods-flask>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/rpc-methods>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+    "@metamask/rate-limit-controller>@metamask/rpc-errors": {
+      "packages": {
+        "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": true,
+        "@metamask/rpc-errors>fast-safe-stringify": true
       }
     },
     "@metamask/safe-event-emitter": {
@@ -2282,12 +1595,6 @@
         "@metamask/utils>@scure/base": true
       }
     },
-    "@metamask/scure-bip39>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
     "@metamask/selected-network-controller": {
       "packages": {
         "@metamask/base-controller": true,
@@ -2301,40 +1608,14 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/signature-controller>@metamask/eth-sig-util": true,
         "@metamask/keyring-controller": true,
         "@metamask/logging-controller": true,
-        "@metamask/message-manager>jsonschema": true,
-        "@metamask/signature-controller>@metamask/eth-sig-util": true,
         "@metamask/utils": true,
         "browserify>buffer": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/signature-controller>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
+        "webpack>events": true,
+        "@metamask/message-manager>jsonschema": true,
+        "uuid": true
       }
     },
     "@metamask/smart-transactions-controller": {
@@ -2347,47 +1628,17 @@
         "setInterval": true
       },
       "packages": {
+        "@metamask/smart-transactions-controller>@ethereumjs/tx": true,
+        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
         "@ethersproject/bytes": true,
         "@metamask/controller-utils": true,
         "@metamask/eth-query": true,
         "@metamask/polling-controller": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/tx": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
-        "@metamask/smart-transactions-controller>bignumber.js": true,
         "@metamask/transaction-controller": true,
+        "@metamask/smart-transactions-controller>bignumber.js": true,
         "browserify>buffer": true,
         "fast-json-patch": true,
         "lodash": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@ethereumjs/tx": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
-        "@trezor/connect-web>@trezor/connect>@ethereumjs/common": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@metamask/controllers>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/smart-transactions-controller>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
       }
     },
     "@metamask/snaps-controllers": {
@@ -2407,72 +1658,22 @@
         "@metamask/permission-controller": true,
         "@metamask/post-message-stream": true,
         "@metamask/rpc-errors": true,
-        "@metamask/snaps-controllers>@xstate/fsm": true,
-        "@metamask/snaps-controllers>concat-stream": true,
-        "@metamask/snaps-controllers>get-npm-tarball-url": true,
-        "@metamask/snaps-controllers>nanoid": true,
-        "@metamask/snaps-controllers>readable-web-to-node-stream": true,
-        "@metamask/snaps-controllers>tar-stream": true,
+        "@metamask/snaps-utils>@metamask/snaps-registry": true,
         "@metamask/snaps-rpc-methods": true,
         "@metamask/snaps-sdk": true,
         "@metamask/snaps-utils": true,
-        "@metamask/snaps-utils>@metamask/snaps-registry": true,
         "@metamask/utils": true,
+        "@metamask/snaps-controllers>@xstate/fsm": true,
         "browserify>browserify-zlib": true,
+        "@metamask/snaps-controllers>concat-stream": true,
         "eslint>fast-deep-equal": true,
+        "@metamask/snaps-controllers>get-npm-tarball-url": true,
         "immer": true,
+        "@metamask/snaps-controllers>nanoid": true,
         "readable-stream": true,
-        "semver": true
-      }
-    },
-    "@metamask/snaps-controllers-flask>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/snaps-controllers>concat-stream": {
-      "packages": {
-        "browserify>buffer": true,
-        "browserify>concat-stream>typedarray": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
-        "terser>source-map-support>buffer-from": true
-      }
-    },
-    "@metamask/snaps-controllers>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/snaps-controllers>readable-web-to-node-stream": {
-      "packages": {
-        "readable-stream": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream": {
-      "packages": {
-        "@metamask/snaps-controllers>tar-stream>b4a": true,
-        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
-        "@metamask/snaps-controllers>tar-stream>streamx": true,
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>b4a": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>streamx": {
-      "packages": {
-        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
-        "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
-      "globals": {
-        "queueMicrotask": true
+        "@metamask/snaps-controllers>readable-web-to-node-stream": true,
+        "semver": true,
+        "@metamask/snaps-controllers>tar-stream": true
       }
     },
     "@metamask/snaps-execution-environments": {
@@ -2485,15 +1686,23 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/snaps-utils>@metamask/snaps-registry": {
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@noble/hashes": true
+      }
+    },
     "@metamask/snaps-rpc-methods": {
       "packages": {
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/permission-controller": true,
         "@metamask/rpc-errors": true,
         "@metamask/snaps-sdk": true,
-        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
-        "@metamask/utils": true,
         "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
         "@noble/hashes": true
       }
     },
@@ -2503,20 +1712,8 @@
       },
       "packages": {
         "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/snaps-sdk>@metamask/key-tree": {
-      "globals": {
-        "crypto.subtle": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/scure-bip39": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "@noble/hashes": true
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true
       }
     },
     "@metamask/snaps-utils": {
@@ -2535,74 +1732,23 @@
         "fetch": true
       },
       "packages": {
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/permission-controller": true,
         "@metamask/rpc-errors": true,
-        "@metamask/snaps-sdk": true,
-        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils>@metamask/slip44": true,
+        "@metamask/snaps-sdk": true,
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "chalk": true,
         "@metamask/snaps-utils>cron-parser": true,
         "@metamask/snaps-utils>fast-json-stable-stringify": true,
         "@metamask/snaps-utils>fast-xml-parser": true,
         "@metamask/snaps-utils>marked": true,
         "@metamask/snaps-utils>rfdc": true,
-        "@metamask/snaps-utils>validate-npm-package-name": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@noble/hashes": true,
-        "chalk": true,
-        "semver": true
-      }
-    },
-    "@metamask/snaps-utils>@metamask/snaps-registry": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/snaps-utils>cron-parser": {
-      "packages": {
-        "browserify>browser-resolve": true,
-        "luxon": true
-      }
-    },
-    "@metamask/snaps-utils>fast-xml-parser": {
-      "globals": {
-        "entityName": true,
-        "val": true
-      },
-      "packages": {
-        "@metamask/snaps-utils>fast-xml-parser>strnum": true
-      }
-    },
-    "@metamask/snaps-utils>marked": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true,
-        "define": true
-      }
-    },
-    "@metamask/snaps-utils>rfdc": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/snaps-utils>validate-npm-package-name": {
-      "packages": {
-        "@metamask/snaps-utils>validate-npm-package-name>builtins": true
-      }
-    },
-    "@metamask/snaps-utils>validate-npm-package-name>builtins": {
-      "packages": {
-        "process": true,
-        "semver": true
-      }
-    },
-    "@metamask/test-bundler>@ethersproject/networks": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
+        "semver": true,
+        "@metamask/snaps-utils>validate-npm-package-name": true
       }
     },
     "@metamask/transaction-controller": {
@@ -2613,6 +1759,7 @@
         "setTimeout": true
       },
       "packages": {
+        "@metamask/transaction-controller>@ethereumjs/common": true,
         "@ethereumjs/tx": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
         "@ethersproject/abi": true,
@@ -2623,43 +1770,18 @@
         "@metamask/eth-query": true,
         "@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/name-controller>async-mutex": true,
         "@metamask/network-controller": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/transaction-controller>@ethereumjs/common": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
         "bn.js": true,
         "browserify>buffer": true,
         "eth-method-registry": true,
+        "webpack>events": true,
         "fast-json-patch": true,
         "lodash": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/transaction-controller>@ethereumjs/common": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/nonce-tracker": {
-      "packages": {
-        "@ethersproject/providers": true,
-        "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": true,
-        "browserify>assert": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
+        "uuid": true
       }
     },
     "@metamask/user-operation-controller": {
@@ -2673,13 +1795,13 @@
         "@metamask/gas-fee-controller": true,
         "@metamask/polling-controller": true,
         "@metamask/rpc-errors": true,
+        "@metamask/utils>@metamask/superstruct": true,
         "@metamask/transaction-controller": true,
         "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
         "bn.js": true,
+        "webpack>events": true,
         "lodash": true,
-        "uuid": true,
-        "webpack>events": true
+        "uuid": true
       }
     },
     "@metamask/utils": {
@@ -2689,63 +1811,336 @@
       },
       "packages": {
         "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
         "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
         "browserify>buffer": true,
         "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
         "semver": true
       }
     },
-    "@metamask/utils>@scure/base": {
+    "@metamask/abi-utils>@metamask/utils": {
       "globals": {
         "TextDecoder": true,
         "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/browser-passworder>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-json-rpc-middleware>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-snap-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-api>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/name-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/permission-log-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
       }
     },
     "@ngraveio/bc-ur": {
       "packages": {
         "@ngraveio/bc-ur>@keystonehq/alias-sampling": true,
+        "browserify>assert": true,
         "@ngraveio/bc-ur>bignumber.js": true,
+        "browserify>buffer": true,
         "@ngraveio/bc-ur>cbor-sync": true,
         "@ngraveio/bc-ur>crc": true,
         "@ngraveio/bc-ur>jsbi": true,
-        "addons-linter>sha.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true
+        "addons-linter>sha.js": true
       }
     },
-    "@ngraveio/bc-ur>assert>object-is": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true
-      }
-    },
-    "@ngraveio/bc-ur>bignumber.js": {
+    "@metamask/profile-sync-controller>@noble/ciphers": {
       "globals": {
-        "crypto": true,
-        "define": true
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "crypto": true
       }
     },
-    "@ngraveio/bc-ur>cbor-sync": {
+    "@ethereumjs/tx>ethereum-cryptography>@noble/curves": {
       "globals": {
-        "define": true
+        "TextEncoder": true
       },
       "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ngraveio/bc-ur>crc": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ngraveio/bc-ur>jsbi": {
-      "globals": {
-        "define": true
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": true
       }
     },
     "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/scure-bip39>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -2762,6 +2157,20 @@
         "navigator.userAgent": true
       }
     },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": {
+      "globals": {
+        "console.log": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": {
+      "globals": {
+        "XMLHttpRequest": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true
+      }
+    },
     "@reduxjs/toolkit": {
       "globals": {
         "AbortController": true,
@@ -2773,42 +2182,46 @@
         "setTimeout": true
       },
       "packages": {
-        "@reduxjs/toolkit>reselect": true,
         "immer": true,
         "process": true,
         "redux": true,
-        "redux-thunk": true
+        "redux-thunk": true,
+        "@reduxjs/toolkit>reselect": true
+      }
+    },
+    "react-router-dom-v5-compat>@remix-run/router": {
+      "globals": {
+        "AbortController": true,
+        "DOMException": true,
+        "FormData": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "console": true,
+        "document.defaultView": true
+      }
+    },
+    "@metamask/utils>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": true,
+        "@metamask/utils>@scure/base": true
       }
     },
     "@segment/loosely-validate-event": {
       "packages": {
-        "@segment/loosely-validate-event>component-type": true,
-        "@segment/loosely-validate-event>join-component": true,
         "browserify>assert": true,
-        "browserify>buffer": true
-      }
-    },
-    "@sentry/browser": {
-      "globals": {
-        "PerformanceObserver.supportedEntryTypes": true,
-        "Request": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_DEBUG__": true,
-        "__SENTRY_RELEASE__": true,
-        "addEventListener": true,
-        "console.error": true,
-        "indexedDB.open": true,
-        "performance.timeOrigin": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@sentry/browser>@sentry-internal/browser-utils": true,
-        "@sentry/browser>@sentry-internal/feedback": true,
-        "@sentry/browser>@sentry-internal/replay": true,
-        "@sentry/browser>@sentry-internal/replay-canvas": true,
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "browserify>buffer": true,
+        "@segment/loosely-validate-event>component-type": true,
+        "@segment/loosely-validate-event>join-component": true
       }
     },
     "@sentry/browser>@sentry-internal/browser-utils": {
@@ -2841,6 +2254,25 @@
         "isSecureContext": true,
         "requestAnimationFrame": true,
         "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/replay-canvas": {
+      "globals": {
+        "Blob": true,
+        "HTMLCanvasElement": true,
+        "HTMLImageElement": true,
+        "ImageData": true,
+        "URL.createObjectURL": true,
+        "WeakRef": true,
+        "Worker": true,
+        "cancelAnimationFrame": true,
+        "console.error": true,
+        "createImageBitmap": true,
+        "document": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2896,21 +2328,25 @@
         "@sentry/utils": true
       }
     },
-    "@sentry/browser>@sentry-internal/replay-canvas": {
+    "@sentry/browser": {
       "globals": {
-        "Blob": true,
-        "HTMLCanvasElement": true,
-        "HTMLImageElement": true,
-        "ImageData": true,
-        "URL.createObjectURL": true,
-        "WeakRef": true,
-        "Worker": true,
-        "cancelAnimationFrame": true,
+        "PerformanceObserver.supportedEntryTypes": true,
+        "Request": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_RELEASE__": true,
+        "addEventListener": true,
         "console.error": true,
-        "createImageBitmap": true,
-        "document": true
+        "indexedDB.open": true,
+        "performance.timeOrigin": true,
+        "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/browser-utils": true,
+        "@sentry/browser>@sentry-internal/feedback": true,
+        "@sentry/browser>@sentry-internal/replay-canvas": true,
+        "@sentry/browser>@sentry-internal/replay": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
@@ -3006,20 +2442,61 @@
         "btoa": true
       }
     },
-    "@storybook/addon-docs>remark-external-links>mdast-util-definitions": {
-      "packages": {
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "@storybook/addon-knobs>qs": {
-      "packages": {
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "@swc/helpers>tslib": {
+    "@metamask/controller-utils>@spruceid/siwe-parser": {
       "globals": {
-        "SuppressedError": true,
-        "define": true
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": {
+      "globals": {
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": {
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary>@stablelib/int": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@stablelib/random": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": true,
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true,
+        "browserify>browser-resolve": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect-common": {
+      "globals": {
+        "console.warn": true,
+        "localStorage.getItem": true,
+        "localStorage.setItem": true,
+        "navigator": true,
+        "setTimeout": true,
+        "window": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": true,
+        "@trezor/connect-web>@trezor/utils": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": {
+      "packages": {
+        "@metamask/eth-sig-util": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web": {
@@ -3046,35 +2523,20 @@
         "setTimeout": true
       },
       "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect": true,
         "@trezor/connect-web>@trezor/connect-common": true,
+        "@trezor/connect-web>@trezor/connect": true,
         "@trezor/connect-web>@trezor/utils": true,
-        "webpack>events": true
+        "webpack>events": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect": {
       "packages": {
-        "@swc/helpers>tslib": true,
         "@trezor/connect-web>@trezor/connect>@trezor/protobuf": true,
         "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": true,
         "@trezor/connect-web>@trezor/connect>@trezor/transport": true,
-        "@trezor/connect-web>@trezor/utils": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect-common": {
-      "globals": {
-        "console.warn": true,
-        "localStorage.getItem": true,
-        "localStorage.setItem": true,
-        "navigator": true,
-        "setTimeout": true,
-        "window": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": true,
-        "@trezor/connect-web>@trezor/utils": true
+        "@trezor/connect-web>@trezor/utils": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": {
@@ -3090,71 +2552,17 @@
         "screen.width": true
       },
       "packages": {
+        "process": true,
         "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": true,
-        "process": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@ethereumjs/common": {
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": true,
-        "webpack>events": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
+        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": true
       }
     },
     "@trezor/connect-web>@trezor/connect>@trezor/protobuf": {
       "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": true,
         "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": true,
-        "browserify>buffer": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": {
-      "globals": {
-        "process": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/base64": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/eventemitter": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/float": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/path": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/pool": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/utf8": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": {
-      "globals": {
-        "console.log": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": {
-      "globals": {
-        "XMLHttpRequest": true
-      },
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true
+        "browserify>buffer": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": {
@@ -3181,16 +2589,10 @@
         "setTimeout": true
       },
       "packages": {
-        "@swc/helpers>tslib": true,
         "@trezor/connect-web>@trezor/utils>bignumber.js": true,
         "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@trezor/connect-web>@trezor/utils>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
+        "webpack>events": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@welldone-software/why-did-you-render": {
@@ -3243,21 +2645,155 @@
         "@zxing/library>ts-custom-error": true
       }
     },
-    "addons-linter>sha.js": {
+    "extension-port-stream>readable-stream>abort-controller": {
+      "globals": {
+        "AbortController": true
+      }
+    },
+    "currency-formatter>accounting": {
+      "globals": {
+        "define": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets>aes-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>aes-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "chalk>ansi-styles": {
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
+        "chalk>ansi-styles>color-convert": true
+      }
+    },
+    "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>array-buffer-byte-length": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>es-abstract>is-array-buffer": true
+      }
+    },
+    "crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "browserify>vm-browserify": true
+      }
+    },
+    "browserify>assert": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "react>object-assign": true,
+        "browserify>assert>util": true
+      }
+    },
+    "@metamask/name-controller>async-mutex": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>available-typed-arrays": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>typed-array-length>possible-typed-array-names": true
       }
     },
     "await-semaphore": {
       "packages": {
-        "browserify>timers-browserify": true,
+        "process": true,
+        "browserify>timers-browserify": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": {
+      "globals": {
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
         "process": true
       }
     },
-    "axios>form-data": {
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": {
       "globals": {
-        "FormData": true
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
+        "process": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": {
+      "globals": {
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
+        "process": true
+      }
+    },
+    "@metamask/snaps-controllers>tar-stream>b4a": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>multibase>base-x": {
+      "packages": {
+        "koa>content-disposition>safe-buffer": true
       }
     },
     "base32-encode": {
@@ -3266,6 +2802,48 @@
       }
     },
     "bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/notification-services-controller>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/smart-transactions-controller>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@ngraveio/bc-ur>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@trezor/connect-web>@trezor/utils>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>bignumber.js": {
       "globals": {
         "crypto": true,
         "define": true
@@ -3284,123 +2862,107 @@
         "browserify>browser-resolve": true
       }
     },
+    "eth-lattice-keyring>gridplus-sdk>borc": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": true,
+        "browserify>buffer": true,
+        "buffer>ieee754": true,
+        "eth-lattice-keyring>gridplus-sdk>borc>iso-url": true
+      }
+    },
     "bowser": {
       "globals": {
         "define": true
       }
     },
-    "browserify>assert": {
+    "@metamask/ppom-validator>elliptic>brorand": {
       "globals": {
-        "Buffer": true
+        "crypto": true,
+        "msCrypto": true
       },
       "packages": {
-        "browserify>assert>util": true,
-        "react>object-assign": true
+        "browserify>browser-resolve": true
       }
     },
-    "browserify>assert>util": {
-      "globals": {
-        "console.error": true,
-        "console.log": true,
-        "console.trace": true,
-        "process": true
-      },
+    "ethereumjs-util>ethereum-cryptography>browserify-aes": {
       "packages": {
-        "browserify>assert>util>inherits": true,
-        "process": true
+        "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "crypto-browserify>browserify-cipher": {
+      "packages": {
+        "ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "crypto-browserify>browserify-cipher>browserify-des": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>browserify-des": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "crypto-browserify>browserify-cipher>browserify-des>des.js": true,
+        "pumpify>inherits": true
+      }
+    },
+    "crypto-browserify>public-encrypt>browserify-rsa": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "crypto-browserify>browserify-sign": {
+      "packages": {
+        "bn.js": true,
+        "crypto-browserify>public-encrypt>browserify-rsa": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "crypto-browserify>create-hmac": true,
+        "@metamask/ppom-validator>elliptic": true,
+        "pumpify>inherits": true,
+        "crypto-browserify>public-encrypt>parse-asn1": true,
+        "stream-browserify": true
       }
     },
     "browserify>browserify-zlib": {
       "packages": {
         "browserify>assert": true,
-        "browserify>browserify-zlib>pako": true,
         "browserify>buffer": true,
-        "browserify>util": true,
+        "browserify>browserify-zlib>pako": true,
         "process": true,
-        "stream-browserify": true
+        "stream-browserify": true,
+        "browserify>util": true
       }
     },
-    "browserify>buffer": {
-      "globals": {
-        "console": true
-      },
+    "ethereumjs-util>ethereum-cryptography>bs58check>bs58": {
       "packages": {
-        "base64-js": true,
-        "buffer>ieee754": true
+        "@ensdomains/content-hash>multihashes>multibase>base-x": true
       }
     },
-    "browserify>punycode": {
-      "globals": {
-        "define": true
-      }
-    },
-    "browserify>string_decoder": {
+    "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": {
       "packages": {
+        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58>base-x": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>bs58check": {
+      "packages": {
+        "ethereumjs-util>ethereum-cryptography>bs58check>bs58": true,
+        "ethereumjs-util>create-hash": true,
         "koa>content-disposition>safe-buffer": true
       }
     },
-    "browserify>timers-browserify": {
-      "globals": {
-        "clearInterval": true,
-        "clearTimeout": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
+    "eth-lattice-keyring>gridplus-sdk>bs58check": {
       "packages": {
-        "process": true
-      }
-    },
-    "browserify>url": {
-      "packages": {
-        "@storybook/addon-knobs>qs": true,
-        "browserify>punycode": true
-      }
-    },
-    "browserify>util": {
-      "globals": {
-        "console.error": true,
-        "console.log": true,
-        "console.trace": true
-      },
-      "packages": {
-        "browserify>util>is-arguments": true,
-        "browserify>util>is-typed-array": true,
-        "browserify>util>which-typed-array": true,
-        "koa>is-generator-function": true,
-        "process": true,
-        "pumpify>inherits": true
-      }
-    },
-    "browserify>util>is-arguments": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "browserify>util>is-typed-array": {
-      "packages": {
-        "browserify>util>which-typed-array": true
-      }
-    },
-    "browserify>util>which-typed-array": {
-      "packages": {
-        "browserify>util>which-typed-array>for-each": true,
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>available-typed-arrays": true,
-        "string.prototype.matchall>es-abstract>gopd": true
-      }
-    },
-    "browserify>util>which-typed-array>for-each": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>is-callable": true
-      }
-    },
-    "browserify>vm-browserify": {
-      "globals": {
-        "document.body.appendChild": true,
-        "document.body.removeChild": true,
-        "document.createElement": true
+        "@noble/hashes": true,
+        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": true
       }
     },
     "buffer": {
@@ -3412,20 +2974,52 @@
         "buffer>ieee754": true
       }
     },
+    "terser>source-map-support>buffer-from": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "browserify>buffer": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "base64-js": true,
+        "buffer>ieee754": true
+      }
+    },
+    "@metamask/snaps-utils>validate-npm-package-name>builtins": {
+      "packages": {
+        "process": true,
+        "semver": true
+      }
+    },
+    "string.prototype.matchall>call-bind": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>call-bind>set-function-length": true
+      }
+    },
+    "@ngraveio/bc-ur>cbor-sync": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
     "chalk": {
       "packages": {
         "chalk>ansi-styles": true,
         "chalk>supports-color": true
-      }
-    },
-    "chalk>ansi-styles": {
-      "packages": {
-        "chalk>ansi-styles>color-convert": true
-      }
-    },
-    "chalk>ansi-styles>color-convert": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
       }
     },
     "chart.js": {
@@ -3449,15 +3043,31 @@
         "chart.js>@kurkle/color": true
       }
     },
-    "chart.js>@kurkle/color": {
-      "globals": {
-        "define": true
+    "@ensdomains/content-hash>cids": {
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase": true,
+        "@ensdomains/content-hash>multicodec": true,
+        "@ensdomains/content-hash>cids>multihashes": true,
+        "@ensdomains/content-hash>cids>uint8arrays": true
+      }
+    },
+    "ethereumjs-util>create-hash>cipher-base": {
+      "packages": {
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true,
+        "stream-browserify": true,
+        "browserify>string_decoder": true
       }
     },
     "classnames": {
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "@metamask/jazzicon>color>clone": {
+      "packages": {
+        "browserify>buffer": true
       }
     },
     "cockatiel": {
@@ -3471,6 +3081,37 @@
       },
       "packages": {
         "process": true
+      }
+    },
+    "chalk>ansi-styles>color-convert": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-convert": {
+      "packages": {
+        "@metamask/jazzicon>color>color-convert>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-string": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color": {
+      "packages": {
+        "@metamask/jazzicon>color>clone": true,
+        "@metamask/jazzicon>color>color-convert": true,
+        "@metamask/jazzicon>color>color-string": true
+      }
+    },
+    "@metamask/snaps-controllers>concat-stream": {
+      "packages": {
+        "terser>source-map-support>buffer-from": true,
+        "browserify>buffer": true,
+        "pumpify>inherits": true,
+        "readable-stream": true,
+        "browserify>concat-stream>typedarray": true
       }
     },
     "copy-to-clipboard": {
@@ -3491,10 +3132,47 @@
         "copy-to-clipboard>toggle-selection": true
       }
     },
-    "copy-to-clipboard>toggle-selection": {
+    "@ethereumjs/tx>@ethereumjs/common>crc-32": {
       "globals": {
-        "document.activeElement": true,
-        "document.getSelection": true
+        "DO_NOT_EXPORT_CRC": true,
+        "define": true
+      }
+    },
+    "@ngraveio/bc-ur>crc": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "crypto-browserify>create-ecdh": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "ethereumjs-util>create-hash": {
+      "packages": {
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "pumpify>inherits": true,
+        "ethereumjs-util>create-hash>md5.js": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "crypto-browserify>create-hmac": {
+      "packages": {
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "ethereumjs-util>create-hash": true,
+        "pumpify>inherits": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "@metamask/snaps-utils>cron-parser": {
+      "packages": {
+        "browserify>browser-resolve": true,
+        "luxon": true
       }
     },
     "crypto-browserify": {
@@ -3502,156 +3180,44 @@
         "crypto-browserify>browserify-cipher": true,
         "crypto-browserify>browserify-sign": true,
         "crypto-browserify>create-ecdh": true,
+        "ethereumjs-util>create-hash": true,
         "crypto-browserify>create-hmac": true,
         "crypto-browserify>diffie-hellman": true,
         "crypto-browserify>pbkdf2": true,
         "crypto-browserify>public-encrypt": true,
         "crypto-browserify>randombytes": true,
-        "crypto-browserify>randomfill": true,
-        "ethereumjs-util>create-hash": true
+        "crypto-browserify>randomfill": true
       }
     },
-    "crypto-browserify>browserify-cipher": {
-      "packages": {
-        "crypto-browserify>browserify-cipher>browserify-des": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>browserify-des": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>browserify-des>des.js": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>browserify-des>des.js": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>evp_bytestokey": {
-      "packages": {
-        "ethereumjs-util>create-hash>md5.js": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "crypto-browserify>browserify-sign": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>create-hmac": true,
-        "crypto-browserify>public-encrypt>browserify-rsa": true,
-        "crypto-browserify>public-encrypt>parse-asn1": true,
-        "ethereumjs-util>create-hash": true,
-        "pumpify>inherits": true,
-        "stream-browserify": true
-      }
-    },
-    "crypto-browserify>create-ecdh": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "crypto-browserify>create-hmac": {
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>diffie-hellman": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>diffie-hellman>miller-rabin": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "crypto-browserify>diffie-hellman>miller-rabin": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>brorand": true,
-        "bn.js": true
-      }
-    },
-    "crypto-browserify>pbkdf2": {
+    "@metamask/ppom-validator>crypto-js": {
       "globals": {
         "crypto": true,
-        "process": true,
-        "queueMicrotask": true,
-        "setImmediate": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
-      }
-    },
-    "crypto-browserify>public-encrypt": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>public-encrypt>browserify-rsa": true,
-        "crypto-browserify>public-encrypt>parse-asn1": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>create-hash": true
-      }
-    },
-    "crypto-browserify>public-encrypt>browserify-rsa": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "crypto-browserify>public-encrypt>parse-asn1": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "crypto-browserify>pbkdf2": true,
-        "crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes": true
-      }
-    },
-    "crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "browserify>vm-browserify": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>randombytes": {
-      "globals": {
-        "crypto": true,
+        "define": true,
         "msCrypto": true
       },
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
+        "browserify>browser-resolve": true
       }
     },
-    "crypto-browserify>randomfill": {
+    "react-beautiful-dnd>css-box-model": {
       "globals": {
-        "crypto": true,
-        "msCrypto": true
+        "getComputedStyle": true,
+        "pageXOffset": true,
+        "pageYOffset": true
       },
       "packages": {
-        "crypto-browserify>randombytes": true,
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
+        "react-router-dom>tiny-invariant": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": {
+      "globals": {
+        "document.createElement": true,
+        "document.documentElement": true,
+        "getComputedStyle": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true
       }
     },
     "currency-formatter": {
@@ -3659,16 +3225,6 @@
         "currency-formatter>accounting": true,
         "currency-formatter>locale-currency": true,
         "react>object-assign": true
-      }
-    },
-    "currency-formatter>accounting": {
-      "globals": {
-        "define": true
-      }
-    },
-    "currency-formatter>locale-currency": {
-      "globals": {
-        "countryCode": true
       }
     },
     "debounce-stream": {
@@ -3684,35 +3240,107 @@
         "setTimeout": true
       }
     },
+    "nock>debug": {
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "nock>debug>ms": true,
+        "process": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>array-buffer-byte-length": true,
+        "string.prototype.matchall>call-bind": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "browserify>util>is-arguments": true,
+        "string.prototype.matchall>es-abstract>is-array-buffer": true,
+        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
+        "string.prototype.matchall>es-abstract>is-regex": true,
+        "string.prototype.matchall>es-abstract>is-shared-array-buffer": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
+        "@ngraveio/bc-ur>assert>object-is": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
+        "gulp>vinyl-fs>object.assign": true,
+        "string.prototype.matchall>regexp.prototype.flags": true,
+        "string.prototype.matchall>side-channel": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection": true,
+        "browserify>util>which-typed-array": true
+      }
+    },
+    "string.prototype.matchall>define-properties>define-data-property": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>gopd": true
+      }
+    },
+    "string.prototype.matchall>define-properties": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>browserify-des>des.js": {
+      "packages": {
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true
+      }
+    },
+    "crypto-browserify>diffie-hellman": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "crypto-browserify>diffie-hellman>miller-rabin": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "@material-ui/core>react-transition-group>dom-helpers": {
+      "packages": {
+        "@babel/runtime": true
+      }
+    },
     "debounce-stream>duplexer": {
       "packages": {
         "stream-browserify": true
       }
     },
-    "debounce-stream>through": {
+    "@metamask/ppom-validator>elliptic": {
       "packages": {
+        "bn.js": true,
+        "@metamask/ppom-validator>elliptic>brorand": true,
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "@metamask/ppom-validator>elliptic>hmac-drbg": true,
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "string.prototype.matchall>call-bind>es-define-property": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>es-get-iterator": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>has-symbols": true,
+        "browserify>util>is-arguments": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
         "process": true,
-        "stream-browserify": true
-      }
-    },
-    "depcheck>@vue/compiler-sfc>postcss>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "depcheck>is-core-module>hasown": {
-      "packages": {
-        "browserify>has>function-bind": true
-      }
-    },
-    "dependency-tree>precinct>detective-postcss>postcss>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "eslint-plugin-react>array-includes>is-string": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": true
       }
     },
     "eth-ens-namehash": {
@@ -3720,22 +3348,9 @@
         "name": "write"
       },
       "packages": {
-        "@metamask/ethjs>js-sha3": true,
         "browserify>buffer": true,
-        "eth-ens-namehash>idna-uts46-hx": true
-      }
-    },
-    "eth-ens-namehash>idna-uts46-hx": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "browserify>punycode": true
-      }
-    },
-    "eth-keyring-controller>@metamask/browser-passworder": {
-      "globals": {
-        "crypto": true
+        "eth-ens-namehash>idna-uts46-hx": true,
+        "@metamask/ethjs>js-sha3": true
       }
     },
     "eth-lattice-keyring": {
@@ -3753,9 +3368,246 @@
         "bn.js": true,
         "browserify>buffer": true,
         "crypto-browserify": true,
+        "webpack>events": true,
         "eth-lattice-keyring>gridplus-sdk": true,
-        "eth-lattice-keyring>rlp": true,
-        "webpack>events": true
+        "eth-lattice-keyring>rlp": true
+      }
+    },
+    "eth-method-registry": {
+      "packages": {
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs-query": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true
+      },
+      "packages": {
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": true,
+        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>ethereum-cryptography>keccak": true,
+        "crypto-browserify>randombytes": true,
+        "ganache>secp256k1": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": {
+      "packages": {
+        "browserify>assert": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "browserify>buffer": true,
+        "crypto-browserify>create-hmac": true,
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "ethereumjs-util>ethereum-cryptography>keccak": true,
+        "crypto-browserify>randombytes": true,
+        "koa>content-disposition>safe-buffer": true,
+        "ganache>secp256k1": true
+      }
+    },
+    "ethereumjs-util": {
+      "packages": {
+        "browserify>assert": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "ethereumjs-util>ethereum-cryptography": true,
+        "browserify>insert-module-globals>is-buffer": true,
+        "ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": {
+      "packages": {
+        "browserify>assert": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
+        "browserify>insert-module-globals>is-buffer": true,
+        "ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>aes-js": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "browserify>buffer": true,
+        "crypto-browserify": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": true,
+        "crypto-browserify>randombytes": true,
+        "ethers>@ethersproject/json-wallets>scrypt-js": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>utf8": true,
+        "uuid": true
+      }
+    },
+    "ethers": {
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/providers": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/solidity": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/units": true,
+        "@ethersproject/wallet": true,
+        "ethers>@ethersproject/web": true,
+        "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": {
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "@ethersproject/providers": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/solidity": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/units": true,
+        "@ethersproject/wallet": true,
+        "@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "@metamask/ethjs>ethjs-abi": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ethjs>js-sha3": true,
+        "@metamask/ethjs>ethjs-abi>number-to-bn": true
+      }
+    },
+    "webpack>events": {
+      "globals": {
+        "console": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>evp_bytestokey": {
+      "packages": {
+        "ethereumjs-util>create-hash>md5.js": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "extension-port-stream": {
+      "packages": {
+        "browserify>buffer": true,
+        "extension-port-stream>readable-stream": true
+      }
+    },
+    "fast-json-patch": {
+      "globals": {
+        "addEventListener": true,
+        "clearTimeout": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      }
+    },
+    "@metamask/snaps-utils>fast-xml-parser": {
+      "globals": {
+        "entityName": true,
+        "val": true
+      },
+      "packages": {
+        "@metamask/snaps-utils>fast-xml-parser>strnum": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase": {
+      "packages": {
+        "@metamask/notification-services-controller>firebase>@firebase/app": true,
+        "@metamask/notification-services-controller>firebase>@firebase/messaging": true
+      }
+    },
+    "react-focus-lock>focus-lock": {
+      "globals": {
+        "HTMLIFrameElement": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.DOCUMENT_NODE": true,
+        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
+        "Node.DOCUMENT_POSITION_CONTAINS": true,
+        "Node.ELEMENT_NODE": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "browserify>util>which-typed-array>for-each": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>is-callable": true
+      }
+    },
+    "axios>form-data": {
+      "globals": {
+        "FormData": true
+      }
+    },
+    "fuse.js": {
+      "globals": {
+        "console": true,
+        "define": true
+      }
+    },
+    "string.prototype.matchall>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>es-abstract>has-proto": true,
+        "string.prototype.matchall>has-symbols": true,
+        "depcheck>is-core-module>hasown": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>gopd": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk": {
@@ -3773,545 +3625,63 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethersproject/abi": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/ethjs>js-sha3": true,
-        "@metamask/keyring-api>bech32": true,
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": true,
+        "@ethersproject/abi": true,
+        "@metamask/eth-sig-util": true,
         "eth-lattice-keyring>gridplus-sdk>aes-js": true,
+        "@metamask/keyring-api>bech32": true,
         "eth-lattice-keyring>gridplus-sdk>bignumber.js": true,
+        "bn.js": true,
         "eth-lattice-keyring>gridplus-sdk>borc": true,
         "eth-lattice-keyring>gridplus-sdk>bs58check": true,
-        "eth-lattice-keyring>gridplus-sdk>secp256k1": true,
-        "eth-lattice-keyring>gridplus-sdk>uuid": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "@metamask/ppom-validator>elliptic": true,
         "ethers>@ethersproject/sha2>hash.js": true,
-        "lodash": true
+        "@metamask/ethjs>js-sha3": true,
+        "lodash": true,
+        "eth-lattice-keyring>gridplus-sdk>secp256k1": true,
+        "eth-lattice-keyring>gridplus-sdk>uuid": true
       }
     },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
+    "string.prototype.matchall>es-abstract>has-property-descriptors": {
       "packages": {
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
-        "webpack>events": true
+        "string.prototype.matchall>call-bind>es-define-property": true
       }
     },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": {
+    "koa>is-generator-function>has-tostringtag": {
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": true,
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": {
-      "packages": {
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
-        "webpack>events": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>aes-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "browserify>buffer": true,
-        "buffer>ieee754": true,
-        "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": true,
-        "eth-lattice-keyring>gridplus-sdk>borc>iso-url": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc>iso-url": {
-      "globals": {
-        "URL": true,
-        "URLSearchParams": true,
-        "location": true,
-        "navigator": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bs58check": {
-      "packages": {
-        "@noble/hashes": true,
-        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": {
-      "packages": {
-        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58>base-x": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>secp256k1": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "eth-lattice-keyring>rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "eth-method-registry": {
-      "packages": {
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true
-      }
-    },
-    "ethereumjs-util": {
-      "packages": {
-        "bn.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>ethereum-cryptography": true,
-        "ethereumjs-util>rlp": true
-      }
-    },
-    "ethereumjs-util>create-hash": {
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>create-hash>md5.js": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>create-hash>cipher-base": {
-      "packages": {
-        "browserify>string_decoder": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true,
-        "stream-browserify": true
-      }
-    },
-    "ethereumjs-util>create-hash>md5.js": {
-      "packages": {
-        "ethereumjs-util>create-hash>md5.js>hash-base": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
+        "string.prototype.matchall>has-symbols": true
       }
     },
     "ethereumjs-util>create-hash>md5.js>hash-base": {
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
         "pumpify>inherits": true,
-        "readable-stream": true
-      }
-    },
-    "ethereumjs-util>create-hash>ripemd160": {
-      "packages": {
-        "browserify>buffer": true,
-        "ethereumjs-util>create-hash>md5.js>hash-base": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>ethereum-cryptography>keccak": true,
-        "ganache>secp256k1": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>browserify-aes": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>bs58check": {
-      "packages": {
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check>bs58": true,
+        "readable-stream": true,
         "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>bs58check>bs58": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase>base-x": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>keccak": {
-      "packages": {
-        "browserify>buffer": true,
-        "readable-stream": true
-      }
-    },
-    "ethereumjs-util>rlp": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers": {
-      "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "@ethersproject/wallet": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/solidity": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true,
-        "ethers>@ethersproject/units": true,
-        "ethers>@ethersproject/web": true,
-        "ethers>@ethersproject/wordlists": true
-      }
-    },
-    "ethers>@ethersproject/abstract-provider": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/abstract-signer": {
-      "packages": {
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/address": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/rlp": true
-      }
-    },
-    "ethers>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true
-      }
-    },
-    "ethers>@ethersproject/basex": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/constants": {
-      "packages": {
-        "@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hdnode": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/json-wallets>aes-js": true,
-        "ethers>@ethersproject/json-wallets>scrypt-js": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/pbkdf2": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets>aes-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets>scrypt-js": {
-      "globals": {
-        "define": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>timers-browserify": true
-      }
-    },
-    "ethers>@ethersproject/keccak256": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@metamask/ethjs>js-sha3": true
-      }
-    },
-    "ethers>@ethersproject/logger": {
-      "globals": {
-        "console": true
-      }
-    },
-    "ethers>@ethersproject/pbkdf2": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/sha2": true
-      }
-    },
-    "ethers>@ethersproject/properties": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers": {
-      "globals": {
-        "WebSocket": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "console.log": true,
-        "console.warn": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/abstract-provider": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers>@ethersproject/networks": true,
-        "ethers>@ethersproject/providers>@ethersproject/web": true,
-        "ethers>@ethersproject/providers>bech32": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/networks": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/random": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/rlp": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/sha2": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/sha2>hash.js": true
       }
     },
     "ethers>@ethersproject/sha2>hash.js": {
       "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "pumpify>inherits": true
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true
       }
     },
-    "ethers>@ethersproject/signing-key": {
+    "depcheck>is-core-module>hasown": {
       "packages": {
-        "@ethersproject/bytes": true,
-        "@metamask/ppom-validator>elliptic": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
+        "browserify>has>function-bind": true
       }
     },
-    "ethers>@ethersproject/solidity": {
+    "@metamask/eth-trezor-keyring>hdkey": {
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/strings": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/transactions": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/signing-key": true
-      }
-    },
-    "ethers>@ethersproject/units": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/wordlists": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "extension-port-stream": {
-      "packages": {
-        "browserify>buffer": true,
-        "extension-port-stream>readable-stream": true
-      }
-    },
-    "extension-port-stream>readable-stream": {
-      "globals": {
-        "AbortController": true,
-        "AggregateError": true,
-        "Blob": true
-      },
-      "packages": {
-        "browserify>buffer": true,
-        "browserify>string_decoder": true,
-        "extension-port-stream>readable-stream>abort-controller": true,
-        "process": true,
-        "webpack>events": true
-      }
-    },
-    "extension-port-stream>readable-stream>abort-controller": {
-      "globals": {
-        "AbortController": true
-      }
-    },
-    "fast-json-patch": {
-      "globals": {
-        "addEventListener": true,
-        "clearTimeout": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
-    "fuse.js": {
-      "globals": {
-        "console": true,
-        "define": true
-      }
-    },
-    "ganache>secp256k1": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true
-      }
-    },
-    "gulp>vinyl-fs>object.assign": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>has-symbols": true
+        "browserify>assert": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "crypto-browserify": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "ganache>secp256k1": true
       }
     },
     "he": {
@@ -4327,15 +3697,100 @@
         "document.querySelector": true
       }
     },
-    "https-browserify": {
+    "react-router-dom>history": {
+      "globals": {
+        "addEventListener": true,
+        "confirm": true,
+        "document": true,
+        "history": true,
+        "location": true,
+        "navigator.userAgent": true,
+        "removeEventListener": true
+      },
       "packages": {
-        "browserify>url": true,
-        "stream-http": true
+        "react-router-dom>history>resolve-pathname": true,
+        "react-router-dom>tiny-invariant": true,
+        "react-router-dom>tiny-warning": true,
+        "react-router-dom>history>value-equal": true
       }
     },
-    "koa>content-disposition>safe-buffer": {
+    "@metamask/ppom-validator>elliptic>hmac-drbg": {
       "packages": {
-        "browserify>buffer": true
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "react-redux>hoist-non-react-statics": {
+      "packages": {
+        "prop-types>react-is": true
+      }
+    },
+    "https-browserify": {
+      "packages": {
+        "stream-http": true,
+        "browserify>url": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>idb": {
+      "globals": {
+        "DOMException": true,
+        "IDBCursor": true,
+        "IDBDatabase": true,
+        "IDBIndex": true,
+        "IDBObjectStore": true,
+        "IDBRequest": true,
+        "IDBTransaction": true,
+        "indexedDB.deleteDatabase": true,
+        "indexedDB.open": true
+      }
+    },
+    "eth-ens-namehash>idna-uts46-hx": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "browserify>punycode": true
+      }
+    },
+    "string.prototype.matchall>internal-slot": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "depcheck>is-core-module>hasown": true,
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "browserify>util>is-arguments": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-array-buffer": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>unbox-primitive>has-bigints": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
       }
     },
     "koa>is-generator-function": {
@@ -4343,9 +3798,145 @@
         "koa>is-generator-function>has-tostringtag": true
       }
     },
-    "koa>is-generator-function>has-tostringtag": {
+    "@material-ui/core>@material-ui/styles>jss>is-in-browser": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-regex": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-shared-array-buffer": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true
+      }
+    },
+    "eslint-plugin-react>array-includes>is-string": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
       "packages": {
         "string.prototype.matchall>has-symbols": true
+      }
+    },
+    "browserify>util>is-typed-array": {
+      "packages": {
+        "browserify>util>which-typed-array": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>borc>iso-url": {
+      "globals": {
+        "URL": true,
+        "URLSearchParams": true,
+        "location": true,
+        "navigator": true
+      }
+    },
+    "@ensdomains/content-hash>js-base64": {
+      "globals": {
+        "Base64": "write",
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true,
+        "define": true
+      },
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "@metamask/ethjs>js-sha3": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "process": true
+      }
+    },
+    "@ngraveio/bc-ur>jsbi": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@metamask/message-manager>jsonschema": {
+      "packages": {
+        "browserify>url": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case>hyphenate-style-name": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": {
+      "globals": {
+        "CSS": true
+      },
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-global": {
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-nested": {
+      "packages": {
+        "@babel/runtime": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": true,
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss": {
+      "globals": {
+        "CSS": true,
+        "document.createElement": true,
+        "document.querySelector": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>keccak": {
+      "packages": {
+        "browserify>buffer": true,
+        "readable-stream": true
+      }
+    },
+    "currency-formatter>locale-currency": {
+      "globals": {
+        "countryCode": true
       }
     },
     "localforage": {
@@ -4425,6 +4016,120 @@
         "Intl": true
       }
     },
+    "@metamask/snaps-utils>marked": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true,
+        "define": true
+      }
+    },
+    "ethereumjs-util>create-hash>md5.js": {
+      "packages": {
+        "ethereumjs-util>create-hash>md5.js>hash-base": true,
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "@storybook/addon-docs>remark-external-links>mdast-util-definitions": {
+      "packages": {
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
+        "react-syntax-highlighter>refractor>parse-entities": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>remark-rehype>mdast-util-to-hast": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@storybook/addon-docs>remark-external-links>mdast-util-definitions": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "@ethereumjs/tx>@ethereumjs/util>micro-ftch": {
+      "globals": {
+        "Headers": true,
+        "TextDecoder": true,
+        "URL": true,
+        "btoa": true,
+        "fetch": true
+      },
+      "packages": {
+        "browserify>browserify-zlib": true,
+        "browserify>buffer": true,
+        "https-browserify": true,
+        "process": true,
+        "stream-http": true,
+        "browserify>url": true,
+        "browserify>util": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
+      "packages": {
+        "react-syntax-highlighter>refractor>parse-entities": true
+      }
+    },
+    "crypto-browserify>diffie-hellman>miller-rabin": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ppom-validator>elliptic>brorand": true
+      }
+    },
+    "@ensdomains/content-hash>cids>multibase": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase>@multiformats/base-x": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>multibase": {
+      "packages": {
+        "@ensdomains/content-hash>multihashes>multibase>base-x": true,
+        "browserify>buffer": true,
+        "@ensdomains/content-hash>multihashes>web-encoding": true
+      }
+    },
+    "@ensdomains/content-hash>multicodec": {
+      "packages": {
+        "@ensdomains/content-hash>multicodec>uint8arrays": true,
+        "sass-embedded>varint": true
+      }
+    },
+    "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "console.warn": true,
+        "crypto.subtle.digest": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes": {
+      "packages": {
+        "browserify>buffer": true,
+        "@ensdomains/content-hash>multihashes>multibase": true,
+        "@ensdomains/content-hash>multihashes>varint": true,
+        "@ensdomains/content-hash>multihashes>web-encoding": true
+      }
+    },
+    "@ensdomains/content-hash>cids>multihashes": {
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase": true,
+        "@ensdomains/content-hash>cids>uint8arrays": true,
+        "@ensdomains/content-hash>cids>multihashes>varint": true
+      }
+    },
     "nanoid": {
       "globals": {
         "crypto": true,
@@ -4432,17 +4137,54 @@
         "navigator": true
       }
     },
-    "nock>debug": {
+    "@metamask/approval-controller>nanoid": {
       "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "nock>debug>ms": true,
-        "process": true
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/smart-transactions-controller>@metamask/controllers>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/notification-controller>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/permission-controller>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/rpc-methods>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/rpc-methods-flask>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/snaps-controllers>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/snaps-controllers-flask>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "depcheck>@vue/compiler-sfc>postcss>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "dependency-tree>precinct>detective-postcss>postcss>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
       }
     },
     "node-fetch": {
@@ -4453,9 +4195,122 @@
         "fetch": true
       }
     },
+    "@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "@metamask/ethjs>ethjs-abi>number-to-bn": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>object-inspect": {
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "browserify>browser-resolve": true
+      }
+    },
+    "@ngraveio/bc-ur>assert>object-is": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true
+      }
+    },
+    "gulp>vinyl-fs>object.assign": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>has-symbols": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "@metamask/object-multiplex>once": {
+      "packages": {
+        "@metamask/object-multiplex>once>wrappy": true
+      }
+    },
+    "crypto-browserify>public-encrypt>parse-asn1": {
+      "packages": {
+        "crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
+        "ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "browserify>buffer": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "crypto-browserify>pbkdf2": true
+      }
+    },
+    "react-syntax-highlighter>refractor>parse-entities": {
+      "globals": {
+        "document.createElement": true
+      }
+    },
     "path-browserify": {
       "packages": {
         "process": true
+      }
+    },
+    "serve-handler>path-to-regexp": {
+      "packages": {
+        "serve-handler>path-to-regexp>isarray": true
+      }
+    },
+    "crypto-browserify>pbkdf2": {
+      "globals": {
+        "crypto": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethereumjs-util>create-hash": true,
+        "process": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "@material-ui/core>popper.js": {
+      "globals": {
+        "MSInputMethodContext": true,
+        "Node.DOCUMENT_POSITION_FOLLOWING": true,
+        "cancelAnimationFrame": true,
+        "console.warn": true,
+        "define": true,
+        "devicePixelRatio": true,
+        "document": true,
+        "getComputedStyle": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "navigator": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      }
+    },
+    "react-tippy>popper.js": {
+      "globals": {
+        "MSInputMethodContext": true,
+        "Node.DOCUMENT_POSITION_FOLLOWING": true,
+        "cancelAnimationFrame": true,
+        "console.warn": true,
+        "define": true,
+        "devicePixelRatio": true,
+        "document": true,
+        "getComputedStyle": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "navigator.userAgent": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
       }
     },
     "process": {
@@ -4470,26 +4325,51 @@
         "promise-to-callback>set-immediate-shim": true
       }
     },
-    "promise-to-callback>set-immediate-shim": {
-      "globals": {
-        "setTimeout.apply": true
-      },
-      "packages": {
-        "browserify>timers-browserify": true
-      }
-    },
     "prop-types": {
       "globals": {
         "console": true
       },
       "packages": {
-        "prop-types>react-is": true,
-        "react>object-assign": true
+        "react>object-assign": true,
+        "prop-types>react-is": true
       }
     },
-    "prop-types>react-is": {
+    "react-markdown>property-information": {
+      "packages": {
+        "watchify>xtend": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": {
       "globals": {
-        "console": true
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/base64": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/eventemitter": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/float": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/path": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/pool": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/utf8": true
+      }
+    },
+    "crypto-browserify>public-encrypt": {
+      "packages": {
+        "bn.js": true,
+        "crypto-browserify>public-encrypt>browserify-rsa": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "crypto-browserify>public-encrypt>parse-asn1": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "browserify>punycode": {
+      "globals": {
+        "define": true
       }
     },
     "qrcode-generator": {
@@ -4506,13 +4386,55 @@
         "react": true
       }
     },
+    "@storybook/addon-knobs>qs": {
+      "packages": {
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
+      "globals": {
+        "queueMicrotask": true
+      }
+    },
+    "react-beautiful-dnd>raf-schd": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "requestAnimationFrame": true
+      }
+    },
+    "crypto-browserify>randombytes": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "process": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "ethereumjs-wallet>randombytes": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "crypto-browserify>randomfill": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "process": true,
+        "crypto-browserify>randombytes": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
     "react": {
       "globals": {
         "console": true
       },
       "packages": {
-        "prop-types": true,
-        "react>object-assign": true
+        "react>object-assign": true,
+        "prop-types": true
       }
     },
     "react-beautiful-dnd": {
@@ -4534,35 +4456,14 @@
       },
       "packages": {
         "@babel/runtime": true,
-        "react": true,
         "react-beautiful-dnd>css-box-model": true,
         "react-beautiful-dnd>memoize-one": true,
         "react-beautiful-dnd>raf-schd": true,
-        "react-beautiful-dnd>use-memo-one": true,
+        "react": true,
         "react-dom": true,
         "react-redux": true,
-        "redux": true
-      }
-    },
-    "react-beautiful-dnd>css-box-model": {
-      "globals": {
-        "getComputedStyle": true,
-        "pageXOffset": true,
-        "pageYOffset": true
-      },
-      "packages": {
-        "react-router-dom>tiny-invariant": true
-      }
-    },
-    "react-beautiful-dnd>raf-schd": {
-      "globals": {
-        "cancelAnimationFrame": true,
-        "requestAnimationFrame": true
-      }
-    },
-    "react-beautiful-dnd>use-memo-one": {
-      "packages": {
-        "react": true
+        "redux": true,
+        "react-beautiful-dnd>use-memo-one": true
       }
     },
     "react-chartjs-2": {
@@ -4571,6 +4472,12 @@
       },
       "packages": {
         "chart.js": true,
+        "react": true
+      }
+    },
+    "react-focus-lock>react-clientside-effect": {
+      "packages": {
+        "@babel/runtime": true,
         "react": true
       }
     },
@@ -4615,22 +4522,28 @@
         "trustedTypes": true
       },
       "packages": {
+        "react>object-assign": true,
         "prop-types": true,
         "react": true,
-        "react-dom>scheduler": true,
-        "react>object-assign": true
+        "react-dom>scheduler": true
       }
     },
-    "react-dom>scheduler": {
+    "react-responsive-carousel>react-easy-swipe": {
       "globals": {
-        "MessageChannel": true,
-        "cancelAnimationFrame": true,
-        "clearTimeout": true,
-        "console": true,
-        "navigator": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
+        "addEventListener": true,
+        "define": true,
+        "document.addEventListener": true,
+        "document.removeEventListener": true
+      },
+      "packages": {
+        "prop-types": true,
+        "react": true
+      }
+    },
+    "react-popper>react-fast-compare": {
+      "globals": {
+        "Element": true,
+        "console.warn": true
       }
     },
     "react-focus-lock": {
@@ -4644,51 +4557,12 @@
       },
       "packages": {
         "@babel/runtime": true,
+        "react-focus-lock>focus-lock": true,
         "prop-types": true,
         "react": true,
-        "react-focus-lock>focus-lock": true,
         "react-focus-lock>react-clientside-effect": true,
         "react-focus-lock>use-callback-ref": true,
         "react-focus-lock>use-sidecar": true
-      }
-    },
-    "react-focus-lock>focus-lock": {
-      "globals": {
-        "HTMLIFrameElement": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
-        "Node.DOCUMENT_NODE": true,
-        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
-        "Node.DOCUMENT_POSITION_CONTAINS": true,
-        "Node.ELEMENT_NODE": true,
-        "console.error": true,
-        "console.warn": true,
-        "document": true,
-        "getComputedStyle": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "react-focus-lock>react-clientside-effect": {
-      "packages": {
-        "@babel/runtime": true,
-        "react": true
-      }
-    },
-    "react-focus-lock>use-callback-ref": {
-      "packages": {
-        "react": true
-      }
-    },
-    "react-focus-lock>use-sidecar": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true,
-        "react": true,
-        "react-focus-lock>use-sidecar>detect-node-es": true
       }
     },
     "react-idle-timer": {
@@ -4712,15 +4586,30 @@
         "react": true
       }
     },
+    "prop-types>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-markdown>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-redux>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
     "react-markdown": {
       "globals": {
         "console.warn": true
       },
       "packages": {
-        "prop-types": true,
-        "react": true,
         "react-markdown>comma-separated-tokens": true,
+        "prop-types": true,
         "react-markdown>property-information": true,
+        "react": true,
         "react-markdown>react-is": true,
         "react-markdown>remark-parse": true,
         "react-markdown>remark-rehype": true,
@@ -4729,96 +4618,6 @@
         "react-markdown>unified": true,
         "react-markdown>unist-util-visit": true,
         "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>property-information": {
-      "packages": {
-        "watchify>xtend": true
-      }
-    },
-    "react-markdown>react-is": {
-      "globals": {
-        "console": true
-      }
-    },
-    "react-markdown>remark-parse": {
-      "packages": {
-        "react-markdown>remark-parse>mdast-util-from-markdown": true
-      }
-    },
-    "react-markdown>remark-parse>mdast-util-from-markdown": {
-      "packages": {
-        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
-        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
-        "react-markdown>remark-parse>mdast-util-from-markdown>unist-util-stringify-position": true,
-        "react-syntax-highlighter>refractor>parse-entities": true
-      }
-    },
-    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
-      "packages": {
-        "react-syntax-highlighter>refractor>parse-entities": true
-      }
-    },
-    "react-markdown>remark-rehype": {
-      "packages": {
-        "react-markdown>remark-rehype>mdast-util-to-hast": true
-      }
-    },
-    "react-markdown>remark-rehype>mdast-util-to-hast": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@storybook/addon-docs>remark-external-links>mdast-util-definitions": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "react-markdown>style-to-object": {
-      "packages": {
-        "react-markdown>style-to-object>inline-style-parser": true
-      }
-    },
-    "react-markdown>unified": {
-      "packages": {
-        "mocha>yargs-unparser>is-plain-obj": true,
-        "react-markdown>unified>bail": true,
-        "react-markdown>unified>extend": true,
-        "react-markdown>unified>is-buffer": true,
-        "react-markdown>unified>trough": true,
-        "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>unist-util-visit": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-visit-parents": true
-      }
-    },
-    "react-markdown>unist-util-visit>unist-util-visit-parents": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-is": true
-      }
-    },
-    "react-markdown>vfile": {
-      "packages": {
-        "path-browserify": true,
-        "process": true,
-        "react-markdown>vfile>is-buffer": true,
-        "react-markdown>vfile>replace-ext": true,
-        "react-markdown>vfile>vfile-message": true
-      }
-    },
-    "react-markdown>vfile>replace-ext": {
-      "packages": {
-        "path-browserify": true
-      }
-    },
-    "react-markdown>vfile>vfile-message": {
-      "packages": {
-        "react-markdown>vfile>unist-util-stringify-position": true
       }
     },
     "react-popper": {
@@ -4832,17 +4631,6 @@
         "react-popper>warning": true
       }
     },
-    "react-popper>react-fast-compare": {
-      "globals": {
-        "Element": true,
-        "console.warn": true
-      }
-    },
-    "react-popper>warning": {
-      "globals": {
-        "console": true
-      }
-    },
     "react-redux": {
       "globals": {
         "console": true,
@@ -4850,21 +4638,11 @@
       },
       "packages": {
         "@babel/runtime": true,
+        "react-redux>hoist-non-react-statics": true,
         "prop-types": true,
         "react": true,
         "react-dom": true,
-        "react-redux>hoist-non-react-statics": true,
         "react-redux>react-is": true
-      }
-    },
-    "react-redux>hoist-non-react-statics": {
-      "packages": {
-        "prop-types>react-is": true
-      }
-    },
-    "react-redux>react-is": {
-      "globals": {
-        "console": true
       }
     },
     "react-responsive-carousel": {
@@ -4885,23 +4663,11 @@
         "react-responsive-carousel>react-easy-swipe": true
       }
     },
-    "react-responsive-carousel>react-easy-swipe": {
-      "globals": {
-        "addEventListener": true,
-        "define": true,
-        "document.addEventListener": true,
-        "document.removeEventListener": true
-      },
-      "packages": {
-        "prop-types": true,
-        "react": true
-      }
-    },
     "react-router-dom": {
       "packages": {
+        "react-router-dom>history": true,
         "prop-types": true,
         "react": true,
-        "react-router-dom>history": true,
         "react-router-dom>react-router": true,
         "react-router-dom>tiny-invariant": true,
         "react-router-dom>tiny-warning": true
@@ -4927,26 +4693,24 @@
         "setTimeout": true
       },
       "packages": {
+        "react-router-dom-v5-compat>@remix-run/router": true,
         "history": true,
         "react": true,
         "react-dom": true,
         "react-router-dom": true,
-        "react-router-dom-v5-compat>@remix-run/router": true,
         "react-router-dom-v5-compat>react-router": true
       }
     },
-    "react-router-dom-v5-compat>@remix-run/router": {
-      "globals": {
-        "AbortController": true,
-        "DOMException": true,
-        "FormData": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "URL": true,
-        "URLSearchParams": true,
-        "console": true,
-        "document.defaultView": true
+    "react-router-dom>react-router": {
+      "packages": {
+        "react-router-dom>history": true,
+        "react-redux>hoist-non-react-statics": true,
+        "serve-handler>path-to-regexp": true,
+        "prop-types": true,
+        "react": true,
+        "prop-types>react-is": true,
+        "react-router-dom>tiny-invariant": true,
+        "react-router-dom>tiny-warning": true
       }
     },
     "react-router-dom-v5-compat>react-router": {
@@ -4955,42 +4719,8 @@
         "define": true
       },
       "packages": {
-        "react": true,
-        "react-router-dom-v5-compat>@remix-run/router": true
-      }
-    },
-    "react-router-dom>history": {
-      "globals": {
-        "addEventListener": true,
-        "confirm": true,
-        "document": true,
-        "history": true,
-        "location": true,
-        "navigator.userAgent": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "react-router-dom>history>resolve-pathname": true,
-        "react-router-dom>history>value-equal": true,
-        "react-router-dom>tiny-invariant": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "react-router-dom>react-router": {
-      "packages": {
-        "prop-types": true,
-        "prop-types>react-is": true,
-        "react": true,
-        "react-redux>hoist-non-react-statics": true,
-        "react-router-dom>history": true,
-        "react-router-dom>tiny-invariant": true,
-        "react-router-dom>tiny-warning": true,
-        "serve-handler>path-to-regexp": true
-      }
-    },
-    "react-router-dom>tiny-warning": {
-      "globals": {
-        "console": true
+        "react-router-dom-v5-compat>@remix-run/router": true,
+        "react": true
       }
     },
     "react-simple-file-input": {
@@ -5002,11 +4732,6 @@
       "packages": {
         "prop-types": true,
         "react": true
-      }
-    },
-    "react-syntax-highlighter>refractor>parse-entities": {
-      "globals": {
-        "document.createElement": true
       }
     },
     "react-tippy": {
@@ -5031,26 +4756,9 @@
         "setTimeout": true
       },
       "packages": {
+        "react-tippy>popper.js": true,
         "react": true,
-        "react-dom": true,
-        "react-tippy>popper.js": true
-      }
-    },
-    "react-tippy>popper.js": {
-      "globals": {
-        "MSInputMethodContext": true,
-        "Node.DOCUMENT_POSITION_FOLLOWING": true,
-        "cancelAnimationFrame": true,
-        "console.warn": true,
-        "define": true,
-        "devicePixelRatio": true,
-        "document": true,
-        "getComputedStyle": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "navigator.userAgent": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
+        "react-dom": true
       }
     },
     "react-toggle-button": {
@@ -5065,22 +4773,46 @@
         "react": true
       }
     },
+    "@material-ui/core>react-transition-group": {
+      "globals": {
+        "Element": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@material-ui/core>react-transition-group>dom-helpers": true,
+        "prop-types": true,
+        "react": true,
+        "react-dom": true
+      }
+    },
     "readable-stream": {
       "packages": {
         "browserify>browser-resolve": true,
         "browserify>buffer": true,
-        "browserify>string_decoder": true,
-        "process": true,
+        "webpack>events": true,
         "pumpify>inherits": true,
-        "readable-stream>util-deprecate": true,
-        "webpack>events": true
+        "process": true,
+        "browserify>string_decoder": true,
+        "readable-stream>util-deprecate": true
       }
     },
-    "readable-stream>util-deprecate": {
+    "extension-port-stream>readable-stream": {
       "globals": {
-        "console.trace": true,
-        "console.warn": true,
-        "localStorage": true
+        "AbortController": true,
+        "AggregateError": true,
+        "Blob": true
+      },
+      "packages": {
+        "extension-port-stream>readable-stream>abort-controller": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "process": true,
+        "browserify>string_decoder": true
+      }
+    },
+    "@metamask/snaps-controllers>readable-web-to-node-stream": {
+      "packages": {
+        "readable-stream": true
       }
     },
     "redux": {
@@ -5091,6 +4823,111 @@
         "@babel/runtime": true
       }
     },
+    "string.prototype.matchall>regexp.prototype.flags": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+      }
+    },
+    "react-markdown>remark-parse": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown": true
+      }
+    },
+    "react-markdown>remark-rehype": {
+      "packages": {
+        "react-markdown>remark-rehype>mdast-util-to-hast": true
+      }
+    },
+    "react-markdown>vfile>replace-ext": {
+      "packages": {
+        "path-browserify": true
+      }
+    },
+    "@metamask/network-controller>reselect": {
+      "globals": {
+        "WeakRef": true,
+        "console.warn": true,
+        "unstable_autotrackMemoize": true
+      }
+    },
+    "@metamask/snaps-utils>rfdc": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "ethereumjs-util>create-hash>ripemd160": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>md5.js>hash-base": true,
+        "pumpify>inherits": true
+      }
+    },
+    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "eth-lattice-keyring>rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "ethereumjs-util>rlp": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true
+      }
+    },
+    "wait-on>rxjs": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setInterval.apply": true,
+        "setTimeout.apply": true
+      }
+    },
+    "koa>content-disposition>safe-buffer": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "react-dom>scheduler": {
+      "globals": {
+        "MessageChannel": true,
+        "cancelAnimationFrame": true,
+        "clearTimeout": true,
+        "console": true,
+        "navigator": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets>scrypt-js": {
+      "globals": {
+        "define": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>timers-browserify": true
+      }
+    },
+    "ganache>secp256k1": {
+      "packages": {
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>secp256k1": {
+      "packages": {
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
     "semver": {
       "globals": {
         "console.error": true
@@ -5099,16 +4936,69 @@
         "process": true
       }
     },
-    "serve-handler>path-to-regexp": {
+    "string.prototype.matchall>call-bind>set-function-length": {
       "packages": {
-        "serve-handler>path-to-regexp>isarray": true
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "promise-to-callback>set-immediate-shim": {
+      "globals": {
+        "setTimeout.apply": true
+      },
+      "packages": {
+        "browserify>timers-browserify": true
+      }
+    },
+    "addons-linter>sha.js": {
+      "packages": {
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "string.prototype.matchall>side-channel": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>object-inspect": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": true,
+        "@metamask/profile-sync-controller>siwe>@stablelib/random": true,
+        "ethers": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>valid-url": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": {
+      "globals": {
+        "StopIteration": true
+      },
+      "packages": {
+        "string.prototype.matchall>internal-slot": true
       }
     },
     "stream-browserify": {
       "packages": {
+        "webpack>events": true,
         "pumpify>inherits": true,
-        "readable-stream": true,
-        "webpack>events": true
+        "readable-stream": true
       }
     },
     "stream-http": {
@@ -5127,160 +5017,195 @@
       },
       "packages": {
         "browserify>buffer": true,
-        "browserify>url": true,
-        "process": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
         "stream-http>builtin-status-codes": true,
+        "pumpify>inherits": true,
+        "process": true,
+        "readable-stream": true,
+        "browserify>url": true,
         "watchify>xtend": true
       }
     },
-    "string.prototype.matchall>call-bind": {
+    "@metamask/snaps-controllers>tar-stream>streamx": {
       "packages": {
-        "browserify>has>function-bind": true,
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>call-bind>set-function-length": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "webpack>events": true,
+        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
+        "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": true
       }
     },
-    "string.prototype.matchall>call-bind>es-define-property": {
+    "browserify>string_decoder": {
       "packages": {
-        "string.prototype.matchall>get-intrinsic": true
+        "koa>content-disposition>safe-buffer": true
       }
     },
-    "string.prototype.matchall>call-bind>set-function-length": {
+    "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>gopd": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true
       }
     },
-    "string.prototype.matchall>define-properties": {
+    "react-markdown>style-to-object": {
       "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+        "react-markdown>style-to-object>inline-style-parser": true
       }
     },
-    "string.prototype.matchall>define-properties>define-data-property": {
+    "@metamask/snaps-controllers>tar-stream": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>gopd": true
+        "@metamask/snaps-controllers>tar-stream>b4a": true,
+        "browserify>browser-resolve": true,
+        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
+        "@metamask/snaps-controllers>tar-stream>streamx": true
       }
     },
-    "string.prototype.matchall>es-abstract>array-buffer-byte-length": {
+    "debounce-stream>through": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>is-array-buffer": true
+        "process": true,
+        "stream-browserify": true
       }
     },
-    "string.prototype.matchall>es-abstract>available-typed-arrays": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>typed-array-length>possible-typed-array-names": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
-      "packages": {
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>gopd": {
-      "packages": {
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>has-property-descriptors": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-array-buffer": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-callable": {
+    "browserify>timers-browserify": {
       "globals": {
-        "document": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-regex": {
+        "clearInterval": true,
+        "clearTimeout": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
       "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
+        "process": true
       }
     },
-    "string.prototype.matchall>es-abstract>is-shared-array-buffer": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>object-inspect": {
+    "react-router-dom>tiny-warning": {
       "globals": {
-        "HTMLElement": true,
-        "WeakRef": true
+        "console": true
+      }
+    },
+    "copy-to-clipboard>toggle-selection": {
+      "globals": {
+        "document.activeElement": true,
+        "document.getSelection": true
+      }
+    },
+    "@swc/helpers>tslib": {
+      "globals": {
+        "SuppressedError": true,
+        "define": true
+      }
+    },
+    "@metamask/eth-sig-util>tweetnacl": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "nacl": "write"
       },
       "packages": {
         "browserify>browser-resolve": true
       }
     },
-    "string.prototype.matchall>get-intrinsic": {
+    "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": {
       "globals": {
-        "AggregateError": true,
-        "FinalizationRegistry": true,
-        "WeakRef": true
+        "define": true
+      }
+    },
+    "@ensdomains/content-hash>cids>uint8arrays": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
       },
       "packages": {
-        "browserify>has>function-bind": true,
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>has-proto": true,
-        "string.prototype.matchall>has-symbols": true
+        "@ensdomains/content-hash>cids>multibase": true
       }
     },
-    "string.prototype.matchall>internal-slot": {
+    "@ensdomains/content-hash>multicodec>uint8arrays": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
       "packages": {
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>side-channel": true
+        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true
       }
     },
-    "string.prototype.matchall>regexp.prototype.flags": {
+    "react-markdown>unified": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+        "react-markdown>unified>bail": true,
+        "react-markdown>unified>extend": true,
+        "react-markdown>unified>is-buffer": true,
+        "mocha>yargs-unparser>is-plain-obj": true,
+        "react-markdown>unified>trough": true,
+        "react-markdown>vfile": true
       }
     },
-    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+    "react-markdown>unist-util-visit>unist-util-visit-parents": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+        "react-markdown>unist-util-visit>unist-util-is": true
       }
     },
-    "string.prototype.matchall>side-channel": {
+    "react-markdown>unist-util-visit": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>object-inspect": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "terser>source-map-support>buffer-from": {
-      "packages": {
-        "browserify>buffer": true
+        "react-markdown>unist-util-visit>unist-util-visit-parents": true
       }
     },
     "uri-js": {
       "globals": {
         "define": true
+      }
+    },
+    "browserify>url": {
+      "packages": {
+        "browserify>punycode": true,
+        "@storybook/addon-knobs>qs": true
+      }
+    },
+    "react-focus-lock>use-callback-ref": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-beautiful-dnd>use-memo-one": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-focus-lock>use-sidecar": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "react-focus-lock>use-sidecar>detect-node-es": true,
+        "react": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "readable-stream>util-deprecate": {
+      "globals": {
+        "console.trace": true,
+        "console.warn": true,
+        "localStorage": true
+      }
+    },
+    "browserify>assert>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true,
+        "process": true
+      },
+      "packages": {
+        "browserify>assert>util>inherits": true,
+        "process": true
+      }
+    },
+    "browserify>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "browserify>util>is-arguments": true,
+        "koa>is-generator-function": true,
+        "browserify>util>is-typed-array": true,
+        "process": true,
+        "browserify>util>which-typed-array": true
       }
     },
     "uuid": {
@@ -5289,15 +5214,64 @@
         "msCrypto": true
       }
     },
-    "wait-on>rxjs": {
+    "@metamask/eth-snap-keyring>uuid": {
       "globals": {
-        "cancelAnimationFrame": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setInterval.apply": true,
-        "setTimeout.apply": true
+        "crypto": true
+      }
+    },
+    "@metamask/keyring-api>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "web3-stream-provider>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/snaps-utils>validate-npm-package-name": {
+      "packages": {
+        "@metamask/snaps-utils>validate-npm-package-name>builtins": true
+      }
+    },
+    "react-markdown>vfile>vfile-message": {
+      "packages": {
+        "react-markdown>vfile>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>vfile": {
+      "packages": {
+        "react-markdown>vfile>is-buffer": true,
+        "path-browserify": true,
+        "process": true,
+        "react-markdown>vfile>replace-ext": true,
+        "react-markdown>vfile>vfile-message": true
+      }
+    },
+    "browserify>vm-browserify": {
+      "globals": {
+        "document.body.appendChild": true,
+        "document.body.removeChild": true,
+        "document.createElement": true
+      }
+    },
+    "react-popper>warning": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>web-encoding": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "browserify>util": true
       }
     },
     "web3": {
@@ -5310,14 +5284,14 @@
         "setTimeout": true
       },
       "packages": {
-        "browserify>util": true,
         "readable-stream": true,
+        "browserify>util": true,
         "web3-stream-provider>uuid": true
       }
     },
-    "web3-stream-provider>uuid": {
+    "@metamask/controllers>web3": {
       "globals": {
-        "crypto": true
+        "XMLHttpRequest": true
       }
     },
     "webextension-polyfill": {
@@ -5329,9 +5303,35 @@
         "define": true
       }
     },
-    "webpack>events": {
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": {
+      "packages": {
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-collection": {
+      "packages": {
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakmap": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": true
+      }
+    },
+    "browserify>util>which-typed-array": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>available-typed-arrays": true,
+        "string.prototype.matchall>call-bind": true,
+        "browserify>util>which-typed-array>for-each": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": {
       "globals": {
-        "console": true
+        "XMLHttpRequest": true
       }
     }
   }

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2645,7 +2645,7 @@
         "@zxing/library>ts-custom-error": true
       }
     },
-    "extension-port-stream>readable-stream>abort-controller": {
+    "@lavamoat/lavapack>readable-stream>abort-controller": {
       "globals": {
         "AbortController": true
       }
@@ -4803,7 +4803,7 @@
         "Blob": true
       },
       "packages": {
-        "extension-port-stream>readable-stream>abort-controller": true,
+        "@lavamoat/lavapack>readable-stream>abort-controller": true,
         "browserify>buffer": true,
         "webpack>events": true,
         "process": true,

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -5,115 +5,70 @@
         "regeneratorRuntime": "write"
       }
     },
+    "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": {
+      "globals": {
+        "SuppressedError": true
+      }
+    },
     "@ensdomains/content-hash": {
       "globals": {
         "console.warn": true
       },
       "packages": {
+        "browserify>buffer": true,
         "@ensdomains/content-hash>cids": true,
         "@ensdomains/content-hash>js-base64": true,
         "@ensdomains/content-hash>multicodec": true,
-        "@ensdomains/content-hash>multihashes": true,
-        "browserify>buffer": true
+        "@ensdomains/content-hash>multihashes": true
       }
     },
-    "@ensdomains/content-hash>cids": {
+    "@ethereumjs/tx>@ethereumjs/common": {
       "packages": {
-        "@ensdomains/content-hash>cids>multibase": true,
-        "@ensdomains/content-hash>cids>multihashes": true,
-        "@ensdomains/content-hash>cids>uint8arrays": true,
-        "@ensdomains/content-hash>multicodec": true
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "webpack>events": true
       }
     },
-    "@ensdomains/content-hash>cids>multibase": {
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "@metamask/transaction-controller>@ethereumjs/common": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "webpack>events": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@ethereumjs/common": {
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "webpack>events": true
+      }
+    },
+    "@ethereumjs/tx>@ethereumjs/rlp": {
       "globals": {
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase>@multiformats/base-x": true
       }
     },
-    "@ensdomains/content-hash>cids>multihashes": {
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase": true,
-        "@ensdomains/content-hash>cids>multihashes>varint": true,
-        "@ensdomains/content-hash>cids>uint8arrays": true
-      }
-    },
-    "@ensdomains/content-hash>cids>uint8arrays": {
+    "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": {
       "globals": {
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>cids>multibase": true
       }
     },
-    "@ensdomains/content-hash>js-base64": {
+    "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": {
       "globals": {
-        "Base64": "write",
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "atob": true,
-        "btoa": true,
-        "define": true
-      },
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec": {
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays": true,
-        "sass-embedded>varint": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec>uint8arrays": {
-      "globals": {
-        "Buffer": true,
-        "TextDecoder": true,
         "TextEncoder": true
-      },
-      "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true
-      }
-    },
-    "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "console.warn": true,
-        "crypto.subtle.digest": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase": true,
-        "@ensdomains/content-hash>multihashes>varint": true,
-        "@ensdomains/content-hash>multihashes>web-encoding": true,
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>multibase": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase>base-x": true,
-        "@ensdomains/content-hash>multihashes>web-encoding": true,
-        "browserify>buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>multibase>base-x": {
-      "packages": {
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@ensdomains/content-hash>multihashes>web-encoding": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "browserify>util": true
       }
     },
     "@ethereumjs/tx": {
@@ -121,28 +76,36 @@
         "@ethereumjs/tx>@ethereumjs/common": true,
         "@ethereumjs/tx>@ethereumjs/rlp": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>insert-module-globals>is-buffer": true
       }
     },
-    "@ethereumjs/tx>@ethereumjs/common": {
+    "@metamask/smart-transactions-controller>@ethereumjs/tx": {
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "browserify>buffer": true,
+        "@trezor/connect-web>@trezor/connect>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": {
+      "globals": {
+        "console.warn": true,
+        "fetch": true
+      },
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "webpack>events": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/common>crc-32": {
-      "globals": {
-        "DO_NOT_EXPORT_CRC": true,
-        "define": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/rlp": {
-      "globals": {
-        "TextEncoder": true
       }
     },
     "@ethereumjs/tx>@ethereumjs/util": {
@@ -151,78 +114,33 @@
       },
       "packages": {
         "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": true,
-        "@ethereumjs/tx>@ethereumjs/util>micro-ftch": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true,
         "browserify>insert-module-globals>is-buffer": true,
-        "webpack>events": true
+        "@ethereumjs/tx>@ethereumjs/util>micro-ftch": true
       }
     },
-    "@ethereumjs/tx>@ethereumjs/util>@ethereumjs/rlp": {
+    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": {
       "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@ethereumjs/tx>@ethereumjs/util>micro-ftch": {
-      "globals": {
-        "Headers": true,
-        "TextDecoder": true,
-        "URL": true,
-        "btoa": true,
+        "console.warn": true,
         "fetch": true
       },
       "packages": {
-        "browserify>browserify-zlib": true,
-        "browserify>buffer": true,
-        "browserify>url": true,
-        "browserify>util": true,
-        "https-browserify": true,
-        "process": true,
-        "stream-http": true
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true
       }
     },
-    "@ethereumjs/tx>ethereum-cryptography": {
+    "@metamask/smart-transactions-controller>@ethereumjs/util": {
       "globals": {
-        "TextDecoder": true,
-        "crypto": true
+        "console.warn": true,
+        "fetch": true
       },
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": true,
-        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/curves": {
-      "globals": {
-        "TextEncoder": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
-      }
-    },
-    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack>events": true
       }
     },
     "@ethersproject/abi": {
@@ -230,27 +148,70 @@
         "console.log": true
       },
       "packages": {
+        "ethers>@ethersproject/address": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/strings": true
       }
     },
+    "ethers>@ethersproject/abstract-provider": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
+    "ethers>@ethersproject/abstract-signer": {
+      "packages": {
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
+    "ethers>@ethersproject/address": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/rlp": true
+      }
+    },
+    "ethers>@ethersproject/base64": {
+      "globals": {
+        "atob": true,
+        "btoa": true
+      },
+      "packages": {
+        "@ethersproject/bytes": true
+      }
+    },
+    "ethers>@ethersproject/basex": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/properties": true
+      }
+    },
     "@ethersproject/bignumber": {
       "packages": {
         "@ethersproject/bytes": true,
-        "bn.js": true,
-        "ethers>@ethersproject/logger": true
+        "ethers>@ethersproject/logger": true,
+        "bn.js": true
       }
     },
     "@ethersproject/bytes": {
       "packages": {
         "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/constants": {
+      "packages": {
+        "@ethersproject/bignumber": true
       }
     },
     "@ethersproject/contracts": {
@@ -259,11 +220,11 @@
       },
       "packages": {
         "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/transactions": true
@@ -271,10 +232,10 @@
     },
     "@ethersproject/hash": {
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
         "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
@@ -283,9 +244,9 @@
     },
     "@ethersproject/hdnode": {
       "packages": {
+        "ethers>@ethersproject/basex": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/bytes": true,
-        "ethers>@ethersproject/basex": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/pbkdf2": true,
         "ethers>@ethersproject/properties": true,
@@ -294,6 +255,54 @@
         "ethers>@ethersproject/strings": true,
         "ethers>@ethersproject/transactions": true,
         "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets": {
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bytes": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/pbkdf2": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/json-wallets>aes-js": true,
+        "ethers>@ethersproject/json-wallets>scrypt-js": true
+      }
+    },
+    "ethers>@ethersproject/keccak256": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "@metamask/ethjs>js-sha3": true
+      }
+    },
+    "ethers>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "ethers>@ethersproject/providers>@ethersproject/networks": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "@metamask/test-bundler>@ethersproject/networks": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/pbkdf2": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/sha2": true
+      }
+    },
+    "ethers>@ethersproject/properties": {
+      "packages": {
+        "ethers>@ethersproject/logger": true
       }
     },
     "@ethersproject/providers": {
@@ -307,24 +316,55 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/providers>@ethersproject/web": true,
-        "@ethersproject/providers>bech32": true,
-        "@metamask/test-bundler>@ethersproject/networks": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
         "ethers>@ethersproject/base64": true,
         "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
         "ethers>@ethersproject/logger": true,
+        "@metamask/test-bundler>@ethersproject/networks": true,
         "ethers>@ethersproject/properties": true,
         "ethers>@ethersproject/random": true,
         "ethers>@ethersproject/sha2": true,
         "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
+        "ethers>@ethersproject/transactions": true,
+        "@ethersproject/providers>@ethersproject/web": true,
+        "@ethersproject/providers>bech32": true
+      }
+    },
+    "ethers>@ethersproject/providers": {
+      "globals": {
+        "WebSocket": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "console.warn": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethers>@ethersproject/abstract-provider": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/hash": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/providers>@ethersproject/networks": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/providers>bech32": true
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
@@ -332,28 +372,77 @@
         "crypto.getRandomValues": true
       }
     },
-    "@ethersproject/providers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
+    "ethers>@ethersproject/random": {
       "packages": {
         "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/rlp": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/sha2": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/sha2>hash.js": true
+      }
+    },
+    "ethers>@ethersproject/signing-key": {
+      "packages": {
+        "@ethersproject/bytes": true,
         "ethers>@ethersproject/logger": true,
         "ethers>@ethersproject/properties": true,
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "ethers>@ethersproject/solidity": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/sha2": true,
         "ethers>@ethersproject/strings": true
+      }
+    },
+    "ethers>@ethersproject/strings": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "ethers>@ethersproject/logger": true
+      }
+    },
+    "ethers>@ethersproject/transactions": {
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/signing-key": true
+      }
+    },
+    "ethers>@ethersproject/units": {
+      "packages": {
+        "@ethersproject/bignumber": true,
+        "ethers>@ethersproject/logger": true
       }
     },
     "@ethersproject/wallet": {
       "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
         "ethers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/address": true,
+        "@ethersproject/bytes": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
         "ethers>@ethersproject/json-wallets": true,
         "ethers>@ethersproject/keccak256": true,
         "ethers>@ethersproject/logger": true,
@@ -363,12 +452,170 @@
         "ethers>@ethersproject/transactions": true
       }
     },
+    "@ethersproject/providers>@ethersproject/web": {
+      "globals": {
+        "clearTimeout": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
+      }
+    },
+    "ethers>@ethersproject/providers>@ethersproject/web": {
+      "globals": {
+        "clearTimeout": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
+      }
+    },
+    "ethers>@ethersproject/web": {
+      "globals": {
+        "clearTimeout": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethers>@ethersproject/base64": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
+      }
+    },
+    "ethers>@ethersproject/wordlists": {
+      "packages": {
+        "@ethersproject/bytes": true,
+        "@ethersproject/hash": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/strings": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app": {
+      "globals": {
+        "FinalizationRegistry": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": true,
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": {
+      "packages": {
+        "@metamask/notification-services-controller>firebase>@firebase/util": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/installations": {
+      "globals": {
+        "BroadcastChannel": true,
+        "Headers": true,
+        "btoa": true,
+        "console.error": true,
+        "crypto": true,
+        "fetch": true,
+        "msCrypto": true,
+        "navigator.onLine": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/notification-services-controller>firebase>@firebase/app": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/messaging": {
+      "globals": {
+        "Headers": true,
+        "Notification.maxActions": true,
+        "Notification.permission": true,
+        "Notification.requestPermission": true,
+        "PushSubscription.prototype.hasOwnProperty": true,
+        "ServiceWorkerRegistration": true,
+        "URL": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "clients.matchAll": true,
+        "clients.openWindow": true,
+        "console.warn": true,
+        "document": true,
+        "fetch": true,
+        "indexedDB": true,
+        "location.href": true,
+        "location.origin": true,
+        "navigator": true,
+        "origin.replace": true,
+        "registration.showNotification": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/notification-services-controller>firebase>@firebase/app": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
+        "@metamask/notification-services-controller>firebase>@firebase/installations": true,
+        "@metamask/notification-services-controller>firebase>@firebase/util": true,
+        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/util": {
+      "globals": {
+        "atob": true,
+        "browser": true,
+        "btoa": true,
+        "chrome": true,
+        "console": true,
+        "document": true,
+        "indexedDB": true,
+        "navigator": true,
+        "process": true,
+        "self": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "process": true
+      }
+    },
+    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": {
+      "packages": {
+        "@ethereumjs/tx": true,
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@keystonehq/bc-ur-registry-eth": true,
+        "browserify>buffer": true,
+        "@metamask/eth-trezor-keyring>hdkey": true,
+        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": true,
+        "uuid": true
+      }
+    },
     "@keystonehq/bc-ur-registry-eth": {
       "packages": {
         "@ethereumjs/tx>@ethereumjs/util": true,
         "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
         "browserify>buffer": true,
+        "@metamask/eth-trezor-keyring>hdkey": true,
         "uuid": true
       }
     },
@@ -378,38 +625,27 @@
       },
       "packages": {
         "@ngraveio/bc-ur": true,
-        "@swc/helpers>tslib": true,
-        "browserify>buffer": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
         "buffer": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true
+        "browserify>buffer": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@keystonehq/metamask-airgapped-keyring": {
       "packages": {
         "@ethereumjs/tx": true,
-        "@keystonehq/bc-ur-registry-eth": true,
         "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": true,
+        "@keystonehq/bc-ur-registry-eth": true,
         "@metamask/obs-store": true,
         "browserify>buffer": true,
+        "webpack>events": true,
         "ethereumjs-util>rlp": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring": {
-      "packages": {
-        "@ethereumjs/tx": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@keystonehq/bc-ur-registry-eth": true,
-        "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
-        "browserify>buffer": true,
         "uuid": true
       }
     },
-    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": {
+    "chart.js>@kurkle/color": {
       "globals": {
-        "TextEncoder": true
+        "define": true
       }
     },
     "@lavamoat/lavadome-react": {
@@ -423,6 +659,58 @@
       },
       "packages": {
         "react": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
+      "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": true,
+        "@metamask/ppom-validator>crypto-js": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/rlp": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": true,
+        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": true,
+        "browserify>buffer": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "wait-on>rxjs": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": {
+      "globals": {
+        "__ledgerLogsListen": "write",
+        "console.error": true
       }
     },
     "@material-ui/core": {
@@ -453,13 +741,13 @@
         "@material-ui/core>@material-ui/system": true,
         "@material-ui/core>@material-ui/utils": true,
         "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
         "@material-ui/core>popper.js": true,
-        "@material-ui/core>react-transition-group": true,
         "prop-types": true,
-        "prop-types>react-is": true,
         "react": true,
         "react-dom": true,
-        "react-redux>hoist-non-react-statics": true
+        "prop-types>react-is": true,
+        "@material-ui/core>react-transition-group": true
       }
     },
     "@material-ui/core>@material-ui/styles": {
@@ -471,7 +759,9 @@
       },
       "packages": {
         "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss": true,
+        "@material-ui/core>@material-ui/utils": true,
+        "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
         "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": true,
         "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": true,
         "@material-ui/core>@material-ui/styles>jss-plugin-global": true,
@@ -479,76 +769,9 @@
         "@material-ui/core>@material-ui/styles>jss-plugin-props-sort": true,
         "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": true,
         "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": true,
-        "@material-ui/core>@material-ui/utils": true,
-        "@material-ui/core>clsx": true,
+        "@material-ui/core>@material-ui/styles>jss": true,
         "prop-types": true,
-        "react": true,
-        "react-redux>hoist-non-react-statics": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss": {
-      "globals": {
-        "CSS": true,
-        "document.createElement": true,
-        "document.querySelector": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case>hyphenate-style-name": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": {
-      "globals": {
-        "CSS": true
-      },
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-global": {
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-nested": {
-      "packages": {
-        "@babel/runtime": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": {
-      "packages": {
-        "@material-ui/core>@material-ui/styles>jss": true,
-        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": {
-      "globals": {
-        "document.createElement": true,
-        "document.documentElement": true,
-        "getComputedStyle": true
-      },
-      "packages": {
-        "@babel/runtime": true,
-        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true
-      }
-    },
-    "@material-ui/core>@material-ui/styles>jss>is-in-browser": {
-      "globals": {
-        "document": true
+        "react": true
       }
     },
     "@material-ui/core>@material-ui/system": {
@@ -568,38 +791,10 @@
         "prop-types>react-is": true
       }
     },
-    "@material-ui/core>popper.js": {
+    "@metamask-institutional/custody-keyring>@metamask-institutional/configuration-client": {
       "globals": {
-        "MSInputMethodContext": true,
-        "Node.DOCUMENT_POSITION_FOLLOWING": true,
-        "cancelAnimationFrame": true,
-        "console.warn": true,
-        "define": true,
-        "devicePixelRatio": true,
-        "document": true,
-        "getComputedStyle": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "navigator": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
-      }
-    },
-    "@material-ui/core>react-transition-group": {
-      "globals": {
-        "Element": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@material-ui/core>react-transition-group>dom-helpers": true,
-        "prop-types": true,
-        "react": true,
-        "react-dom": true
-      }
-    },
-    "@material-ui/core>react-transition-group>dom-helpers": {
-      "packages": {
-        "@babel/runtime": true
+        "console.log": true,
+        "fetch": true
       }
     },
     "@metamask-institutional/custody-controller": {
@@ -622,14 +817,8 @@
         "@metamask-institutional/types": true,
         "@metamask/obs-store": true,
         "crypto-browserify": true,
-        "gulp-sass>lodash.clonedeep": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask-institutional/custody-keyring>@metamask-institutional/configuration-client": {
-      "globals": {
-        "console.log": true,
-        "fetch": true
+        "webpack>events": true,
+        "gulp-sass>lodash.clonedeep": true
       }
     },
     "@metamask-institutional/extension": {
@@ -696,34 +885,19 @@
     },
     "@metamask/abi-utils": {
       "packages": {
-        "@metamask/abi-utils>@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/abi-utils>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
         "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
+        "@metamask/abi-utils>@metamask/utils": true
       }
     },
     "@metamask/accounts-controller": {
       "packages": {
         "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "@metamask/base-controller": true,
         "@metamask/eth-snap-keyring": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
         "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
         "uuid": true
       }
     },
@@ -738,27 +912,14 @@
         "@metamask/announcement-controller>@metamask/base-controller": true
       }
     },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
     "@metamask/approval-controller": {
       "globals": {
         "console.info": true
       },
       "packages": {
-        "@metamask/approval-controller>nanoid": true,
         "@metamask/base-controller": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/approval-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+        "@metamask/rpc-errors": true,
+        "@metamask/approval-controller>nanoid": true
       }
     },
     "@metamask/assets-controllers": {
@@ -775,8 +936,8 @@
         "setTimeout": true
       },
       "packages": {
-        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
+        "ethers>@ethersproject/address": true,
         "@ethersproject/bignumber": true,
         "@ethersproject/contracts": true,
         "@ethersproject/providers": true,
@@ -786,19 +947,43 @@
         "@metamask/controller-utils": true,
         "@metamask/eth-query": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/name-controller>async-mutex": true,
         "@metamask/polling-controller": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
         "bn.js": true,
         "cockatiel": true,
-        "ethers>@ethersproject/address": true,
         "lodash": true,
+        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true,
         "single-call-balance-checker-abi": true,
         "uuid": true
       }
     },
     "@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/announcement-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/name-controller>@metamask/base-controller": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "immer": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/base-controller": {
       "globals": {
         "setTimeout": true
       },
@@ -822,19 +1007,9 @@
         "browserify>buffer": true
       }
     },
-    "@metamask/browser-passworder>@metamask/utils": {
+    "eth-keyring-controller>@metamask/browser-passworder": {
       "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
+        "crypto": true
       }
     },
     "@metamask/controller-utils": {
@@ -846,43 +1021,13 @@
       },
       "packages": {
         "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/controller-utils>@spruceid/siwe-parser": true,
         "@metamask/ethjs>@metamask/ethjs-unit": true,
         "@metamask/utils": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser": true,
         "bn.js": true,
         "browserify>buffer": true,
-        "eslint>fast-deep-equal": true,
-        "eth-ens-namehash": true
-      }
-    },
-    "@metamask/controller-utils>@spruceid/siwe-parser": {
-      "globals": {
-        "console.error": true,
-        "console.log": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/controllers>web3": {
-      "globals": {
-        "XMLHttpRequest": true
-      }
-    },
-    "@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch": {
-      "globals": {
-        "fetch": true
-      }
-    },
-    "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
-      "globals": {
-        "fetch": true
+        "eth-ens-namehash": true,
+        "eslint>fast-deep-equal": true
       }
     },
     "@metamask/ens-controller": {
@@ -894,6 +1039,44 @@
         "punycode": true
       }
     },
+    "@metamask/eth-token-tracker>@metamask/eth-block-tracker": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": true,
+        "@metamask/eth-query>json-rpc-random-id": true,
+        "pify": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-block-tracker": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/safe-event-emitter": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": true,
+        "@metamask/eth-query>json-rpc-random-id": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-hd-keyring": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/scure-bip39": true,
+        "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true
+      }
+    },
     "@metamask/eth-json-rpc-filters": {
       "globals": {
         "console.error": true
@@ -901,9 +1084,21 @@
       "packages": {
         "@metamask/eth-query": true,
         "@metamask/json-rpc-engine": true,
-        "@metamask/name-controller>async-mutex": true,
         "@metamask/safe-event-emitter": true,
+        "@metamask/name-controller>async-mutex": true,
         "pify": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-json-rpc-infura": {
+      "globals": {
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": true
       }
     },
     "@metamask/eth-json-rpc-middleware": {
@@ -913,27 +1108,12 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/eth-json-rpc-middleware>@metamask/utils": true,
-        "@metamask/eth-json-rpc-middleware>klona": true,
-        "@metamask/eth-json-rpc-middleware>safe-stable-stringify": true,
         "@metamask/eth-sig-util": true,
         "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/eth-json-rpc-middleware>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
+        "@metamask/rpc-errors": true,
+        "@metamask/eth-json-rpc-middleware>@metamask/utils": true,
+        "@metamask/eth-json-rpc-middleware>klona": true,
+        "@metamask/eth-json-rpc-middleware>safe-stable-stringify": true
       }
     },
     "@metamask/eth-json-rpc-provider": {
@@ -954,165 +1134,14 @@
         "removeEventListener": true
       },
       "packages": {
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
         "@ethereumjs/tx": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
         "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": true,
         "@metamask/eth-sig-util": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
         "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@ethersproject/abi": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": true,
-        "browserify>buffer": true,
-        "ethers>@ethersproject/rlp": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
-      "packages": {
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/errors": {
-      "globals": {
-        "console.warn": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
-      "packages": {
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": true,
-        "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": true,
-        "@metamask/ppom-validator>crypto-js": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "wait-on>rxjs": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": {
-      "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "@ethersproject/providers": true,
-        "@ethersproject/providers>@ethersproject/web": true,
-        "@ethersproject/wallet": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/solidity": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true,
-        "ethers>@ethersproject/units": true,
-        "ethers>@ethersproject/wordlists": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/logs": {
-      "globals": {
-        "__ledgerLogsListen": "write",
-        "console.error": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": {
-      "globals": {
-        "Blob": true,
-        "FormData": true,
-        "URLSearchParams": true,
-        "XMLHttpRequest": true,
-        "btoa": true,
-        "console.warn": true,
-        "document": true,
-        "location.href": true,
-        "navigator": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "axios>form-data": true,
-        "browserify>buffer": true,
-        "process": true
-      }
-    },
-    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
+        "webpack>events": true,
+        "@metamask/eth-trezor-keyring>hdkey": true
       }
     },
     "@metamask/eth-query": {
@@ -1124,37 +1153,55 @@
     "@metamask/eth-sig-util": {
       "packages": {
         "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "@metamask/abi-utils": true,
         "@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
         "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
         "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
       }
     },
-    "@metamask/eth-sig-util>tweetnacl": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true,
-        "nacl": "write"
-      },
+    "@metamask/eth-snap-keyring>@metamask/eth-sig-util": {
       "packages": {
-        "browserify>browser-resolve": true
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/eth-snap-keyring>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/signature-controller>@metamask/eth-sig-util": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/abi-utils": true,
+        "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>tweetnacl": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-simple-keyring": {
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "crypto-browserify>randombytes": true
       }
     },
     "@metamask/eth-snap-keyring": {
@@ -1165,42 +1212,11 @@
       "packages": {
         "@ethereumjs/tx": true,
         "@metamask/eth-snap-keyring>@metamask/eth-sig-util": true,
-        "@metamask/eth-snap-keyring>@metamask/utils": true,
-        "@metamask/eth-snap-keyring>uuid": true,
         "@metamask/keyring-api": true,
         "@metamask/utils>@metamask/superstruct": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-snap-keyring>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
         "@metamask/eth-snap-keyring>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/eth-snap-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-snap-keyring>uuid": {
-      "globals": {
-        "crypto": true
+        "webpack>events": true,
+        "@metamask/eth-snap-keyring>uuid": true
       }
     },
     "@metamask/eth-token-tracker": {
@@ -1210,128 +1226,12 @@
       "packages": {
         "@babel/runtime": true,
         "@metamask/eth-token-tracker>@metamask/eth-block-tracker": true,
-        "@metamask/eth-token-tracker>deep-equal": true,
         "@metamask/ethjs-contract": true,
         "@metamask/ethjs-query": true,
         "@metamask/safe-event-emitter": true,
         "bn.js": true,
+        "@metamask/eth-token-tracker>deep-equal": true,
         "human-standard-token-abi": true
-      }
-    },
-    "@metamask/eth-token-tracker>@metamask/eth-block-tracker": {
-      "globals": {
-        "clearTimeout": true,
-        "console.error": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": true,
-        "@metamask/safe-event-emitter": true,
-        "pify": true
-      }
-    },
-    "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator": true,
-        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection": true,
-        "@ngraveio/bc-ur>assert>object-is": true,
-        "browserify>util>is-arguments": true,
-        "browserify>util>which-typed-array": true,
-        "gulp>vinyl-fs>object.assign": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>array-buffer-byte-length": true,
-        "string.prototype.matchall>es-abstract>is-array-buffer": true,
-        "string.prototype.matchall>es-abstract>is-regex": true,
-        "string.prototype.matchall>es-abstract>is-shared-array-buffer": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>regexp.prototype.flags": true,
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>es-get-iterator": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": true,
-        "browserify>util>is-arguments": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "process": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": {
-      "globals": {
-        "StopIteration": true
-      },
-      "packages": {
-        "string.prototype.matchall>internal-slot": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": true,
-        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>unbox-primitive>has-bigints": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-collection": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
-        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakmap": true,
-        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": true
-      }
-    },
-    "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true
       }
     },
     "@metamask/eth-trezor-keyring": {
@@ -1342,26 +1242,10 @@
         "@ethereumjs/tx": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
         "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": true,
-        "@metamask/eth-trezor-keyring>hdkey": true,
         "@trezor/connect-web": true,
         "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": {
-      "packages": {
-        "@metamask/eth-sig-util": true,
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/eth-trezor-keyring>hdkey": {
-      "packages": {
-        "browserify>assert": true,
-        "crypto-browserify": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ganache>secp256k1": true,
-        "koa>content-disposition>safe-buffer": true
+        "webpack>events": true,
+        "@metamask/eth-trezor-keyring>hdkey": true
       }
     },
     "@metamask/etherscan-link": {
@@ -1376,16 +1260,16 @@
       },
       "packages": {
         "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true,
         "@metamask/ethjs>@metamask/ethjs-filter": true,
         "@metamask/ethjs>@metamask/ethjs-provider-http": true,
+        "@metamask/ethjs-query": true,
         "@metamask/ethjs>@metamask/ethjs-unit": true,
         "@metamask/ethjs>@metamask/ethjs-util": true,
         "@metamask/ethjs>@metamask/number-to-bn": true,
-        "@metamask/ethjs>ethjs-abi": true,
-        "@metamask/ethjs>js-sha3": true,
         "bn.js": true,
-        "browserify>buffer": true
+        "browserify>buffer": true,
+        "@metamask/ethjs>ethjs-abi": true,
+        "@metamask/ethjs>js-sha3": true
       }
     },
     "@metamask/ethjs-contract": {
@@ -1398,6 +1282,25 @@
         "promise-to-callback": true
       }
     },
+    "@metamask/ethjs>@metamask/ethjs-filter": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      }
+    },
+    "@metamask/ethjs-query>@metamask/ethjs-format": {
+      "packages": {
+        "@metamask/ethjs>@metamask/ethjs-util": true,
+        "@metamask/ethjs>@metamask/number-to-bn": true,
+        "@metamask/ethjs-query>@metamask/ethjs-format>ethjs-schema": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-provider-http": {
+      "packages": {
+        "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": true
+      }
+    },
     "@metamask/ethjs-query": {
       "globals": {
         "console": true
@@ -1408,33 +1311,9 @@
         "promise-to-callback": true
       }
     },
-    "@metamask/ethjs-query>@metamask/ethjs-format": {
-      "packages": {
-        "@metamask/ethjs-query>@metamask/ethjs-format>ethjs-schema": true,
-        "@metamask/ethjs>@metamask/ethjs-util": true,
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "@metamask/ethjs>@metamask/number-to-bn": true
-      }
-    },
     "@metamask/ethjs-query>@metamask/ethjs-rpc": {
       "packages": {
         "promise-to-callback": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-filter": {
-      "globals": {
-        "clearInterval": true,
-        "setInterval": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-provider-http": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": {
-      "globals": {
-        "XMLHttpRequest": true
       }
     },
     "@metamask/ethjs>@metamask/ethjs-unit": {
@@ -1445,42 +1324,9 @@
     },
     "@metamask/ethjs>@metamask/ethjs-util": {
       "packages": {
+        "browserify>buffer": true,
         "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true,
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true
-      }
-    },
-    "@metamask/ethjs>@metamask/number-to-bn": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>ethjs-abi": {
-      "packages": {
-        "@metamask/ethjs>ethjs-abi>number-to-bn": true,
-        "@metamask/ethjs>js-sha3": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ethjs>ethjs-abi>number-to-bn": {
-      "packages": {
-        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true,
-        "bn.js": true
-      }
-    },
-    "@metamask/ethjs>js-sha3": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "process": true
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
       }
     },
     "@metamask/gas-fee-controller": {
@@ -1507,28 +1353,6 @@
         "@metamask/jazzicon>mersenne-twister": true
       }
     },
-    "@metamask/jazzicon>color": {
-      "packages": {
-        "@metamask/jazzicon>color>clone": true,
-        "@metamask/jazzicon>color>color-convert": true,
-        "@metamask/jazzicon>color>color-string": true
-      }
-    },
-    "@metamask/jazzicon>color>clone": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/jazzicon>color>color-convert": {
-      "packages": {
-        "@metamask/jazzicon>color>color-convert>color-name": true
-      }
-    },
-    "@metamask/jazzicon>color>color-string": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
-      }
-    },
     "@metamask/json-rpc-engine": {
       "packages": {
         "@metamask/rpc-errors": true,
@@ -1547,35 +1371,27 @@
         "readable-stream": true
       }
     },
+    "@metamask/snaps-sdk>@metamask/key-tree": {
+      "globals": {
+        "crypto.subtle": true
+      },
+      "packages": {
+        "@metamask/scure-bip39": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true
+      }
+    },
     "@metamask/keyring-api": {
       "globals": {
         "URL": true
       },
       "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
         "@metamask/keyring-api>@metamask/utils": true,
         "@metamask/keyring-api>bech32": true,
-        "@metamask/keyring-api>uuid": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/keyring-api>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-api>uuid": {
-      "globals": {
-        "crypto": true
+        "@metamask/keyring-api>uuid": true
       }
     },
     "@metamask/keyring-controller": {
@@ -1586,126 +1402,9 @@
         "@metamask/keyring-controller>@metamask/eth-hd-keyring": true,
         "@metamask/keyring-controller>@metamask/eth-sig-util": true,
         "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
-        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "@metamask/utils": true,
         "@metamask/name-controller>async-mutex": true,
-        "@metamask/utils": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-hd-keyring": {
-      "globals": {
-        "TextEncoder": true
-      },
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": true,
-        "@metamask/scure-bip39": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-simple-keyring": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": true,
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet": {
-      "packages": {
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": true,
-        "@metamask/keyring-controller>ethereumjs-wallet>utf8": true,
-        "browserify>buffer": true,
-        "crypto-browserify": true,
-        "crypto-browserify>randombytes": true,
-        "eth-lattice-keyring>gridplus-sdk>aes-js": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ethers>@ethersproject/json-wallets>scrypt-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": {
-      "packages": {
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "crypto-browserify>create-hmac": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check": true,
-        "ethereumjs-util>ethereum-cryptography>keccak": true,
-        "ethers>@ethersproject/sha2>hash.js": true,
-        "ganache>secp256k1": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": {
-      "packages": {
-        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
-        "bn.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>rlp": true
+        "@metamask/keyring-controller>ethereumjs-wallet": true
       }
     },
     "@metamask/logging-controller": {
@@ -1734,13 +1433,8 @@
         "@metamask/controller-utils": true,
         "@metamask/utils": true,
         "browserify>buffer": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/message-manager>jsonschema": {
-      "packages": {
-        "browserify>url": true
+        "webpack>events": true,
+        "uuid": true
       }
     },
     "@metamask/name-controller": {
@@ -1748,42 +1442,10 @@
         "fetch": true
       },
       "packages": {
-        "@metamask/controller-utils": true,
         "@metamask/name-controller>@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
         "@metamask/name-controller>@metamask/utils": true,
         "@metamask/name-controller>async-mutex": true
-      }
-    },
-    "@metamask/name-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/name-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/name-controller>async-mutex": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
       }
     },
     "@metamask/network-controller": {
@@ -1795,85 +1457,26 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
         "@metamask/eth-json-rpc-middleware": true,
         "@metamask/eth-json-rpc-provider": true,
         "@metamask/eth-query": true,
         "@metamask/json-rpc-engine": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/network-controller>reselect": true,
         "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
         "@metamask/utils": true,
         "eslint>fast-deep-equal": true,
+        "@metamask/network-controller>reselect": true,
         "uri-js": true,
         "uuid": true
       }
     },
-    "@metamask/network-controller>@metamask/eth-block-tracker": {
-      "globals": {
-        "clearTimeout": true,
-        "console.error": true,
-        "setTimeout": true
-      },
+    "@metamask/transaction-controller>@metamask/nonce-tracker": {
       "packages": {
-        "@metamask/eth-query>json-rpc-random-id": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": true,
-        "@metamask/safe-event-emitter": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-json-rpc-infura": {
-      "globals": {
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": true,
-        "@metamask/rpc-errors": true
-      }
-    },
-    "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/network-controller>reselect": {
-      "globals": {
-        "WeakRef": true,
-        "console.warn": true,
-        "unstable_autotrackMemoize": true
-      }
-    },
-    "@metamask/notification-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+        "@ethersproject/providers": true,
+        "browserify>assert": true,
+        "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": true
       }
     },
     "@metamask/notification-services-controller": {
@@ -1885,141 +1488,21 @@
         "removeEventListener": true
       },
       "packages": {
+        "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": true,
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
-        "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": true,
-        "@metamask/notification-services-controller>bignumber.js": true,
-        "@metamask/notification-services-controller>firebase": true,
         "@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
+        "@metamask/notification-services-controller>bignumber.js": true,
+        "@metamask/notification-services-controller>firebase": true,
         "loglevel": true,
         "uuid": true
       }
     },
-    "@metamask/notification-services-controller>@contentful/rich-text-html-renderer": {
-      "globals": {
-        "SuppressedError": true
-      }
-    },
-    "@metamask/notification-services-controller>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase": {
+    "@metamask/ethjs>@metamask/number-to-bn": {
       "packages": {
-        "@metamask/notification-services-controller>firebase>@firebase/app": true,
-        "@metamask/notification-services-controller>firebase>@firebase/messaging": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app": {
-      "globals": {
-        "FinalizationRegistry": true,
-        "console.warn": true
-      },
-      "packages": {
-        "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": {
-      "packages": {
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/logger": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/app>idb": {
-      "globals": {
-        "DOMException": true,
-        "IDBCursor": true,
-        "IDBDatabase": true,
-        "IDBIndex": true,
-        "IDBObjectStore": true,
-        "IDBRequest": true,
-        "IDBTransaction": true,
-        "indexedDB.deleteDatabase": true,
-        "indexedDB.open": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/installations": {
-      "globals": {
-        "BroadcastChannel": true,
-        "Headers": true,
-        "btoa": true,
-        "console.error": true,
-        "crypto": true,
-        "fetch": true,
-        "msCrypto": true,
-        "navigator.onLine": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/notification-services-controller>firebase>@firebase/app": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/messaging": {
-      "globals": {
-        "Headers": true,
-        "Notification.maxActions": true,
-        "Notification.permission": true,
-        "Notification.requestPermission": true,
-        "PushSubscription.prototype.hasOwnProperty": true,
-        "ServiceWorkerRegistration": true,
-        "URL": true,
-        "addEventListener": true,
-        "atob": true,
-        "btoa": true,
-        "clients.matchAll": true,
-        "clients.openWindow": true,
-        "console.warn": true,
-        "document": true,
-        "fetch": true,
-        "indexedDB": true,
-        "location.href": true,
-        "location.origin": true,
-        "navigator": true,
-        "origin.replace": true,
-        "registration.showNotification": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/notification-services-controller>firebase>@firebase/app": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>@firebase/component": true,
-        "@metamask/notification-services-controller>firebase>@firebase/app>idb": true,
-        "@metamask/notification-services-controller>firebase>@firebase/installations": true,
-        "@metamask/notification-services-controller>firebase>@firebase/util": true,
-        "@swc/helpers>tslib": true
-      }
-    },
-    "@metamask/notification-services-controller>firebase>@firebase/util": {
-      "globals": {
-        "atob": true,
-        "browser": true,
-        "btoa": true,
-        "chrome": true,
-        "console": true,
-        "document": true,
-        "indexedDB": true,
-        "navigator": true,
-        "process": true,
-        "self": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "process": true
+        "bn.js": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
       }
     },
     "@metamask/object-multiplex": {
@@ -2029,11 +1512,6 @@
       "packages": {
         "@metamask/object-multiplex>once": true,
         "readable-stream": true
-      }
-    },
-    "@metamask/object-multiplex>once": {
-      "packages": {
-        "@metamask/object-multiplex>once>wrappy": true
       }
     },
     "@metamask/obs-store": {
@@ -2050,37 +1528,17 @@
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/json-rpc-engine": true,
-        "@metamask/permission-controller>nanoid": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "deep-freeze-strict": true,
-        "immer": true
-      }
-    },
-    "@metamask/permission-controller>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+        "immer": true,
+        "@metamask/permission-controller>nanoid": true
       }
     },
     "@metamask/permission-log-controller": {
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/permission-log-controller>@metamask/utils": true
-      }
-    },
-    "@metamask/permission-log-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
       }
     },
     "@metamask/phishing-controller": {
@@ -2091,12 +1549,12 @@
         "fetch": true
       },
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
         "@noble/hashes": true,
-        "punycode": true,
-        "webpack-cli>fastest-levenshtein": true
+        "@ethereumjs/tx>ethereum-cryptography": true,
+        "webpack-cli>fastest-levenshtein": true,
+        "punycode": true
       }
     },
     "@metamask/polling-controller": {
@@ -2127,21 +1585,6 @@
         "readable-stream": true
       }
     },
-    "@metamask/post-message-stream>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
     "@metamask/ppom-validator": {
       "globals": {
         "URL": true,
@@ -2151,48 +1594,11 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
-        "@metamask/eth-query>json-rpc-random-id": true,
+        "await-semaphore": true,
+        "browserify>buffer": true,
         "@metamask/ppom-validator>crypto-js": true,
         "@metamask/ppom-validator>elliptic": true,
-        "await-semaphore": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/ppom-validator>crypto-js": {
-      "globals": {
-        "crypto": true,
-        "define": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>brorand": true,
-        "@metamask/ppom-validator>elliptic>hmac-drbg": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true,
-        "bn.js": true,
-        "ethers>@ethersproject/sha2>hash.js": true,
-        "pumpify>inherits": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic>brorand": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/ppom-validator>elliptic>hmac-drbg": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true,
-        "ethers>@ethersproject/sha2>hash.js": true
+        "@metamask/eth-query>json-rpc-random-id": true
       }
     },
     "@metamask/preferences-controller": {
@@ -2221,55 +1627,10 @@
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
         "@metamask/profile-sync-controller>@noble/ciphers": true,
-        "@metamask/profile-sync-controller>siwe": true,
         "@noble/hashes": true,
         "browserify>buffer": true,
-        "loglevel": true
-      }
-    },
-    "@metamask/profile-sync-controller>@noble/ciphers": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>valid-url": true,
-        "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": true,
-        "@metamask/profile-sync-controller>siwe>@stablelib/random": true,
-        "ethers": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": {
-      "globals": {
-        "console.error": true,
-        "console.log": true
-      },
-      "packages": {
-        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@stablelib/random": {
-      "globals": {
-        "crypto": true,
-        "msCrypto": true
-      },
-      "packages": {
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": true,
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true,
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": {
-      "packages": {
-        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary>@stablelib/int": true
+        "loglevel": true,
+        "@metamask/profile-sync-controller>siwe": true
       }
     },
     "@metamask/queued-request-controller": {
@@ -2291,50 +1652,6 @@
         "@metamask/rate-limit-controller>@metamask/utils": true
       }
     },
-    "@metamask/rate-limit-controller>@metamask/base-controller": {
-      "globals": {
-        "setTimeout": true
-      },
-      "packages": {
-        "immer": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/rpc-errors": {
-      "packages": {
-        "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": true,
-        "@metamask/rpc-errors>fast-safe-stringify": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
-      }
-    },
     "@metamask/remote-feature-flag-controller": {
       "packages": {
         "@metamask/base-controller": true,
@@ -2343,18 +1660,14 @@
     },
     "@metamask/rpc-errors": {
       "packages": {
-        "@metamask/rpc-errors>fast-safe-stringify": true,
-        "@metamask/utils": true
+        "@metamask/utils": true,
+        "@metamask/rpc-errors>fast-safe-stringify": true
       }
     },
-    "@metamask/rpc-methods-flask>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/rpc-methods>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
+    "@metamask/rate-limit-controller>@metamask/rpc-errors": {
+      "packages": {
+        "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": true,
+        "@metamask/rpc-errors>fast-safe-stringify": true
       }
     },
     "@metamask/safe-event-emitter": {
@@ -2374,12 +1687,6 @@
         "@metamask/utils>@scure/base": true
       }
     },
-    "@metamask/scure-bip39>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
-      }
-    },
     "@metamask/selected-network-controller": {
       "packages": {
         "@metamask/base-controller": true,
@@ -2393,40 +1700,14 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/signature-controller>@metamask/eth-sig-util": true,
         "@metamask/keyring-controller": true,
         "@metamask/logging-controller": true,
-        "@metamask/message-manager>jsonschema": true,
-        "@metamask/signature-controller>@metamask/eth-sig-util": true,
         "@metamask/utils": true,
         "browserify>buffer": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/signature-controller>@metamask/eth-sig-util": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/abi-utils": true,
-        "@metamask/eth-sig-util>tweetnacl": true,
-        "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      },
-      "packages": {
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
-        "@noble/hashes": true,
-        "browserify>buffer": true,
-        "nock>debug": true,
-        "semver": true
+        "webpack>events": true,
+        "@metamask/message-manager>jsonschema": true,
+        "uuid": true
       }
     },
     "@metamask/smart-transactions-controller": {
@@ -2439,47 +1720,17 @@
         "setInterval": true
       },
       "packages": {
+        "@metamask/smart-transactions-controller>@ethereumjs/tx": true,
+        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
         "@ethersproject/bytes": true,
         "@metamask/controller-utils": true,
         "@metamask/eth-query": true,
         "@metamask/polling-controller": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/tx": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
-        "@metamask/smart-transactions-controller>bignumber.js": true,
         "@metamask/transaction-controller": true,
+        "@metamask/smart-transactions-controller>bignumber.js": true,
         "browserify>buffer": true,
         "fast-json-patch": true,
         "lodash": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@ethereumjs/tx": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/smart-transactions-controller>@ethereumjs/util": true,
-        "@trezor/connect-web>@trezor/connect>@ethereumjs/common": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/smart-transactions-controller>@metamask/controllers>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/smart-transactions-controller>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
       }
     },
     "@metamask/snaps-controllers": {
@@ -2499,72 +1750,22 @@
         "@metamask/permission-controller": true,
         "@metamask/post-message-stream": true,
         "@metamask/rpc-errors": true,
-        "@metamask/snaps-controllers>@xstate/fsm": true,
-        "@metamask/snaps-controllers>concat-stream": true,
-        "@metamask/snaps-controllers>get-npm-tarball-url": true,
-        "@metamask/snaps-controllers>nanoid": true,
-        "@metamask/snaps-controllers>readable-web-to-node-stream": true,
-        "@metamask/snaps-controllers>tar-stream": true,
+        "@metamask/snaps-utils>@metamask/snaps-registry": true,
         "@metamask/snaps-rpc-methods": true,
         "@metamask/snaps-sdk": true,
         "@metamask/snaps-utils": true,
-        "@metamask/snaps-utils>@metamask/snaps-registry": true,
         "@metamask/utils": true,
+        "@metamask/snaps-controllers>@xstate/fsm": true,
         "browserify>browserify-zlib": true,
+        "@metamask/snaps-controllers>concat-stream": true,
         "eslint>fast-deep-equal": true,
+        "@metamask/snaps-controllers>get-npm-tarball-url": true,
         "immer": true,
+        "@metamask/snaps-controllers>nanoid": true,
         "readable-stream": true,
-        "semver": true
-      }
-    },
-    "@metamask/snaps-controllers-flask>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/snaps-controllers>concat-stream": {
-      "packages": {
-        "browserify>buffer": true,
-        "browserify>concat-stream>typedarray": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
-        "terser>source-map-support>buffer-from": true
-      }
-    },
-    "@metamask/snaps-controllers>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "@metamask/snaps-controllers>readable-web-to-node-stream": {
-      "packages": {
-        "readable-stream": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream": {
-      "packages": {
-        "@metamask/snaps-controllers>tar-stream>b4a": true,
-        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
-        "@metamask/snaps-controllers>tar-stream>streamx": true,
-        "browserify>browser-resolve": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>b4a": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>streamx": {
-      "packages": {
-        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
-        "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
-      "globals": {
-        "queueMicrotask": true
+        "@metamask/snaps-controllers>readable-web-to-node-stream": true,
+        "semver": true,
+        "@metamask/snaps-controllers>tar-stream": true
       }
     },
     "@metamask/snaps-execution-environments": {
@@ -2577,15 +1778,23 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/snaps-utils>@metamask/snaps-registry": {
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@noble/hashes": true
+      }
+    },
     "@metamask/snaps-rpc-methods": {
       "packages": {
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/permission-controller": true,
         "@metamask/rpc-errors": true,
         "@metamask/snaps-sdk": true,
-        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
-        "@metamask/utils": true,
         "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
         "@noble/hashes": true
       }
     },
@@ -2595,20 +1804,8 @@
       },
       "packages": {
         "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true
-      }
-    },
-    "@metamask/snaps-sdk>@metamask/key-tree": {
-      "globals": {
-        "crypto.subtle": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/scure-bip39": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@scure/base": true,
-        "@noble/hashes": true
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true
       }
     },
     "@metamask/snaps-utils": {
@@ -2627,74 +1824,23 @@
         "fetch": true
       },
       "packages": {
+        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/permission-controller": true,
         "@metamask/rpc-errors": true,
-        "@metamask/snaps-sdk": true,
-        "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils>@metamask/slip44": true,
+        "@metamask/snaps-sdk": true,
+        "@metamask/utils>@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "chalk": true,
         "@metamask/snaps-utils>cron-parser": true,
         "@metamask/snaps-utils>fast-json-stable-stringify": true,
         "@metamask/snaps-utils>fast-xml-parser": true,
         "@metamask/snaps-utils>marked": true,
         "@metamask/snaps-utils>rfdc": true,
-        "@metamask/snaps-utils>validate-npm-package-name": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@noble/hashes": true,
-        "chalk": true,
-        "semver": true
-      }
-    },
-    "@metamask/snaps-utils>@metamask/snaps-registry": {
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
-        "@noble/hashes": true
-      }
-    },
-    "@metamask/snaps-utils>cron-parser": {
-      "packages": {
-        "browserify>browser-resolve": true,
-        "luxon": true
-      }
-    },
-    "@metamask/snaps-utils>fast-xml-parser": {
-      "globals": {
-        "entityName": true,
-        "val": true
-      },
-      "packages": {
-        "@metamask/snaps-utils>fast-xml-parser>strnum": true
-      }
-    },
-    "@metamask/snaps-utils>marked": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true,
-        "define": true
-      }
-    },
-    "@metamask/snaps-utils>rfdc": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/snaps-utils>validate-npm-package-name": {
-      "packages": {
-        "@metamask/snaps-utils>validate-npm-package-name>builtins": true
-      }
-    },
-    "@metamask/snaps-utils>validate-npm-package-name>builtins": {
-      "packages": {
-        "process": true,
-        "semver": true
-      }
-    },
-    "@metamask/test-bundler>@ethersproject/networks": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
+        "semver": true,
+        "@metamask/snaps-utils>validate-npm-package-name": true
       }
     },
     "@metamask/transaction-controller": {
@@ -2705,6 +1851,7 @@
         "setTimeout": true
       },
       "packages": {
+        "@metamask/transaction-controller>@ethereumjs/common": true,
         "@ethereumjs/tx": true,
         "@ethereumjs/tx>@ethereumjs/util": true,
         "@ethersproject/abi": true,
@@ -2715,43 +1862,18 @@
         "@metamask/eth-query": true,
         "@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/name-controller>async-mutex": true,
         "@metamask/network-controller": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/transaction-controller>@ethereumjs/common": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true,
+        "@metamask/name-controller>async-mutex": true,
         "bn.js": true,
         "browserify>buffer": true,
         "eth-method-registry": true,
+        "webpack>events": true,
         "fast-json-patch": true,
         "lodash": true,
-        "uuid": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/transaction-controller>@ethereumjs/common": {
-      "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethereumjs/tx>@ethereumjs/util": true,
-        "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/nonce-tracker": {
-      "packages": {
-        "@ethersproject/providers": true,
-        "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": true,
-        "browserify>assert": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
+        "uuid": true
       }
     },
     "@metamask/user-operation-controller": {
@@ -2765,13 +1887,13 @@
         "@metamask/gas-fee-controller": true,
         "@metamask/polling-controller": true,
         "@metamask/rpc-errors": true,
+        "@metamask/utils>@metamask/superstruct": true,
         "@metamask/transaction-controller": true,
         "@metamask/utils": true,
-        "@metamask/utils>@metamask/superstruct": true,
         "bn.js": true,
+        "webpack>events": true,
         "lodash": true,
-        "uuid": true,
-        "webpack>events": true
+        "uuid": true
       }
     },
     "@metamask/utils": {
@@ -2781,63 +1903,336 @@
       },
       "packages": {
         "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
         "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
         "browserify>buffer": true,
         "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
         "semver": true
       }
     },
-    "@metamask/utils>@scure/base": {
+    "@metamask/abi-utils>@metamask/utils": {
       "globals": {
         "TextDecoder": true,
         "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/browser-passworder>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-token-tracker>@metamask/eth-block-tracker>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-block-tracker>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-hd-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/network-controller>@metamask/eth-json-rpc-infura>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-json-rpc-middleware>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/signature-controller>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-controller>@metamask/eth-simple-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/eth-snap-keyring>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/keyring-api>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/name-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/permission-log-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
+      }
+    },
+    "@metamask/rate-limit-controller>@metamask/rpc-errors>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@metamask/superstruct": true,
+        "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
+        "semver": true
       }
     },
     "@ngraveio/bc-ur": {
       "packages": {
         "@ngraveio/bc-ur>@keystonehq/alias-sampling": true,
+        "browserify>assert": true,
         "@ngraveio/bc-ur>bignumber.js": true,
+        "browserify>buffer": true,
         "@ngraveio/bc-ur>cbor-sync": true,
         "@ngraveio/bc-ur>crc": true,
         "@ngraveio/bc-ur>jsbi": true,
-        "addons-linter>sha.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true
+        "addons-linter>sha.js": true
       }
     },
-    "@ngraveio/bc-ur>assert>object-is": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true
-      }
-    },
-    "@ngraveio/bc-ur>bignumber.js": {
+    "@metamask/profile-sync-controller>@noble/ciphers": {
       "globals": {
-        "crypto": true,
-        "define": true
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "crypto": true
       }
     },
-    "@ngraveio/bc-ur>cbor-sync": {
+    "@ethereumjs/tx>ethereum-cryptography>@noble/curves": {
       "globals": {
-        "define": true
+        "TextEncoder": true
       },
       "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ngraveio/bc-ur>crc": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "@ngraveio/bc-ur>jsbi": {
-      "globals": {
-        "define": true
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": true
       }
     },
     "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/scure-bip39>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@noble/curves>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": {
       "globals": {
         "TextEncoder": true,
         "crypto": true
@@ -2854,6 +2249,20 @@
         "navigator.userAgent": true
       }
     },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": {
+      "globals": {
+        "console.log": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": {
+      "globals": {
+        "XMLHttpRequest": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true
+      }
+    },
     "@reduxjs/toolkit": {
       "globals": {
         "AbortController": true,
@@ -2865,42 +2274,46 @@
         "setTimeout": true
       },
       "packages": {
-        "@reduxjs/toolkit>reselect": true,
         "immer": true,
         "process": true,
         "redux": true,
-        "redux-thunk": true
+        "redux-thunk": true,
+        "@reduxjs/toolkit>reselect": true
+      }
+    },
+    "react-router-dom-v5-compat>@remix-run/router": {
+      "globals": {
+        "AbortController": true,
+        "DOMException": true,
+        "FormData": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "console": true,
+        "document.defaultView": true
+      }
+    },
+    "@metamask/utils>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
+      "packages": {
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32>@noble/hashes": true,
+        "@metamask/utils>@scure/base": true
       }
     },
     "@segment/loosely-validate-event": {
       "packages": {
-        "@segment/loosely-validate-event>component-type": true,
-        "@segment/loosely-validate-event>join-component": true,
         "browserify>assert": true,
-        "browserify>buffer": true
-      }
-    },
-    "@sentry/browser": {
-      "globals": {
-        "PerformanceObserver.supportedEntryTypes": true,
-        "Request": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_DEBUG__": true,
-        "__SENTRY_RELEASE__": true,
-        "addEventListener": true,
-        "console.error": true,
-        "indexedDB.open": true,
-        "performance.timeOrigin": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@sentry/browser>@sentry-internal/browser-utils": true,
-        "@sentry/browser>@sentry-internal/feedback": true,
-        "@sentry/browser>@sentry-internal/replay": true,
-        "@sentry/browser>@sentry-internal/replay-canvas": true,
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "browserify>buffer": true,
+        "@segment/loosely-validate-event>component-type": true,
+        "@segment/loosely-validate-event>join-component": true
       }
     },
     "@sentry/browser>@sentry-internal/browser-utils": {
@@ -2933,6 +2346,25 @@
         "isSecureContext": true,
         "requestAnimationFrame": true,
         "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/replay-canvas": {
+      "globals": {
+        "Blob": true,
+        "HTMLCanvasElement": true,
+        "HTMLImageElement": true,
+        "ImageData": true,
+        "URL.createObjectURL": true,
+        "WeakRef": true,
+        "Worker": true,
+        "cancelAnimationFrame": true,
+        "console.error": true,
+        "createImageBitmap": true,
+        "document": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2988,21 +2420,25 @@
         "@sentry/utils": true
       }
     },
-    "@sentry/browser>@sentry-internal/replay-canvas": {
+    "@sentry/browser": {
       "globals": {
-        "Blob": true,
-        "HTMLCanvasElement": true,
-        "HTMLImageElement": true,
-        "ImageData": true,
-        "URL.createObjectURL": true,
-        "WeakRef": true,
-        "Worker": true,
-        "cancelAnimationFrame": true,
+        "PerformanceObserver.supportedEntryTypes": true,
+        "Request": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_RELEASE__": true,
+        "addEventListener": true,
         "console.error": true,
-        "createImageBitmap": true,
-        "document": true
+        "indexedDB.open": true,
+        "performance.timeOrigin": true,
+        "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/browser-utils": true,
+        "@sentry/browser>@sentry-internal/feedback": true,
+        "@sentry/browser>@sentry-internal/replay-canvas": true,
+        "@sentry/browser>@sentry-internal/replay": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
@@ -3098,20 +2534,61 @@
         "btoa": true
       }
     },
-    "@storybook/addon-docs>remark-external-links>mdast-util-definitions": {
-      "packages": {
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "@storybook/addon-knobs>qs": {
-      "packages": {
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "@swc/helpers>tslib": {
+    "@metamask/controller-utils>@spruceid/siwe-parser": {
       "globals": {
-        "SuppressedError": true,
-        "define": true
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": {
+      "globals": {
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": {
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary>@stablelib/int": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe>@stablelib/random": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/binary": true,
+        "@metamask/profile-sync-controller>siwe>@stablelib/random>@stablelib/wipe": true,
+        "browserify>browser-resolve": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect-common": {
+      "globals": {
+        "console.warn": true,
+        "localStorage.getItem": true,
+        "localStorage.setItem": true,
+        "navigator": true,
+        "setTimeout": true,
+        "window": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": true,
+        "@trezor/connect-web>@trezor/utils": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/eth-trezor-keyring>@trezor/connect-plugin-ethereum": {
+      "packages": {
+        "@metamask/eth-sig-util": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web": {
@@ -3138,35 +2615,20 @@
         "setTimeout": true
       },
       "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect": true,
         "@trezor/connect-web>@trezor/connect-common": true,
+        "@trezor/connect-web>@trezor/connect": true,
         "@trezor/connect-web>@trezor/utils": true,
-        "webpack>events": true
+        "webpack>events": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect": {
       "packages": {
-        "@swc/helpers>tslib": true,
         "@trezor/connect-web>@trezor/connect>@trezor/protobuf": true,
         "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": true,
         "@trezor/connect-web>@trezor/connect>@trezor/transport": true,
-        "@trezor/connect-web>@trezor/utils": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect-common": {
-      "globals": {
-        "console.warn": true,
-        "localStorage.getItem": true,
-        "localStorage.setItem": true,
-        "navigator": true,
-        "setTimeout": true,
-        "window": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": true,
-        "@trezor/connect-web>@trezor/utils": true
+        "@trezor/connect-web>@trezor/utils": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils": {
@@ -3182,71 +2644,17 @@
         "screen.width": true
       },
       "packages": {
+        "process": true,
         "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": true,
-        "process": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@ethereumjs/common": {
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": true,
-        "webpack>events": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@ethereumjs/common>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
+        "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": true
       }
     },
     "@trezor/connect-web>@trezor/connect>@trezor/protobuf": {
       "packages": {
-        "@swc/helpers>tslib": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": true,
         "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": true,
-        "browserify>buffer": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": {
-      "globals": {
-        "process": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/base64": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/eventemitter": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/float": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/path": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/pool": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/utf8": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": {
-      "globals": {
-        "console.log": true
-      }
-    },
-    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": {
-      "globals": {
-        "XMLHttpRequest": true
-      },
-      "packages": {
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
-        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true
+        "browserify>buffer": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@trezor/connect-web>@trezor/connect>@trezor/schema-utils": {
@@ -3273,16 +2681,10 @@
         "setTimeout": true
       },
       "packages": {
-        "@swc/helpers>tslib": true,
         "@trezor/connect-web>@trezor/utils>bignumber.js": true,
         "browserify>buffer": true,
-        "webpack>events": true
-      }
-    },
-    "@trezor/connect-web>@trezor/utils>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
+        "webpack>events": true,
+        "@swc/helpers>tslib": true
       }
     },
     "@welldone-software/why-did-you-render": {
@@ -3335,21 +2737,155 @@
         "@zxing/library>ts-custom-error": true
       }
     },
-    "addons-linter>sha.js": {
+    "extension-port-stream>readable-stream>abort-controller": {
+      "globals": {
+        "AbortController": true
+      }
+    },
+    "currency-formatter>accounting": {
+      "globals": {
+        "define": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets>aes-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>aes-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "chalk>ansi-styles": {
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
+        "chalk>ansi-styles>color-convert": true
+      }
+    },
+    "@metamask/controller-utils>@spruceid/siwe-parser>apg-js": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>array-buffer-byte-length": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>es-abstract>is-array-buffer": true
+      }
+    },
+    "crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "browserify>vm-browserify": true
+      }
+    },
+    "browserify>assert": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "react>object-assign": true,
+        "browserify>assert>util": true
+      }
+    },
+    "@metamask/name-controller>async-mutex": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/nonce-tracker>async-mutex": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>available-typed-arrays": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>typed-array-length>possible-typed-array-names": true
       }
     },
     "await-semaphore": {
       "packages": {
-        "browserify>timers-browserify": true,
+        "process": true,
+        "browserify>timers-browserify": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/domain-service>axios": {
+      "globals": {
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
         "process": true
       }
     },
-    "axios>form-data": {
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>axios": {
       "globals": {
-        "FormData": true
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
+        "process": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>axios": {
+      "globals": {
+        "Blob": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "axios>form-data": true,
+        "process": true
+      }
+    },
+    "@metamask/snaps-controllers>tar-stream>b4a": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>multibase>base-x": {
+      "packages": {
+        "koa>content-disposition>safe-buffer": true
       }
     },
     "base32-encode": {
@@ -3358,6 +2894,48 @@
       }
     },
     "bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/notification-services-controller>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@metamask/smart-transactions-controller>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@ngraveio/bc-ur>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@trezor/connect-web>@trezor/utils>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>bignumber.js": {
       "globals": {
         "crypto": true,
         "define": true
@@ -3376,123 +2954,107 @@
         "browserify>browser-resolve": true
       }
     },
+    "eth-lattice-keyring>gridplus-sdk>borc": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": true,
+        "browserify>buffer": true,
+        "buffer>ieee754": true,
+        "eth-lattice-keyring>gridplus-sdk>borc>iso-url": true
+      }
+    },
     "bowser": {
       "globals": {
         "define": true
       }
     },
-    "browserify>assert": {
+    "@metamask/ppom-validator>elliptic>brorand": {
       "globals": {
-        "Buffer": true
+        "crypto": true,
+        "msCrypto": true
       },
       "packages": {
-        "browserify>assert>util": true,
-        "react>object-assign": true
+        "browserify>browser-resolve": true
       }
     },
-    "browserify>assert>util": {
-      "globals": {
-        "console.error": true,
-        "console.log": true,
-        "console.trace": true,
-        "process": true
-      },
+    "ethereumjs-util>ethereum-cryptography>browserify-aes": {
       "packages": {
-        "browserify>assert>util>inherits": true,
-        "process": true
+        "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "crypto-browserify>browserify-cipher": {
+      "packages": {
+        "ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "crypto-browserify>browserify-cipher>browserify-des": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>browserify-des": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "crypto-browserify>browserify-cipher>browserify-des>des.js": true,
+        "pumpify>inherits": true
+      }
+    },
+    "crypto-browserify>public-encrypt>browserify-rsa": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "crypto-browserify>browserify-sign": {
+      "packages": {
+        "bn.js": true,
+        "crypto-browserify>public-encrypt>browserify-rsa": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "crypto-browserify>create-hmac": true,
+        "@metamask/ppom-validator>elliptic": true,
+        "pumpify>inherits": true,
+        "crypto-browserify>public-encrypt>parse-asn1": true,
+        "stream-browserify": true
       }
     },
     "browserify>browserify-zlib": {
       "packages": {
         "browserify>assert": true,
-        "browserify>browserify-zlib>pako": true,
         "browserify>buffer": true,
-        "browserify>util": true,
+        "browserify>browserify-zlib>pako": true,
         "process": true,
-        "stream-browserify": true
+        "stream-browserify": true,
+        "browserify>util": true
       }
     },
-    "browserify>buffer": {
-      "globals": {
-        "console": true
-      },
+    "ethereumjs-util>ethereum-cryptography>bs58check>bs58": {
       "packages": {
-        "base64-js": true,
-        "buffer>ieee754": true
+        "@ensdomains/content-hash>multihashes>multibase>base-x": true
       }
     },
-    "browserify>punycode": {
-      "globals": {
-        "define": true
-      }
-    },
-    "browserify>string_decoder": {
+    "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": {
       "packages": {
+        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58>base-x": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>bs58check": {
+      "packages": {
+        "ethereumjs-util>ethereum-cryptography>bs58check>bs58": true,
+        "ethereumjs-util>create-hash": true,
         "koa>content-disposition>safe-buffer": true
       }
     },
-    "browserify>timers-browserify": {
-      "globals": {
-        "clearInterval": true,
-        "clearTimeout": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
+    "eth-lattice-keyring>gridplus-sdk>bs58check": {
       "packages": {
-        "process": true
-      }
-    },
-    "browserify>url": {
-      "packages": {
-        "@storybook/addon-knobs>qs": true,
-        "browserify>punycode": true
-      }
-    },
-    "browserify>util": {
-      "globals": {
-        "console.error": true,
-        "console.log": true,
-        "console.trace": true
-      },
-      "packages": {
-        "browserify>util>is-arguments": true,
-        "browserify>util>is-typed-array": true,
-        "browserify>util>which-typed-array": true,
-        "koa>is-generator-function": true,
-        "process": true,
-        "pumpify>inherits": true
-      }
-    },
-    "browserify>util>is-arguments": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "browserify>util>is-typed-array": {
-      "packages": {
-        "browserify>util>which-typed-array": true
-      }
-    },
-    "browserify>util>which-typed-array": {
-      "packages": {
-        "browserify>util>which-typed-array>for-each": true,
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>available-typed-arrays": true,
-        "string.prototype.matchall>es-abstract>gopd": true
-      }
-    },
-    "browserify>util>which-typed-array>for-each": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>is-callable": true
-      }
-    },
-    "browserify>vm-browserify": {
-      "globals": {
-        "document.body.appendChild": true,
-        "document.body.removeChild": true,
-        "document.createElement": true
+        "@noble/hashes": true,
+        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": true
       }
     },
     "buffer": {
@@ -3504,20 +3066,52 @@
         "buffer>ieee754": true
       }
     },
+    "terser>source-map-support>buffer-from": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "browserify>buffer": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "base64-js": true,
+        "buffer>ieee754": true
+      }
+    },
+    "@metamask/snaps-utils>validate-npm-package-name>builtins": {
+      "packages": {
+        "process": true,
+        "semver": true
+      }
+    },
+    "string.prototype.matchall>call-bind": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>call-bind>set-function-length": true
+      }
+    },
+    "@ngraveio/bc-ur>cbor-sync": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
     "chalk": {
       "packages": {
         "chalk>ansi-styles": true,
         "chalk>supports-color": true
-      }
-    },
-    "chalk>ansi-styles": {
-      "packages": {
-        "chalk>ansi-styles>color-convert": true
-      }
-    },
-    "chalk>ansi-styles>color-convert": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
       }
     },
     "chart.js": {
@@ -3541,15 +3135,31 @@
         "chart.js>@kurkle/color": true
       }
     },
-    "chart.js>@kurkle/color": {
-      "globals": {
-        "define": true
+    "@ensdomains/content-hash>cids": {
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase": true,
+        "@ensdomains/content-hash>multicodec": true,
+        "@ensdomains/content-hash>cids>multihashes": true,
+        "@ensdomains/content-hash>cids>uint8arrays": true
+      }
+    },
+    "ethereumjs-util>create-hash>cipher-base": {
+      "packages": {
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true,
+        "stream-browserify": true,
+        "browserify>string_decoder": true
       }
     },
     "classnames": {
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "@metamask/jazzicon>color>clone": {
+      "packages": {
+        "browserify>buffer": true
       }
     },
     "cockatiel": {
@@ -3563,6 +3173,37 @@
       },
       "packages": {
         "process": true
+      }
+    },
+    "chalk>ansi-styles>color-convert": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-convert": {
+      "packages": {
+        "@metamask/jazzicon>color>color-convert>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-string": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color": {
+      "packages": {
+        "@metamask/jazzicon>color>clone": true,
+        "@metamask/jazzicon>color>color-convert": true,
+        "@metamask/jazzicon>color>color-string": true
+      }
+    },
+    "@metamask/snaps-controllers>concat-stream": {
+      "packages": {
+        "terser>source-map-support>buffer-from": true,
+        "browserify>buffer": true,
+        "pumpify>inherits": true,
+        "readable-stream": true,
+        "browserify>concat-stream>typedarray": true
       }
     },
     "copy-to-clipboard": {
@@ -3583,10 +3224,47 @@
         "copy-to-clipboard>toggle-selection": true
       }
     },
-    "copy-to-clipboard>toggle-selection": {
+    "@ethereumjs/tx>@ethereumjs/common>crc-32": {
       "globals": {
-        "document.activeElement": true,
-        "document.getSelection": true
+        "DO_NOT_EXPORT_CRC": true,
+        "define": true
+      }
+    },
+    "@ngraveio/bc-ur>crc": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "crypto-browserify>create-ecdh": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "ethereumjs-util>create-hash": {
+      "packages": {
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "pumpify>inherits": true,
+        "ethereumjs-util>create-hash>md5.js": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "crypto-browserify>create-hmac": {
+      "packages": {
+        "ethereumjs-util>create-hash>cipher-base": true,
+        "ethereumjs-util>create-hash": true,
+        "pumpify>inherits": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "@metamask/snaps-utils>cron-parser": {
+      "packages": {
+        "browserify>browser-resolve": true,
+        "luxon": true
       }
     },
     "crypto-browserify": {
@@ -3594,156 +3272,44 @@
         "crypto-browserify>browserify-cipher": true,
         "crypto-browserify>browserify-sign": true,
         "crypto-browserify>create-ecdh": true,
+        "ethereumjs-util>create-hash": true,
         "crypto-browserify>create-hmac": true,
         "crypto-browserify>diffie-hellman": true,
         "crypto-browserify>pbkdf2": true,
         "crypto-browserify>public-encrypt": true,
         "crypto-browserify>randombytes": true,
-        "crypto-browserify>randomfill": true,
-        "ethereumjs-util>create-hash": true
+        "crypto-browserify>randomfill": true
       }
     },
-    "crypto-browserify>browserify-cipher": {
-      "packages": {
-        "crypto-browserify>browserify-cipher>browserify-des": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>browserify-des": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>browserify-des>des.js": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>browserify-des>des.js": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>browserify-cipher>evp_bytestokey": {
-      "packages": {
-        "ethereumjs-util>create-hash>md5.js": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "crypto-browserify>browserify-sign": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>create-hmac": true,
-        "crypto-browserify>public-encrypt>browserify-rsa": true,
-        "crypto-browserify>public-encrypt>parse-asn1": true,
-        "ethereumjs-util>create-hash": true,
-        "pumpify>inherits": true,
-        "stream-browserify": true
-      }
-    },
-    "crypto-browserify>create-ecdh": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "crypto-browserify>create-hmac": {
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>diffie-hellman": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>diffie-hellman>miller-rabin": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "crypto-browserify>diffie-hellman>miller-rabin": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>brorand": true,
-        "bn.js": true
-      }
-    },
-    "crypto-browserify>pbkdf2": {
+    "@metamask/ppom-validator>crypto-js": {
       "globals": {
         "crypto": true,
-        "process": true,
-        "queueMicrotask": true,
-        "setImmediate": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
-      }
-    },
-    "crypto-browserify>public-encrypt": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>public-encrypt>browserify-rsa": true,
-        "crypto-browserify>public-encrypt>parse-asn1": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>create-hash": true
-      }
-    },
-    "crypto-browserify>public-encrypt>browserify-rsa": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true
-      }
-    },
-    "crypto-browserify>public-encrypt>parse-asn1": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "crypto-browserify>pbkdf2": true,
-        "crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes": true
-      }
-    },
-    "crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "bn.js": true,
-        "browserify>buffer": true,
-        "browserify>vm-browserify": true,
-        "pumpify>inherits": true
-      }
-    },
-    "crypto-browserify>randombytes": {
-      "globals": {
-        "crypto": true,
+        "define": true,
         "msCrypto": true
       },
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
+        "browserify>browser-resolve": true
       }
     },
-    "crypto-browserify>randomfill": {
+    "react-beautiful-dnd>css-box-model": {
       "globals": {
-        "crypto": true,
-        "msCrypto": true
+        "getComputedStyle": true,
+        "pageXOffset": true,
+        "pageYOffset": true
       },
       "packages": {
-        "crypto-browserify>randombytes": true,
-        "koa>content-disposition>safe-buffer": true,
-        "process": true
+        "react-router-dom>tiny-invariant": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": {
+      "globals": {
+        "document.createElement": true,
+        "document.documentElement": true,
+        "getComputedStyle": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true
       }
     },
     "currency-formatter": {
@@ -3751,16 +3317,6 @@
         "currency-formatter>accounting": true,
         "currency-formatter>locale-currency": true,
         "react>object-assign": true
-      }
-    },
-    "currency-formatter>accounting": {
-      "globals": {
-        "define": true
-      }
-    },
-    "currency-formatter>locale-currency": {
-      "globals": {
-        "countryCode": true
       }
     },
     "debounce-stream": {
@@ -3776,35 +3332,107 @@
         "setTimeout": true
       }
     },
+    "nock>debug": {
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "nock>debug>ms": true,
+        "process": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>array-buffer-byte-length": true,
+        "string.prototype.matchall>call-bind": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "browserify>util>is-arguments": true,
+        "string.prototype.matchall>es-abstract>is-array-buffer": true,
+        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
+        "string.prototype.matchall>es-abstract>is-regex": true,
+        "string.prototype.matchall>es-abstract>is-shared-array-buffer": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
+        "@ngraveio/bc-ur>assert>object-is": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
+        "gulp>vinyl-fs>object.assign": true,
+        "string.prototype.matchall>regexp.prototype.flags": true,
+        "string.prototype.matchall>side-channel": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection": true,
+        "browserify>util>which-typed-array": true
+      }
+    },
+    "string.prototype.matchall>define-properties>define-data-property": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>gopd": true
+      }
+    },
+    "string.prototype.matchall>define-properties": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>browserify-des>des.js": {
+      "packages": {
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true
+      }
+    },
+    "crypto-browserify>diffie-hellman": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "crypto-browserify>diffie-hellman>miller-rabin": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "@material-ui/core>react-transition-group>dom-helpers": {
+      "packages": {
+        "@babel/runtime": true
+      }
+    },
     "debounce-stream>duplexer": {
       "packages": {
         "stream-browserify": true
       }
     },
-    "debounce-stream>through": {
+    "@metamask/ppom-validator>elliptic": {
       "packages": {
+        "bn.js": true,
+        "@metamask/ppom-validator>elliptic>brorand": true,
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "@metamask/ppom-validator>elliptic>hmac-drbg": true,
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "string.prototype.matchall>call-bind>es-define-property": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>es-get-iterator": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>has-symbols": true,
+        "browserify>util>is-arguments": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
         "process": true,
-        "stream-browserify": true
-      }
-    },
-    "depcheck>@vue/compiler-sfc>postcss>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "depcheck>is-core-module>hasown": {
-      "packages": {
-        "browserify>has>function-bind": true
-      }
-    },
-    "dependency-tree>precinct>detective-postcss>postcss>nanoid": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "eslint-plugin-react>array-includes>is-string": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": true
       }
     },
     "eth-ens-namehash": {
@@ -3812,22 +3440,9 @@
         "name": "write"
       },
       "packages": {
-        "@metamask/ethjs>js-sha3": true,
         "browserify>buffer": true,
-        "eth-ens-namehash>idna-uts46-hx": true
-      }
-    },
-    "eth-ens-namehash>idna-uts46-hx": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "browserify>punycode": true
-      }
-    },
-    "eth-keyring-controller>@metamask/browser-passworder": {
-      "globals": {
-        "crypto": true
+        "eth-ens-namehash>idna-uts46-hx": true,
+        "@metamask/ethjs>js-sha3": true
       }
     },
     "eth-lattice-keyring": {
@@ -3845,9 +3460,246 @@
         "bn.js": true,
         "browserify>buffer": true,
         "crypto-browserify": true,
+        "webpack>events": true,
         "eth-lattice-keyring>gridplus-sdk": true,
-        "eth-lattice-keyring>rlp": true,
-        "webpack>events": true
+        "eth-lattice-keyring>rlp": true
+      }
+    },
+    "eth-method-registry": {
+      "packages": {
+        "@metamask/ethjs-contract": true,
+        "@metamask/ethjs-query": true
+      }
+    },
+    "@ethereumjs/tx>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true
+      },
+      "packages": {
+        "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
+        "@ethereumjs/tx>ethereum-cryptography>@noble/hashes": true,
+        "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>ethereum-cryptography>keccak": true,
+        "crypto-browserify>randombytes": true,
+        "ganache>secp256k1": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": {
+      "packages": {
+        "browserify>assert": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "browserify>buffer": true,
+        "crypto-browserify>create-hmac": true,
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "ethereumjs-util>ethereum-cryptography>keccak": true,
+        "crypto-browserify>randombytes": true,
+        "koa>content-disposition>safe-buffer": true,
+        "ganache>secp256k1": true
+      }
+    },
+    "ethereumjs-util": {
+      "packages": {
+        "browserify>assert": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "ethereumjs-util>ethereum-cryptography": true,
+        "browserify>insert-module-globals>is-buffer": true,
+        "ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": {
+      "packages": {
+        "browserify>assert": true,
+        "bn.js": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
+        "browserify>insert-module-globals>is-buffer": true,
+        "ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/keyring-controller>ethereumjs-wallet": {
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>aes-js": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "browserify>buffer": true,
+        "crypto-browserify": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>ethereumjs-util": true,
+        "crypto-browserify>randombytes": true,
+        "ethers>@ethersproject/json-wallets>scrypt-js": true,
+        "@metamask/keyring-controller>ethereumjs-wallet>utf8": true,
+        "uuid": true
+      }
+    },
+    "ethers": {
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "ethers>@ethersproject/providers": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/solidity": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/units": true,
+        "@ethersproject/wallet": true,
+        "ethers>@ethersproject/web": true,
+        "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "@metamask/eth-ledger-bridge-keyring>@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>ethers": {
+      "packages": {
+        "@ethersproject/abi": true,
+        "ethers>@ethersproject/abstract-signer": true,
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/base64": true,
+        "ethers>@ethersproject/basex": true,
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bytes": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/hash": true,
+        "@ethersproject/hdnode": true,
+        "ethers>@ethersproject/json-wallets": true,
+        "ethers>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/logger": true,
+        "ethers>@ethersproject/properties": true,
+        "@ethersproject/providers": true,
+        "ethers>@ethersproject/random": true,
+        "ethers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/sha2": true,
+        "ethers>@ethersproject/signing-key": true,
+        "ethers>@ethersproject/solidity": true,
+        "ethers>@ethersproject/strings": true,
+        "ethers>@ethersproject/transactions": true,
+        "ethers>@ethersproject/units": true,
+        "@ethersproject/wallet": true,
+        "@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/wordlists": true
+      }
+    },
+    "@metamask/ethjs>ethjs-abi": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true,
+        "@metamask/ethjs>js-sha3": true,
+        "@metamask/ethjs>ethjs-abi>number-to-bn": true
+      }
+    },
+    "webpack>events": {
+      "globals": {
+        "console": true
+      }
+    },
+    "crypto-browserify>browserify-cipher>evp_bytestokey": {
+      "packages": {
+        "ethereumjs-util>create-hash>md5.js": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "extension-port-stream": {
+      "packages": {
+        "browserify>buffer": true,
+        "extension-port-stream>readable-stream": true
+      }
+    },
+    "fast-json-patch": {
+      "globals": {
+        "addEventListener": true,
+        "clearTimeout": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      }
+    },
+    "@metamask/snaps-utils>fast-xml-parser": {
+      "globals": {
+        "entityName": true,
+        "val": true
+      },
+      "packages": {
+        "@metamask/snaps-utils>fast-xml-parser>strnum": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase": {
+      "packages": {
+        "@metamask/notification-services-controller>firebase>@firebase/app": true,
+        "@metamask/notification-services-controller>firebase>@firebase/messaging": true
+      }
+    },
+    "react-focus-lock>focus-lock": {
+      "globals": {
+        "HTMLIFrameElement": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.DOCUMENT_NODE": true,
+        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
+        "Node.DOCUMENT_POSITION_CONTAINS": true,
+        "Node.ELEMENT_NODE": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@swc/helpers>tslib": true
+      }
+    },
+    "browserify>util>which-typed-array>for-each": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>is-callable": true
+      }
+    },
+    "axios>form-data": {
+      "globals": {
+        "FormData": true
+      }
+    },
+    "fuse.js": {
+      "globals": {
+        "console": true,
+        "define": true
+      }
+    },
+    "string.prototype.matchall>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>es-abstract>has-proto": true,
+        "string.prototype.matchall>has-symbols": true,
+        "depcheck>is-core-module>hasown": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>gopd": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk": {
@@ -3865,545 +3717,63 @@
         "setTimeout": true
       },
       "packages": {
-        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
-        "@ethersproject/abi": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "@metamask/eth-sig-util": true,
-        "@metamask/ethjs>js-sha3": true,
-        "@metamask/keyring-api>bech32": true,
-        "@metamask/ppom-validator>elliptic": true,
-        "bn.js": true,
-        "browserify>buffer": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": true,
+        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": true,
+        "@ethersproject/abi": true,
+        "@metamask/eth-sig-util": true,
         "eth-lattice-keyring>gridplus-sdk>aes-js": true,
+        "@metamask/keyring-api>bech32": true,
         "eth-lattice-keyring>gridplus-sdk>bignumber.js": true,
+        "bn.js": true,
         "eth-lattice-keyring>gridplus-sdk>borc": true,
         "eth-lattice-keyring>gridplus-sdk>bs58check": true,
-        "eth-lattice-keyring>gridplus-sdk>secp256k1": true,
-        "eth-lattice-keyring>gridplus-sdk>uuid": true,
+        "browserify>buffer": true,
+        "@ethereumjs/tx>@ethereumjs/common>crc-32": true,
+        "@metamask/ppom-validator>elliptic": true,
         "ethers>@ethersproject/sha2>hash.js": true,
-        "lodash": true
+        "@metamask/ethjs>js-sha3": true,
+        "lodash": true,
+        "eth-lattice-keyring>gridplus-sdk>secp256k1": true,
+        "eth-lattice-keyring>gridplus-sdk>uuid": true
       }
     },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
+    "string.prototype.matchall>es-abstract>has-property-descriptors": {
       "packages": {
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
-        "webpack>events": true
+        "string.prototype.matchall>call-bind>es-define-property": true
       }
     },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": {
+    "koa>is-generator-function>has-tostringtag": {
       "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": true,
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/common": {
-      "packages": {
-        "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": true,
-        "webpack>events": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx>@ethereumjs/util": {
-      "globals": {
-        "console.warn": true,
-        "fetch": true
-      },
-      "packages": {
-        "@ethereumjs/tx>ethereum-cryptography": true,
-        "@metamask/eth-ledger-bridge-keyring>@ethereumjs/rlp": true,
-        "webpack>events": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>aes-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "browserify>buffer": true,
-        "buffer>ieee754": true,
-        "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": true,
-        "eth-lattice-keyring>gridplus-sdk>borc>iso-url": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc>bignumber.js": {
-      "globals": {
-        "crypto": true,
-        "define": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>borc>iso-url": {
-      "globals": {
-        "URL": true,
-        "URLSearchParams": true,
-        "location": true,
-        "navigator": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bs58check": {
-      "packages": {
-        "@noble/hashes": true,
-        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>bs58check>bs58": {
-      "packages": {
-        "eth-lattice-keyring>gridplus-sdk>bs58check>bs58>base-x": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>secp256k1": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>uuid": {
-      "globals": {
-        "crypto": true
-      }
-    },
-    "eth-lattice-keyring>rlp": {
-      "globals": {
-        "TextEncoder": true
-      }
-    },
-    "eth-method-registry": {
-      "packages": {
-        "@metamask/ethjs-contract": true,
-        "@metamask/ethjs-query": true
-      }
-    },
-    "ethereumjs-util": {
-      "packages": {
-        "bn.js": true,
-        "browserify>assert": true,
-        "browserify>buffer": true,
-        "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>ethereum-cryptography": true,
-        "ethereumjs-util>rlp": true
-      }
-    },
-    "ethereumjs-util>create-hash": {
-      "packages": {
-        "addons-linter>sha.js": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>create-hash>md5.js": true,
-        "ethereumjs-util>create-hash>ripemd160": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>create-hash>cipher-base": {
-      "packages": {
-        "browserify>string_decoder": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true,
-        "stream-browserify": true
-      }
-    },
-    "ethereumjs-util>create-hash>md5.js": {
-      "packages": {
-        "ethereumjs-util>create-hash>md5.js>hash-base": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
+        "string.prototype.matchall>has-symbols": true
       }
     },
     "ethereumjs-util>create-hash>md5.js>hash-base": {
       "packages": {
-        "koa>content-disposition>safe-buffer": true,
         "pumpify>inherits": true,
-        "readable-stream": true
-      }
-    },
-    "ethereumjs-util>create-hash>ripemd160": {
-      "packages": {
-        "browserify>buffer": true,
-        "ethereumjs-util>create-hash>md5.js>hash-base": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>randombytes": true,
-        "ethereumjs-util>ethereum-cryptography>keccak": true,
-        "ganache>secp256k1": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>browserify-aes": {
-      "packages": {
-        "browserify>buffer": true,
-        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
-        "ethereumjs-util>create-hash>cipher-base": true,
-        "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
-        "koa>content-disposition>safe-buffer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
-      "packages": {
-        "browserify>buffer": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>bs58check": {
-      "packages": {
-        "ethereumjs-util>create-hash": true,
-        "ethereumjs-util>ethereum-cryptography>bs58check>bs58": true,
+        "readable-stream": true,
         "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>bs58check>bs58": {
-      "packages": {
-        "@ensdomains/content-hash>multihashes>multibase>base-x": true
-      }
-    },
-    "ethereumjs-util>ethereum-cryptography>keccak": {
-      "packages": {
-        "browserify>buffer": true,
-        "readable-stream": true
-      }
-    },
-    "ethereumjs-util>rlp": {
-      "packages": {
-        "bn.js": true,
-        "browserify>buffer": true
-      }
-    },
-    "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers": {
-      "packages": {
-        "@ethersproject/abi": true,
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/hash": true,
-        "@ethersproject/hdnode": true,
-        "@ethersproject/wallet": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/signing-key": true,
-        "ethers>@ethersproject/solidity": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true,
-        "ethers>@ethersproject/units": true,
-        "ethers>@ethersproject/web": true,
-        "ethers>@ethersproject/wordlists": true
-      }
-    },
-    "ethers>@ethersproject/abstract-provider": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/abstract-signer": {
-      "packages": {
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/address": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/rlp": true
-      }
-    },
-    "ethers>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true
-      }
-    },
-    "ethers>@ethersproject/basex": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/constants": {
-      "packages": {
-        "@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hdnode": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/json-wallets>aes-js": true,
-        "ethers>@ethersproject/json-wallets>scrypt-js": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/pbkdf2": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets>aes-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "ethers>@ethersproject/json-wallets>scrypt-js": {
-      "globals": {
-        "define": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>timers-browserify": true
-      }
-    },
-    "ethers>@ethersproject/keccak256": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@metamask/ethjs>js-sha3": true
-      }
-    },
-    "ethers>@ethersproject/logger": {
-      "globals": {
-        "console": true
-      }
-    },
-    "ethers>@ethersproject/pbkdf2": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/sha2": true
-      }
-    },
-    "ethers>@ethersproject/properties": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers": {
-      "globals": {
-        "WebSocket": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "console.log": true,
-        "console.warn": true,
-        "setInterval": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/abstract-provider": true,
-        "ethers>@ethersproject/abstract-signer": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/basex": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers>@ethersproject/networks": true,
-        "ethers>@ethersproject/providers>@ethersproject/web": true,
-        "ethers>@ethersproject/providers>bech32": true,
-        "ethers>@ethersproject/random": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/strings": true,
-        "ethers>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/networks": {
-      "packages": {
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/random": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/rlp": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/sha2": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/sha2>hash.js": true
       }
     },
     "ethers>@ethersproject/sha2>hash.js": {
       "packages": {
-        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
-        "pumpify>inherits": true
+        "pumpify>inherits": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true
       }
     },
-    "ethers>@ethersproject/signing-key": {
+    "depcheck>is-core-module>hasown": {
       "packages": {
-        "@ethersproject/bytes": true,
-        "@metamask/ppom-validator>elliptic": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true
+        "browserify>has>function-bind": true
       }
     },
-    "ethers>@ethersproject/solidity": {
+    "@metamask/eth-trezor-keyring>hdkey": {
       "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/sha2": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/strings": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/transactions": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/address": true,
-        "ethers>@ethersproject/constants": true,
-        "ethers>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/signing-key": true
-      }
-    },
-    "ethers>@ethersproject/units": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "ethers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/web": {
-      "globals": {
-        "clearTimeout": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@ethersproject/bytes": true,
-        "ethers>@ethersproject/base64": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/wordlists": {
-      "packages": {
-        "@ethersproject/bytes": true,
-        "@ethersproject/hash": true,
-        "ethers>@ethersproject/logger": true,
-        "ethers>@ethersproject/properties": true,
-        "ethers>@ethersproject/strings": true
-      }
-    },
-    "extension-port-stream": {
-      "packages": {
-        "browserify>buffer": true,
-        "extension-port-stream>readable-stream": true
-      }
-    },
-    "extension-port-stream>readable-stream": {
-      "globals": {
-        "AbortController": true,
-        "AggregateError": true,
-        "Blob": true
-      },
-      "packages": {
-        "browserify>buffer": true,
-        "browserify>string_decoder": true,
-        "extension-port-stream>readable-stream>abort-controller": true,
-        "process": true,
-        "webpack>events": true
-      }
-    },
-    "extension-port-stream>readable-stream>abort-controller": {
-      "globals": {
-        "AbortController": true
-      }
-    },
-    "fast-json-patch": {
-      "globals": {
-        "addEventListener": true,
-        "clearTimeout": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      }
-    },
-    "fuse.js": {
-      "globals": {
-        "console": true,
-        "define": true
-      }
-    },
-    "ganache>secp256k1": {
-      "packages": {
-        "@metamask/ppom-validator>elliptic": true
-      }
-    },
-    "gulp>vinyl-fs>object.assign": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>has-symbols": true
+        "browserify>assert": true,
+        "ethereumjs-util>ethereum-cryptography>bs58check": true,
+        "crypto-browserify": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "ganache>secp256k1": true
       }
     },
     "he": {
@@ -4419,15 +3789,100 @@
         "document.querySelector": true
       }
     },
-    "https-browserify": {
+    "react-router-dom>history": {
+      "globals": {
+        "addEventListener": true,
+        "confirm": true,
+        "document": true,
+        "history": true,
+        "location": true,
+        "navigator.userAgent": true,
+        "removeEventListener": true
+      },
       "packages": {
-        "browserify>url": true,
-        "stream-http": true
+        "react-router-dom>history>resolve-pathname": true,
+        "react-router-dom>tiny-invariant": true,
+        "react-router-dom>tiny-warning": true,
+        "react-router-dom>history>value-equal": true
       }
     },
-    "koa>content-disposition>safe-buffer": {
+    "@metamask/ppom-validator>elliptic>hmac-drbg": {
       "packages": {
-        "browserify>buffer": true
+        "ethers>@ethersproject/sha2>hash.js": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-assert": true,
+        "@metamask/ppom-validator>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "react-redux>hoist-non-react-statics": {
+      "packages": {
+        "prop-types>react-is": true
+      }
+    },
+    "https-browserify": {
+      "packages": {
+        "stream-http": true,
+        "browserify>url": true
+      }
+    },
+    "@metamask/notification-services-controller>firebase>@firebase/app>idb": {
+      "globals": {
+        "DOMException": true,
+        "IDBCursor": true,
+        "IDBDatabase": true,
+        "IDBIndex": true,
+        "IDBObjectStore": true,
+        "IDBRequest": true,
+        "IDBTransaction": true,
+        "indexedDB.deleteDatabase": true,
+        "indexedDB.open": true
+      }
+    },
+    "eth-ens-namehash>idna-uts46-hx": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "browserify>punycode": true
+      }
+    },
+    "string.prototype.matchall>internal-slot": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "depcheck>is-core-module>hasown": true,
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "browserify>util>is-arguments": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-array-buffer": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>unbox-primitive>has-bigints": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
       }
     },
     "koa>is-generator-function": {
@@ -4435,9 +3890,145 @@
         "koa>is-generator-function>has-tostringtag": true
       }
     },
-    "koa>is-generator-function>has-tostringtag": {
+    "@material-ui/core>@material-ui/styles>jss>is-in-browser": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-regex": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-shared-array-buffer": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true
+      }
+    },
+    "eslint-plugin-react>array-includes>is-string": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
       "packages": {
         "string.prototype.matchall>has-symbols": true
+      }
+    },
+    "browserify>util>is-typed-array": {
+      "packages": {
+        "browserify>util>which-typed-array": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>borc>iso-url": {
+      "globals": {
+        "URL": true,
+        "URLSearchParams": true,
+        "location": true,
+        "navigator": true
+      }
+    },
+    "@ensdomains/content-hash>js-base64": {
+      "globals": {
+        "Base64": "write",
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true,
+        "define": true
+      },
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "@metamask/ethjs>js-sha3": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "process": true
+      }
+    },
+    "@ngraveio/bc-ur>jsbi": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@metamask/message-manager>jsonschema": {
+      "packages": {
+        "browserify>url": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-camel-case": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss-plugin-camel-case>hyphenate-style-name": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-default-unit": {
+      "globals": {
+        "CSS": true
+      },
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-global": {
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-nested": {
+      "packages": {
+        "@babel/runtime": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-rule-value-function": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer": {
+      "packages": {
+        "@material-ui/core>@material-ui/styles>jss-plugin-vendor-prefixer>css-vendor": true,
+        "@material-ui/core>@material-ui/styles>jss": true
+      }
+    },
+    "@material-ui/core>@material-ui/styles>jss": {
+      "globals": {
+        "CSS": true,
+        "document.createElement": true,
+        "document.querySelector": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "@material-ui/core>@material-ui/styles>jss>is-in-browser": true,
+        "react-router-dom>tiny-warning": true
+      }
+    },
+    "ethereumjs-util>ethereum-cryptography>keccak": {
+      "packages": {
+        "browserify>buffer": true,
+        "readable-stream": true
+      }
+    },
+    "currency-formatter>locale-currency": {
+      "globals": {
+        "countryCode": true
       }
     },
     "localforage": {
@@ -4517,6 +4108,120 @@
         "Intl": true
       }
     },
+    "@metamask/snaps-utils>marked": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true,
+        "define": true
+      }
+    },
+    "ethereumjs-util>create-hash>md5.js": {
+      "packages": {
+        "ethereumjs-util>create-hash>md5.js>hash-base": true,
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "@storybook/addon-docs>remark-external-links>mdast-util-definitions": {
+      "packages": {
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
+        "react-syntax-highlighter>refractor>parse-entities": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>remark-rehype>mdast-util-to-hast": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@storybook/addon-docs>remark-external-links>mdast-util-definitions": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "@ethereumjs/tx>@ethereumjs/util>micro-ftch": {
+      "globals": {
+        "Headers": true,
+        "TextDecoder": true,
+        "URL": true,
+        "btoa": true,
+        "fetch": true
+      },
+      "packages": {
+        "browserify>browserify-zlib": true,
+        "browserify>buffer": true,
+        "https-browserify": true,
+        "process": true,
+        "stream-http": true,
+        "browserify>url": true,
+        "browserify>util": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
+      "packages": {
+        "react-syntax-highlighter>refractor>parse-entities": true
+      }
+    },
+    "crypto-browserify>diffie-hellman>miller-rabin": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ppom-validator>elliptic>brorand": true
+      }
+    },
+    "@ensdomains/content-hash>cids>multibase": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase>@multiformats/base-x": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>multibase": {
+      "packages": {
+        "@ensdomains/content-hash>multihashes>multibase>base-x": true,
+        "browserify>buffer": true,
+        "@ensdomains/content-hash>multihashes>web-encoding": true
+      }
+    },
+    "@ensdomains/content-hash>multicodec": {
+      "packages": {
+        "@ensdomains/content-hash>multicodec>uint8arrays": true,
+        "sass-embedded>varint": true
+      }
+    },
+    "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "console.warn": true,
+        "crypto.subtle.digest": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes": {
+      "packages": {
+        "browserify>buffer": true,
+        "@ensdomains/content-hash>multihashes>multibase": true,
+        "@ensdomains/content-hash>multihashes>varint": true,
+        "@ensdomains/content-hash>multihashes>web-encoding": true
+      }
+    },
+    "@ensdomains/content-hash>cids>multihashes": {
+      "packages": {
+        "@ensdomains/content-hash>cids>multibase": true,
+        "@ensdomains/content-hash>cids>uint8arrays": true,
+        "@ensdomains/content-hash>cids>multihashes>varint": true
+      }
+    },
     "nanoid": {
       "globals": {
         "crypto": true,
@@ -4524,17 +4229,54 @@
         "navigator": true
       }
     },
-    "nock>debug": {
+    "@metamask/approval-controller>nanoid": {
       "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "nock>debug>ms": true,
-        "process": true
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/smart-transactions-controller>@metamask/controllers>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/notification-controller>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/permission-controller>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/rpc-methods>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/rpc-methods-flask>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/snaps-controllers>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "@metamask/snaps-controllers-flask>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "depcheck>@vue/compiler-sfc>postcss>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "dependency-tree>precinct>detective-postcss>postcss>nanoid": {
+      "globals": {
+        "crypto.getRandomValues": true
       }
     },
     "node-fetch": {
@@ -4545,9 +4287,122 @@
         "fetch": true
       }
     },
+    "@metamask/controllers>web3-provider-engine>cross-fetch>node-fetch": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "@metamask/ethjs>ethjs-abi>number-to-bn": {
+      "packages": {
+        "bn.js": true,
+        "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>object-inspect": {
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "browserify>browser-resolve": true
+      }
+    },
+    "@ngraveio/bc-ur>assert>object-is": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true
+      }
+    },
+    "gulp>vinyl-fs>object.assign": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>has-symbols": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "@metamask/object-multiplex>once": {
+      "packages": {
+        "@metamask/object-multiplex>once>wrappy": true
+      }
+    },
+    "crypto-browserify>public-encrypt>parse-asn1": {
+      "packages": {
+        "crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
+        "ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "browserify>buffer": true,
+        "crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "crypto-browserify>pbkdf2": true
+      }
+    },
+    "react-syntax-highlighter>refractor>parse-entities": {
+      "globals": {
+        "document.createElement": true
+      }
+    },
     "path-browserify": {
       "packages": {
         "process": true
+      }
+    },
+    "serve-handler>path-to-regexp": {
+      "packages": {
+        "serve-handler>path-to-regexp>isarray": true
+      }
+    },
+    "crypto-browserify>pbkdf2": {
+      "globals": {
+        "crypto": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethereumjs-util>create-hash": true,
+        "process": true,
+        "ethereumjs-util>create-hash>ripemd160": true,
+        "koa>content-disposition>safe-buffer": true,
+        "addons-linter>sha.js": true
+      }
+    },
+    "@material-ui/core>popper.js": {
+      "globals": {
+        "MSInputMethodContext": true,
+        "Node.DOCUMENT_POSITION_FOLLOWING": true,
+        "cancelAnimationFrame": true,
+        "console.warn": true,
+        "define": true,
+        "devicePixelRatio": true,
+        "document": true,
+        "getComputedStyle": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "navigator": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      }
+    },
+    "react-tippy>popper.js": {
+      "globals": {
+        "MSInputMethodContext": true,
+        "Node.DOCUMENT_POSITION_FOLLOWING": true,
+        "cancelAnimationFrame": true,
+        "console.warn": true,
+        "define": true,
+        "devicePixelRatio": true,
+        "document": true,
+        "getComputedStyle": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "navigator.userAgent": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
       }
     },
     "process": {
@@ -4562,26 +4417,51 @@
         "promise-to-callback>set-immediate-shim": true
       }
     },
-    "promise-to-callback>set-immediate-shim": {
-      "globals": {
-        "setTimeout.apply": true
-      },
-      "packages": {
-        "browserify>timers-browserify": true
-      }
-    },
     "prop-types": {
       "globals": {
         "console": true
       },
       "packages": {
-        "prop-types>react-is": true,
-        "react>object-assign": true
+        "react>object-assign": true,
+        "prop-types>react-is": true
       }
     },
-    "prop-types>react-is": {
+    "react-markdown>property-information": {
+      "packages": {
+        "watchify>xtend": true
+      }
+    },
+    "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": {
       "globals": {
-        "console": true
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/aspromise": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/base64": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/codegen": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/eventemitter": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/fetch": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/float": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/inquire": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/path": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/pool": true,
+        "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs>@protobufjs/utf8": true
+      }
+    },
+    "crypto-browserify>public-encrypt": {
+      "packages": {
+        "bn.js": true,
+        "crypto-browserify>public-encrypt>browserify-rsa": true,
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash": true,
+        "crypto-browserify>public-encrypt>parse-asn1": true,
+        "crypto-browserify>randombytes": true
+      }
+    },
+    "browserify>punycode": {
+      "globals": {
+        "define": true
       }
     },
     "qrcode-generator": {
@@ -4598,13 +4478,55 @@
         "react": true
       }
     },
+    "@storybook/addon-knobs>qs": {
+      "packages": {
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
+      "globals": {
+        "queueMicrotask": true
+      }
+    },
+    "react-beautiful-dnd>raf-schd": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "requestAnimationFrame": true
+      }
+    },
+    "crypto-browserify>randombytes": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "process": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "ethereumjs-wallet>randombytes": {
+      "globals": {
+        "crypto.getRandomValues": true
+      }
+    },
+    "crypto-browserify>randomfill": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "process": true,
+        "crypto-browserify>randombytes": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
     "react": {
       "globals": {
         "console": true
       },
       "packages": {
-        "prop-types": true,
-        "react>object-assign": true
+        "react>object-assign": true,
+        "prop-types": true
       }
     },
     "react-beautiful-dnd": {
@@ -4626,35 +4548,14 @@
       },
       "packages": {
         "@babel/runtime": true,
-        "react": true,
         "react-beautiful-dnd>css-box-model": true,
         "react-beautiful-dnd>memoize-one": true,
         "react-beautiful-dnd>raf-schd": true,
-        "react-beautiful-dnd>use-memo-one": true,
+        "react": true,
         "react-dom": true,
         "react-redux": true,
-        "redux": true
-      }
-    },
-    "react-beautiful-dnd>css-box-model": {
-      "globals": {
-        "getComputedStyle": true,
-        "pageXOffset": true,
-        "pageYOffset": true
-      },
-      "packages": {
-        "react-router-dom>tiny-invariant": true
-      }
-    },
-    "react-beautiful-dnd>raf-schd": {
-      "globals": {
-        "cancelAnimationFrame": true,
-        "requestAnimationFrame": true
-      }
-    },
-    "react-beautiful-dnd>use-memo-one": {
-      "packages": {
-        "react": true
+        "redux": true,
+        "react-beautiful-dnd>use-memo-one": true
       }
     },
     "react-chartjs-2": {
@@ -4663,6 +4564,12 @@
       },
       "packages": {
         "chart.js": true,
+        "react": true
+      }
+    },
+    "react-focus-lock>react-clientside-effect": {
+      "packages": {
+        "@babel/runtime": true,
         "react": true
       }
     },
@@ -4707,22 +4614,16 @@
         "trustedTypes": true
       },
       "packages": {
+        "react>object-assign": true,
         "prop-types": true,
         "react": true,
-        "react-dom>scheduler": true,
-        "react>object-assign": true
+        "react-dom>scheduler": true
       }
     },
-    "react-dom>scheduler": {
+    "react-popper>react-fast-compare": {
       "globals": {
-        "MessageChannel": true,
-        "cancelAnimationFrame": true,
-        "clearTimeout": true,
-        "console": true,
-        "navigator": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
+        "Element": true,
+        "console.warn": true
       }
     },
     "react-focus-lock": {
@@ -4736,51 +4637,12 @@
       },
       "packages": {
         "@babel/runtime": true,
+        "react-focus-lock>focus-lock": true,
         "prop-types": true,
         "react": true,
-        "react-focus-lock>focus-lock": true,
         "react-focus-lock>react-clientside-effect": true,
         "react-focus-lock>use-callback-ref": true,
         "react-focus-lock>use-sidecar": true
-      }
-    },
-    "react-focus-lock>focus-lock": {
-      "globals": {
-        "HTMLIFrameElement": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
-        "Node.DOCUMENT_NODE": true,
-        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
-        "Node.DOCUMENT_POSITION_CONTAINS": true,
-        "Node.ELEMENT_NODE": true,
-        "console.error": true,
-        "console.warn": true,
-        "document": true,
-        "getComputedStyle": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true
-      }
-    },
-    "react-focus-lock>react-clientside-effect": {
-      "packages": {
-        "@babel/runtime": true,
-        "react": true
-      }
-    },
-    "react-focus-lock>use-callback-ref": {
-      "packages": {
-        "react": true
-      }
-    },
-    "react-focus-lock>use-sidecar": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@swc/helpers>tslib": true,
-        "react": true,
-        "react-focus-lock>use-sidecar>detect-node-es": true
       }
     },
     "react-idle-timer": {
@@ -4804,15 +4666,30 @@
         "react": true
       }
     },
+    "prop-types>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-markdown>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-redux>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
     "react-markdown": {
       "globals": {
         "console.warn": true
       },
       "packages": {
-        "prop-types": true,
-        "react": true,
         "react-markdown>comma-separated-tokens": true,
+        "prop-types": true,
         "react-markdown>property-information": true,
+        "react": true,
         "react-markdown>react-is": true,
         "react-markdown>remark-parse": true,
         "react-markdown>remark-rehype": true,
@@ -4821,96 +4698,6 @@
         "react-markdown>unified": true,
         "react-markdown>unist-util-visit": true,
         "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>property-information": {
-      "packages": {
-        "watchify>xtend": true
-      }
-    },
-    "react-markdown>react-is": {
-      "globals": {
-        "console": true
-      }
-    },
-    "react-markdown>remark-parse": {
-      "packages": {
-        "react-markdown>remark-parse>mdast-util-from-markdown": true
-      }
-    },
-    "react-markdown>remark-parse>mdast-util-from-markdown": {
-      "packages": {
-        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
-        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
-        "react-markdown>remark-parse>mdast-util-from-markdown>unist-util-stringify-position": true,
-        "react-syntax-highlighter>refractor>parse-entities": true
-      }
-    },
-    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
-      "packages": {
-        "react-syntax-highlighter>refractor>parse-entities": true
-      }
-    },
-    "react-markdown>remark-rehype": {
-      "packages": {
-        "react-markdown>remark-rehype>mdast-util-to-hast": true
-      }
-    },
-    "react-markdown>remark-rehype>mdast-util-to-hast": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@storybook/addon-docs>remark-external-links>mdast-util-definitions": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
-        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "react-markdown>style-to-object": {
-      "packages": {
-        "react-markdown>style-to-object>inline-style-parser": true
-      }
-    },
-    "react-markdown>unified": {
-      "packages": {
-        "mocha>yargs-unparser>is-plain-obj": true,
-        "react-markdown>unified>bail": true,
-        "react-markdown>unified>extend": true,
-        "react-markdown>unified>is-buffer": true,
-        "react-markdown>unified>trough": true,
-        "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>unist-util-visit": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-visit-parents": true
-      }
-    },
-    "react-markdown>unist-util-visit>unist-util-visit-parents": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-is": true
-      }
-    },
-    "react-markdown>vfile": {
-      "packages": {
-        "path-browserify": true,
-        "process": true,
-        "react-markdown>vfile>is-buffer": true,
-        "react-markdown>vfile>replace-ext": true,
-        "react-markdown>vfile>vfile-message": true
-      }
-    },
-    "react-markdown>vfile>replace-ext": {
-      "packages": {
-        "path-browserify": true
-      }
-    },
-    "react-markdown>vfile>vfile-message": {
-      "packages": {
-        "react-markdown>vfile>unist-util-stringify-position": true
       }
     },
     "react-popper": {
@@ -4924,17 +4711,6 @@
         "react-popper>warning": true
       }
     },
-    "react-popper>react-fast-compare": {
-      "globals": {
-        "Element": true,
-        "console.warn": true
-      }
-    },
-    "react-popper>warning": {
-      "globals": {
-        "console": true
-      }
-    },
     "react-redux": {
       "globals": {
         "console": true,
@@ -4942,21 +4718,11 @@
       },
       "packages": {
         "@babel/runtime": true,
+        "react-redux>hoist-non-react-statics": true,
         "prop-types": true,
         "react": true,
         "react-dom": true,
-        "react-redux>hoist-non-react-statics": true,
         "react-redux>react-is": true
-      }
-    },
-    "react-redux>hoist-non-react-statics": {
-      "packages": {
-        "prop-types>react-is": true
-      }
-    },
-    "react-redux>react-is": {
-      "globals": {
-        "console": true
       }
     },
     "react-responsive-carousel": {
@@ -4967,9 +4733,9 @@
     },
     "react-router-dom": {
       "packages": {
+        "react-router-dom>history": true,
         "prop-types": true,
         "react": true,
-        "react-router-dom>history": true,
         "react-router-dom>react-router": true,
         "react-router-dom>tiny-invariant": true,
         "react-router-dom>tiny-warning": true
@@ -4995,26 +4761,24 @@
         "setTimeout": true
       },
       "packages": {
+        "react-router-dom-v5-compat>@remix-run/router": true,
         "history": true,
         "react": true,
         "react-dom": true,
         "react-router-dom": true,
-        "react-router-dom-v5-compat>@remix-run/router": true,
         "react-router-dom-v5-compat>react-router": true
       }
     },
-    "react-router-dom-v5-compat>@remix-run/router": {
-      "globals": {
-        "AbortController": true,
-        "DOMException": true,
-        "FormData": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "URL": true,
-        "URLSearchParams": true,
-        "console": true,
-        "document.defaultView": true
+    "react-router-dom>react-router": {
+      "packages": {
+        "react-router-dom>history": true,
+        "react-redux>hoist-non-react-statics": true,
+        "serve-handler>path-to-regexp": true,
+        "prop-types": true,
+        "react": true,
+        "prop-types>react-is": true,
+        "react-router-dom>tiny-invariant": true,
+        "react-router-dom>tiny-warning": true
       }
     },
     "react-router-dom-v5-compat>react-router": {
@@ -5023,42 +4787,8 @@
         "define": true
       },
       "packages": {
-        "react": true,
-        "react-router-dom-v5-compat>@remix-run/router": true
-      }
-    },
-    "react-router-dom>history": {
-      "globals": {
-        "addEventListener": true,
-        "confirm": true,
-        "document": true,
-        "history": true,
-        "location": true,
-        "navigator.userAgent": true,
-        "removeEventListener": true
-      },
-      "packages": {
-        "react-router-dom>history>resolve-pathname": true,
-        "react-router-dom>history>value-equal": true,
-        "react-router-dom>tiny-invariant": true,
-        "react-router-dom>tiny-warning": true
-      }
-    },
-    "react-router-dom>react-router": {
-      "packages": {
-        "prop-types": true,
-        "prop-types>react-is": true,
-        "react": true,
-        "react-redux>hoist-non-react-statics": true,
-        "react-router-dom>history": true,
-        "react-router-dom>tiny-invariant": true,
-        "react-router-dom>tiny-warning": true,
-        "serve-handler>path-to-regexp": true
-      }
-    },
-    "react-router-dom>tiny-warning": {
-      "globals": {
-        "console": true
+        "react-router-dom-v5-compat>@remix-run/router": true,
+        "react": true
       }
     },
     "react-simple-file-input": {
@@ -5070,11 +4800,6 @@
       "packages": {
         "prop-types": true,
         "react": true
-      }
-    },
-    "react-syntax-highlighter>refractor>parse-entities": {
-      "globals": {
-        "document.createElement": true
       }
     },
     "react-tippy": {
@@ -5099,26 +4824,9 @@
         "setTimeout": true
       },
       "packages": {
+        "react-tippy>popper.js": true,
         "react": true,
-        "react-dom": true,
-        "react-tippy>popper.js": true
-      }
-    },
-    "react-tippy>popper.js": {
-      "globals": {
-        "MSInputMethodContext": true,
-        "Node.DOCUMENT_POSITION_FOLLOWING": true,
-        "cancelAnimationFrame": true,
-        "console.warn": true,
-        "define": true,
-        "devicePixelRatio": true,
-        "document": true,
-        "getComputedStyle": true,
-        "innerHeight": true,
-        "innerWidth": true,
-        "navigator.userAgent": true,
-        "requestAnimationFrame": true,
-        "setTimeout": true
+        "react-dom": true
       }
     },
     "react-toggle-button": {
@@ -5133,22 +4841,46 @@
         "react": true
       }
     },
+    "@material-ui/core>react-transition-group": {
+      "globals": {
+        "Element": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@material-ui/core>react-transition-group>dom-helpers": true,
+        "prop-types": true,
+        "react": true,
+        "react-dom": true
+      }
+    },
     "readable-stream": {
       "packages": {
         "browserify>browser-resolve": true,
         "browserify>buffer": true,
-        "browserify>string_decoder": true,
-        "process": true,
+        "webpack>events": true,
         "pumpify>inherits": true,
-        "readable-stream>util-deprecate": true,
-        "webpack>events": true
+        "process": true,
+        "browserify>string_decoder": true,
+        "readable-stream>util-deprecate": true
       }
     },
-    "readable-stream>util-deprecate": {
+    "extension-port-stream>readable-stream": {
       "globals": {
-        "console.trace": true,
-        "console.warn": true,
-        "localStorage": true
+        "AbortController": true,
+        "AggregateError": true,
+        "Blob": true
+      },
+      "packages": {
+        "extension-port-stream>readable-stream>abort-controller": true,
+        "browserify>buffer": true,
+        "webpack>events": true,
+        "process": true,
+        "browserify>string_decoder": true
+      }
+    },
+    "@metamask/snaps-controllers>readable-web-to-node-stream": {
+      "packages": {
+        "readable-stream": true
       }
     },
     "redux": {
@@ -5159,6 +4891,111 @@
         "@babel/runtime": true
       }
     },
+    "string.prototype.matchall>regexp.prototype.flags": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+      }
+    },
+    "react-markdown>remark-parse": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown": true
+      }
+    },
+    "react-markdown>remark-rehype": {
+      "packages": {
+        "react-markdown>remark-rehype>mdast-util-to-hast": true
+      }
+    },
+    "react-markdown>vfile>replace-ext": {
+      "packages": {
+        "path-browserify": true
+      }
+    },
+    "@metamask/network-controller>reselect": {
+      "globals": {
+        "WeakRef": true,
+        "console.warn": true,
+        "unstable_autotrackMemoize": true
+      }
+    },
+    "@metamask/snaps-utils>rfdc": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "ethereumjs-util>create-hash>ripemd160": {
+      "packages": {
+        "browserify>buffer": true,
+        "ethereumjs-util>create-hash>md5.js>hash-base": true,
+        "pumpify>inherits": true
+      }
+    },
+    "@keystonehq/metamask-airgapped-keyring>@keystonehq/base-eth-keyring>rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "eth-lattice-keyring>rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "ethereumjs-util>rlp": {
+      "packages": {
+        "bn.js": true,
+        "browserify>buffer": true
+      }
+    },
+    "wait-on>rxjs": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setInterval.apply": true,
+        "setTimeout.apply": true
+      }
+    },
+    "koa>content-disposition>safe-buffer": {
+      "packages": {
+        "browserify>buffer": true
+      }
+    },
+    "react-dom>scheduler": {
+      "globals": {
+        "MessageChannel": true,
+        "cancelAnimationFrame": true,
+        "clearTimeout": true,
+        "console": true,
+        "navigator": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      }
+    },
+    "ethers>@ethersproject/json-wallets>scrypt-js": {
+      "globals": {
+        "define": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>timers-browserify": true
+      }
+    },
+    "ganache>secp256k1": {
+      "packages": {
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>secp256k1": {
+      "packages": {
+        "@metamask/ppom-validator>elliptic": true
+      }
+    },
     "semver": {
       "globals": {
         "console.error": true
@@ -5167,16 +5004,69 @@
         "process": true
       }
     },
-    "serve-handler>path-to-regexp": {
+    "string.prototype.matchall>call-bind>set-function-length": {
       "packages": {
-        "serve-handler>path-to-regexp>isarray": true
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "promise-to-callback>set-immediate-shim": {
+      "globals": {
+        "setTimeout.apply": true
+      },
+      "packages": {
+        "browserify>timers-browserify": true
+      }
+    },
+    "addons-linter>sha.js": {
+      "packages": {
+        "pumpify>inherits": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "string.prototype.matchall>side-channel": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>object-inspect": true
+      }
+    },
+    "@metamask/profile-sync-controller>siwe": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/profile-sync-controller>siwe>@spruceid/siwe-parser": true,
+        "@metamask/profile-sync-controller>siwe>@stablelib/random": true,
+        "ethers": true,
+        "@metamask/controller-utils>@spruceid/siwe-parser>valid-url": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>es-get-iterator>stop-iteration-iterator": {
+      "globals": {
+        "StopIteration": true
+      },
+      "packages": {
+        "string.prototype.matchall>internal-slot": true
       }
     },
     "stream-browserify": {
       "packages": {
+        "webpack>events": true,
         "pumpify>inherits": true,
-        "readable-stream": true,
-        "webpack>events": true
+        "readable-stream": true
       }
     },
     "stream-http": {
@@ -5195,160 +5085,195 @@
       },
       "packages": {
         "browserify>buffer": true,
-        "browserify>url": true,
-        "process": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
         "stream-http>builtin-status-codes": true,
+        "pumpify>inherits": true,
+        "process": true,
+        "readable-stream": true,
+        "browserify>url": true,
         "watchify>xtend": true
       }
     },
-    "string.prototype.matchall>call-bind": {
+    "@metamask/snaps-controllers>tar-stream>streamx": {
       "packages": {
-        "browserify>has>function-bind": true,
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>call-bind>set-function-length": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "webpack>events": true,
+        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
+        "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": true
       }
     },
-    "string.prototype.matchall>call-bind>es-define-property": {
+    "browserify>string_decoder": {
       "packages": {
-        "string.prototype.matchall>get-intrinsic": true
+        "koa>content-disposition>safe-buffer": true
       }
     },
-    "string.prototype.matchall>call-bind>set-function-length": {
+    "@metamask/ethjs>@metamask/ethjs-util>strip-hex-prefix": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>gopd": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "@metamask/ethjs>@metamask/ethjs-util>is-hex-prefixed": true
       }
     },
-    "string.prototype.matchall>define-properties": {
+    "react-markdown>style-to-object": {
       "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+        "react-markdown>style-to-object>inline-style-parser": true
       }
     },
-    "string.prototype.matchall>define-properties>define-data-property": {
+    "@metamask/snaps-controllers>tar-stream": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>gopd": true
+        "@metamask/snaps-controllers>tar-stream>b4a": true,
+        "browserify>browser-resolve": true,
+        "@metamask/snaps-controllers>tar-stream>fast-fifo": true,
+        "@metamask/snaps-controllers>tar-stream>streamx": true
       }
     },
-    "string.prototype.matchall>es-abstract>array-buffer-byte-length": {
+    "debounce-stream>through": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>is-array-buffer": true
+        "process": true,
+        "stream-browserify": true
       }
     },
-    "string.prototype.matchall>es-abstract>available-typed-arrays": {
-      "packages": {
-        "string.prototype.matchall>es-abstract>typed-array-length>possible-typed-array-names": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
-      "packages": {
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>gopd": {
-      "packages": {
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>has-property-descriptors": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-array-buffer": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-callable": {
+    "browserify>timers-browserify": {
       "globals": {
-        "document": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-regex": {
+        "clearInterval": true,
+        "clearTimeout": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
       "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
+        "process": true
       }
     },
-    "string.prototype.matchall>es-abstract>is-shared-array-buffer": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>object-inspect": {
+    "react-router-dom>tiny-warning": {
       "globals": {
-        "HTMLElement": true,
-        "WeakRef": true
+        "console": true
+      }
+    },
+    "copy-to-clipboard>toggle-selection": {
+      "globals": {
+        "document.activeElement": true,
+        "document.getSelection": true
+      }
+    },
+    "@swc/helpers>tslib": {
+      "globals": {
+        "SuppressedError": true,
+        "define": true
+      }
+    },
+    "@metamask/eth-sig-util>tweetnacl": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "nacl": "write"
       },
       "packages": {
         "browserify>browser-resolve": true
       }
     },
-    "string.prototype.matchall>get-intrinsic": {
+    "@trezor/connect-web>@trezor/connect-common>@trezor/env-utils>ua-parser-js": {
       "globals": {
-        "AggregateError": true,
-        "FinalizationRegistry": true,
-        "WeakRef": true
+        "define": true
+      }
+    },
+    "@ensdomains/content-hash>cids>uint8arrays": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
       },
       "packages": {
-        "browserify>has>function-bind": true,
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>has-proto": true,
-        "string.prototype.matchall>has-symbols": true
+        "@ensdomains/content-hash>cids>multibase": true
       }
     },
-    "string.prototype.matchall>internal-slot": {
+    "@ensdomains/content-hash>multicodec>uint8arrays": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
       "packages": {
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>side-channel": true
+        "@ensdomains/content-hash>multicodec>uint8arrays>multiformats": true
       }
     },
-    "string.prototype.matchall>regexp.prototype.flags": {
+    "react-markdown>unified": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+        "react-markdown>unified>bail": true,
+        "react-markdown>unified>extend": true,
+        "react-markdown>unified>is-buffer": true,
+        "mocha>yargs-unparser>is-plain-obj": true,
+        "react-markdown>unified>trough": true,
+        "react-markdown>vfile": true
       }
     },
-    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+    "react-markdown>unist-util-visit>unist-util-visit-parents": {
       "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+        "react-markdown>unist-util-visit>unist-util-is": true
       }
     },
-    "string.prototype.matchall>side-channel": {
+    "react-markdown>unist-util-visit": {
       "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>object-inspect": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "terser>source-map-support>buffer-from": {
-      "packages": {
-        "browserify>buffer": true
+        "react-markdown>unist-util-visit>unist-util-visit-parents": true
       }
     },
     "uri-js": {
       "globals": {
         "define": true
+      }
+    },
+    "browserify>url": {
+      "packages": {
+        "browserify>punycode": true,
+        "@storybook/addon-knobs>qs": true
+      }
+    },
+    "react-focus-lock>use-callback-ref": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-beautiful-dnd>use-memo-one": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-focus-lock>use-sidecar": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "react-focus-lock>use-sidecar>detect-node-es": true,
+        "react": true,
+        "@swc/helpers>tslib": true
+      }
+    },
+    "readable-stream>util-deprecate": {
+      "globals": {
+        "console.trace": true,
+        "console.warn": true,
+        "localStorage": true
+      }
+    },
+    "browserify>assert>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true,
+        "process": true
+      },
+      "packages": {
+        "browserify>assert>util>inherits": true,
+        "process": true
+      }
+    },
+    "browserify>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "browserify>util>is-arguments": true,
+        "koa>is-generator-function": true,
+        "browserify>util>is-typed-array": true,
+        "process": true,
+        "browserify>util>which-typed-array": true
       }
     },
     "uuid": {
@@ -5357,15 +5282,64 @@
         "msCrypto": true
       }
     },
-    "wait-on>rxjs": {
+    "@metamask/eth-snap-keyring>uuid": {
       "globals": {
-        "cancelAnimationFrame": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setInterval.apply": true,
-        "setTimeout.apply": true
+        "crypto": true
+      }
+    },
+    "@metamask/keyring-api>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "web3-stream-provider>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@metamask/snaps-utils>validate-npm-package-name": {
+      "packages": {
+        "@metamask/snaps-utils>validate-npm-package-name>builtins": true
+      }
+    },
+    "react-markdown>vfile>vfile-message": {
+      "packages": {
+        "react-markdown>vfile>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>vfile": {
+      "packages": {
+        "react-markdown>vfile>is-buffer": true,
+        "path-browserify": true,
+        "process": true,
+        "react-markdown>vfile>replace-ext": true,
+        "react-markdown>vfile>vfile-message": true
+      }
+    },
+    "browserify>vm-browserify": {
+      "globals": {
+        "document.body.appendChild": true,
+        "document.body.removeChild": true,
+        "document.createElement": true
+      }
+    },
+    "react-popper>warning": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ensdomains/content-hash>multihashes>web-encoding": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "browserify>util": true
       }
     },
     "web3": {
@@ -5378,14 +5352,14 @@
         "setTimeout": true
       },
       "packages": {
-        "browserify>util": true,
         "readable-stream": true,
+        "browserify>util": true,
         "web3-stream-provider>uuid": true
       }
     },
-    "web3-stream-provider>uuid": {
+    "@metamask/controllers>web3": {
       "globals": {
-        "crypto": true
+        "XMLHttpRequest": true
       }
     },
     "webextension-polyfill": {
@@ -5397,9 +5371,35 @@
         "define": true
       }
     },
-    "webpack>events": {
+    "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive": {
+      "packages": {
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-bigint": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-boolean-object": true,
+        "@metamask/eth-token-tracker>deep-equal>which-boxed-primitive>is-number-object": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>which-collection": {
+      "packages": {
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-map": true,
+        "@metamask/eth-token-tracker>deep-equal>es-get-iterator>is-set": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakmap": true,
+        "@metamask/eth-token-tracker>deep-equal>which-collection>is-weakset": true
+      }
+    },
+    "browserify>util>which-typed-array": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>available-typed-arrays": true,
+        "string.prototype.matchall>call-bind": true,
+        "browserify>util>which-typed-array>for-each": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "@metamask/ethjs>@metamask/ethjs-provider-http>xhr2": {
       "globals": {
-        "console": true
+        "XMLHttpRequest": true
       }
     }
   }

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2737,7 +2737,7 @@
         "@zxing/library>ts-custom-error": true
       }
     },
-    "extension-port-stream>readable-stream>abort-controller": {
+    "@lavamoat/lavapack>readable-stream>abort-controller": {
       "globals": {
         "AbortController": true
       }
@@ -4871,7 +4871,7 @@
         "Blob": true
       },
       "packages": {
-        "extension-port-stream>readable-stream>abort-controller": true,
+        "@lavamoat/lavapack>readable-stream>abort-controller": true,
         "browserify>buffer": true,
         "webpack>events": true,
         "process": true,

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -15,7 +15,7 @@
         "process": true
       },
       "packages": {
-        "@babel/code-frame>@babel/highlight": true,
+        "lavamoat>@babel/highlight": true,
         "postcss>picocolors": true
       }
     },
@@ -177,17 +177,6 @@
         "depcheck>resolve": true
       }
     },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": {
-      "packages": {
-        "@babel/core>@babel/template": true,
-        "@babel/core>@babel/types": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": {
-      "packages": {
-        "@babel/core>@babel/types": true
-      }
-    },
     "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-member-expression-to-functions": {
       "packages": {
         "@babel/core>@babel/types": true
@@ -246,11 +235,6 @@
         "@babel/core>@babel/types": true
       }
     },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": {
-      "packages": {
-        "@babel/core>@babel/types": true
-      }
-    },
     "@babel/preset-env>@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator>@babel/helper-wrap-function": {
       "packages": {
         "@babel/core>@babel/template": true,
@@ -264,13 +248,13 @@
         "@babel/core>@babel/types": true
       }
     },
-    "@babel/code-frame>@babel/highlight": {
+    "lavamoat>@babel/highlight": {
       "globals": {
         "process": true
       },
       "packages": {
         "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
-        "@babel/code-frame>@babel/highlight>chalk": true,
+        "lavamoat>@babel/highlight>chalk": true,
         "loose-envify>js-tokens": true,
         "postcss>picocolors": true
       }
@@ -821,34 +805,7 @@
         "depcheck>@babel/traverse>globals": true
       }
     },
-    "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse": {
-      "globals": {
-        "console.log": true
-      },
-      "packages": {
-        "@babel/code-frame": true,
-        "@babel/core>@babel/generator": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-environment-visitor": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": true,
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/parser": true,
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/types": true,
-        "nock>debug": true,
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>globals": true
-      }
-    },
     "@babel/core>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env": true
-      },
-      "packages": {
-        "@babel/core>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
-      }
-    },
-    "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/types": {
       "globals": {
         "console.warn": true,
         "process.env": true
@@ -1033,13 +990,13 @@
     },
     "@lavamoat/lavapack": {
       "builtin": {
-        "assert": true,
-        "buffer.Buffer.from": true,
-        "fs.promises.readFile": true,
-        "fs.promises.writeFile": true,
-        "fs.readFileSync": true,
-        "path.join": true,
-        "path.relative": true
+        "node:assert": true,
+        "node:buffer.Buffer.from": true,
+        "node:fs.promises.readFile": true,
+        "node:fs.promises.writeFile": true,
+        "node:fs.readFileSync": true,
+        "node:path.join": true,
+        "node:path.relative": true
       },
       "globals": {
         "__dirname": true,
@@ -1052,11 +1009,10 @@
       "packages": {
         "browserify>JSONStream": true,
         "@lavamoat/lavapack>combine-source-map": true,
-        "@lavamoat/lavapack>convert-source-map": true,
         "eslint>espree": true,
         "@lavamoat/lavapack>json-stable-stringify": true,
-        "lavamoat-viz>lavamoat-core": true,
-        "readable-stream": true,
+        "lavamoat>lavamoat-core": true,
+        "@lavamoat/lavapack>readable-stream": true,
         "through2": true,
         "@lavamoat/lavapack>umd": true
       }
@@ -1225,14 +1181,21 @@
         "assert": true,
         "path": true
       },
+      "globals": {
+        "afterAll": true,
+        "process.cwd": true
+      },
       "packages": {
         "eslint>@eslint-community/eslint-utils": true,
+        "eslint>@eslint-community": true,
         "@typescript-eslint/parser>@typescript-eslint/scope-manager": true,
         "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager": true,
         "eslint-plugin-jest>@typescript-eslint/experimental-utils>@typescript-eslint/types": true,
         "@typescript-eslint/parser>@typescript-eslint/types": true,
         "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/types": true,
+        "@typescript-eslint/parser>@typescript-eslint": true,
         "eslint": true,
+        "eslint-plugin-jest>@typescript-eslint/utils>eslint-scope": true,
         "eslint>eslint-scope": true,
         "webpack>eslint-scope": true,
         "eslint-plugin-jest>@typescript-eslint/utils>webpack>eslint-scope": true,
@@ -1261,6 +1224,11 @@
       "packages": {
         "browserify>JSONStream>jsonparse": true,
         "debounce-stream>through": true
+      }
+    },
+    "@lavamoat/lavapack>readable-stream>abort-controller": {
+      "packages": {
+        "@lavamoat/lavapack>readable-stream>abort-controller>event-target-shim": true
       }
     },
     "eslint>espree>acorn-jsx": {
@@ -1338,7 +1306,7 @@
         "chalk>ansi-styles>color-convert": true
       }
     },
-    "@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
+    "lavamoat>@babel/highlight>chalk>ansi-styles": {
       "packages": {
         "@metamask/jazzicon>color>color-convert": true
       }
@@ -1779,15 +1747,15 @@
         "chalk>supports-color": true
       }
     },
-    "@babel/code-frame>@babel/highlight>chalk": {
+    "lavamoat>@babel/highlight>chalk": {
       "globals": {
         "process.env.TERM": true,
         "process.platform": true
       },
       "packages": {
-        "@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
-        "@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
-        "@babel/code-frame>@babel/highlight>chalk>supports-color": true
+        "lavamoat>@babel/highlight>chalk>ansi-styles": true,
+        "lavamoat>@babel/highlight>chalk>escape-string-regexp": true,
+        "lavamoat>@babel/highlight>chalk>supports-color": true
       }
     },
     "gulp-livereload>chalk": {
@@ -2037,19 +2005,11 @@
       "packages": {
         "terser>source-map-support>buffer-from": true,
         "pumpify>inherits": true,
-        "readable-stream": true,
+        "lavamoat-browserify>concat-stream>readable-stream": true,
         "browserify>concat-stream>typedarray": true
       }
     },
     "@babel/core>convert-source-map": {
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "value": true
-      }
-    },
-    "@lavamoat/lavapack>convert-source-map": {
       "globals": {
         "Buffer": true,
         "atob": true,
@@ -2484,18 +2444,6 @@
         "duplexify>stream-shift": true
       }
     },
-    "lavamoat-browserify>duplexify": {
-      "globals": {
-        "Buffer": true,
-        "process.nextTick": true
-      },
-      "packages": {
-        "duplexify>end-of-stream": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
-        "duplexify>stream-shift": true
-      }
-    },
     "gulp>vinyl-fs>glob-stream>pumpify>duplexify": {
       "globals": {
         "Buffer": true,
@@ -2891,6 +2839,15 @@
         "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals>eslint-scope>estraverse": true
       }
     },
+    "eslint-plugin-jest>@typescript-eslint/utils>eslint-scope": {
+      "builtin": {
+        "assert": true
+      },
+      "packages": {
+        "eslint>eslint-scope>esrecurse": true,
+        "eslint-plugin-jest>@typescript-eslint/utils>eslint-scope>estraverse": true
+      }
+    },
     "eslint>eslint-scope": {
       "builtin": {
         "assert": true
@@ -2898,6 +2855,15 @@
       "packages": {
         "eslint>eslint-scope>esrecurse": true,
         "eslint-plugin-react>estraverse": true
+      }
+    },
+    "webpack>eslint-scope": {
+      "builtin": {
+        "assert": true
+      },
+      "packages": {
+        "eslint>eslint-scope>esrecurse": true,
+        "webpack>eslint-scope>estraverse": true
       }
     },
     "eslint-plugin-jest>@typescript-eslint/experimental-utils>eslint-utils": {
@@ -2974,6 +2940,13 @@
         "gulp-livereload>event-stream>split": true,
         "gulp-livereload>event-stream>stream-combiner": true,
         "debounce-stream>through": true
+      }
+    },
+    "@lavamoat/lavapack>readable-stream>abort-controller>event-target-shim": {
+      "globals": {
+        "Event": true,
+        "EventTarget": true,
+        "console": true
       }
     },
     "stylelint>execall": {
@@ -4222,7 +4195,7 @@
       "packages": {
         "string.prototype.matchall>call-bind": true,
         "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "lavamoat>json-stable-stringify>jsonify": true,
+        "@lavamoat/lavapack>json-stable-stringify>jsonify": true,
         "@lavamoat/lavapack>json-stable-stringify>object-keys": true
       }
     },
@@ -4351,14 +4324,14 @@
     },
     "lavamoat-browserify": {
       "builtin": {
-        "fs.existsSync": true,
-        "fs.mkdirSync": true,
-        "fs.readFileSync": true,
-        "fs.writeFileSync": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.resolve": true,
-        "util.callbackify": true
+        "node:fs.existsSync": true,
+        "node:fs.mkdirSync": true,
+        "node:fs.readFileSync": true,
+        "node:fs.writeFileSync": true,
+        "node:path.dirname": true,
+        "node:path.extname": true,
+        "node:path.resolve": true,
+        "node:util.callbackify": true
       },
       "globals": {
         "console.warn": true,
@@ -4370,14 +4343,13 @@
         "@lavamoat/lavapack": true,
         "browserify>browser-resolve": true,
         "lavamoat-browserify>concat-stream": true,
-        "lavamoat-browserify>duplexify": true,
-        "@lavamoat/lavapack>json-stable-stringify": true,
-        "lavamoat-viz>lavamoat-core": true,
-        "readable-stream": true,
+        "duplexify": true,
+        "lavamoat>lavamoat-core": true,
+        "lavamoat-browserify>readable-stream": true,
         "through2": true
       }
     },
-    "lavamoat-viz>lavamoat-core": {
+    "lavamoat>lavamoat-core": {
       "builtin": {
         "node:events": true,
         "node:fs.readFileSync": true,
@@ -4393,17 +4365,17 @@
       },
       "packages": {
         "@lavamoat/lavapack>json-stable-stringify": true,
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu": true,
+        "lavamoat>lavamoat-tofu": true,
         "lavamoat>lavamoat-core>merge-deep": true
       }
     },
-    "lavamoat-viz>lavamoat-core>lavamoat-tofu": {
+    "lavamoat>lavamoat-tofu": {
       "globals": {
         "console.log": true
       },
       "packages": {
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/parser": true,
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse": true
+        "lavamoat>lavamoat-tofu>@babel/parser": true,
+        "depcheck>@babel/traverse": true
       }
     },
     "lavamoat>lavamoat-core>merge-deep>clone-deep>lazy-cache": {
@@ -6222,6 +6194,11 @@
         "eslint-plugin-prettier>prettier-linter-helpers>fast-diff": true
       }
     },
+    "process": {
+      "globals": {
+        "process": true
+      }
+    },
     "vinyl>cloneable-readable>process-nextick-args": {
       "globals": {
         "process.nextTick": true,
@@ -6356,6 +6333,29 @@
         "readable-stream>util-deprecate": true
       }
     },
+    "@lavamoat/lavapack>readable-stream": {
+      "builtin": {
+        "buffer.Blob": true,
+        "buffer.Buffer": true,
+        "events.EventEmitter": true,
+        "events.addAbortListener": true,
+        "stream": true,
+        "string_decoder.StringDecoder": true
+      },
+      "globals": {
+        "AbortController": true,
+        "AbortSignal": true,
+        "AggregateError": true,
+        "Blob": true,
+        "ERR_INVALID_ARG_TYPE": true,
+        "process.env.READABLE_STREAM": true,
+        "queueMicrotask": true
+      },
+      "packages": {
+        "@lavamoat/lavapack>readable-stream>abort-controller": true,
+        "process": true
+      }
+    },
     "vinyl-buffer>bl>readable-stream": {
       "builtin": {
         "events.EventEmitter": true,
@@ -6425,6 +6425,25 @@
         "readable-stream-2>process-nextick-args": true,
         "browserify>concat-stream>readable-stream>safe-buffer": true,
         "browserify>concat-stream>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "lavamoat-browserify>concat-stream>readable-stream": {
+      "builtin": {
+        "buffer.Buffer": true,
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.env.READABLE_STREAM": true,
+        "process.nextTick": true,
+        "process.stderr": true,
+        "process.stdout": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "browserify>string_decoder": true,
         "readable-stream>util-deprecate": true
       }
     },
@@ -6546,6 +6565,29 @@
         "gulp-watch>readable-stream>safe-buffer": true,
         "gulp-watch>readable-stream>string_decoder": true,
         "readable-stream>util-deprecate": true
+      }
+    },
+    "lavamoat-browserify>readable-stream": {
+      "builtin": {
+        "buffer.Blob": true,
+        "buffer.Buffer": true,
+        "events.EventEmitter": true,
+        "events.addAbortListener": true,
+        "stream": true,
+        "string_decoder.StringDecoder": true
+      },
+      "globals": {
+        "AbortController": true,
+        "AbortSignal": true,
+        "AggregateError": true,
+        "Blob": true,
+        "ERR_INVALID_ARG_TYPE": true,
+        "process.env.READABLE_STREAM": true,
+        "queueMicrotask": true
+      },
+      "packages": {
+        "@lavamoat/lavapack>readable-stream>abort-controller": true,
+        "process": true
       }
     },
     "gulp>vinyl-fs>lazystream>readable-stream": {
@@ -8185,7 +8227,7 @@
         "chalk>supports-color>has-flag": true
       }
     },
-    "@babel/code-frame>@babel/highlight>chalk>supports-color": {
+    "lavamoat>@babel/highlight>chalk>supports-color": {
       "builtin": {
         "os.release": true
       },

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1,5 +1,14 @@
 {
   "resources": {
+    "@babel/core>@ampproject/remapping": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "terser>@jridgewell/source-map>@jridgewell/gen-mapping": true,
+        "terser-webpack-plugin>@jridgewell/trace-mapping": true
+      }
+    },
     "@babel/code-frame": {
       "globals": {
         "console.warn": true,
@@ -8,48 +17,6 @@
       "packages": {
         "@babel/code-frame>@babel/highlight": true,
         "postcss>picocolors": true
-      }
-    },
-    "@babel/code-frame>@babel/highlight": {
-      "globals": {
-        "process": true
-      },
-      "packages": {
-        "@babel/code-frame>@babel/highlight>chalk": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
-        "loose-envify>js-tokens": true,
-        "postcss>picocolors": true
-      }
-    },
-    "@babel/code-frame>@babel/highlight>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
-        "@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
-        "@babel/code-frame>@babel/highlight>chalk>supports-color": true
-      }
-    },
-    "@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
-      "packages": {
-        "@metamask/jazzicon>color>color-convert": true
-      }
-    },
-    "@babel/code-frame>@babel/highlight>chalk>supports-color": {
-      "builtin": {
-        "os.release": true
-      },
-      "globals": {
-        "process.env": true,
-        "process.platform": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.versions.node.split": true
-      },
-      "packages": {
-        "gulp-livereload>chalk>supports-color>has-flag": true
       }
     },
     "@babel/core": {
@@ -75,18 +42,13 @@
       },
       "packages": {
         "$root$": true,
-        "@babel/code-frame": true,
         "@babel/core>@ampproject/remapping": true,
+        "@babel/code-frame": true,
         "@babel/core>@babel/generator": true,
         "@babel/core>@babel/helper-compilation-targets": true,
         "@babel/core>@babel/helper-module-transforms": true,
         "@babel/core>@babel/helpers": true,
         "@babel/core>@babel/parser": true,
-        "@babel/core>@babel/template": true,
-        "@babel/core>@babel/types": true,
-        "@babel/core>convert-source-map": true,
-        "@babel/core>gensync": true,
-        "@babel/core>semver": true,
         "@babel/plugin-proposal-class-properties": true,
         "@babel/plugin-proposal-nullish-coalescing-operator": true,
         "@babel/plugin-proposal-object-rest-spread": true,
@@ -96,125 +58,14 @@
         "@babel/preset-env": true,
         "@babel/preset-react": true,
         "@babel/preset-typescript": true,
-        "depcheck>@babel/traverse": true,
-        "depcheck>json5": true,
-        "nock>debug": true
-      }
-    },
-    "@babel/core>@ampproject/remapping": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "terser-webpack-plugin>@jridgewell/trace-mapping": true,
-        "terser>@jridgewell/source-map>@jridgewell/gen-mapping": true
-      }
-    },
-    "@babel/core>@babel/generator": {
-      "globals": {
-        "console.error": true,
-        "console.warn": true
-      },
-      "packages": {
-        "@babel/core>@babel/generator>jsesc": true,
-        "@babel/core>@babel/types": true,
-        "terser-webpack-plugin>@jridgewell/trace-mapping": true,
-        "terser>@jridgewell/source-map>@jridgewell/gen-mapping": true
-      }
-    },
-    "@babel/core>@babel/generator>jsesc": {
-      "globals": {
-        "Buffer": true
-      }
-    },
-    "@babel/core>@babel/helper-compilation-targets": {
-      "globals": {
-        "console.warn": true,
-        "process.env.BROWSERSLIST": true,
-        "process.env.BROWSERSLIST_CONFIG": true,
-        "process.versions.node": true
-      },
-      "packages": {
-        "@babel/core>@babel/helper-compilation-targets>lru-cache": true,
-        "@babel/core>@babel/helper-compilation-targets>semver": true,
-        "@babel/preset-env>@babel/compat-data": true,
-        "@babel/preset-env>@babel/helper-validator-option": true,
-        "browserslist": true
-      }
-    },
-    "@babel/core>@babel/helper-compilation-targets>lru-cache": {
-      "packages": {
-        "@babel/core>@babel/helper-compilation-targets>lru-cache>yallist": true
-      }
-    },
-    "@babel/core>@babel/helper-compilation-targets>semver": {
-      "globals": {
-        "console": true,
-        "process": true
-      }
-    },
-    "@babel/core>@babel/helper-module-transforms": {
-      "builtin": {
-        "assert": true,
-        "path.basename": true,
-        "path.extname": true
-      },
-      "packages": {
-        "@babel/core": true,
-        "@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": true,
-        "@babel/core>@babel/helper-module-transforms>@babel/helper-simple-access": true,
-        "depcheck>@babel/traverse": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
-      }
-    },
-    "@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": {
-      "builtin": {
-        "assert": true
-      },
-      "packages": {
-        "@babel/core>@babel/types": true
-      }
-    },
-    "@babel/core>@babel/helper-module-transforms>@babel/helper-simple-access": {
-      "packages": {
-        "@babel/core>@babel/types": true
-      }
-    },
-    "@babel/core>@babel/helpers": {
-      "packages": {
         "@babel/core>@babel/template": true,
-        "@babel/core>@babel/types": true
-      }
-    },
-    "@babel/core>@babel/template": {
-      "packages": {
-        "@babel/code-frame": true,
-        "@babel/core>@babel/parser": true,
-        "@babel/core>@babel/types": true
-      }
-    },
-    "@babel/core>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env": true
-      },
-      "packages": {
-        "@babel/core>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
-      }
-    },
-    "@babel/core>convert-source-map": {
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "value": true
-      }
-    },
-    "@babel/core>semver": {
-      "globals": {
-        "console": true,
-        "process": true
+        "depcheck>@babel/traverse": true,
+        "@babel/core>@babel/types": true,
+        "@babel/core>convert-source-map": true,
+        "nock>debug": true,
+        "@babel/core>gensync": true,
+        "depcheck>json5": true,
+        "@babel/core>semver": true
       }
     },
     "@babel/eslint-parser": {
@@ -230,125 +81,198 @@
       },
       "packages": {
         "@babel/core": true,
+        "@babel/parser": true,
         "@babel/core>@babel/parser": true,
+        "depcheck>@babel/parser": true,
+        "lavamoat>lavamoat-tofu>@babel/parser": true,
         "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals": true,
+        "eslint": true,
         "@babel/eslint-parser>eslint-scope": true,
         "@babel/eslint-parser>eslint-visitor-keys": true,
-        "@babel/eslint-parser>semver": true,
-        "@babel/parser": true,
-        "depcheck>@babel/parser": true,
-        "eslint": true,
-        "lavamoat>lavamoat-tofu>@babel/parser": true
-      }
-    },
-    "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals": {
-      "packages": {
-        "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals>eslint-scope": true
-      }
-    },
-    "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals>eslint-scope": {
-      "builtin": {
-        "assert": true
-      },
-      "packages": {
-        "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals>eslint-scope>estraverse": true,
-        "eslint>eslint-scope>esrecurse": true
-      }
-    },
-    "@babel/eslint-parser>semver": {
-      "globals": {
-        "console": true,
-        "process": true
+        "@babel/eslint-parser>semver": true
       }
     },
     "@babel/eslint-plugin": {
       "packages": {
-        "@babel/eslint-plugin>eslint-rule-composer": true,
-        "eslint": true
+        "eslint": true,
+        "@babel/eslint-plugin>eslint-rule-composer": true
       }
     },
-    "@babel/plugin-transform-logical-assignment-operators": {
+    "@babel/core>@babel/generator": {
+      "globals": {
+        "console.error": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@babel/core>@babel/types": true,
+        "terser>@jridgewell/source-map>@jridgewell/gen-mapping": true,
+        "terser-webpack-plugin>@jridgewell/trace-mapping": true,
+        "@babel/core>@babel/generator>jsesc": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": {
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-exponentiation-operator>@babel/helper-builder-binary-assignment-operator-visitor": {
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/core>@babel/helper-compilation-targets": {
+      "globals": {
+        "console.warn": true,
+        "process.env.BROWSERSLIST": true,
+        "process.env.BROWSERSLIST_CONFIG": true,
+        "process.versions.node": true
+      },
+      "packages": {
+        "@babel/preset-env>@babel/compat-data": true,
+        "@babel/preset-env>@babel/helper-validator-option": true,
+        "browserslist": true,
+        "@babel/core>@babel/helper-compilation-targets>lru-cache": true,
+        "@babel/core>@babel/helper-compilation-targets>semver": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": {
+      "globals": {
+        "console.warn": true
+      },
       "packages": {
         "@babel/core": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-syntax-logical-assignment-operators": true
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-member-expression-to-functions": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-optimise-call-expression": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers": true,
+        "@babel/preset-env>@babel/plugin-transform-for-of>@babel/helper-skip-transparent-expression-wrappers": true,
+        "depcheck>@babel/traverse": true,
+        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin>semver": true
       }
     },
-    "@babel/preset-env": {
+    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": {
+      "packages": {
+        "@babel/core": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core": true,
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>semver": true
+      }
+    },
+    "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider": {
+      "builtin": {
+        "module": true,
+        "path": true
+      },
       "globals": {
         "console.log": true,
         "console.warn": true,
-        "process.cwd": true,
-        "process.env.BABEL_ENV": true
+        "process.exitCode": "write",
+        "process.versions.node": true
       },
       "packages": {
+        "@babel/core": true,
         "@babel/core>@babel/helper-compilation-targets": true,
-        "@babel/plugin-transform-logical-assignment-operators": true,
-        "@babel/preset-env>@babel/compat-data": true,
         "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/helper-validator-option": true,
-        "@babel/preset-env>@babel/plugin-bugfix-firefox-class-in-computed-class-key": true,
-        "@babel/preset-env>@babel/plugin-bugfix-safari-class-field-initializer-scope": true,
-        "@babel/preset-env>@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": true,
-        "@babel/preset-env>@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": true,
-        "@babel/preset-env>@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": true,
-        "@babel/preset-env>@babel/plugin-syntax-import-assertions": true,
-        "@babel/preset-env>@babel/plugin-syntax-import-attributes": true,
-        "@babel/preset-env>@babel/plugin-syntax-unicode-sets-regex": true,
-        "@babel/preset-env>@babel/plugin-transform-arrow-functions": true,
-        "@babel/preset-env>@babel/plugin-transform-async-generator-functions": true,
-        "@babel/preset-env>@babel/plugin-transform-async-to-generator": true,
-        "@babel/preset-env>@babel/plugin-transform-block-scoped-functions": true,
-        "@babel/preset-env>@babel/plugin-transform-block-scoping": true,
-        "@babel/preset-env>@babel/plugin-transform-class-properties": true,
-        "@babel/preset-env>@babel/plugin-transform-class-static-block": true,
-        "@babel/preset-env>@babel/plugin-transform-classes": true,
-        "@babel/preset-env>@babel/plugin-transform-computed-properties": true,
-        "@babel/preset-env>@babel/plugin-transform-destructuring": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex": true,
-        "@babel/preset-env>@babel/plugin-transform-duplicate-keys": true,
-        "@babel/preset-env>@babel/plugin-transform-duplicate-named-capturing-groups-regex": true,
-        "@babel/preset-env>@babel/plugin-transform-dynamic-import": true,
-        "@babel/preset-env>@babel/plugin-transform-exponentiation-operator": true,
-        "@babel/preset-env>@babel/plugin-transform-export-namespace-from": true,
-        "@babel/preset-env>@babel/plugin-transform-for-of": true,
-        "@babel/preset-env>@babel/plugin-transform-function-name": true,
-        "@babel/preset-env>@babel/plugin-transform-json-strings": true,
-        "@babel/preset-env>@babel/plugin-transform-literals": true,
-        "@babel/preset-env>@babel/plugin-transform-member-expression-literals": true,
-        "@babel/preset-env>@babel/plugin-transform-modules-amd": true,
-        "@babel/preset-env>@babel/plugin-transform-modules-commonjs": true,
-        "@babel/preset-env>@babel/plugin-transform-modules-systemjs": true,
-        "@babel/preset-env>@babel/plugin-transform-modules-umd": true,
-        "@babel/preset-env>@babel/plugin-transform-named-capturing-groups-regex": true,
-        "@babel/preset-env>@babel/plugin-transform-new-target": true,
-        "@babel/preset-env>@babel/plugin-transform-nullish-coalescing-operator": true,
-        "@babel/preset-env>@babel/plugin-transform-numeric-separator": true,
-        "@babel/preset-env>@babel/plugin-transform-object-rest-spread": true,
-        "@babel/preset-env>@babel/plugin-transform-object-super": true,
-        "@babel/preset-env>@babel/plugin-transform-optional-catch-binding": true,
-        "@babel/preset-env>@babel/plugin-transform-optional-chaining": true,
-        "@babel/preset-env>@babel/plugin-transform-parameters": true,
-        "@babel/preset-env>@babel/plugin-transform-private-methods": true,
-        "@babel/preset-env>@babel/plugin-transform-private-property-in-object": true,
-        "@babel/preset-env>@babel/plugin-transform-property-literals": true,
-        "@babel/preset-env>@babel/plugin-transform-regenerator": true,
-        "@babel/preset-env>@babel/plugin-transform-reserved-words": true,
-        "@babel/preset-env>@babel/plugin-transform-shorthand-properties": true,
-        "@babel/preset-env>@babel/plugin-transform-spread": true,
-        "@babel/preset-env>@babel/plugin-transform-sticky-regex": true,
-        "@babel/preset-env>@babel/plugin-transform-template-literals": true,
-        "@babel/preset-env>@babel/plugin-transform-typeof-symbol": true,
-        "@babel/preset-env>@babel/plugin-transform-unicode-escapes": true,
-        "@babel/preset-env>@babel/plugin-transform-unicode-property-regex": true,
-        "@babel/preset-env>@babel/plugin-transform-unicode-regex": true,
-        "@babel/preset-env>@babel/plugin-transform-unicode-sets-regex": true,
-        "@babel/preset-env>@babel/preset-modules": true,
-        "@babel/preset-env>babel-plugin-polyfill-corejs2": true,
-        "@babel/preset-env>babel-plugin-polyfill-corejs3": true,
-        "@babel/preset-env>babel-plugin-polyfill-regenerator": true,
-        "@babel/preset-env>core-js-compat": true,
-        "@babel/preset-env>semver": true
+        "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>lodash.debounce": true,
+        "depcheck>resolve": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": {
+      "packages": {
+        "@babel/core>@babel/template": true,
+        "@babel/core>@babel/types": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": {
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-member-expression-to-functions": {
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": {
+      "builtin": {
+        "assert": true
+      },
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/core>@babel/helper-module-transforms": {
+      "builtin": {
+        "assert": true,
+        "path.basename": true,
+        "path.extname": true
+      },
+      "packages": {
+        "@babel/core": true,
+        "@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": true,
+        "@babel/core>@babel/helper-module-transforms>@babel/helper-simple-access": true,
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
+        "depcheck>@babel/traverse": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-optimise-call-expression": {
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator": {
+      "packages": {
+        "@babel/core": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
+        "@babel/preset-env>@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator>@babel/helper-wrap-function": true,
+        "depcheck>@babel/traverse": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers": {
+      "packages": {
+        "@babel/core": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-member-expression-to-functions": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-optimise-call-expression": true,
+        "depcheck>@babel/traverse": true
+      }
+    },
+    "@babel/core>@babel/helper-module-transforms>@babel/helper-simple-access": {
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-for-of>@babel/helper-skip-transparent-expression-wrappers": {
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": {
+      "packages": {
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator>@babel/helper-wrap-function": {
+      "packages": {
+        "@babel/core>@babel/template": true,
+        "depcheck>@babel/traverse": true,
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/core>@babel/helpers": {
+      "packages": {
+        "@babel/core>@babel/template": true,
+        "@babel/core>@babel/types": true
+      }
+    },
+    "@babel/code-frame>@babel/highlight": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
+        "@babel/code-frame>@babel/highlight>chalk": true,
+        "loose-envify>js-tokens": true,
+        "postcss>picocolors": true
       }
     },
     "@babel/preset-env>@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
@@ -393,10 +317,20 @@
         "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
+    "@babel/preset-typescript>@babel/plugin-syntax-jsx": {
+      "packages": {
+        "@babel/preset-env>@babel/helper-plugin-utils": true
+      }
+    },
+    "@babel/preset-typescript>@babel/plugin-transform-typescript>@babel/plugin-syntax-typescript": {
+      "packages": {
+        "@babel/preset-env>@babel/helper-plugin-utils": true
+      }
+    },
     "@babel/preset-env>@babel/plugin-syntax-unicode-sets-regex": {
       "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-arrow-functions": {
@@ -420,21 +354,6 @@
         "@babel/preset-env>@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator": true
       }
     },
-    "@babel/preset-env>@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator": {
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator>@babel/helper-wrap-function": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
-        "depcheck>@babel/traverse": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-async-to-generator>@babel/helper-remap-async-to-generator>@babel/helper-wrap-function": {
-      "packages": {
-        "@babel/core>@babel/template": true,
-        "@babel/core>@babel/types": true,
-        "depcheck>@babel/traverse": true
-      }
-    },
     "@babel/preset-env>@babel/plugin-transform-block-scoped-functions": {
       "packages": {
         "@babel/core": true,
@@ -449,55 +368,32 @@
     },
     "@babel/preset-env>@babel/plugin-transform-class-properties": {
       "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true
+        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-class-static-block": {
       "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true
+        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-classes": {
       "packages": {
         "@babel/core": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
         "@babel/core>@babel/helper-compilation-targets": true,
         "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
         "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>globals": true,
-        "depcheck>@babel/traverse": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": {
-      "packages": {
-        "@babel/core>@babel/types": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers": {
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-member-expression-to-functions": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-optimise-call-expression": true,
-        "depcheck>@babel/traverse": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-member-expression-to-functions": {
-      "packages": {
-        "@babel/core>@babel/types": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-optimise-call-expression": {
-      "packages": {
-        "@babel/core>@babel/types": true
+        "depcheck>@babel/traverse": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>globals": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-computed-properties": {
       "packages": {
         "@babel/core": true,
-        "@babel/core>@babel/template": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true
+        "@babel/preset-env>@babel/helper-plugin-utils": true,
+        "@babel/core>@babel/template": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-destructuring": {
@@ -508,55 +404,8 @@
     },
     "@babel/preset-env>@babel/plugin-transform-dotall-regex": {
       "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": {
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>semver": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core": {
-      "globals": {
-        "characterClassItem.kind": true
-      },
-      "packages": {
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regenerate": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsgen": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsparser": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-ecmascript": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-value-ecmascript": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regenerate": {
-      "globals": {
-        "define": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsgen": {
-      "globals": {
-        "define": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsparser": {
-      "globals": {
-        "regjsparser": "write"
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-ecmascript": {
-      "packages": {
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-ecmascript>unicode-canonical-property-names-ecmascript": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-ecmascript>unicode-property-aliases-ecmascript": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>semver": {
-      "globals": {
-        "console": true,
-        "process": true
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-duplicate-keys": {
@@ -567,8 +416,8 @@
     },
     "@babel/preset-env>@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
       "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-dynamic-import": {
@@ -579,13 +428,8 @@
     "@babel/preset-env>@babel/plugin-transform-exponentiation-operator": {
       "packages": {
         "@babel/core": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-exponentiation-operator>@babel/helper-builder-binary-assignment-operator-visitor": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-exponentiation-operator>@babel/helper-builder-binary-assignment-operator-visitor": {
-      "packages": {
-        "@babel/core>@babel/types": true
+        "@babel/preset-env>@babel/plugin-transform-exponentiation-operator>@babel/helper-builder-binary-assignment-operator-visitor": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-export-namespace-from": {
@@ -599,11 +443,6 @@
         "@babel/core": true,
         "@babel/preset-env>@babel/helper-plugin-utils": true,
         "@babel/preset-env>@babel/plugin-transform-for-of>@babel/helper-skip-transparent-expression-wrappers": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-for-of>@babel/helper-skip-transparent-expression-wrappers": {
-      "packages": {
-        "@babel/core>@babel/types": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-function-name": {
@@ -623,6 +462,13 @@
         "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
+    "@babel/plugin-transform-logical-assignment-operators": {
+      "packages": {
+        "@babel/core": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true,
+        "@babel/preset-env>@babel/plugin-syntax-logical-assignment-operators": true
+      }
+    },
     "@babel/preset-env>@babel/plugin-transform-member-expression-literals": {
       "packages": {
         "@babel/core": true,
@@ -640,8 +486,8 @@
       "packages": {
         "@babel/core": true,
         "@babel/core>@babel/helper-module-transforms": true,
-        "@babel/core>@babel/helper-module-transforms>@babel/helper-simple-access": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true
+        "@babel/preset-env>@babel/helper-plugin-utils": true,
+        "@babel/core>@babel/helper-module-transforms>@babel/helper-simple-access": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-modules-systemjs": {
@@ -652,8 +498,8 @@
         "@babel/core": true,
         "@babel/core>@babel/helper-module-transforms": true,
         "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "depcheck>@babel/traverse": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
+        "depcheck>@babel/traverse": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-modules-umd": {
@@ -669,8 +515,8 @@
     },
     "@babel/preset-env>@babel/plugin-transform-named-capturing-groups-regex": {
       "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-new-target": {
@@ -725,36 +571,15 @@
     },
     "@babel/preset-env>@babel/plugin-transform-private-methods": {
       "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": {
-      "globals": {
-        "console.warn": true
-      },
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-member-expression-to-functions": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-replace-supers>@babel/helper-optimise-call-expression": true,
-        "@babel/preset-env>@babel/plugin-transform-for-of>@babel/helper-skip-transparent-expression-wrappers": true,
-        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin>semver": true,
-        "depcheck>@babel/traverse": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin>semver": {
-      "globals": {
-        "console": true,
-        "process": true
+        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-private-property-in-object": {
       "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
         "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
-        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true
+        "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-property-literals": {
@@ -763,19 +588,42 @@
         "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
+    "@babel/preset-react>@babel/plugin-transform-react-display-name": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true
+      },
+      "packages": {
+        "@babel/core": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
+      }
+    },
+    "@babel/preset-react>@babel/plugin-transform-react-jsx-development": {
+      "packages": {
+        "@babel/preset-react>@babel/plugin-transform-react-jsx": true
+      }
+    },
+    "@babel/preset-react>@babel/plugin-transform-react-jsx": {
+      "packages": {
+        "@babel/core": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
+        "@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true,
+        "@babel/preset-typescript>@babel/plugin-syntax-jsx": true
+      }
+    },
+    "@babel/preset-react>@babel/plugin-transform-react-pure-annotations": {
+      "packages": {
+        "@babel/core": true,
+        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
+      }
+    },
     "@babel/preset-env>@babel/plugin-transform-regenerator": {
       "packages": {
         "@babel/preset-env>@babel/helper-plugin-utils": true,
         "@babel/preset-env>@babel/plugin-transform-regenerator>regenerator-transform": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-regenerator>regenerator-transform": {
-      "builtin": {
-        "assert": true,
-        "util.inherits": true
-      },
-      "packages": {
-        "@babel/runtime": true
       }
     },
     "@babel/preset-env>@babel/plugin-transform-reserved-words": {
@@ -815,143 +663,6 @@
         "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
-    "@babel/preset-env>@babel/plugin-transform-unicode-escapes": {
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-unicode-property-regex": {
-      "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-unicode-regex": {
-      "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true
-      }
-    },
-    "@babel/preset-env>@babel/plugin-transform-unicode-sets-regex": {
-      "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true
-      }
-    },
-    "@babel/preset-env>babel-plugin-polyfill-corejs2": {
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>@babel/compat-data": true,
-        "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider": true,
-        "@babel/preset-env>babel-plugin-polyfill-corejs2>semver": true
-      }
-    },
-    "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider": {
-      "builtin": {
-        "module": true,
-        "path": true
-      },
-      "globals": {
-        "console.log": true,
-        "console.warn": true,
-        "process.exitCode": "write",
-        "process.versions.node": true
-      },
-      "packages": {
-        "@babel/core": true,
-        "@babel/core>@babel/helper-compilation-targets": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>lodash.debounce": true,
-        "depcheck>resolve": true
-      }
-    },
-    "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>lodash.debounce": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      }
-    },
-    "@babel/preset-env>babel-plugin-polyfill-corejs2>semver": {
-      "globals": {
-        "console": true,
-        "process": true
-      }
-    },
-    "@babel/preset-env>babel-plugin-polyfill-corejs3": {
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider": true,
-        "@babel/preset-env>core-js-compat": true
-      }
-    },
-    "@babel/preset-env>babel-plugin-polyfill-regenerator": {
-      "packages": {
-        "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider": true
-      }
-    },
-    "@babel/preset-env>semver": {
-      "globals": {
-        "console": true,
-        "process": true
-      }
-    },
-    "@babel/preset-react": {
-      "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/helper-validator-option": true,
-        "@babel/preset-react>@babel/plugin-transform-react-display-name": true,
-        "@babel/preset-react>@babel/plugin-transform-react-jsx": true,
-        "@babel/preset-react>@babel/plugin-transform-react-jsx-development": true,
-        "@babel/preset-react>@babel/plugin-transform-react-pure-annotations": true
-      }
-    },
-    "@babel/preset-react>@babel/plugin-transform-react-display-name": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true
-      },
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true
-      }
-    },
-    "@babel/preset-react>@babel/plugin-transform-react-jsx": {
-      "packages": {
-        "@babel/core": true,
-        "@babel/core>@babel/helper-module-transforms>@babel/helper-module-imports": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
-        "@babel/preset-typescript>@babel/plugin-syntax-jsx": true
-      }
-    },
-    "@babel/preset-react>@babel/plugin-transform-react-jsx-development": {
-      "packages": {
-        "@babel/preset-react>@babel/plugin-transform-react-jsx": true
-      }
-    },
-    "@babel/preset-react>@babel/plugin-transform-react-pure-annotations": {
-      "packages": {
-        "@babel/core": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true
-      }
-    },
-    "@babel/preset-typescript": {
-      "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
-        "@babel/preset-env>@babel/helper-validator-option": true,
-        "@babel/preset-env>@babel/plugin-transform-modules-commonjs": true,
-        "@babel/preset-typescript>@babel/plugin-syntax-jsx": true,
-        "@babel/preset-typescript>@babel/plugin-transform-typescript": true
-      }
-    },
-    "@babel/preset-typescript>@babel/plugin-syntax-jsx": {
-      "packages": {
-        "@babel/preset-env>@babel/helper-plugin-utils": true
-      }
-    },
     "@babel/preset-typescript>@babel/plugin-transform-typescript": {
       "builtin": {
         "assert": true
@@ -961,85 +672,363 @@
       },
       "packages": {
         "@babel/core": true,
-        "@babel/preset-env>@babel/helper-plugin-utils": true,
         "@babel/preset-env>@babel/plugin-transform-classes>@babel/helper-annotate-as-pure": true,
-        "@babel/preset-env>@babel/plugin-transform-for-of>@babel/helper-skip-transparent-expression-wrappers": true,
         "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true,
+        "@babel/preset-env>@babel/plugin-transform-for-of>@babel/helper-skip-transparent-expression-wrappers": true,
         "@babel/preset-typescript>@babel/plugin-transform-typescript>@babel/plugin-syntax-typescript": true
       }
     },
-    "@babel/preset-typescript>@babel/plugin-transform-typescript>@babel/plugin-syntax-typescript": {
+    "@babel/preset-env>@babel/plugin-transform-unicode-escapes": {
       "packages": {
+        "@babel/core": true,
         "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
-    "@babel/register>clone-deep>is-plain-object": {
+    "@babel/preset-env>@babel/plugin-transform-unicode-property-regex": {
       "packages": {
-        "gulp>gulp-cli>isobject": true
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
       }
     },
-    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog": {
+    "@babel/preset-env>@babel/plugin-transform-unicode-regex": {
+      "packages": {
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-unicode-sets-regex": {
+      "packages": {
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true
+      }
+    },
+    "@babel/preset-env": {
+      "globals": {
+        "console.log": true,
+        "console.warn": true,
+        "process.cwd": true,
+        "process.env.BABEL_ENV": true
+      },
+      "packages": {
+        "@babel/preset-env>@babel/compat-data": true,
+        "@babel/core>@babel/helper-compilation-targets": true,
+        "@babel/preset-env>@babel/helper-plugin-utils": true,
+        "@babel/preset-env>@babel/helper-validator-option": true,
+        "@babel/preset-env>@babel/plugin-bugfix-firefox-class-in-computed-class-key": true,
+        "@babel/preset-env>@babel/plugin-bugfix-safari-class-field-initializer-scope": true,
+        "@babel/preset-env>@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": true,
+        "@babel/preset-env>@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": true,
+        "@babel/preset-env>@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": true,
+        "@babel/preset-env>@babel/plugin-syntax-import-assertions": true,
+        "@babel/preset-env>@babel/plugin-syntax-import-attributes": true,
+        "@babel/preset-env>@babel/plugin-syntax-unicode-sets-regex": true,
+        "@babel/preset-env>@babel/plugin-transform-arrow-functions": true,
+        "@babel/preset-env>@babel/plugin-transform-async-generator-functions": true,
+        "@babel/preset-env>@babel/plugin-transform-async-to-generator": true,
+        "@babel/preset-env>@babel/plugin-transform-block-scoped-functions": true,
+        "@babel/preset-env>@babel/plugin-transform-block-scoping": true,
+        "@babel/preset-env>@babel/plugin-transform-class-properties": true,
+        "@babel/preset-env>@babel/plugin-transform-class-static-block": true,
+        "@babel/preset-env>@babel/plugin-transform-classes": true,
+        "@babel/preset-env>@babel/plugin-transform-computed-properties": true,
+        "@babel/preset-env>@babel/plugin-transform-destructuring": true,
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex": true,
+        "@babel/preset-env>@babel/plugin-transform-duplicate-keys": true,
+        "@babel/preset-env>@babel/plugin-transform-duplicate-named-capturing-groups-regex": true,
+        "@babel/preset-env>@babel/plugin-transform-dynamic-import": true,
+        "@babel/preset-env>@babel/plugin-transform-exponentiation-operator": true,
+        "@babel/preset-env>@babel/plugin-transform-export-namespace-from": true,
+        "@babel/preset-env>@babel/plugin-transform-for-of": true,
+        "@babel/preset-env>@babel/plugin-transform-function-name": true,
+        "@babel/preset-env>@babel/plugin-transform-json-strings": true,
+        "@babel/preset-env>@babel/plugin-transform-literals": true,
+        "@babel/plugin-transform-logical-assignment-operators": true,
+        "@babel/preset-env>@babel/plugin-transform-member-expression-literals": true,
+        "@babel/preset-env>@babel/plugin-transform-modules-amd": true,
+        "@babel/preset-env>@babel/plugin-transform-modules-commonjs": true,
+        "@babel/preset-env>@babel/plugin-transform-modules-systemjs": true,
+        "@babel/preset-env>@babel/plugin-transform-modules-umd": true,
+        "@babel/preset-env>@babel/plugin-transform-named-capturing-groups-regex": true,
+        "@babel/preset-env>@babel/plugin-transform-new-target": true,
+        "@babel/preset-env>@babel/plugin-transform-nullish-coalescing-operator": true,
+        "@babel/preset-env>@babel/plugin-transform-numeric-separator": true,
+        "@babel/preset-env>@babel/plugin-transform-object-rest-spread": true,
+        "@babel/preset-env>@babel/plugin-transform-object-super": true,
+        "@babel/preset-env>@babel/plugin-transform-optional-catch-binding": true,
+        "@babel/preset-env>@babel/plugin-transform-optional-chaining": true,
+        "@babel/preset-env>@babel/plugin-transform-parameters": true,
+        "@babel/preset-env>@babel/plugin-transform-private-methods": true,
+        "@babel/preset-env>@babel/plugin-transform-private-property-in-object": true,
+        "@babel/preset-env>@babel/plugin-transform-property-literals": true,
+        "@babel/preset-env>@babel/plugin-transform-regenerator": true,
+        "@babel/preset-env>@babel/plugin-transform-reserved-words": true,
+        "@babel/preset-env>@babel/plugin-transform-shorthand-properties": true,
+        "@babel/preset-env>@babel/plugin-transform-spread": true,
+        "@babel/preset-env>@babel/plugin-transform-sticky-regex": true,
+        "@babel/preset-env>@babel/plugin-transform-template-literals": true,
+        "@babel/preset-env>@babel/plugin-transform-typeof-symbol": true,
+        "@babel/preset-env>@babel/plugin-transform-unicode-escapes": true,
+        "@babel/preset-env>@babel/plugin-transform-unicode-property-regex": true,
+        "@babel/preset-env>@babel/plugin-transform-unicode-regex": true,
+        "@babel/preset-env>@babel/plugin-transform-unicode-sets-regex": true,
+        "@babel/preset-env>@babel/preset-modules": true,
+        "@babel/preset-env>babel-plugin-polyfill-corejs2": true,
+        "@babel/preset-env>babel-plugin-polyfill-corejs3": true,
+        "@babel/preset-env>babel-plugin-polyfill-regenerator": true,
+        "@babel/preset-env>core-js-compat": true,
+        "@babel/preset-env>semver": true
+      }
+    },
+    "@babel/preset-react": {
+      "packages": {
+        "@babel/preset-env>@babel/helper-plugin-utils": true,
+        "@babel/preset-env>@babel/helper-validator-option": true,
+        "@babel/preset-react>@babel/plugin-transform-react-display-name": true,
+        "@babel/preset-react>@babel/plugin-transform-react-jsx-development": true,
+        "@babel/preset-react>@babel/plugin-transform-react-jsx": true,
+        "@babel/preset-react>@babel/plugin-transform-react-pure-annotations": true
+      }
+    },
+    "@babel/preset-typescript": {
+      "packages": {
+        "@babel/preset-env>@babel/helper-plugin-utils": true,
+        "@babel/preset-env>@babel/helper-validator-option": true,
+        "@babel/preset-typescript>@babel/plugin-syntax-jsx": true,
+        "@babel/preset-env>@babel/plugin-transform-modules-commonjs": true,
+        "@babel/preset-typescript>@babel/plugin-transform-typescript": true
+      }
+    },
+    "@babel/core>@babel/template": {
+      "packages": {
+        "@babel/code-frame": true,
+        "@babel/core>@babel/parser": true,
+        "@babel/core>@babel/types": true
+      }
+    },
+    "depcheck>@babel/traverse": {
+      "globals": {
+        "console.log": true
+      },
+      "packages": {
+        "@babel/code-frame": true,
+        "@babel/core>@babel/generator": true,
+        "@babel/core>@babel/parser": true,
+        "@babel/core>@babel/template": true,
+        "@babel/core>@babel/types": true,
+        "babel/preset-env>b@babel/types": true,
+        "nock>debug": true,
+        "depcheck>@babel/traverse>globals": true
+      }
+    },
+    "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse": {
+      "globals": {
+        "console.log": true
+      },
+      "packages": {
+        "@babel/code-frame": true,
+        "@babel/core>@babel/generator": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-environment-visitor": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": true,
+        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": true,
+        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/parser": true,
+        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/types": true,
+        "nock>debug": true,
+        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>globals": true
+      }
+    },
+    "@babel/core>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env": true
+      },
+      "packages": {
+        "@babel/core>@babel/types>@babel/helper-string-parser": true,
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
+      }
+    },
+    "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/types": {
+      "globals": {
+        "console.warn": true,
+        "process.env": true
+      },
+      "packages": {
+        "@babel/core>@babel/types>@babel/helper-string-parser": true,
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
+      }
+    },
+    "sass-embedded>@bufbuild/protobuf": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "__values": true,
+        "process": true
+      }
+    },
+    "ts-node>@cspotcode/source-map-support": {
       "builtin": {
-        "events.EventEmitter": true,
+        "fs": true,
+        "path.isAbsolute": true,
+        "path.join": true,
+        "path.normalize": true,
+        "path.resolve": true,
+        "url.fileURLToPath": true,
+        "url.pathToFileURL": true,
+        "util.inspect": true
+      },
+      "globals": {
+        "Buffer.from": true,
+        "URL": true,
+        "XMLHttpRequest": true,
+        "console.error": true,
+        "process": true
+      },
+      "packages": {
+        "ts-node>@cspotcode/source-map-support>@jridgewell/trace-mapping": true
+      }
+    },
+    "eslint-plugin-jsdoc>@es-joy/jsdoccomment": {
+      "packages": {
+        "eslint-plugin-jsdoc>comment-parser": true,
+        "eslint>esquery": true,
+        "eslint-plugin-jsdoc>@es-joy/jsdoccomment>jsdoc-type-pratt-parser": true
+      }
+    },
+    "eslint>@eslint-community/eslint-utils": {
+      "packages": {
+        "eslint>eslint-visitor-keys": true
+      }
+    },
+    "eslint>@eslint/eslintrc": {
+      "builtin": {
+        "assert": true,
+        "fs": true,
+        "module": true,
+        "os": true,
+        "path": true,
+        "url": true,
         "util": true
       },
       "globals": {
-        "process.nextTick": true,
-        "process.stderr": true
+        "__filename": true,
+        "process.cwd": true,
+        "process.emitWarning": true,
+        "process.platform": true
       },
       "packages": {
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>are-we-there-yet": true,
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge": true,
-        "@storybook/react>@storybook/node-logger>npmlog>console-control-strings": true,
-        "nyc>yargs>set-blocking": true
+        "$root$": true,
+        "@babel/eslint-parser": true,
+        "@babel/eslint-plugin": true,
+        "@metamask/eslint-config": true,
+        "@metamask/eslint-config-nodejs": true,
+        "@metamask/eslint-config-typescript": true,
+        "@typescript-eslint/eslint-plugin": true,
+        "eslint>ajv": true,
+        "nock>debug": true,
+        "eslint": true,
+        "eslint-config-prettier": true,
+        "eslint-plugin-import": true,
+        "eslint-plugin-jsdoc": true,
+        "eslint-plugin-node": true,
+        "eslint-plugin-prettier": true,
+        "eslint-plugin-react": true,
+        "eslint-plugin-react-hooks": true,
+        "eslint>globals": true,
+        "eslint>ignore": true,
+        "eslint>minimatch": true,
+        "mocha>strip-json-comments": true
       }
     },
-    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>are-we-there-yet": {
+    "gulp-sourcemaps>@gulp-sourcemaps/identity-map": {
+      "packages": {
+        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>acorn": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>normalize-path": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>source-map": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>through2": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/map-sources": {
+      "packages": {
+        "gulp-watch>anymatch>normalize-path": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2": true
+      }
+    },
+    "eslint>@humanwhocodes/config-array": {
       "builtin": {
-        "events.EventEmitter": true,
-        "util.inherits": true
+        "path.dirname": true,
+        "path.join": true,
+        "path.relative": true
       },
       "packages": {
-        "koa>delegates": true,
-        "readable-stream": true
+        "eslint>@humanwhocodes/config-array>@humanwhocodes/object-schema": true,
+        "nock>debug": true,
+        "eslint>minimatch": true
       }
     },
-    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge": {
-      "builtin": {
-        "util.format": true
-      },
+    "terser>@jridgewell/source-map>@jridgewell/gen-mapping": {
       "globals": {
-        "clearInterval": true,
-        "process": true,
-        "setImmediate": true,
-        "setInterval": true
+        "define": true
       },
       "packages": {
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>aproba": true,
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width": true,
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": true,
-        "@storybook/react>@storybook/node-logger>npmlog>console-control-strings": true,
-        "@storybook/react>@storybook/node-logger>npmlog>gauge>has-unicode": true,
-        "@storybook/react>@storybook/node-logger>npmlog>gauge>wide-align": true,
-        "nyc>signal-exit": true,
-        "react>object-assign": true
+        "terser>@jridgewell/source-map>@jridgewell/gen-mapping>@jridgewell/set-array": true,
+        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
+        "terser-webpack-plugin>@jridgewell/trace-mapping": true
       }
     },
-    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width": {
-      "packages": {
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": true,
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": true,
-        "gulp>gulp-cli>yargs>string-width>code-point-at": true
+    "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": {
+      "globals": {
+        "define": true
       }
     },
-    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": {
-      "packages": {
-        "gulp>gulp-cli>yargs>string-width>is-fullwidth-code-point>number-is-nan": true
+    "terser>@jridgewell/source-map>@jridgewell/gen-mapping>@jridgewell/set-array": {
+      "globals": {
+        "define": true
       }
     },
-    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": {
+    "terser>@jridgewell/source-map": {
       "packages": {
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi>ansi-regex": true
+        "terser>@jridgewell/source-map>@jridgewell/gen-mapping": true,
+        "terser-webpack-plugin>@jridgewell/trace-mapping": true
+      }
+    },
+    "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "define": true
+      }
+    },
+    "ts-node>@cspotcode/source-map-support>@jridgewell/trace-mapping": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "terser-webpack-plugin>@jridgewell/trace-mapping": {
+      "globals": {
+        "define": true
+      },
+      "packages": {
+        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
+        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "lavamoat>@lavamoat/aa": {
+      "builtin": {
+        "node:fs.lstatSync": true,
+        "node:fs.readFileSync": true,
+        "node:fs.realpathSync": true,
+        "node:path.dirname": true,
+        "node:path.join": true,
+        "node:path.relative": true
+      },
+      "packages": {
+        "depcheck>resolve": true
       }
     },
     "@lavamoat/lavapack": {
@@ -1061,54 +1050,15 @@
         "setTimeout": true
       },
       "packages": {
+        "browserify>JSONStream": true,
         "@lavamoat/lavapack>combine-source-map": true,
         "@lavamoat/lavapack>convert-source-map": true,
-        "@lavamoat/lavapack>json-stable-stringify": true,
-        "@lavamoat/lavapack>umd": true,
-        "browserify>JSONStream": true,
         "eslint>espree": true,
+        "@lavamoat/lavapack>json-stable-stringify": true,
         "lavamoat-viz>lavamoat-core": true,
         "readable-stream": true,
-        "through2": true
-      }
-    },
-    "@lavamoat/lavapack>combine-source-map": {
-      "builtin": {
-        "path.dirname": true,
-        "path.join": true
-      },
-      "globals": {
-        "process.platform": true
-      },
-      "packages": {
-        "@lavamoat/lavapack>combine-source-map>inline-source-map": true,
-        "@lavamoat/lavapack>combine-source-map>lodash.memoize": true,
-        "@lavamoat/lavapack>combine-source-map>source-map": true,
-        "nyc>convert-source-map": true
-      }
-    },
-    "@lavamoat/lavapack>combine-source-map>inline-source-map": {
-      "globals": {
-        "Buffer.from": true
-      },
-      "packages": {
-        "@lavamoat/lavapack>combine-source-map>inline-source-map>source-map": true
-      }
-    },
-    "@lavamoat/lavapack>convert-source-map": {
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "value": true
-      }
-    },
-    "@lavamoat/lavapack>json-stable-stringify": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "lavamoat>json-stable-stringify>jsonify": true,
-        "string.prototype.matchall>call-bind": true
+        "through2": true,
+        "@lavamoat/lavapack>umd": true
       }
     },
     "@metamask/build-utils": {
@@ -1124,37 +1074,16 @@
       },
       "packages": {
         "@metamask/utils>@metamask/superstruct": true,
-        "@metamask/utils>@scure/base": true,
-        "@metamask/utils>pony-cause": true,
         "@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
         "nock>debug": true,
+        "@metamask/utils>pony-cause": true,
         "semver": true
       }
     },
-    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
+    "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals": {
       "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "@metamask/jazzicon>color>clone": {
-      "globals": {
-        "Buffer": true
-      }
-    },
-    "@metamask/jazzicon>color>color-convert": {
-      "packages": {
-        "@metamask/jazzicon>color>color-convert>color-name": true
-      }
-    },
-    "@metamask/object-multiplex>once": {
-      "packages": {
-        "@metamask/object-multiplex>once>wrappy": true
-      }
-    },
-    "@metamask/utils>@scure/base": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true
+        "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals>eslint-scope": true
       }
     },
     "@noble/hashes": {
@@ -1163,91 +1092,118 @@
         "crypto": true
       }
     },
-    "@sentry/cli>which>isexe": {
+    "eslint>@nodelib/fs.walk>@nodelib/fs.scandir": {
       "builtin": {
-        "fs": true
+        "fs.lstat": true,
+        "fs.lstatSync": true,
+        "fs.readdir": true,
+        "fs.readdirSync": true,
+        "fs.stat": true,
+        "fs.statSync": true,
+        "path.sep": true
       },
       "globals": {
-        "TESTING_WINDOWS": true,
-        "process.env.PATHEXT": true,
-        "process.getgid": true,
-        "process.getuid": true,
-        "process.platform": true
-      }
-    },
-    "@storybook/addon-knobs>qs": {
+        "process.versions.node": true
+      },
       "packages": {
-        "string.prototype.matchall>side-channel": true
+        "fast-glob>@nodelib/fs.stat": true,
+        "eslint>@nodelib/fs.walk>@nodelib/fs.scandir>run-parallel": true
       }
     },
-    "@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir": {
+    "fast-glob>@nodelib/fs.stat": {
       "builtin": {
-        "os.homedir": true
+        "fs.lstat": true,
+        "fs.lstatSync": true,
+        "fs.stat": true,
+        "fs.statSync": true
+      }
+    },
+    "eslint>@nodelib/fs.walk": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "path.sep": true,
+        "stream.Readable": true
       },
       "globals": {
-        "process.env": true,
-        "process.getuid": true,
-        "process.platform": true
-      }
-    },
-    "@storybook/react>@storybook/node-logger>npmlog>gauge>has-unicode": {
-      "builtin": {
-        "os.type": true
+        "setImmediate": true
       },
-      "globals": {
-        "process.env.LANG": true,
-        "process.env.LC_ALL": true,
-        "process.env.LC_CTYPE": true
-      }
-    },
-    "@storybook/react>@storybook/node-logger>npmlog>gauge>wide-align": {
       "packages": {
-        "yargs>string-width": true
+        "eslint>@nodelib/fs.walk>@nodelib/fs.scandir": true,
+        "eslint>@nodelib/fs.walk>fastq": true
       }
     },
-    "@storybook/react>acorn-walk": {
+    "@metamask/utils>@scure/base": {
       "globals": {
-        "define": true
+        "TextDecoder": true,
+        "TextEncoder": true
       }
     },
-    "@storybook/test-runner>jest-circus>p-limit": {
+    "stylelint>@stylelint/postcss-css-in-js": {
+      "globals": {
+        "__dirname": true
+      },
       "packages": {
-        "@storybook/test-runner>jest-circus>p-limit>yocto-queue": true
+        "@babel/core": true,
+        "stylelint>postcss-syntax": true,
+        "stylelint>postcss": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown": {
+      "packages": {
+        "stylelint>postcss-html": true,
+        "stylelint>postcss-syntax": true,
+        "stylelint>@stylelint/postcss-markdown>remark": true,
+        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after": true
       }
     },
     "@typescript-eslint/eslint-plugin": {
       "packages": {
+        "@typescript-eslint/parser>@typescript-eslint/scope-manager": true,
         "@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils": true,
         "@typescript-eslint/eslint-plugin>@typescript-eslint/utils": true,
-        "@typescript-eslint/eslint-plugin>tsutils": true,
-        "@typescript-eslint/parser>@typescript-eslint/scope-manager": true,
-        "eslint": true,
         "eslint-plugin-jest>@typescript-eslint/utils": true,
         "eslint>debug": true,
-        "eslint>regexpp": true,
+        "eslint": true,
         "globby>ignore": true,
+        "eslint>regexpp": true,
         "semver": true,
+        "@typescript-eslint/eslint-plugin>tsutils": true,
         "typescript": true
+      }
+    },
+    "eslint-plugin-jest>@typescript-eslint/experimental-utils": {
+      "builtin": {
+        "path": true
+      },
+      "packages": {
+        "@typescript-eslint/parser>@typescript-eslint/scope-manager": true,
+        "eslint-plugin-jest>@typescript-eslint/experimental-utils>@typescript-eslint/types": true,
+        "@typescript-eslint/parser>@typescript-eslint/types": true,
+        "eslint": true,
+        "eslint>eslint-scope": true,
+        "webpack>eslint-scope": true,
+        "eslint-plugin-jest>@typescript-eslint/experimental-utils>eslint-utils": true,
+        "eslint>eslint-utils": true
+      }
+    },
+    "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager": {
+      "builtin": {
+        "path": true
+      },
+      "packages": {
+        "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/types": true,
+        "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager>@typescript-eslint/visitor-keys": true
       }
     },
     "@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils": {
       "packages": {
-        "@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils>debug": true,
         "@typescript-eslint/eslint-plugin>@typescript-eslint/utils": true,
-        "@typescript-eslint/eslint-plugin>tsutils": true,
         "eslint-plugin-jest>@typescript-eslint/utils": true,
+        "@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils>debug": true,
         "eslint>debug": true,
         "nock>debug": true,
+        "@typescript-eslint/eslint-plugin>tsutils": true,
         "typescript": true
-      }
-    },
-    "@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils>debug": {
-      "globals": {
-        "console.debug": true,
-        "console.log": true
-      },
-      "packages": {
-        "@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils>debug>ms": true
       }
     },
     "@typescript-eslint/eslint-plugin>@typescript-eslint/utils": {
@@ -1259,9 +1215,264 @@
         "@typescript-eslint/parser>@typescript-eslint/types": true,
         "@typescript-eslint/utils": true,
         "eslint": true,
-        "eslint-plugin-mocha>eslint-utils": true,
+        "webpack>eslint-scope": true,
         "eslint>eslint-utils": true,
-        "webpack>eslint-scope": true
+        "eslint-plugin-mocha>eslint-utils": true
+      }
+    },
+    "eslint-plugin-jest>@typescript-eslint/utils": {
+      "builtin": {
+        "assert": true,
+        "path": true
+      },
+      "packages": {
+        "eslint>@eslint-community/eslint-utils": true,
+        "@typescript-eslint/parser>@typescript-eslint/scope-manager": true,
+        "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager": true,
+        "eslint-plugin-jest>@typescript-eslint/experimental-utils>@typescript-eslint/types": true,
+        "@typescript-eslint/parser>@typescript-eslint/types": true,
+        "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/types": true,
+        "eslint": true,
+        "eslint>eslint-scope": true,
+        "webpack>eslint-scope": true,
+        "eslint-plugin-jest>@typescript-eslint/utils>webpack>eslint-scope": true,
+        "eslint>eslint-utils": true,
+        "eslint-plugin-mocha>eslint-utils": true,
+        "semver": true
+      }
+    },
+    "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager>@typescript-eslint/visitor-keys": {
+      "builtin": {
+        "path": true
+      },
+      "packages": {
+        "eslint>eslint-visitor-keys": true
+      }
+    },
+    "eslint>@ungap/structured-clone": {
+      "globals": {
+        "structuredClone": true
+      }
+    },
+    "browserify>JSONStream": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "browserify>JSONStream>jsonparse": true,
+        "debounce-stream>through": true
+      }
+    },
+    "eslint>espree>acorn-jsx": {
+      "packages": {
+        "jsdom>acorn": true
+      }
+    },
+    "browserify>syntax-error>acorn-node": {
+      "packages": {
+        "@storybook/react>acorn-walk": true,
+        "browserify>syntax-error>acorn-node>acorn": true,
+        "watchify>xtend": true
+      }
+    },
+    "@storybook/react>acorn-walk": {
+      "globals": {
+        "define": true
+      }
+    },
+    "ts-node>acorn-walk": {
+      "globals": {
+        "define": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/identity-map>acorn": {
+      "globals": {
+        "define": true
+      }
+    },
+    "browserify>syntax-error>acorn-node>acorn": {
+      "globals": {
+        "define": true
+      }
+    },
+    "gulp-sourcemaps>acorn": {
+      "globals": {
+        "define": true
+      }
+    },
+    "jsdom>acorn": {
+      "globals": {
+        "console": true,
+        "define": true
+      }
+    },
+    "del>p-map>aggregate-error": {
+      "packages": {
+        "del>p-map>aggregate-error>clean-stack": true,
+        "prettier-eslint>indent-string": true
+      }
+    },
+    "eslint>ajv": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "eslint>fast-deep-equal": true,
+        "@metamask/snaps-utils>fast-json-stable-stringify": true,
+        "eslint>ajv>json-schema-traverse": true,
+        "uri-js": true
+      }
+    },
+    "gulp-watch>ansi-colors": {
+      "packages": {
+        "fancy-log>ansi-gray>ansi-wrap": true
+      }
+    },
+    "fancy-log>ansi-gray": {
+      "packages": {
+        "fancy-log>ansi-gray>ansi-wrap": true
+      }
+    },
+    "chalk>ansi-styles": {
+      "packages": {
+        "chalk>ansi-styles>color-convert": true
+      }
+    },
+    "@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
+      "packages": {
+        "@metamask/jazzicon>color>color-convert": true
+      }
+    },
+    "gulp-livereload>chalk>ansi-styles": {
+      "packages": {
+        "@metamask/jazzicon>color>color-convert": true
+      }
+    },
+    "stylelint>table>slice-ansi>ansi-styles": {
+      "packages": {
+        "@metamask/jazzicon>color>color-convert": true
+      }
+    },
+    "chokidar>anymatch": {
+      "packages": {
+        "chokidar>anymatch>normalize-path": true,
+        "chokidar>anymatch>picomatch": true
+      }
+    },
+    "gulp>glob-watcher>anymatch": {
+      "builtin": {
+        "path.sep": true
+      },
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch": true,
+        "gulp-watch>anymatch>normalize-path": true
+      }
+    },
+    "gulp-watch>anymatch": {
+      "builtin": {
+        "path.sep": true
+      },
+      "packages": {
+        "gulp-watch>anymatch>micromatch": true,
+        "gulp-watch>anymatch>normalize-path": true
+      }
+    },
+    "gulp>vinyl-fs>vinyl-sourcemap>append-buffer": {
+      "builtin": {
+        "os.EOL": true
+      },
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>vinyl-sourcemap>append-buffer>buffer-equal": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>are-we-there-yet": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "util.inherits": true
+      },
+      "packages": {
+        "koa>delegates": true,
+        "readable-stream": true
+      }
+    },
+    "ts-node>arg": {
+      "globals": {
+        "process.argv.slice": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>arr-diff": {
+      "packages": {
+        "gulp>undertaker>arr-flatten": true
+      }
+    },
+    "gulp>undertaker>bach>arr-filter": {
+      "packages": {
+        "gulp>undertaker>arr-map>make-iterator": true
+      }
+    },
+    "gulp>undertaker>arr-map": {
+      "packages": {
+        "gulp>undertaker>arr-map>make-iterator": true
+      }
+    },
+    "eslint-plugin-react>array-includes": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>es-abstract": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "eslint-plugin-react>array-includes>is-string": true
+      }
+    },
+    "gulp>undertaker>bach>array-initial": {
+      "packages": {
+        "gulp>undertaker>object.defaults>array-slice": true,
+        "gulp>undertaker>bach>array-last>is-number": true
+      }
+    },
+    "gulp>undertaker>bach>array-last": {
+      "packages": {
+        "gulp>undertaker>bach>array-last>is-number": true
+      }
+    },
+    "eslint-plugin-import>array.prototype.flat": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>es-abstract": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables": true
+      }
+    },
+    "eslint-plugin-react>array.prototype.flatmap": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>es-abstract": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables": true
+      }
+    },
+    "gulp>glob-watcher>async-done": {
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "duplexify>end-of-stream": true,
+        "@metamask/object-multiplex>once": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>glob-watcher>async-done>stream-exhaust": true
+      }
+    },
+    "gulp>undertaker>bach>async-settle": {
+      "packages": {
+        "gulp>glob-watcher>async-done": true
+      }
+    },
+    "gulp-sourcemaps>css>source-map-resolve>atob": {
+      "globals": {
+        "Buffer.from": true
       }
     },
     "autoprefixer": {
@@ -1271,13 +1482,49 @@
         "process.env.AUTOPREFIXER_GRID": true
       },
       "packages": {
+        "browserslist": true,
         "autoprefixer>caniuse-lite": true,
         "autoprefixer>fraction.js": true,
         "autoprefixer>normalize-range": true,
-        "browserslist": true,
-        "postcss": true,
         "postcss>picocolors": true,
+        "postcss": true,
         "stylelint>postcss-value-parser": true
+      }
+    },
+    "stylelint>autoprefixer": {
+      "globals": {
+        "console": true,
+        "process.cwd": true,
+        "process.env.AUTOPREFIXER_GRID": true
+      },
+      "packages": {
+        "browserslist": true,
+        "autoprefixer>caniuse-lite": true,
+        "autoprefixer>normalize-range": true,
+        "stylelint>autoprefixer>num2fraction": true,
+        "stylelint>postcss>picocolors": true,
+        "stylelint>postcss-value-parser": true,
+        "stylelint>postcss": true
+      }
+    },
+    "@babel/preset-env>babel-plugin-polyfill-corejs2": {
+      "packages": {
+        "@babel/preset-env>@babel/compat-data": true,
+        "@babel/core": true,
+        "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider": true,
+        "@babel/preset-env>babel-plugin-polyfill-corejs2>semver": true
+      }
+    },
+    "@babel/preset-env>babel-plugin-polyfill-corejs3": {
+      "packages": {
+        "@babel/core": true,
+        "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider": true,
+        "@babel/preset-env>core-js-compat": true
+      }
+    },
+    "@babel/preset-env>babel-plugin-polyfill-regenerator": {
+      "packages": {
+        "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider": true
       }
     },
     "babelify": {
@@ -1295,22 +1542,126 @@
         "@babel/core": true
       }
     },
-    "bify-module-groups": {
+    "gulp>undertaker>bach": {
+      "builtin": {
+        "assert.ok": true
+      },
       "packages": {
-        "bify-module-groups>through2": true,
-        "pify": true,
-        "pumpify>pump": true
+        "gulp>undertaker>bach>arr-filter": true,
+        "gulp>undertaker>arr-flatten": true,
+        "gulp>undertaker>arr-map": true,
+        "gulp>undertaker>bach>array-each": true,
+        "gulp>undertaker>bach>array-initial": true,
+        "gulp>undertaker>bach>array-last": true,
+        "gulp>glob-watcher>async-done": true,
+        "gulp>undertaker>bach>async-settle": true,
+        "gulp>vinyl-fs>vinyl-sourcemap>now-and-later": true
       }
     },
-    "bify-module-groups>through2": {
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base": {
       "builtin": {
         "util.inherits": true
       },
-      "globals": {
-        "process.nextTick": true
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>component-emitter": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>define-property": true,
+        "gulp>gulp-cli>isobject": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>mixin-deep": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>pascalcase": true
+      }
+    },
+    "bify-module-groups": {
+      "packages": {
+        "pify": true,
+        "pumpify>pump": true,
+        "bify-module-groups>through2": true
+      }
+    },
+    "vinyl-buffer>bl": {
+      "builtin": {
+        "util.inherits": true
       },
       "packages": {
-        "readable-stream": true
+        "vinyl-buffer>bl>readable-stream": true,
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "gulp-livereload>tiny-lr>body": {
+      "builtin": {
+        "querystring.parse": true
+      },
+      "packages": {
+        "gulp-livereload>tiny-lr>body>continuable-cache": true,
+        "gulp-livereload>tiny-lr>body>error": true,
+        "gulp-livereload>tiny-lr>body>raw-body": true,
+        "gulp-livereload>tiny-lr>body>safe-json-parse": true
+      }
+    },
+    "eslint>minimatch>brace-expansion": {
+      "packages": {
+        "stylelint>balanced-match": true,
+        "eslint>minimatch>brace-expansion>concat-map": true
+      }
+    },
+    "chokidar>braces": {
+      "packages": {
+        "chokidar>braces>fill-range": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>braces": {
+      "packages": {
+        "gulp>undertaker>arr-flatten": true,
+        "gulp>gulp-cli>matchdep>micromatch>array-unique": true,
+        "gulp>glob-watcher>anymatch>micromatch>braces>extend-shallow": true,
+        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range": true,
+        "gulp>gulp-cli>isobject": true,
+        "gulp-watch>anymatch>micromatch>braces>repeat-element": true,
+        "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
+        "gulp>gulp-cli>matchdep>micromatch>braces>split-string": true,
+        "gulp>gulp-cli>matchdep>micromatch>to-regex": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>braces": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>braces>expand-range": true,
+        "gulp-watch>anymatch>micromatch>braces>preserve": true,
+        "gulp-watch>anymatch>micromatch>braces>repeat-element": true
+      }
+    },
+    "browserify>browser-pack": {
+      "builtin": {
+        "fs.readFileSync": true,
+        "path.join": true,
+        "path.relative": true
+      },
+      "globals": {
+        "__dirname": true,
+        "process.cwd": true
+      },
+      "packages": {
+        "browserify>JSONStream": true,
+        "@lavamoat/lavapack>combine-source-map": true,
+        "watchify>defined": true,
+        "koa>content-disposition>safe-buffer": true,
+        "browserify>browser-pack>through2": true,
+        "@lavamoat/lavapack>umd": true
+      }
+    },
+    "browserify>browser-resolve": {
+      "builtin": {
+        "fs.readFile": true,
+        "fs.readFileSync": true,
+        "path": true
+      },
+      "globals": {
+        "__dirname": true,
+        "process.platform": true
+      },
+      "packages": {
+        "depcheck>resolve": true
       }
     },
     "browserify": {
@@ -1334,610 +1685,19 @@
         "browserify>browser-resolve": true,
         "browserify>cached-path-relative": true,
         "browserify>concat-stream": true,
+        "watchify>defined": true,
         "browserify>deps-sort": true,
         "browserify>has": true,
+        "lavamoat>htmlescape": true,
+        "pumpify>inherits": true,
         "browserify>insert-module-globals": true,
+        "labeled-stream-splicer": true,
         "browserify>module-deps": true,
         "browserify>read-only-stream": true,
+        "depcheck>resolve": true,
         "browserify>shasum-object": true,
         "browserify>syntax-error": true,
         "browserify>through2": true,
-        "depcheck>resolve": true,
-        "labeled-stream-splicer": true,
-        "lavamoat>htmlescape": true,
-        "pumpify>inherits": true,
-        "watchify>defined": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>JSONStream": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>JSONStream>jsonparse": true,
-        "debounce-stream>through": true
-      }
-    },
-    "browserify>JSONStream>jsonparse": {
-      "globals": {
-        "Buffer": true
-      }
-    },
-    "browserify>browser-pack": {
-      "builtin": {
-        "fs.readFileSync": true,
-        "path.join": true,
-        "path.relative": true
-      },
-      "globals": {
-        "__dirname": true,
-        "process.cwd": true
-      },
-      "packages": {
-        "@lavamoat/lavapack>combine-source-map": true,
-        "@lavamoat/lavapack>umd": true,
-        "browserify>JSONStream": true,
-        "browserify>browser-pack>through2": true,
-        "koa>content-disposition>safe-buffer": true,
-        "watchify>defined": true
-      }
-    },
-    "browserify>browser-pack>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "browserify>browser-pack>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>browser-pack>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>browser-pack>through2>readable-stream>isarray": true,
-        "browserify>browser-pack>through2>readable-stream>safe-buffer": true,
-        "browserify>browser-pack>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>browser-pack>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>browser-pack>through2>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>browser-pack>through2>readable-stream>string_decoder>safe-buffer": true
-      }
-    },
-    "browserify>browser-pack>through2>readable-stream>string_decoder>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>browser-resolve": {
-      "builtin": {
-        "fs.readFile": true,
-        "fs.readFileSync": true,
-        "path": true
-      },
-      "globals": {
-        "__dirname": true,
-        "process.platform": true
-      },
-      "packages": {
-        "depcheck>resolve": true
-      }
-    },
-    "browserify>cached-path-relative": {
-      "builtin": {
-        "path": true
-      },
-      "globals": {
-        "process.cwd": true
-      }
-    },
-    "browserify>concat-stream": {
-      "globals": {
-        "Buffer.concat": true,
-        "Buffer.isBuffer": true
-      },
-      "packages": {
-        "browserify>concat-stream>readable-stream": true,
-        "browserify>concat-stream>typedarray": true,
-        "pumpify>inherits": true,
-        "terser>source-map-support>buffer-from": true
-      }
-    },
-    "browserify>concat-stream>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>concat-stream>readable-stream>isarray": true,
-        "browserify>concat-stream>readable-stream>safe-buffer": true,
-        "browserify>concat-stream>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>concat-stream>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>concat-stream>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>concat-stream>readable-stream>safe-buffer": true
-      }
-    },
-    "browserify>deps-sort": {
-      "packages": {
-        "browserify>deps-sort>through2": true,
-        "browserify>shasum-object": true
-      }
-    },
-    "browserify>deps-sort>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "browserify>deps-sort>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>deps-sort>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>deps-sort>through2>readable-stream>isarray": true,
-        "browserify>deps-sort>through2>readable-stream>safe-buffer": true,
-        "browserify>deps-sort>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>deps-sort>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>deps-sort>through2>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>deps-sort>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "browserify>duplexer2": {
-      "packages": {
-        "browserify>duplexer2>readable-stream": true
-      }
-    },
-    "browserify>duplexer2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>duplexer2>readable-stream>isarray": true,
-        "browserify>duplexer2>readable-stream>safe-buffer": true,
-        "browserify>duplexer2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>duplexer2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>duplexer2>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>duplexer2>readable-stream>safe-buffer": true
-      }
-    },
-    "browserify>has": {
-      "packages": {
-        "browserify>has>function-bind": true
-      }
-    },
-    "browserify>insert-module-globals": {
-      "builtin": {
-        "path.dirname": true,
-        "path.isAbsolute": true,
-        "path.relative": true,
-        "path.sep": true
-      },
-      "globals": {
-        "Buffer.concat": true,
-        "Buffer.isBuffer": true
-      },
-      "packages": {
-        "@lavamoat/lavapack>combine-source-map": true,
-        "browserify>insert-module-globals>through2": true,
-        "browserify>insert-module-globals>undeclared-identifiers": true,
-        "browserify>syntax-error>acorn-node": true,
-        "gulp-watch>path-is-absolute": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>insert-module-globals>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "browserify>insert-module-globals>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>insert-module-globals>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>insert-module-globals>through2>readable-stream>isarray": true,
-        "browserify>insert-module-globals>through2>readable-stream>safe-buffer": true,
-        "browserify>insert-module-globals>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>insert-module-globals>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>insert-module-globals>through2>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>insert-module-globals>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "browserify>insert-module-globals>undeclared-identifiers": {
-      "packages": {
-        "browserify>insert-module-globals>undeclared-identifiers>get-assigned-identifiers": true,
-        "browserify>syntax-error>acorn-node": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>insert-module-globals>undeclared-identifiers>get-assigned-identifiers": {
-      "builtin": {
-        "assert.equal": true
-      }
-    },
-    "browserify>module-deps": {
-      "builtin": {
-        "fs.createReadStream": true,
-        "fs.readFile": true,
-        "path.delimiter": true,
-        "path.dirname": true,
-        "path.join": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "process.cwd": true,
-        "process.env.NODE_PATH": true,
-        "process.nextTick": true,
-        "process.platform": true,
-        "setTimeout": true,
-        "tr": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true,
-        "browserify>cached-path-relative": true,
-        "browserify>concat-stream": true,
-        "browserify>duplexer2": true,
-        "browserify>module-deps>detective": true,
-        "browserify>module-deps>readable-stream": true,
-        "browserify>module-deps>stream-combiner2": true,
-        "browserify>module-deps>through2": true,
-        "browserify>parents": true,
-        "depcheck>resolve": true,
-        "loose-envify": true,
-        "pumpify>inherits": true,
-        "watchify>defined": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>module-deps>detective": {
-      "packages": {
-        "browserify>syntax-error>acorn-node": true,
-        "watchify>defined": true
-      }
-    },
-    "browserify>module-deps>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>module-deps>readable-stream>isarray": true,
-        "browserify>module-deps>readable-stream>safe-buffer": true,
-        "browserify>module-deps>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>module-deps>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>module-deps>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>module-deps>readable-stream>safe-buffer": true
-      }
-    },
-    "browserify>module-deps>stream-combiner2": {
-      "packages": {
-        "browserify>duplexer2": true,
-        "browserify>module-deps>stream-combiner2>readable-stream": true
-      }
-    },
-    "browserify>module-deps>stream-combiner2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>module-deps>stream-combiner2>readable-stream>isarray": true,
-        "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": true,
-        "browserify>module-deps>stream-combiner2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>module-deps>stream-combiner2>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": true
-      }
-    },
-    "browserify>module-deps>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "browserify>module-deps>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>parents": {
-      "globals": {
-        "process.cwd": true,
-        "process.platform": true
-      },
-      "packages": {
-        "browserify>parents>path-platform": true
-      }
-    },
-    "browserify>parents>path-platform": {
-      "builtin": {
-        "path": true,
-        "util.isObject": true,
-        "util.isString": true
-      },
-      "globals": {
-        "process.cwd": true,
-        "process.env": true,
-        "process.platform": true
-      }
-    },
-    "browserify>read-only-stream": {
-      "packages": {
-        "browserify>read-only-stream>readable-stream": true
-      }
-    },
-    "browserify>read-only-stream>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>read-only-stream>readable-stream>isarray": true,
-        "browserify>read-only-stream>readable-stream>safe-buffer": true,
-        "browserify>read-only-stream>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>read-only-stream>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>read-only-stream>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>read-only-stream>readable-stream>safe-buffer": true
-      }
-    },
-    "browserify>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "browserify>readable-stream>isarray": true,
-        "browserify>readable-stream>safe-buffer": true,
-        "browserify>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "browserify>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "browserify>readable-stream>string_decoder": {
-      "packages": {
-        "browserify>readable-stream>safe-buffer": true
-      }
-    },
-    "browserify>shasum-object": {
-      "builtin": {
-        "crypto.createHash": true
-      },
-      "globals": {
-        "Buffer.isBuffer": true
-      },
-      "packages": {
-        "@metamask/rpc-errors>fast-safe-stringify": true
-      }
-    },
-    "browserify>string_decoder": {
-      "packages": {
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "browserify>syntax-error": {
-      "packages": {
-        "browserify>syntax-error>acorn-node": true
-      }
-    },
-    "browserify>syntax-error>acorn-node": {
-      "packages": {
-        "@storybook/react>acorn-walk": true,
-        "browserify>syntax-error>acorn-node>acorn": true,
-        "watchify>xtend": true
-      }
-    },
-    "browserify>syntax-error>acorn-node>acorn": {
-      "globals": {
-        "define": true
-      }
-    },
-    "browserify>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "browserify>readable-stream": true,
         "watchify>xtend": true
       }
     },
@@ -1963,38 +1723,95 @@
         "browserslist>node-releases": true
       }
     },
+    "sass-embedded>buffer-builder": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "gulp-zip>yazl>buffer-crc32": {
+      "builtin": {
+        "buffer.Buffer": true
+      }
+    },
+    "gulp>vinyl-fs>vinyl-sourcemap>append-buffer>buffer-equal": {
+      "builtin": {
+        "buffer.Buffer.isBuffer": true
+      }
+    },
+    "terser>source-map-support>buffer-from": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>component-emitter": true,
+        "gulp>gulp-cli>array-sort>get-value": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value": true,
+        "gulp>gulp-cli>isobject": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>to-object-path": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>union-value": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value": true
+      }
+    },
+    "browserify>cached-path-relative": {
+      "builtin": {
+        "path": true
+      },
+      "globals": {
+        "process.cwd": true
+      }
+    },
+    "string.prototype.matchall>call-bind": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>call-bind>set-function-length": true
+      }
+    },
     "chalk": {
       "packages": {
         "chalk>ansi-styles": true,
         "chalk>supports-color": true
       }
     },
-    "chalk>ansi-styles": {
-      "packages": {
-        "chalk>ansi-styles>color-convert": true
-      }
-    },
-    "chalk>ansi-styles>color-convert": {
-      "packages": {
-        "jest-canvas-mock>moo-color>color-name": true
-      }
-    },
-    "chalk>supports-color": {
-      "builtin": {
-        "os.release": true,
-        "tty.isatty": true
-      },
+    "@babel/code-frame>@babel/highlight>chalk": {
       "globals": {
-        "process.env": true,
+        "process.env.TERM": true,
         "process.platform": true
       },
       "packages": {
-        "chalk>supports-color>has-flag": true
+        "@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
+        "@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
+        "@babel/code-frame>@babel/highlight>chalk>supports-color": true
       }
     },
-    "chalk>supports-color>has-flag": {
+    "gulp-livereload>chalk": {
       "globals": {
-        "process.argv": true
+        "process.env.TERM": true,
+        "process.platform": true
+      },
+      "packages": {
+        "gulp-livereload>chalk>ansi-styles": true,
+        "gulp-livereload>chalk>escape-string-regexp": true,
+        "gulp-livereload>chalk>supports-color": true
+      }
+    },
+    "postcss-discard-font-face>postcss>chalk": {
+      "globals": {
+        "process.env.TERM": true,
+        "process.platform": true
+      },
+      "packages": {
+        "postcss-discard-font-face>postcss>chalk>ansi-styles": true,
+        "postcss-discard-font-face>postcss>chalk>escape-string-regexp": true,
+        "prettier-eslint>loglevel-colored-level-prefix>chalk>has-ansi": true,
+        "postcss-discard-font-face>postcss>chalk>strip-ansi": true,
+        "postcss-discard-font-face>postcss>chalk>supports-color": true
       }
     },
     "chokidar": {
@@ -2036,91 +1853,511 @@
         "chokidar>anymatch": true,
         "chokidar>braces": true,
         "chokidar>fsevents": true,
+        "eslint>glob-parent": true,
         "chokidar>is-binary-path": true,
-        "chokidar>normalize-path": true,
-        "chokidar>readdirp": true,
         "del>is-glob": true,
-        "eslint>glob-parent": true
+        "chokidar>normalize-path": true,
+        "chokidar>readdirp": true
       }
     },
-    "chokidar>anymatch": {
+    "gulp>glob-watcher>chokidar": {
       "packages": {
-        "chokidar>anymatch>normalize-path": true,
-        "chokidar>anymatch>picomatch": true
+        "gulp>glob-watcher>chokidar>fsevents": true
       }
     },
-    "chokidar>anymatch>picomatch": {
+    "gulp-watch>chokidar": {
       "builtin": {
-        "path.basename": true,
-        "path.sep": true
-      },
-      "globals": {
-        "process.platform": true,
-        "process.version.slice": true
-      }
-    },
-    "chokidar>braces": {
-      "packages": {
-        "chokidar>braces>fill-range": true
-      }
-    },
-    "chokidar>braces>fill-range": {
-      "builtin": {
-        "util.inspect": true
-      },
-      "packages": {
-        "chokidar>braces>fill-range>to-regex-range": true
-      }
-    },
-    "chokidar>braces>fill-range>to-regex-range": {
-      "packages": {
-        "chokidar>braces>fill-range>to-regex-range>is-number": true
-      }
-    },
-    "chokidar>fsevents": {
-      "globals": {
-        "console.assert": true,
-        "process.platform": true
-      },
-      "native": true
-    },
-    "chokidar>is-binary-path": {
-      "builtin": {
-        "path.extname": true
-      },
-      "packages": {
-        "chokidar>is-binary-path>binary-extensions": true
-      }
-    },
-    "chokidar>readdirp": {
-      "builtin": {
+        "events.EventEmitter": true,
         "fs": true,
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
         "path.join": true,
         "path.relative": true,
         "path.resolve": true,
-        "path.sep": true,
-        "stream.Readable": true,
-        "util.promisify": true
+        "path.sep": true
       },
       "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "process.env.CHOKIDAR_INTERVAL": true,
+        "process.env.CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR": true,
+        "process.env.CHOKIDAR_USEPOLLING": true,
+        "process.nextTick": true,
         "process.platform": true,
-        "process.versions.node.split": true
+        "setTimeout": true
       },
       "packages": {
-        "chokidar>anymatch>picomatch": true
+        "gulp-watch>chokidar>anymatch": true,
+        "gulp-watch>chokidar>async-each": true,
+        "gulp-watch>chokidar>braces": true,
+        "gulp-watch>chokidar>fsevents": true,
+        "gulp-watch>glob-parent": true,
+        "pumpify>inherits": true,
+        "gulp-watch>chokidar>is-binary-path": true,
+        "eslint>is-glob": true,
+        "chokidar>normalize-path": true,
+        "gulp-watch>path-is-absolute": true,
+        "gulp-watch>chokidar>readdirp": true,
+        "gulp-watch>chokidar>upath": true
       }
     },
-    "debounce-stream>duplexer": {
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils": {
       "builtin": {
-        "stream": true
+        "util": true
+      },
+      "packages": {
+        "gulp-zip>plugin-error>arr-union": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": true,
+        "gulp>gulp-cli>isobject": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend": true
       }
     },
-    "debounce-stream>through": {
+    "del>p-map>aggregate-error>clean-stack": {
       "builtin": {
-        "stream": true
+        "os.homedir": true
+      }
+    },
+    "yargs>cliui": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "yargs>string-width": true,
+        "eslint>strip-ansi": true,
+        "yargs>cliui>wrap-ansi": true
+      }
+    },
+    "vinyl>clone-buffer": {
+      "builtin": {
+        "buffer.Buffer": true
+      }
+    },
+    "lavamoat>lavamoat-core>merge-deep>clone-deep": {
+      "packages": {
+        "lavamoat>lavamoat-core>merge-deep>clone-deep>for-own": true,
+        "@babel/register>clone-deep>is-plain-object": true,
+        "lavamoat>lavamoat-core>merge-deep>kind-of": true,
+        "lavamoat>lavamoat-core>merge-deep>clone-deep>lazy-cache": true,
+        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone": true
+      }
+    },
+    "stylelint>execall>clone-regexp": {
+      "packages": {
+        "stylelint>execall>clone-regexp>is-regexp": true
+      }
+    },
+    "vinyl>clone-stats": {
+      "builtin": {
+        "fs.Stats": true
+      }
+    },
+    "gulp-watch>vinyl-file>vinyl>clone-stats": {
+      "builtin": {
+        "fs.Stats": true
+      }
+    },
+    "@metamask/jazzicon>color>clone": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "vinyl>clone": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "vinyl>cloneable-readable": {
+      "packages": {
+        "pumpify>inherits": true,
+        "vinyl>cloneable-readable>process-nextick-args": true,
+        "vinyl>cloneable-readable>through2": true
+      }
+    },
+    "gulp>undertaker>collection-map": {
+      "packages": {
+        "gulp>undertaker>arr-map": true,
+        "gulp>undertaker>object.reduce>for-own": true,
+        "gulp>undertaker>arr-map>make-iterator": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>map-visit": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>object-visit": true
+      }
+    },
+    "chalk>ansi-styles>color-convert": {
+      "packages": {
+        "jest-canvas-mock>moo-color>color-name": true
+      }
+    },
+    "@metamask/jazzicon>color>color-convert": {
+      "packages": {
+        "@metamask/jazzicon>color>color-convert>color-name": true
+      }
+    },
+    "fancy-log>color-support": {
+      "globals": {
+        "process": true
+      }
+    },
+    "@lavamoat/lavapack>combine-source-map": {
+      "builtin": {
+        "path.dirname": true,
+        "path.join": true
       },
       "globals": {
-        "process.nextTick": true
+        "process.platform": true
+      },
+      "packages": {
+        "nyc>convert-source-map": true,
+        "@lavamoat/lavapack>combine-source-map>inline-source-map": true,
+        "@lavamoat/lavapack>combine-source-map>lodash.memoize": true,
+        "@lavamoat/lavapack>combine-source-map>source-map": true
+      }
+    },
+    "browserify>concat-stream": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "terser>source-map-support>buffer-from": true,
+        "pumpify>inherits": true,
+        "browserify>concat-stream>readable-stream": true,
+        "browserify>concat-stream>typedarray": true
+      }
+    },
+    "lavamoat-browserify>concat-stream": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "terser>source-map-support>buffer-from": true,
+        "pumpify>inherits": true,
+        "readable-stream": true,
+        "browserify>concat-stream>typedarray": true
+      }
+    },
+    "@babel/core>convert-source-map": {
+      "globals": {
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "value": true
+      }
+    },
+    "@lavamoat/lavapack>convert-source-map": {
+      "globals": {
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "value": true
+      }
+    },
+    "nyc>convert-source-map": {
+      "builtin": {
+        "fs.readFileSync": true,
+        "path.join": true
+      },
+      "globals": {
+        "Buffer.from": true
+      }
+    },
+    "readable-stream-2>core-util-is": {
+      "globals": {
+        "Buffer.isBuffer": true
+      }
+    },
+    "stylelint>cosmiconfig": {
+      "builtin": {
+        "fs": true,
+        "os": true,
+        "path": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "eslint>@eslint/eslintrc>import-fresh": true,
+        "depcheck>cosmiconfig>parse-json": true,
+        "globby>dir-glob>path-type": true,
+        "stylelint>cosmiconfig>yaml": true
+      }
+    },
+    "ts-node>create-require": {
+      "builtin": {
+        "fs.lstatSync": true,
+        "module.Module": true,
+        "module.createRequire": true,
+        "module.createRequireFromPath": true,
+        "path.dirname": true,
+        "path.join": true
+      },
+      "globals": {
+        "process.cwd": true
+      }
+    },
+    "gulp-sourcemaps>css": {
+      "builtin": {
+        "fs.readFileSync": true,
+        "path.dirname": true,
+        "path.sep": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "gulp-sourcemaps>css>source-map-resolve": true,
+        "gulp-sourcemaps>css>source-map": true
+      }
+    },
+    "resolve-url-loader>es6-iterator>d": {
+      "packages": {
+        "resolve-url-loader>es6-iterator>es5-ext": true,
+        "resolve-url-loader>es6-iterator>d>type": true
+      }
+    },
+    "gulp-sourcemaps>debug-fabulous": {
+      "packages": {
+        "gulp-sourcemaps>debug-fabulous>debug": true,
+        "gulp-sourcemaps>debug-fabulous>memoizee": true,
+        "react>object-assign": true
+      }
+    },
+    "@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils>debug": {
+      "globals": {
+        "console.debug": true,
+        "console.log": true
+      },
+      "packages": {
+        "@typescript-eslint/eslint-plugin>@typescript-eslint/type-utils>debug>ms": true
+      }
+    },
+    "gulp-sourcemaps>debug-fabulous>debug": {
+      "builtin": {
+        "tty.isatty": true,
+        "util": true
+      },
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "mocha>ms": true,
+        "mocha>supports-color": true
+      }
+    },
+    "eslint-import-resolver-node>debug": {
+      "builtin": {
+        "tty.isatty": true,
+        "util": true
+      },
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "mocha>ms": true,
+        "mocha>supports-color": true
+      }
+    },
+    "eslint-plugin-import>eslint-module-utils>debug": {
+      "builtin": {
+        "tty.isatty": true,
+        "util": true
+      },
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "mocha>ms": true,
+        "mocha>supports-color": true
+      }
+    },
+    "eslint-plugin-import>debug": {
+      "builtin": {
+        "fs.SyncWriteStream": true,
+        "net.Socket": true,
+        "tty.WriteStream": true,
+        "tty.isatty": true,
+        "util": true
+      },
+      "globals": {
+        "chrome": true,
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "eslint-plugin-import>debug>ms": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug": {
+      "builtin": {
+        "fs.SyncWriteStream": true,
+        "net.Socket": true,
+        "tty.WriteStream": true,
+        "tty.isatty": true,
+        "util": true
+      },
+      "globals": {
+        "chrome": true,
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug>ms": true
+      }
+    },
+    "gulp-livereload>debug": {
+      "builtin": {
+        "tty.isatty": true,
+        "util": true
+      },
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "mocha>ms": true,
+        "gulp-livereload>chalk>supports-color": true
+      }
+    },
+    "nock>debug": {
+      "builtin": {
+        "tty.isatty": true,
+        "util.deprecate": true,
+        "util.formatWithOptions": true,
+        "util.inspect": true
+      },
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "nock>debug>ms": true,
+        "mocha>supports-color": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>debug": {
+      "builtin": {
+        "fs.SyncWriteStream": true,
+        "net.Socket": true,
+        "tty.WriteStream": true,
+        "tty.isatty": true,
+        "util": true
+      },
+      "globals": {
+        "chrome": true,
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>debug>ms": true
+      }
+    },
+    "gulp-livereload>tiny-lr>debug": {
+      "builtin": {
+        "tty.isatty": true,
+        "util": true
+      },
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "mocha>ms": true,
+        "mocha>supports-color": true
+      }
+    },
+    "gulp>undertaker>last-run>default-resolution": {
+      "globals": {
+        "process.version.match": true
+      }
+    },
+    "string.prototype.matchall>define-properties>define-data-property": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>gopd": true
+      }
+    },
+    "string.prototype.matchall>define-properties": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>define-property": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property": {
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>define-property": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>define-property": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true,
+        "gulp>gulp-cli>isobject": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>nanomatch>define-property": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true,
+        "gulp>gulp-cli>isobject": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>define-property": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>to-regex>define-property": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true,
+        "gulp>gulp-cli>isobject": true
       }
     },
     "del": {
@@ -2133,105 +2370,162 @@
         "process.platform": true
       },
       "packages": {
+        "globby": true,
         "del>graceful-fs": true,
         "del>is-glob": true,
         "del>is-path-cwd": true,
         "del>is-path-inside": true,
         "del>p-map": true,
         "del>rimraf": true,
-        "del>slash": true,
-        "globby": true
+        "del>slash": true
       }
     },
-    "del>graceful-fs": {
+    "browserify>deps-sort": {
+      "packages": {
+        "browserify>shasum-object": true,
+        "browserify>deps-sort>through2": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc": {
       "builtin": {
-        "assert.equal": true,
-        "constants.O_SYMLINK": true,
-        "constants.O_WRONLY": true,
-        "constants.hasOwnProperty": true,
-        "fs": true,
-        "stream.Stream.call": true,
-        "util": true
+        "child_process.spawnSync": true,
+        "fs.readdirSync": true,
+        "os.platform": true
       },
       "globals": {
-        "clearTimeout": true,
-        "console.error": true,
-        "process": true,
+        "process.env": true
+      }
+    },
+    "browserify>module-deps>detective": {
+      "packages": {
+        "browserify>syntax-error>acorn-node": true,
+        "watchify>defined": true
+      }
+    },
+    "ts-node>diff": {
+      "globals": {
         "setTimeout": true
       }
     },
-    "del>is-glob": {
-      "packages": {
-        "del>is-glob>is-extglob": true
-      }
-    },
-    "del>is-path-cwd": {
+    "globby>dir-glob": {
       "builtin": {
-        "path.resolve": true
+        "path.extname": true,
+        "path.isAbsolute": true,
+        "path.join": true,
+        "path.posix.join": true
       },
       "globals": {
-        "process.cwd": true,
-        "process.platform": true
-      }
-    },
-    "del>is-path-inside": {
-      "builtin": {
-        "path.relative": true,
-        "path.resolve": true,
-        "path.sep": true
-      }
-    },
-    "del>p-map": {
-      "packages": {
-        "del>p-map>aggregate-error": true
-      }
-    },
-    "del>p-map>aggregate-error": {
-      "packages": {
-        "del>p-map>aggregate-error>clean-stack": true,
-        "prettier-eslint>indent-string": true
-      }
-    },
-    "del>p-map>aggregate-error>clean-stack": {
-      "builtin": {
-        "os.homedir": true
-      }
-    },
-    "del>rimraf": {
-      "builtin": {
-        "assert": true,
-        "fs": true,
-        "path.join": true
+        "process.cwd": true
       },
+      "packages": {
+        "globby>dir-glob>path-type": true
+      }
+    },
+    "eslint>doctrine": {
+      "builtin": {
+        "assert": true
+      },
+      "packages": {
+        "eslint>esutils": true
+      }
+    },
+    "eslint-plugin-import>doctrine": {
+      "builtin": {
+        "assert": true
+      },
+      "packages": {
+        "eslint>esutils": true
+      }
+    },
+    "eslint-plugin-react>doctrine": {
+      "builtin": {
+        "assert": true
+      },
+      "packages": {
+        "eslint>esutils": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2>domutils>dom-serializer": {
+      "packages": {
+        "stylelint>postcss-html>htmlparser2>domelementtype": true,
+        "stylelint>postcss-html>htmlparser2>entities": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2>domhandler": {
+      "packages": {
+        "stylelint>postcss-html>htmlparser2>domelementtype": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2>domutils": {
+      "packages": {
+        "stylelint>postcss-html>htmlparser2>domutils>dom-serializer": true,
+        "stylelint>postcss-html>htmlparser2>domelementtype": true
+      }
+    },
+    "browserify>duplexer2": {
+      "packages": {
+        "browserify>duplexer2>readable-stream": true
+      }
+    },
+    "debounce-stream>duplexer": {
+      "builtin": {
+        "stream": true
+      }
+    },
+    "duplexify": {
       "globals": {
-        "process.platform": true,
-        "setTimeout": true
+        "Buffer": true,
+        "process.nextTick": true
       },
       "packages": {
-        "nyc>glob": true
+        "duplexify>end-of-stream": true,
+        "pumpify>inherits": true,
+        "readable-stream": true,
+        "duplexify>stream-shift": true
       }
     },
-    "depcheck>@babel/traverse": {
+    "lavamoat-browserify>duplexify": {
       "globals": {
-        "console.log": true
+        "Buffer": true,
+        "process.nextTick": true
       },
       "packages": {
-        "@babel/code-frame": true,
-        "@babel/core>@babel/generator": true,
-        "@babel/core>@babel/parser": true,
-        "@babel/core>@babel/template": true,
-        "@babel/core>@babel/types": true,
-        "babel/preset-env>b@babel/types": true,
-        "depcheck>@babel/traverse>globals": true,
-        "nock>debug": true
+        "duplexify>end-of-stream": true,
+        "pumpify>inherits": true,
+        "readable-stream": true,
+        "duplexify>stream-shift": true
       }
     },
-    "depcheck>cosmiconfig>parse-json": {
+    "gulp>vinyl-fs>glob-stream>pumpify>duplexify": {
+      "globals": {
+        "Buffer": true,
+        "process.nextTick": true
+      },
       "packages": {
-        "@babel/code-frame": true,
-        "depcheck>cosmiconfig>parse-json>error-ex": true,
-        "depcheck>cosmiconfig>parse-json>lines-and-columns": true,
-        "webpack>json-parse-even-better-errors": true
+        "duplexify>end-of-stream": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>glob-stream>readable-stream": true,
+        "duplexify>stream-shift": true
+      }
+    },
+    "gulp>vinyl-fs>pumpify>duplexify": {
+      "globals": {
+        "Buffer": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "duplexify>end-of-stream": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>readable-stream": true,
+        "duplexify>stream-shift": true
+      }
+    },
+    "duplexify>end-of-stream": {
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "@metamask/object-multiplex>once": true
       }
     },
     "depcheck>cosmiconfig>parse-json>error-ex": {
@@ -2242,81 +2536,99 @@
         "depcheck>cosmiconfig>parse-json>error-ex>is-arrayish": true
       }
     },
-    "depcheck>is-core-module": {
-      "globals": {
-        "process.versions": true
+    "gulp-livereload>tiny-lr>body>error": {
+      "builtin": {
+        "assert": true
       },
       "packages": {
+        "gulp-livereload>tiny-lr>body>error>string-template": true,
+        "watchify>xtend": true
+      }
+    },
+    "string.prototype.matchall>es-abstract": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>call-bind>es-define-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>es-object-atoms": true,
+        "string.prototype.matchall>es-abstract>es-set-tostringtag": true,
+        "string.prototype.matchall>es-abstract>es-to-primitive": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
+        "string.prototype.matchall>es-abstract>has-proto": true,
+        "string.prototype.matchall>has-symbols": true,
+        "depcheck>is-core-module>hasown": true,
+        "string.prototype.matchall>internal-slot": true,
+        "string.prototype.matchall>es-abstract>is-callable": true,
+        "string.prototype.matchall>es-abstract>is-regex": true,
+        "eslint-plugin-react>array-includes>is-string": true,
+        "string.prototype.matchall>es-abstract>object-inspect": true,
+        "string.prototype.matchall>es-abstract>safe-regex-test": true,
+        "string.prototype.matchall>es-abstract>string.prototype.trim": true
+      }
+    },
+    "string.prototype.matchall>call-bind>es-define-property": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>es-object-atoms": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>es-set-tostringtag": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true,
+        "koa>is-generator-function>has-tostringtag": true,
         "depcheck>is-core-module>hasown": true
       }
     },
-    "depcheck>is-core-module>hasown": {
+    "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables": {
       "packages": {
-        "browserify>has>function-bind": true
+        "browserify>has": true
       }
     },
-    "depcheck>json5": {
-      "globals": {
-        "console.warn": true
+    "string.prototype.matchall>es-abstract>es-to-primitive": {
+      "packages": {
+        "string.prototype.matchall>es-abstract>is-callable": true,
+        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
+        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true
       }
     },
-    "depcheck>resolve": {
+    "resolve-url-loader>es6-iterator>es5-ext": {
+      "packages": {
+        "resolve-url-loader>es6-iterator>es6-symbol": true
+      }
+    },
+    "resolve-url-loader>es6-iterator": {
+      "packages": {
+        "resolve-url-loader>es6-iterator>d": true,
+        "resolve-url-loader>es6-iterator>es5-ext": true,
+        "resolve-url-loader>es6-iterator>es6-symbol": true
+      }
+    },
+    "resolve-url-loader>es6-iterator>es6-symbol": {
+      "packages": {
+        "resolve-url-loader>es6-iterator>d": true,
+        "resolve-url-loader>es6-iterator>es6-symbol>ext": true
+      }
+    },
+    "gulp>undertaker>es6-weak-map": {
+      "packages": {
+        "resolve-url-loader>es6-iterator>d": true,
+        "resolve-url-loader>es6-iterator>es5-ext": true,
+        "resolve-url-loader>es6-iterator": true,
+        "resolve-url-loader>es6-iterator>es6-symbol": true
+      }
+    },
+    "yargs>escalade": {
       "builtin": {
-        "fs.readFile": true,
-        "fs.readFileSync": true,
-        "fs.realpath": true,
-        "fs.realpathSync": true,
-        "fs.stat": true,
+        "fs.readdirSync": true,
         "fs.statSync": true,
-        "os.homedir": true,
         "path.dirname": true,
-        "path.join": true,
-        "path.parse": true,
-        "path.relative": true,
         "path.resolve": true
-      },
-      "globals": {
-        "process.env.HOME": true,
-        "process.env.HOMEDRIVE": true,
-        "process.env.HOMEPATH": true,
-        "process.env.LNAME": true,
-        "process.env.LOGNAME": true,
-        "process.env.USER": true,
-        "process.env.USERNAME": true,
-        "process.env.USERPROFILE": true,
-        "process.getuid": true,
-        "process.nextTick": true,
-        "process.platform": true,
-        "process.versions.pnp": true
-      },
-      "packages": {
-        "depcheck>is-core-module": true,
-        "depcheck>resolve>path-parse": true
-      }
-    },
-    "depcheck>resolve>path-parse": {
-      "globals": {
-        "process.platform": true
-      }
-    },
-    "duplexify": {
-      "globals": {
-        "Buffer": true,
-        "process.nextTick": true
-      },
-      "packages": {
-        "duplexify>end-of-stream": true,
-        "duplexify>stream-shift": true,
-        "pumpify>inherits": true,
-        "readable-stream": true
-      }
-    },
-    "duplexify>end-of-stream": {
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "@metamask/object-multiplex>once": true
       }
     },
     "eslint": {
@@ -2353,8 +2665,6 @@
         "process": true
       },
       "packages": {
-        "del>is-glob": true,
-        "del>is-path-inside": true,
         "eslint>@eslint-community/eslint-utils": true,
         "eslint>@eslint-community/regexpp": true,
         "eslint>@eslint/eslintrc": true,
@@ -2363,7 +2673,9 @@
         "eslint>@nodelib/fs.walk": true,
         "eslint>@ungap/structured-clone": true,
         "eslint>ajv": true,
+        "nock>debug": true,
         "eslint>doctrine": true,
+        "mocha>escape-string-regexp": true,
         "eslint>eslint-scope": true,
         "eslint>eslint-visitor-keys": true,
         "eslint>espree": true,
@@ -2371,19 +2683,19 @@
         "eslint>esutils": true,
         "eslint>fast-deep-equal": true,
         "eslint>file-entry-cache": true,
+        "mocha>find-up": true,
         "eslint>glob-parent": true,
         "eslint>globals": true,
         "eslint>graphemer": true,
         "eslint>ignore": true,
         "eslint>imurmurhash": true,
+        "del>is-glob": true,
+        "del>is-path-inside": true,
         "eslint>json-stable-stringify-without-jsonify": true,
         "eslint>levn": true,
         "eslint>lodash.merge": true,
         "eslint>minimatch": true,
-        "eslint>natural-compare": true,
-        "mocha>escape-string-regexp": true,
-        "mocha>find-up": true,
-        "nock>debug": true
+        "eslint>natural-compare": true
       }
     },
     "eslint-config-prettier": {
@@ -2398,25 +2710,8 @@
         "path.resolve": true
       },
       "packages": {
-        "depcheck>resolve": true,
-        "eslint-import-resolver-node>debug": true
-      }
-    },
-    "eslint-import-resolver-node>debug": {
-      "builtin": {
-        "tty.isatty": true,
-        "util": true
-      },
-      "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "mocha>ms": true,
-        "mocha>supports-color": true
+        "eslint-import-resolver-node>debug": true,
+        "depcheck>resolve": true
       }
     },
     "eslint-import-resolver-typescript": {
@@ -2428,73 +2723,11 @@
         "process.cwd": true
       },
       "packages": {
+        "nock>debug": true,
+        "nyc>glob": true,
         "del>is-glob": true,
         "depcheck>resolve": true,
-        "eslint-plugin-import>tsconfig-paths": true,
-        "nock>debug": true,
-        "nyc>glob": true
-      }
-    },
-    "eslint-plugin-import": {
-      "builtin": {
-        "fs": true,
-        "path": true,
-        "vm": true
-      },
-      "globals": {
-        "process.cwd": true,
-        "process.env": true
-      },
-      "packages": {
-        "browserify>has": true,
-        "del>is-glob": true,
-        "depcheck>is-core-module": true,
-        "eslint": true,
-        "eslint-plugin-import>array.prototype.flat": true,
-        "eslint-plugin-import>debug": true,
-        "eslint-plugin-import>doctrine": true,
-        "eslint-plugin-import>eslint-module-utils": true,
-        "eslint-plugin-import>tsconfig-paths": true,
-        "eslint-plugin-react>array-includes": true,
-        "eslint-plugin-react>object.values": true,
-        "eslint>minimatch": true,
-        "typescript": true
-      }
-    },
-    "eslint-plugin-import>array.prototype.flat": {
-      "packages": {
-        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>es-abstract": true
-      }
-    },
-    "eslint-plugin-import>debug": {
-      "builtin": {
-        "fs.SyncWriteStream": true,
-        "net.Socket": true,
-        "tty.WriteStream": true,
-        "tty.isatty": true,
-        "util": true
-      },
-      "globals": {
-        "chrome": true,
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "eslint-plugin-import>debug>ms": true
-      }
-    },
-    "eslint-plugin-import>doctrine": {
-      "builtin": {
-        "assert": true
-      },
-      "packages": {
-        "eslint>esutils": true
+        "eslint-plugin-import>tsconfig-paths": true
       }
     },
     "eslint-plugin-import>eslint-module-utils": {
@@ -2518,97 +2751,41 @@
       },
       "packages": {
         "@babel/eslint-parser": true,
-        "eslint-import-resolver-node": true,
         "eslint-plugin-import>eslint-module-utils>debug": true,
+        "eslint-import-resolver-node": true,
         "eslint-plugin-import>eslint-module-utils>find-up": true
       }
     },
-    "eslint-plugin-import>eslint-module-utils>debug": {
+    "eslint-plugin-node>eslint-plugin-es": {
+      "packages": {
+        "eslint-plugin-node>eslint-utils": true,
+        "eslint-plugin-node>eslint-plugin-es>regexpp": true
+      }
+    },
+    "eslint-plugin-import": {
       "builtin": {
-        "tty.isatty": true,
-        "util": true
+        "fs": true,
+        "path": true,
+        "vm": true
       },
       "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "mocha>ms": true,
-        "mocha>supports-color": true
-      }
-    },
-    "eslint-plugin-import>eslint-module-utils>find-up": {
-      "builtin": {
-        "path.dirname": true,
-        "path.join": true,
-        "path.parse": true,
-        "path.resolve": true
-      },
-      "packages": {
-        "eslint-plugin-import>eslint-module-utils>find-up>locate-path": true
-      }
-    },
-    "eslint-plugin-import>eslint-module-utils>find-up>locate-path": {
-      "builtin": {
-        "path.resolve": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate": true,
-        "eslint-plugin-import>eslint-module-utils>find-up>locate-path>path-exists": true
-      }
-    },
-    "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate": {
-      "packages": {
-        "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate>p-limit": true
-      }
-    },
-    "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate>p-limit": {
-      "packages": {
-        "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate>p-limit>p-try": true
-      }
-    },
-    "eslint-plugin-import>eslint-module-utils>find-up>locate-path>path-exists": {
-      "builtin": {
-        "fs.access": true,
-        "fs.accessSync": true
-      }
-    },
-    "eslint-plugin-import>tsconfig-paths": {
-      "builtin": {
-        "fs.existsSync": true,
-        "fs.lstatSync": true,
-        "fs.readFile": true,
-        "fs.readFileSync": true,
-        "fs.stat": true,
-        "fs.statSync": true,
-        "module._resolveFilename": true,
-        "module.builtinModules": true,
-        "path.dirname": true,
-        "path.isAbsolute": true,
-        "path.join": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "console.warn": true,
-        "process.argv.slice": true,
         "process.cwd": true,
         "process.env": true
       },
       "packages": {
-        "eslint-plugin-import>tsconfig-paths>json5": true,
-        "eslint-plugin-import>tsconfig-paths>strip-bom": true,
-        "wait-on>minimist": true
-      }
-    },
-    "eslint-plugin-import>tsconfig-paths>json5": {
-      "globals": {
-        "console.warn": true
+        "eslint-plugin-react>array-includes": true,
+        "eslint-plugin-import>array.prototype.flat": true,
+        "eslint-plugin-import>debug": true,
+        "eslint-plugin-import>doctrine": true,
+        "eslint": true,
+        "eslint-plugin-import>eslint-module-utils": true,
+        "browserify>has": true,
+        "depcheck>is-core-module": true,
+        "del>is-glob": true,
+        "eslint>minimatch": true,
+        "eslint-plugin-react>object.values": true,
+        "eslint-plugin-import>tsconfig-paths": true,
+        "typescript": true
       }
     },
     "eslint-plugin-jest": {
@@ -2625,105 +2802,17 @@
         "eslint-plugin-jest>@typescript-eslint/utils": true
       }
     },
-    "eslint-plugin-jest>@typescript-eslint/experimental-utils": {
-      "builtin": {
-        "path": true
-      },
-      "packages": {
-        "@typescript-eslint/parser>@typescript-eslint/scope-manager": true,
-        "@typescript-eslint/parser>@typescript-eslint/types": true,
-        "eslint": true,
-        "eslint-plugin-jest>@typescript-eslint/experimental-utils>@typescript-eslint/types": true,
-        "eslint-plugin-jest>@typescript-eslint/experimental-utils>eslint-utils": true,
-        "eslint>eslint-scope": true,
-        "eslint>eslint-utils": true,
-        "webpack>eslint-scope": true
-      }
-    },
-    "eslint-plugin-jest>@typescript-eslint/experimental-utils>eslint-utils": {
-      "packages": {
-        "eslint-plugin-jest>@typescript-eslint/experimental-utils>eslint-utils>eslint-visitor-keys": true
-      }
-    },
-    "eslint-plugin-jest>@typescript-eslint/utils": {
-      "builtin": {
-        "assert": true,
-        "path": true
-      },
-      "packages": {
-        "@typescript-eslint/parser>@typescript-eslint/scope-manager": true,
-        "@typescript-eslint/parser>@typescript-eslint/types": true,
-        "eslint": true,
-        "eslint-plugin-jest>@typescript-eslint/experimental-utils>@typescript-eslint/types": true,
-        "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager": true,
-        "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/types": true,
-        "eslint-plugin-jest>@typescript-eslint/utils>webpack>eslint-scope": true,
-        "eslint-plugin-mocha>eslint-utils": true,
-        "eslint>@eslint-community/eslint-utils": true,
-        "eslint>eslint-scope": true,
-        "eslint>eslint-utils": true,
-        "semver": true,
-        "webpack>eslint-scope": true
-      }
-    },
-    "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager": {
-      "builtin": {
-        "path": true
-      },
-      "packages": {
-        "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager>@typescript-eslint/visitor-keys": true,
-        "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/types": true
-      }
-    },
-    "eslint-plugin-jest>@typescript-eslint/utils>@typescript-eslint/scope-manager>@typescript-eslint/visitor-keys": {
-      "builtin": {
-        "path": true
-      },
-      "packages": {
-        "eslint>eslint-visitor-keys": true
-      }
-    },
-    "eslint-plugin-jest>@typescript-eslint/utils>eslint-utils": {
-      "packages": {
-        "eslint-plugin-jest>@typescript-eslint/utils>eslint-utils>eslint-visitor-keys": true,
-        "eslint>@eslint-community/eslint-utils": true,
-        "semver": true
-      }
-    },
     "eslint-plugin-jsdoc": {
       "packages": {
-        "eslint": true,
         "eslint-plugin-jsdoc>@es-joy/jsdoccomment": true,
         "eslint-plugin-jsdoc>are-docs-informative": true,
         "eslint-plugin-jsdoc>comment-parser": true,
-        "eslint-plugin-jsdoc>spdx-expression-parse": true,
-        "eslint>esquery": true,
-        "mocha>escape-string-regexp": true,
         "nock>debug": true,
-        "semver": true
-      }
-    },
-    "eslint-plugin-jsdoc>@es-joy/jsdoccomment": {
-      "packages": {
-        "eslint-plugin-jsdoc>@es-joy/jsdoccomment>jsdoc-type-pratt-parser": true,
-        "eslint-plugin-jsdoc>comment-parser": true,
-        "eslint>esquery": true
-      }
-    },
-    "eslint-plugin-jsdoc>@es-joy/jsdoccomment>jsdoc-type-pratt-parser": {
-      "globals": {
-        "define": true
-      }
-    },
-    "eslint-plugin-jsdoc>spdx-expression-parse": {
-      "packages": {
-        "eslint-plugin-jsdoc>spdx-expression-parse>spdx-exceptions": true,
-        "eslint-plugin-jsdoc>spdx-expression-parse>spdx-license-ids": true
-      }
-    },
-    "eslint-plugin-mocha>eslint-utils": {
-      "packages": {
-        "eslint-plugin-mocha>eslint-utils>eslint-visitor-keys": true
+        "mocha>escape-string-regexp": true,
+        "eslint": true,
+        "eslint>esquery": true,
+        "semver": true,
+        "eslint-plugin-jsdoc>spdx-expression-parse": true
       }
     },
     "eslint-plugin-node": {
@@ -2744,40 +2833,18 @@
         "process.cwd": true
       },
       "packages": {
-        "depcheck>resolve": true,
         "eslint-plugin-node>eslint-plugin-es": true,
         "eslint-plugin-node>eslint-utils": true,
-        "eslint-plugin-node>semver": true,
         "eslint>ignore": true,
-        "eslint>minimatch": true
-      }
-    },
-    "eslint-plugin-node>eslint-plugin-es": {
-      "packages": {
-        "eslint-plugin-node>eslint-plugin-es>regexpp": true,
-        "eslint-plugin-node>eslint-utils": true
-      }
-    },
-    "eslint-plugin-node>eslint-utils": {
-      "packages": {
-        "eslint-plugin-node>eslint-utils>eslint-visitor-keys": true
-      }
-    },
-    "eslint-plugin-node>semver": {
-      "globals": {
-        "console": true,
-        "process": true
+        "eslint>minimatch": true,
+        "depcheck>resolve": true,
+        "eslint-plugin-node>semver": true
       }
     },
     "eslint-plugin-prettier": {
       "packages": {
-        "eslint-plugin-prettier>prettier-linter-helpers": true,
-        "prettier": true
-      }
-    },
-    "eslint-plugin-prettier>prettier-linter-helpers": {
-      "packages": {
-        "eslint-plugin-prettier>prettier-linter-helpers>fast-diff": true
+        "prettier": true,
+        "eslint-plugin-prettier>prettier-linter-helpers": true
       }
     },
     "eslint-plugin-react": {
@@ -2793,20 +2860,20 @@
         "process.cwd": true
       },
       "packages": {
-        "eslint": true,
         "eslint-plugin-react>array-includes": true,
         "eslint-plugin-react>array.prototype.flatmap": true,
         "eslint-plugin-react>doctrine": true,
+        "eslint": true,
         "eslint-plugin-react>estraverse": true,
         "eslint-plugin-react>jsx-ast-utils": true,
+        "eslint>minimatch": true,
         "eslint-plugin-react>object.entries": true,
         "eslint-plugin-react>object.fromentries": true,
         "eslint-plugin-react>object.hasown": true,
         "eslint-plugin-react>object.values": true,
+        "prop-types": true,
         "eslint-plugin-react>resolve": true,
         "eslint-plugin-react>semver": true,
-        "eslint>minimatch": true,
-        "prop-types": true,
         "string.prototype.matchall": true
       }
     },
@@ -2815,256 +2882,13 @@
         "process.env.NODE_ENV": true
       }
     },
-    "eslint-plugin-react>array-includes": {
-      "packages": {
-        "eslint-plugin-react>array-includes>is-string": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>es-abstract": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "eslint-plugin-react>array-includes>is-string": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true
-      }
-    },
-    "eslint-plugin-react>array.prototype.flatmap": {
-      "packages": {
-        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>es-abstract": true
-      }
-    },
-    "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables": {
-      "packages": {
-        "browserify>has": true
-      }
-    },
-    "eslint-plugin-react>doctrine": {
+    "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals>eslint-scope": {
       "builtin": {
         "assert": true
       },
       "packages": {
-        "eslint>esutils": true
-      }
-    },
-    "eslint-plugin-react>jsx-ast-utils": {
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>object.assign": true
-      }
-    },
-    "eslint-plugin-react>object.entries": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>es-abstract": true
-      }
-    },
-    "eslint-plugin-react>object.fromentries": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>es-abstract": true
-      }
-    },
-    "eslint-plugin-react>object.hasown": {
-      "packages": {
-        "string.prototype.matchall>es-abstract": true
-      }
-    },
-    "eslint-plugin-react>resolve": {
-      "builtin": {
-        "fs.readFile": true,
-        "fs.readFileSync": true,
-        "fs.realpath": true,
-        "fs.realpathSync": true,
-        "fs.stat": true,
-        "fs.statSync": true,
-        "os.homedir": true,
-        "path.dirname": true,
-        "path.join": true,
-        "path.parse": true,
-        "path.relative": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "process.env.HOME": true,
-        "process.env.HOMEDRIVE": true,
-        "process.env.HOMEPATH": true,
-        "process.env.LNAME": true,
-        "process.env.LOGNAME": true,
-        "process.env.USER": true,
-        "process.env.USERNAME": true,
-        "process.env.USERPROFILE": true,
-        "process.getuid": true,
-        "process.nextTick": true,
-        "process.platform": true,
-        "process.versions.pnp": true
-      },
-      "packages": {
-        "depcheck>is-core-module": true,
-        "depcheck>resolve>path-parse": true
-      }
-    },
-    "eslint-plugin-react>semver": {
-      "globals": {
-        "console": true,
-        "process": true
-      }
-    },
-    "eslint>@eslint-community/eslint-utils": {
-      "packages": {
-        "eslint>eslint-visitor-keys": true
-      }
-    },
-    "eslint>@eslint/eslintrc": {
-      "builtin": {
-        "assert": true,
-        "fs": true,
-        "module": true,
-        "os": true,
-        "path": true,
-        "url": true,
-        "util": true
-      },
-      "globals": {
-        "__filename": true,
-        "process.cwd": true,
-        "process.emitWarning": true,
-        "process.platform": true
-      },
-      "packages": {
-        "$root$": true,
-        "@babel/eslint-parser": true,
-        "@babel/eslint-plugin": true,
-        "@metamask/eslint-config": true,
-        "@metamask/eslint-config-nodejs": true,
-        "@metamask/eslint-config-typescript": true,
-        "@typescript-eslint/eslint-plugin": true,
-        "eslint": true,
-        "eslint-config-prettier": true,
-        "eslint-plugin-import": true,
-        "eslint-plugin-jsdoc": true,
-        "eslint-plugin-node": true,
-        "eslint-plugin-prettier": true,
-        "eslint-plugin-react": true,
-        "eslint-plugin-react-hooks": true,
-        "eslint>ajv": true,
-        "eslint>globals": true,
-        "eslint>ignore": true,
-        "eslint>minimatch": true,
-        "mocha>strip-json-comments": true,
-        "nock>debug": true
-      }
-    },
-    "eslint>@eslint/eslintrc>import-fresh": {
-      "builtin": {
-        "path.dirname": true
-      },
-      "globals": {
-        "__dirname": true,
-        "__filename": true
-      },
-      "packages": {
-        "eslint>@eslint/eslintrc>import-fresh>parent-module": true,
-        "eslint>@eslint/eslintrc>import-fresh>resolve-from": true
-      }
-    },
-    "eslint>@eslint/eslintrc>import-fresh>parent-module": {
-      "packages": {
-        "@metamask/test-bundler>ow>callsites": true
-      }
-    },
-    "eslint>@eslint/eslintrc>import-fresh>resolve-from": {
-      "builtin": {
-        "fs.realpathSync": true,
-        "module._nodeModulePaths": true,
-        "module._resolveFilename": true,
-        "path.join": true,
-        "path.resolve": true
-      }
-    },
-    "eslint>@humanwhocodes/config-array": {
-      "builtin": {
-        "path.dirname": true,
-        "path.join": true,
-        "path.relative": true
-      },
-      "packages": {
-        "eslint>@humanwhocodes/config-array>@humanwhocodes/object-schema": true,
-        "eslint>minimatch": true,
-        "nock>debug": true
-      }
-    },
-    "eslint>@nodelib/fs.walk": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "path.sep": true,
-        "stream.Readable": true
-      },
-      "globals": {
-        "setImmediate": true
-      },
-      "packages": {
-        "eslint>@nodelib/fs.walk>@nodelib/fs.scandir": true,
-        "eslint>@nodelib/fs.walk>fastq": true
-      }
-    },
-    "eslint>@nodelib/fs.walk>@nodelib/fs.scandir": {
-      "builtin": {
-        "fs.lstat": true,
-        "fs.lstatSync": true,
-        "fs.readdir": true,
-        "fs.readdirSync": true,
-        "fs.stat": true,
-        "fs.statSync": true,
-        "path.sep": true
-      },
-      "globals": {
-        "process.versions.node": true
-      },
-      "packages": {
-        "eslint>@nodelib/fs.walk>@nodelib/fs.scandir>run-parallel": true,
-        "fast-glob>@nodelib/fs.stat": true
-      }
-    },
-    "eslint>@nodelib/fs.walk>@nodelib/fs.scandir>run-parallel": {
-      "globals": {
-        "process.nextTick": true
-      }
-    },
-    "eslint>@nodelib/fs.walk>fastq": {
-      "packages": {
-        "eslint>@nodelib/fs.walk>fastq>reusify": true
-      }
-    },
-    "eslint>@ungap/structured-clone": {
-      "globals": {
-        "structuredClone": true
-      }
-    },
-    "eslint>ajv": {
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "@metamask/snaps-utils>fast-json-stable-stringify": true,
-        "eslint>ajv>json-schema-traverse": true,
-        "eslint>fast-deep-equal": true,
-        "uri-js": true
-      }
-    },
-    "eslint>doctrine": {
-      "builtin": {
-        "assert": true
-      },
-      "packages": {
-        "eslint>esutils": true
+        "eslint>eslint-scope>esrecurse": true,
+        "@babel/eslint-parser>@nicolo-ribaudo/eslint-scope-5-internals>eslint-scope>estraverse": true
       }
     },
     "eslint>eslint-scope": {
@@ -3072,25 +2896,37 @@
         "assert": true
       },
       "packages": {
-        "eslint-plugin-react>estraverse": true,
-        "eslint>eslint-scope>esrecurse": true
+        "eslint>eslint-scope>esrecurse": true,
+        "eslint-plugin-react>estraverse": true
       }
     },
-    "eslint>eslint-scope>esrecurse": {
+    "eslint-plugin-jest>@typescript-eslint/experimental-utils>eslint-utils": {
       "packages": {
-        "eslint-plugin-react>estraverse": true
+        "eslint-plugin-jest>@typescript-eslint/experimental-utils>eslint-utils>eslint-visitor-keys": true
+      }
+    },
+    "eslint-plugin-jest>@typescript-eslint/utils>eslint-utils": {
+      "packages": {
+        "eslint>@eslint-community/eslint-utils": true,
+        "eslint-plugin-jest>@typescript-eslint/utils>eslint-utils>eslint-visitor-keys": true,
+        "semver": true
+      }
+    },
+    "eslint-plugin-mocha>eslint-utils": {
+      "packages": {
+        "eslint-plugin-mocha>eslint-utils>eslint-visitor-keys": true
+      }
+    },
+    "eslint-plugin-node>eslint-utils": {
+      "packages": {
+        "eslint-plugin-node>eslint-utils>eslint-visitor-keys": true
       }
     },
     "eslint>espree": {
       "packages": {
-        "eslint>eslint-visitor-keys": true,
         "eslint>espree>acorn-jsx": true,
-        "jsdom>acorn": true
-      }
-    },
-    "eslint>espree>acorn-jsx": {
-      "packages": {
-        "jsdom>acorn": true
+        "jsdom>acorn": true,
+        "eslint>eslint-visitor-keys": true
       }
     },
     "eslint>esquery": {
@@ -3098,81 +2934,9 @@
         "define": true
       }
     },
-    "eslint>file-entry-cache": {
-      "builtin": {
-        "crypto.createHash": true,
-        "fs.readFileSync": true,
-        "fs.statSync": true,
-        "path.basename": true,
-        "path.dirname": true
-      },
+    "eslint>eslint-scope>esrecurse": {
       "packages": {
-        "eslint>file-entry-cache>flat-cache": true
-      }
-    },
-    "eslint>file-entry-cache>flat-cache": {
-      "builtin": {
-        "fs.existsSync": true,
-        "fs.mkdirSync": true,
-        "fs.readFileSync": true,
-        "fs.writeFileSync": true,
-        "path.basename": true,
-        "path.dirname": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "__dirname": true
-      },
-      "packages": {
-        "del>rimraf": true,
-        "eslint>file-entry-cache>flat-cache>flatted": true
-      }
-    },
-    "eslint>glob-parent": {
-      "builtin": {
-        "os.platform": true,
-        "path.posix.dirname": true
-      },
-      "packages": {
-        "del>is-glob": true
-      }
-    },
-    "eslint>ignore": {
-      "globals": {
-        "process": true
-      }
-    },
-    "eslint>levn": {
-      "packages": {
-        "eslint>levn>prelude-ls": true,
-        "eslint>levn>type-check": true
-      }
-    },
-    "eslint>levn>type-check": {
-      "packages": {
-        "eslint>levn>prelude-ls": true
-      }
-    },
-    "eslint>minimatch": {
-      "builtin": {
-        "path": true
-      },
-      "globals": {
-        "console": true
-      },
-      "packages": {
-        "eslint>minimatch>brace-expansion": true
-      }
-    },
-    "eslint>minimatch>brace-expansion": {
-      "packages": {
-        "eslint>minimatch>brace-expansion>concat-map": true,
-        "stylelint>balanced-match": true
-      }
-    },
-    "eslint>strip-ansi": {
-      "packages": {
-        "eslint>strip-ansi>ansi-regex": true
+        "eslint-plugin-react>estraverse": true
       }
     },
     "eta": {
@@ -3182,6 +2946,121 @@
       },
       "globals": {
         "define": true
+      }
+    },
+    "gulp-sourcemaps>debug-fabulous>memoizee>event-emitter": {
+      "packages": {
+        "resolve-url-loader>es6-iterator>d": true,
+        "resolve-url-loader>es6-iterator>es5-ext": true
+      }
+    },
+    "gulp-livereload>event-stream": {
+      "builtin": {
+        "buffer.Buffer.isBuffer": true,
+        "stream.Stream": true
+      },
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.isBuffer": true,
+        "console.error": true,
+        "process.nextTick": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "debounce-stream>duplexer": true,
+        "gulp-livereload>event-stream>from": true,
+        "gulp-livereload>event-stream>map-stream": true,
+        "gulp-livereload>event-stream>pause-stream": true,
+        "gulp-livereload>event-stream>split": true,
+        "gulp-livereload>event-stream>stream-combiner": true,
+        "debounce-stream>through": true
+      }
+    },
+    "stylelint>execall": {
+      "packages": {
+        "stylelint>execall>clone-regexp": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets": {
+      "globals": {
+        "__filename": true
+      },
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug": true,
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property": true,
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>extend-shallow": true,
+        "gulp>gulp-cli>matchdep>micromatch>extglob>expand-brackets>posix-character-classes": true,
+        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
+        "gulp>gulp-cli>matchdep>micromatch>to-regex": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>expand-brackets": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>expand-brackets>is-posix-bracket": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>braces>expand-range": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range": true
+      }
+    },
+    "resolve-url-loader>es6-iterator>es6-symbol>ext": {
+      "globals": {
+        "__global__": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>braces>extend-shallow": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>extend-shallow": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>extend-shallow": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>extend-shallow": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
+      }
+    },
+    "gulp-zip>plugin-error>extend-shallow": {
+      "packages": {
+        "gulp-zip>plugin-error>extend-shallow>assign-symbols": true,
+        "gulp-zip>plugin-error>extend-shallow>is-extendable": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value>extend-shallow": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>extend-shallow": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>array-unique": true,
+        "gulp>glob-watcher>anymatch>micromatch>extglob>define-property": true,
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets": true,
+        "gulp>glob-watcher>anymatch>micromatch>extglob>extend-shallow": true,
+        "gulp>gulp-cli>matchdep>micromatch>fragment-cache": true,
+        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
+        "gulp>gulp-cli>matchdep>micromatch>to-regex": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>extglob": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>is-extglob": true
       }
     },
     "fancy-log": {
@@ -3202,14 +3081,17 @@
         "fancy-log>time-stamp": true
       }
     },
-    "fancy-log>ansi-gray": {
-      "packages": {
-        "fancy-log>ansi-gray>ansi-wrap": true
-      }
-    },
-    "fancy-log>color-support": {
+    "gulp-watch>fancy-log": {
       "globals": {
-        "process": true
+        "console": true,
+        "process.argv.indexOf": true,
+        "process.stderr.write": true,
+        "process.stdout.write": true
+      },
+      "packages": {
+        "fancy-log>ansi-gray": true,
+        "fancy-log>color-support": true,
+        "fancy-log>time-stamp": true
       }
     },
     "fast-glob": {
@@ -3231,28 +3113,192 @@
         "process.cwd": true
       },
       "packages": {
+        "fast-glob>@nodelib/fs.stat": true,
         "eslint>@nodelib/fs.walk": true,
         "eslint>glob-parent": true,
-        "fast-glob>@nodelib/fs.stat": true,
-        "fast-glob>micromatch": true,
-        "globby>merge2": true
+        "globby>merge2": true,
+        "fast-glob>micromatch": true
       }
     },
-    "fast-glob>@nodelib/fs.stat": {
+    "eslint>@nodelib/fs.walk>fastq": {
+      "packages": {
+        "eslint>@nodelib/fs.walk>fastq>reusify": true
+      }
+    },
+    "gulp-livereload>tiny-lr>faye-websocket": {
       "builtin": {
-        "fs.lstat": true,
-        "fs.lstatSync": true,
-        "fs.stat": true,
-        "fs.statSync": true
+        "net.connect": true,
+        "stream.Stream": true,
+        "tls.connect": true,
+        "url.parse": true,
+        "util.inherits": true
+      },
+      "globals": {
+        "Buffer": true,
+        "clearInterval": true,
+        "process.nextTick": true,
+        "setInterval": true
+      },
+      "packages": {
+        "webpack-dev-server>sockjs>websocket-driver": true
       }
     },
-    "fast-glob>micromatch": {
+    "eslint>file-entry-cache": {
+      "builtin": {
+        "crypto.createHash": true,
+        "fs.readFileSync": true,
+        "fs.statSync": true,
+        "path.basename": true,
+        "path.dirname": true
+      },
+      "packages": {
+        "eslint>file-entry-cache>flat-cache": true
+      }
+    },
+    "stylelint>file-entry-cache": {
+      "builtin": {
+        "crypto.createHash": true,
+        "fs.readFileSync": true,
+        "fs.statSync": true,
+        "path.basename": true,
+        "path.dirname": true
+      },
+      "packages": {
+        "stylelint>file-entry-cache>flat-cache": true
+      }
+    },
+    "chokidar>braces>fill-range": {
       "builtin": {
         "util.inspect": true
       },
       "packages": {
-        "chokidar>anymatch>picomatch": true,
-        "chokidar>braces": true
+        "chokidar>braces>fill-range>to-regex-range": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range": {
+      "builtin": {
+        "util.inspect": true
+      },
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>extend-shallow": true,
+        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
+        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>to-regex-range": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>is-number": true,
+        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>isobject": true,
+        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>randomatic": true,
+        "gulp-watch>anymatch>micromatch>braces>repeat-element": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
+      }
+    },
+    "eslint-plugin-import>eslint-module-utils>find-up": {
+      "builtin": {
+        "path.dirname": true,
+        "path.join": true,
+        "path.parse": true,
+        "path.resolve": true
+      },
+      "packages": {
+        "eslint-plugin-import>eslint-module-utils>find-up>locate-path": true
+      }
+    },
+    "mocha>find-up": {
+      "builtin": {
+        "path.dirname": true,
+        "path.parse": true,
+        "path.resolve": true
+      },
+      "packages": {
+        "mocha>find-up>locate-path": true,
+        "nyc>find-up>path-exists": true
+      }
+    },
+    "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "Buffer.concat": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream": true
+      }
+    },
+    "eslint>file-entry-cache>flat-cache": {
+      "builtin": {
+        "fs.existsSync": true,
+        "fs.mkdirSync": true,
+        "fs.readFileSync": true,
+        "fs.writeFileSync": true,
+        "path.basename": true,
+        "path.dirname": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "__dirname": true
+      },
+      "packages": {
+        "eslint>file-entry-cache>flat-cache>flatted": true,
+        "del>rimraf": true
+      }
+    },
+    "stylelint>file-entry-cache>flat-cache": {
+      "builtin": {
+        "fs.existsSync": true,
+        "fs.readFileSync": true,
+        "path.basename": true,
+        "path.dirname": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "__dirname": true
+      },
+      "packages": {
+        "stylelint>file-entry-cache>flat-cache>flatted": true,
+        "stylelint>file-entry-cache>flat-cache>rimraf": true,
+        "stylelint>file-entry-cache>flat-cache>write": true
+      }
+    },
+    "gulp>vinyl-fs>lead>flush-write-stream": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream": true
+      }
+    },
+    "lavamoat>lavamoat-core>merge-deep>clone-deep>for-own": {
+      "packages": {
+        "gulp>undertaker>object.reduce>for-own>for-in": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>object.omit>for-own": {
+      "packages": {
+        "gulp>undertaker>object.reduce>for-own>for-in": true
+      }
+    },
+    "gulp>undertaker>object.reduce>for-own": {
+      "packages": {
+        "gulp>undertaker>object.reduce>for-own>for-in": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>fragment-cache": {
+      "packages": {
+        "gulp>gulp-cli>liftoff>fined>parse-filepath>map-cache": true
+      }
+    },
+    "gulp-livereload>event-stream>from": {
+      "builtin": {
+        "stream": true
+      },
+      "globals": {
+        "process.nextTick": true
       }
     },
     "fs-extra": {
@@ -3285,987 +3331,67 @@
         "fs-extra>universalify": true
       }
     },
-    "fs-extra>jsonfile": {
-      "builtin": {
-        "fs": true
-      },
-      "globals": {
-        "Buffer.isBuffer": true
-      },
-      "packages": {
-        "del>graceful-fs": true
-      }
-    },
-    "gh-pages>globby>pinkie-promise": {
-      "packages": {
-        "gh-pages>globby>pinkie-promise>pinkie": true
-      }
-    },
-    "gh-pages>globby>pinkie-promise>pinkie": {
-      "globals": {
-        "process": true,
-        "setImmediate": true,
-        "setTimeout": true
-      }
-    },
-    "globby": {
-      "builtin": {
-        "fs.Stats": true,
-        "fs.readFile": true,
-        "fs.readFileSync": true,
-        "fs.statSync": true,
-        "path.dirname": true,
-        "path.isAbsolute": true,
-        "path.join": true,
-        "path.posix.join": true,
-        "path.relative": true,
-        "stream.Transform": true,
-        "util.promisify": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "del>slash": true,
-        "eslint>ignore": true,
-        "fast-glob": true,
-        "globby>array-union": true,
-        "globby>dir-glob": true,
-        "globby>merge2": true
-      }
-    },
-    "globby>dir-glob": {
-      "builtin": {
-        "path.extname": true,
-        "path.isAbsolute": true,
-        "path.join": true,
-        "path.posix.join": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "globby>dir-glob>path-type": true
-      }
-    },
-    "globby>dir-glob>path-type": {
-      "builtin": {
-        "fs": true,
-        "util.promisify": true
-      }
-    },
-    "globby>merge2": {
-      "builtin": {
-        "stream.PassThrough": true
-      },
-      "globals": {
-        "process.nextTick": true
-      }
-    },
-    "gulp": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "packages": {
-        "gulp>glob-watcher": true,
-        "gulp>undertaker": true,
-        "gulp>vinyl-fs": true
-      }
-    },
-    "gulp-livereload": {
-      "builtin": {
-        "path.relative": true
-      },
-      "packages": {
-        "fancy-log": true,
-        "gulp-livereload>chalk": true,
-        "gulp-livereload>debug": true,
-        "gulp-livereload>event-stream": true,
-        "gulp-livereload>lodash.assign": true,
-        "gulp-livereload>tiny-lr": true
-      }
-    },
-    "gulp-livereload>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "gulp-livereload>chalk>ansi-styles": true,
-        "gulp-livereload>chalk>escape-string-regexp": true,
-        "gulp-livereload>chalk>supports-color": true
-      }
-    },
-    "gulp-livereload>chalk>ansi-styles": {
-      "packages": {
-        "@metamask/jazzicon>color>color-convert": true
-      }
-    },
-    "gulp-livereload>chalk>supports-color": {
-      "builtin": {
-        "os.release": true
-      },
-      "globals": {
-        "process.env": true,
-        "process.platform": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.versions.node.split": true
-      },
-      "packages": {
-        "gulp-livereload>chalk>supports-color>has-flag": true
-      }
-    },
-    "gulp-livereload>chalk>supports-color>has-flag": {
-      "globals": {
-        "process.argv": true
-      }
-    },
-    "gulp-livereload>debug": {
-      "builtin": {
-        "tty.isatty": true,
-        "util": true
-      },
-      "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "gulp-livereload>chalk>supports-color": true,
-        "mocha>ms": true
-      }
-    },
-    "gulp-livereload>event-stream": {
-      "builtin": {
-        "buffer.Buffer.isBuffer": true,
-        "stream.Stream": true
-      },
-      "globals": {
-        "Buffer.concat": true,
-        "Buffer.isBuffer": true,
-        "console.error": true,
-        "process.nextTick": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "debounce-stream>duplexer": true,
-        "debounce-stream>through": true,
-        "gulp-livereload>event-stream>from": true,
-        "gulp-livereload>event-stream>map-stream": true,
-        "gulp-livereload>event-stream>pause-stream": true,
-        "gulp-livereload>event-stream>split": true,
-        "gulp-livereload>event-stream>stream-combiner": true
-      }
-    },
-    "gulp-livereload>event-stream>from": {
-      "builtin": {
-        "stream": true
-      },
-      "globals": {
-        "process.nextTick": true
-      }
-    },
-    "gulp-livereload>event-stream>map-stream": {
-      "builtin": {
-        "stream.Stream": true
-      },
-      "globals": {
-        "process.nextTick": true
-      }
-    },
-    "gulp-livereload>event-stream>pause-stream": {
-      "packages": {
-        "debounce-stream>through": true
-      }
-    },
-    "gulp-livereload>event-stream>split": {
-      "builtin": {
-        "string_decoder.StringDecoder": true
-      },
-      "packages": {
-        "debounce-stream>through": true
-      }
-    },
-    "gulp-livereload>event-stream>stream-combiner": {
-      "packages": {
-        "debounce-stream>duplexer": true
-      }
-    },
-    "gulp-livereload>tiny-lr": {
-      "builtin": {
-        "events": true,
-        "fs": true,
-        "http": true,
-        "https": true,
-        "url.parse": true
-      },
-      "globals": {
-        "console.error": true
-      },
-      "packages": {
-        "@storybook/addon-knobs>qs": true,
-        "gulp-livereload>tiny-lr>body": true,
-        "gulp-livereload>tiny-lr>debug": true,
-        "gulp-livereload>tiny-lr>faye-websocket": true,
-        "react>object-assign": true
-      }
-    },
-    "gulp-livereload>tiny-lr>body": {
-      "builtin": {
-        "querystring.parse": true
-      },
-      "packages": {
-        "gulp-livereload>tiny-lr>body>continuable-cache": true,
-        "gulp-livereload>tiny-lr>body>error": true,
-        "gulp-livereload>tiny-lr>body>raw-body": true,
-        "gulp-livereload>tiny-lr>body>safe-json-parse": true
-      }
-    },
-    "gulp-livereload>tiny-lr>body>error": {
-      "builtin": {
-        "assert": true
-      },
-      "packages": {
-        "gulp-livereload>tiny-lr>body>error>string-template": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp-livereload>tiny-lr>body>raw-body": {
-      "globals": {
-        "Buffer.concat": true,
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp-livereload>tiny-lr>body>raw-body>bytes": true,
-        "gulp-livereload>tiny-lr>body>raw-body>string_decoder": true
-      }
-    },
-    "gulp-livereload>tiny-lr>body>raw-body>string_decoder": {
-      "builtin": {
-        "buffer.Buffer": true
-      }
-    },
-    "gulp-livereload>tiny-lr>debug": {
-      "builtin": {
-        "tty.isatty": true,
-        "util": true
-      },
-      "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "mocha>ms": true,
-        "mocha>supports-color": true
-      }
-    },
-    "gulp-livereload>tiny-lr>faye-websocket": {
-      "builtin": {
-        "net.connect": true,
-        "stream.Stream": true,
-        "tls.connect": true,
-        "url.parse": true,
-        "util.inherits": true
-      },
-      "globals": {
-        "Buffer": true,
-        "clearInterval": true,
-        "process.nextTick": true,
-        "setInterval": true
-      },
-      "packages": {
-        "webpack-dev-server>sockjs>websocket-driver": true
-      }
-    },
-    "gulp-postcss": {
+    "gulp>vinyl-fs>fs-mkdirp-stream": {
       "builtin": {
         "path.dirname": true,
-        "path.isAbsolute": true,
-        "path.join": true,
-        "stream.Transform": true
-      },
-      "globals": {
-        "Buffer.from": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "fancy-log": true,
-        "gulp-postcss>postcss-load-config": true,
-        "gulp-zip>plugin-error": true,
-        "postcss": true,
-        "vinyl-sourcemaps-apply": true
-      }
-    },
-    "gulp-postcss>postcss-load-config": {
-      "builtin": {
-        "module.createRequire": true,
-        "module.createRequireFromPath": true,
         "path.resolve": true
       },
       "globals": {
-        "process.cwd": true,
-        "process.env.NODE_ENV": true
-      },
-      "packages": {
-        "gulp-postcss>postcss-load-config>lilconfig": true,
-        "gulp-postcss>postcss-load-config>yaml": true,
-        "ts-node": true
-      }
-    },
-    "gulp-postcss>postcss-load-config>lilconfig": {
-      "builtin": {
-        "fs.accessSync": true,
-        "fs.promises.access": true,
-        "fs.promises.readFile": true,
-        "fs.readFileSync": true,
-        "os.homedir": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.parse": true,
-        "path.resolve": true,
-        "path.sep": true
-      },
-      "globals": {
-        "process.cwd": true
-      }
-    },
-    "gulp-postcss>postcss-load-config>yaml": {
-      "globals": {
-        "Buffer": true,
-        "YAML_SILENCE_DEPRECATION_WARNINGS": true,
-        "YAML_SILENCE_WARNINGS": true,
-        "atob": true,
-        "btoa": true,
-        "console.warn": true,
-        "process": true
-      }
-    },
-    "gulp-sass": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.relative": true,
-        "stream.Transform": true
-      },
-      "globals": {
-        "process.cwd": true,
-        "process.exit": true,
-        "process.stderr.write": true
-      },
-      "packages": {
-        "eslint>strip-ansi": true,
-        "gulp-sass>lodash.clonedeep": true,
-        "gulp-sass>replace-ext": true,
-        "gulp-zip>plugin-error": true,
-        "postcss>picocolors": true,
-        "vinyl-sourcemaps-apply": true
-      }
-    },
-    "gulp-sass>replace-ext": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.sep": true
-      }
-    },
-    "gulp-sort": {
-      "packages": {
-        "gulp-sort>through2": true
-      }
-    },
-    "gulp-sort>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp-sort>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp-sort>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp-sort>through2>readable-stream>isarray": true,
-        "gulp-sort>through2>readable-stream>safe-buffer": true,
-        "gulp-sort>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp-sort>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp-sort>through2>readable-stream>string_decoder": {
-      "packages": {
-        "gulp-sort>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp-sourcemaps": {
-      "builtin": {
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.relative": true,
-        "path.resolve": true,
-        "path.sep": true
-      },
-      "globals": {
-        "Buffer.concat": true,
-        "Buffer.from": true
+        "process.umask": true
       },
       "packages": {
         "del>graceful-fs": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/identity-map": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/map-sources": true,
-        "gulp-sourcemaps>acorn": true,
-        "gulp-sourcemaps>css": true,
-        "gulp-sourcemaps>debug-fabulous": true,
-        "gulp-sourcemaps>detect-newline": true,
-        "gulp-sourcemaps>source-map": true,
-        "gulp-sourcemaps>strip-bom-string": true,
-        "gulp-sourcemaps>through2": true,
-        "nyc>convert-source-map": true
+        "gulp>vinyl-fs>fs-mkdirp-stream>through2": true
       }
     },
-    "gulp-sourcemaps>@gulp-sourcemaps/identity-map": {
-      "packages": {
-        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>acorn": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>normalize-path": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>source-map": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>through2": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/identity-map>acorn": {
-      "globals": {
-        "define": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss": {
+    "nyc>glob>fs.realpath": {
       "builtin": {
-        "fs": true,
-        "path": true
-      },
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "console": true,
-        "process.env.NODE_ENV": true
-      },
-      "packages": {
-        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss>picocolors": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>source-map": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss>picocolors": {
-      "builtin": {
-        "tty.isatty": true
-      },
-      "globals": {
-        "process.argv.includes": true,
-        "process.env": true,
-        "process.platform": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/identity-map>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "readable-stream": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/map-sources": {
-      "packages": {
-        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2": true,
-        "gulp-watch>anymatch>normalize-path": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>isarray": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>safe-buffer": true,
-        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>string_decoder": {
-      "packages": {
-        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp-sourcemaps>acorn": {
-      "globals": {
-        "define": true
-      }
-    },
-    "gulp-sourcemaps>css": {
-      "builtin": {
-        "fs.readFileSync": true,
-        "path.dirname": true,
-        "path.sep": true
-      },
-      "packages": {
-        "gulp-sourcemaps>css>source-map": true,
-        "gulp-sourcemaps>css>source-map-resolve": true,
-        "pumpify>inherits": true
-      }
-    },
-    "gulp-sourcemaps>css>source-map-resolve": {
-      "builtin": {
-        "path.sep": true,
-        "url.resolve": true
-      },
-      "globals": {
-        "TextDecoder": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp-sourcemaps>css>source-map-resolve>atob": true,
-        "gulp-sourcemaps>css>source-map-resolve>decode-uri-component": true
-      }
-    },
-    "gulp-sourcemaps>css>source-map-resolve>atob": {
-      "globals": {
-        "Buffer.from": true
-      }
-    },
-    "gulp-sourcemaps>debug-fabulous": {
-      "packages": {
-        "gulp-sourcemaps>debug-fabulous>debug": true,
-        "gulp-sourcemaps>debug-fabulous>memoizee": true,
-        "react>object-assign": true
-      }
-    },
-    "gulp-sourcemaps>debug-fabulous>debug": {
-      "builtin": {
-        "tty.isatty": true,
-        "util": true
-      },
-      "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "mocha>ms": true,
-        "mocha>supports-color": true
-      }
-    },
-    "gulp-sourcemaps>debug-fabulous>memoizee": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "gulp-sourcemaps>debug-fabulous>memoizee>event-emitter": true,
-        "gulp-sourcemaps>debug-fabulous>memoizee>is-promise": true,
-        "gulp-sourcemaps>debug-fabulous>memoizee>lru-queue": true,
-        "gulp-sourcemaps>debug-fabulous>memoizee>next-tick": true,
-        "gulp-sourcemaps>debug-fabulous>memoizee>timers-ext": true,
-        "resolve-url-loader>es6-iterator>d": true,
-        "resolve-url-loader>es6-iterator>es5-ext": true
-      }
-    },
-    "gulp-sourcemaps>debug-fabulous>memoizee>event-emitter": {
-      "packages": {
-        "resolve-url-loader>es6-iterator>d": true,
-        "resolve-url-loader>es6-iterator>es5-ext": true
-      }
-    },
-    "gulp-sourcemaps>debug-fabulous>memoizee>lru-queue": {
-      "packages": {
-        "resolve-url-loader>es6-iterator>es5-ext": true
-      }
-    },
-    "gulp-sourcemaps>debug-fabulous>memoizee>next-tick": {
-      "globals": {
-        "MutationObserver": true,
-        "WebKitMutationObserver": true,
-        "document": true,
-        "process": true,
-        "queueMicrotask": true,
-        "setImmediate": true,
-        "setTimeout": true
-      }
-    },
-    "gulp-sourcemaps>debug-fabulous>memoizee>timers-ext": {
-      "packages": {
-        "resolve-url-loader>es6-iterator>es5-ext": true
-      }
-    },
-    "gulp-sourcemaps>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp-sourcemaps>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp-sourcemaps>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp-sourcemaps>through2>readable-stream>isarray": true,
-        "gulp-sourcemaps>through2>readable-stream>safe-buffer": true,
-        "gulp-sourcemaps>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp-sourcemaps>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp-sourcemaps>through2>readable-stream>string_decoder": {
-      "packages": {
-        "gulp-sourcemaps>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp-stylelint": {
-      "builtin": {
-        "fs.mkdir": true,
-        "fs.writeFile": true,
-        "path.dirname": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "Buffer.from": true,
-        "process.cwd": true,
-        "process.nextTick": true
-      },
-      "packages": {
-        "eslint>strip-ansi": true,
-        "fancy-log": true,
-        "gulp-stylelint>through2": true,
-        "gulp-zip>plugin-error": true,
-        "source-map": true,
-        "stylelint": true
-      }
-    },
-    "gulp-stylelint>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "readable-stream": true
-      }
-    },
-    "gulp-watch": {
-      "builtin": {
-        "path.dirname": true,
+        "fs.lstat": true,
+        "fs.lstatSync": true,
+        "fs.readlink": true,
+        "fs.readlinkSync": true,
+        "fs.realpath": true,
+        "fs.realpathSync": true,
+        "fs.stat": true,
+        "fs.statSync": true,
         "path.normalize": true,
         "path.resolve": true
       },
       "globals": {
-        "process.arch": true,
-        "process.cwd": true,
+        "console.error": true,
+        "console.trace": true,
+        "process.env.NODE_DEBUG": true,
+        "process.nextTick": true,
+        "process.noDeprecation": true,
         "process.platform": true,
-        "process.version": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "chokidar": true,
-        "eslint>glob-parent": true,
-        "gulp-watch>ansi-colors": true,
-        "gulp-watch>anymatch": true,
-        "gulp-watch>fancy-log": true,
-        "gulp-watch>path-is-absolute": true,
-        "gulp-watch>readable-stream": true,
-        "gulp-watch>slash": true,
-        "gulp-watch>vinyl-file": true,
-        "gulp-zip>plugin-error": true,
-        "react>object-assign": true,
-        "vinyl": true
+        "process.throwDeprecation": true,
+        "process.traceDeprecation": true,
+        "process.version": true
       }
     },
-    "gulp-watch>ansi-colors": {
-      "packages": {
-        "fancy-log>ansi-gray>ansi-wrap": true
-      }
-    },
-    "gulp-watch>anymatch": {
-      "builtin": {
-        "path.sep": true
-      },
-      "packages": {
-        "gulp-watch>anymatch>micromatch": true,
-        "gulp-watch>anymatch>normalize-path": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch": {
-      "builtin": {
-        "path.sep": true
-      },
+    "chokidar>fsevents": {
       "globals": {
-        "process": true
+        "console.assert": true,
+        "process.platform": true
       },
-      "packages": {
-        "gulp-watch>anymatch>micromatch>arr-diff": true,
-        "gulp-watch>anymatch>micromatch>array-unique": true,
-        "gulp-watch>anymatch>micromatch>braces": true,
-        "gulp-watch>anymatch>micromatch>expand-brackets": true,
-        "gulp-watch>anymatch>micromatch>extglob": true,
-        "gulp-watch>anymatch>micromatch>filename-regex": true,
-        "gulp-watch>anymatch>micromatch>is-extglob": true,
-        "gulp-watch>anymatch>micromatch>is-glob": true,
-        "gulp-watch>anymatch>micromatch>kind-of": true,
-        "gulp-watch>anymatch>micromatch>object.omit": true,
-        "gulp-watch>anymatch>micromatch>parse-glob": true,
-        "gulp-watch>anymatch>micromatch>regex-cache": true,
-        "gulp-watch>anymatch>normalize-path": true
-      }
+      "native": true
     },
-    "gulp-watch>anymatch>micromatch>arr-diff": {
-      "packages": {
-        "gulp>undertaker>arr-flatten": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>braces": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>braces>expand-range": true,
-        "gulp-watch>anymatch>micromatch>braces>preserve": true,
-        "gulp-watch>anymatch>micromatch>braces>repeat-element": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>braces>expand-range": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>is-number": true,
-        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>isobject": true,
-        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>randomatic": true,
-        "gulp-watch>anymatch>micromatch>braces>repeat-element": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>is-number": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>is-number>kind-of": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>is-number>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>isobject": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>isobject>isarray": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>randomatic": {
-      "packages": {
-        "@babel/register>clone-deep>kind-of": true,
-        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>randomatic>math-random": true,
-        "gulp>undertaker>bach>array-last>is-number": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>randomatic>math-random": {
-      "builtin": {
-        "crypto.randomBytes": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>expand-brackets": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>expand-brackets>is-posix-bracket": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>extglob": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>is-extglob": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>is-glob": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>is-extglob": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>object.omit": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>for-own": true,
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>object.omit>for-own": {
-      "packages": {
-        "gulp>undertaker>object.reduce>for-own>for-in": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>parse-glob": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>is-extglob": true,
-        "gulp-watch>anymatch>micromatch>parse-glob>glob-base": true,
-        "gulp-watch>anymatch>micromatch>parse-glob>is-dotfile": true,
-        "gulp-watch>anymatch>micromatch>parse-glob>is-glob": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>parse-glob>glob-base": {
-      "builtin": {
-        "path.dirname": true
-      },
-      "packages": {
-        "eslint>glob-parent": true,
-        "gulp-watch>anymatch>micromatch>parse-glob>glob-base>is-glob": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>parse-glob>glob-base>is-glob": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>is-extglob": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>parse-glob>is-glob": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>is-extglob": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>regex-cache": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>regex-cache>is-equal-shallow": true
-      }
-    },
-    "gulp-watch>anymatch>micromatch>regex-cache>is-equal-shallow": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>regex-cache>is-equal-shallow>is-primitive": true
-      }
-    },
-    "gulp-watch>anymatch>normalize-path": {
-      "packages": {
-        "vinyl>remove-trailing-separator": true
-      }
-    },
-    "gulp-watch>chokidar": {
+    "gulp>glob-watcher>chokidar>fsevents": {
       "builtin": {
         "events.EventEmitter": true,
-        "fs": true,
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
+        "fs.stat": true,
         "path.join": true,
-        "path.relative": true,
-        "path.resolve": true,
-        "path.sep": true
+        "util.inherits": true
       },
       "globals": {
-        "clearTimeout": true,
-        "console.error": true,
-        "process.env.CHOKIDAR_INTERVAL": true,
-        "process.env.CHOKIDAR_PRINT_FSEVENTS_REQUIRE_ERROR": true,
-        "process.env.CHOKIDAR_USEPOLLING": true,
+        "__dirname": true,
+        "console.assert": true,
         "process.nextTick": true,
         "process.platform": true,
-        "setTimeout": true
+        "setImmediate": true
       },
       "packages": {
-        "chokidar>normalize-path": true,
-        "eslint>is-glob": true,
-        "gulp-watch>chokidar>anymatch": true,
-        "gulp-watch>chokidar>async-each": true,
-        "gulp-watch>chokidar>braces": true,
-        "gulp-watch>chokidar>fsevents": true,
-        "gulp-watch>chokidar>is-binary-path": true,
-        "gulp-watch>chokidar>readdirp": true,
-        "gulp-watch>chokidar>upath": true,
-        "gulp-watch>glob-parent": true,
-        "gulp-watch>path-is-absolute": true,
-        "pumpify>inherits": true
+        "gulp-watch>chokidar>fsevents>node-pre-gyp": true
       }
     },
     "gulp-watch>chokidar>fsevents": {
@@ -4286,296 +3412,44 @@
         "gulp-watch>chokidar>fsevents>node-pre-gyp": true
       }
     },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp": {
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge": {
       "builtin": {
-        "events.EventEmitter": true,
-        "fs.existsSync": true,
-        "fs.readFileSync": true,
-        "fs.renameSync": true,
-        "path.dirname": true,
-        "path.existsSync": true,
-        "path.join": true,
-        "path.resolve": true,
-        "url.parse": true,
-        "url.resolve": true,
-        "util.inherits": true
+        "util.format": true
       },
       "globals": {
-        "__dirname": true,
-        "console.log": true,
-        "process.arch": true,
-        "process.cwd": true,
-        "process.env": true,
-        "process.platform": true,
-        "process.version.substr": true,
-        "process.versions": true
+        "clearInterval": true,
+        "process": true,
+        "setImmediate": true,
+        "setInterval": true
       },
       "packages": {
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>semver": true
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>aproba": true,
+        "@storybook/react>@storybook/node-logger>npmlog>console-control-strings": true,
+        "@storybook/react>@storybook/node-logger>npmlog>gauge>has-unicode": true,
+        "react>object-assign": true,
+        "nyc>signal-exit": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": true,
+        "@storybook/react>@storybook/node-logger>npmlog>gauge>wide-align": true
       }
     },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc": {
+    "browserify>insert-module-globals>undeclared-identifiers>get-assigned-identifiers": {
       "builtin": {
-        "child_process.spawnSync": true,
-        "fs.readdirSync": true,
-        "os.platform": true
-      },
-      "globals": {
-        "process.env": true
+        "assert.equal": true
       }
     },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt": {
-      "builtin": {
-        "path": true,
-        "stream.Stream": true,
-        "url": true
-      },
+    "string.prototype.matchall>get-intrinsic": {
       "globals": {
-        "console": true,
-        "process.argv": true,
-        "process.env.DEBUG_NOPT": true,
-        "process.env.NOPT_DEBUG": true,
-        "process.platform": true
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
       },
       "packages": {
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>nopt>abbrev": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv": {
-      "builtin": {
-        "child_process.exec": true,
-        "path": true
-      },
-      "globals": {
-        "process.env.COMPUTERNAME": true,
-        "process.env.ComSpec": true,
-        "process.env.EDITOR": true,
-        "process.env.HOSTNAME": true,
-        "process.env.PATH": true,
-        "process.env.PROMPT": true,
-        "process.env.PS1": true,
-        "process.env.Path": true,
-        "process.env.SHELL": true,
-        "process.env.USER": true,
-        "process.env.USERDOMAIN": true,
-        "process.env.USERNAME": true,
-        "process.env.VISUAL": true,
-        "process.env.path": true,
-        "process.nextTick": true,
-        "process.platform": true
-      },
-      "packages": {
-        "@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": {
-      "globals": {
-        "process.env.SystemRoot": true,
-        "process.env.TEMP": true,
-        "process.env.TMP": true,
-        "process.env.TMPDIR": true,
-        "process.env.windir": true,
-        "process.platform": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": {
-      "builtin": {
-        "assert": true,
-        "fs": true,
-        "path.join": true
-      },
-      "globals": {
-        "process.platform": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "nyc>glob": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>semver": {
-      "globals": {
-        "console": true,
-        "process": true
-      }
-    },
-    "gulp-watch>fancy-log": {
-      "globals": {
-        "console": true,
-        "process.argv.indexOf": true,
-        "process.stderr.write": true,
-        "process.stdout.write": true
-      },
-      "packages": {
-        "fancy-log>ansi-gray": true,
-        "fancy-log>color-support": true,
-        "fancy-log>time-stamp": true
-      }
-    },
-    "gulp-watch>path-is-absolute": {
-      "globals": {
-        "process.platform": true
-      }
-    },
-    "gulp-watch>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp-watch>readable-stream>isarray": true,
-        "gulp-watch>readable-stream>safe-buffer": true,
-        "gulp-watch>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp-watch>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp-watch>readable-stream>string_decoder": {
-      "packages": {
-        "gulp-watch>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp-watch>vinyl-file": {
-      "builtin": {
-        "path.resolve": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "del>graceful-fs": true,
-        "gh-pages>globby>pinkie-promise": true,
-        "gulp-watch>vinyl-file>pify": true,
-        "gulp-watch>vinyl-file>strip-bom": true,
-        "gulp-watch>vinyl-file>strip-bom-stream": true,
-        "gulp-watch>vinyl-file>vinyl": true
-      }
-    },
-    "gulp-watch>vinyl-file>strip-bom": {
-      "globals": {
-        "Buffer.isBuffer": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>remove-bom-buffer>is-utf8": true
-      }
-    },
-    "gulp-watch>vinyl-file>strip-bom-stream": {
-      "packages": {
-        "gulp-watch>vinyl-file>strip-bom": true,
-        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream": true
-      }
-    },
-    "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "Buffer.concat": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream": true
-      }
-    },
-    "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>isarray": true,
-        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>safe-buffer": true,
-        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>string_decoder": {
-      "packages": {
-        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp-watch>vinyl-file>vinyl": {
-      "builtin": {
-        "buffer.Buffer": true,
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.relative": true,
-        "stream.PassThrough": true,
-        "stream.Stream": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "@metamask/jazzicon>color>clone": true,
-        "gulp-watch>vinyl-file>vinyl>clone-stats": true,
-        "gulp-watch>vinyl-file>vinyl>replace-ext": true
-      }
-    },
-    "gulp-watch>vinyl-file>vinyl>clone-stats": {
-      "builtin": {
-        "fs.Stats": true
-      }
-    },
-    "gulp-watch>vinyl-file>vinyl>replace-ext": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true
-      }
-    },
-    "gulp-zip": {
-      "builtin": {
-        "buffer.constants.MAX_LENGTH": true,
-        "path.join": true
-      },
-      "packages": {
-        "gulp-zip>get-stream": true,
-        "gulp-zip>plugin-error": true,
-        "gulp-zip>through2": true,
-        "gulp-zip>yazl": true,
-        "vinyl": true
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "browserify>has>function-bind": true,
+        "string.prototype.matchall>es-abstract>has-proto": true,
+        "string.prototype.matchall>has-symbols": true,
+        "depcheck>is-core-module>hasown": true
       }
     },
     "gulp-zip>get-stream": {
@@ -4590,885 +3464,22 @@
         "pumpify>pump": true
       }
     },
-    "gulp-zip>plugin-error": {
+    "gulp-watch>anymatch>micromatch>parse-glob>glob-base": {
       "builtin": {
-        "util.inherits": true
+        "path.dirname": true
       },
       "packages": {
-        "gulp-watch>ansi-colors": true,
-        "gulp-zip>plugin-error>arr-diff": true,
-        "gulp-zip>plugin-error>arr-union": true,
-        "gulp-zip>plugin-error>extend-shallow": true
+        "eslint>glob-parent": true,
+        "gulp-watch>anymatch>micromatch>parse-glob>glob-base>is-glob": true
       }
     },
-    "gulp-zip>plugin-error>extend-shallow": {
-      "packages": {
-        "gulp-zip>plugin-error>extend-shallow>assign-symbols": true,
-        "gulp-zip>plugin-error>extend-shallow>is-extendable": true
-      }
-    },
-    "gulp-zip>plugin-error>extend-shallow>is-extendable": {
-      "packages": {
-        "@babel/register>clone-deep>is-plain-object": true
-      }
-    },
-    "gulp-zip>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "readable-stream": true
-      }
-    },
-    "gulp-zip>yazl": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "fs.createReadStream": true,
-        "fs.stat": true,
-        "stream.PassThrough": true,
-        "stream.Transform": true,
-        "util.inherits": true,
-        "zlib.DeflateRaw": true,
-        "zlib.deflateRaw": true
-      },
-      "globals": {
-        "Buffer": true,
-        "setImmediate": true,
-        "utf8FileName.length": true
-      },
-      "packages": {
-        "gulp-zip>yazl>buffer-crc32": true
-      }
-    },
-    "gulp-zip>yazl>buffer-crc32": {
-      "builtin": {
-        "buffer.Buffer": true
-      }
-    },
-    "gulp>glob-watcher": {
-      "packages": {
-        "chokidar": true,
-        "gulp>glob-watcher>anymatch": true,
-        "gulp>glob-watcher>async-done": true,
-        "gulp>glob-watcher>is-negated-glob": true,
-        "gulp>glob-watcher>just-debounce": true,
-        "gulp>undertaker>object.defaults": true
-      }
-    },
-    "gulp>glob-watcher>anymatch": {
-      "builtin": {
-        "path.sep": true
-      },
-      "packages": {
-        "gulp-watch>anymatch>normalize-path": true,
-        "gulp>glob-watcher>anymatch>micromatch": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch": {
-      "builtin": {
-        "path.basename": true,
-        "path.sep": true,
-        "util.inspect": true
-      },
-      "globals": {
-        "process.platform": true
-      },
-      "packages": {
-        "@babel/register>clone-deep>kind-of": true,
-        "gulp-zip>plugin-error>arr-diff": true,
-        "gulp-zip>plugin-error>extend-shallow": true,
-        "gulp>glob-watcher>anymatch>micromatch>braces": true,
-        "gulp>glob-watcher>anymatch>micromatch>define-property": true,
-        "gulp>glob-watcher>anymatch>micromatch>extglob": true,
-        "gulp>gulp-cli>liftoff>fined>object.pick": true,
-        "gulp>gulp-cli>matchdep>micromatch>array-unique": true,
-        "gulp>gulp-cli>matchdep>micromatch>fragment-cache": true,
-        "gulp>gulp-cli>matchdep>micromatch>nanomatch": true,
-        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
-        "gulp>gulp-cli>matchdep>micromatch>to-regex": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>braces": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>braces>repeat-element": true,
-        "gulp>glob-watcher>anymatch>micromatch>braces>extend-shallow": true,
-        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range": true,
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>array-unique": true,
-        "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node": true,
-        "gulp>gulp-cli>matchdep>micromatch>braces>split-string": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
-        "gulp>gulp-cli>matchdep>micromatch>to-regex": true,
-        "gulp>undertaker>arr-flatten": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>braces>extend-shallow": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range": {
-      "builtin": {
-        "util.inspect": true
-      },
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>extend-shallow": true,
-        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number": true,
-        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>to-regex-range": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>extend-shallow": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number": {
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number>kind-of": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>to-regex-range": {
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>define-property": {
-      "packages": {
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob": {
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>extglob>define-property": true,
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets": true,
-        "gulp>glob-watcher>anymatch>micromatch>extglob>extend-shallow": true,
-        "gulp>gulp-cli>matchdep>micromatch>array-unique": true,
-        "gulp>gulp-cli>matchdep>micromatch>fragment-cache": true,
-        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
-        "gulp>gulp-cli>matchdep>micromatch>to-regex": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>define-property": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets": {
-      "globals": {
-        "__filename": true
-      },
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug": true,
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property": true,
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>extend-shallow": true,
-        "gulp>gulp-cli>matchdep>micromatch>extglob>expand-brackets>posix-character-classes": true,
-        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
-        "gulp>gulp-cli>matchdep>micromatch>to-regex": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug": {
-      "builtin": {
-        "fs.SyncWriteStream": true,
-        "net.Socket": true,
-        "tty.WriteStream": true,
-        "tty.isatty": true,
-        "util": true
-      },
-      "globals": {
-        "chrome": true,
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>debug>ms": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property": {
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor": {
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-accessor-descriptor": true,
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-data-descriptor": true,
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>kind-of": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-accessor-descriptor": {
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-accessor-descriptor>kind-of": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-accessor-descriptor>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-data-descriptor": {
-      "packages": {
-        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-data-descriptor>kind-of": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-data-descriptor>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>extend-shallow": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
-      }
-    },
-    "gulp>glob-watcher>anymatch>micromatch>extglob>extend-shallow": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
-      }
-    },
-    "gulp>glob-watcher>async-done": {
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "@metamask/object-multiplex>once": true,
-        "duplexify>end-of-stream": true,
-        "gulp>glob-watcher>async-done>stream-exhaust": true,
-        "readable-stream-2>process-nextick-args": true
-      }
-    },
-    "gulp>glob-watcher>async-done>stream-exhaust": {
-      "builtin": {
-        "stream.Writable": true,
-        "util.inherits": true
-      },
-      "globals": {
-        "setImmediate": true
-      }
-    },
-    "gulp>glob-watcher>chokidar": {
-      "packages": {
-        "gulp>glob-watcher>chokidar>fsevents": true
-      }
-    },
-    "gulp>glob-watcher>chokidar>fsevents": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "fs.stat": true,
-        "path.join": true,
-        "util.inherits": true
-      },
-      "globals": {
-        "__dirname": true,
-        "console.assert": true,
-        "process.nextTick": true,
-        "process.platform": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp-watch>chokidar>fsevents>node-pre-gyp": true
-      }
-    },
-    "gulp>glob-watcher>just-debounce": {
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      }
-    },
-    "gulp>gulp-cli>liftoff>fined>object.pick": {
-      "packages": {
-        "gulp>gulp-cli>isobject": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node": {
-      "packages": {
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>define-property": true,
-        "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>snapdragon-util": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>define-property": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>snapdragon-util": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>snapdragon-util>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>snapdragon-util>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>braces>split-string": {
-      "packages": {
-        "gulp-zip>plugin-error>extend-shallow": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": {
-      "packages": {
-        "@babel/register>clone-deep>kind-of": true,
-        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor>is-accessor-descriptor": true,
-        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor>is-data-descriptor": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor>is-accessor-descriptor": {
-      "packages": {
-        "@babel/register>clone-deep>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor>is-data-descriptor": {
-      "packages": {
-        "@babel/register>clone-deep>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>fragment-cache": {
-      "packages": {
-        "gulp>gulp-cli>liftoff>fined>parse-filepath>map-cache": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>nanomatch": {
-      "builtin": {
-        "path.basename": true,
-        "path.sep": true,
-        "util.inspect": true
-      },
-      "packages": {
-        "@babel/register>clone-deep>kind-of": true,
-        "gulp-zip>plugin-error>arr-diff": true,
-        "gulp-zip>plugin-error>extend-shallow": true,
-        "gulp>gulp-cli>liftoff>fined>object.pick": true,
-        "gulp>gulp-cli>matchdep>micromatch>array-unique": true,
-        "gulp>gulp-cli>matchdep>micromatch>fragment-cache": true,
-        "gulp>gulp-cli>matchdep>micromatch>nanomatch>define-property": true,
-        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
-        "gulp>gulp-cli>matchdep>micromatch>to-regex": true,
-        "nyc>spawn-wrap>is-windows": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>nanomatch>define-property": {
-      "packages": {
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>regex-not": {
-      "packages": {
-        "gulp-zip>plugin-error>extend-shallow": true,
-        "gulp>gulp-cli>matchdep>micromatch>to-regex>safe-regex": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon": {
-      "builtin": {
-        "fs.readFileSync": true,
-        "path.dirname": true,
-        "util.inspect": true
-      },
-      "globals": {
-        "__filename": true
-      },
-      "packages": {
-        "gulp>gulp-cli>liftoff>fined>parse-filepath>map-cache": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>debug": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>extend-shallow": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>source-map": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>use": true,
-        "resolve-url-loader>rework>css>source-map-resolve": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "packages": {
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>component-emitter": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>define-property": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>mixin-deep": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>pascalcase": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base": {
-      "packages": {
-        "gulp>gulp-cli>array-sort>get-value": true,
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>to-object-path": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>union-value": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>component-emitter": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>map-visit": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>object-visit": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>map-visit": {
-      "builtin": {
-        "util.inspect": true
-      },
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>object-visit": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>object-visit": {
-      "packages": {
-        "gulp>gulp-cli>isobject": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value": {
-      "packages": {
-        "gulp>gulp-cli>array-sort>get-value": true,
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>is-number": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>is-number": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>is-number>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>is-number>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value": {
-      "packages": {
-        "@babel/register>clone-deep>is-plain-object": true,
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true,
-        "gulp>gulp-cli>matchdep>micromatch>braces>split-string": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value>extend-shallow": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value>extend-shallow": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>to-object-path": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>to-object-path>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>to-object-path>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>union-value": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true,
-        "gulp-zip>plugin-error>arr-union": true,
-        "gulp>gulp-cli>array-sort>get-value": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value": {
-      "packages": {
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value": {
-      "packages": {
-        "gulp>gulp-cli>array-sort>get-value": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value>has-values": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value>isobject": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value>isobject": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value>isobject>isarray": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils": {
-      "builtin": {
-        "util": true
-      },
-      "packages": {
-        "gulp-zip>plugin-error>arr-union": true,
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy>copy-descriptor": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy>kind-of": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>define-property": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>mixin-deep": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>mixin-deep>is-extendable": true,
-        "gulp>undertaker>object.reduce>for-own>for-in": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>mixin-deep>is-extendable": {
-      "packages": {
-        "@babel/register>clone-deep>is-plain-object": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>debug": {
-      "builtin": {
-        "fs.SyncWriteStream": true,
-        "net.Socket": true,
-        "tty.WriteStream": true,
-        "tty.isatty": true,
-        "util": true
-      },
-      "globals": {
-        "chrome": true,
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
-      },
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>debug>ms": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-accessor-descriptor": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor": true,
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-accessor-descriptor": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>extend-shallow": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>snapdragon>use": {
-      "packages": {
-        "@babel/register>clone-deep>kind-of": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>to-regex": {
-      "packages": {
-        "gulp-zip>plugin-error>extend-shallow": true,
-        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
-        "gulp>gulp-cli>matchdep>micromatch>to-regex>define-property": true,
-        "gulp>gulp-cli>matchdep>micromatch>to-regex>safe-regex": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>to-regex>define-property": {
-      "packages": {
-        "gulp>gulp-cli>isobject": true,
-        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": true
-      }
-    },
-    "gulp>gulp-cli>matchdep>micromatch>to-regex>safe-regex": {
-      "packages": {
-        "gulp>gulp-cli>matchdep>micromatch>to-regex>safe-regex>ret": true
-      }
-    },
-    "gulp>gulp-cli>replace-homedir>is-absolute": {
-      "packages": {
-        "gulp>gulp-cli>replace-homedir>is-absolute>is-relative": true,
-        "nyc>spawn-wrap>is-windows": true
-      }
-    },
-    "gulp>gulp-cli>replace-homedir>is-absolute>is-relative": {
-      "packages": {
-        "gulp>gulp-cli>replace-homedir>is-absolute>is-relative>is-unc-path": true
-      }
-    },
-    "gulp>gulp-cli>replace-homedir>is-absolute>is-relative>is-unc-path": {
-      "packages": {
-        "gulp>gulp-cli>replace-homedir>is-absolute>is-relative>is-unc-path>unc-path-regex": true
-      }
-    },
-    "gulp>undertaker": {
-      "builtin": {
-        "assert": true,
-        "events.EventEmitter": true,
-        "util.inherits": true
-      },
-      "globals": {
-        "process.env.UNDERTAKER_SETTLE": true,
-        "process.env.UNDERTAKER_TIME_RESOLUTION": true,
-        "process.hrtime": true
-      },
-      "packages": {
-        "gulp>undertaker>arr-flatten": true,
-        "gulp>undertaker>arr-map": true,
-        "gulp>undertaker>bach": true,
-        "gulp>undertaker>collection-map": true,
-        "gulp>undertaker>es6-weak-map": true,
-        "gulp>undertaker>last-run": true,
-        "gulp>undertaker>object.defaults": true,
-        "gulp>undertaker>object.reduce": true,
-        "gulp>undertaker>undertaker-registry": true
-      }
-    },
-    "gulp>undertaker>arr-map": {
-      "packages": {
-        "gulp>undertaker>arr-map>make-iterator": true
-      }
-    },
-    "gulp>undertaker>arr-map>make-iterator": {
-      "packages": {
-        "@babel/register>clone-deep>kind-of": true
-      }
-    },
-    "gulp>undertaker>bach": {
-      "builtin": {
-        "assert.ok": true
-      },
-      "packages": {
-        "gulp>glob-watcher>async-done": true,
-        "gulp>undertaker>arr-flatten": true,
-        "gulp>undertaker>arr-map": true,
-        "gulp>undertaker>bach>arr-filter": true,
-        "gulp>undertaker>bach>array-each": true,
-        "gulp>undertaker>bach>array-initial": true,
-        "gulp>undertaker>bach>array-last": true,
-        "gulp>undertaker>bach>async-settle": true,
-        "gulp>vinyl-fs>vinyl-sourcemap>now-and-later": true
-      }
-    },
-    "gulp>undertaker>bach>arr-filter": {
-      "packages": {
-        "gulp>undertaker>arr-map>make-iterator": true
-      }
-    },
-    "gulp>undertaker>bach>array-initial": {
-      "packages": {
-        "gulp>undertaker>bach>array-last>is-number": true,
-        "gulp>undertaker>object.defaults>array-slice": true
-      }
-    },
-    "gulp>undertaker>bach>array-last": {
-      "packages": {
-        "gulp>undertaker>bach>array-last>is-number": true
-      }
-    },
-    "gulp>undertaker>bach>async-settle": {
-      "packages": {
-        "gulp>glob-watcher>async-done": true
-      }
-    },
-    "gulp>undertaker>collection-map": {
-      "packages": {
-        "gulp>undertaker>arr-map": true,
-        "gulp>undertaker>arr-map>make-iterator": true,
-        "gulp>undertaker>object.reduce>for-own": true
-      }
-    },
-    "gulp>undertaker>es6-weak-map": {
-      "packages": {
-        "resolve-url-loader>es6-iterator": true,
-        "resolve-url-loader>es6-iterator>d": true,
-        "resolve-url-loader>es6-iterator>es5-ext": true,
-        "resolve-url-loader>es6-iterator>es6-symbol": true
-      }
-    },
-    "gulp>undertaker>last-run": {
-      "builtin": {
-        "assert": true
-      },
-      "packages": {
-        "gulp>undertaker>es6-weak-map": true,
-        "gulp>undertaker>last-run>default-resolution": true
-      }
-    },
-    "gulp>undertaker>last-run>default-resolution": {
-      "globals": {
-        "process.version.match": true
-      }
-    },
-    "gulp>undertaker>object.defaults": {
-      "packages": {
-        "gulp>gulp-cli>isobject": true,
-        "gulp>undertaker>bach>array-each": true,
-        "gulp>undertaker>object.defaults>array-slice": true,
-        "gulp>undertaker>object.reduce>for-own": true
-      }
-    },
-    "gulp>undertaker>object.reduce": {
-      "packages": {
-        "gulp>undertaker>arr-map>make-iterator": true,
-        "gulp>undertaker>object.reduce>for-own": true
-      }
-    },
-    "gulp>undertaker>object.reduce>for-own": {
-      "packages": {
-        "gulp>undertaker>object.reduce>for-own>for-in": true
-      }
-    },
-    "gulp>vinyl-fs": {
+    "eslint>glob-parent": {
       "builtin": {
         "os.platform": true,
-        "path.relative": true,
-        "path.resolve": true,
-        "util.inherits": true
-      },
-      "globals": {
-        "Buffer.isBuffer": true,
-        "process.cwd": true,
-        "process.geteuid": true,
-        "process.getuid": true,
-        "process.nextTick": true
+        "path.posix.dirname": true
       },
       "packages": {
-        "del>graceful-fs": true,
-        "gulp>vinyl-fs>fs-mkdirp-stream": true,
-        "gulp>vinyl-fs>glob-stream": true,
-        "gulp>vinyl-fs>is-valid-glob": true,
-        "gulp>vinyl-fs>lazystream": true,
-        "gulp>vinyl-fs>lead": true,
-        "gulp>vinyl-fs>object.assign": true,
-        "gulp>vinyl-fs>pumpify": true,
-        "gulp>vinyl-fs>readable-stream": true,
-        "gulp>vinyl-fs>remove-bom-buffer": true,
-        "gulp>vinyl-fs>remove-bom-stream": true,
-        "gulp>vinyl-fs>resolve-options": true,
-        "gulp>vinyl-fs>through2": true,
-        "gulp>vinyl-fs>to-through": true,
-        "gulp>vinyl-fs>value-or-function": true,
-        "gulp>vinyl-fs>vinyl-sourcemap": true,
-        "vinyl": true
-      }
-    },
-    "gulp>vinyl-fs>fs-mkdirp-stream": {
-      "builtin": {
-        "path.dirname": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "process.umask": true
-      },
-      "packages": {
-        "del>graceful-fs": true,
-        "gulp>vinyl-fs>fs-mkdirp-stream>through2": true
-      }
-    },
-    "gulp>vinyl-fs>fs-mkdirp-stream>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>isarray": true,
-        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>safe-buffer": true
+        "del>is-glob": true
       }
     },
     "gulp>vinyl-fs>glob-stream": {
@@ -5480,543 +3491,332 @@
         "process.nextTick": true
       },
       "packages": {
+        "react-markdown>unified>extend": true,
         "eslint>glob-parent": true,
+        "nyc>glob": true,
         "gulp>glob-watcher>is-negated-glob": true,
         "gulp>vinyl-fs>glob-stream>ordered-read-streams": true,
         "gulp>vinyl-fs>glob-stream>pumpify": true,
         "gulp>vinyl-fs>glob-stream>readable-stream": true,
+        "vinyl>remove-trailing-separator": true,
         "gulp>vinyl-fs>glob-stream>to-absolute-glob": true,
-        "gulp>vinyl-fs>glob-stream>unique-stream": true,
-        "nyc>glob": true,
-        "react-markdown>unified>extend": true,
-        "vinyl>remove-trailing-separator": true
+        "gulp>vinyl-fs>glob-stream>unique-stream": true
       }
     },
-    "gulp>vinyl-fs>glob-stream>ordered-read-streams": {
-      "builtin": {
-        "util.inherits": true
-      },
+    "gulp>glob-watcher": {
       "packages": {
-        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream": true
+        "gulp>glob-watcher>anymatch": true,
+        "gulp>glob-watcher>async-done": true,
+        "chokidar": true,
+        "gulp>glob-watcher>is-negated-glob": true,
+        "gulp>glob-watcher>just-debounce": true,
+        "gulp>undertaker>object.defaults": true
       }
     },
-    "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream": {
+    "nyc>glob": {
       "builtin": {
+        "assert": true,
         "events.EventEmitter": true,
-        "stream": true,
+        "fs": true,
+        "path.join": true,
+        "path.resolve": true,
         "util": true
       },
       "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>isarray": true,
-        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>pumpify": {
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>pumpify>duplexify": true,
-        "gulp>vinyl-fs>glob-stream>pumpify>pump": true,
-        "pumpify>inherits": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>pumpify>duplexify": {
-      "globals": {
-        "Buffer": true,
-        "process.nextTick": true
-      },
-      "packages": {
-        "duplexify>end-of-stream": true,
-        "duplexify>stream-shift": true,
-        "gulp>vinyl-fs>glob-stream>readable-stream": true,
-        "pumpify>inherits": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>pumpify>pump": {
-      "builtin": {
-        "fs": true
-      },
-      "packages": {
-        "@metamask/object-multiplex>once": true,
-        "duplexify>end-of-stream": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>readable-stream>isarray": true,
-        "gulp>vinyl-fs>glob-stream>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>glob-stream>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>to-absolute-glob": {
-      "builtin": {
-        "path.resolve": true
-      },
-      "globals": {
+        "console.error": true,
         "process.cwd": true,
+        "process.nextTick": true,
         "process.platform": true
       },
       "packages": {
-        "gulp>glob-watcher>is-negated-glob": true,
-        "gulp>gulp-cli>replace-homedir>is-absolute": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>unique-stream": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify": true,
-        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter": {
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>isarray": true,
-        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>string_decoder": true,
+        "nyc>glob>fs.realpath": true,
+        "nyc>glob>inflight": true,
         "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>lazystream": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>lazystream>readable-stream": true
-      }
-    },
-    "gulp>vinyl-fs>lazystream>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>lazystream>readable-stream>isarray": true,
-        "gulp>vinyl-fs>lazystream>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>lazystream>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>lazystream>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>lazystream>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>lazystream>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>lead": {
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>lead>flush-write-stream": true
-      }
-    },
-    "gulp>vinyl-fs>lead>flush-write-stream": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream": true,
-        "pumpify>inherits": true
-      }
-    },
-    "gulp>vinyl-fs>lead>flush-write-stream>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>isarray": true,
-        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>object.assign": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "gulp>vinyl-fs>pumpify": {
-      "packages": {
-        "gulp>vinyl-fs>pumpify>duplexify": true,
-        "gulp>vinyl-fs>pumpify>pump": true,
-        "pumpify>inherits": true
-      }
-    },
-    "gulp>vinyl-fs>pumpify>duplexify": {
-      "globals": {
-        "Buffer": true,
-        "process.nextTick": true
-      },
-      "packages": {
-        "duplexify>end-of-stream": true,
-        "duplexify>stream-shift": true,
-        "gulp>vinyl-fs>readable-stream": true,
-        "pumpify>inherits": true
-      }
-    },
-    "gulp>vinyl-fs>pumpify>pump": {
-      "builtin": {
-        "fs": true
-      },
-      "packages": {
+        "eslint>minimatch": true,
         "@metamask/object-multiplex>once": true,
-        "duplexify>end-of-stream": true
+        "gulp-watch>path-is-absolute": true
       }
     },
-    "gulp>vinyl-fs>readable-stream": {
+    "stylelint>global-modules": {
       "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>readable-stream>isarray": true,
-        "gulp>vinyl-fs>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>remove-bom-buffer": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true,
-        "gulp>vinyl-fs>remove-bom-buffer>is-utf8": true
-      }
-    },
-    "gulp>vinyl-fs>remove-bom-stream": {
-      "packages": {
-        "gulp>vinyl-fs>remove-bom-buffer": true,
-        "gulp>vinyl-fs>remove-bom-stream>through2": true,
-        "koa>content-disposition>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>remove-bom-stream>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>isarray": true,
-        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>string_decoder>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>string_decoder>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>resolve-options": {
-      "packages": {
-        "gulp>vinyl-fs>value-or-function": true
-      }
-    },
-    "gulp>vinyl-fs>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp>vinyl-fs>to-through": {
-      "packages": {
-        "gulp>vinyl-fs>to-through>through2": true
-      }
-    },
-    "gulp>vinyl-fs>to-through>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>to-through>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "gulp>vinyl-fs>to-through>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "gulp>vinyl-fs>to-through>through2>readable-stream>isarray": true,
-        "gulp>vinyl-fs>to-through>through2>readable-stream>safe-buffer": true,
-        "gulp>vinyl-fs>to-through>through2>readable-stream>string_decoder": true,
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
-      }
-    },
-    "gulp>vinyl-fs>to-through>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "gulp>vinyl-fs>to-through>through2>readable-stream>string_decoder": {
-      "packages": {
-        "gulp>vinyl-fs>to-through>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "gulp>vinyl-fs>vinyl-sourcemap": {
-      "builtin": {
-        "path.dirname": true,
-        "path.join": true,
-        "path.relative": true,
         "path.resolve": true
       },
       "globals": {
-        "Buffer": true
+        "process.env.OSTYPE": true,
+        "process.platform": true
       },
       "packages": {
-        "del>graceful-fs": true,
-        "gulp-watch>anymatch>normalize-path": true,
-        "gulp>vinyl-fs>remove-bom-buffer": true,
-        "gulp>vinyl-fs>vinyl-sourcemap>append-buffer": true,
-        "gulp>vinyl-fs>vinyl-sourcemap>now-and-later": true,
-        "nyc>convert-source-map": true,
-        "vinyl": true
+        "stylelint>global-modules>global-prefix": true
       }
     },
-    "gulp>vinyl-fs>vinyl-sourcemap>append-buffer": {
+    "stylelint>global-modules>global-prefix": {
       "builtin": {
-        "os.EOL": true
+        "fs.readFileSync": true,
+        "fs.realpathSync": true,
+        "os.homedir": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true
       },
       "globals": {
-        "Buffer": true
+        "process.env.APPDATA": true,
+        "process.env.DESTDIR": true,
+        "process.env.OSTYPE": true,
+        "process.env.PREFIX": true,
+        "process.execPath": true,
+        "process.platform": true
       },
       "packages": {
-        "gulp>vinyl-fs>vinyl-sourcemap>append-buffer>buffer-equal": true
+        "stylelint>global-modules>global-prefix>ini": true,
+        "stylelint>global-modules>global-prefix>which": true
       }
     },
-    "gulp>vinyl-fs>vinyl-sourcemap>append-buffer>buffer-equal": {
+    "globby": {
       "builtin": {
-        "buffer.Buffer.isBuffer": true
-      }
-    },
-    "gulp>vinyl-fs>vinyl-sourcemap>now-and-later": {
+        "fs.Stats": true,
+        "fs.readFile": true,
+        "fs.readFileSync": true,
+        "fs.statSync": true,
+        "path.dirname": true,
+        "path.isAbsolute": true,
+        "path.join": true,
+        "path.posix.join": true,
+        "path.relative": true,
+        "stream.Transform": true,
+        "util.promisify": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
       "packages": {
-        "@metamask/object-multiplex>once": true
+        "globby>array-union": true,
+        "globby>dir-glob": true,
+        "fast-glob": true,
+        "eslint>ignore": true,
+        "globby>merge2": true,
+        "del>slash": true
       }
     },
-    "ini": {
-      "globals": {
-        "process": true
+    "stylelint>globjoin": {
+      "builtin": {
+        "path.join": true
       }
     },
-    "jsdom>acorn": {
+    "stylelint>postcss-sass>gonzales-pe": {
       "globals": {
-        "console": true,
+        "console.error": true,
         "define": true
       }
     },
-    "koa>content-disposition>safe-buffer": {
+    "string.prototype.matchall>es-abstract>gopd": {
+      "packages": {
+        "string.prototype.matchall>get-intrinsic": true
+      }
+    },
+    "del>graceful-fs": {
       "builtin": {
-        "buffer": true
+        "assert.equal": true,
+        "constants.O_SYMLINK": true,
+        "constants.O_WRONLY": true,
+        "constants.hasOwnProperty": true,
+        "fs": true,
+        "stream.Stream.call": true,
+        "util": true
+      },
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "process": true,
+        "setTimeout": true
+      }
+    },
+    "gulp": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "packages": {
+        "gulp>glob-watcher": true,
+        "gulp>undertaker": true,
+        "gulp>vinyl-fs": true
+      }
+    },
+    "gulp-livereload": {
+      "builtin": {
+        "path.relative": true
+      },
+      "packages": {
+        "gulp-livereload>chalk": true,
+        "gulp-livereload>debug": true,
+        "gulp-livereload>event-stream": true,
+        "fancy-log": true,
+        "gulp-livereload>lodash.assign": true,
+        "gulp-livereload>tiny-lr": true
+      }
+    },
+    "gulp-postcss": {
+      "builtin": {
+        "path.dirname": true,
+        "path.isAbsolute": true,
+        "path.join": true,
+        "stream.Transform": true
+      },
+      "globals": {
+        "Buffer.from": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "fancy-log": true,
+        "gulp-zip>plugin-error": true,
+        "postcss": true,
+        "gulp-postcss>postcss-load-config": true,
+        "vinyl-sourcemaps-apply": true
+      }
+    },
+    "gulp-sass": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.relative": true,
+        "stream.Transform": true
+      },
+      "globals": {
+        "process.cwd": true,
+        "process.exit": true,
+        "process.stderr.write": true
+      },
+      "packages": {
+        "gulp-sass>lodash.clonedeep": true,
+        "postcss>picocolors": true,
+        "gulp-zip>plugin-error": true,
+        "gulp-sass>replace-ext": true,
+        "eslint>strip-ansi": true,
+        "vinyl-sourcemaps-apply": true
+      }
+    },
+    "gulp-sort": {
+      "packages": {
+        "gulp-sort>through2": true
+      }
+    },
+    "gulp-sourcemaps": {
+      "builtin": {
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.relative": true,
+        "path.resolve": true,
+        "path.sep": true
+      },
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "gulp-sourcemaps>@gulp-sourcemaps/identity-map": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/map-sources": true,
+        "gulp-sourcemaps>acorn": true,
+        "nyc>convert-source-map": true,
+        "gulp-sourcemaps>css": true,
+        "gulp-sourcemaps>debug-fabulous": true,
+        "gulp-sourcemaps>detect-newline": true,
+        "del>graceful-fs": true,
+        "gulp-sourcemaps>source-map": true,
+        "gulp-sourcemaps>strip-bom-string": true,
+        "gulp-sourcemaps>through2": true
+      }
+    },
+    "gulp-stylelint": {
+      "builtin": {
+        "fs.mkdir": true,
+        "fs.writeFile": true,
+        "path.dirname": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "Buffer.from": true,
+        "process.cwd": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "fancy-log": true,
+        "gulp-zip>plugin-error": true,
+        "source-map": true,
+        "eslint>strip-ansi": true,
+        "stylelint": true,
+        "gulp-stylelint>through2": true
+      }
+    },
+    "gulp-watch": {
+      "builtin": {
+        "path.dirname": true,
+        "path.normalize": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "process.arch": true,
+        "process.cwd": true,
+        "process.platform": true,
+        "process.version": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "gulp-watch>ansi-colors": true,
+        "gulp-watch>anymatch": true,
+        "chokidar": true,
+        "gulp-watch>fancy-log": true,
+        "eslint>glob-parent": true,
+        "react>object-assign": true,
+        "gulp-watch>path-is-absolute": true,
+        "gulp-zip>plugin-error": true,
+        "gulp-watch>readable-stream": true,
+        "gulp-watch>slash": true,
+        "vinyl": true,
+        "gulp-watch>vinyl-file": true
+      }
+    },
+    "gulp-zip": {
+      "builtin": {
+        "buffer.constants.MAX_LENGTH": true,
+        "path.join": true
+      },
+      "packages": {
+        "gulp-zip>get-stream": true,
+        "gulp-zip>plugin-error": true,
+        "gulp-zip>through2": true,
+        "vinyl": true,
+        "gulp-zip>yazl": true
+      }
+    },
+    "prettier-eslint>loglevel-colored-level-prefix>chalk>has-ansi": {
+      "packages": {
+        "prettier-eslint>loglevel-colored-level-prefix>chalk>has-ansi>ansi-regex": true
+      }
+    },
+    "chalk>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
+      }
+    },
+    "gulp-livereload>chalk>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
+      }
+    },
+    "mocha>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
+      }
+    },
+    "postcss-discard-font-face>postcss>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>has-property-descriptors": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-define-property": true
       }
     },
     "koa>is-generator-function>has-tostringtag": {
@@ -6024,54 +3824,529 @@
         "string.prototype.matchall>has-symbols": true
       }
     },
+    "@storybook/react>@storybook/node-logger>npmlog>gauge>has-unicode": {
+      "builtin": {
+        "os.type": true
+      },
+      "globals": {
+        "process.env.LANG": true,
+        "process.env.LC_ALL": true,
+        "process.env.LC_CTYPE": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value": {
+      "packages": {
+        "gulp>gulp-cli>array-sort>get-value": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values": true,
+        "gulp>gulp-cli>isobject": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value": {
+      "packages": {
+        "gulp>gulp-cli>array-sort>get-value": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value>has-values": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value>isobject": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>is-number": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>kind-of": true
+      }
+    },
+    "browserify>has": {
+      "packages": {
+        "browserify>has>function-bind": true
+      }
+    },
+    "depcheck>is-core-module>hasown": {
+      "packages": {
+        "browserify>has>function-bind": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2": {
+      "builtin": {
+        "buffer.Buffer": true,
+        "events.EventEmitter": true,
+        "string_decoder.StringDecoder": true
+      },
+      "packages": {
+        "stylelint>postcss-html>htmlparser2>domelementtype": true,
+        "stylelint>postcss-html>htmlparser2>domhandler": true,
+        "stylelint>postcss-html>htmlparser2>domutils": true,
+        "stylelint>postcss-html>htmlparser2>entities": true,
+        "pumpify>inherits": true,
+        "readable-stream": true
+      }
+    },
+    "webpack-dev-server>sockjs>websocket-driver>http-parser-js": {
+      "builtin": {
+        "assert.equal": true,
+        "assert.ok": true
+      }
+    },
+    "eslint>ignore": {
+      "globals": {
+        "process": true
+      }
+    },
+    "sass-embedded>immutable": {
+      "globals": {
+        "console": true,
+        "define": true
+      }
+    },
+    "eslint>@eslint/eslintrc>import-fresh": {
+      "builtin": {
+        "path.dirname": true
+      },
+      "globals": {
+        "__dirname": true,
+        "__filename": true
+      },
+      "packages": {
+        "eslint>@eslint/eslintrc>import-fresh>parent-module": true,
+        "eslint>@eslint/eslintrc>import-fresh>resolve-from": true
+      }
+    },
+    "nyc>glob>inflight": {
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "@metamask/object-multiplex>once": true,
+        "@metamask/object-multiplex>once>wrappy": true
+      }
+    },
+    "pumpify>inherits": {
+      "builtin": {
+        "util.inherits": true
+      }
+    },
+    "ini": {
+      "globals": {
+        "process": true
+      }
+    },
+    "stylelint>global-modules>global-prefix>ini": {
+      "globals": {
+        "process": true
+      }
+    },
+    "@lavamoat/lavapack>combine-source-map>inline-source-map": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@lavamoat/lavapack>combine-source-map>inline-source-map>source-map": true
+      }
+    },
+    "browserify>insert-module-globals": {
+      "builtin": {
+        "path.dirname": true,
+        "path.isAbsolute": true,
+        "path.relative": true,
+        "path.sep": true
+      },
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "browserify>syntax-error>acorn-node": true,
+        "@lavamoat/lavapack>combine-source-map": true,
+        "gulp-watch>path-is-absolute": true,
+        "browserify>insert-module-globals>through2": true,
+        "browserify>insert-module-globals>undeclared-identifiers": true,
+        "watchify>xtend": true
+      }
+    },
+    "string.prototype.matchall>internal-slot": {
+      "packages": {
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "depcheck>is-core-module>hasown": true,
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "gulp>gulp-cli>replace-homedir>is-absolute": {
+      "packages": {
+        "gulp>gulp-cli>replace-homedir>is-absolute>is-relative": true,
+        "nyc>spawn-wrap>is-windows": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-accessor-descriptor": {
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-accessor-descriptor>kind-of": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor>is-accessor-descriptor": {
+      "packages": {
+        "@babel/register>clone-deep>kind-of": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-accessor-descriptor": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor>kind-of": true
+      }
+    },
+    "react-syntax-highlighter>refractor>parse-entities>is-alphanumerical": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true
+      }
+    },
+    "chokidar>is-binary-path": {
+      "builtin": {
+        "path.extname": true
+      },
+      "packages": {
+        "chokidar>is-binary-path>binary-extensions": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "depcheck>is-core-module": {
+      "globals": {
+        "process.versions": true
+      },
+      "packages": {
+        "depcheck>is-core-module>hasown": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-data-descriptor": {
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-data-descriptor>kind-of": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor>is-data-descriptor": {
+      "packages": {
+        "@babel/register>clone-deep>kind-of": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor>kind-of": true
+      }
+    },
+    "@metamask/eth-token-tracker>deep-equal>is-date-object": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor": {
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-accessor-descriptor": true,
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-data-descriptor": true,
+        "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>kind-of": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor>is-accessor-descriptor": true,
+        "gulp>gulp-cli>matchdep>micromatch>define-property>is-descriptor>is-data-descriptor": true,
+        "@babel/register>clone-deep>kind-of": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-accessor-descriptor": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>kind-of": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>regex-cache>is-equal-shallow": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>regex-cache>is-equal-shallow>is-primitive": true
+      }
+    },
+    "gulp-zip>plugin-error>extend-shallow>is-extendable": {
+      "packages": {
+        "@babel/register>clone-deep>is-plain-object": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>mixin-deep>is-extendable": {
+      "packages": {
+        "@babel/register>clone-deep>is-plain-object": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": {
+      "packages": {
+        "gulp>gulp-cli>yargs>string-width>is-fullwidth-code-point>number-is-nan": true
+      }
+    },
+    "del>is-glob": {
+      "packages": {
+        "del>is-glob>is-extglob": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>parse-glob>glob-base>is-glob": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>is-extglob": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>is-glob": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>is-extglob": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>parse-glob>is-glob": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>is-extglob": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number": {
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number>kind-of": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>is-number": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>is-number>kind-of": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>is-number": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>is-number>kind-of": true
+      }
+    },
+    "del>is-path-cwd": {
+      "builtin": {
+        "path.resolve": true
+      },
+      "globals": {
+        "process.cwd": true,
+        "process.platform": true
+      }
+    },
+    "del>is-path-inside": {
+      "builtin": {
+        "path.relative": true,
+        "path.resolve": true,
+        "path.sep": true
+      }
+    },
+    "@babel/register>clone-deep>is-plain-object": {
+      "packages": {
+        "gulp>gulp-cli>isobject": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>is-regex": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "gulp>gulp-cli>replace-homedir>is-absolute>is-relative": {
+      "packages": {
+        "gulp>gulp-cli>replace-homedir>is-absolute>is-relative>is-unc-path": true
+      }
+    },
+    "eslint-plugin-react>array-includes>is-string": {
+      "packages": {
+        "koa>is-generator-function>has-tostringtag": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
+      "packages": {
+        "string.prototype.matchall>has-symbols": true
+      }
+    },
+    "gulp>gulp-cli>replace-homedir>is-absolute>is-relative>is-unc-path": {
+      "packages": {
+        "gulp>gulp-cli>replace-homedir>is-absolute>is-relative>is-unc-path>unc-path-regex": true
+      }
+    },
+    "mocha>log-symbols>is-unicode-supported": {
+      "globals": {
+        "process.env.CI": true,
+        "process.env.TERM": true,
+        "process.env.TERM_PROGRAM": true,
+        "process.env.WT_SESSION": true,
+        "process.platform": true
+      }
+    },
+    "nyc>spawn-wrap>is-windows": {
+      "globals": {
+        "define": true,
+        "isWindows": "write",
+        "process": true
+      }
+    },
+    "@sentry/cli>which>isexe": {
+      "builtin": {
+        "fs": true
+      },
+      "globals": {
+        "TESTING_WINDOWS": true,
+        "process.env.PATHEXT": true,
+        "process.getgid": true,
+        "process.getuid": true,
+        "process.platform": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>isobject": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>isobject>isarray": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value>isobject": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value>isobject>isarray": true
+      }
+    },
+    "postcss-discard-font-face>postcss>js-base64": {
+      "globals": {
+        "Base64": "write",
+        "define": true
+      }
+    },
+    "eslint-plugin-jsdoc>@es-joy/jsdoccomment>jsdoc-type-pratt-parser": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@babel/core>@babel/generator>jsesc": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "webpack>json-parse-even-better-errors": {
+      "globals": {
+        "Buffer.isBuffer": true
+      }
+    },
+    "@lavamoat/lavapack>json-stable-stringify": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "@lavamoat/lavapack>json-stable-stringify>isarray": true,
+        "lavamoat>json-stable-stringify>jsonify": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "depcheck>json5": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "eslint-plugin-import>tsconfig-paths>json5": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "fs-extra>jsonfile": {
+      "builtin": {
+        "fs": true
+      },
+      "globals": {
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "del>graceful-fs": true
+      }
+    },
+    "browserify>JSONStream>jsonparse": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "eslint-plugin-react>jsx-ast-utils": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>object.assign": true
+      }
+    },
+    "gulp>glob-watcher>just-debounce": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-accessor-descriptor>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>extglob>expand-brackets>define-property>is-descriptor>is-data-descriptor>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property>is-descriptor>is-data-descriptor>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>is-number>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>has-value>has-values>is-number>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "lavamoat>lavamoat-core>merge-deep>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>kind-of": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>snapdragon-util>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>to-object-path>kind-of": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true
+      }
+    },
     "labeled-stream-splicer": {
       "packages": {
-        "labeled-stream-splicer>stream-splicer": true,
-        "pumpify>inherits": true
-      }
-    },
-    "labeled-stream-splicer>stream-splicer": {
-      "globals": {
-        "process.nextTick": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "labeled-stream-splicer>stream-splicer>readable-stream": true,
-        "pumpify>inherits": true
-      }
-    },
-    "labeled-stream-splicer>stream-splicer>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "labeled-stream-splicer>stream-splicer>readable-stream>isarray": true,
-        "labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": true,
-        "labeled-stream-splicer>stream-splicer>readable-stream>string_decoder": true,
         "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true
+        "labeled-stream-splicer>stream-splicer": true
       }
     },
-    "labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": {
+    "gulp>undertaker>last-run": {
       "builtin": {
-        "buffer": true
-      }
-    },
-    "labeled-stream-splicer>stream-splicer>readable-stream>string_decoder": {
+        "assert": true
+      },
       "packages": {
-        "labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": true
+        "gulp>undertaker>last-run>default-resolution": true,
+        "gulp>undertaker>es6-weak-map": true
       }
     },
     "lavamoat-browserify": {
@@ -6091,39 +4366,15 @@
         "setTimeout": true
       },
       "packages": {
+        "lavamoat>@lavamoat/aa": true,
         "@lavamoat/lavapack": true,
-        "@lavamoat/lavapack>json-stable-stringify": true,
         "browserify>browser-resolve": true,
         "lavamoat-browserify>concat-stream": true,
         "lavamoat-browserify>duplexify": true,
+        "@lavamoat/lavapack>json-stable-stringify": true,
         "lavamoat-viz>lavamoat-core": true,
-        "lavamoat>@lavamoat/aa": true,
         "readable-stream": true,
         "through2": true
-      }
-    },
-    "lavamoat-browserify>concat-stream": {
-      "globals": {
-        "Buffer.concat": true,
-        "Buffer.isBuffer": true
-      },
-      "packages": {
-        "browserify>concat-stream>typedarray": true,
-        "pumpify>inherits": true,
-        "readable-stream": true,
-        "terser>source-map-support>buffer-from": true
-      }
-    },
-    "lavamoat-browserify>duplexify": {
-      "globals": {
-        "Buffer": true,
-        "process.nextTick": true
-      },
-      "packages": {
-        "duplexify>end-of-stream": true,
-        "duplexify>stream-shift": true,
-        "pumpify>inherits": true,
-        "readable-stream": true
       }
     },
     "lavamoat-viz>lavamoat-core": {
@@ -6155,87 +4406,10 @@
         "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse": true
       }
     },
-    "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse": {
-      "globals": {
-        "console.log": true
-      },
-      "packages": {
-        "@babel/code-frame": true,
-        "@babel/core>@babel/generator": true,
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/parser": true,
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/types": true,
-        "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>globals": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-environment-visitor": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": true,
-        "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": true,
-        "nock>debug": true
-      }
-    },
-    "lavamoat-viz>lavamoat-core>lavamoat-tofu>@babel/traverse>@babel/types": {
-      "globals": {
-        "console.warn": true,
-        "process.env": true
-      },
-      "packages": {
-        "@babel/core>@babel/types>@babel/helper-string-parser": true,
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true
-      }
-    },
-    "lavamoat>@lavamoat/aa": {
-      "builtin": {
-        "node:fs.lstatSync": true,
-        "node:fs.readFileSync": true,
-        "node:fs.realpathSync": true,
-        "node:path.dirname": true,
-        "node:path.join": true,
-        "node:path.relative": true
-      },
-      "packages": {
-        "depcheck>resolve": true
-      }
-    },
-    "lavamoat>lavamoat-core>merge-deep": {
-      "packages": {
-        "gulp-zip>plugin-error>arr-union": true,
-        "lavamoat>lavamoat-core>merge-deep>clone-deep": true,
-        "lavamoat>lavamoat-core>merge-deep>kind-of": true
-      }
-    },
-    "lavamoat>lavamoat-core>merge-deep>clone-deep": {
-      "packages": {
-        "@babel/register>clone-deep>is-plain-object": true,
-        "lavamoat>lavamoat-core>merge-deep>clone-deep>for-own": true,
-        "lavamoat>lavamoat-core>merge-deep>clone-deep>lazy-cache": true,
-        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone": true,
-        "lavamoat>lavamoat-core>merge-deep>kind-of": true
-      }
-    },
-    "lavamoat>lavamoat-core>merge-deep>clone-deep>for-own": {
-      "packages": {
-        "gulp>undertaker>object.reduce>for-own>for-in": true
-      }
-    },
     "lavamoat>lavamoat-core>merge-deep>clone-deep>lazy-cache": {
       "globals": {
         "process.env.TRAVIS": true,
         "process.env.UNLAZY": true
-      }
-    },
-    "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true,
-        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>kind-of": true,
-        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>lazy-cache": true,
-        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>mixin-object": true
-      }
-    },
-    "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>kind-of": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
       }
     },
     "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>lazy-cache": {
@@ -6243,60 +4417,55 @@
         "process.env.UNLAZY": true
       }
     },
-    "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>mixin-object": {
-      "packages": {
-        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true,
-        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>mixin-object>for-in": true
-      }
-    },
-    "lavamoat>lavamoat-core>merge-deep>kind-of": {
-      "packages": {
-        "browserify>insert-module-globals>is-buffer": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-function-name": {
-      "packages": {
-        "@babel/core>@babel/template": true,
-        "@babel/core>@babel/types": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-hoist-variables": {
-      "packages": {
-        "@babel/core>@babel/types": true
-      }
-    },
-    "lavamoat>lavamoat-tofu>@babel/traverse>@babel/helper-split-export-declaration": {
-      "packages": {
-        "@babel/core>@babel/types": true
-      }
-    },
-    "lodash": {
-      "globals": {
-        "define": true
-      }
-    },
-    "loose-envify": {
+    "gulp>vinyl-fs>lazystream": {
       "builtin": {
-        "stream.PassThrough": true,
-        "stream.Transform": true,
         "util.inherits": true
       },
-      "globals": {
-        "process.env": true
-      },
       "packages": {
-        "loose-envify>js-tokens": true
+        "gulp>vinyl-fs>lazystream>readable-stream": true
       }
     },
-    "mocha>find-up": {
-      "builtin": {
-        "path.dirname": true,
-        "path.parse": true,
-        "path.resolve": true
+    "gulp>vinyl-fs>lead": {
+      "globals": {
+        "process.nextTick": true
       },
       "packages": {
-        "mocha>find-up>locate-path": true,
-        "nyc>find-up>path-exists": true
+        "gulp>vinyl-fs>lead>flush-write-stream": true
+      }
+    },
+    "eslint>levn": {
+      "packages": {
+        "eslint>levn>prelude-ls": true,
+        "eslint>levn>type-check": true
+      }
+    },
+    "gulp-postcss>postcss-load-config>lilconfig": {
+      "builtin": {
+        "fs.accessSync": true,
+        "fs.promises.access": true,
+        "fs.promises.readFile": true,
+        "fs.readFileSync": true,
+        "os.homedir": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.parse": true,
+        "path.resolve": true,
+        "path.sep": true
+      },
+      "globals": {
+        "process.cwd": true
+      }
+    },
+    "eslint-plugin-import>eslint-module-utils>find-up>locate-path": {
+      "builtin": {
+        "path.resolve": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate": true,
+        "eslint-plugin-import>eslint-module-utils>find-up>locate-path>path-exists": true
       }
     },
     "mocha>find-up>locate-path": {
@@ -6315,9 +4484,15 @@
         "mocha>find-up>locate-path>p-locate": true
       }
     },
-    "mocha>find-up>locate-path>p-locate": {
-      "packages": {
-        "@storybook/test-runner>jest-circus>p-limit": true
+    "lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@babel/preset-env>babel-plugin-polyfill-corejs2>@babel/helper-define-polyfill-provider>lodash.debounce": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
       }
     },
     "mocha>log-symbols": {
@@ -6326,31 +4501,173 @@
         "mocha>log-symbols>is-unicode-supported": true
       }
     },
-    "mocha>log-symbols>is-unicode-supported": {
-      "globals": {
-        "process.env.CI": true,
-        "process.env.TERM": true,
-        "process.env.TERM_PROGRAM": true,
-        "process.env.WT_SESSION": true,
-        "process.platform": true
-      }
-    },
-    "mocha>supports-color": {
+    "loose-envify": {
       "builtin": {
-        "os.release": true,
-        "tty.isatty": true
+        "stream.PassThrough": true,
+        "stream.Transform": true,
+        "util.inherits": true
       },
       "globals": {
-        "process.env": true,
+        "process.env": true
+      },
+      "packages": {
+        "loose-envify>js-tokens": true
+      }
+    },
+    "@babel/core>@babel/helper-compilation-targets>lru-cache": {
+      "packages": {
+        "@babel/core>@babel/helper-compilation-targets>lru-cache>yallist": true
+      }
+    },
+    "gulp-sourcemaps>debug-fabulous>memoizee>lru-queue": {
+      "packages": {
+        "resolve-url-loader>es6-iterator>es5-ext": true
+      }
+    },
+    "gulp>undertaker>arr-map>make-iterator": {
+      "packages": {
+        "@babel/register>clone-deep>kind-of": true
+      }
+    },
+    "gulp-livereload>event-stream>map-stream": {
+      "builtin": {
+        "stream.Stream": true
+      },
+      "globals": {
+        "process.nextTick": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>map-visit": {
+      "builtin": {
+        "util.inspect": true
+      },
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>object-visit": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>markdown-table": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>randomatic>math-random": {
+      "builtin": {
+        "crypto.randomBytes": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": {
+      "packages": {
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "gulp-sourcemaps>debug-fabulous>memoizee": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "resolve-url-loader>es6-iterator>d": true,
+        "resolve-url-loader>es6-iterator>es5-ext": true,
+        "gulp-sourcemaps>debug-fabulous>memoizee>event-emitter": true,
+        "gulp-sourcemaps>debug-fabulous>memoizee>is-promise": true,
+        "gulp-sourcemaps>debug-fabulous>memoizee>lru-queue": true,
+        "gulp-sourcemaps>debug-fabulous>memoizee>next-tick": true,
+        "gulp-sourcemaps>debug-fabulous>memoizee>timers-ext": true
+      }
+    },
+    "lavamoat>lavamoat-core>merge-deep": {
+      "packages": {
+        "gulp-zip>plugin-error>arr-union": true,
+        "lavamoat>lavamoat-core>merge-deep>clone-deep": true,
+        "lavamoat>lavamoat-core>merge-deep>kind-of": true
+      }
+    },
+    "globby>merge2": {
+      "builtin": {
+        "stream.PassThrough": true
+      },
+      "globals": {
+        "process.nextTick": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch": {
+      "builtin": {
+        "path.basename": true,
+        "path.sep": true,
+        "util.inspect": true
+      },
+      "globals": {
         "process.platform": true
       },
       "packages": {
-        "mocha>supports-color>has-flag": true
+        "gulp-zip>plugin-error>arr-diff": true,
+        "gulp>gulp-cli>matchdep>micromatch>array-unique": true,
+        "gulp>glob-watcher>anymatch>micromatch>braces": true,
+        "gulp>glob-watcher>anymatch>micromatch>define-property": true,
+        "gulp-zip>plugin-error>extend-shallow": true,
+        "gulp>glob-watcher>anymatch>micromatch>extglob": true,
+        "gulp>gulp-cli>matchdep>micromatch>fragment-cache": true,
+        "@babel/register>clone-deep>kind-of": true,
+        "gulp>gulp-cli>matchdep>micromatch>nanomatch": true,
+        "gulp>gulp-cli>liftoff>fined>object.pick": true,
+        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
+        "gulp>gulp-cli>matchdep>micromatch>to-regex": true
       }
     },
-    "mocha>supports-color>has-flag": {
+    "gulp-watch>anymatch>micromatch": {
+      "builtin": {
+        "path.sep": true
+      },
       "globals": {
-        "process.argv": true
+        "process": true
+      },
+      "packages": {
+        "gulp-watch>anymatch>micromatch>arr-diff": true,
+        "gulp-watch>anymatch>micromatch>array-unique": true,
+        "gulp-watch>anymatch>micromatch>braces": true,
+        "gulp-watch>anymatch>micromatch>expand-brackets": true,
+        "gulp-watch>anymatch>micromatch>extglob": true,
+        "gulp-watch>anymatch>micromatch>filename-regex": true,
+        "gulp-watch>anymatch>micromatch>is-extglob": true,
+        "gulp-watch>anymatch>micromatch>is-glob": true,
+        "gulp-watch>anymatch>micromatch>kind-of": true,
+        "gulp-watch>anymatch>normalize-path": true,
+        "gulp-watch>anymatch>micromatch>object.omit": true,
+        "gulp-watch>anymatch>micromatch>parse-glob": true,
+        "gulp-watch>anymatch>micromatch>regex-cache": true
+      }
+    },
+    "fast-glob>micromatch": {
+      "builtin": {
+        "util.inspect": true
+      },
+      "packages": {
+        "chokidar>braces": true,
+        "chokidar>anymatch>picomatch": true
+      }
+    },
+    "eslint>minimatch": {
+      "builtin": {
+        "path": true
+      },
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "eslint>minimatch>brace-expansion": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>mixin-deep": {
+      "packages": {
+        "gulp>undertaker>object.reduce>for-own>for-in": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>mixin-deep>is-extendable": true
+      }
+    },
+    "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>mixin-object": {
+      "packages": {
+        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>mixin-object>for-in": true,
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
       }
     },
     "mockttp>portfinder>mkdirp": {
@@ -6360,35 +4677,352 @@
         "path.resolve": true
       }
     },
-    "nock>debug": {
+    "browserify>module-deps": {
       "builtin": {
-        "tty.isatty": true,
-        "util.deprecate": true,
-        "util.formatWithOptions": true,
-        "util.inspect": true
+        "fs.createReadStream": true,
+        "fs.readFile": true,
+        "path.delimiter": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true
       },
       "globals": {
-        "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
-        "process": true
+        "process.cwd": true,
+        "process.env.NODE_PATH": true,
+        "process.nextTick": true,
+        "process.platform": true,
+        "setTimeout": true,
+        "tr": true
       },
       "packages": {
-        "mocha>supports-color": true,
-        "nock>debug>ms": true
+        "browserify>browser-resolve": true,
+        "browserify>cached-path-relative": true,
+        "browserify>concat-stream": true,
+        "watchify>defined": true,
+        "browserify>module-deps>detective": true,
+        "browserify>duplexer2": true,
+        "pumpify>inherits": true,
+        "loose-envify": true,
+        "browserify>parents": true,
+        "browserify>module-deps>readable-stream": true,
+        "depcheck>resolve": true,
+        "browserify>module-deps>stream-combiner2": true,
+        "browserify>module-deps>through2": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>nanomatch": {
+      "builtin": {
+        "path.basename": true,
+        "path.sep": true,
+        "util.inspect": true
+      },
+      "packages": {
+        "gulp-zip>plugin-error>arr-diff": true,
+        "gulp>gulp-cli>matchdep>micromatch>array-unique": true,
+        "gulp>gulp-cli>matchdep>micromatch>nanomatch>define-property": true,
+        "gulp-zip>plugin-error>extend-shallow": true,
+        "gulp>gulp-cli>matchdep>micromatch>fragment-cache": true,
+        "nyc>spawn-wrap>is-windows": true,
+        "@babel/register>clone-deep>kind-of": true,
+        "gulp>gulp-cli>liftoff>fined>object.pick": true,
+        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon": true,
+        "gulp>gulp-cli>matchdep>micromatch>to-regex": true
+      }
+    },
+    "gulp-sourcemaps>debug-fabulous>memoizee>next-tick": {
+      "globals": {
+        "MutationObserver": true,
+        "WebKitMutationObserver": true,
+        "document": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "fs.existsSync": true,
+        "fs.readFileSync": true,
+        "fs.renameSync": true,
+        "path.dirname": true,
+        "path.existsSync": true,
+        "path.join": true,
+        "path.resolve": true,
+        "url.parse": true,
+        "url.resolve": true,
+        "util.inherits": true
+      },
+      "globals": {
+        "__dirname": true,
+        "console.log": true,
+        "process.arch": true,
+        "process.cwd": true,
+        "process.env": true,
+        "process.platform": true,
+        "process.version.substr": true,
+        "process.versions": true
+      },
+      "packages": {
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>semver": true
       }
     },
     "node-sass": {
       "native": true
     },
-    "nyc>convert-source-map": {
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt": {
       "builtin": {
-        "fs.readFileSync": true,
-        "path.join": true
+        "path": true,
+        "stream.Stream": true,
+        "url": true
       },
       "globals": {
-        "Buffer.from": true
+        "console": true,
+        "process.argv": true,
+        "process.env.DEBUG_NOPT": true,
+        "process.env.NOPT_DEBUG": true,
+        "process.platform": true
+      },
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>nopt>abbrev": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv": true
+      }
+    },
+    "gulp-watch>anymatch>normalize-path": {
+      "packages": {
+        "vinyl>remove-trailing-separator": true
+      }
+    },
+    "stylelint>normalize-selector": {
+      "globals": {
+        "define": true
+      }
+    },
+    "gulp>vinyl-fs>vinyl-sourcemap>now-and-later": {
+      "packages": {
+        "@metamask/object-multiplex>once": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "util": true
+      },
+      "globals": {
+        "process.nextTick": true,
+        "process.stderr": true
+      },
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>are-we-there-yet": true,
+        "@storybook/react>@storybook/node-logger>npmlog>console-control-strings": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge": true,
+        "nyc>yargs>set-blocking": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy>copy-descriptor": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy>kind-of": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>object-inspect": {
+      "builtin": {
+        "util.inspect": true
+      },
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>collection-visit>object-visit": {
+      "packages": {
+        "gulp>gulp-cli>isobject": true
+      }
+    },
+    "gulp>vinyl-fs>object.assign": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>has-symbols": true,
+        "@lavamoat/lavapack>json-stable-stringify>object-keys": true
+      }
+    },
+    "gulp>undertaker>object.defaults": {
+      "packages": {
+        "gulp>undertaker>bach>array-each": true,
+        "gulp>undertaker>object.defaults>array-slice": true,
+        "gulp>undertaker>object.reduce>for-own": true,
+        "gulp>gulp-cli>isobject": true
+      }
+    },
+    "eslint-plugin-react>object.entries": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>es-abstract": true
+      }
+    },
+    "eslint-plugin-react>object.fromentries": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>es-abstract": true
+      }
+    },
+    "eslint-plugin-react>object.hasown": {
+      "packages": {
+        "string.prototype.matchall>es-abstract": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>object.omit": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>object.omit>for-own": true,
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true
+      }
+    },
+    "gulp>gulp-cli>liftoff>fined>object.pick": {
+      "packages": {
+        "gulp>gulp-cli>isobject": true
+      }
+    },
+    "gulp>undertaker>object.reduce": {
+      "packages": {
+        "gulp>undertaker>object.reduce>for-own": true,
+        "gulp>undertaker>arr-map>make-iterator": true
+      }
+    },
+    "@metamask/object-multiplex>once": {
+      "packages": {
+        "@metamask/object-multiplex>once>wrappy": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>ordered-read-streams": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream": true
+      }
+    },
+    "@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir": {
+      "builtin": {
+        "os.homedir": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.getuid": true,
+        "process.platform": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": {
+      "globals": {
+        "process.env.SystemRoot": true,
+        "process.env.TEMP": true,
+        "process.env.TMP": true,
+        "process.env.TMPDIR": true,
+        "process.env.windir": true,
+        "process.platform": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv": {
+      "builtin": {
+        "child_process.exec": true,
+        "path": true
+      },
+      "globals": {
+        "process.env.COMPUTERNAME": true,
+        "process.env.ComSpec": true,
+        "process.env.EDITOR": true,
+        "process.env.HOSTNAME": true,
+        "process.env.PATH": true,
+        "process.env.PROMPT": true,
+        "process.env.PS1": true,
+        "process.env.Path": true,
+        "process.env.SHELL": true,
+        "process.env.USER": true,
+        "process.env.USERDOMAIN": true,
+        "process.env.USERNAME": true,
+        "process.env.VISUAL": true,
+        "process.env.path": true,
+        "process.nextTick": true,
+        "process.platform": true
+      },
+      "packages": {
+        "@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": true
+      }
+    },
+    "@storybook/test-runner>jest-circus>p-limit": {
+      "packages": {
+        "@storybook/test-runner>jest-circus>p-limit>yocto-queue": true
+      }
+    },
+    "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate>p-limit": {
+      "packages": {
+        "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate>p-limit>p-try": true
+      }
+    },
+    "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate": {
+      "packages": {
+        "eslint-plugin-import>eslint-module-utils>find-up>locate-path>p-locate>p-limit": true
+      }
+    },
+    "mocha>find-up>locate-path>p-locate": {
+      "packages": {
+        "@storybook/test-runner>jest-circus>p-limit": true
+      }
+    },
+    "del>p-map": {
+      "packages": {
+        "del>p-map>aggregate-error": true
+      }
+    },
+    "eslint>@eslint/eslintrc>import-fresh>parent-module": {
+      "packages": {
+        "@metamask/test-bundler>ow>callsites": true
+      }
+    },
+    "browserify>parents": {
+      "globals": {
+        "process.cwd": true,
+        "process.platform": true
+      },
+      "packages": {
+        "browserify>parents>path-platform": true
+      }
+    },
+    "react-syntax-highlighter>refractor>parse-entities": {
+      "packages": {
+        "react-syntax-highlighter>refractor>parse-entities>character-entities-legacy": true,
+        "react-syntax-highlighter>refractor>parse-entities>character-entities": true,
+        "react-syntax-highlighter>refractor>parse-entities>character-reference-invalid": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-alphanumerical": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-hexadecimal": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>parse-glob": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>parse-glob>glob-base": true,
+        "gulp-watch>anymatch>micromatch>parse-glob>is-dotfile": true,
+        "gulp-watch>anymatch>micromatch>is-extglob": true,
+        "gulp-watch>anymatch>micromatch>parse-glob>is-glob": true
+      }
+    },
+    "depcheck>cosmiconfig>parse-json": {
+      "packages": {
+        "@babel/code-frame": true,
+        "depcheck>cosmiconfig>parse-json>error-ex": true,
+        "webpack>json-parse-even-better-errors": true,
+        "depcheck>cosmiconfig>parse-json>lines-and-columns": true
       }
     },
     "nyc>find-up>path-exists": {
@@ -6398,93 +5032,151 @@
         "util.promisify": true
       }
     },
-    "nyc>glob": {
+    "eslint-plugin-import>eslint-module-utils>find-up>locate-path>path-exists": {
       "builtin": {
-        "assert": true,
-        "events.EventEmitter": true,
-        "fs": true,
-        "path.join": true,
-        "path.resolve": true,
-        "util": true
-      },
+        "fs.access": true,
+        "fs.accessSync": true
+      }
+    },
+    "gulp-watch>path-is-absolute": {
       "globals": {
-        "console.error": true,
-        "process.cwd": true,
-        "process.nextTick": true,
         "process.platform": true
-      },
-      "packages": {
-        "@metamask/object-multiplex>once": true,
-        "eslint>minimatch": true,
-        "gulp-watch>path-is-absolute": true,
-        "nyc>glob>fs.realpath": true,
-        "nyc>glob>inflight": true,
-        "pumpify>inherits": true
       }
     },
-    "nyc>glob>fs.realpath": {
+    "depcheck>resolve>path-parse": {
+      "globals": {
+        "process.platform": true
+      }
+    },
+    "browserify>parents>path-platform": {
       "builtin": {
-        "fs.lstat": true,
-        "fs.lstatSync": true,
-        "fs.readlink": true,
-        "fs.readlinkSync": true,
-        "fs.realpath": true,
-        "fs.realpathSync": true,
-        "fs.stat": true,
-        "fs.statSync": true,
-        "path.normalize": true,
-        "path.resolve": true
+        "path": true,
+        "util.isObject": true,
+        "util.isString": true
       },
       "globals": {
-        "console.error": true,
-        "console.trace": true,
-        "process.env.NODE_DEBUG": true,
-        "process.nextTick": true,
-        "process.noDeprecation": true,
+        "process.cwd": true,
+        "process.env": true,
+        "process.platform": true
+      }
+    },
+    "globby>dir-glob>path-type": {
+      "builtin": {
+        "fs": true,
+        "util.promisify": true
+      }
+    },
+    "gulp-livereload>event-stream>pause-stream": {
+      "packages": {
+        "debounce-stream>through": true
+      }
+    },
+    "postcss>picocolors": {
+      "globals": {
+        "process": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss>picocolors": {
+      "builtin": {
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.argv.includes": true,
+        "process.env": true,
+        "process.platform": true
+      }
+    },
+    "stylelint>postcss-less>postcss>picocolors": {
+      "builtin": {
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.argv.includes": true,
+        "process.env": true,
+        "process.platform": true
+      }
+    },
+    "stylelint>postcss-safe-parser>postcss>picocolors": {
+      "builtin": {
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.argv.includes": true,
+        "process.env": true,
+        "process.platform": true
+      }
+    },
+    "stylelint>postcss-sass>postcss>picocolors": {
+      "builtin": {
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.argv.includes": true,
+        "process.env": true,
+        "process.platform": true
+      }
+    },
+    "stylelint>postcss-scss>postcss>picocolors": {
+      "builtin": {
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.argv.includes": true,
+        "process.env": true,
+        "process.platform": true
+      }
+    },
+    "stylelint>postcss>picocolors": {
+      "builtin": {
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.argv.includes": true,
+        "process.env": true,
+        "process.platform": true
+      }
+    },
+    "stylelint>sugarss>postcss>picocolors": {
+      "builtin": {
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.argv.includes": true,
+        "process.env": true,
+        "process.platform": true
+      }
+    },
+    "chokidar>anymatch>picomatch": {
+      "builtin": {
+        "path.basename": true,
+        "path.sep": true
+      },
+      "globals": {
         "process.platform": true,
-        "process.throwDeprecation": true,
-        "process.traceDeprecation": true,
-        "process.version": true
+        "process.version.slice": true
       }
     },
-    "nyc>glob>inflight": {
+    "gh-pages>globby>pinkie-promise": {
+      "packages": {
+        "gh-pages>globby>pinkie-promise>pinkie": true
+      }
+    },
+    "gh-pages>globby>pinkie-promise>pinkie": {
       "globals": {
-        "process.nextTick": true
+        "process": true,
+        "setImmediate": true,
+        "setTimeout": true
+      }
+    },
+    "gulp-zip>plugin-error": {
+      "builtin": {
+        "util.inherits": true
       },
       "packages": {
-        "@metamask/object-multiplex>once": true,
-        "@metamask/object-multiplex>once>wrappy": true
-      }
-    },
-    "nyc>resolve-from": {
-      "builtin": {
-        "fs.realpathSync": true,
-        "module._nodeModulePaths": true,
-        "module._resolveFilename": true,
-        "path.join": true,
-        "path.resolve": true
-      }
-    },
-    "nyc>signal-exit": {
-      "builtin": {
-        "assert.equal": true,
-        "events": true
-      },
-      "globals": {
-        "process": true
-      }
-    },
-    "nyc>spawn-wrap>is-windows": {
-      "globals": {
-        "define": true,
-        "isWindows": "write",
-        "process": true
-      }
-    },
-    "nyc>yargs>set-blocking": {
-      "globals": {
-        "process.stderr": true,
-        "process.stdout": true
+        "gulp-watch>ansi-colors": true,
+        "gulp-zip>plugin-error>arr-diff": true,
+        "gulp-zip>plugin-error>arr-union": true,
+        "gulp-zip>plugin-error>extend-shallow": true
       }
     },
     "postcss": {
@@ -6521,6 +5213,99 @@
         "postcss-discard-font-face>postcss": true
       }
     },
+    "stylelint>postcss-html": {
+      "globals": {
+        "__dirname": true
+      },
+      "packages": {
+        "stylelint>postcss-html>htmlparser2": true,
+        "stylelint>postcss-syntax": true
+      }
+    },
+    "stylelint>postcss-less": {
+      "packages": {
+        "stylelint>postcss-less>postcss": true
+      }
+    },
+    "gulp-postcss>postcss-load-config": {
+      "builtin": {
+        "module.createRequire": true,
+        "module.createRequireFromPath": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "process.cwd": true,
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "gulp-postcss>postcss-load-config>lilconfig": true,
+        "ts-node": true,
+        "gulp-postcss>postcss-load-config>yaml": true
+      }
+    },
+    "stylelint>postcss-reporter": {
+      "packages": {
+        "lodash": true
+      }
+    },
+    "postcss-rtlcss": {
+      "globals": {
+        "SuppressedError": true
+      },
+      "packages": {
+        "postcss": true,
+        "postcss-rtlcss>rtlcss": true
+      }
+    },
+    "stylelint>postcss-safe-parser": {
+      "packages": {
+        "stylelint>postcss-safe-parser>postcss": true
+      }
+    },
+    "stylelint>postcss-sass": {
+      "packages": {
+        "stylelint>postcss-sass>gonzales-pe": true,
+        "stylelint>postcss-sass>postcss": true
+      }
+    },
+    "stylelint>postcss-scss": {
+      "packages": {
+        "stylelint>postcss-scss>postcss": true
+      }
+    },
+    "stylelint>postcss-selector-parser": {
+      "packages": {
+        "stylelint>postcss-selector-parser>cssesc": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "stylelint>postcss-syntax": {
+      "builtin": {
+        "path.isAbsolute": true,
+        "path.resolve": true,
+        "path.sep": true
+      },
+      "packages": {
+        "stylelint>postcss": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss": {
+      "builtin": {
+        "fs": true,
+        "path": true
+      },
+      "globals": {
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console": true,
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>postcss>picocolors": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/identity-map>source-map": true
+      }
+    },
     "postcss-discard-font-face>postcss": {
       "builtin": {
         "fs": true,
@@ -6536,73 +5321,106 @@
         "postcss-discard-font-face>postcss>supports-color": true
       }
     },
-    "postcss-discard-font-face>postcss>chalk": {
+    "stylelint>postcss-less>postcss": {
+      "builtin": {
+        "fs": true,
+        "path": true
+      },
       "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console": true,
+        "process.env.NODE_ENV": true
       },
       "packages": {
-        "postcss-discard-font-face>postcss>chalk>ansi-styles": true,
-        "postcss-discard-font-face>postcss>chalk>escape-string-regexp": true,
-        "postcss-discard-font-face>postcss>chalk>strip-ansi": true,
-        "postcss-discard-font-face>postcss>chalk>supports-color": true,
-        "prettier-eslint>loglevel-colored-level-prefix>chalk>has-ansi": true
+        "stylelint>postcss-less>postcss>picocolors": true,
+        "stylelint>postcss-less>postcss>source-map": true
       }
     },
-    "postcss-discard-font-face>postcss>chalk>strip-ansi": {
-      "packages": {
-        "postcss-discard-font-face>postcss>chalk>strip-ansi>ansi-regex": true
-      }
-    },
-    "postcss-discard-font-face>postcss>chalk>supports-color": {
+    "stylelint>postcss-safe-parser>postcss": {
+      "builtin": {
+        "fs": true,
+        "path": true
+      },
       "globals": {
-        "process.argv": true,
-        "process.env": true,
-        "process.platform": true,
-        "process.stdout": true
-      }
-    },
-    "postcss-discard-font-face>postcss>js-base64": {
-      "globals": {
-        "Base64": "write",
-        "define": true
-      }
-    },
-    "postcss-discard-font-face>postcss>supports-color": {
-      "globals": {
-        "process": true
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console": true,
+        "process.env.NODE_ENV": true
       },
       "packages": {
-        "postcss-discard-font-face>postcss>supports-color>has-flag": true
+        "stylelint>postcss-safe-parser>postcss>picocolors": true,
+        "stylelint>postcss-safe-parser>postcss>source-map": true
       }
     },
-    "postcss-discard-font-face>postcss>supports-color>has-flag": {
+    "stylelint>postcss-sass>postcss": {
+      "builtin": {
+        "fs": true,
+        "path": true
+      },
       "globals": {
-        "process.argv": true
-      }
-    },
-    "postcss-rtlcss": {
-      "globals": {
-        "SuppressedError": true
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console": true,
+        "process.env.NODE_ENV": true
       },
       "packages": {
-        "postcss": true,
-        "postcss-rtlcss>rtlcss": true
+        "stylelint>postcss-sass>postcss>picocolors": true,
+        "stylelint>postcss-sass>postcss>source-map": true
       }
     },
-    "postcss-rtlcss>rtlcss": {
+    "stylelint>postcss-scss>postcss": {
+      "builtin": {
+        "fs": true,
+        "path": true
+      },
+      "globals": {
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console": true,
+        "process.env.NODE_ENV": true
+      },
       "packages": {
-        "postcss": true
+        "stylelint>postcss-scss>postcss>picocolors": true,
+        "stylelint>postcss-scss>postcss>source-map": true
       }
     },
-    "postcss>picocolors": {
+    "stylelint>postcss": {
+      "builtin": {
+        "fs": true,
+        "path": true
+      },
       "globals": {
-        "process": true
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console": true,
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "stylelint>postcss>picocolors": true,
+        "stylelint>postcss>source-map": true
       }
     },
-    "postcss>source-map-js": {
+    "stylelint>sugarss>postcss": {
+      "builtin": {
+        "fs": true,
+        "path": true
+      },
       "globals": {
-        "console": true
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console": true,
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "stylelint>sugarss>postcss>picocolors": true,
+        "stylelint>sugarss>postcss>source-map": true
       }
     },
     "prettier": {
@@ -7399,9 +6217,25 @@
         "zipToModeAwareCache": true
       }
     },
-    "prettier-eslint>loglevel-colored-level-prefix>chalk>has-ansi": {
+    "eslint-plugin-prettier>prettier-linter-helpers": {
       "packages": {
-        "prettier-eslint>loglevel-colored-level-prefix>chalk>has-ansi>ansi-regex": true
+        "eslint-plugin-prettier>prettier-linter-helpers>fast-diff": true
+      }
+    },
+    "vinyl>cloneable-readable>process-nextick-args": {
+      "globals": {
+        "process.nextTick": true,
+        "process.version": true
+      }
+    },
+    "readable-stream-2>process-nextick-args": {
+      "globals": {
+        "process": true
+      }
+    },
+    "vinyl>cloneable-readable>through2>readable-stream>process-nextick-args": {
+      "globals": {
+        "process": true
       }
     },
     "prop-types": {
@@ -7410,26 +6244,8 @@
         "process.env.NODE_ENV": true
       },
       "packages": {
-        "prop-types>react-is": true,
-        "react>object-assign": true
-      }
-    },
-    "prop-types>react-is": {
-      "globals": {
-        "console": true,
-        "process.env.NODE_ENV": true
-      }
-    },
-    "pumpify": {
-      "packages": {
-        "duplexify": true,
-        "pumpify>inherits": true,
-        "pumpify>pump": true
-      }
-    },
-    "pumpify>inherits": {
-      "builtin": {
-        "util.inherits": true
+        "react>object-assign": true,
+        "prop-types>react-is": true
       }
     },
     "pumpify>pump": {
@@ -7440,8 +6256,59 @@
         "process.version": true
       },
       "packages": {
-        "@metamask/object-multiplex>once": true,
-        "duplexify>end-of-stream": true
+        "duplexify>end-of-stream": true,
+        "@metamask/object-multiplex>once": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>pumpify>pump": {
+      "builtin": {
+        "fs": true
+      },
+      "packages": {
+        "duplexify>end-of-stream": true,
+        "@metamask/object-multiplex>once": true
+      }
+    },
+    "gulp>vinyl-fs>pumpify>pump": {
+      "builtin": {
+        "fs": true
+      },
+      "packages": {
+        "duplexify>end-of-stream": true,
+        "@metamask/object-multiplex>once": true
+      }
+    },
+    "pumpify": {
+      "packages": {
+        "duplexify": true,
+        "pumpify>inherits": true,
+        "pumpify>pump": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>pumpify": {
+      "packages": {
+        "gulp>vinyl-fs>glob-stream>pumpify>duplexify": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>glob-stream>pumpify>pump": true
+      }
+    },
+    "gulp>vinyl-fs>pumpify": {
+      "packages": {
+        "gulp>vinyl-fs>pumpify>duplexify": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>pumpify>pump": true
+      }
+    },
+    "@storybook/addon-knobs>qs": {
+      "packages": {
+        "string.prototype.matchall>side-channel": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>randomatic": {
+      "packages": {
+        "gulp>undertaker>bach>array-last>is-number": true,
+        "@babel/register>clone-deep>kind-of": true,
+        "gulp-watch>anymatch>micromatch>braces>expand-range>fill-range>randomatic>math-random": true
       }
     },
     "randomcolor": {
@@ -7449,70 +6316,25 @@
         "define": true
       }
     },
-    "react-markdown>unified": {
-      "packages": {
-        "mocha>yargs-unparser>is-plain-obj": true,
-        "react-markdown>unified>bail": true,
-        "react-markdown>unified>extend": true,
-        "react-markdown>unified>is-buffer": true,
-        "react-markdown>unified>trough": true,
-        "react-markdown>vfile": true
-      }
-    },
-    "react-markdown>unist-util-visit": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-visit-parents": true
-      }
-    },
-    "react-markdown>unist-util-visit>unist-util-visit-parents": {
-      "packages": {
-        "react-markdown>unist-util-visit>unist-util-is": true
-      }
-    },
-    "react-markdown>vfile": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.sep": true
-      },
+    "gulp-livereload>tiny-lr>body>raw-body": {
       "globals": {
-        "process.cwd": true
+        "Buffer.concat": true,
+        "process.nextTick": true
       },
       "packages": {
-        "react-markdown>vfile>is-buffer": true,
-        "react-markdown>vfile>replace-ext": true,
-        "react-markdown>vfile>vfile-message": true
+        "gulp-livereload>tiny-lr>body>raw-body>bytes": true,
+        "gulp-livereload>tiny-lr>body>raw-body>string_decoder": true
       }
     },
-    "react-markdown>vfile>replace-ext": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true
+    "prop-types>react-is": {
+      "globals": {
+        "console": true,
+        "process.env.NODE_ENV": true
       }
     },
-    "react-markdown>vfile>vfile-message": {
+    "browserify>read-only-stream": {
       "packages": {
-        "react-markdown>vfile>unist-util-stringify-position": true
-      }
-    },
-    "react-syntax-highlighter>refractor>parse-entities": {
-      "packages": {
-        "react-syntax-highlighter>refractor>parse-entities>character-entities": true,
-        "react-syntax-highlighter>refractor>parse-entities>character-entities-legacy": true,
-        "react-syntax-highlighter>refractor>parse-entities>character-reference-invalid": true,
-        "react-syntax-highlighter>refractor>parse-entities>is-alphanumerical": true,
-        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
-        "react-syntax-highlighter>refractor>parse-entities>is-hexadecimal": true
-      }
-    },
-    "react-syntax-highlighter>refractor>parse-entities>is-alphanumerical": {
-      "packages": {
-        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true
+        "browserify>read-only-stream>readable-stream": true
       }
     },
     "readable-stream": {
@@ -7529,78 +6351,1157 @@
         "process.stdout": true
       },
       "packages": {
-        "browserify>string_decoder": true,
         "pumpify>inherits": true,
+        "browserify>string_decoder": true,
         "readable-stream>util-deprecate": true
       }
     },
-    "readable-stream-2>core-util-is": {
-      "globals": {
-        "Buffer.isBuffer": true
-      }
-    },
-    "readable-stream-2>process-nextick-args": {
-      "globals": {
-        "process": true
-      }
-    },
-    "readable-stream>util-deprecate": {
+    "vinyl-buffer>bl>readable-stream": {
       "builtin": {
-        "util.deprecate": true
-      }
-    },
-    "resolve-url-loader>es6-iterator": {
-      "packages": {
-        "resolve-url-loader>es6-iterator>d": true,
-        "resolve-url-loader>es6-iterator>es5-ext": true,
-        "resolve-url-loader>es6-iterator>es6-symbol": true
-      }
-    },
-    "resolve-url-loader>es6-iterator>d": {
-      "packages": {
-        "resolve-url-loader>es6-iterator>d>type": true,
-        "resolve-url-loader>es6-iterator>es5-ext": true
-      }
-    },
-    "resolve-url-loader>es6-iterator>es5-ext": {
-      "packages": {
-        "resolve-url-loader>es6-iterator>es6-symbol": true
-      }
-    },
-    "resolve-url-loader>es6-iterator>es6-symbol": {
-      "packages": {
-        "resolve-url-loader>es6-iterator>d": true,
-        "resolve-url-loader>es6-iterator>es6-symbol>ext": true
-      }
-    },
-    "resolve-url-loader>es6-iterator>es6-symbol>ext": {
-      "globals": {
-        "__global__": true
-      }
-    },
-    "resolve-url-loader>rework>css>source-map-resolve": {
-      "builtin": {
-        "url.resolve": true
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
       },
       "globals": {
-        "TextDecoder": true,
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
         "setImmediate": true
       },
       "packages": {
-        "gulp-sourcemaps>css>source-map-resolve>atob": true,
-        "gulp-sourcemaps>css>source-map-resolve>decode-uri-component": true,
-        "resolve-url-loader>rework>css>source-map-resolve>source-map-url": true,
-        "resolve-url-loader>rework>css>urix": true
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "vinyl-buffer>bl>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "vinyl-buffer>bl>readable-stream>safe-buffer": true,
+        "vinyl-buffer>bl>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
       }
     },
-    "resolve-url-loader>rework>css>source-map-resolve>source-map-url": {
+    "browserify>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>readable-stream>safe-buffer": true,
+        "browserify>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>concat-stream>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>concat-stream>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>concat-stream>readable-stream>safe-buffer": true,
+        "browserify>concat-stream>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>duplexer2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>duplexer2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>duplexer2>readable-stream>safe-buffer": true,
+        "browserify>duplexer2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>safe-buffer": true,
+        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>lead>flush-write-stream>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>glob-stream>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>glob-stream>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>glob-stream>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp-watch>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp-watch>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp-watch>readable-stream>safe-buffer": true,
+        "gulp-watch>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>lazystream>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>lazystream>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>lazystream>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>lazystream>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>module-deps>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>module-deps>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>module-deps>readable-stream>safe-buffer": true,
+        "browserify>module-deps>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>read-only-stream>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>read-only-stream>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>read-only-stream>readable-stream>safe-buffer": true,
+        "browserify>read-only-stream>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>module-deps>stream-combiner2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>module-deps>stream-combiner2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": true,
+        "browserify>module-deps>stream-combiner2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "labeled-stream-splicer>stream-splicer>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "labeled-stream-splicer>stream-splicer>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": true,
+        "labeled-stream-splicer>stream-splicer>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>safe-buffer": true,
+        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>browser-pack>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>browser-pack>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>browser-pack>through2>readable-stream>safe-buffer": true,
+        "browserify>browser-pack>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "vinyl>cloneable-readable>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "vinyl>cloneable-readable>through2>readable-stream>isarray": true,
+        "vinyl>cloneable-readable>through2>readable-stream>process-nextick-args": true,
+        "vinyl>cloneable-readable>through2>readable-stream>safe-buffer": true,
+        "vinyl>cloneable-readable>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>deps-sort>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>deps-sort>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>deps-sort>through2>readable-stream>safe-buffer": true,
+        "browserify>deps-sort>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp-sort>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp-sort>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp-sort>through2>readable-stream>safe-buffer": true,
+        "gulp-sort>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp-sourcemaps>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp-sourcemaps>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp-sourcemaps>through2>readable-stream>safe-buffer": true,
+        "gulp-sourcemaps>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "browserify>insert-module-globals>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "browserify>insert-module-globals>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "browserify>insert-module-globals>through2>readable-stream>safe-buffer": true,
+        "browserify>insert-module-globals>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>to-through>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>to-through>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>to-through>through2>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>to-through>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "vinyl-source-stream>through2>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "vinyl-source-stream>through2>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "vinyl-source-stream>through2>readable-stream>safe-buffer": true,
+        "vinyl-source-stream>through2>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "gulp>vinyl-fs>readable-stream": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.browser": true,
+        "process.env.READABLE_STREAM": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "readable-stream-2>core-util-is": true,
+        "pumpify>inherits": true,
+        "gulp>vinyl-fs>readable-stream>isarray": true,
+        "readable-stream-2>process-nextick-args": true,
+        "gulp>vinyl-fs>readable-stream>safe-buffer": true,
+        "gulp>vinyl-fs>readable-stream>string_decoder": true,
+        "readable-stream>util-deprecate": true
+      }
+    },
+    "chokidar>readdirp": {
+      "builtin": {
+        "fs": true,
+        "path.join": true,
+        "path.relative": true,
+        "path.resolve": true,
+        "path.sep": true,
+        "stream.Readable": true,
+        "util.promisify": true
+      },
+      "globals": {
+        "process.platform": true,
+        "process.versions.node.split": true
+      },
+      "packages": {
+        "chokidar>anymatch>picomatch": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regenerate": {
       "globals": {
         "define": true
       }
     },
-    "resolve-url-loader>rework>css>urix": {
+    "@babel/preset-env>@babel/plugin-transform-regenerator>regenerator-transform": {
       "builtin": {
+        "assert": true,
+        "util.inherits": true
+      },
+      "packages": {
+        "@babel/runtime": true
+      }
+    },
+    "gulp-watch>anymatch>micromatch>regex-cache": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>regex-cache>is-equal-shallow": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>regex-not": {
+      "packages": {
+        "gulp-zip>plugin-error>extend-shallow": true,
+        "gulp>gulp-cli>matchdep>micromatch>to-regex>safe-regex": true
+      }
+    },
+    "string.prototype.matchall>regexp.prototype.flags": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>define-properties": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core": {
+      "globals": {
+        "characterClassItem.kind": true
+      },
+      "packages": {
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regenerate": true,
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsgen": true,
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsparser": true,
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-ecmascript": true,
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-value-ecmascript": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsgen": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>regjsparser": {
+      "globals": {
+        "regjsparser": "write"
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-parse": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>collapse-white-space": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-word-character": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
+        "react-syntax-highlighter>refractor>parse-entities": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim-trailing-lines": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>vfile-location": true,
+        "watchify>xtend": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>is-alphanumeric": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>longest-streak": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>markdown-table": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": true,
+        "react-syntax-highlighter>refractor>parse-entities": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
+        "watchify>xtend": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": true,
+        "react-markdown>unified": true
+      }
+    },
+    "gulp>vinyl-fs>remove-bom-buffer": {
+      "packages": {
+        "browserify>insert-module-globals>is-buffer": true,
+        "gulp>vinyl-fs>remove-bom-buffer>is-utf8": true
+      }
+    },
+    "gulp>vinyl-fs>remove-bom-stream": {
+      "packages": {
+        "gulp>vinyl-fs>remove-bom-buffer": true,
+        "koa>content-disposition>safe-buffer": true,
+        "gulp>vinyl-fs>remove-bom-stream>through2": true
+      }
+    },
+    "vinyl>remove-trailing-separator": {
+      "globals": {
+        "process.platform": true
+      }
+    },
+    "gulp-sass>replace-ext": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
         "path.sep": true
+      }
+    },
+    "react-markdown>vfile>replace-ext": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true
+      }
+    },
+    "vinyl>replace-ext": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.sep": true
+      }
+    },
+    "gulp-watch>vinyl-file>vinyl>replace-ext": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true
+      }
+    },
+    "yargs>require-directory": {
+      "builtin": {
+        "fs.readdirSync": true,
+        "fs.statSync": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true
+      }
+    },
+    "eslint>@eslint/eslintrc>import-fresh>resolve-from": {
+      "builtin": {
+        "fs.realpathSync": true,
+        "module._nodeModulePaths": true,
+        "module._resolveFilename": true,
+        "path.join": true,
+        "path.resolve": true
+      }
+    },
+    "nyc>resolve-from": {
+      "builtin": {
+        "fs.realpathSync": true,
+        "module._nodeModulePaths": true,
+        "module._resolveFilename": true,
+        "path.join": true,
+        "path.resolve": true
+      }
+    },
+    "gulp>vinyl-fs>resolve-options": {
+      "packages": {
+        "gulp>vinyl-fs>value-or-function": true
+      }
+    },
+    "depcheck>resolve": {
+      "builtin": {
+        "fs.readFile": true,
+        "fs.readFileSync": true,
+        "fs.realpath": true,
+        "fs.realpathSync": true,
+        "fs.stat": true,
+        "fs.statSync": true,
+        "os.homedir": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.parse": true,
+        "path.relative": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "process.env.HOME": true,
+        "process.env.HOMEDRIVE": true,
+        "process.env.HOMEPATH": true,
+        "process.env.LNAME": true,
+        "process.env.LOGNAME": true,
+        "process.env.USER": true,
+        "process.env.USERNAME": true,
+        "process.env.USERPROFILE": true,
+        "process.getuid": true,
+        "process.nextTick": true,
+        "process.platform": true,
+        "process.versions.pnp": true
+      },
+      "packages": {
+        "depcheck>is-core-module": true,
+        "depcheck>resolve>path-parse": true
+      }
+    },
+    "eslint-plugin-react>resolve": {
+      "builtin": {
+        "fs.readFile": true,
+        "fs.readFileSync": true,
+        "fs.realpath": true,
+        "fs.realpathSync": true,
+        "fs.stat": true,
+        "fs.statSync": true,
+        "os.homedir": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.parse": true,
+        "path.relative": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "process.env.HOME": true,
+        "process.env.HOMEDRIVE": true,
+        "process.env.HOMEPATH": true,
+        "process.env.LNAME": true,
+        "process.env.LOGNAME": true,
+        "process.env.USER": true,
+        "process.env.USERNAME": true,
+        "process.env.USERPROFILE": true,
+        "process.getuid": true,
+        "process.nextTick": true,
+        "process.platform": true,
+        "process.versions.pnp": true
+      },
+      "packages": {
+        "depcheck>is-core-module": true,
+        "depcheck>resolve>path-parse": true
+      }
+    },
+    "del>rimraf": {
+      "builtin": {
+        "assert": true,
+        "fs": true,
+        "path.join": true
+      },
+      "globals": {
+        "process.platform": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "nyc>glob": true
+      }
+    },
+    "stylelint>file-entry-cache>flat-cache>rimraf": {
+      "builtin": {
+        "assert": true,
+        "fs": true,
+        "path.join": true
+      },
+      "globals": {
+        "process.platform": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "nyc>glob": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": {
+      "builtin": {
+        "assert": true,
+        "fs": true,
+        "path.join": true
+      },
+      "globals": {
+        "process.platform": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "nyc>glob": true
+      }
+    },
+    "postcss-rtlcss>rtlcss": {
+      "packages": {
+        "postcss": true
+      }
+    },
+    "eslint>@nodelib/fs.walk>@nodelib/fs.scandir>run-parallel": {
+      "globals": {
+        "process.nextTick": true
+      }
+    },
+    "wait-on>rxjs": {
+      "globals": {
+        "cancelAnimationFrame": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "performance": true,
+        "requestAnimationFrame": true,
+        "setInterval.apply": true,
+        "setTimeout.apply": true
+      }
+    },
+    "koa>content-disposition>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "vinyl-buffer>bl>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>concat-stream>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>duplexer2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp-watch>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>lazystream>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>module-deps>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>read-only-stream>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>browser-pack>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "vinyl>cloneable-readable>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>deps-sort>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp-sort>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp-sourcemaps>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>insert-module-globals>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>to-through>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "vinyl-source-stream>through2>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>readable-stream>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "vinyl-buffer>bl>readable-stream>string_decoder>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "browserify>browser-pack>through2>readable-stream>string_decoder>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>string_decoder>safe-buffer": {
+      "builtin": {
+        "buffer": true
+      }
+    },
+    "string.prototype.matchall>es-abstract>safe-regex-test": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>is-regex": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>to-regex>safe-regex": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>to-regex>safe-regex>ret": true
       }
     },
     "sass": {
@@ -7651,37 +7552,183 @@
         "process.stderr.write": true
       },
       "packages": {
-        "mocha>supports-color": true,
         "sass-embedded>@bufbuild/protobuf": true,
         "sass-embedded>buffer-builder": true,
         "sass-embedded>immutable": true,
-        "sass-embedded>varint": true,
-        "wait-on>rxjs": true
-      }
-    },
-    "sass-embedded>@bufbuild/protobuf": {
-      "globals": {
-        "TextDecoder": true,
-        "TextEncoder": true,
-        "__values": true,
-        "process": true
-      }
-    },
-    "sass-embedded>buffer-builder": {
-      "globals": {
-        "Buffer": true
-      }
-    },
-    "sass-embedded>immutable": {
-      "globals": {
-        "console": true,
-        "define": true
+        "wait-on>rxjs": true,
+        "mocha>supports-color": true,
+        "sass-embedded>varint": true
       }
     },
     "semver": {
       "globals": {
         "console.error": true,
         "process": true
+      }
+    },
+    "@babel/core>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "@babel/eslint-parser>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "@babel/core>@babel/helper-compilation-targets>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-private-methods>@babel/helper-create-class-features-plugin>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "@babel/preset-env>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "@babel/preset-env>babel-plugin-polyfill-corejs2>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "eslint-plugin-node>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "eslint-plugin-react>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>semver": {
+      "globals": {
+        "console": true,
+        "process": true
+      }
+    },
+    "nyc>yargs>set-blocking": {
+      "globals": {
+        "process.stderr": true,
+        "process.stdout": true
+      }
+    },
+    "string.prototype.matchall>call-bind>set-function-length": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>gopd": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
+      "packages": {
+        "string.prototype.matchall>define-properties>define-data-property": true,
+        "string.prototype.matchall>call-bind>es-errors": true,
+        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
+        "string.prototype.matchall>es-abstract>has-property-descriptors": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value>extend-shallow": true,
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true,
+        "@babel/register>clone-deep>is-plain-object": true,
+        "gulp>gulp-cli>matchdep>micromatch>braces>split-string": true
+      }
+    },
+    "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone": {
+      "packages": {
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true,
+        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>kind-of": true,
+        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>lazy-cache": true,
+        "lavamoat>lavamoat-core>merge-deep>clone-deep>shallow-clone>mixin-object": true
+      }
+    },
+    "browserify>shasum-object": {
+      "builtin": {
+        "crypto.createHash": true
+      },
+      "globals": {
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "@metamask/rpc-errors>fast-safe-stringify": true
+      }
+    },
+    "string.prototype.matchall>side-channel": {
+      "packages": {
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>get-intrinsic": true,
+        "string.prototype.matchall>es-abstract>object-inspect": true
+      }
+    },
+    "nyc>signal-exit": {
+      "builtin": {
+        "assert.equal": true,
+        "events": true
+      },
+      "globals": {
+        "process": true
+      }
+    },
+    "stylelint>table>slice-ansi": {
+      "packages": {
+        "stylelint>table>slice-ansi>ansi-styles": true,
+        "stylelint>table>slice-ansi>astral-regex": true,
+        "stylelint>table>slice-ansi>is-fullwidth-code-point": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>define-property": true,
+        "gulp>gulp-cli>isobject": true,
+        "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>snapdragon-util": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>snapdragon-util": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>braces>snapdragon-node>snapdragon-util>kind-of": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon": {
+      "builtin": {
+        "fs.readFileSync": true,
+        "path.dirname": true,
+        "util.inspect": true
+      },
+      "globals": {
+        "__filename": true
+      },
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>debug": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>extend-shallow": true,
+        "gulp>gulp-cli>liftoff>fined>parse-filepath>map-cache": true,
+        "resolve-url-loader>rework>css>source-map-resolve": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>source-map": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>use": true
       }
     },
     "source-map": {
@@ -7698,6 +7745,145 @@
         "fetch": true
       }
     },
+    "postcss>source-map-js": {
+      "globals": {
+        "console": true
+      }
+    },
+    "gulp-sourcemaps>css>source-map-resolve": {
+      "builtin": {
+        "path.sep": true,
+        "url.resolve": true
+      },
+      "globals": {
+        "TextDecoder": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "gulp-sourcemaps>css>source-map-resolve>atob": true,
+        "gulp-sourcemaps>css>source-map-resolve>decode-uri-component": true
+      }
+    },
+    "resolve-url-loader>rework>css>source-map-resolve": {
+      "builtin": {
+        "url.resolve": true
+      },
+      "globals": {
+        "TextDecoder": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "gulp-sourcemaps>css>source-map-resolve>atob": true,
+        "gulp-sourcemaps>css>source-map-resolve>decode-uri-component": true,
+        "resolve-url-loader>rework>css>source-map-resolve>source-map-url": true,
+        "resolve-url-loader>rework>css>urix": true
+      }
+    },
+    "terser>source-map-support": {
+      "builtin": {
+        "fs": true,
+        "path.dirname": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "XMLHttpRequest": true,
+        "console.error": true,
+        "process": true
+      },
+      "packages": {
+        "terser>source-map-support>buffer-from": true,
+        "terser>source-map-support>source-map": true
+      }
+    },
+    "resolve-url-loader>rework>css>source-map-resolve>source-map-url": {
+      "globals": {
+        "define": true
+      }
+    },
+    "eslint-plugin-jsdoc>spdx-expression-parse": {
+      "packages": {
+        "eslint-plugin-jsdoc>spdx-expression-parse>spdx-exceptions": true,
+        "eslint-plugin-jsdoc>spdx-expression-parse>spdx-license-ids": true
+      }
+    },
+    "stylelint>specificity": {
+      "globals": {
+        "define": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>braces>split-string": {
+      "packages": {
+        "gulp-zip>plugin-error>extend-shallow": true
+      }
+    },
+    "gulp-livereload>event-stream>split": {
+      "builtin": {
+        "string_decoder.StringDecoder": true
+      },
+      "packages": {
+        "debounce-stream>through": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>define-property": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>class-utils>static-extend>object-copy": true
+      }
+    },
+    "browserify>module-deps>stream-combiner2": {
+      "packages": {
+        "browserify>duplexer2": true,
+        "browserify>module-deps>stream-combiner2>readable-stream": true
+      }
+    },
+    "gulp-livereload>event-stream>stream-combiner": {
+      "packages": {
+        "debounce-stream>duplexer": true
+      }
+    },
+    "gulp>glob-watcher>async-done>stream-exhaust": {
+      "builtin": {
+        "stream.Writable": true,
+        "util.inherits": true
+      },
+      "globals": {
+        "setImmediate": true
+      }
+    },
+    "labeled-stream-splicer>stream-splicer": {
+      "globals": {
+        "process.nextTick": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "labeled-stream-splicer>stream-splicer>readable-stream": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width": {
+      "packages": {
+        "gulp>gulp-cli>yargs>string-width>code-point-at": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": true
+      }
+    },
+    "stylelint>table>string-width": {
+      "packages": {
+        "stylelint>table>string-width>emoji-regex": true,
+        "stylelint>table>slice-ansi>is-fullwidth-code-point": true,
+        "stylelint>table>string-width>strip-ansi": true
+      }
+    },
+    "yargs>string-width": {
+      "packages": {
+        "yargs>string-width>emoji-regex": true,
+        "yargs>string-width>is-fullwidth-code-point": true,
+        "eslint>strip-ansi": true
+      }
+    },
     "string.prototype.matchall": {
       "packages": {
         "string.prototype.matchall>call-bind": true,
@@ -7705,127 +7891,6 @@
         "string.prototype.matchall>es-abstract": true,
         "string.prototype.matchall>has-symbols": true,
         "string.prototype.matchall>regexp.prototype.flags": true
-      }
-    },
-    "string.prototype.matchall>call-bind": {
-      "packages": {
-        "browserify>has>function-bind": true,
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>call-bind>set-function-length": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>call-bind>es-define-property": {
-      "packages": {
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>call-bind>set-function-length": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>gopd": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>define-properties": {
-      "packages": {
-        "@lavamoat/lavapack>json-stable-stringify>object-keys": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
-      }
-    },
-    "string.prototype.matchall>define-properties>define-data-property": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>gopd": true
-      }
-    },
-    "string.prototype.matchall>es-abstract": {
-      "packages": {
-        "depcheck>is-core-module>hasown": true,
-        "eslint-plugin-react>array-includes>is-string": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>call-bind>es-define-property": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>es-object-atoms": true,
-        "string.prototype.matchall>es-abstract>es-set-tostringtag": true,
-        "string.prototype.matchall>es-abstract>es-to-primitive": true,
-        "string.prototype.matchall>es-abstract>gopd": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true,
-        "string.prototype.matchall>es-abstract>has-proto": true,
-        "string.prototype.matchall>es-abstract>is-callable": true,
-        "string.prototype.matchall>es-abstract>is-regex": true,
-        "string.prototype.matchall>es-abstract>object-inspect": true,
-        "string.prototype.matchall>es-abstract>safe-regex-test": true,
-        "string.prototype.matchall>es-abstract>string.prototype.trim": true,
-        "string.prototype.matchall>get-intrinsic": true,
-        "string.prototype.matchall>has-symbols": true,
-        "string.prototype.matchall>internal-slot": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>es-object-atoms": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>es-set-tostringtag": {
-      "packages": {
-        "depcheck>is-core-module>hasown": true,
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>es-to-primitive": {
-      "packages": {
-        "@metamask/eth-token-tracker>deep-equal>is-date-object": true,
-        "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": true,
-        "string.prototype.matchall>es-abstract>is-callable": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>es-to-primitive>is-symbol": {
-      "packages": {
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>gopd": {
-      "packages": {
-        "string.prototype.matchall>get-intrinsic": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>has-property-descriptors": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-define-property": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-callable": {
-      "globals": {
-        "document": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>is-regex": {
-      "packages": {
-        "koa>is-generator-function>has-tostringtag": true,
-        "string.prototype.matchall>call-bind": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>object-inspect": {
-      "builtin": {
-        "util.inspect": true
-      },
-      "globals": {
-        "HTMLElement": true,
-        "WeakRef": true
-      }
-    },
-    "string.prototype.matchall>es-abstract>safe-regex-test": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>is-regex": true
       }
     },
     "string.prototype.matchall>es-abstract>string.prototype.trim": {
@@ -7836,48 +7901,192 @@
         "string.prototype.matchall>es-abstract>es-object-atoms": true
       }
     },
-    "string.prototype.matchall>get-intrinsic": {
+    "browserify>string_decoder": {
+      "packages": {
+        "koa>content-disposition>safe-buffer": true
+      }
+    },
+    "gulp-livereload>tiny-lr>body>raw-body>string_decoder": {
+      "builtin": {
+        "buffer.Buffer": true
+      }
+    },
+    "vinyl-buffer>bl>readable-stream>string_decoder": {
+      "packages": {
+        "vinyl-buffer>bl>readable-stream>string_decoder>safe-buffer": true
+      }
+    },
+    "browserify>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>readable-stream>safe-buffer": true
+      }
+    },
+    "browserify>concat-stream>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>concat-stream>readable-stream>safe-buffer": true
+      }
+    },
+    "browserify>duplexer2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>duplexer2>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>string_decoder": {
+      "packages": {
+        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>lead>flush-write-stream>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>glob-stream>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp-watch>readable-stream>string_decoder": {
+      "packages": {
+        "gulp-watch>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>lazystream>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>lazystream>readable-stream>safe-buffer": true
+      }
+    },
+    "browserify>module-deps>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>module-deps>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>glob-stream>ordered-read-streams>readable-stream>safe-buffer": true
+      }
+    },
+    "browserify>read-only-stream>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>read-only-stream>readable-stream>safe-buffer": true
+      }
+    },
+    "browserify>module-deps>stream-combiner2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>module-deps>stream-combiner2>readable-stream>safe-buffer": true
+      }
+    },
+    "labeled-stream-splicer>stream-splicer>readable-stream>string_decoder": {
+      "packages": {
+        "labeled-stream-splicer>stream-splicer>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>string_decoder": {
+      "packages": {
+        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "browserify>browser-pack>through2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>browser-pack>through2>readable-stream>string_decoder>safe-buffer": true
+      }
+    },
+    "vinyl>cloneable-readable>through2>readable-stream>string_decoder": {
+      "packages": {
+        "vinyl>cloneable-readable>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "browserify>deps-sort>through2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>deps-sort>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp-sort>through2>readable-stream>string_decoder": {
+      "packages": {
+        "gulp-sort>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp-sourcemaps>through2>readable-stream>string_decoder": {
+      "packages": {
+        "gulp-sourcemaps>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "browserify>insert-module-globals>through2>readable-stream>string_decoder": {
+      "packages": {
+        "browserify>insert-module-globals>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream>string_decoder>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>to-through>through2>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>to-through>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "vinyl-source-stream>through2>readable-stream>string_decoder": {
+      "packages": {
+        "vinyl-source-stream>through2>readable-stream>safe-buffer": true
+      }
+    },
+    "gulp>vinyl-fs>readable-stream>string_decoder": {
+      "packages": {
+        "gulp>vinyl-fs>readable-stream>safe-buffer": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities>character-entities-html4": true,
+        "react-syntax-highlighter>refractor>parse-entities>character-entities-legacy": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-alphanumerical": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
+        "react-syntax-highlighter>refractor>parse-entities>is-hexadecimal": true
+      }
+    },
+    "postcss-discard-font-face>postcss>chalk>strip-ansi": {
+      "packages": {
+        "postcss-discard-font-face>postcss>chalk>strip-ansi>ansi-regex": true
+      }
+    },
+    "eslint>strip-ansi": {
+      "packages": {
+        "eslint>strip-ansi>ansi-regex": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": {
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi>ansi-regex": true
+      }
+    },
+    "stylelint>table>string-width>strip-ansi": {
+      "packages": {
+        "stylelint>table>string-width>strip-ansi>ansi-regex": true
+      }
+    },
+    "gulp-watch>vinyl-file>strip-bom-stream": {
+      "packages": {
+        "gulp-watch>vinyl-file>strip-bom-stream>first-chunk-stream": true,
+        "gulp-watch>vinyl-file>strip-bom": true
+      }
+    },
+    "gulp-watch>vinyl-file>strip-bom": {
       "globals": {
-        "AggregateError": true,
-        "FinalizationRegistry": true,
-        "WeakRef": true
+        "Buffer.isBuffer": true
       },
       "packages": {
-        "browserify>has>function-bind": true,
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>es-abstract>has-proto": true,
-        "string.prototype.matchall>has-symbols": true
-      }
-    },
-    "string.prototype.matchall>internal-slot": {
-      "packages": {
-        "depcheck>is-core-module>hasown": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>side-channel": true
-      }
-    },
-    "string.prototype.matchall>regexp.prototype.flags": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties": true,
-        "string.prototype.matchall>regexp.prototype.flags>set-function-name": true
-      }
-    },
-    "string.prototype.matchall>regexp.prototype.flags>set-function-name": {
-      "packages": {
-        "string.prototype.matchall>call-bind>es-errors": true,
-        "string.prototype.matchall>define-properties>define-data-property": true,
-        "string.prototype.matchall>es-abstract>function.prototype.name>functions-have-names": true,
-        "string.prototype.matchall>es-abstract>has-property-descriptors": true
-      }
-    },
-    "string.prototype.matchall>side-channel": {
-      "packages": {
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract>object-inspect": true,
-        "string.prototype.matchall>get-intrinsic": true
+        "gulp>vinyl-fs>remove-bom-buffer>is-utf8": true
       }
     },
     "stylelint": {
@@ -7906,32 +8115,29 @@
         "process.stdout.isTTY": true
       },
       "packages": {
-        "chalk": true,
-        "del>slash": true,
-        "eslint>ignore": true,
-        "eslint>imurmurhash": true,
-        "fast-glob>micromatch": true,
-        "globby": true,
-        "lodash": true,
-        "mocha>log-symbols": true,
-        "nock>debug": true,
-        "nyc>resolve-from": true,
         "stylelint>@stylelint/postcss-css-in-js": true,
         "stylelint>@stylelint/postcss-markdown": true,
         "stylelint>autoprefixer": true,
         "stylelint>balanced-match": true,
+        "chalk": true,
         "stylelint>cosmiconfig": true,
+        "nock>debug": true,
         "stylelint>execall": true,
         "stylelint>file-entry-cache": true,
         "stylelint>global-modules": true,
+        "globby": true,
         "stylelint>globjoin": true,
         "stylelint>html-tags": true,
+        "eslint>ignore": true,
         "stylelint>import-lazy": true,
+        "eslint>imurmurhash": true,
         "stylelint>known-css-properties": true,
         "stylelint>leven": true,
+        "lodash": true,
+        "mocha>log-symbols": true,
         "stylelint>mathml-tag-names": true,
+        "fast-glob>micromatch": true,
         "stylelint>normalize-selector": true,
-        "stylelint>postcss": true,
         "stylelint>postcss-html": true,
         "stylelint>postcss-less": true,
         "stylelint>postcss-media-query-parser": true,
@@ -7943,58 +8149,605 @@
         "stylelint>postcss-selector-parser": true,
         "stylelint>postcss-syntax": true,
         "stylelint>postcss-value-parser": true,
+        "stylelint>postcss": true,
+        "nyc>resolve-from": true,
+        "del>slash": true,
         "stylelint>specificity": true,
+        "yargs>string-width": true,
         "stylelint>style-search": true,
         "stylelint>sugarss": true,
         "stylelint>svg-tags": true,
         "stylelint>table": true,
-        "stylelint>write-file-atomic": true,
-        "yargs>string-width": true
+        "stylelint>write-file-atomic": true
       }
     },
-    "stylelint>@stylelint/postcss-css-in-js": {
+    "stylelint>sugarss": {
+      "packages": {
+        "stylelint>sugarss>postcss": true
+      }
+    },
+    "superstruct": {
       "globals": {
-        "__dirname": true
+        "console.warn": true,
+        "define": true
+      }
+    },
+    "chalk>supports-color": {
+      "builtin": {
+        "os.release": true,
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.platform": true
       },
       "packages": {
-        "@babel/core": true,
-        "stylelint>postcss": true,
-        "stylelint>postcss-syntax": true
+        "chalk>supports-color>has-flag": true
       }
     },
-    "stylelint>@stylelint/postcss-markdown": {
+    "@babel/code-frame>@babel/highlight>chalk>supports-color": {
+      "builtin": {
+        "os.release": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.platform": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.versions.node.split": true
+      },
       "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark": true,
-        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after": true,
-        "stylelint>postcss-html": true,
-        "stylelint>postcss-syntax": true
+        "gulp-livereload>chalk>supports-color>has-flag": true
       }
     },
-    "stylelint>@stylelint/postcss-markdown>remark": {
+    "gulp-livereload>chalk>supports-color": {
+      "builtin": {
+        "os.release": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.platform": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.versions.node.split": true
+      },
       "packages": {
-        "react-markdown>unified": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": true
+        "gulp-livereload>chalk>supports-color>has-flag": true
       }
     },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse": {
+    "postcss-discard-font-face>postcss>chalk>supports-color": {
+      "globals": {
+        "process.argv": true,
+        "process.env": true,
+        "process.platform": true,
+        "process.stdout": true
+      }
+    },
+    "mocha>supports-color": {
+      "builtin": {
+        "os.release": true,
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.platform": true
+      },
       "packages": {
-        "react-syntax-highlighter>refractor>parse-entities": true,
-        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>collapse-white-space": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-word-character": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim-trailing-lines": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>vfile-location": true,
+        "mocha>supports-color>has-flag": true
+      }
+    },
+    "postcss-discard-font-face>postcss>supports-color": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "postcss-discard-font-face>postcss>supports-color>has-flag": true
+      }
+    },
+    "browserify>syntax-error": {
+      "packages": {
+        "browserify>syntax-error>acorn-node": true
+      }
+    },
+    "stylelint>table": {
+      "globals": {
+        "process.stdout.write": true
+      },
+      "packages": {
+        "eslint>ajv": true,
+        "lodash": true,
+        "stylelint>table>slice-ansi": true,
+        "stylelint>table>string-width": true
+      }
+    },
+    "terser": {
+      "globals": {
+        "Buffer": true,
+        "atob": true,
+        "btoa": true,
+        "console.log": true,
+        "console.warn": true,
+        "define": true,
+        "process": true
+      },
+      "packages": {
+        "terser>@jridgewell/source-map": true,
+        "jsdom>acorn": true
+      }
+    },
+    "through2": {
+      "packages": {
+        "readable-stream": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter": {
+      "packages": {
+        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2": true,
         "watchify>xtend": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/identity-map>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "readable-stream": true
+      }
+    },
+    "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp-sourcemaps>@gulp-sourcemaps/map-sources>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "bify-module-groups>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "readable-stream": true
+      }
+    },
+    "browserify>browser-pack>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "browserify>browser-pack>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "browserify>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "browserify>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "vinyl>cloneable-readable>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "vinyl>cloneable-readable>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "browserify>deps-sort>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "browserify>deps-sort>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp>vinyl-fs>fs-mkdirp-stream>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>fs-mkdirp-stream>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp-sort>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp-sort>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp-sourcemaps>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp-sourcemaps>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp-stylelint>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "readable-stream": true
+      }
+    },
+    "gulp-zip>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "readable-stream": true
+      }
+    },
+    "browserify>insert-module-globals>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "browserify>insert-module-globals>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "browserify>module-deps>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "browserify>module-deps>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp>vinyl-fs>remove-bom-stream>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>remove-bom-stream>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp>vinyl-fs>to-through>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>to-through>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "vinyl-buffer>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "vinyl-buffer>bl>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp>vinyl-fs>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "vinyl-source-stream>through2": {
+      "builtin": {
+        "util.inherits": true
+      },
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "vinyl-source-stream>through2>readable-stream": true,
+        "watchify>xtend": true
+      }
+    },
+    "debounce-stream>through": {
+      "builtin": {
+        "stream": true
+      },
+      "globals": {
+        "process.nextTick": true
+      }
+    },
+    "gulp-sourcemaps>debug-fabulous>memoizee>timers-ext": {
+      "packages": {
+        "resolve-url-loader>es6-iterator>es5-ext": true
+      }
+    },
+    "gulp-livereload>tiny-lr": {
+      "builtin": {
+        "events": true,
+        "fs": true,
+        "http": true,
+        "https": true,
+        "url.parse": true
+      },
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "gulp-livereload>tiny-lr>body": true,
+        "gulp-livereload>tiny-lr>debug": true,
+        "gulp-livereload>tiny-lr>faye-websocket": true,
+        "react>object-assign": true,
+        "@storybook/addon-knobs>qs": true
+      }
+    },
+    "gulp>vinyl-fs>glob-stream>to-absolute-glob": {
+      "builtin": {
+        "path.resolve": true
+      },
+      "globals": {
+        "process.cwd": true,
+        "process.platform": true
+      },
+      "packages": {
+        "gulp>gulp-cli>replace-homedir>is-absolute": true,
+        "gulp>glob-watcher>is-negated-glob": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>to-object-path": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>to-object-path>kind-of": true
+      }
+    },
+    "chokidar>braces>fill-range>to-regex-range": {
+      "packages": {
+        "chokidar>braces>fill-range>to-regex-range>is-number": true
+      }
+    },
+    "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>to-regex-range": {
+      "packages": {
+        "gulp>glob-watcher>anymatch>micromatch>braces>fill-range>is-number": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>to-regex": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>to-regex>define-property": true,
+        "gulp-zip>plugin-error>extend-shallow": true,
+        "gulp>gulp-cli>matchdep>micromatch>regex-not": true,
+        "gulp>gulp-cli>matchdep>micromatch>to-regex>safe-regex": true
+      }
+    },
+    "gulp>vinyl-fs>to-through": {
+      "packages": {
+        "gulp>vinyl-fs>to-through>through2": true
+      }
+    },
+    "ts-node": {
+      "builtin": {
+        "assert": true,
+        "console.Console": true,
+        "fs.Stats": true,
+        "fs.readFileSync": true,
+        "fs.realpathSync": true,
+        "fs.statSync": true,
+        "module": true,
+        "os.homedir": true,
+        "path": true,
+        "repl.Recoverable": true,
+        "repl.start": true,
+        "url.URL": true,
+        "url.fileURLToPath": true,
+        "url.format": true,
+        "url.parse": true,
+        "url.pathToFileURL": true,
+        "util.inspect.custom": true,
+        "vm.Script": true
+      },
+      "globals": {
+        "Buffer.from": true,
+        "ERR_INVALID_ARG_VALUE": true,
+        "__dirname": true,
+        "console": true,
+        "process": true,
+        "value": true
+      },
+      "packages": {
+        "ts-node>@cspotcode/source-map-support": true,
+        "ts-node>@tsconfig/node10": true,
+        "ts-node>@tsconfig/node12": true,
+        "ts-node>@tsconfig/node14": true,
+        "ts-node>@tsconfig/node16": true,
+        "ts-node>acorn-walk": true,
+        "jsdom>acorn": true,
+        "ts-node>arg": true,
+        "ts-node>create-require": true,
+        "ts-node>diff": true,
+        "ts-node>make-error": true,
+        "ts-node>v8-compile-cache-lib": true,
+        "ts-node>yn": true
+      }
+    },
+    "eslint-plugin-import>tsconfig-paths": {
+      "builtin": {
+        "fs.existsSync": true,
+        "fs.lstatSync": true,
+        "fs.readFile": true,
+        "fs.readFileSync": true,
+        "fs.stat": true,
+        "fs.statSync": true,
+        "module._resolveFilename": true,
+        "module.builtinModules": true,
+        "path.dirname": true,
+        "path.isAbsolute": true,
+        "path.join": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "console.warn": true,
+        "process.argv.slice": true,
+        "process.cwd": true,
+        "process.env": true
+      },
+      "packages": {
+        "eslint-plugin-import>tsconfig-paths>json5": true,
+        "wait-on>minimist": true,
+        "eslint-plugin-import>tsconfig-paths>strip-bom": true
+      }
+    },
+    "tsutils": {
+      "packages": {
+        "tslib": true,
+        "typescript": true
+      }
+    },
+    "eslint>levn>type-check": {
+      "packages": {
+        "eslint>levn>prelude-ls": true
+      }
+    },
+    "stylelint>write-file-atomic>typedarray-to-buffer": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "stylelint>write-file-atomic>is-typedarray": true
+      }
+    },
+    "typescript": {
+      "builtin": {
+        "buffer.Buffer": true,
+        "crypto": true,
+        "fs": true,
+        "inspector": true,
+        "module.findPnpApi": true,
+        "os.EOL": true,
+        "os.platform": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true,
+        "perf_hooks.PerformanceObserver": true,
+        "perf_hooks.performance": true
+      },
+      "globals": {
+        "Intl.Collator": true,
+        "PerformanceObserver": true,
+        "__dirname": true,
+        "__filename": true,
+        "clearTimeout": true,
+        "console": true,
+        "gc": true,
+        "globalThis": true,
+        "onProfilerEvent": true,
+        "performance": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "terser>source-map-support": true
+      }
+    },
+    "browserify>insert-module-globals>undeclared-identifiers": {
+      "packages": {
+        "browserify>syntax-error>acorn-node": true,
+        "browserify>insert-module-globals>undeclared-identifiers>get-assigned-identifiers": true,
+        "watchify>xtend": true
+      }
+    },
+    "gulp>undertaker": {
+      "builtin": {
+        "assert": true,
+        "events.EventEmitter": true,
+        "util.inherits": true
+      },
+      "globals": {
+        "process.env.UNDERTAKER_SETTLE": true,
+        "process.env.UNDERTAKER_TIME_RESOLUTION": true,
+        "process.hrtime": true
+      },
+      "packages": {
+        "gulp>undertaker>arr-flatten": true,
+        "gulp>undertaker>arr-map": true,
+        "gulp>undertaker>bach": true,
+        "gulp>undertaker>collection-map": true,
+        "gulp>undertaker>es6-weak-map": true,
+        "gulp>undertaker>last-run": true,
+        "gulp>undertaker>object.defaults": true,
+        "gulp>undertaker>object.reduce": true,
+        "gulp>undertaker>undertaker-registry": true
       }
     },
     "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": {
@@ -8003,46 +8756,34 @@
         "watchify>xtend": true
       }
     },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": {
+    "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-ecmascript": {
       "packages": {
-        "react-markdown>unist-util-visit": true
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-ecmascript>unicode-canonical-property-names-ecmascript": true,
+        "@babel/preset-env>@babel/plugin-transform-dotall-regex>@babel/helper-create-regexp-features-plugin>regexpu-core>unicode-match-property-ecmascript>unicode-property-aliases-ecmascript": true
       }
     },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": {
+    "react-markdown>unified": {
       "packages": {
-        "react-syntax-highlighter>refractor>parse-entities": true,
-        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>is-alphanumeric": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>longest-streak": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>markdown-table": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": true,
-        "watchify>xtend": true
+        "react-markdown>unified>bail": true,
+        "react-markdown>unified>extend": true,
+        "react-markdown>unified>is-buffer": true,
+        "mocha>yargs-unparser>is-plain-obj": true,
+        "react-markdown>unified>trough": true,
+        "react-markdown>vfile": true
       }
     },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>markdown-table": {
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>union-value": {
       "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
+        "gulp-zip>plugin-error>arr-union": true,
+        "gulp>gulp-cli>array-sort>get-value": true,
+        "gulp-watch>anymatch>micromatch>object.omit>is-extendable": true,
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>set-value": true
       }
     },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": {
+    "gulp>vinyl-fs>glob-stream>unique-stream": {
       "packages": {
-        "react-markdown>unist-util-visit": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": {
-      "packages": {
-        "react-syntax-highlighter>refractor>parse-entities>character-entities-legacy": true,
-        "react-syntax-highlighter>refractor>parse-entities>is-alphanumerical": true,
-        "react-syntax-highlighter>refractor>parse-entities>is-decimal": true,
-        "react-syntax-highlighter>refractor>parse-entities>is-hexadecimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities>character-entities-html4": true
+        "@lavamoat/lavapack>json-stable-stringify": true,
+        "gulp>vinyl-fs>glob-stream>unique-stream>through2-filter": true
       }
     },
     "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after": {
@@ -8050,150 +8791,261 @@
         "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after>unist-util-is": true
       }
     },
-    "stylelint>autoprefixer": {
-      "globals": {
-        "console": true,
-        "process.cwd": true,
-        "process.env.AUTOPREFIXER_GRID": true
-      },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": {
       "packages": {
-        "autoprefixer>caniuse-lite": true,
-        "autoprefixer>normalize-range": true,
-        "browserslist": true,
-        "stylelint>autoprefixer>num2fraction": true,
-        "stylelint>postcss": true,
-        "stylelint>postcss-value-parser": true,
-        "stylelint>postcss>picocolors": true
+        "react-markdown>unist-util-visit": true
       }
     },
-    "stylelint>cosmiconfig": {
+    "react-markdown>unist-util-visit>unist-util-visit-parents": {
+      "packages": {
+        "react-markdown>unist-util-visit>unist-util-is": true
+      }
+    },
+    "react-markdown>unist-util-visit": {
+      "packages": {
+        "react-markdown>unist-util-visit>unist-util-visit-parents": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value": {
+      "packages": {
+        "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value>has-value": true,
+        "gulp>gulp-cli>isobject": true
+      }
+    },
+    "uri-js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "resolve-url-loader>rework>css>urix": {
       "builtin": {
-        "fs": true,
-        "os": true,
-        "path": true
+        "path.sep": true
+      }
+    },
+    "gulp>gulp-cli>matchdep>micromatch>snapdragon>use": {
+      "packages": {
+        "@babel/register>clone-deep>kind-of": true
+      }
+    },
+    "readable-stream>util-deprecate": {
+      "builtin": {
+        "util.deprecate": true
+      }
+    },
+    "ts-node>v8-compile-cache-lib": {
+      "builtin": {
+        "crypto.createHash": true,
+        "fs.mkdirSync": true,
+        "fs.readFileSync": true,
+        "fs.statSync": true,
+        "fs.unlinkSync": true,
+        "fs.writeFileSync": true,
+        "module._cache": true,
+        "module._extensions": true,
+        "module._resolveFilename": true,
+        "module._resolveLookupPaths": true,
+        "module.prototype._compile": true,
+        "module.wrap": true,
+        "os.tmpdir": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true,
+        "vm.Script": true
+      },
+      "globals": {
+        "Buffer": true,
+        "process": true
+      }
+    },
+    "react-markdown>vfile>vfile-message": {
+      "packages": {
+        "react-markdown>vfile>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>vfile": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.sep": true
       },
       "globals": {
         "process.cwd": true
       },
       "packages": {
-        "depcheck>cosmiconfig>parse-json": true,
-        "eslint>@eslint/eslintrc>import-fresh": true,
-        "globby>dir-glob>path-type": true,
-        "stylelint>cosmiconfig>yaml": true
+        "react-markdown>vfile>is-buffer": true,
+        "react-markdown>vfile>replace-ext": true,
+        "react-markdown>vfile>vfile-message": true
       }
     },
-    "stylelint>cosmiconfig>yaml": {
-      "globals": {
-        "Buffer": true,
-        "YAML_SILENCE_DEPRECATION_WARNINGS": true,
-        "YAML_SILENCE_WARNINGS": true,
-        "atob": true,
-        "btoa": true,
-        "console.warn": true,
-        "process": true
-      }
-    },
-    "stylelint>execall": {
-      "packages": {
-        "stylelint>execall>clone-regexp": true
-      }
-    },
-    "stylelint>execall>clone-regexp": {
-      "packages": {
-        "stylelint>execall>clone-regexp>is-regexp": true
-      }
-    },
-    "stylelint>file-entry-cache": {
+    "vinyl": {
       "builtin": {
-        "crypto.createHash": true,
-        "fs.readFileSync": true,
-        "fs.statSync": true,
-        "path.basename": true,
-        "path.dirname": true
-      },
-      "packages": {
-        "stylelint>file-entry-cache>flat-cache": true
-      }
-    },
-    "stylelint>file-entry-cache>flat-cache": {
-      "builtin": {
-        "fs.existsSync": true,
-        "fs.readFileSync": true,
+        "buffer.Buffer.isBuffer": true,
         "path.basename": true,
         "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.normalize": true,
+        "path.relative": true,
+        "util.inspect.custom": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "vinyl>clone-buffer": true,
+        "vinyl>clone-stats": true,
+        "vinyl>clone": true,
+        "vinyl>cloneable-readable": true,
+        "vinyl>remove-trailing-separator": true,
+        "vinyl>replace-ext": true
+      }
+    },
+    "vinyl-buffer": {
+      "packages": {
+        "vinyl-buffer>bl": true,
+        "vinyl-buffer>through2": true
+      }
+    },
+    "gulp-watch>vinyl-file": {
+      "builtin": {
         "path.resolve": true
       },
       "globals": {
-        "__dirname": true
+        "process.cwd": true
       },
       "packages": {
-        "stylelint>file-entry-cache>flat-cache>flatted": true,
-        "stylelint>file-entry-cache>flat-cache>rimraf": true,
-        "stylelint>file-entry-cache>flat-cache>write": true
+        "del>graceful-fs": true,
+        "gulp-watch>vinyl-file>pify": true,
+        "gh-pages>globby>pinkie-promise": true,
+        "gulp-watch>vinyl-file>strip-bom-stream": true,
+        "gulp-watch>vinyl-file>strip-bom": true,
+        "gulp-watch>vinyl-file>vinyl": true
       }
     },
-    "stylelint>file-entry-cache>flat-cache>rimraf": {
+    "gulp>vinyl-fs": {
       "builtin": {
-        "assert": true,
-        "fs": true,
+        "os.platform": true,
+        "path.relative": true,
+        "path.resolve": true,
+        "util.inherits": true
+      },
+      "globals": {
+        "Buffer.isBuffer": true,
+        "process.cwd": true,
+        "process.geteuid": true,
+        "process.getuid": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>fs-mkdirp-stream": true,
+        "gulp>vinyl-fs>glob-stream": true,
+        "del>graceful-fs": true,
+        "gulp>vinyl-fs>is-valid-glob": true,
+        "gulp>vinyl-fs>lazystream": true,
+        "gulp>vinyl-fs>lead": true,
+        "gulp>vinyl-fs>object.assign": true,
+        "gulp>vinyl-fs>pumpify": true,
+        "gulp>vinyl-fs>readable-stream": true,
+        "gulp>vinyl-fs>remove-bom-buffer": true,
+        "gulp>vinyl-fs>remove-bom-stream": true,
+        "gulp>vinyl-fs>resolve-options": true,
+        "gulp>vinyl-fs>through2": true,
+        "gulp>vinyl-fs>to-through": true,
+        "gulp>vinyl-fs>value-or-function": true,
+        "vinyl": true,
+        "gulp>vinyl-fs>vinyl-sourcemap": true
+      }
+    },
+    "vinyl-source-stream": {
+      "builtin": {
+        "path.resolve": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "vinyl-source-stream>through2": true,
+        "vinyl": true
+      }
+    },
+    "gulp>vinyl-fs>vinyl-sourcemap": {
+      "builtin": {
+        "path.dirname": true,
+        "path.join": true,
+        "path.relative": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "gulp>vinyl-fs>vinyl-sourcemap>append-buffer": true,
+        "nyc>convert-source-map": true,
+        "del>graceful-fs": true,
+        "gulp-watch>anymatch>normalize-path": true,
+        "gulp>vinyl-fs>vinyl-sourcemap>now-and-later": true,
+        "gulp>vinyl-fs>remove-bom-buffer": true,
+        "vinyl": true
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "packages": {
+        "vinyl-sourcemaps-apply>source-map": true
+      }
+    },
+    "gulp-watch>vinyl-file>vinyl": {
+      "builtin": {
+        "buffer.Buffer": true,
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.relative": true,
+        "stream.PassThrough": true,
+        "stream.Stream": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "gulp-watch>vinyl-file>vinyl>clone-stats": true,
+        "@metamask/jazzicon>color>clone": true,
+        "gulp-watch>vinyl-file>vinyl>replace-ext": true
+      }
+    },
+    "watchify": {
+      "builtin": {
         "path.join": true
       },
       "globals": {
-        "process.platform": true,
+        "clearTimeout": true,
         "setTimeout": true
       },
       "packages": {
-        "nyc>glob": true
+        "chokidar>anymatch": true,
+        "chokidar": true,
+        "through2": true,
+        "watchify>xtend": true
       }
     },
-    "stylelint>file-entry-cache>flat-cache>write": {
+    "webpack-dev-server>sockjs>websocket-driver": {
       "builtin": {
-        "fs.createWriteStream": true,
-        "fs.writeFile": true,
-        "fs.writeFileSync": true,
-        "path.dirname": true
-      },
-      "packages": {
-        "mockttp>portfinder>mkdirp": true
-      }
-    },
-    "stylelint>global-modules": {
-      "builtin": {
-        "path.resolve": true
+        "crypto.createHash": true,
+        "crypto.randomBytes": true,
+        "events.EventEmitter": true,
+        "stream.Stream": true,
+        "url.parse": true,
+        "util.inherits": true
       },
       "globals": {
-        "process.env.OSTYPE": true,
-        "process.platform": true
+        "process.version": true
       },
       "packages": {
-        "stylelint>global-modules>global-prefix": true
-      }
-    },
-    "stylelint>global-modules>global-prefix": {
-      "builtin": {
-        "fs.readFileSync": true,
-        "fs.realpathSync": true,
-        "os.homedir": true,
-        "path.dirname": true,
-        "path.join": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "process.env.APPDATA": true,
-        "process.env.DESTDIR": true,
-        "process.env.OSTYPE": true,
-        "process.env.PREFIX": true,
-        "process.execPath": true,
-        "process.platform": true
-      },
-      "packages": {
-        "stylelint>global-modules>global-prefix>ini": true,
-        "stylelint>global-modules>global-prefix>which": true
-      }
-    },
-    "stylelint>global-modules>global-prefix>ini": {
-      "globals": {
-        "process": true
+        "webpack-dev-server>sockjs>websocket-driver>http-parser-js": true,
+        "koa>content-disposition>safe-buffer": true,
+        "webpack-dev-server>sockjs>websocket-driver>websocket-extensions": true
       }
     },
     "stylelint>global-modules>global-prefix>which": {
@@ -8211,310 +9063,16 @@
         "@sentry/cli>which>isexe": true
       }
     },
-    "stylelint>globjoin": {
-      "builtin": {
-        "path.join": true
-      }
-    },
-    "stylelint>normalize-selector": {
-      "globals": {
-        "define": true
-      }
-    },
-    "stylelint>postcss": {
-      "builtin": {
-        "fs": true,
-        "path": true
-      },
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "console": true,
-        "process.env.NODE_ENV": true
-      },
+    "@storybook/react>@storybook/node-logger>npmlog>gauge>wide-align": {
       "packages": {
-        "stylelint>postcss>picocolors": true,
-        "stylelint>postcss>source-map": true
+        "yargs>string-width": true
       }
     },
-    "stylelint>postcss-html": {
-      "globals": {
-        "__dirname": true
-      },
+    "yargs>cliui>wrap-ansi": {
       "packages": {
-        "stylelint>postcss-html>htmlparser2": true,
-        "stylelint>postcss-syntax": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2": {
-      "builtin": {
-        "buffer.Buffer": true,
-        "events.EventEmitter": true,
-        "string_decoder.StringDecoder": true
-      },
-      "packages": {
-        "pumpify>inherits": true,
-        "readable-stream": true,
-        "stylelint>postcss-html>htmlparser2>domelementtype": true,
-        "stylelint>postcss-html>htmlparser2>domhandler": true,
-        "stylelint>postcss-html>htmlparser2>domutils": true,
-        "stylelint>postcss-html>htmlparser2>entities": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2>domhandler": {
-      "packages": {
-        "stylelint>postcss-html>htmlparser2>domelementtype": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2>domutils": {
-      "packages": {
-        "stylelint>postcss-html>htmlparser2>domelementtype": true,
-        "stylelint>postcss-html>htmlparser2>domutils>dom-serializer": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2>domutils>dom-serializer": {
-      "packages": {
-        "stylelint>postcss-html>htmlparser2>domelementtype": true,
-        "stylelint>postcss-html>htmlparser2>entities": true
-      }
-    },
-    "stylelint>postcss-less": {
-      "packages": {
-        "stylelint>postcss-less>postcss": true
-      }
-    },
-    "stylelint>postcss-less>postcss": {
-      "builtin": {
-        "fs": true,
-        "path": true
-      },
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "console": true,
-        "process.env.NODE_ENV": true
-      },
-      "packages": {
-        "stylelint>postcss-less>postcss>picocolors": true,
-        "stylelint>postcss-less>postcss>source-map": true
-      }
-    },
-    "stylelint>postcss-less>postcss>picocolors": {
-      "builtin": {
-        "tty.isatty": true
-      },
-      "globals": {
-        "process.argv.includes": true,
-        "process.env": true,
-        "process.platform": true
-      }
-    },
-    "stylelint>postcss-reporter": {
-      "packages": {
-        "lodash": true
-      }
-    },
-    "stylelint>postcss-safe-parser": {
-      "packages": {
-        "stylelint>postcss-safe-parser>postcss": true
-      }
-    },
-    "stylelint>postcss-safe-parser>postcss": {
-      "builtin": {
-        "fs": true,
-        "path": true
-      },
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "console": true,
-        "process.env.NODE_ENV": true
-      },
-      "packages": {
-        "stylelint>postcss-safe-parser>postcss>picocolors": true,
-        "stylelint>postcss-safe-parser>postcss>source-map": true
-      }
-    },
-    "stylelint>postcss-safe-parser>postcss>picocolors": {
-      "builtin": {
-        "tty.isatty": true
-      },
-      "globals": {
-        "process.argv.includes": true,
-        "process.env": true,
-        "process.platform": true
-      }
-    },
-    "stylelint>postcss-sass": {
-      "packages": {
-        "stylelint>postcss-sass>gonzales-pe": true,
-        "stylelint>postcss-sass>postcss": true
-      }
-    },
-    "stylelint>postcss-sass>gonzales-pe": {
-      "globals": {
-        "console.error": true,
-        "define": true
-      }
-    },
-    "stylelint>postcss-sass>postcss": {
-      "builtin": {
-        "fs": true,
-        "path": true
-      },
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "console": true,
-        "process.env.NODE_ENV": true
-      },
-      "packages": {
-        "stylelint>postcss-sass>postcss>picocolors": true,
-        "stylelint>postcss-sass>postcss>source-map": true
-      }
-    },
-    "stylelint>postcss-sass>postcss>picocolors": {
-      "builtin": {
-        "tty.isatty": true
-      },
-      "globals": {
-        "process.argv.includes": true,
-        "process.env": true,
-        "process.platform": true
-      }
-    },
-    "stylelint>postcss-scss": {
-      "packages": {
-        "stylelint>postcss-scss>postcss": true
-      }
-    },
-    "stylelint>postcss-scss>postcss": {
-      "builtin": {
-        "fs": true,
-        "path": true
-      },
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "console": true,
-        "process.env.NODE_ENV": true
-      },
-      "packages": {
-        "stylelint>postcss-scss>postcss>picocolors": true,
-        "stylelint>postcss-scss>postcss>source-map": true
-      }
-    },
-    "stylelint>postcss-scss>postcss>picocolors": {
-      "builtin": {
-        "tty.isatty": true
-      },
-      "globals": {
-        "process.argv.includes": true,
-        "process.env": true,
-        "process.platform": true
-      }
-    },
-    "stylelint>postcss-selector-parser": {
-      "packages": {
-        "readable-stream>util-deprecate": true,
-        "stylelint>postcss-selector-parser>cssesc": true
-      }
-    },
-    "stylelint>postcss-syntax": {
-      "builtin": {
-        "path.isAbsolute": true,
-        "path.resolve": true,
-        "path.sep": true
-      },
-      "packages": {
-        "stylelint>postcss": true
-      }
-    },
-    "stylelint>postcss>picocolors": {
-      "builtin": {
-        "tty.isatty": true
-      },
-      "globals": {
-        "process.argv.includes": true,
-        "process.env": true,
-        "process.platform": true
-      }
-    },
-    "stylelint>specificity": {
-      "globals": {
-        "define": true
-      }
-    },
-    "stylelint>sugarss": {
-      "packages": {
-        "stylelint>sugarss>postcss": true
-      }
-    },
-    "stylelint>sugarss>postcss": {
-      "builtin": {
-        "fs": true,
-        "path": true
-      },
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "console": true,
-        "process.env.NODE_ENV": true
-      },
-      "packages": {
-        "stylelint>sugarss>postcss>picocolors": true,
-        "stylelint>sugarss>postcss>source-map": true
-      }
-    },
-    "stylelint>sugarss>postcss>picocolors": {
-      "builtin": {
-        "tty.isatty": true
-      },
-      "globals": {
-        "process.argv.includes": true,
-        "process.env": true,
-        "process.platform": true
-      }
-    },
-    "stylelint>table": {
-      "globals": {
-        "process.stdout.write": true
-      },
-      "packages": {
-        "eslint>ajv": true,
-        "lodash": true,
-        "stylelint>table>slice-ansi": true,
-        "stylelint>table>string-width": true
-      }
-    },
-    "stylelint>table>slice-ansi": {
-      "packages": {
-        "stylelint>table>slice-ansi>ansi-styles": true,
-        "stylelint>table>slice-ansi>astral-regex": true,
-        "stylelint>table>slice-ansi>is-fullwidth-code-point": true
-      }
-    },
-    "stylelint>table>slice-ansi>ansi-styles": {
-      "packages": {
-        "@metamask/jazzicon>color>color-convert": true
-      }
-    },
-    "stylelint>table>string-width": {
-      "packages": {
-        "stylelint>table>slice-ansi>is-fullwidth-code-point": true,
-        "stylelint>table>string-width>emoji-regex": true,
-        "stylelint>table>string-width>strip-ansi": true
-      }
-    },
-    "stylelint>table>string-width>strip-ansi": {
-      "packages": {
-        "stylelint>table>string-width>strip-ansi>ansi-regex": true
+        "chalk>ansi-styles": true,
+        "yargs>string-width": true,
+        "eslint>strip-ansi": true
       }
     },
     "stylelint>write-file-atomic": {
@@ -8551,579 +9109,27 @@
       },
       "packages": {
         "eslint>imurmurhash": true,
-        "nyc>signal-exit": true,
         "stylelint>write-file-atomic>is-typedarray": true,
+        "nyc>signal-exit": true,
         "stylelint>write-file-atomic>typedarray-to-buffer": true
       }
     },
-    "stylelint>write-file-atomic>typedarray-to-buffer": {
-      "globals": {
-        "Buffer.from": true
-      },
-      "packages": {
-        "stylelint>write-file-atomic>is-typedarray": true
-      }
-    },
-    "superstruct": {
-      "globals": {
-        "console.warn": true,
-        "define": true
-      }
-    },
-    "terser": {
-      "globals": {
-        "Buffer": true,
-        "atob": true,
-        "btoa": true,
-        "console.log": true,
-        "console.warn": true,
-        "define": true,
-        "process": true
-      },
-      "packages": {
-        "jsdom>acorn": true,
-        "terser>@jridgewell/source-map": true
-      }
-    },
-    "terser-webpack-plugin>@jridgewell/trace-mapping": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
-        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
-      }
-    },
-    "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": {
-      "globals": {
-        "define": true
-      }
-    },
-    "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": {
-      "globals": {
-        "Buffer": true,
-        "TextDecoder": true,
-        "define": true
-      }
-    },
-    "terser>@jridgewell/source-map": {
-      "packages": {
-        "terser-webpack-plugin>@jridgewell/trace-mapping": true,
-        "terser>@jridgewell/source-map>@jridgewell/gen-mapping": true
-      }
-    },
-    "terser>@jridgewell/source-map>@jridgewell/gen-mapping": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "terser-webpack-plugin>@jridgewell/trace-mapping": true,
-        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true,
-        "terser>@jridgewell/source-map>@jridgewell/gen-mapping>@jridgewell/set-array": true
-      }
-    },
-    "terser>@jridgewell/source-map>@jridgewell/gen-mapping>@jridgewell/set-array": {
-      "globals": {
-        "define": true
-      }
-    },
-    "terser>source-map-support": {
+    "stylelint>file-entry-cache>flat-cache>write": {
       "builtin": {
-        "fs": true,
-        "path.dirname": true,
-        "path.resolve": true
-      },
-      "globals": {
-        "XMLHttpRequest": true,
-        "console.error": true,
-        "process": true
-      },
-      "packages": {
-        "terser>source-map-support>buffer-from": true,
-        "terser>source-map-support>source-map": true
-      }
-    },
-    "terser>source-map-support>buffer-from": {
-      "globals": {
-        "Buffer": true
-      }
-    },
-    "through2": {
-      "packages": {
-        "readable-stream": true
-      }
-    },
-    "ts-node": {
-      "builtin": {
-        "assert": true,
-        "console.Console": true,
-        "fs.Stats": true,
-        "fs.readFileSync": true,
-        "fs.realpathSync": true,
-        "fs.statSync": true,
-        "module": true,
-        "os.homedir": true,
-        "path": true,
-        "repl.Recoverable": true,
-        "repl.start": true,
-        "url.URL": true,
-        "url.fileURLToPath": true,
-        "url.format": true,
-        "url.parse": true,
-        "url.pathToFileURL": true,
-        "util.inspect.custom": true,
-        "vm.Script": true
-      },
-      "globals": {
-        "Buffer.from": true,
-        "ERR_INVALID_ARG_VALUE": true,
-        "__dirname": true,
-        "console": true,
-        "process": true,
-        "value": true
-      },
-      "packages": {
-        "jsdom>acorn": true,
-        "ts-node>@cspotcode/source-map-support": true,
-        "ts-node>@tsconfig/node10": true,
-        "ts-node>@tsconfig/node12": true,
-        "ts-node>@tsconfig/node14": true,
-        "ts-node>@tsconfig/node16": true,
-        "ts-node>acorn-walk": true,
-        "ts-node>arg": true,
-        "ts-node>create-require": true,
-        "ts-node>diff": true,
-        "ts-node>make-error": true,
-        "ts-node>v8-compile-cache-lib": true,
-        "ts-node>yn": true
-      }
-    },
-    "ts-node>@cspotcode/source-map-support": {
-      "builtin": {
-        "fs": true,
-        "path.isAbsolute": true,
-        "path.join": true,
-        "path.normalize": true,
-        "path.resolve": true,
-        "url.fileURLToPath": true,
-        "url.pathToFileURL": true,
-        "util.inspect": true
-      },
-      "globals": {
-        "Buffer.from": true,
-        "URL": true,
-        "XMLHttpRequest": true,
-        "console.error": true,
-        "process": true
-      },
-      "packages": {
-        "ts-node>@cspotcode/source-map-support>@jridgewell/trace-mapping": true
-      }
-    },
-    "ts-node>@cspotcode/source-map-support>@jridgewell/trace-mapping": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/resolve-uri": true,
-        "terser-webpack-plugin>@jridgewell/trace-mapping>@jridgewell/sourcemap-codec": true
-      }
-    },
-    "ts-node>acorn-walk": {
-      "globals": {
-        "define": true
-      }
-    },
-    "ts-node>arg": {
-      "globals": {
-        "process.argv.slice": true
-      }
-    },
-    "ts-node>create-require": {
-      "builtin": {
-        "fs.lstatSync": true,
-        "module.Module": true,
-        "module.createRequire": true,
-        "module.createRequireFromPath": true,
-        "path.dirname": true,
-        "path.join": true
-      },
-      "globals": {
-        "process.cwd": true
-      }
-    },
-    "ts-node>diff": {
-      "globals": {
-        "setTimeout": true
-      }
-    },
-    "ts-node>v8-compile-cache-lib": {
-      "builtin": {
-        "crypto.createHash": true,
-        "fs.mkdirSync": true,
-        "fs.readFileSync": true,
-        "fs.statSync": true,
-        "fs.unlinkSync": true,
+        "fs.createWriteStream": true,
+        "fs.writeFile": true,
         "fs.writeFileSync": true,
-        "module._cache": true,
-        "module._extensions": true,
-        "module._resolveFilename": true,
-        "module._resolveLookupPaths": true,
-        "module.prototype._compile": true,
-        "module.wrap": true,
-        "os.tmpdir": true,
-        "path.dirname": true,
-        "path.join": true,
-        "path.resolve": true,
-        "vm.Script": true
+        "path.dirname": true
       },
-      "globals": {
-        "Buffer": true,
-        "process": true
-      }
-    },
-    "tsutils": {
       "packages": {
-        "tslib": true,
-        "typescript": true
+        "mockttp>portfinder>mkdirp": true
       }
     },
-    "typescript": {
+    "yargs>y18n": {
       "builtin": {
-        "buffer.Buffer": true,
-        "crypto": true,
         "fs": true,
-        "inspector": true,
-        "module.findPnpApi": true,
-        "os.EOL": true,
-        "os.platform": true,
-        "path.dirname": true,
-        "path.join": true,
-        "path.resolve": true,
-        "perf_hooks.PerformanceObserver": true,
-        "perf_hooks.performance": true
-      },
-      "globals": {
-        "Intl.Collator": true,
-        "PerformanceObserver": true,
-        "__dirname": true,
-        "__filename": true,
-        "clearTimeout": true,
-        "console": true,
-        "gc": true,
-        "globalThis": true,
-        "onProfilerEvent": true,
-        "performance": true,
-        "process": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "terser>source-map-support": true
-      }
-    },
-    "uri-js": {
-      "globals": {
-        "define": true
-      }
-    },
-    "vinyl": {
-      "builtin": {
-        "buffer.Buffer.isBuffer": true,
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.normalize": true,
-        "path.relative": true,
-        "util.inspect.custom": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "vinyl>clone": true,
-        "vinyl>clone-buffer": true,
-        "vinyl>clone-stats": true,
-        "vinyl>cloneable-readable": true,
-        "vinyl>remove-trailing-separator": true,
-        "vinyl>replace-ext": true
-      }
-    },
-    "vinyl-buffer": {
-      "packages": {
-        "vinyl-buffer>bl": true,
-        "vinyl-buffer>through2": true
-      }
-    },
-    "vinyl-buffer>bl": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "vinyl-buffer>bl>readable-stream": true
-      }
-    },
-    "vinyl-buffer>bl>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
+        "path": true,
         "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true,
-        "vinyl-buffer>bl>readable-stream>isarray": true,
-        "vinyl-buffer>bl>readable-stream>safe-buffer": true,
-        "vinyl-buffer>bl>readable-stream>string_decoder": true
-      }
-    },
-    "vinyl-buffer>bl>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "vinyl-buffer>bl>readable-stream>string_decoder": {
-      "packages": {
-        "vinyl-buffer>bl>readable-stream>string_decoder>safe-buffer": true
-      }
-    },
-    "vinyl-buffer>bl>readable-stream>string_decoder>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "vinyl-buffer>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "vinyl-buffer>bl>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "vinyl-source-stream": {
-      "builtin": {
-        "path.resolve": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "vinyl": true,
-        "vinyl-source-stream>through2": true
-      }
-    },
-    "vinyl-source-stream>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "vinyl-source-stream>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "vinyl-source-stream>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream-2>process-nextick-args": true,
-        "readable-stream>util-deprecate": true,
-        "vinyl-source-stream>through2>readable-stream>isarray": true,
-        "vinyl-source-stream>through2>readable-stream>safe-buffer": true,
-        "vinyl-source-stream>through2>readable-stream>string_decoder": true
-      }
-    },
-    "vinyl-source-stream>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "vinyl-source-stream>through2>readable-stream>string_decoder": {
-      "packages": {
-        "vinyl-source-stream>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "vinyl-sourcemaps-apply": {
-      "packages": {
-        "vinyl-sourcemaps-apply>source-map": true
-      }
-    },
-    "vinyl>clone": {
-      "globals": {
-        "Buffer": true
-      }
-    },
-    "vinyl>clone-buffer": {
-      "builtin": {
-        "buffer.Buffer": true
-      }
-    },
-    "vinyl>clone-stats": {
-      "builtin": {
-        "fs.Stats": true
-      }
-    },
-    "vinyl>cloneable-readable": {
-      "packages": {
-        "pumpify>inherits": true,
-        "vinyl>cloneable-readable>process-nextick-args": true,
-        "vinyl>cloneable-readable>through2": true
-      }
-    },
-    "vinyl>cloneable-readable>process-nextick-args": {
-      "globals": {
-        "process.nextTick": true,
-        "process.version": true
-      }
-    },
-    "vinyl>cloneable-readable>through2": {
-      "builtin": {
-        "util.inherits": true
-      },
-      "globals": {
-        "process.nextTick": true
-      },
-      "packages": {
-        "vinyl>cloneable-readable>through2>readable-stream": true,
-        "watchify>xtend": true
-      }
-    },
-    "vinyl>cloneable-readable>through2>readable-stream": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.browser": true,
-        "process.env.READABLE_STREAM": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.version.slice": true,
-        "setImmediate": true
-      },
-      "packages": {
-        "pumpify>inherits": true,
-        "readable-stream-2>core-util-is": true,
-        "readable-stream>util-deprecate": true,
-        "vinyl>cloneable-readable>through2>readable-stream>isarray": true,
-        "vinyl>cloneable-readable>through2>readable-stream>process-nextick-args": true,
-        "vinyl>cloneable-readable>through2>readable-stream>safe-buffer": true,
-        "vinyl>cloneable-readable>through2>readable-stream>string_decoder": true
-      }
-    },
-    "vinyl>cloneable-readable>through2>readable-stream>process-nextick-args": {
-      "globals": {
-        "process": true
-      }
-    },
-    "vinyl>cloneable-readable>through2>readable-stream>safe-buffer": {
-      "builtin": {
-        "buffer": true
-      }
-    },
-    "vinyl>cloneable-readable>through2>readable-stream>string_decoder": {
-      "packages": {
-        "vinyl>cloneable-readable>through2>readable-stream>safe-buffer": true
-      }
-    },
-    "vinyl>remove-trailing-separator": {
-      "globals": {
-        "process.platform": true
-      }
-    },
-    "vinyl>replace-ext": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.sep": true
-      }
-    },
-    "wait-on>rxjs": {
-      "globals": {
-        "cancelAnimationFrame": true,
-        "clearInterval": true,
-        "clearTimeout": true,
-        "performance": true,
-        "requestAnimationFrame": true,
-        "setInterval.apply": true,
-        "setTimeout.apply": true
-      }
-    },
-    "watchify": {
-      "builtin": {
-        "path.join": true
-      },
-      "globals": {
-        "clearTimeout": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "chokidar": true,
-        "chokidar>anymatch": true,
-        "through2": true,
-        "watchify>xtend": true
-      }
-    },
-    "webpack-dev-server>sockjs>websocket-driver": {
-      "builtin": {
-        "crypto.createHash": true,
-        "crypto.randomBytes": true,
-        "events.EventEmitter": true,
-        "stream.Stream": true,
-        "url.parse": true,
-        "util.inherits": true
-      },
-      "globals": {
-        "process.version": true
-      },
-      "packages": {
-        "koa>content-disposition>safe-buffer": true,
-        "webpack-dev-server>sockjs>websocket-driver>http-parser-js": true,
-        "webpack-dev-server>sockjs>websocket-driver>websocket-extensions": true
-      }
-    },
-    "webpack-dev-server>sockjs>websocket-driver>http-parser-js": {
-      "builtin": {
-        "assert.equal": true,
-        "assert.ok": true
-      }
-    },
-    "webpack>json-parse-even-better-errors": {
-      "globals": {
-        "Buffer.isBuffer": true
       }
     },
     "yaml": {
@@ -9133,6 +9139,28 @@
         "btoa": true,
         "console.dir": true,
         "console.log": true,
+        "console.warn": true,
+        "process": true
+      }
+    },
+    "stylelint>cosmiconfig>yaml": {
+      "globals": {
+        "Buffer": true,
+        "YAML_SILENCE_DEPRECATION_WARNINGS": true,
+        "YAML_SILENCE_WARNINGS": true,
+        "atob": true,
+        "btoa": true,
+        "console.warn": true,
+        "process": true
+      }
+    },
+    "gulp-postcss>postcss-load-config>yaml": {
+      "globals": {
+        "Buffer": true,
+        "YAML_SILENCE_DEPRECATION_WARNINGS": true,
+        "YAML_SILENCE_WARNINGS": true,
+        "atob": true,
+        "btoa": true,
         "console.warn": true,
         "process": true
       }
@@ -9151,13 +9179,13 @@
         "process": true
       },
       "packages": {
-        "yargs-parser": true,
         "yargs>cliui": true,
         "yargs>escalade": true,
         "yargs>get-caller-file": true,
         "yargs>require-directory": true,
         "yargs>string-width": true,
-        "yargs>y18n": true
+        "yargs>y18n": true,
+        "yargs-parser": true
       }
     },
     "yargs-parser": {
@@ -9171,54 +9199,6 @@
         "process": true
       }
     },
-    "yargs>cliui": {
-      "globals": {
-        "process": true
-      },
-      "packages": {
-        "eslint>strip-ansi": true,
-        "yargs>cliui>wrap-ansi": true,
-        "yargs>string-width": true
-      }
-    },
-    "yargs>cliui>wrap-ansi": {
-      "packages": {
-        "chalk>ansi-styles": true,
-        "eslint>strip-ansi": true,
-        "yargs>string-width": true
-      }
-    },
-    "yargs>escalade": {
-      "builtin": {
-        "fs.readdirSync": true,
-        "fs.statSync": true,
-        "path.dirname": true,
-        "path.resolve": true
-      }
-    },
-    "yargs>require-directory": {
-      "builtin": {
-        "fs.readdirSync": true,
-        "fs.statSync": true,
-        "path.dirname": true,
-        "path.join": true,
-        "path.resolve": true
-      }
-    },
-    "yargs>string-width": {
-      "packages": {
-        "eslint>strip-ansi": true,
-        "yargs>string-width>emoji-regex": true,
-        "yargs>string-width>is-fullwidth-code-point": true
-      }
-    },
-    "yargs>y18n": {
-      "builtin": {
-        "fs": true,
-        "path": true,
-        "util": true
-      }
-    },
     "yargs>yargs-parser": {
       "builtin": {
         "fs": true,
@@ -9227,6 +9207,26 @@
       },
       "globals": {
         "process": true
+      }
+    },
+    "gulp-zip>yazl": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "fs.createReadStream": true,
+        "fs.stat": true,
+        "stream.PassThrough": true,
+        "stream.Transform": true,
+        "util.inherits": true,
+        "zlib.DeflateRaw": true,
+        "zlib.deflateRaw": true
+      },
+      "globals": {
+        "Buffer": true,
+        "setImmediate": true,
+        "utf8FileName.length": true
+      },
+      "packages": {
+        "gulp-zip>yazl>buffer-crc32": true
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -451,9 +451,9 @@
     "@babel/preset-typescript": "^7.25.9",
     "@babel/register": "^7.25.9",
     "@jest/globals": "^29.7.0",
-    "@lavamoat/allow-scripts": "^3.0.4",
+    "@lavamoat/allow-scripts": "^3.3.1",
     "@lavamoat/lavadome-core": "0.0.10",
-    "@lavamoat/lavapack": "^6.1.0",
+    "@lavamoat/lavapack": "^7.0.5",
     "@lgbot/madge": "^6.2.0",
     "@lydell/node-pty": "^1.0.1",
     "@metamask/api-specs": "^0.9.3",
@@ -610,8 +610,8 @@
     "jsdom": "^16.7.0",
     "json-schema-to-ts": "^3.0.1",
     "koa": "^2.7.0",
-    "lavamoat": "^8.0.2",
-    "lavamoat-browserify": "^17.0.4",
+    "lavamoat": "^9.0.5",
+    "lavamoat-browserify": "^18.1.2",
     "lavamoat-viz": "^7.0.5",
     "level": "^8.0.1",
     "lockfile-lint": "^4.10.6",
@@ -750,7 +750,8 @@
       "resolve-url-loader>es6-iterator>d>es5-ext>esniff>es5-ext": false,
       "level>classic-level": false,
       "jest-preview": false,
-      "@metamask/solana-wallet-snap>@solana/web3.js>bigint-buffer": false
+      "@metamask/solana-wallet-snap>@solana/web3.js>bigint-buffer": false,
+      "@lavamoat/allow-scripts>@lavamoat/preinstall-always-fail": false
     }
   },
   "packageManager": "yarn@4.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,13 +78,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:7.22.13":
-  version: 7.22.13
-  resolution: "@babel/code-frame@npm:7.22.13"
+"@babel/code-frame@npm:7.26.2":
+  version: 7.26.2
+  resolution: "@babel/code-frame@npm:7.26.2"
   dependencies:
-    "@babel/highlight": "npm:^7.22.13"
-    chalk: "npm:^2.4.2"
-  checksum: 10/bf6ae6ba3a510adfda6a211b4a89b0f1c98ca1352b745c077d113f3b568141e0d44ce750b9ac2a80143ba5c8c4080c50fcfc1aa11d86e194ea6785f62520eb5a
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.0.0"
+  checksum: 10/db2c2122af79d31ca916755331bb4bac96feb2b334cdaca5097a6b467fdd41963b89b14b6836a14f083de7ff887fc78fa1b3c10b14e743d33e12dbfe5ee3d223
   languageName: node
   linkType: hard
 
@@ -441,18 +442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:7.22.20":
-  version: 7.22.20
-  resolution: "@babel/highlight@npm:7.22.20"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.22.20"
-    chalk: "npm:^2.4.2"
-    js-tokens: "npm:^4.0.0"
-  checksum: 10/1aabc95b2cb7f67adc26c7049554306f1435bfedb76b9731c36ff3d7cdfcb32bd65a6dd06985644124eb2100bd911721d9e5c4f5ac40b7f0da2995a61bf8da92
-  languageName: node
-  linkType: hard
-
-"@babel/highlight@npm:^7.22.13, @babel/highlight@npm:^7.25.9":
+"@babel/highlight@npm:7.25.9, @babel/highlight@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/highlight@npm:7.25.9"
   dependencies:
@@ -479,6 +469,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10/3e5ebb903a6f71629a9d0226743e37fe3d961e79911d2698b243637f66c4df7e3e0a42c07838bc0e7cc9fcd585d9be8f4134a145b9459ee4a459420fb0d1360b
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:7.26.2":
+  version: 7.26.2
+  resolution: "@babel/parser@npm:7.26.2"
+  dependencies:
+    "@babel/types": "npm:^7.26.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/8baee43752a3678ad9f9e360ec845065eeee806f1fdc8e0f348a8a0e13eef0959dabed4a197c978896c493ea205c804d0a1187cc52e4a1ba017c7935bab4983d
   languageName: node
   linkType: hard
 
@@ -1620,7 +1621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.12.5, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.23.2, @babel/traverse@npm:^7.25.9":
+"@babel/traverse@npm:7.25.9, @babel/traverse@npm:^7.12.5, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.23.2, @babel/traverse@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/traverse@npm:7.25.9"
   dependencies:
@@ -1646,13 +1647,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.0, @babel/types@npm:^7.13.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.24.0, @babel/types@npm:^7.24.7, @babel/types@npm:^7.25.9, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:7.26.0, @babel/types@npm:^7.0.0, @babel/types@npm:^7.12.0, @babel/types@npm:^7.13.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.24.0, @babel/types@npm:^7.24.7, @babel/types@npm:^7.25.9, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.26.0
   resolution: "@babel/types@npm:7.26.0"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.25.9"
     "@babel/helper-validator-identifier": "npm:^7.25.9"
   checksum: 10/40780741ecec886ed9edae234b5eb4976968cc70d72b4e5a40d55f83ff2cc457de20f9b0f4fe9d858350e43dab0ea496e7ef62e2b2f08df699481a76df02cd6e
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.26.0":
+  version: 7.26.3
+  resolution: "@babel/types@npm:7.26.3"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.25.9"
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+  checksum: 10/c31d0549630a89abfa11410bf82a318b0c87aa846fbf5f9905e47ba5e2aa44f41cc746442f105d622c519e4dc532d35a8d8080460ff4692f9fc7485fbf3a00eb
   languageName: node
   linkType: hard
 
@@ -1895,6 +1906,13 @@ __metadata:
   version: 1.1.0
   resolution: "@endo/env-options@npm:1.1.0"
   checksum: 10/c362b5ccda9407c7049d4f5812023b9f5123116282719a4b296702f93baca7030066359af0b8bf869f8d7736f85d5fe12d21e1375049b10a482eb9bae3715797
+  languageName: node
+  linkType: hard
+
+"@endo/env-options@npm:^1.1.7":
+  version: 1.1.8
+  resolution: "@endo/env-options@npm:1.1.8"
+  checksum: 10/f7e84346599dd2bcb6365c314e9a8129c5ebbb457476de72ed896ea461d616c0b7e0dfc7733e20c0abb8400212fb5eafdae993bcfd4cbfe92acbb5c881a6ad0d
   languageName: node
   linkType: hard
 
@@ -4179,29 +4197,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lavamoat/aa@npm:^4.0.1, @lavamoat/aa@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@lavamoat/aa@npm:4.2.0"
+"@lavamoat/aa@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@lavamoat/aa@npm:4.3.1"
   dependencies:
     resolve: "npm:1.22.8"
   bin:
     lavamoat-ls: src/cli.js
-  checksum: 10/13901bfe71b74fefac707d6f94651a1f26d72825f24391b59cc712d33e671dd492123891071c900104cf806a48b543b8d19c9f04110c532b3acfa6928fd00cc0
+  checksum: 10/664692b22c6fcf44a47259ec3b48873c0064872a5a285c7ee4ddc0f99217d5a6653236304cc393f03970f0810694ab44d1f02ce4c980ce86cc24b0e27e9c622f
   languageName: node
   linkType: hard
 
-"@lavamoat/allow-scripts@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "@lavamoat/allow-scripts@npm:3.0.4"
+"@lavamoat/allow-scripts@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@lavamoat/allow-scripts@npm:3.3.1"
   dependencies:
-    "@lavamoat/aa": "npm:^4.2.0"
-    "@npmcli/run-script": "npm:7.0.4"
-    bin-links: "npm:4.0.3"
+    "@lavamoat/aa": "npm:^4.3.1"
+    "@npmcli/run-script": "npm:8.1.0"
+    bin-links: "npm:4.0.4"
     npm-normalize-package-bin: "npm:3.0.1"
+    type-fest: "npm:4.30.0"
     yargs: "npm:17.7.2"
+  peerDependencies:
+    "@lavamoat/preinstall-always-fail": "*"
   bin:
     allow-scripts: src/cli.js
-  checksum: 10/02975c9187d9cfe2c2bd0d2b645a49a04f5bd7c8cc95fa10fbc7fb15988f170d27e76bb6f977908957c2c369447eca35d3c3f3ad7e91d685c33d22ae39a86a98
+  checksum: 10/78bb7502136cee509592e66a1824a3e049a392e79740d99f528774743934d28e2099d3e80beded9a6623ce8842250d6207ebeea694d08c87e4fd8e2899eb0d7a
   languageName: node
   linkType: hard
 
@@ -4234,20 +4255,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lavamoat/lavapack@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "@lavamoat/lavapack@npm:6.1.0"
+"@lavamoat/lavapack@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "@lavamoat/lavapack@npm:7.0.5"
   dependencies:
     JSONStream: "npm:1.3.5"
     combine-source-map: "npm:0.8.0"
-    convert-source-map: "npm:2.0.0"
     espree: "npm:9.6.1"
     json-stable-stringify: "npm:1.1.1"
-    lavamoat-core: "npm:^15.1.2"
-    readable-stream: "npm:3.6.2"
+    lavamoat-core: "npm:^16.2.2"
+    readable-stream: "npm:4.5.2"
     through2: "npm:4.0.2"
     umd: "npm:3.0.3"
-  checksum: 10/faf4425e740c5abb9a441b6e872921943d48129f8f2120ce26672119824cea5dfcbcb7ae7113ece639a34c924794e3f6088564281672421bf31b40c25cfc93dc
+  checksum: 10/47e8e1c5d8c39817db75a579a513f0a89f8b479092174828f606c9afa8d0543168648788624fccefde778a7d38bfddfb1b4e18bf70b315de34b99dee140ba035
   languageName: node
   linkType: hard
 
@@ -4262,6 +4282,17 @@ __metadata:
   version: 2.0.2
   resolution: "@lavamoat/snow@npm:2.0.2"
   checksum: 10/613d4b7f42a80fb0c447f124ef0b7497afc7e5a5f81edd961975e14f35e9cfcbde04f649155f5d2fdcc334d5a190246ae90e23d53ca4e126e672e229c26895ae
+  languageName: node
+  linkType: hard
+
+"@lavamoat/sourcemap-validator@npm:2.1.1":
+  version: 2.1.1
+  resolution: "@lavamoat/sourcemap-validator@npm:2.1.1"
+  dependencies:
+    jsesc: "npm:~0.3.x"
+    lodash: "npm:^4.17.21"
+    source-map: "npm:~0.1.x"
+  checksum: 10/a4b11acd50be05be60504c9f6db3d681e6d3bbf186a9fbc04a7597a28a1bd26d95c7fdee4d060ff02e58159060bb0dc921887a2831f03a2fcad48ef12237ac7c
   languageName: node
   linkType: hard
 
@@ -6635,16 +6666,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/run-script@npm:7.0.4":
-  version: 7.0.4
-  resolution: "@npmcli/run-script@npm:7.0.4"
+"@npmcli/run-script@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@npmcli/run-script@npm:8.1.0"
   dependencies:
     "@npmcli/node-gyp": "npm:^3.0.0"
     "@npmcli/package-json": "npm:^5.0.0"
     "@npmcli/promise-spawn": "npm:^7.0.0"
     node-gyp: "npm:^10.0.0"
+    proc-log: "npm:^4.0.0"
     which: "npm:^4.0.0"
-  checksum: 10/f09268051f74af7d7be46e9911a23126d531160c338d3c05d53e6cd7994b88271fb4ec524139fe7f2d826525f15a281eafef3be02831adc1f68556a8a668621a
+  checksum: 10/256bd580f82b98db93e54065bf9bcc94946be4f2d668a062cf756cb8ea091f58ef7154b3d2450d79738081a150f25cc48f6075351911e672f24ffd34350f02f2
   languageName: node
   linkType: hard
 
@@ -10023,7 +10055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.0.6, @types/babel__traverse@npm:^7.18.0":
+"@types/babel__traverse@npm:*, @types/babel__traverse@npm:7.20.6, @types/babel__traverse@npm:^7.0.6, @types/babel__traverse@npm:^7.18.0":
   version: 7.20.6
   resolution: "@types/babel__traverse@npm:7.20.6"
   dependencies:
@@ -12298,6 +12330,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"amdefine@npm:>=0.0.4":
+  version: 1.0.1
+  resolution: "amdefine@npm:1.0.1"
+  checksum: 10/517df65fc33d3ff14fe5c0057e041b03d603a2254dea7968b05dfbfa3041eb8430ea6729e305bc428c03fad03f162de91a4b256692d27d7b81d3ee691312cffe
+  languageName: node
+  linkType: hard
+
 "ansi-align@npm:^2.0.0":
   version: 2.0.0
   resolution: "ansi-align@npm:2.0.0"
@@ -13530,15 +13569,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bin-links@npm:4.0.3":
-  version: 4.0.3
-  resolution: "bin-links@npm:4.0.3"
+"bin-links@npm:4.0.4":
+  version: 4.0.4
+  resolution: "bin-links@npm:4.0.4"
   dependencies:
     cmd-shim: "npm:^6.0.0"
     npm-normalize-package-bin: "npm:^3.0.0"
     read-cmd-shim: "npm:^4.0.0"
     write-file-atomic: "npm:^5.0.0"
-  checksum: 10/8b4eec67e5d000768cc5a8cd4399d3af55eab059b2b6f864f96ad69bd73d8c4702a9f002a54747d11643cbd3e2a043d91f12bceedcfdcd96321cf186cfb33802
+  checksum: 10/58d62143aacdbb783b076e9bdd970d8470f2750e1076d6fd1ae559fa532c4647478dd2550a911ba22d4c9e6339881451046e2fbc4b8958f4bf3bf8e5144d1e4d
   languageName: node
   linkType: hard
 
@@ -15648,6 +15687,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"corepack@npm:0.29.4":
+  version: 0.29.4
+  resolution: "corepack@npm:0.29.4"
+  bin:
+    corepack: ./dist/corepack.js
+    pnpm: ./dist/pnpm.js
+    pnpx: ./dist/pnpx.js
+    yarn: ./dist/yarn.js
+    yarnpkg: ./dist/yarnpkg.js
+  checksum: 10/814fb0c1d77fdebc1d87770c88115bd5623c21d1a00a1bb94d8dc588017d3d5b7ffae92ac628b0796e32ceecf71db809b6d9dc9046d0a765157ddfefa6378b9c
+  languageName: node
+  linkType: hard
+
 "cors-gate@npm:^1.1.3":
   version: 1.1.3
   resolution: "cors-gate@npm:1.1.3"
@@ -17269,15 +17321,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexify@npm:4.1.2":
-  version: 4.1.2
-  resolution: "duplexify@npm:4.1.2"
+"duplexify@npm:4.1.3, duplexify@npm:^4.1.1":
+  version: 4.1.3
+  resolution: "duplexify@npm:4.1.3"
   dependencies:
     end-of-stream: "npm:^1.4.1"
     inherits: "npm:^2.0.3"
     readable-stream: "npm:^3.1.1"
-    stream-shift: "npm:^1.0.0"
-  checksum: 10/eeb4f362defa4da0b2474d853bc4edfa446faeb1bde76819a68035632c118de91f6a58e6fe05c84f6e6de2548f8323ec8473aa9fe37332c99e4d77539747193e
+    stream-shift: "npm:^1.0.2"
+  checksum: 10/b44b98ba0ffac3a658b4b1bf877219e996db288c5ae6f3dc55ca9b2cbef7df60c10eabfdd947f3d73a623eb9975a74a66d6d61e6f26bff90155315adb362aa77
   languageName: node
   linkType: hard
 
@@ -17290,18 +17342,6 @@ __metadata:
     readable-stream: "npm:^2.0.0"
     stream-shift: "npm:^1.0.0"
   checksum: 10/7799984d178fb57e11c43f5f172a10f795322ec85ff664c2a98d2c2de6deeb9d7a30b810f83923dcd7ebe0f1786724b8aee2b62ca4577522141f93d6d48fb31c
-  languageName: node
-  linkType: hard
-
-"duplexify@npm:^4.1.1":
-  version: 4.1.3
-  resolution: "duplexify@npm:4.1.3"
-  dependencies:
-    end-of-stream: "npm:^1.4.1"
-    inherits: "npm:^2.0.3"
-    readable-stream: "npm:^3.1.1"
-    stream-shift: "npm:^1.0.2"
-  checksum: 10/b44b98ba0ffac3a658b4b1bf877219e996db288c5ae6f3dc55ca9b2cbef7df60c10eabfdd947f3d73a623eb9975a74a66d6d61e6f26bff90155315adb362aa77
   languageName: node
   linkType: hard
 
@@ -24417,6 +24457,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsesc@npm:~0.3.x":
+  version: 0.3.0
+  resolution: "jsesc@npm:0.3.0"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 10/381917c354b54025e3821f5cd724faf1b0ffa6c6e7b95a9ad1768146aea44175541832e2c5b6f9ec71f88d58968a22ab1f47fccbc35d171dc09234afd21b28e9
+  languageName: node
+  linkType: hard
+
 "json-buffer@npm:3.0.0":
   version: 3.0.0
   resolution: "json-buffer@npm:3.0.0"
@@ -24512,15 +24561,6 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: 10/12786c2e2f22c27439e6db0532ba321f1d0617c27ad8cb1c352a0e9249a50182fd1ba8b52a18899291604b0c32eafa8afd09e51203f19109a0537f68db2b652d
-  languageName: node
-  linkType: hard
-
-"json-stable-stringify@npm:1.0.2":
-  version: 1.0.2
-  resolution: "json-stable-stringify@npm:1.0.2"
-  dependencies:
-    jsonify: "npm:^0.0.1"
-  checksum: 10/96c8d697520072231c4916b7c0084ea857418cad0d06dc910f89a40df3824386a8eee5ed83ceea25b6052d67223fe821f9b1e51be311383104c5b2305b1dc87e
   languageName: node
   linkType: hard
 
@@ -25020,39 +25060,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lavamoat-browserify@npm:^17.0.4":
-  version: 17.0.4
-  resolution: "lavamoat-browserify@npm:17.0.4"
+"lavamoat-browserify@npm:^18.1.2":
+  version: 18.1.2
+  resolution: "lavamoat-browserify@npm:18.1.2"
   dependencies:
-    "@lavamoat/aa": "npm:^4.0.1"
-    "@lavamoat/lavapack": "npm:^6.1.0"
+    "@lavamoat/aa": "npm:^4.3.1"
+    "@lavamoat/lavapack": "npm:^7.0.5"
+    "@lavamoat/sourcemap-validator": "npm:2.1.1"
     browser-resolve: "npm:2.0.0"
     concat-stream: "npm:2.0.0"
     convert-source-map: "npm:2.0.0"
-    duplexify: "npm:4.1.2"
-    json-stable-stringify: "npm:1.1.1"
-    lavamoat-core: "npm:^15.1.2"
+    duplexify: "npm:4.1.3"
+    lavamoat-core: "npm:^16.2.2"
     pify: "npm:5.0.0"
-    readable-stream: "npm:3.6.2"
+    readable-stream: "npm:4.5.2"
     source-map: "npm:0.7.4"
     through2: "npm:4.0.2"
-  checksum: 10/84db338bb7ea412e62cd531bd1eab231e899c481314816a88d519cc24f4466283b2654dac06e87a03be28e609a3b91131b7abe499a09a2f2981f7ad9731e4937
+  checksum: 10/80df727d28076cca29d65a316d95681796051197f3a90414529c80e3d6d5455eabaf100d22ae905c1690c790b9d501bc7811fd39f99cda70196398bbe46a6d7e
   languageName: node
   linkType: hard
 
-"lavamoat-core@npm:15.1.1":
-  version: 15.1.1
-  resolution: "lavamoat-core@npm:15.1.1"
-  dependencies:
-    json-stable-stringify: "npm:1.0.2"
-    lavamoat-tofu: "npm:^7.1.0"
-    merge-deep: "npm:3.0.3"
-    type-fest: "npm:4.7.1"
-  checksum: 10/7564f6d6f5c5e7934ec93a87d46c687928c8635ec0dabaf4aaea5595df0a097c3cb23131180cff7a23ed6bf444ef01b627168e08546e8f654844a11be31864fa
-  languageName: node
-  linkType: hard
-
-"lavamoat-core@npm:^15.1.2, lavamoat-core@npm:^15.2.1":
+"lavamoat-core@npm:^15.2.1":
   version: 15.3.0
   resolution: "lavamoat-core@npm:15.3.0"
   dependencies:
@@ -25065,19 +25093,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lavamoat-core@patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch":
-  version: 15.1.1
-  resolution: "lavamoat-core@patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch::version=15.1.1&hash=95165a"
+"lavamoat-core@npm:^16.2.2":
+  version: 16.2.2
+  resolution: "lavamoat-core@npm:16.2.2"
   dependencies:
-    json-stable-stringify: "npm:1.0.2"
-    lavamoat-tofu: "npm:^7.1.0"
+    "@babel/types": "npm:7.26.0"
+    json-stable-stringify: "npm:1.1.1"
+    lavamoat-tofu: "npm:^8.0.4"
     merge-deep: "npm:3.0.3"
-    type-fest: "npm:4.7.1"
-  checksum: 10/e408e3fd65987e0083a4649da3b158ace2eb55379add58a2a0c9a2d1b9b5aee86d03dd44dc616796a5c1c07f303c0691db7c41877b2c3cc4ce86d80af229844b
+    ses: "npm:1.9.0"
+    type-fest: "npm:4.30.0"
+  bin:
+    lavamoat-sort-policy: src/policy-sort-cli.js
+  checksum: 10/4509a560ec6f35aabf3f2915beeaefb526db06121b0bea40864c8f75d0b3e55df089bedd719392a3224dab040fa03a2593c998a66ea23ca820c29de038aa448b
   languageName: node
   linkType: hard
 
-"lavamoat-tofu@npm:^7.1.0, lavamoat-tofu@npm:^7.2.3":
+"lavamoat-tofu@npm:^7.2.3":
   version: 7.2.3
   resolution: "lavamoat-tofu@npm:7.2.3"
   dependencies:
@@ -25089,6 +25121,21 @@ __metadata:
   peerDependencies:
     lavamoat-core: ^15.3.0
   checksum: 10/c0f67b47107b1fa6b319c37fca74611adb42b0d1bcf593923dd200e8de1783ff3f05435f806842cef888cfd2b8d589889541b8fdaa7aeb445482516dc0e8bfcc
+  languageName: node
+  linkType: hard
+
+"lavamoat-tofu@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "lavamoat-tofu@npm:8.0.4"
+  dependencies:
+    "@babel/parser": "npm:7.26.2"
+    "@babel/traverse": "npm:7.25.9"
+    "@babel/types": "npm:7.26.0"
+    "@types/babel__traverse": "npm:7.20.6"
+    type-fest: "npm:4.30.0"
+  peerDependencies:
+    lavamoat-core: ">15.4.0"
+  checksum: 10/2ed4689beca070bae5b3e712609bc1de075c343573054205415a06d7a5f28b4347a137afe266a22b054eb053050bfd0d38f2ccb693f819b274105079373bed9d
   languageName: node
   linkType: hard
 
@@ -25108,25 +25155,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lavamoat@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "lavamoat@npm:8.0.2"
+"lavamoat@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "lavamoat@npm:9.0.5"
   dependencies:
-    "@babel/code-frame": "npm:7.22.13"
-    "@babel/highlight": "npm:7.22.20"
-    "@lavamoat/aa": "npm:^4.0.1"
+    "@babel/code-frame": "npm:7.26.2"
+    "@babel/highlight": "npm:7.25.9"
+    "@lavamoat/aa": "npm:^4.3.1"
     bindings: "npm:1.5.0"
+    corepack: "npm:0.29.4"
     htmlescape: "npm:1.1.1"
-    json-stable-stringify: "npm:1.0.2"
-    lavamoat-core: "npm:^15.1.1"
-    lavamoat-tofu: "npm:^7.1.0"
-    node-gyp-build: "npm:4.6.1"
+    lavamoat-core: "npm:^16.2.2"
+    lavamoat-tofu: "npm:^8.0.4"
+    node-gyp-build: "npm:4.8.4"
     resolve: "npm:1.22.8"
     yargs: "npm:17.7.2"
   bin:
     lavamoat: src/cli.js
     lavamoat-run-command: src/run-command.js
-  checksum: 10/644b59c86bfd75e33154ee0794aea6e44b64dd649814cb98829d232af117c338311fd65827a098bfb1e815aca6e2456c9a247fb35202d50c16cb08a8930d7689
+  checksum: 10/9b97782d5f2d4a80eeba75f450399c256c1ab05a79c3ceded623d70b1c7e4eda055528d9ab1a578bc898c1e4a86a907d282661d0c974858c5321a3e40d17d7d3
   languageName: node
   linkType: hard
 
@@ -26358,10 +26405,10 @@ __metadata:
     "@jest/globals": "npm:^29.7.0"
     "@keystonehq/bc-ur-registry-eth": "npm:^0.19.1"
     "@keystonehq/metamask-airgapped-keyring": "npm:^0.14.1"
-    "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@lavamoat/allow-scripts": "npm:^3.3.1"
     "@lavamoat/lavadome-core": "npm:0.0.10"
     "@lavamoat/lavadome-react": "npm:0.0.17"
-    "@lavamoat/lavapack": "npm:^6.1.0"
+    "@lavamoat/lavapack": "npm:^7.0.5"
     "@lavamoat/snow": "npm:^2.0.2"
     "@lgbot/madge": "npm:^6.2.0"
     "@lydell/node-pty": "npm:^1.0.1"
@@ -26642,8 +26689,8 @@ __metadata:
     json-schema-to-ts: "npm:^3.0.1"
     koa: "npm:^2.7.0"
     labeled-stream-splicer: "npm:^2.0.2"
-    lavamoat: "npm:^8.0.2"
-    lavamoat-browserify: "npm:^17.0.4"
+    lavamoat: "npm:^9.0.5"
+    lavamoat-browserify: "npm:^18.1.2"
     lavamoat-viz: "npm:^7.0.5"
     level: "npm:^8.0.1"
     localforage: "npm:^1.9.0"
@@ -28046,14 +28093,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:4.6.1":
-  version: 4.6.1
-  resolution: "node-gyp-build@npm:4.6.1"
+"node-gyp-build@npm:4.8.4":
+  version: 4.8.4
+  resolution: "node-gyp-build@npm:4.8.4"
   bin:
     node-gyp-build: bin.js
     node-gyp-build-optional: optional.js
     node-gyp-build-test: build-test.js
-  checksum: 10/79b948377492ae8e1aa1c18071661e6020c11f8847d5ce822abd67ec02bee5b21715b1b4861041d2b40d16633824476735bc9a60e81c82c49e715d55ee29b206
+  checksum: 10/6a7d62289d1afc419fc8fc9bd00aa4e554369e50ca0acbc215cb91446148b75ff7e2a3b53c2c5b2c09a39d416d69f3d3237937860373104b5fe429bf30ad9ac5
   languageName: node
   linkType: hard
 
@@ -31437,6 +31484,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:4.5.2":
+  version: 4.5.2
+  resolution: "readable-stream@npm:4.5.2"
+  dependencies:
+    abort-controller: "npm:^3.0.0"
+    buffer: "npm:^6.0.3"
+    events: "npm:^3.3.0"
+    process: "npm:^0.11.10"
+    string_decoder: "npm:^1.3.0"
+  checksum: 10/01b128a559c5fd76a898495f858cf0a8839f135e6a69e3409f986e88460134791657eb46a2ff16826f331682a3c4d0c5a75cef5e52ef259711021ba52b1c2e82
+  languageName: node
+  linkType: hard
+
 "readable-stream@npm:^3.6.2 || ^4.4.2, readable-stream@npm:^4.0.0":
   version: 4.4.2
   resolution: "readable-stream@npm:4.4.2"
@@ -33257,6 +33317,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ses@npm:1.9.0":
+  version: 1.9.0
+  resolution: "ses@npm:1.9.0"
+  dependencies:
+    "@endo/env-options": "npm:^1.1.7"
+  checksum: 10/6a1a54d3a62839b1fb888a71136960ad042bed89bdb2e20417fd7ef8880387b30d5fe6aa2420ec58992962f790f0392c65a84c5d3be36e0ebbc4d604d8795174
+  languageName: node
+  linkType: hard
+
 "ses@npm:^1.1.0":
   version: 1.1.0
   resolution: "ses@npm:1.1.0"
@@ -33789,6 +33858,15 @@ __metadata:
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
   checksum: 10/9b4ac749ec5b5831cad1f8cc4c19c4298ebc7474b24a0acf293e2f040f03f8eeccb3d01f12aa0f90cf46d555c887e03912b83a042c627f419bda5152d89c5269
+  languageName: node
+  linkType: hard
+
+"source-map@npm:~0.1.x":
+  version: 0.1.43
+  resolution: "source-map@npm:0.1.43"
+  dependencies:
+    amdefine: "npm:>=0.0.4"
+  checksum: 10/6fe101dc2745bd75700636144a71ef4d2819f37cfa0a3ee9c8f2b1c3f6799f5c2f8f8d64e5e2ba3af4db447bf72eaf09b3964da9804d58b06cf6fe1fb9f093f5
   languageName: node
   linkType: hard
 
@@ -35618,10 +35696,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:4.7.1":
-  version: 4.7.1
-  resolution: "type-fest@npm:4.7.1"
-  checksum: 10/ef21f317738080d71d8603a65bd7136e1e0246980b407e9fe6b4c35cc239b712dd737b06c391e7cde8213d8a733449930b6cc5a3417324b90dddeb84fa167629
+"type-fest@npm:4.30.0":
+  version: 4.30.0
+  resolution: "type-fest@npm:4.30.0"
+  checksum: 10/46c733df4feb87dfd281fba4fa3913dc38b45136be35adffbcef95e13414105a4669476c1f8686680b9c98e59ed5dc85efe42caf67adbaa04f48dfc41f8330fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

This lavamoat update brings a different sorting comparator for policy.json files that will produce more readable diffs.
This PR has 2 commits - one that reorders the policy without making any changes and another that updates lavamoat packages on top of that.

For better clarity on the policy.json files, inspect each commit separately.

This is going to be hard to review and merge because conflict resolution requires a redo. Gonna have to schedule it carefully.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
