### PR TITLE
fix: Remove use of boolean value for metrics properties

### DIFF
--- a/ui/pages/confirmations/hooks/useTrackERC20WithoutDecimalInformation.ts
+++ b/ui/pages/confirmations/hooks/useTrackERC20WithoutDecimalInformation.ts
@@ -39,7 +39,7 @@ const useTrackERC20WithoutDecimalInformation = (
           event: MetaMetricsEventName.SimulationIncompleteAssetDisplayed,
           category: MetaMetricsEventCategory.Confirmations,
           properties: {
-            token_decimals_available: false,
+            token_decimals_available: 'not_available',
             asset_address: tokenAddress,
             asset_type: TokenStandard.ERC20,
             chain_id: chainId,


### PR DESCRIPTION
## **Description**

Remove use of boolean value for metrics property.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3811

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
