### PR TITLE
feat: Add new metric sending_value to Transaction * events

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.test.ts
@@ -76,6 +76,7 @@ describe('useTokenValues', () => {
       decodedTransferValue: '7',
       displayTransferValue: '7',
       fiatDisplayValue: '$6.37',
+      fiatValue: 6.37,
       pending: false,
     });
   });
@@ -122,6 +123,7 @@ describe('useTokenValues', () => {
       decodedTransferValue: '7',
       displayTransferValue: '7',
       fiatDisplayValue: null,
+      fiatValue: null,
       pending: false,
     });
   });

--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
@@ -89,6 +89,7 @@ export const useTokenValues = (transactionMeta: TransactionMeta) => {
     decodedTransferValue,
     displayTransferValue,
     fiatDisplayValue,
+    fiatValue,
     pending: pending || isDecodedTransferValuePending,
   };
 };

--- a/ui/pages/confirmations/components/confirm/info/hooks/useSendingValueMetric.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useSendingValueMetric.test.ts
@@ -1,0 +1,104 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { renderHook } from '@testing-library/react-hooks';
+import { useEffect, useState } from 'react';
+import { genUnapprovedTokenTransferConfirmation } from '../../../../../../../test/data/confirmations/token-transfer';
+import { useTransactionEventFragment } from '../../../../hooks/useTransactionEventFragment';
+import { useSendingValueMetric } from './useSendingValueMetric';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useEffect: jest.fn(),
+  useState: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useTransactionEventFragment');
+
+describe('useSimulationMetrics', () => {
+  const useTransactionEventFragmentMock = jest.mocked(
+    useTransactionEventFragment,
+  );
+
+  const useStateMock = jest.mocked(useState);
+  const useEffectMock = jest.mocked(useEffect);
+
+  // TODO: Replace `any` with type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let updateTransactionEventFragmentMock: jest.MockedFunction<any>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    updateTransactionEventFragmentMock = jest.fn();
+
+    useTransactionEventFragmentMock.mockReturnValue({
+      updateTransactionEventFragment: updateTransactionEventFragmentMock,
+    });
+
+    // TODO: Replace `any` with type
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useStateMock.mockImplementation(((initialValue: any) => [
+      initialValue,
+      jest.fn(),
+      // TODO: Replace `any` with type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ]) as any);
+
+    useEffectMock.mockImplementation((fn) => fn());
+  });
+
+  describe('useSendingValueMetric', () => {
+    it('Updates the event property', async () => {
+      const MOCK_FIAT_VALUE = 10;
+      const transactionMeta = genUnapprovedTokenTransferConfirmation(
+        {},
+      ) as TransactionMeta;
+      const props = { transactionMeta, fiatValue: MOCK_FIAT_VALUE };
+
+      renderHook(() => useSendingValueMetric(props));
+
+      expect(updateTransactionEventFragmentMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            sending_value: MOCK_FIAT_VALUE,
+          }),
+        }),
+        '1d7c08c0-fe54-11ee-9243-91b1e533746a',
+      );
+
+      jest.restoreAllMocks();
+    });
+
+    it('Does not updates the event property if fiat value is undefined', async () => {
+      const MOCK_FIAT_VALUE = undefined;
+      const transactionMeta = genUnapprovedTokenTransferConfirmation(
+        {},
+      ) as TransactionMeta;
+      const props = { transactionMeta, fiatValue: MOCK_FIAT_VALUE };
+
+      renderHook(() => useSendingValueMetric(props));
+
+      expect(updateTransactionEventFragmentMock).not.toHaveBeenCalled();
+
+      jest.restoreAllMocks();
+    });
+
+    it('Does not updates the event property if fiat value is empty string', async () => {
+      const MOCK_FIAT_VALUE = '' as const;
+      const transactionMeta = genUnapprovedTokenTransferConfirmation(
+        {},
+      ) as TransactionMeta;
+      const props = { transactionMeta, fiatValue: MOCK_FIAT_VALUE };
+
+      renderHook(() => useSendingValueMetric(props));
+
+      expect(updateTransactionEventFragmentMock).not.toHaveBeenCalled();
+
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/ui/pages/confirmations/components/confirm/info/hooks/useSendingValueMetric.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useSendingValueMetric.ts
@@ -1,0 +1,26 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { useEffect } from 'react';
+import { useTransactionEventFragment } from '../../../../hooks/useTransactionEventFragment';
+
+export type UseSendingValueMetricProps = {
+  transactionMeta: TransactionMeta;
+  fiatValue: number | undefined | '';
+};
+
+export const useSendingValueMetric = ({
+  transactionMeta,
+  fiatValue,
+}: UseSendingValueMetricProps) => {
+  const { updateTransactionEventFragment } = useTransactionEventFragment();
+
+  const transactionId = transactionMeta.id;
+  const properties = { sending_value: fiatValue };
+  const sensitiveProperties = {};
+  const params = { properties, sensitiveProperties };
+
+  useEffect(() => {
+    if (fiatValue !== undefined && fiatValue !== '') {
+      updateTransactionEventFragment(params, transactionId);
+    }
+  }, [updateTransactionEventFragment, transactionId, JSON.stringify(params)]);
+};

--- a/ui/pages/confirmations/components/confirm/info/shared/native-send-heading/native-send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/native-send-heading/native-send-heading.tsx
@@ -32,6 +32,7 @@ import {
 import { getMultichainNetwork } from '../../../../../../../selectors/multichain';
 import { useConfirmContext } from '../../../../../context/confirm';
 import { formatAmount } from '../../../../simulation-details/formatAmount';
+import { useSendingValueMetric } from '../../hooks/useSendingValueMetric';
 
 const NativeSendHeading = () => {
   const { currentConfirmation: transactionMeta } =
@@ -113,6 +114,8 @@ const NativeSendHeading = () => {
         {fiatDisplayValue}
       </Text>
     );
+
+  useSendingValueMetric({ transactionMeta, fiatValue });
 
   return (
     <Box

--- a/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
@@ -22,6 +22,7 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { getPreferences } from '../../../../../../../selectors';
 import { useConfirmContext } from '../../../../../context/confirm';
 import { useTokenValues } from '../../hooks/use-token-values';
+import { useSendingValueMetric } from '../../hooks/useSendingValueMetric';
 import { useTokenDetails } from '../../hooks/useTokenDetails';
 import { ConfirmLoader } from '../confirm-loader/confirm-loader';
 
@@ -34,6 +35,7 @@ const SendHeading = () => {
     decodedTransferValue,
     displayTransferValue,
     fiatDisplayValue,
+    fiatValue,
     pending,
   } = useTokenValues(transactionMeta);
 
@@ -84,6 +86,8 @@ const SendHeading = () => {
         {fiatDisplayValue}
       </Text>
     );
+
+  useSendingValueMetric({ transactionMeta, fiatValue });
 
   if (pending) {
     return <ConfirmLoader />;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a `useSendingValueMetric` hook that uses `updateTransactionEventFragment` to add the `sending_value` property on erc20 and native token transfers. The value is sent as an unformatted decimal javascript number.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29134?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3784

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

Native token send: 
<img width="682" alt="Screenshot 2024-12-12 at 11 40 43" src="https://github.com/user-attachments/assets/0d4f6d5f-9164-46e2-b3ee-99b94cfe761f" />

ERC20 token send:
<img width="682" alt="Screenshot 2024-12-12 at 11 41 47" src="https://github.com/user-attachments/assets/49066f30-ed2d-4bb1-9948-8604127299aa" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
