### PR TITLE
ci: Improve accuracy of `wait-for-circleci-workflow-status`

### DIFF
--- a/.github/workflows/wait-for-circleci-workflow-status.yml
+++ b/.github/workflows/wait-for-circleci-workflow-status.yml
@@ -13,8 +13,12 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPOSITORY: ${{ github.event.repository.name }}
           BRANCH: ${{ github.head_ref || github.ref_name }}
+          # For a `push` event, the HEAD commit hash is `github.sha`.
+          # For a `pull_request` event, `github.sha` is instead the base branch commit hash. The
+          # HEAD commit hash is `pull_request.head.sha`.
+          HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          pipeline_id=$(curl --silent "https://circleci.com/api/v2/project/gh/$OWNER/$REPOSITORY/pipeline?branch=$BRANCH" | jq -r ".items[0].id")
+          pipeline_id=$(curl --silent "https://circleci.com/api/v2/project/gh/$OWNER/$REPOSITORY/pipeline?branch=$BRANCH" | jq -r ".items[] | select(.vcs.revision == \"${HEAD_COMMIT_HASH}\" ) | .id")
           workflow_status=$(curl --silent "https://circleci.com/api/v2/pipeline/$pipeline_id/workflow" | jq -r ".items[0].status")
 
           if [ "$workflow_status" == "running" ]; then

--- a/.github/workflows/wait-for-circleci-workflow-status.yml
+++ b/.github/workflows/wait-for-circleci-workflow-status.yml
@@ -18,9 +18,8 @@ jobs:
           # HEAD commit hash is `pull_request.head.sha`.
           HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          echo "Looking for pipeline for commit ${HEAD_COMMIT_HASH}"
           pipeline_id=$(curl --silent "https://circleci.com/api/v2/project/gh/$OWNER/$REPOSITORY/pipeline?branch=$BRANCH" | jq -r ".items | map(select(.vcs.revision == \"${HEAD_COMMIT_HASH}\" )) | first | .id")
-          echo "Found pipeline ID ${pipeline_id}"
+          echo "Waiting for pipeline '${pipeline_id}' for commit hash '${HEAD_COMMIT_HASH}'"
           workflow_status=$(curl --silent "https://circleci.com/api/v2/pipeline/$pipeline_id/workflow" | jq -r ".items[0].status")
 
           if [ "$workflow_status" == "running" ]; then

--- a/.github/workflows/wait-for-circleci-workflow-status.yml
+++ b/.github/workflows/wait-for-circleci-workflow-status.yml
@@ -18,7 +18,7 @@ jobs:
           # HEAD commit hash is `pull_request.head.sha`.
           HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          pipeline_id=$(curl --silent "https://circleci.com/api/v2/project/gh/$OWNER/$REPOSITORY/pipeline?branch=$BRANCH" | jq -r ".items[] | select(.vcs.revision == \"${HEAD_COMMIT_HASH}\" ) | .id")
+          pipeline_id=$(curl --silent "https://circleci.com/api/v2/project/gh/$OWNER/$REPOSITORY/pipeline?branch=$BRANCH" | jq -r ".items | map(select(.vcs.revision == \"${HEAD_COMMIT_HASH}\" )) | first | .id")
           workflow_status=$(curl --silent "https://circleci.com/api/v2/pipeline/$pipeline_id/workflow" | jq -r ".items[0].status")
 
           if [ "$workflow_status" == "running" ]; then

--- a/.github/workflows/wait-for-circleci-workflow-status.yml
+++ b/.github/workflows/wait-for-circleci-workflow-status.yml
@@ -18,7 +18,9 @@ jobs:
           # HEAD commit hash is `pull_request.head.sha`.
           HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
+          echo "Looking for pipeline for commit ${HEAD_COMMIT_HASH}"
           pipeline_id=$(curl --silent "https://circleci.com/api/v2/project/gh/$OWNER/$REPOSITORY/pipeline?branch=$BRANCH" | jq -r ".items | map(select(.vcs.revision == \"${HEAD_COMMIT_HASH}\" )) | first | .id")
+          echo "Found pipeline ID ${pipeline_id}"
           workflow_status=$(curl --silent "https://circleci.com/api/v2/pipeline/$pipeline_id/workflow" | jq -r ".items[0].status")
 
           if [ "$workflow_status" == "running" ]; then


### PR DESCRIPTION
## **Description**

The GitHub Actions workflow `wait-for-circleci-workflow-status` has been updated to ensure that it waits for the correct workflow. Previously it always chose the most recent workflow for the given branch, but it may have chosen a workflow corresponding to the wrong commit. It has been updated to find one matching the same commit that triggered the GitHub Actions workflow.

A log has been added to help diagnose any future problems with this workflow, and to help with verification.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29310?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

Check the logs of the "Wait for CircleCI workflow status" job, and see that the workflow ID it's waiting on is correct when making multiple successive commits (comparing the timing using the CircleCI dashboard)

Unfortunately the ID logged in the action is not shown on the CircleCI UI, but you can download the pipeline data with this command: `curl 'https://circleci.com/api/v2/project/gh/MetaMask/metamask-extension/pipeline?branch=[branch]' > pipeline.json` and look through the `pipeline.json` file for an entry that matches the logged ID. The `number` field is the pipeline number, which is in the CircleCI workflow URL (e.g. `https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/[pipeline number]/workflows/[some other number]`)

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
