### PR TITLE
feat: center backup toast

### DIFF
--- a/ui/components/app/home-notification/index.scss
+++ b/ui/components/app/home-notification/index.scss
@@ -10,10 +10,9 @@
   border-radius: 8px;
   min-height: 116px;
   padding: 16px;
+  width: calc(100% - 16px);
+  max-width: 472px;
 
-  @include design-system.screen-sm-min {
-    min-width: 472px;
-  }
 
   &__content-container {
     display: flex;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Centers the backup warning toast

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29200?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**

<img width="397" alt="Screenshot 2024-12-13 at 14 54 15" src="https://github.com/user-attachments/assets/aa36f379-b18f-4eb9-95d5-5b08d3f161f2" />


### **After**

<img width="355" alt="Screenshot 2024-12-13 at 14 53 25" src="https://github.com/user-attachments/assets/4869708c-9a03-4d17-9732-6176477ab96f" />
<img width="891" alt="Screenshot 2024-12-13 at 14 53 36" src="https://github.com/user-attachments/assets/5fc462a0-558f-43d9-a332-129d10b4c30a" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
