### PR TITLE
e2e testing: unsupported networks (uninstalled EVM networks) requested as part of `wallet_createSession` request#3817

### DIFF
--- a/test/e2e/flask/multichain-api/create-session.spec.ts
+++ b/test/e2e/flask/multichain-api/create-session.spec.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'assert';
+import { withFixtures } from '../../helpers';
+import { Driver } from '../../webdriver/driver';
+import FixtureBuilder from '../../fixture-builder';
+import {
+  createSessionScopes,
+  DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+  getSessionScopes,
+  openMultichainDappAndConnectWalletWithExternallyConnectable,
+} from './testHelpers';
+
+describe('Multichain API', function () {
+  describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that does NOT match one of the user’s enabled networks', function () {
+    it("the specified EVM scopes that do not match the user's configured networks should be treated as if they were not requested", async function () {
+      await withFixtures(
+        {
+          title: this.test?.fullTitle(),
+          fixtures: new FixtureBuilder()
+            .withNetworkControllerOnMainnet()
+            .build(),
+          ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+        },
+        async ({
+          driver,
+          extensionId,
+        }: {
+          driver: Driver;
+          extensionId: string;
+        }) => {
+          const scopesToIgnore = ['eip155:42161', 'eip155:10'];
+          await openMultichainDappAndConnectWalletWithExternallyConnectable(
+            driver,
+            extensionId,
+          );
+          await createSessionScopes(driver, ['eip155:1', ...scopesToIgnore]);
+
+          const getSessionScopesResult = await getSessionScopes(driver);
+
+          for (const scope of scopesToIgnore) {
+            assert.strictEqual(
+              getSessionScopesResult.sessionScopes[scope],
+              undefined,
+            );
+          }
+        },
+      );
+    });
+  });
+});

--- a/test/e2e/flask/multichain-api/get-session.spec.ts
+++ b/test/e2e/flask/multichain-api/get-session.spec.ts
@@ -1,5 +1,4 @@
 import { strict as assert } from 'assert';
-import _ from 'lodash';
 import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -52,19 +52,16 @@ export async function createSessionScopes(
     await driver.clickElement(`input[name="${scope}"]`);
   }
 
-  await driver.clickElement('#create-session-btn');
+  await driver.clickElement({ text: 'wallet_createSession', tag: 'span' });
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
   await driver.delay(largeDelayMs);
 
   const editButtons = await driver.findElements('[data-testid="edit"]');
   await editButtons[1].click();
-
   await driver.delay(largeDelayMs);
 
   await driver.clickElement('[data-testid="connect-more-chains-button"]');
-
   await driver.clickElement({ text: 'Connect', tag: 'button' });
-
   await driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
 }
 

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { DAPP_URL, largeDelayMs, openDapp, unlockWallet } from '../../helpers';
+import { DAPP_URL, largeDelayMs, openDapp, unlockWallet, WINDOW_TITLES } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import { KnownRpcMethods, KnownNotifications } from '@metamask/multichain';
 
@@ -36,6 +36,36 @@ export async function openMultichainDappAndConnectWalletWithExternallyConnectabl
   await driver.fill('[placeholder="Enter extension ID"]', extensionId);
   await driver.clickElement({ text: 'Connect', tag: 'button' });
   await driver.delay(largeDelayMs);
+}
+
+/**
+ * Sends a request to wallet extension to create session for the passed scopes.
+ *
+ * @param {Driver} driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
+ * @param {string[]} scopes - scopes to create session for.
+ */
+export async function createSessionScopes(
+  driver: Driver,
+  scopes: string[],
+): Promise<void> {
+  for (const scope of scopes) {
+    await driver.clickElement(`input[name="${scope}"]`);
+  }
+
+  await driver.clickElement('#create-session-btn');
+  await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+  await driver.delay(largeDelayMs);
+
+  const editButtons = await driver.findElements('[data-testid="edit"]');
+  await editButtons[1].click();
+
+  await driver.delay(largeDelayMs);
+
+  await driver.clickElement('[data-testid="connect-more-chains-button"]');
+
+  await driver.clickElement({ text: 'Connect', tag: 'button' });
+
+  await driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
 }
 
 /**


### PR DESCRIPTION
wallet_createSession - wallet will ignore unsupported networks