### PR TITLE
fix(27140): fix styles for Slippage Tolerance Button Group in Transaction Settings Modal

### DIFF
--- a/ui/components/ui/button-group/__snapshots__/button-group-component.test.js.snap
+++ b/ui/components/ui/button-group/__snapshots__/button-group-component.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ButtonGroup Component should match snapshot 1`] = `
+exports[`ButtonGroup Component should match snapshot with default variant 1`] = `
 <div>
   <div
     class="someClassName"
@@ -24,6 +24,39 @@ exports[`ButtonGroup Component should match snapshot 1`] = `
       aria-checked="false"
       class="button-group__button"
       data-testid="button-group__button2"
+    />
+  </div>
+</div>
+`;
+
+exports[`ButtonGroup Component should match snapshot with radiogroup variant 1`] = `
+<div>
+  <div
+    class="someClassName radio-button-group"
+    role="radiogroup"
+    style="color: red;"
+  >
+    <button
+      aria-checked="false"
+      class="radio-button-group__button"
+      data-testid="button-group__button0"
+      role="radio"
+    >
+      <div
+        class="mockClass"
+      />
+    </button>
+    <button
+      aria-checked="true"
+      class="radio-button-group__button button-group__button--active radio-button-group__button--active"
+      data-testid="button-group__button1"
+      role="radio"
+    />
+    <button
+      aria-checked="false"
+      class="radio-button-group__button"
+      data-testid="button-group__button2"
+      role="radio"
     />
   </div>
 </div>

