### PR TITLE
chore: disable button while submiting, use finally set submitting to …

### DIFF
--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -110,7 +110,7 @@ export const BridgeCTAButton = () => {
       onClick={() => {
         if (activeQuote && isTxSubmittable) {
           try {
-            // We don't need to worry about setting to true if the tx submission succeeds
+            // We don't need to worry about setting to false if the tx submission succeeds
             // because we route immediately to Activity list page
             setIsSubmitting(true);
 
@@ -126,13 +126,13 @@ export const BridgeCTAButton = () => {
                 },
               });
             submitBridgeTransaction(activeQuote);
-          } catch (error) {
+          } finally {
             setIsSubmitting(false);
           }
         }
       }}
       loading={isSubmitting}
-      disabled={!isTxSubmittable || isQuoteExpired}
+      disabled={!isTxSubmittable || isQuoteExpired || isSubmitting}
     >
       {label}
     </Button>


### PR DESCRIPTION
…false


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29149?quickstart=1)

This PR handles some additional comments from https://github.com/MetaMask/metamask-extension/pull/29109

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
