### PR TITLE
fix: Swap out Spinner component exposed to Snaps

### DIFF
--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -28,6 +28,7 @@ import {
 import { SnapDelineator } from '../snaps/snap-delineator';
 import { Copyable } from '../snaps/copyable';
 import Spinner from '../../ui/spinner';
+import Preloader from '../../ui/icon/preloader';
 import { SnapUIMarkdown } from '../snaps/snap-ui-markdown';
 import { SnapUILink } from '../snaps/snap-ui-link';
 import { SmartTransactionStatusPage } from '../../../pages/smart-transactions/smart-transaction-status-page';
@@ -93,6 +94,7 @@ export const safeComponentList = {
   SnapUIImage,
   BannerAlert,
   Spinner,
+  Preloader,
   ConfirmInfoRow,
   ConfirmInfoRowAddress,
   ConfirmInfoRowValueDouble,

--- a/ui/components/app/snaps/snap-ui-renderer/components/spinner.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/spinner.ts
@@ -2,7 +2,7 @@ import { SpinnerElement } from '@metamask/snaps-sdk/jsx';
 import { UIComponentFactory } from './types';
 
 export const spinner: UIComponentFactory<SpinnerElement> = () => ({
-  element: 'Spinner',
+  element: 'Preloader',
   props: {
     className: 'snap-ui-renderer__spinner',
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Swap out the `Spinner` component exposed to Snaps for the `Preloader` component.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29143?quickstart=1)

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/d4c9a712-67a8-4d1f-b2f2-8d8550d87f27)

## Manual Testing Steps

```ts
import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
import { Box, Spinner } from '@metamask/snaps-sdk/jsx';

/**
 * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
 *
 * @param args - The request handler args as object.
 * @param args.origin - The origin of the request, e.g., the website that
 * invoked the snap.
 * @param args.request - A validated JSON-RPC request object.
 * @returns The result of `snap_dialog`.
 * @throws If the request method is not valid for this snap.
 */
export const onRpcRequest: OnRpcRequestHandler = async ({
  origin,
  request,
}) => {
  switch (request.method) {
    case 'hello':
      return snap.request({
        method: 'snap_dialog',
        params: {
          type: 'confirmation',
          content: (
            <Box>
              <Spinner />
            </Box>
          ),
        },
      });
    default:
      throw new Error('Method not found.');
  }
};

```

