### PR TITLE
chore: delay linea bridge tx to make it less flaky

### DIFF
--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -15,6 +15,7 @@ import useHandleApprovalTx from './useHandleApprovalTx';
 import useHandleBridgeTx from './useHandleBridgeTx';
 
 const debugLog = createProjectLogger('bridge');
+const LINEA_DELAY_MS = 5000;
 
 export default function useSubmitBridgeTransaction() {
   const history = useHistory();
@@ -51,7 +52,9 @@ export default function useSubmitBridgeTransaction() {
       debugLog(
         'Delaying submitting bridge tx to make Linea confirmation more likely',
       );
-      const waitPromise = new Promise((resolve) => setTimeout(resolve, 5000));
+      const waitPromise = new Promise((resolve) =>
+        setTimeout(resolve, LINEA_DELAY_MS),
+      );
       await waitPromise;
     }
 

--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -35,6 +35,7 @@ export const BridgeCTAButton = () => {
   const { maxRefreshCount, refreshRate } = useSelector(getBridgeQuotesConfig);
 
   const { submitBridgeTransaction } = useSubmitBridgeTransaction();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { isNoQuotesAvailable, isInsufficientBalance } =
     useSelector(getValidationErrors);
@@ -108,20 +109,29 @@ export const BridgeCTAButton = () => {
       data-testid="bridge-cta-button"
       onClick={() => {
         if (activeQuote && isTxSubmittable) {
-          quoteRequestProperties &&
-            requestMetadataProperties &&
-            tradeProperties &&
-            trackCrossChainSwapsEvent({
-              event: MetaMetricsEventName.ActionSubmitted,
-              properties: {
-                ...quoteRequestProperties,
-                ...requestMetadataProperties,
-                ...tradeProperties,
-              },
-            });
-          submitBridgeTransaction(activeQuote);
+          try {
+            // We don't need to worry about setting to true if the tx submission succeeds
+            // because we route immediately to Activity list page
+            setIsSubmitting(true);
+
+            quoteRequestProperties &&
+              requestMetadataProperties &&
+              tradeProperties &&
+              trackCrossChainSwapsEvent({
+                event: MetaMetricsEventName.ActionSubmitted,
+                properties: {
+                  ...quoteRequestProperties,
+                  ...requestMetadataProperties,
+                  ...tradeProperties,
+                },
+              });
+            submitBridgeTransaction(activeQuote);
+          } catch (error) {
+            setIsSubmitting(false);
+          }
         }
       }}
+      loading={isSubmitting}
       disabled={!isTxSubmittable || isQuoteExpired}
     >
       {label}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29109?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Set network to Linea
2. Bridge an ERC20 to another network
3. Observe loading spinner on quotes page
4. Get redirected to activity list
5. See successful ERC20 approval and bridge tx 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e6079f43-632e-4bd3-a9e0-54f7c427b541


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
