### PR TITLE
test: fix flaky confirmation E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,6 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,7 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -688,6 +688,15 @@ class FixtureBuilder {
     });
   }
 
+  withPreferencesControllerSmartTransactionsOptedOut() {
+    return this.withPreferencesController({
+      preferences: {
+        smartTransactionsOptInStatus: false,
+        tokenNetworkFilter: {},
+      },
+    });
+  }
+
   withPreferencesControllerAndFeatureFlag(flags) {
     merge(this.fixture.data.PreferencesController, flags);
     return this;

--- a/test/e2e/json-rpc/switchEthereumChain.spec.js
+++ b/test/e2e/json-rpc/switchEthereumChain.spec.js
@@ -262,6 +262,7 @@ describe('Switch Ethereum Chain for two dapps', function () {
           dapp: true,
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleGanache()
+            .withPreferencesControllerSmartTransactionsOptedOut()
             .build(),
           dappOptions: { numberOfDapps: 2 },
           ganacheOptions: {

--- a/test/e2e/page-objects/pages/test-snaps.ts
+++ b/test/e2e/page-objects/pages/test-snaps.ts
@@ -1,9 +1,11 @@
 import { Driver } from '../../webdriver/driver';
 import { TEST_SNAPS_WEBSITE_URL } from '../../snaps/enums';
-import { WINDOW_TITLES } from '../../helpers';
+import { largeDelayMs, WINDOW_TITLES } from '../../helpers';
 
 export class TestSnaps {
   driver: Driver;
+
+  private readonly installedSnapsHeader = '[data-testid="InstalledSnaps"]';
 
   private readonly connectDialogsSnapButton =
     '[data-testid="dialogs"] [data-testid="connect-button"]';
@@ -16,10 +18,14 @@ export class TestSnaps {
 
   async openPage() {
     await this.driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
-    await this.driver.delay(1000);
+    await this.driver.waitForSelector(this.installedSnapsHeader);
   }
 
   async clickConnectDialogsSnapButton() {
+    await this.driver.scrollToElement(
+      this.driver.findClickableElement(this.connectDialogsSnapButton),
+    );
+    await this.driver.delay(largeDelayMs);
     await this.driver.clickElement(this.connectDialogsSnapButton);
   }
 


### PR DESCRIPTION
## **Description**

Fix flaky E2E tests in:

- `test/e2e/json-rpc/switchEthereumChain.spec.js`
- `test/e2e/tests/confirmations/navigation.spec.ts` (Firefox Only)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29104?quickstart=1)

## **Related issues**

Fixes: #29090 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
