### PR TITLE
chore: updating header to use heading sm

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-full-image.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-full-image.test.js.snap
@@ -17,8 +17,8 @@ exports[`NFT full image should match snapshot 1`] = `
           <div
             class="mm-box"
           >
-            <p
-              class="mm-box mm-text mm-text--body-md-bold mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
+            <h2
+              class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
             />
           </div>
           <div

--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-full-image.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-full-image.test.js.snap
@@ -15,15 +15,7 @@ exports[`NFT full image should match snapshot 1`] = `
           class="mm-box mm-header-base multichain-page-header mm-box--padding-4 mm-box--display-flex mm-box--justify-content-center mm-box--width-full"
         >
           <div
-            class="mm-box"
-          >
-            <h2
-              class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
-            />
-          </div>
-          <div
             class="mm-box mm-box--display-flex mm-box--justify-content-flex-end"
-            style="min-width: 0px;"
           >
             <button
               aria-label="Back"

--- a/ui/components/app/connected-accounts-permissions/connected-accounts-permissions.js
+++ b/ui/components/app/connected-accounts-permissions/connected-accounts-permissions.js
@@ -61,11 +61,7 @@ const ConnectedAccountsPermissions = ({ permissions }) => {
         padding={0}
         backgroundColor={BackgroundColor.backgroundDefault}
       >
-        <Text
-          onClick={toggleExpanded}
-          as="h6"
-          variant={TextVariant.bodyMdMedium}
-        >
+        <Text onClick={toggleExpanded} variant={TextVariant.bodyMdMedium}>
           {t('permissions')}
         </Text>
 

--- a/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
+++ b/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
@@ -29,8 +29,8 @@ exports[`Connections Content should render correctly 1`] = `
         <div
           class="mm-box"
         >
-          <p
-            class="mm-box mm-text mm-text--body-md-bold mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
+          <h2
+            class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
             <div
               class="mm-box connections-header__title mm-box--display-flex mm-box--gap-2 mm-box--justify-content-center mm-box--align-items-center"
@@ -45,7 +45,7 @@ exports[`Connections Content should render correctly 1`] = `
                 metamask.github.io
               </span>
             </div>
-          </p>
+          </h2>
         </div>
       </div>
       <div

--- a/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
+++ b/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Connections Content should render correctly 1`] = `
                 style="mask-image: url('./images/icons/global.svg');"
               />
               <span
-                class="mm-box mm-text mm-text--heading-md mm-text--ellipsis mm-text--text-align-center mm-box--color-text-default"
+                class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--color-text-default"
               >
                 metamask.github.io
               </span>

--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -242,7 +242,7 @@ export const Connections = () => {
           )}
           <Text
             as="span"
-            variant={TextVariant.headingMd}
+            variant={TextVariant.headingSm}
             textAlign={TextAlign.Center}
             ellipsis
           >

