### PR TITLE
chore: Revert "feat: add websocket support for c2 detection (#28782)"

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -66,8 +66,6 @@
     "clipboardWrite",
     "http://*/*",
     "https://*/*",
-    "ws://*/*",
-    "wss://*/*",
     "activeTab",
     "webRequest",
     "webRequestBlocking",

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -50,9 +50,7 @@
     "http://localhost:8545/",
     "file://*/*",
     "http://*/*",
-    "https://*/*",
-    "ws://*/*",
-    "wss://*/*"
+    "https://*/*"
   ],
   "icons": {
     "16": "images/icon-16.png",

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -323,7 +323,7 @@ function maybeDetectPhishing(theController) {
       return {};
     },
     {
-      urls: ['http://*/*', 'https://*/*', 'ws://*/*', 'wss://*/*'],
+      urls: ['http://*/*', 'https://*/*'],
     },
     isManifestV2 ? ['blocking'] : [],
   );

--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -72,6 +72,5 @@
   "unresponsive-rpc.test",
   "unresponsive-rpc.url",
   "user-storage.api.cx.metamask.io",
-  "www.4byte.directory",
-  "verify.walletconnect.com"
+  "www.4byte.directory"
 ]

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -4,7 +4,6 @@ const BigNumber = require('bignumber.js');
 const mockttp = require('mockttp');
 const detectPort = require('detect-port');
 const { difference } = require('lodash');
-const WebSocket = require('ws');
 const createStaticServer = require('../../development/create-static-server');
 const { setupMocking } = require('./mock-e2e');
 const { Ganache } = require('./seeder/ganache');
@@ -641,48 +640,6 @@ async function unlockWallet(
   }
 }
 
-/**
- * Simulates a WebSocket connection by executing a script in the browser context.
- *
- * @param {WebDriver} driver - The WebDriver instance.
- * @param {string} hostname - The hostname to connect to.
- */
-async function createWebSocketConnection(driver, hostname) {
-  try {
-    await driver.executeScript(async (wsHostname) => {
-      const url = `ws://${wsHostname}:8000`;
-
-      const socket = new WebSocket(url);
-
-      socket.onopen = () => {
-        console.log('WebSocket connection opened');
-        socket.send('Hello, server!');
-      };
-
-      socket.onerror = (error) => {
-        console.error(
-          'WebSocket error:',
-          error.message || 'Connection blocked',
-        );
-      };
-
-      socket.onmessage = (event) => {
-        console.log('Message received from server:', event.data);
-      };
-
-      socket.onclose = () => {
-        console.log('WebSocket connection closed');
-      };
-    }, hostname);
-  } catch (error) {
-    console.error(
-      `Failed to execute WebSocket connection script for ws://${hostname}:8081`,
-      error,
-    );
-    throw error;
-  }
-}
-
 const logInWithBalanceValidation = async (driver, ganacheServer) => {
   await unlockWallet(driver);
   // Wait for balance to load
@@ -1018,5 +975,4 @@ module.exports = {
   tempToggleSettingRedesignedTransactionConfirmations,
   openMenuSafe,
   sentryRegEx,
-  createWebSocketConnection,
 };

--- a/test/e2e/tests/phishing-controller/mocks.js
+++ b/test/e2e/tests/phishing-controller/mocks.js
@@ -10,9 +10,7 @@ const {
 const lastUpdated = 1;
 const defaultHotlist = { data: [] };
 const defaultC2DomainBlocklist = {
-  recentlyAdded: [
-    '33c8e026e76cea2df82322428554c932961cd80080fa379454350d7f13371f36', // hash for malicious.localhost
-  ],
+  recentlyAdded: [],
   recentlyRemoved: [],
   lastFetchedAt: '2024-08-27T15:30:45Z',
 };
@@ -97,12 +95,15 @@ async function setupPhishingDetectionMocks(
       };
     });
 
-  await mockServer.forGet(C2_DOMAIN_BLOCKLIST_URL).thenCallback(() => {
-    return {
-      statusCode: 200,
-      json: defaultC2DomainBlocklist,
-    };
-  });
+  await mockServer
+    .forGet(C2_DOMAIN_BLOCKLIST_URL)
+    .withQuery({ timestamp: '2024-08-27T15:30:45Z' })
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: defaultC2DomainBlocklist,
+      };
+    });
 
   await mockServer
     .forGet('https://github.com/MetaMask/eth-phishing-detect/issues/new')

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -2,13 +2,13 @@ const { strict: assert } = require('assert');
 const { createServer } = require('node:http');
 const { createDeferredPromise } = require('@metamask/utils');
 const { until } = require('selenium-webdriver');
+
 const {
   defaultGanacheOptions,
   withFixtures,
   openDapp,
   unlockWallet,
   WINDOW_TITLES,
-  createWebSocketConnection,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 const {
@@ -311,80 +311,6 @@ describe('Phishing Detection', function () {
         const expectedPortfolioUrl = `https://portfolio.metamask.io/?metamaskEntry=phishing_page_portfolio_button`;
 
         assert.equal(currentUrl, expectedPortfolioUrl);
-      },
-    );
-  });
-
-  it('should block a website that makes a websocket connection to a malicious command and control server', async function () {
-    const testPageURL = 'http://localhost:8080';
-    await withFixtures(
-      {
-        fixtures: new FixtureBuilder().build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-        testSpecificMock: async (mockServer) => {
-          await mockServer.forAnyWebSocket().thenEcho();
-          await setupPhishingDetectionMocks(mockServer, {
-            blockProvider: BlockProvider.MetaMask,
-          });
-        },
-        dapp: true,
-      },
-      async ({ driver }) => {
-        await unlockWallet(driver);
-
-        await driver.openNewPage(testPageURL);
-
-        await createWebSocketConnection(driver, 'malicious.localhost');
-
-        await driver.switchToWindowWithTitle(
-          'MetaMask Phishing Detection',
-          10000,
-        );
-
-        await driver.waitForSelector({
-          testId: 'unsafe-continue-loaded',
-        });
-
-        await driver.clickElement({
-          text: 'Back to safety',
-        });
-
-        const currentUrl = await driver.getCurrentUrl();
-        const expectedPortfolioUrl = `https://portfolio.metamask.io/?metamaskEntry=phishing_page_portfolio_button`;
-
-        assert.equal(currentUrl, expectedPortfolioUrl);
-      },
-    );
-  });
-
-  it('should not block a website that makes a safe WebSocket connection', async function () {
-    const testPageURL = 'http://localhost:8080/';
-    await withFixtures(
-      {
-        fixtures: new FixtureBuilder().build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-        testSpecificMock: async (mockServer) => {
-          await mockServer.forAnyWebSocket().thenEcho();
-          await setupPhishingDetectionMocks(mockServer, {
-            blockProvider: BlockProvider.MetaMask,
-          });
-        },
-        dapp: true,
-      },
-      async ({ driver }) => {
-        await unlockWallet(driver);
-
-        await driver.openNewPage(testPageURL);
-
-        await createWebSocketConnection(driver, 'safe.localhost');
-
-        await driver.wait(until.titleIs(WINDOW_TITLES.TestDApp), 10000);
-
-        const currentUrl = await driver.getCurrentUrl();
-
-        assert.equal(currentUrl, testPageURL);
       },
     );
   });


### PR DESCRIPTION
This reverts commit e0f6575a6dc80913532f33202b1d3e91b31137b4, which is causing failing e2e tests on main


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29122?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
