### PR TITLE
chore: calc the max total gas fee as well

### DIFF
--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -604,7 +604,13 @@ describe('Bridge selectors', () => {
         },
         gasFee: {
           amount: new BigNumber('7.141025952e-8'),
+          amountMax: new BigNumber('3.49092e-8'),
           valueInCurrency: new BigNumber('7.141025952e-8'),
+          valueInCurrencyMax: new BigNumber('3.49092e-8'),
+        },
+        totalMaxNetworkFee: {
+          amount: new BigNumber('0.0010000349092'),
+          valueInCurrency: new BigNumber('0.0010000349092'),
         },
         totalNetworkFee: {
           valueInCurrency: new BigNumber('0.00100007141025952'),
@@ -698,11 +704,17 @@ describe('Bridge selectors', () => {
         },
         gasFee: {
           amount: new BigNumber('7.141025952e-8'),
+          amountMax: new BigNumber('3.49092e-8'),
           valueInCurrency: new BigNumber('7.141025952e-8'),
+          valueInCurrencyMax: new BigNumber('3.49092e-8'),
         },
         totalNetworkFee: {
           valueInCurrency: new BigNumber('0.00100007141025952'),
           amount: new BigNumber('0.00100007141025952'),
+        },
+        totalMaxNetworkFee: {
+          valueInCurrency: new BigNumber('0.0010000349092'),
+          amount: new BigNumber('0.0010000349092'),
         },
       };
       expect(result.sortedQuotes).toHaveLength(2);
@@ -797,11 +809,17 @@ describe('Bridge selectors', () => {
         },
         gasFee: {
           amount: new BigNumber('7.141025952e-8'),
+          amountMax: new BigNumber('3.49092e-8'),
           valueInCurrency: new BigNumber('7.141025952e-8'),
+          valueInCurrencyMax: new BigNumber('3.49092e-8'),
         },
         totalNetworkFee: {
           valueInCurrency: new BigNumber('0.00100007141025952'),
           amount: new BigNumber('0.00100007141025952'),
+        },
+        totalMaxNetworkFee: {
+          valueInCurrency: new BigNumber('0.0010000349092'),
+          amount: new BigNumber('0.0010000349092'),
         },
       };
       expect(result.sortedQuotes).toHaveLength(2);

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -293,13 +293,13 @@ const _getQuotesWithMetadata = createDeepEqualSelector(
         quote.quote,
         toTokenExchangeRate.valueInCurrency,
       );
-      const gasFee = calcEstimatedAndMaxTotalGasFee(
-        quote,
+      const gasFee = calcEstimatedAndMaxTotalGasFee({
+        bridgeQuote: quote,
         estimatedBaseFeeInDecGwei,
         maxFeePerGasInDecGwei,
         maxPriorityFeePerGasInDecGwei,
         nativeExchangeRate,
-      );
+      });
       const relayerFee = calcRelayerFee(quote, nativeExchangeRate);
       const totalEstimatedNetworkFee = {
         amount: gasFee.amount.plus(relayerFee.amount),

--- a/ui/pages/bridge/types.ts
+++ b/ui/pages/bridge/types.ts
@@ -9,7 +9,8 @@ export type L1GasFees = {
 // valueInCurrency values are calculated based on the user's selected currency
 export type QuoteMetadata = {
   gasFee: { amount: BigNumber; valueInCurrency: BigNumber | null };
-  totalNetworkFee: { amount: BigNumber; valueInCurrency: BigNumber | null }; // gasFees + relayerFees
+  totalNetworkFee: { amount: BigNumber; valueInCurrency: BigNumber | null }; // estimatedGasFees + relayerFees
+  totalMaxNetworkFee: { amount: BigNumber; valueInCurrency: BigNumber | null }; // maxGasFees + relayerFees
   toTokenAmount: { amount: BigNumber; valueInCurrency: BigNumber | null };
   adjustedReturn: { valueInCurrency: BigNumber | null }; // destTokenAmount - totalNetworkFee
   sentAmount: { amount: BigNumber; valueInCurrency: BigNumber | null }; // srcTokenAmount + metabridgeFee

--- a/ui/pages/bridge/utils/quote.test.ts
+++ b/ui/pages/bridge/utils/quote.test.ts
@@ -177,12 +177,13 @@ describe('Bridge quote utils', () => {
         approval: approvalGasLimit ? { gasLimit: approvalGasLimit } : undefined,
         quote: { srcAsset, srcTokenAmount, feeData },
       } as never;
-      const gasFee = calcEstimatedAndMaxTotalGasFee(
-        quote,
-        '0.00010456',
-        '0.0001',
-        2517.42,
-      );
+      const gasFee = calcEstimatedAndMaxTotalGasFee({
+        bridgeQuote: quote,
+        maxFeePerGasInDecGwei: '0.0002',
+        estimatedBaseFeeInDecGwei: '0.00010456',
+        maxPriorityFeePerGasInDecGwei: '0.0001',
+        nativeExchangeRate: 2517.42,
+      });
       const relayerFee = calcRelayerFee(quote, 2517.42);
       const result = {
         amount: gasFee.amount.plus(relayerFee.amount),
@@ -269,12 +270,13 @@ describe('Bridge quote utils', () => {
         quote: { srcAsset, srcTokenAmount, feeData },
         l1GasFeesInHexWei: '0x25F63418AA4',
       } as never;
-      const gasFee = calcEstimatedAndMaxTotalGasFee(
-        quote,
-        '0.00010456',
-        '0.0001',
-        2517.42,
-      );
+      const gasFee = calcEstimatedAndMaxTotalGasFee({
+        bridgeQuote: quote,
+        estimatedBaseFeeInDecGwei: '0.00010456',
+        maxFeePerGasInDecGwei: '0.0002',
+        maxPriorityFeePerGasInDecGwei: '0.0001',
+        nativeExchangeRate: 2517.42,
+      });
       const relayerFee = calcRelayerFee(quote, 2517.42);
       const result = {
         amount: gasFee.amount.plus(relayerFee.amount),

--- a/ui/pages/bridge/utils/quote.test.ts
+++ b/ui/pages/bridge/utils/quote.test.ts
@@ -5,7 +5,7 @@ import {
   calcSentAmount,
   calcSwapRate,
   calcToAmount,
-  calcTotalGasFee,
+  calcEstimatedAndMaxTotalGasFee,
   calcRelayerFee,
   formatEtaInMinutes,
 } from './quote';
@@ -177,7 +177,12 @@ describe('Bridge quote utils', () => {
         approval: approvalGasLimit ? { gasLimit: approvalGasLimit } : undefined,
         quote: { srcAsset, srcTokenAmount, feeData },
       } as never;
-      const gasFee = calcTotalGasFee(quote, '0.00010456', '0.0001', 2517.42);
+      const gasFee = calcEstimatedAndMaxTotalGasFee(
+        quote,
+        '0.00010456',
+        '0.0001',
+        2517.42,
+      );
       const relayerFee = calcRelayerFee(quote, 2517.42);
       const result = {
         amount: gasFee.amount.plus(relayerFee.amount),
@@ -264,7 +269,12 @@ describe('Bridge quote utils', () => {
         quote: { srcAsset, srcTokenAmount, feeData },
         l1GasFeesInHexWei: '0x25F63418AA4',
       } as never;
-      const gasFee = calcTotalGasFee(quote, '0.00010456', '0.0001', 2517.42);
+      const gasFee = calcEstimatedAndMaxTotalGasFee(
+        quote,
+        '0.00010456',
+        '0.0001',
+        2517.42,
+      );
       const relayerFee = calcRelayerFee(quote, 2517.42);
       const result = {
         amount: gasFee.amount.plus(relayerFee.amount),

--- a/ui/pages/bridge/utils/quote.ts
+++ b/ui/pages/bridge/utils/quote.ts
@@ -146,13 +146,19 @@ const calcTotalGasFee = ({
   };
 };
 
-export const calcEstimatedAndMaxTotalGasFee = (
-  bridgeQuote: QuoteResponse & L1GasFees,
-  estimatedBaseFeeInDecGwei: string,
-  maxFeePerGasInDecGwei: string,
-  maxPriorityFeePerGasInDecGwei: string,
-  nativeExchangeRate?: number,
-) => {
+export const calcEstimatedAndMaxTotalGasFee = ({
+  bridgeQuote,
+  estimatedBaseFeeInDecGwei,
+  maxFeePerGasInDecGwei,
+  maxPriorityFeePerGasInDecGwei,
+  nativeExchangeRate,
+}: {
+  bridgeQuote: QuoteResponse & L1GasFees;
+  estimatedBaseFeeInDecGwei: string;
+  maxFeePerGasInDecGwei: string;
+  maxPriorityFeePerGasInDecGwei: string;
+  nativeExchangeRate?: number;
+}) => {
   const { amount, valueInCurrency } = calcTotalGasFee({
     bridgeQuote,
     feePerGasInDecGwei: estimatedBaseFeeInDecGwei,

--- a/ui/pages/bridge/utils/quote.ts
+++ b/ui/pages/bridge/utils/quote.ts
@@ -104,32 +104,35 @@ export const calcRelayerFee = (
   };
 };
 
-export const calcTotalGasFee = (
-  bridgeQuote: QuoteResponse & L1GasFees,
-  estimatedBaseFeeInDecGwei: string,
-  maxPriorityFeePerGasInDecGwei: string,
-  nativeExchangeRate?: number,
-) => {
+const calcTotalGasFee = ({
+  bridgeQuote,
+  feePerGasInDecGwei,
+  priorityFeePerGasInDecGwei,
+  nativeExchangeRate,
+}: {
+  bridgeQuote: QuoteResponse & L1GasFees;
+  feePerGasInDecGwei: string;
+  priorityFeePerGasInDecGwei: string;
+  nativeExchangeRate?: number;
+}) => {
   const { approval, trade, l1GasFeesInHexWei } = bridgeQuote;
+
   const totalGasLimitInDec = sumDecimals(
     trade.gasLimit?.toString() ?? '0',
     approval?.gasLimit?.toString() ?? '0',
   );
-  const feePerGasInDecGwei = sumDecimals(
-    estimatedBaseFeeInDecGwei,
-    maxPriorityFeePerGasInDecGwei,
+  const totalFeePerGasInDecGwei = sumDecimals(
+    feePerGasInDecGwei,
+    priorityFeePerGasInDecGwei,
   );
-
   const l1GasFeesInDecGWei = Numeric.from(
     l1GasFeesInHexWei ?? '0',
     16,
     EtherDenomination.WEI,
   ).toDenomination(EtherDenomination.GWEI);
-
   const gasFeesInDecGwei = totalGasLimitInDec
-    .times(feePerGasInDecGwei)
+    .times(totalFeePerGasInDecGwei)
     .add(l1GasFeesInDecGWei);
-
   const gasFeesInDecEth = new BigNumber(
     gasFeesInDecGwei.shiftedBy(9).toString(),
   );
@@ -140,6 +143,34 @@ export const calcTotalGasFee = (
   return {
     amount: gasFeesInDecEth,
     valueInCurrency: gasFeesInUSD,
+  };
+};
+
+export const calcEstimatedAndMaxTotalGasFee = (
+  bridgeQuote: QuoteResponse & L1GasFees,
+  estimatedBaseFeeInDecGwei: string,
+  maxFeePerGasInDecGwei: string,
+  maxPriorityFeePerGasInDecGwei: string,
+  nativeExchangeRate?: number,
+) => {
+  const { amount, valueInCurrency } = calcTotalGasFee({
+    bridgeQuote,
+    feePerGasInDecGwei: estimatedBaseFeeInDecGwei,
+    priorityFeePerGasInDecGwei: maxPriorityFeePerGasInDecGwei,
+    nativeExchangeRate,
+  });
+  const { amount: amountMax, valueInCurrency: valueInCurrencyMax } =
+    calcTotalGasFee({
+      bridgeQuote,
+      feePerGasInDecGwei: maxFeePerGasInDecGwei,
+      priorityFeePerGasInDecGwei: maxPriorityFeePerGasInDecGwei,
+      nativeExchangeRate,
+    });
+  return {
+    amount,
+    amountMax,
+    valueInCurrency,
+    valueInCurrencyMax,
   };
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29116?quickstart=1)

This PR calculates the max total gas in order to block the submit button.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
