### PR TITLE
feat: show info message when a HW user declines a tx

### DIFF
--- a/ui/ducks/bridge/actions.ts
+++ b/ui/ducks/bridge/actions.ts
@@ -25,6 +25,7 @@ const {
   resetInputFields,
   setSortOrder,
   setSelectedQuote,
+  setWasTxDeclined,
 } = bridgeSlice.actions;
 
 export {
@@ -37,6 +38,7 @@ export {
   setSrcTokenExchangeRates,
   setSortOrder,
   setSelectedQuote,
+  setWasTxDeclined,
 };
 
 const callBridgeControllerMethod = <T>(

--- a/ui/ducks/bridge/bridge.test.ts
+++ b/ui/ducks/bridge/bridge.test.ts
@@ -24,6 +24,7 @@ import {
   updateQuoteRequestParams,
   resetBridgeState,
   setDestTokenExchangeRates,
+  setWasTxDeclined,
 } from './actions';
 
 const middleware = [thunk];
@@ -153,6 +154,7 @@ describe('Ducks - Bridge', () => {
         sortOrder: 'cost_ascending',
         toTokenExchangeRate: null,
         fromTokenExchangeRate: null,
+        wasTxDeclined: false,
       });
     });
   });
@@ -217,6 +219,7 @@ describe('Ducks - Bridge', () => {
         toChainId: null,
         toToken: null,
         toTokenExchangeRate: null,
+        wasTxDeclined: false,
       });
     });
   });
@@ -307,6 +310,17 @@ describe('Ducks - Bridge', () => {
         toTokenExchangeRate: 0.999881,
         sortOrder: 'cost_ascending',
       });
+    });
+  });
+
+  describe('setWasTxDeclined', () => {
+    it('sets the wasTxDeclined flag to true', () => {
+      const state = store.getState().bridge;
+      store.dispatch(setWasTxDeclined(true));
+      const actions = store.getActions();
+      expect(actions[0].type).toStrictEqual('bridge/setWasTxDeclined');
+      const newState = bridgeReducer(state, actions[0]);
+      expect(newState.wasTxDeclined).toStrictEqual(true);
     });
   });
 });

