### PR TITLE
fix: send user to native bridge experience rather than portfolio when…

### DIFF
--- a/ui/components/multichain/account-overview/account-overview-layout.tsx
+++ b/ui/components/multichain/account-overview/account-overview-layout.tsx
@@ -1,13 +1,17 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { isEqual } from 'lodash';
+///: END:ONLY_INCLUDE_IF
 import { removeSlide, updateSlides } from '../../../store/actions';
 import { Carousel } from '..';
 import {
   getSelectedAccountCachedBalance,
   getAppIsLoading,
   getSlides,
+  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   getSwapsDefaultToken,
+  ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import useBridging from '../../../hooks/bridge/useBridging';

--- a/ui/components/multichain/account-overview/account-overview-layout.tsx
+++ b/ui/components/multichain/account-overview/account-overview-layout.tsx
@@ -1,21 +1,15 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { isEqual } from 'lodash';
 import { removeSlide, updateSlides } from '../../../store/actions';
 import { Carousel } from '..';
 import {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-  getSwapsDefaultToken,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
-  getDataCollectionForMarketing,
-  ///: END:ONLY_INCLUDE_IF
   getSelectedAccountCachedBalance,
   getAppIsLoading,
   getSlides,
+  getSwapsDefaultToken,
 } from '../../../selectors';
-///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
-///: END:ONLY_INCLUDE_IF
+import useBridging from '../../../hooks/bridge/useBridging';
 import {
   AccountOverviewTabsProps,
   AccountOverviewTabs,
@@ -43,13 +37,14 @@ export const AccountOverviewLayout = ({
   const totalBalance = useSelector(getSelectedAccountCachedBalance);
   const isLoading = useSelector(getAppIsLoading);
 
+  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
+  const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);
+  ///: END:ONLY_INCLUDE_IF
+
   const hasZeroBalance = totalBalance === ZERO_BALANCE;
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-  const defaultSwapsToken = useSelector(getSwapsDefaultToken);
-  const metaMetricsId = useSelector(getMetaMetricsId);
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
-  const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
+  const { openBridgeExperience } = useBridging();
   ///: END:ONLY_INCLUDE_IF
 
   useEffect(() => {
@@ -78,17 +73,11 @@ export const AccountOverviewLayout = ({
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   const handleCarouselClick = (id: string) => {
     if (id === 'bridge') {
-      const portfolioUrl = getPortfolioUrl(
-        'bridge',
-        'ext_bridge_prepare_swap_link',
-        metaMetricsId,
-        isMetaMetricsEnabled,
-        isMarketingEnabled,
+      openBridgeExperience(
+        'Carousel',
+        defaultSwapsToken,
+        location.pathname.includes('asset') ? '&token=native' : '',
       );
-
-      global.platform.openTab({
-        url: `${portfolioUrl}&token=${defaultSwapsToken}`,
-      });
     }
   };
   ///: END:ONLY_INCLUDE_IF

--- a/ui/components/multichain/account-overview/account-overview-layout.tsx
+++ b/ui/components/multichain/account-overview/account-overview-layout.tsx
@@ -9,7 +9,9 @@ import {
   getSlides,
   getSwapsDefaultToken,
 } from '../../../selectors';
+///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import useBridging from '../../../hooks/bridge/useBridging';
+///: END:ONLY_INCLUDE_IF
 import {
   AccountOverviewTabsProps,
   AccountOverviewTabs,


### PR DESCRIPTION
… carousel clicked


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR sends users to the in app Bridge experience rather than linking them out to the Porfolio when the Bridge cards in the carousel is clicked.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29169?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
