### PR TITLE
chore: improve confirmation re renders

### DIFF
--- a/ui/hooks/useAsyncResult.ts
+++ b/ui/hooks/useAsyncResult.ts
@@ -32,7 +32,9 @@ export function useAsyncResult<T>(
   });
 
   useEffect(() => {
-    setResult({ pending: true });
+    if (!result.pending) {
+      setResult({ pending: true });
+    }
     let cancelled = false;
     asyncFn()
       .then((value) => {

--- a/ui/pages/confirmations/confirm/confirm.tsx
+++ b/ui/pages/confirmations/confirm/confirm.tsx
@@ -1,5 +1,5 @@
 import { ReactNodeLike } from 'prop-types';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, memo } from 'react';
 
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 import { MMISignatureMismatchBanner } from '../../../components/institutional/signature-mismatch-banner';
@@ -44,7 +44,7 @@ const GasFeeContextProviderWrapper: React.FC<{
   );
 };
 
-const Confirm = () => (
+const Confirm = memo(() => (
   <ConfirmContextProvider>
     <TransactionModalContextProvider>
       {/* This context should be removed once we implement the new edit gas fees popovers */}
@@ -79,6 +79,6 @@ const Confirm = () => (
       </GasFeeContextProviderWrapper>
     </TransactionModalContextProvider>
   </ConfirmContextProvider>
-);
+));
 
 export default Confirm;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
After some initial analysis on current re-renders on new Confirmation pages, it was possible to identify two straightforward improvements:

* Wrap current `Confirm` component in `React.memo` (this component is the root component for the redesigned Confirmation pages). This will prevent the redesigned confirmation page from being re-rendered whenever the root `ConfirmTransaction` component is re-rendered.
* In the `useAsyncResult` only set the state to `{ pending: true }` when `pending === false`. This prevents setting the state when it is not needed and preventing unwanted re-renders.

[Note: the analysis was done using UI integration tests with the [why-did-you-render](https://www.npmjs.com/package/@welldone-software/why-did-you-render) package]

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29146?quickstart=1)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