--- a/ui/ducks/bridge/bridge.ts
+++ b/ui/ducks/bridge/bridge.ts
@@ -19,6 +19,7 @@ export type BridgeState = {
   toTokenExchangeRate: number | null; // Exchange rate from the selected token to the default currency (can be fiat or crypto)
   sortOrder: SortOrder;
   selectedQuote: (QuoteResponse & QuoteMetadata) | null; // Alternate quote selected by user. When quotes refresh, the best match will be activated.
+  wasTxDeclined: boolean; // Whether the user declined the transaction. Relevant for hardware wallets.
 };
 
 const initialState: BridgeState = {
@@ -30,6 +31,7 @@ const initialState: BridgeState = {
   toTokenExchangeRate: null,
   sortOrder: SortOrder.COST_ASC,
   selectedQuote: null,
+  wasTxDeclined: false,
 };
 
 export const setSrcTokenExchangeRates = createAsyncThunk(
@@ -67,6 +69,9 @@ const bridgeSlice = createSlice({
     },
     setSelectedQuote: (state, action) => {
       state.selectedQuote = action.payload;
+    },
+    setWasTxDeclined: (state, action) => {
+      state.wasTxDeclined = action.payload;
     },
   },
   extraReducers: (builder) => {

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -554,3 +554,7 @@ export const getValidationErrors = createDeepEqualSelector(
     };
   },
 );
+
+export const getWasTxDeclined = (state: BridgeAppState): boolean => {
+  return state.bridge.wasTxDeclined;
+};

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -16,10 +16,10 @@ import { isHardwareWallet } from '../../../selectors';
 import { getQuoteRequest } from '../../../ducks/bridge/selectors';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
+import { setWasTxDeclined } from '../../../ducks/bridge/actions';
 import useAddToken from './useAddToken';
 import useHandleApprovalTx from './useHandleApprovalTx';
 import useHandleBridgeTx from './useHandleBridgeTx';
-import { setWasTxDeclined } from '../../../ducks/bridge/actions';
 
 const debugLog = createProjectLogger('bridge');
 const LINEA_DELAY_MS = 5000;

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -19,6 +19,7 @@ import { getCurrentChainId } from '../../../../shared/modules/selectors/networks
 import useAddToken from './useAddToken';
 import useHandleApprovalTx from './useHandleApprovalTx';
 import useHandleBridgeTx from './useHandleBridgeTx';
+import { setWasTxDeclined } from '../../../ducks/bridge/actions';
 
 const debugLog = createProjectLogger('bridge');
 const LINEA_DELAY_MS = 5000;
@@ -73,6 +74,7 @@ export default function useSubmitBridgeTransaction() {
     } catch (e) {
       debugLog('Approve transaction failed', e);
       if (hardwareWalletUsed && isHardwareWalletUserRejection(e)) {
+        dispatch(setWasTxDeclined(true));
         history.push(`${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`);
       } else {
         await dispatch(setDefaultHomeActiveTabName('activity'));
@@ -108,6 +110,7 @@ export default function useSubmitBridgeTransaction() {
     } catch (e) {
       debugLog('Bridge transaction failed', e);
       if (hardwareWalletUsed && isHardwareWalletUserRejection(e)) {
+        dispatch(setWasTxDeclined(true));
         history.push(`${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`);
       } else {
         await dispatch(setDefaultHomeActiveTabName('activity'));

--- a/ui/pages/bridge/index.tsx
+++ b/ui/pages/bridge/index.tsx
@@ -34,11 +34,11 @@ import { resetBridgeState, setFromChain } from '../../ducks/bridge/actions';
 import { useGasFeeEstimates } from '../../hooks/useGasFeeEstimates';
 import { useBridgeExchangeRates } from '../../hooks/bridge/useBridgeExchangeRates';
 import { useQuoteFetchEvents } from '../../hooks/bridge/useQuoteFetchEvents';
+import { getWasTxDeclined } from '../../ducks/bridge/selectors';
 import PrepareBridgePage from './prepare/prepare-bridge-page';
 import { BridgeCTAButton } from './prepare/bridge-cta-button';
 import AwaitingSignaturesCancelButton from './awaiting-signatures/awaiting-signatures-cancel-button';
 import AwaitingSignatures from './awaiting-signatures/awaiting-signatures';
-import { getWasTxDeclined } from '../../ducks/bridge/selectors';
 import { BridgeTxDeclinedMessage } from './prepare/bridge-tx-declined-message';
 
 const CrossChainSwap = () => {

--- a/ui/pages/bridge/index.tsx
+++ b/ui/pages/bridge/index.tsx
@@ -38,6 +38,8 @@ import PrepareBridgePage from './prepare/prepare-bridge-page';
 import { BridgeCTAButton } from './prepare/bridge-cta-button';
 import AwaitingSignaturesCancelButton from './awaiting-signatures/awaiting-signatures-cancel-button';
 import AwaitingSignatures from './awaiting-signatures/awaiting-signatures';
+import { getWasTxDeclined } from '../../ducks/bridge/selectors';
+import { BridgeTxDeclinedMessage } from './prepare/bridge-tx-declined-message';
 
 const CrossChainSwap = () => {
   const t = useContext(I18nContext);
@@ -53,6 +55,7 @@ const CrossChainSwap = () => {
   const providerConfig = useSelector(getProviderConfig);
   const isBridgeChain = useSelector(getIsBridgeChain);
   const currency = useSelector(getCurrentCurrency);
+  const wasTxDeclined = useSelector(getWasTxDeclined);
 
   useEffect(() => {
     if (isBridgeChain && isBridgeEnabled && providerConfig) {
@@ -127,7 +130,11 @@ const CrossChainSwap = () => {
                 <PrepareBridgePage />
               </Content>
               <Footer>
-                <BridgeCTAButton />
+                {wasTxDeclined ? (
+                  <BridgeTxDeclinedMessage />
+                ) : (
+                  <BridgeCTAButton />
+                )}
               </Footer>
             </>
           </FeatureToggledRoute>

--- a/ui/pages/bridge/prepare/bridge-tx-declined-message.tsx
+++ b/ui/pages/bridge/prepare/bridge-tx-declined-message.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
-import { AlignItems } from "../../../helpers/constants/design-system";
-import { Display } from "../../../helpers/constants/design-system";
-import { TextColor } from "../../../helpers/constants/design-system";
-import { ButtonLinkSize, Text } from "../../../components/component-library";
-import { ButtonLink } from "../../../components/component-library";
-import { setWasTxDeclined } from "../../../ducks/bridge/actions";
-import { useDispatch } from "react-redux";
+import { useDispatch } from 'react-redux';
+import {
+  AlignItems,
+  Display,
+  TextColor,
+} from '../../../helpers/constants/design-system';
+import {
+  ButtonLinkSize,
+  Text,
+  ButtonLink,
+} from '../../../components/component-library';
+import { setWasTxDeclined } from '../../../ducks/bridge/actions';
 
 export const BridgeTxDeclinedMessage = () => {
   const dispatch = useDispatch();

--- a/ui/pages/bridge/prepare/bridge-tx-declined-message.tsx
+++ b/ui/pages/bridge/prepare/bridge-tx-declined-message.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { AlignItems } from "../../../helpers/constants/design-system";
+import { Display } from "../../../helpers/constants/design-system";
+import { TextColor } from "../../../helpers/constants/design-system";
+import { ButtonLinkSize, Text } from "../../../components/component-library";
+import { ButtonLink } from "../../../components/component-library";
+import { setWasTxDeclined } from "../../../ducks/bridge/actions";
+import { useDispatch } from "react-redux";
+
+export const BridgeTxDeclinedMessage = () => {
+  const dispatch = useDispatch();
+
+  return (
+    <Text
+      color={TextColor.textMuted}
+      display={Display.Flex}
+      alignItems={AlignItems.center}
+      style={{ whiteSpace: 'nowrap' }}
+    >
+      You declined the transaction.
+      <ButtonLink
+        size={ButtonLinkSize.Sm}
+        paddingLeft={1}
+        onClick={() => {
+          dispatch(setWasTxDeclined(false));
+        }}
+      >
+        Get a new quote.
+      </ButtonLink>
+    </Text>
+  );
+};

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -27,6 +27,7 @@ import {
   getToToken,
   getToTokens,
   getToTopAssets,
+  getWasTxDeclined,
 } from '../../../ducks/bridge/selectors';
 import {
   Box,
@@ -77,6 +78,8 @@ const PrepareBridgePage = () => {
 
   const quoteRequest = useSelector(getQuoteRequest);
   const { activeQuote } = useSelector(getBridgeQuotes);
+
+  const wasTxDeclined = useSelector(getWasTxDeclined);
 
   const fromTokenListGenerator = useTokensWithFiltering(
     fromTokens,
@@ -323,7 +326,7 @@ const PrepareBridgePage = () => {
           }}
         />
       </Box>
-      <BridgeQuoteCard />
+      {!wasTxDeclined && <BridgeQuoteCard />}
     </div>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a hardware wallet user declines a transaction during the bridge process, they are redirected back to the bridge setup page. This PR adds an info message to clarify why they were redirected and prompt them to get a new quote.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29198?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to bridge with a hardware wallet
2. Attempt bridge
3. Decline transaction on hardware wallet
4. See info message when you're redirected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
![Screenshot 2024-12-13 at 14 53 00](https://github.com/user-attachments/assets/abbeca68-39d9-4926-b50f-5321949f58ec)

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
