### PR TITLE
chore: add autofocus prop to AssetPicker

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -92,6 +92,7 @@ describe('AssetPickerModal', () => {
       image: 'image.png',
       symbol: 'SYMB',
     },
+    autoFocus: true,
   };
 
   beforeEach(() => {

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -102,6 +102,7 @@ type AssetPickerModalProps = {
     AssetWithDisplayData<NativeAsset> | AssetWithDisplayData<ERC20Asset>
   >;
   isTokenListLoading?: boolean;
+  autoFocus: boolean;
 } & Pick<
   React.ComponentProps<typeof AssetPickerModalTabs>,
   'visibleTabs' | 'defaultActiveTabKey'
@@ -129,6 +130,7 @@ export function AssetPickerModal({
   isTokenListLoading = false,
   isMultiselectEnabled,
   selectedChainIds,
+  autoFocus,
   ...tabProps
 }: AssetPickerModalProps) {
   const t = useI18nContext();
@@ -477,7 +479,7 @@ export function AssetPickerModal({
               <Search
                 searchQuery={searchQuery}
                 onChange={(value) => setSearchQuery(value)}
-                autoFocus={!isMultiselectEnabled}
+                autoFocus={autoFocus}
               />
               <AssetList
                 network={network}

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.tsx
@@ -73,6 +73,7 @@ export type AssetPickerProps = {
   isDisabled?: boolean;
   action?: 'send' | 'receive';
   isMultiselectEnabled?: boolean;
+  autoFocus?: boolean;
   networkProps?: Pick<
     React.ComponentProps<typeof AssetPickerModalNetwork>,
     | 'network'
@@ -105,6 +106,7 @@ export function AssetPicker({
   customTokenListGenerator,
   isTokenListLoading = false,
   isMultiselectEnabled = false,
+  autoFocus = true,
 }: AssetPickerProps) {
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   const t = useI18nContext();
@@ -248,6 +250,7 @@ export function AssetPicker({
         }
         customTokenListGenerator={customTokenListGenerator}
         isTokenListLoading={isTokenListLoading}
+        autoFocus={autoFocus}
       />
 
       {/** If a child prop is passed in, use it as the trigger button instead of the default */}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds an autofocus prop to the AssetPicker, which sets the focus of the Search bar when the asset-picker is open

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29118?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

There should be no changes to the Send page, the only experience that uses this component

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
