### PR TITLE
Fix: Confirmation token logic including useGetTokenStandardAndDetails & useTrackERC20WithoutDecimalInformation

### DIFF
--- a/shared/modules/transaction.utils.ts
+++ b/shared/modules/transaction.utils.ts
@@ -294,10 +294,10 @@ function extractLargeMessageValue(dataToParse: string): string | undefined {
 }
 
 /**
- * JSON.parse has a limitation which coerces values to scientific notation if numbers are greator than
+ * JSON.parse has a limitation which coerces values to scientific notation if numbers are greater than
  * Number.MAX_SAFE_INTEGER. This can cause a loss in precision.
  *
- * Aside from precision concerns, if the value returned was a large number greator than 15 digits,
+ * Aside from precision concerns, if the value returned was a large number greater than 15 digits,
  * e.g. 3.000123123123121e+26, passing the value to BigNumber will throw the error:
  * Error: new BigNumber() number type has more than 15 significant digits
  *

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/value-display/value-display.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/permit-simulation/value-display/value-display.tsx
@@ -86,7 +86,7 @@ const PermitSimulationValueDisplay: React.FC<
       return exchangeRate.times(tokenAmount).toNumber();
     }
     return undefined;
-  }, [exchangeRate, tokenDecimals, value]);
+  }, [exchangeRate, tokenDecimals, tokenId, value]);
 
   const { tokenValue, tokenValueMaxPrecision } = useMemo(() => {
     if (!value || tokenId) {
@@ -99,7 +99,7 @@ const PermitSimulationValueDisplay: React.FC<
       tokenValue: formatAmount('en-US', tokenAmount),
       tokenValueMaxPrecision: formatAmountMaxPrecision('en-US', tokenAmount),
     };
-  }, [tokenDecimals, value]);
+  }, [tokenDecimals, tokenId, value]);
 
   /** Temporary error capturing as we are building out Permit Simulations */
   if (!tokenContract) {

--- a/ui/pages/confirmations/hooks/useGetTokenStandardAndDetails.ts
+++ b/ui/pages/confirmations/hooks/useGetTokenStandardAndDetails.ts
@@ -18,17 +18,16 @@ import {
 export const useGetTokenStandardAndDetails = (
   tokenAddress?: Hex | string | undefined,
 ) => {
-  if (!tokenAddress) {
-    return { decimalsNumber: undefined };
-  }
+  const { value: details } =
+    useAsyncResult<TokenDetailsERC20 | null>(async () => {
+      if (!tokenAddress) {
+        return Promise.resolve(null);
+      }
 
-  const { value: details } = useAsyncResult<TokenDetailsERC20>(
-    async () =>
-      (await memoizedGetTokenStandardAndDetails(
+      return (await memoizedGetTokenStandardAndDetails(
         tokenAddress,
-      )) as TokenDetailsERC20,
-    [tokenAddress],
-  );
+      )) as TokenDetailsERC20;
+    }, [tokenAddress]);
 
   if (!details) {
     return { decimalsNumber: undefined };

--- a/ui/pages/confirmations/hooks/useTrackERC20WithoutDecimalInformation.ts
+++ b/ui/pages/confirmations/hooks/useTrackERC20WithoutDecimalInformation.ts
@@ -51,7 +51,7 @@ const useTrackERC20WithoutDecimalInformation = (
         });
       }
     }
-  }, [tokenDetails, chainId, tokenAddress, trackEvent]);
+  }, []);
 };
 
 export default useTrackERC20WithoutDecimalInformation;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes and cleanup around confirmation

- useTrackERC20WithoutDecimalInformation should only call trackEvent once per use
- useGetTokenStandardAndDetails should consistently call useAsyncResult by removing early return 
- add missing tokenId dep prop to PermitSimulationValueDisplay

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29319?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
