### PR TITLE
feat: event when token list is refreshed

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -766,6 +766,7 @@ export enum MetaMetricsEventName {
   TokenAdded = 'Token Added',
   TokenRemoved = 'Token Removed',
   TokenSortPreference = 'Token Sort Preference',
+  TokenListRefreshed = 'Token List Refreshed',
   NFTRemoved = 'NFT Removed',
   TokenDetected = 'Token Detected',
   TokenHidden = 'Token Hidden',

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -10,6 +10,10 @@ import {
 import AssetListControlBar from './asset-list-control-bar';
 
 describe('AssetListControlBar', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should fire metrics event when refresh button is clicked', async () => {
     const store = configureMockStore([thunk])({
       metamask: {

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -29,6 +29,12 @@ describe('AssetListControlBar', () => {
             ],
           },
         },
+        internalAccounts: {
+          selectedAccount: 'selectedAccount',
+          accounts: {
+            selectedAccount: {},
+          },
+        },
       },
     });
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../../../../test/jest';
+import { MetaMetricsContext } from '../../../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../../../shared/constants/metametrics';
+import AssetListControlBar from './asset-list-control-bar';
+
+describe('AssetListControlBar', () => {
+  it('should fire metrics event when refresh button is clicked', async () => {
+    const store = configureMockStore([thunk])({
+      metamask: {
+        selectedNetworkClientId: 'selectedNetworkClientId',
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            defaultRpcEndpointIndex: 0,
+            rpcEndpoints: [
+              {
+                networkClientId: 'selectedNetworkClientId',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const mockTrackEvent = jest.fn();
+
+    const { findByTestId } = renderWithProvider(
+      <MetaMetricsContext.Provider value={mockTrackEvent}>
+        <AssetListControlBar />
+      </MetaMetricsContext.Provider>,
+      store,
+    );
+
+    const importButton = await findByTestId('import-token-button');
+    importButton.click();
+
+    const refreshListItem = await findByTestId('refreshList__button');
+    refreshListItem.click();
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      category: MetaMetricsEventCategory.Tokens,
+      event: MetaMetricsEventName.TokenListRefreshed,
+    });
+  });
+});

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -154,6 +154,10 @@ const AssetListControlBar = ({ showTokensLinks }: AssetListControlBarProps) => {
   const handleRefresh = () => {
     dispatch(detectTokens());
     closePopover();
+    trackEvent({
+      category: MetaMetricsEventCategory.Tokens,
+      event: MetaMetricsEventName.TokenListRefreshed,
+    });
   };
 
   return (


### PR DESCRIPTION
## **Description**

Adds an event when the user refreshes the token list

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29300?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMASSETS-440

## **Manual testing steps**

- Enable metametrics

- Click this refresh button on the tokens tab:

<img width="277" alt="Screenshot 2024-12-17 at 2 11 33 PM" src="https://github.com/user-attachments/assets/dfc19710-5c13-4b00-8a06-d5751b5b9b4c" />

- Verify an event is emitted.

I test this by adding a console.log in `MetaMetricsController.trackEvent`, but in a production build you may be able to check network requests.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
