### PR TITLE
fix: Remove details option if permission has no description

### DIFF
--- a/ui/components/app/permission-cell/permission-cell-options.js
+++ b/ui/components/app/permission-cell/permission-cell-options.js
@@ -49,6 +49,10 @@ export const PermissionCellOptions = ({
     dispatch(revokeDynamicSnapPermissions(snapId, [permissionName]));
   };
 
+  if (!description && !isRevokable) {
+    return null;
+  }
+
   return (
     <Box ref={ref}>
       <ButtonIcon
@@ -59,16 +63,17 @@ export const PermissionCellOptions = ({
       />
       {showOptions && (
         <Menu anchorElement={ref.current} onHide={handleClose}>
-          <MenuItem onClick={handleDetailsOpen}>
-            <Text
-              variant={TextVariant.bodySm}
-              style={{
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {t('details')}
-            </Text>
-          </MenuItem>
+          {description && (
+            <MenuItem onClick={handleDetailsOpen}>
+              <Text
+                variant={TextVariant.bodySm}
+                style={{
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {t('details')}
+              </Text>
+            </MenuItem>)}
           {isRevokable && (
             <MenuItem onClick={handleRevokePermission}>
               <Text

--- a/ui/components/app/permission-cell/permission-cell-options.js
+++ b/ui/components/app/permission-cell/permission-cell-options.js
@@ -73,7 +73,8 @@ export const PermissionCellOptions = ({
               >
                 {t('details')}
               </Text>
-            </MenuItem>)}
+            </MenuItem>
+          )}
           {isRevokable && (
             <MenuItem onClick={handleRevokePermission}>
               <Text


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove details option if permission has no description, for instance `eth_accounts` has no description currently.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29313?quickstart=1)

## **Manual testing steps**

1. Install Ethereum Provider Snap
2. Connect the Snap to an account
3. Go to Snaps settings
4. See that there is no "details" button for the eth_accounts permission
