### PR TITLE
refactor: allow simultaneous transaction confirmations from alternate chains

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -487,6 +487,7 @@ module.exports = {
               'getNfts',
               'getProviderConfig',
               'getRpcPrefsForCurrentProvider',
+              'getSelectedNetworkClientId',
               'getUSDConversionRate',
               'isCurrentProviderCustom',
             ]

--- a/ui/pages/confirmations/components/confirm/info/hooks/useSupportsEIP1559.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useSupportsEIP1559.ts
@@ -5,17 +5,17 @@ import {
 import { useSelector } from 'react-redux';
 import { isLegacyTransaction } from '../../../../../../helpers/utils/transactions.util';
 import { checkNetworkAndAccountSupports1559 } from '../../../../../../selectors';
-import { getSelectedNetworkClientId } from '../../../../../../../shared/modules/selectors/networks';
 
 export function useSupportsEIP1559(transactionMeta: TransactionMeta) {
+  const { networkClientId, txParams } = transactionMeta ?? {};
+  const { type } = txParams ?? {};
+
   const isLegacyTxn =
-    transactionMeta?.txParams?.type === TransactionEnvelopeType.legacy ||
+    type === TransactionEnvelopeType.legacy ||
     isLegacyTransaction(transactionMeta);
 
-  const selectedNetworkClientId = useSelector(getSelectedNetworkClientId);
-
   const networkAndAccountSupports1559 = useSelector((state) =>
-    checkNetworkAndAccountSupports1559(state, selectedNetworkClientId),
+    checkNetworkAndAccountSupports1559(state, networkClientId),
   );
 
   const supportsEIP1559 = networkAndAccountSupports1559 && !isLegacyTxn;

--- a/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.js
@@ -51,9 +51,10 @@ const TransactionAlerts = ({
   const t = useI18nContext();
   const { chainId } = txData;
 
-  const { nativeCurrency } = useSelector((state) =>
-    selectNetworkConfigurationByChainId(state, chainId),
-  );
+  const { nativeCurrency } =
+    useSelector((state) =>
+      selectNetworkConfigurationByChainId(state, chainId),
+    ) ?? {};
 
   const transactionData = txData.txParams.data;
   const currentTokenSymbol = tokenSymbol || nativeCurrency;

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -180,10 +180,10 @@ export default class ConfirmTransactionBase extends Component {
     maxValue: PropTypes.string,
     smartTransactionsPreferenceEnabled: PropTypes.bool,
     currentChainSupportsSmartTransactions: PropTypes.bool,
-    selectedNetworkClientId: PropTypes.string,
     isSmartTransactionsEnabled: PropTypes.bool,
     hasPriorityApprovalRequest: PropTypes.bool,
     chainId: PropTypes.string,
+    networkClientId: PropTypes.string,
   };
 
   state = {
@@ -1047,17 +1047,17 @@ export default class ConfirmTransactionBase extends Component {
      * while waiting for `gasFeeStartPollingByNetworkClientId` to resolve, the `_isMounted`
      * flag ensures that a call to disconnect happens after promise resolution.
      */
-    gasFeeStartPollingByNetworkClientId(
-      this.props.selectedNetworkClientId,
-    ).then((pollingToken) => {
-      if (this._isMounted) {
-        addPollingTokenToAppState(pollingToken);
-        this.setState({ pollingToken });
-      } else {
-        gasFeeStopPollingByPollingToken(pollingToken);
-        removePollingTokenFromAppState(this.state.pollingToken);
-      }
-    });
+    gasFeeStartPollingByNetworkClientId(this.props.networkClientId).then(
+      (pollingToken) => {
+        if (this._isMounted) {
+          addPollingTokenToAppState(pollingToken);
+          this.setState({ pollingToken });
+        } else {
+          gasFeeStopPollingByPollingToken(pollingToken);
+          removePollingTokenFromAppState(this.state.pollingToken);
+        }
+      },
+    );
 
     window.addEventListener('beforeunload', this._beforeUnloadForGasPolling);
 

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
@@ -71,7 +71,6 @@ import {
   getSendToAccounts,
   findKeyringForAddress,
 } from '../../../ducks/metamask/metamask';
-import { getSelectedNetworkClientId } from '../../../../shared/modules/selectors/networks';
 import {
   addHexPrefix,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
@@ -163,7 +162,6 @@ const mapStateToProps = (state, ownProps) => {
   } = ownProps;
   const { id: paramsTransactionId } = params;
   const isMainnet = getIsMainnet(state);
-  const selectedNetworkClientId = getSelectedNetworkClientId(state);
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   const envType = getEnvironmentType();
@@ -354,7 +352,6 @@ const mapStateToProps = (state, ownProps) => {
     nextNonce,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     isMainnet,
-    selectedNetworkClientId,
     isEthGasPriceFetched,
     noGasPrice,
     supportsEIP1559,

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
@@ -179,7 +179,7 @@ const mapStateToProps = (state, ownProps) => {
   const { txParams = {}, id: transactionId, type } = txData;
   const txId = transactionId || paramsTransactionId;
   const transaction = getUnapprovedTransaction(state, txId) ?? {};
-  const { chainId } = transaction;
+  const { chainId, networkClientId } = transaction;
   const conversionRate = selectConversionRateByChainId(state, chainId);
 
   const {
@@ -364,6 +364,7 @@ const mapStateToProps = (state, ownProps) => {
     nativeCurrency,
     hardwareWalletRequiresConnection,
     chainId,
+    networkClientId,
     isBuyableChain,
     useCurrencyRateCheck: getUseCurrencyRateCheck(state),
     keyringForAccount: keyring,

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.test.js
@@ -343,7 +343,7 @@ describe('Confirm Transaction Base', () => {
     expect(securityProviderBanner).toBeInTheDocument();
   });
 
-  it('should estimated fee details for optimism', async () => {
+  it('should estimate fee details for optimism', async () => {
     const state = {
       metamask: {
         ...baseStore.metamask,

--- a/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
@@ -13,7 +13,6 @@ import {
 } from '../../../ducks/confirm-transaction/confirm-transaction.duck';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import { getSendTo } from '../../../ducks/send';
-import { getSelectedNetworkClientId } from '../../../../shared/modules/selectors/networks';
 import {
   CONFIRM_DEPLOY_CONTRACT_PATH,
   CONFIRM_SEND_ETHER_PATH,
@@ -65,7 +64,6 @@ const ConfirmTransaction = () => {
 
   const unconfirmedTxsSorted = useSelector(unconfirmedTransactionsListSelector);
   const unconfirmedTxs = useSelector(unconfirmedTransactionsHashSelector);
-  const networkClientId = useSelector(getSelectedNetworkClientId);
 
   const totalUnapproved = unconfirmedTxsSorted.length || 0;
   const getTransaction = useCallback(() => {
@@ -129,7 +127,7 @@ const ConfirmTransaction = () => {
     startPolling: (input) =>
       gasFeeStartPollingByNetworkClientId(input.networkClientId),
     stopPollingByPollingToken: gasFeeStopPollingByPollingToken,
-    input: { networkClientId: transaction.networkClientId ?? networkClientId },
+    input: { networkClientId: transaction.networkClientId },
   });
 
   useEffect(() => {

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -28,10 +28,7 @@ import {
   subtractHexes,
   sumHexes,
 } from '../../shared/modules/conversion.utils';
-import {
-  getProviderConfig,
-  getCurrentChainId,
-} from '../../shared/modules/selectors/networks';
+import { getProviderConfig } from '../../shared/modules/selectors/networks';
 import { getAveragePriceEstimateInHexWEI } from './custom-gas';
 import {
   checkNetworkAndAccountSupports1559,
@@ -60,14 +57,12 @@ export const unconfirmedTransactionsListSelector = createSelector(
   unapprovedDecryptMsgsSelector,
   unapprovedEncryptionPublicKeyMsgsSelector,
   unapprovedTypedMessagesSelector,
-  getCurrentChainId,
   (
     unapprovedTxs = {},
     unapprovedPersonalMsgs = {},
     unapprovedDecryptMsgs = {},
     unapprovedEncryptionPublicKeyMsgs = {},
     unapprovedTypedMessages = {},
-    chainId,
   ) =>
     txHelper(
       unapprovedTxs,
@@ -75,7 +70,6 @@ export const unconfirmedTransactionsListSelector = createSelector(
       unapprovedDecryptMsgs,
       unapprovedEncryptionPublicKeyMsgs,
       unapprovedTypedMessages,
-      chainId,
     ) || [],
 );
 
@@ -85,23 +79,17 @@ export const unconfirmedTransactionsHashSelector = createSelector(
   unapprovedDecryptMsgsSelector,
   unapprovedEncryptionPublicKeyMsgsSelector,
   unapprovedTypedMessagesSelector,
-  getCurrentChainId,
   (
     unapprovedTxs = {},
     unapprovedPersonalMsgs = {},
     unapprovedDecryptMsgs = {},
     unapprovedEncryptionPublicKeyMsgs = {},
     unapprovedTypedMessages = {},
-    chainId,
   ) => {
     const filteredUnapprovedTxs = Object.keys(unapprovedTxs).reduce(
       (acc, address) => {
         const transactions = { ...acc };
-
-        if (unapprovedTxs[address].chainId === chainId) {
-          transactions[address] = unapprovedTxs[address];
-        }
-
+        transactions[address] = unapprovedTxs[address];
         return transactions;
       },
       {},

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -72,7 +72,7 @@ export const getCurrentNetworkTransactions = createDeepEqualSelector(
 
 export const getUnapprovedTransactions = createDeepEqualSelector(
   (state) => {
-    const currentNetworkTransactions = getCurrentNetworkTransactions(state);
+    const currentNetworkTransactions = getTransactions(state);
     return filterAndShapeUnapprovedTransactions(currentNetworkTransactions);
   },
   (transactions) => transactions,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29127?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
