### PR TITLE
chore(cherry-pick): migration to remove tokens with null decimals

### DIFF
--- a/app/scripts/migrations/133.1.test.ts
+++ b/app/scripts/migrations/133.1.test.ts
@@ -1,0 +1,224 @@
+import { cloneDeep } from 'lodash';
+import { TokensControllerState } from '@metamask/assets-controllers';
+import { migrate, version } from './133.1';
+
+const sentryCaptureExceptionMock = jest.fn();
+const sentryCaptureMessageMock = jest.fn();
+
+global.sentry = {
+  captureException: sentryCaptureExceptionMock,
+  captureMessage: sentryCaptureMessageMock,
+};
+
+const oldVersion = 133;
+
+const mockStateWithNullDecimals = {
+  meta: { version: oldVersion },
+  data: {
+    TokensController: {
+      allTokens: {
+        '0x1': {
+          '0x123': [
+            { address: '0x1', symbol: 'TOKEN1', decimals: null },
+            { address: '0x2', symbol: 'TOKEN2', decimals: 18 },
+          ],
+        },
+      },
+      allDetectedTokens: {
+        '0x1': {
+          '0x123': [
+            { address: '0x5', symbol: 'TOKEN5', decimals: null },
+            { address: '0x6', symbol: 'TOKEN6', decimals: 6 },
+          ],
+        },
+      },
+      tokens: [
+        { address: '0x7', symbol: 'TOKEN7', decimals: null },
+        { address: '0x8', symbol: 'TOKEN8', decimals: 18 },
+      ],
+      detectedTokens: [
+        { address: '0x9', symbol: 'TOKEN9', decimals: null },
+        { address: '0xA', symbol: 'TOKEN10', decimals: 6 },
+      ],
+    },
+  },
+};
+
+describe(`migration #${version}`, () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it('updates the version metadata', async () => {
+    const oldStorage = cloneDeep(mockStateWithNullDecimals);
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('removes tokens with null decimals from allTokens', async () => {
+    const oldStorage = cloneDeep(mockStateWithNullDecimals);
+
+    const newStorage = await migrate(oldStorage);
+
+    const tokensControllerState = newStorage.data
+      .TokensController as TokensControllerState;
+    const { allTokens } = tokensControllerState;
+
+    expect(allTokens).toEqual({
+      '0x1': {
+        '0x123': [{ address: '0x2', symbol: 'TOKEN2', decimals: 18 }],
+      },
+    });
+  });
+
+  it('removes tokens with null decimals from allDetectedTokens', async () => {
+    const oldStorage = cloneDeep(mockStateWithNullDecimals);
+
+    const newStorage = await migrate(oldStorage);
+
+    const tokensControllerState = newStorage.data
+      .TokensController as TokensControllerState;
+    const { allDetectedTokens } = tokensControllerState;
+
+    expect(allDetectedTokens).toEqual({
+      '0x1': {
+        '0x123': [{ address: '0x6', symbol: 'TOKEN6', decimals: 6 }],
+      },
+    });
+  });
+
+  it('removes tokens with null decimals from tokens array', async () => {
+    const oldStorage = cloneDeep(mockStateWithNullDecimals);
+
+    const newStorage = await migrate(oldStorage);
+
+    const tokensControllerState = newStorage.data
+      .TokensController as TokensControllerState;
+    const { tokens } = tokensControllerState;
+
+    expect(tokens).toEqual([
+      { address: '0x8', symbol: 'TOKEN8', decimals: 18 },
+    ]);
+  });
+
+  it('removes tokens with null decimals from detectedTokens array', async () => {
+    const oldStorage = cloneDeep(mockStateWithNullDecimals);
+
+    const newStorage = await migrate(oldStorage);
+
+    const tokensControllerState = newStorage.data
+      .TokensController as TokensControllerState;
+    const { detectedTokens } = tokensControllerState;
+
+    expect(detectedTokens).toEqual([
+      { address: '0xA', symbol: 'TOKEN10', decimals: 6 },
+    ]);
+  });
+
+  it('logs tokens with null decimals before removing them', async () => {
+    const oldStorage = cloneDeep(mockStateWithNullDecimals);
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureMessageMock).toHaveBeenCalledTimes(4);
+    expect(sentryCaptureMessageMock).toHaveBeenCalledWith(
+      `Migration ${version}: Removed token with decimals === null in allTokens. Address: 0x1`,
+    );
+    expect(sentryCaptureMessageMock).toHaveBeenCalledWith(
+      `Migration ${version}: Removed token with decimals === null in allDetectedTokens. Address: 0x5`,
+    );
+    expect(sentryCaptureMessageMock).toHaveBeenCalledWith(
+      `Migration ${version}: Removed token with decimals === null in tokens. Address: 0x7`,
+    );
+    expect(sentryCaptureMessageMock).toHaveBeenCalledWith(
+      `Migration ${version}: Removed token with decimals === null in detectedTokens. Address: 0x9`,
+    );
+  });
+
+  it('does nothing if all tokens have valid decimals', async () => {
+    const validState = {
+      meta: { version: oldVersion },
+      data: {
+        TokensController: {
+          allTokens: {
+            '0x1': {
+              '0x123': [{ address: '0x2', symbol: 'TOKEN2', decimals: 18 }],
+            },
+          },
+          allDetectedTokens: {
+            '0x1': {
+              '0x123': [{ address: '0x6', symbol: 'TOKEN6', decimals: 6 }],
+            },
+          },
+          tokens: [{ address: '0x8', symbol: 'TOKEN8', decimals: 18 }],
+          detectedTokens: [{ address: '0xA', symbol: 'TOKEN10', decimals: 6 }],
+        },
+      },
+    };
+
+    const oldStorage = cloneDeep(validState);
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+    expect(sentryCaptureMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing if TokensController is missing', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+    expect(sentryCaptureMessageMock).not.toHaveBeenCalled();
+  });
+
+  const invalidState = [
+    {
+      errorMessage: `Migration ${version}: Invalid allTokens state of type 'string'`,
+      label: 'Invalid allTokens',
+      state: { TokensController: { allTokens: 'invalid' } },
+    },
+    {
+      errorMessage: `Migration ${version}: Invalid allDetectedTokens state of type 'string'`,
+      label: 'Invalid allDetectedTokens',
+      state: { TokensController: { allDetectedTokens: 'invalid' } },
+    },
+    {
+      errorMessage: `Migration ${version}: Invalid tokens state of type 'string'`,
+      label: 'Invalid tokens',
+      state: { TokensController: { tokens: 'invalid' } },
+    },
+    {
+      errorMessage: `Migration ${version}: Invalid detectedTokens state of type 'string'`,
+      label: 'Invalid detectedTokens',
+      state: { TokensController: { detectedTokens: 'invalid' } },
+    },
+  ];
+
+  // @ts-expect-error 'each' function is not recognized by TypeScript types
+  it.each(invalidState)(
+    'captures error when state is invalid due to: $label',
+    async ({
+      errorMessage,
+      state,
+    }: {
+      errorMessage: string;
+      state: Record<string, unknown>;
+    }) => {
+      const oldStorage = {
+        meta: { version: oldVersion },
+        data: state,
+      };
+
+      const newStorage = await migrate(cloneDeep(oldStorage));
+
+      expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+        new Error(errorMessage),
+      );
+      expect(newStorage.data).toStrictEqual(oldStorage.data);
+    },
+  );
+});