--- a/ui/components/ui/button-group/button-group-component.test.js
+++ b/ui/components/ui/button-group/button-group-component.test.js
@@ -16,13 +16,23 @@ describe('ButtonGroup Component', () => {
     <button key="a">
       <div className="mockClass" />
     </button>,
-    <button key="b"></button>,
-    <button key="c"></button>,
+    <button key="b" />,
+    <button key="c" />,
   ];
 
-  it('should match snapshot', () => {
+  it('should match snapshot with default variant', () => {
     const { container } = renderWithProvider(
       <ButtonGroup {...props}>{mockButtons}</ButtonGroup>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should match snapshot with radiogroup variant', () => {
+    const { container } = renderWithProvider(
+      <ButtonGroup {...props} variant="radiogroup">
+        {mockButtons}
+      </ButtonGroup>,
     );
 
     expect(container).toMatchSnapshot();

--- a/ui/components/ui/button-group/button-group.component.js
+++ b/ui/components/ui/button-group/button-group.component.js
@@ -74,13 +74,14 @@ export default class ButtonGroup extends PureComponent {
             role={variant === 'radiogroup' ? 'radio' : undefined}
             aria-checked={index === this.state.activeButtonIndex}
             className={classnames(
-              'button-group__button',
+              variant === 'radiogroup'
+                ? 'radio-button-group__button'
+                : 'button-group__button',
               child.props.className,
               {
-                'radio-button': variant === 'radiogroup',
                 'button-group__button--active':
                   index === this.state.activeButtonIndex,
-                'radio-button--active':
+                'radio-button-group__button--active':
                   variant === 'radiogroup' &&
                   index === this.state.activeButtonIndex,
               },

--- a/ui/components/ui/button-group/index.scss
+++ b/ui/components/ui/button-group/index.scss
@@ -38,7 +38,7 @@
 }
 
 .radio-button-group {
-  .radio-button {
+  &__button {
     @include design-system.H7;
 
     color: var(--color-text-alternative);

--- a/ui/pages/swaps/transaction-settings/__snapshots__/transaction-settings.test.js.snap
+++ b/ui/pages/swaps/transaction-settings/__snapshots__/transaction-settings.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`TransactionSettings renders the component with initial props 1`] = `
 <div
-  class="button-group transaction-settings__button-group radio-button-group"
+  class="transaction-settings__button-group radio-button-group"
   role="radiogroup"
 >
   <button
     aria-checked="false"
-    class="button-group__button radio-button"
+    class="radio-button-group__button"
     data-testid="button-group__button0"
     role="radio"
   >
@@ -15,7 +15,7 @@ exports[`TransactionSettings renders the component with initial props 1`] = `
   </button>
   <button
     aria-checked="true"
-    class="button-group__button radio-button button-group__button--active radio-button--active"
+    class="radio-button-group__button button-group__button--active radio-button-group__button--active"
     data-testid="button-group__button1"
     role="radio"
   >
@@ -23,7 +23,7 @@ exports[`TransactionSettings renders the component with initial props 1`] = `
   </button>
   <button
     aria-checked="false"
-    class="button-group__button transaction-settings__button-group-custom-button radio-button"
+    class="radio-button-group__button transaction-settings__button-group-custom-button"
     data-testid="button-group__button2"
     role="radio"
   >

--- a/ui/pages/swaps/transaction-settings/index.scss
+++ b/ui/pages/swaps/transaction-settings/index.scss
@@ -8,6 +8,9 @@
   }
 
   &__button-group {
+    display: flex;
+    flex-direction: row;
+
     & &-custom-button {
       cursor: text;
       display: flex;
@@ -15,7 +18,6 @@
       justify-content: center;
       position: relative;
       min-width: 72px;
-      margin-right: 0;
     }
   }
 

--- a/ui/pages/swaps/transaction-settings/transaction-settings.js
+++ b/ui/pages/swaps/transaction-settings/transaction-settings.js
@@ -16,6 +16,7 @@ import {
   DISPLAY,
   SEVERITIES,
   FlexDirection,
+  BlockSize,
 } from '../../../helpers/constants/design-system';
 import {
   Slippage,
@@ -168,97 +169,93 @@ export default function TransactionSettings({
                       contentText={t('swapSlippageTooltip')}
                     />
                   </Box>
-                  <Box display={DISPLAY.FLEX}>
-                    <ButtonGroup
-                      defaultActiveButtonIndex={
-                        activeButtonIndex === 2 && !customValue
-                          ? 1
-                          : activeButtonIndex
-                      }
-                      variant="radiogroup"
-                      newActiveButtonIndex={activeButtonIndex}
-                      className={classnames(
-                        'button-group',
-                        'transaction-settings__button-group',
-                      )}
+                  <ButtonGroup
+                    defaultActiveButtonIndex={
+                      activeButtonIndex === 2 && !customValue
+                        ? 1
+                        : activeButtonIndex
+                    }
+                    variant="radiogroup"
+                    newActiveButtonIndex={activeButtonIndex}
+                    className={classnames('transaction-settings__button-group')}
+                    style={{ width: BlockSize.Half }}
+                  >
+                    <Button
+                      onClick={() => {
+                        setCustomValue('');
+                        setEnteringCustomValue(false);
+                        setActiveButtonIndex(0);
+                        setNewSlippage(Slippage.default);
+                      }}
                     >
-                      <Button
-                        onClick={() => {
-                          setCustomValue('');
-                          setEnteringCustomValue(false);
-                          setActiveButtonIndex(0);
-                          setNewSlippage(Slippage.default);
-                        }}
-                      >
-                        {t('swapSlippagePercent', [Slippage.default])}
-                      </Button>
-                      <Button
-                        onClick={() => {
-                          setCustomValue('');
-                          setEnteringCustomValue(false);
-                          setActiveButtonIndex(1);
-                          setNewSlippage(Slippage.high);
-                        }}
-                      >
-                        {t('swapSlippagePercent', [Slippage.high])}
-                      </Button>
-                      <Button
-                        className={classnames(
-                          'transaction-settings__button-group-custom-button',
-                          {
-                            'radio-button--danger': isDangerSeverity,
-                          },
-                        )}
-                        onClick={() => {
-                          setActiveButtonIndex(2);
-                          setEnteringCustomValue(true);
-                        }}
-                      >
-                        {enteringCustomValue ? (
-                          <div
-                            className={classnames(
-                              'transaction-settings__custom-input',
-                              {
-                                'transaction-settings__custom-input--danger':
-                                  isDangerSeverity,
-                              },
-                            )}
-                          >
-                            <input
-                              data-testid="transaction-settings-custom-slippage"
-                              onChange={(event) => {
-                                const { value } = event.target;
-                                const isValueNumeric = !isNaN(Number(value));
-                                if (isValueNumeric) {
-                                  setCustomValue(value);
-                                  setNewSlippage(Number(value));
-                                }
-                              }}
-                              type="text"
-                              maxLength="4"
-                              ref={setInputRef}
-                              onBlur={() => {
+                      {t('swapSlippagePercent', [Slippage.default])}
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        setCustomValue('');
+                        setEnteringCustomValue(false);
+                        setActiveButtonIndex(1);
+                        setNewSlippage(Slippage.high);
+                      }}
+                    >
+                      {t('swapSlippagePercent', [Slippage.high])}
+                    </Button>
+                    <Button
+                      className={classnames(
+                        'transaction-settings__button-group-custom-button',
+                        {
+                          'radio-button--danger': isDangerSeverity,
+                        },
+                      )}
+                      onClick={() => {
+                        setActiveButtonIndex(2);
+                        setEnteringCustomValue(true);
+                      }}
+                    >
+                      {enteringCustomValue ? (
+                        <div
+                          className={classnames(
+                            'transaction-settings__custom-input',
+                            {
+                              'transaction-settings__custom-input--danger':
+                                isDangerSeverity,
+                            },
+                          )}
+                        >
+                          <input
+                            data-testid="transaction-settings-custom-slippage"
+                            onChange={(event) => {
+                              const { value } = event.target;
+                              const isValueNumeric = !isNaN(Number(value));
+                              if (isValueNumeric) {
+                                setCustomValue(value);
+                                setNewSlippage(Number(value));
+                              }
+                            }}
+                            type="text"
+                            maxLength="4"
+                            ref={setInputRef}
+                            onBlur={() => {
+                              setEnteringCustomValue(false);
+                            }}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter') {
                                 setEnteringCustomValue(false);
-                              }}
-                              onKeyDown={(event) => {
-                                if (event.key === 'Enter') {
-                                  setEnteringCustomValue(false);
-                                }
-                              }}
-                              value={customValue || ''}
-                            />
-                          </div>
-                        ) : (
-                          customValueText
-                        )}
-                        {(customValue || enteringCustomValue) && (
-                          <div className="transaction-settings__percentage-suffix">
-                            %
-                          </div>
-                        )}
-                      </Button>
-                    </ButtonGroup>
-                  </Box>
+                              }
+                            }}
+                            value={customValue || ''}
+                          />
+                        </div>
+                      ) : (
+                        customValueText
+                      )}
+                      {(customValue || enteringCustomValue) && (
+                        <div className="transaction-settings__percentage-suffix">
+                          %
+                        </div>
+                      )}
+                    </Button>
+                  </ButtonGroup>
                 </>
               )}
             </>


### PR DESCRIPTION
This PR aims to fix a broken visual display for Slippage Tolerance Button Group in Transaction Settings Modal.
After inspecting the styles for `ButtonGroup`, which is the component applies to this part of UI, has overwritten issues of styles between `button-group__button` and `radio-button`. Hence the solution is to specify css based on variant more clearly and avoid the overwrite problem.
<img width="321" alt="Screenshot 2024-12-16 at 18 59 19" src="https://github.com/user-attachments/assets/09a9cce7-a308-4049-a0c6-a001659c301e" />



<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29246?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27140

## **Manual testing steps**

1. Click "Swap" from the home screen.
2. In the swap interface, click the cog icon in the top right to open the transaction settings modal.
3. Observe the slippage tolerance button group—it's visually broken.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="339" alt="1" src="https://github.com/user-attachments/assets/187e1024-0c0c-42fd-9fda-bc72725a7483" />


<!-- [screenshots/recordings] -->

### **After**
<img width="766" alt="Screenshot 2024-12-16 at 19 19 04" src="https://github.com/user-attachments/assets/ee4f1eb5-ee47-4ac0-aaee-df65b7346cae" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
