### PR TITLE
fix: personal sign message - decode message to UTF-8 string only if it is valid UTF-8

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.test.tsx
@@ -9,9 +9,13 @@ import {
   getMockTypedSignConfirmStateForRequest,
 } from '../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
-import { signatureRequestSIWE } from '../../../../../../../test/data/confirmations/personal_sign';
-import * as utils from '../../../../utils';
+import {
+  signatureRequestSIWE,
+  unapprovedPersonalSignMsg,
+} from '../../../../../../../test/data/confirmations/personal_sign';
 import * as snapUtils from '../../../../../../helpers/utils/snaps';
+import { SignatureRequestType } from '../../../../types/confirm';
+import * as utils from '../../../../utils';
 import PersonalSignInfo from './personal-sign';
 
 jest.mock(
@@ -183,5 +187,23 @@ describe('PersonalSignInfo', () => {
     expect(
       queryByText('This is the site asking for your signature.'),
     ).toBeDefined();
+  });
+
+  it('display hex message value if it can not be converted to valid UTF-8 string', () => {
+    const message =
+      '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
+    const state = getMockPersonalSignConfirmStateForRequest({
+      ...unapprovedPersonalSignMsg,
+      msgParams: {
+        ...unapprovedPersonalSignMsg.msgParams,
+        data: message,
+      },
+    } as SignatureRequestType);
+    const mockStore = configureMockStore([])(state);
+    const { getByText } = renderWithConfirmContextProvider(
+      <PersonalSignInfo />,
+      mockStore,
+    );
+    expect(getByText(message)).toBeDefined();
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
@@ -38,7 +38,16 @@ import { selectUseTransactionSimulations } from '../../../../selectors/preferenc
 import { SignatureRequestType } from '../../../../types/confirm';
 import { isSIWESignatureRequest } from '../../../../utils';
 import { SigningInWithRow } from '../shared/sign-in-with-row/sign-in-with-row';
+import { isValidUTF8 } from '../utils';
 import { SIWESignInfo } from './siwe-sign';
+
+const getMessageText = (hexString?: string) => {
+  if (!hexString) {
+    return hexString;
+  }
+  const messageText = sanitizeString(hexToText(hexString));
+  return isValidUTF8(messageText) ? messageText : hexString;
+};
 
 const PersonalSignInfo: React.FC = () => {
   const t = useI18nContext();
@@ -52,9 +61,7 @@ const PersonalSignInfo: React.FC = () => {
   }
 
   const isSIWE = isSIWESignatureRequest(currentConfirmation);
-  const messageText = sanitizeString(
-    hexToText(currentConfirmation.msgParams?.data),
-  );
+  const messageText = getMessageText(currentConfirmation.msgParams?.data);
 
   let toolTipMessage;
   if (!isSIWE) {

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
@@ -61,7 +61,9 @@ const PersonalSignInfo: React.FC = () => {
   }
 
   const isSIWE = isSIWESignatureRequest(currentConfirmation);
-  const messageText = getMessageText(currentConfirmation.msgParams?.data);
+  const messageText = getMessageText(
+    currentConfirmation.msgParams?.data as string,
+  );
 
   let toolTipMessage;
   if (!isSIWE) {

--- a/ui/pages/confirmations/components/confirm/info/utils.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/utils.test.ts
@@ -4,6 +4,7 @@ import { DecodedTransactionDataSource } from '../../../../../../shared/types/tra
 import {
   getIsRevokeSetApprovalForAll,
   hasValueAndNativeBalanceMismatch,
+  isValidUTF8,
 } from './utils';
 
 describe('getIsRevokeSetApprovalForAll', () => {
@@ -139,5 +140,13 @@ describe('hasValueAndNativeBalanceMismatch', () => {
     } as unknown as TransactionMeta;
 
     expect(hasValueAndNativeBalanceMismatch(transaction)).toBe(true);
+  });
+});
+
+describe('isValidUTF8', () => {
+  it('returns true for valid UTF-8 string', () => {
+    expect(isValidUTF8('Hello')).toEqual(true);
+    expect(isValidUTF8('\xC3\x28')).toEqual(true);
+    expect(isValidUTF8('😀')).toEqual(true);
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/utils.ts
+++ b/ui/pages/confirmations/components/confirm/info/utils.ts
@@ -110,3 +110,17 @@ export function hasValueAndNativeBalanceMismatch(
     nativeBalanceChange?.isDecrease === false,
   );
 }
+
+export function isValidUTF8(inputString: string) {
+  try {
+    const encoder = new TextEncoder();
+    const encoded = encoder.encode(inputString);
+
+    const decoder = new TextDecoder('utf-8', { fatal: true });
+    decoder.decode(encoded);
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Converts personal sign message to UTF-8 string only if it can be converted to valid UTF-8 string.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/3931

## **Manual testing steps**

1. Send personal sign request to extension with message string `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
2. Check on confirmation page that it is displayed as UTF-8 string

## **Screenshots/Recordings**
<img width="360" alt="Screenshot 2024-12-16 at 6 53 30 PM" src="https://github.com/user-attachments/assets/b2053d70-dbed-4bd3-8e77-d0ba3f4150bc" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
