### PR TITLE
fix: Network URL toPunycodeUrl preserve no path slash

### DIFF
--- a/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.test.js
+++ b/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.test.js
@@ -159,6 +159,7 @@ describe('add-ethereum-chain confirmation', () => {
           "Attackers sometimes mimic sites by making small changes to the site address. Make sure you're interacting with the intended site before you continue. Punycode version: https://xn--ifura-dig.io/gnosis",
         ),
       ).toBeInTheDocument();
+      expect(getByText('https://iոfura.io/gnosis')).toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/confirmations/utils/confirm.test.ts
+++ b/ui/pages/confirmations/utils/confirm.test.ts
@@ -99,10 +99,6 @@ describe('confirm util', () => {
       expect(toPunycodeURL('https://iոfura.io/')).toStrictEqual(
         'https://xn--ifura-dig.io/',
       );
-
-      expect(toPunycodeURL('https://www.google.com')).toStrictEqual(
-        'https://www.google.com',
-      );
       expect(
         toPunycodeURL('https://iոfura.io/gnosis:5050?test=iոfura&foo=bar'),
       ).toStrictEqual(

--- a/ui/pages/confirmations/utils/confirm.test.ts
+++ b/ui/pages/confirmations/utils/confirm.test.ts
@@ -93,8 +93,15 @@ describe('confirm util', () => {
       expect(toPunycodeURL('https://iոfura.io/gnosis')).toStrictEqual(
         'https://xn--ifura-dig.io/gnosis',
       );
+      expect(toPunycodeURL('https://iոfura.io')).toStrictEqual(
+        'https://xn--ifura-dig.io',
+      );
+      expect(toPunycodeURL('https://iոfura.io/')).toStrictEqual(
+        'https://xn--ifura-dig.io/',
+      );
+
       expect(toPunycodeURL('https://www.google.com')).toStrictEqual(
-        'https://www.google.com/',
+        'https://www.google.com',
       );
       expect(
         toPunycodeURL('https://iոfura.io/gnosis:5050?test=iոfura&foo=bar'),
@@ -102,7 +109,7 @@ describe('confirm util', () => {
         'https://xn--ifura-dig.io/gnosis:5050?test=i%D5%B8fura&foo=bar',
       );
       expect(toPunycodeURL('https://www.google.com')).toStrictEqual(
-        'https://www.google.com/',
+        'https://www.google.com',
       );
     });
   });

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -80,7 +80,12 @@ export const isValidASCIIURL = (urlString?: string) => {
 
 export const toPunycodeURL = (urlString: string) => {
   try {
-    return new URL(urlString).href;
+    const url = new URL(urlString);
+    const { protocol, hostname, port, search, hash } = url;
+    const pathname =
+      url.pathname === '/' && !urlString.endsWith('/') ? '' : url.pathname;
+
+    return `${protocol}//${hostname}${port}${pathname}${search}${hash}`;
   } catch (err: unknown) {
     console.error(`Failed to convert URL to Punycode: ${err}`);
     return undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29325?quickstart=1)

## **Related issues**

Related to: https://github.com/MetaMask/metamask-extension/pull/29322

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