--- a/ui/components/multichain/pages/page/components/header/header.tsx
+++ b/ui/components/multichain/pages/page/components/header/header.tsx
@@ -55,8 +55,9 @@ export const Header = ({
       {...props}
     >
       <Text
+        as="h2"
         display={Display.Block}
-        variant={TextVariant.bodyMdBold}
+        variant={TextVariant.headingSm}
         textAlign={TextAlign.Center}
         paddingInlineStart={8}
         paddingInlineEnd={8}

--- a/ui/components/multichain/pages/page/components/header/header.tsx
+++ b/ui/components/multichain/pages/page/components/header/header.tsx
@@ -54,18 +54,20 @@ export const Header = ({
       endAccessory={endAccessory}
       {...props}
     >
-      <Text
-        as="h2"
-        display={Display.Block}
-        variant={TextVariant.headingSm}
-        textAlign={TextAlign.Center}
-        paddingInlineStart={8}
-        paddingInlineEnd={8}
-        ellipsis
-        {...textProps}
-      >
-        {children}
-      </Text>
+      {children && (
+        <Text
+          as="h2"
+          display={Display.Block}
+          variant={TextVariant.headingSm}
+          textAlign={TextAlign.Center}
+          paddingInlineStart={8}
+          paddingInlineEnd={8}
+          ellipsis
+          {...textProps}
+        >
+          {children}
+        </Text>
+      )}
     </HeaderBase>
   );
 };

--- a/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
+++ b/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
@@ -29,15 +29,15 @@ exports[`All Connections render renders correctly 1`] = `
         <div
           class="mm-box"
         >
-          <p
-            class="mm-box mm-text mm-text--body-md-bold mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
+          <h2
+            class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
             <span
               class="mm-box mm-text mm-text--heading-md mm-text--text-align-center mm-box--color-text-default"
             >
               Permissions
             </span>
-          </p>
+          </h2>
         </div>
       </div>
       <div

--- a/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
+++ b/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
@@ -32,11 +32,7 @@ exports[`All Connections render renders correctly 1`] = `
           <h2
             class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
-            <span
-              class="mm-box mm-text mm-text--heading-md mm-text--text-align-center mm-box--color-text-default"
-            >
-              Permissions
-            </span>
+            Permissions
           </h2>
         </div>
       </div>

--- a/ui/components/multichain/pages/permissions-page/permissions-page.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.js
@@ -77,13 +77,7 @@ export const PermissionsPage = () => {
           />
         }
       >
-        <Text
-          as="span"
-          variant={TextVariant.headingMd}
-          textAlign={TextAlign.Center}
-        >
-          {t('permissions')}
-        </Text>
+        {t('permissions')}
       </Header>
       <Content padding={0}>
         <Box ref={headerRef}></Box>

--- a/ui/components/multichain/pages/review-permissions-page/__snapshots__/review-permissions-page.test.tsx.snap
+++ b/ui/components/multichain/pages/review-permissions-page/__snapshots__/review-permissions-page.test.tsx.snap
@@ -29,8 +29,8 @@ exports[`ReviewPermissions should render correctly 1`] = `
         <div
           class="mm-box"
         >
-          <p
-            class="mm-box mm-text mm-text--body-md-bold mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
+          <h2
+            class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
             <div
               class="mm-box connections-header__title mm-box--display-flex mm-box--gap-2 mm-box--justify-content-center mm-box--align-items-center"
@@ -43,7 +43,7 @@ exports[`ReviewPermissions should render correctly 1`] = `
                 class="mm-box mm-text mm-text--heading-md mm-text--ellipsis mm-text--text-align-center mm-box--color-text-default"
               />
             </div>
-          </p>
+          </h2>
         </div>
       </div>
       <div

--- a/ui/components/multichain/pages/review-permissions-page/__snapshots__/review-permissions-page.test.tsx.snap
+++ b/ui/components/multichain/pages/review-permissions-page/__snapshots__/review-permissions-page.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`ReviewPermissions should render correctly 1`] = `
                 style="mask-image: url('./images/icons/global.svg');"
               />
               <span
-                class="mm-box mm-text mm-text--heading-md mm-text--ellipsis mm-text--text-align-center mm-box--color-text-default"
+                class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--color-text-default"
               />
             </div>
           </h2>

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -28,11 +28,11 @@ exports[`SendPage render and initialization should render correctly even when a 
         <div
           class="mm-box"
         >
-          <h4
+          <h2
             class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
             Send
-          </h4>
+          </h2>
         </div>
       </div>
       <div

--- a/ui/components/multichain/permissions-header/permissions-header.tsx
+++ b/ui/components/multichain/permissions-header/permissions-header.tsx
@@ -71,7 +71,7 @@ export const PermissionsHeader = ({
         )}
         <Text
           as="span"
-          variant={TextVariant.headingMd}
+          variant={TextVariant.headingSm}
           textAlign={TextAlign.Center}
           ellipsis
         >

--- a/ui/pages/bridge/__snapshots__/index.test.tsx.snap
+++ b/ui/pages/bridge/__snapshots__/index.test.tsx.snap
@@ -28,11 +28,11 @@ exports[`Bridge renders the component with initial props 1`] = `
         <div
           class="mm-box"
         >
-          <h4
+          <h2
             class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
             Bridge
-          </h4>
+          </h2>
         </div>
         <div
           class="mm-box mm-box--display-flex mm-box--justify-content-flex-end"

--- a/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
+++ b/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
@@ -15,8 +15,8 @@ exports[`ConnectPage should render correctly 1`] = `
         <div
           class="mm-box"
         >
-          <p
-            class="mm-box mm-text mm-text--body-md-bold mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
+          <h2
+            class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
             <h2
               class="mm-box mm-text mm-text--heading-lg mm-box--color-text-default"
@@ -29,7 +29,7 @@ exports[`ConnectPage should render correctly 1`] = `
               This site wants to
               : 
             </p>
-          </p>
+          </h2>
         </div>
       </div>
       <div
@@ -265,8 +265,8 @@ exports[`ConnectPage should render with defaults from the requested permissions 
         <div
           class="mm-box"
         >
-          <p
-            class="mm-box mm-text mm-text--body-md-bold mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
+          <h2
+            class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-8 mm-box--padding-inline-end-8 mm-box--display-block mm-box--color-text-default"
           >
             <h2
               class="mm-box mm-text mm-text--heading-lg mm-box--color-text-default"
@@ -279,7 +279,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
               This site wants to
               : 
             </p>
-          </p>
+          </h2>
         </div>
       </div>
       <div


### PR DESCRIPTION
## **Description**

This PR updates the header component text styling to use semantic HTML and consistent heading styles. The changes include:
- Changed text element from `<p>` to `<h2>`
- Updated text variant from `bodyMdBold` to `headingSm`
- Improves accessibility by using proper heading hierarchy
- Maintains consistent styling across multiple pages using the header component

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29308?quickstart=1)

## **Related issues**

Partially fixes: https://github.com/MetaMask/metamask-extension/issues/29306

## **Manual testing steps**

1. Navigate to pages using the header component (NFT details, Connections, Permissions pages)
2. Verify header text appears correctly with new heading styles
3. Verify layout and alignment remain consistent
4. Check that accessibility tools properly recognize the heading structure

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
