### PR TITLE
chore: updating menu item to use text component

### DIFF
--- a/ui/components/ui/menu/menu-item.js
+++ b/ui/components/ui/menu/menu-item.js
@@ -66,7 +66,7 @@ const MenuItem = React.forwardRef(
         />
       )}
       <div>
-        <div>{children}</div>
+        <Text as="div">{children}</Text>
         {subtitle ? <Text variant={TextVariant.bodyXs}>{subtitle}</Text> : null}
       </div>
     </button>

--- a/ui/components/ui/menu/menu.scss
+++ b/ui/components/ui/menu/menu.scss
@@ -33,7 +33,7 @@
   text-align: start;
   align-items: center;
   width: 100%;
-  padding: 14px 16px;
+  padding: 16px;
   cursor: pointer;
   color: inherit;
 


### PR DESCRIPTION
## **Description**

This PR updates the MenuItem component to better align with our design system by:
1. Implementing responsive text sizes - 14px for small screens and 16px for large screens
2. Adjusting the padding to improve visual spacing and alignment

These changes improve consistency across the application and enhance the overall user experience by providing better readability and spacing across different device sizes.

1. Reason for change: MenuItem text size and padding are not following our design system guidelines
2. Solution: Update text sizing and padding using our design system's specifications

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29304?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26668

## **Manual testing steps**

1. Open MetaMask extension
2. Click on any menu with MenuItems
3. Verify text is 14px on small screens (< 768px)
4. Verify text is 16px on large screens (≥ 768px)
5. Verify padding provides proper spacing around menu items
6. Verify all alignments and spacing remain consistent with icons and subtitles

## **Screenshots/Recordings**

### **Before**

Menu item is locked to 16px font size and y:14px x:16px padding

https://github.com/user-attachments/assets/6978a281-7de2-4141-a664-117952f63195

### **After**

Menu item uses responsive typography to 14px/16px font size and y:16px x:16px padding

https://github.com/user-attachments/assets/0dd13e70-0be2-4f85-8399-6337ce379e02

Other menus using the `MenuItem` still function as expected in both expanded and popup views.

https://github.com/user-attachments/assets/4d3a215a-6778-452d-84e1-535bb10b9b2e



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.