--- a/app/scripts/migrations/133.1.ts
+++ b/app/scripts/migrations/133.1.ts
@@ -1,0 +1,187 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 133.1;
+
+/**
+ * Removes tokens with `decimals === null` from `allTokens`, `allDetectedTokens`, `tokens`, and `detectedTokens`.
+ * Captures exceptions for invalid states using Sentry and logs tokens with `decimals === null`.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly
+ * what we persist to disk.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+/**
+ * Transforms the TokensController state to remove tokens with `decimals === null`.
+ *
+ * @param state - The persisted MetaMask state.
+ */
+function transformState(state: Record<string, unknown>): void {
+  if (!hasProperty(state, 'TokensController')) {
+    return;
+  }
+
+  const tokensControllerState = state.TokensController;
+
+  if (!isObject(tokensControllerState)) {
+    global.sentry?.captureException(
+      new Error(
+        `Migration ${version}: Invalid TokensController state of type '${typeof tokensControllerState}'`,
+      ),
+    );
+    return;
+  }
+
+  // Validate and transform `allTokens`
+  if (hasProperty(tokensControllerState, 'allTokens')) {
+    if (isObject(tokensControllerState.allTokens)) {
+      tokensControllerState.allTokens = transformTokenCollection(
+        tokensControllerState.allTokens,
+        'allTokens',
+      );
+    } else {
+      global.sentry?.captureException(
+        new Error(
+          `Migration ${version}: Invalid allTokens state of type '${typeof tokensControllerState.allTokens}'`,
+        ),
+      );
+    }
+  }
+
+  // Validate and transform `allDetectedTokens`
+  if (hasProperty(tokensControllerState, 'allDetectedTokens')) {
+    if (isObject(tokensControllerState.allDetectedTokens)) {
+      tokensControllerState.allDetectedTokens = transformTokenCollection(
+        tokensControllerState.allDetectedTokens,
+        'allDetectedTokens',
+      );
+    } else {
+      global.sentry?.captureException(
+        new Error(
+          `Migration ${version}: Invalid allDetectedTokens state of type '${typeof tokensControllerState.allDetectedTokens}'`,
+        ),
+      );
+    }
+  }
+
+  // Transform `tokens` array
+  if (
+    hasProperty(tokensControllerState, 'tokens') &&
+    Array.isArray(tokensControllerState.tokens)
+  ) {
+    tokensControllerState.tokens = tokensControllerState.tokens.filter(
+      (token) => {
+        if (
+          isObject(token) &&
+          hasProperty(token, 'decimals') &&
+          token.decimals === null &&
+          hasProperty(token, 'address')
+        ) {
+          global.sentry?.captureMessage(
+            `Migration ${version}: Removed token with decimals === null in tokens. Address: ${token.address}`,
+          );
+          return false;
+        }
+        return true;
+      },
+    );
+  } else if (hasProperty(tokensControllerState, 'tokens')) {
+    global.sentry?.captureException(
+      new Error(
+        `Migration ${version}: Invalid tokens state of type '${typeof tokensControllerState.tokens}'`,
+      ),
+    );
+  }
+
+  // Transform `detectedTokens` array
+  if (
+    hasProperty(tokensControllerState, 'detectedTokens') &&
+    Array.isArray(tokensControllerState.detectedTokens)
+  ) {
+    tokensControllerState.detectedTokens =
+      tokensControllerState.detectedTokens.filter((token) => {
+        if (
+          isObject(token) &&
+          hasProperty(token, 'decimals') &&
+          token.decimals === null &&
+          hasProperty(token, 'address')
+        ) {
+          global.sentry?.captureMessage(
+            `Migration ${version}: Removed token with decimals === null in detectedTokens. Address: ${token.address}`,
+          );
+          return false;
+        }
+        return true;
+      });
+  } else if (hasProperty(tokensControllerState, 'detectedTokens')) {
+    global.sentry?.captureException(
+      new Error(
+        `Migration ${version}: Invalid detectedTokens state of type '${typeof tokensControllerState.detectedTokens}'`,
+      ),
+    );
+  }
+}
+
+/**
+ * Removes tokens with `decimals === null` from a token collection and logs their addresses.
+ *
+ * @param tokenCollection - The token collection to transform.
+ * @param propertyName - The name of the property being transformed (for logging purposes).
+ * @returns The updated token collection.
+ */
+function transformTokenCollection(
+  tokenCollection: Record<string, unknown>,
+  propertyName: string,
+) {
+  const updatedState: Record<string, unknown> = {};
+
+  for (const [chainId, accounts] of Object.entries(tokenCollection)) {
+    if (isObject(accounts)) {
+      const updatedTokensAccounts: Record<string, unknown[]> = {};
+
+      for (const [account, tokens] of Object.entries(accounts)) {
+        if (Array.isArray(tokens)) {
+          // Filter tokens and log those with `decimals === null`
+          const filteredTokens = tokens.filter((token) => {
+            if (
+              isObject(token) &&
+              hasProperty(token, 'decimals') &&
+              token.decimals === null &&
+              hasProperty(token, 'address')
+            ) {
+              global.sentry?.captureMessage(
+                `Migration ${version}: Removed token with decimals === null in ${propertyName}. Address: ${token.address}`,
+              );
+              return false; // Exclude token
+            }
+            return (
+              isObject(token) &&
+              hasProperty(token, 'decimals') &&
+              token.decimals !== null
+            );
+          });
+
+          updatedTokensAccounts[account] = filteredTokens;
+        }
+      }
+
+      updatedState[chainId] = updatedTokensAccounts;
+    }
+  }
+
+  return updatedState;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -155,6 +155,7 @@ const migrations = [
   require('./131.1'),
   require('./132'),
   require('./133'),
+  require('./133.1'),
 ];
 
 export default migrations;


### PR DESCRIPTION
Cherry picks https://github.com/MetaMask/metamask-extension/pull/29245 to v12.9.2