### PR TITLE
feat(14507): improve error message for failed txn in activity details view

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6404,6 +6404,9 @@
   "transactionFailed": {
     "message": "Transaction Failed"
   },
+  "transactionFailedBannerMessage": {
+    "message": "This transaction would have cost you extra fees, so we stopped it. Your money is still in your wallet."
+  },
   "transactionFee": {
     "message": "Transaction fee"
   },

--- a/test/e2e/tests/dapp-interactions/failing-contract.spec.js
+++ b/test/e2e/tests/dapp-interactions/failing-contract.spec.js
@@ -72,6 +72,15 @@ describe('Failing contract interaction ', function () {
           css: '.activity-list-item .transaction-status-label',
           text: 'Failed',
         });
+        // inspect transaction details
+        await driver.clickElement({
+          css: '.activity-list-item .transaction-status-label',
+          text: 'Failed',
+        });
+        await driver.waitForSelector('.transaction-list-item-details');
+        await driver.waitForSelector(
+          '[data-testid="transaction-list-item-details-banner-error-message"]',
+        );
       },
     );
   });

--- a/ui/components/app/transaction-list-item-details/index.scss
+++ b/ui/components/app/transaction-list-item-details/index.scss
@@ -49,6 +49,8 @@
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+    height: 42px;
+    justify-content: space-between;
 
     .btn-link {
       font-size: 12px;
@@ -62,9 +64,10 @@
   }
 
   &__operations {
-    margin: 0 0 16px 16px;
+    margin: 0 16px 16px 16px;
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    align-items: center;
   }
 
   &__header {

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -13,9 +13,19 @@ import Tooltip from '../../ui/tooltip';
 import CancelButton from '../cancel-button';
 import Popover from '../../ui/popover';
 import { Box } from '../../component-library/box';
+import { Text } from '../../component-library/text';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+} from '../../component-library/banner-alert';
+import {
+  TextVariant,
+  ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+  IconColor,
+  ///: END:ONLY_INCLUDE_IF
+} from '../../../helpers/constants/design-system';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
-import { Icon, IconName, Text } from '../../component-library';
-import { IconColor } from '../../../helpers/constants/design-system';
+import { Icon, IconName } from '../../component-library';
 ///: END:ONLY_INCLUDE_IF
 import { SECOND } from '../../../../shared/constants/time';
 import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';
@@ -55,6 +65,7 @@ export default class TransactionListItemDetails extends PureComponent {
     recipientNickname: PropTypes.string,
     transactionStatus: PropTypes.func,
     isCustomNetwork: PropTypes.bool,
+    showErrorBanner: PropTypes.bool,
     history: PropTypes.object,
     blockExplorerLinkText: PropTypes.object,
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
@@ -204,6 +215,7 @@ export default class TransactionListItemDetails extends PureComponent {
       onClose,
       recipientNickname,
       showCancel,
+      showErrorBanner,
       transactionStatus: TransactionStatus,
       blockExplorerLinkText,
       ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
@@ -220,6 +232,17 @@ export default class TransactionListItemDetails extends PureComponent {
       <Popover title={title} onClose={onClose}>
         <div className="transaction-list-item-details">
           <div className="transaction-list-item-details__operations">
+            {showErrorBanner && (
+              <BannerAlert severity={BannerAlertSeverity.Warning}>
+                <Text
+                  variant={TextVariant.bodyMd}
+                  as="h6"
+                  data-testid="transaction-list-item-details-banner-error-message"
+                >
+                  {t('transactionFailedBannerMessage')}
+                </Text>
+              </BannerAlert>
+            )}
             <div className="transaction-list-item-details__header-buttons">
               {showSpeedUp && (
                 <Button
@@ -246,7 +269,7 @@ export default class TransactionListItemDetails extends PureComponent {
                     className="transaction-list-item-details__header-button"
                     data-testid="rety-button"
                   >
-                    <i className="fa fa-sync"></i>
+                    <i className="fa fa-sync" />
                   </Button>
                 </Tooltip>
               )}
@@ -258,22 +281,18 @@ export default class TransactionListItemDetails extends PureComponent {
               data-testid="transaction-list-item-details-tx-status"
             >
               <div>{t('status')}</div>
-              <div>
-                <TransactionStatus />
-              </div>
+              <TransactionStatus />
             </div>
             <div className="transaction-list-item-details__tx-hash">
-              <div>
-                <Button
-                  type="link"
-                  onClick={this.handleBlockExplorerClick}
-                  disabled={!hash}
-                >
-                  {blockExplorerLinkText.firstPart === 'addBlockExplorer'
-                    ? t('addBlockExplorer')
-                    : t('viewOnBlockExplorer')}
-                </Button>
-              </div>
+              <Button
+                type="link"
+                onClick={this.handleBlockExplorerClick}
+                disabled={!hash}
+              >
+                {blockExplorerLinkText.firstPart === 'addBlockExplorer'
+                  ? t('addBlockExplorer')
+                  : t('viewOnBlockExplorer')}
+              </Button>
               <div>
                 <Tooltip
                   wrapperClassName="transaction-list-item-details__header-button"

--- a/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
@@ -125,6 +125,7 @@ export default function SmartTransactionListItem({
               date={date}
               status={displayedStatusKey}
               statusOnly
+              shouldShowTooltip={false}
             />
           )}
         />

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -459,6 +459,7 @@ function TransactionListItemInner({
             !hasCancelled &&
             !isBridgeTx
           }
+          showErrorBanner={Boolean(error)}
           transactionStatus={() => (
             <TransactionStatusLabel
               isPending={isPending}
@@ -467,6 +468,7 @@ function TransactionListItemInner({
               date={date}
               status={displayedStatusKey}
               statusOnly
+              shouldShowTooltip={false}
               ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
               custodyStatus={transactionGroup.primaryTransaction.custodyStatus}
               custodyStatusDisplayText={

--- a/ui/components/app/transaction-status-label/__snapshots__/transaction-status-label.test.js.snap
+++ b/ui/components/app/transaction-status-label/__snapshots__/transaction-status-label.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TransactionStatusLabel Component should render CONFIRMED properly 1`] = `
+exports[`TransactionStatusLabel Component renders CONFIRMED properly and tooltip 1`] = `
 <div>
   <div
     class="transaction-status-label transaction-status-label--confirmed"
@@ -10,7 +10,7 @@ exports[`TransactionStatusLabel Component should render CONFIRMED properly 1`] =
 </div>
 `;
 
-exports[`TransactionStatusLabel Component should render PENDING properly 1`] = `
+exports[`TransactionStatusLabel Component renders PENDING properly and tooltip 1`] = `
 <div>
   <div
     class="transaction-status-label transaction-status-label--pending transaction-status-label--pending"
@@ -20,7 +20,7 @@ exports[`TransactionStatusLabel Component should render PENDING properly 1`] = `
 </div>
 `;
 
-exports[`TransactionStatusLabel Component should render QUEUED properly 1`] = `
+exports[`TransactionStatusLabel Component renders QUEUED properly and tooltip 1`] = `
 <div>
   <div
     class="transaction-status-label transaction-status-label--queued transaction-status-label--queued"
@@ -30,7 +30,7 @@ exports[`TransactionStatusLabel Component should render QUEUED properly 1`] = `
 </div>
 `;
 
-exports[`TransactionStatusLabel Component should render SIGNING if status is approved 1`] = `
+exports[`TransactionStatusLabel Component renders SIGNING properly and tooltip 1`] = `
 <div>
   <div
     class="transaction-status-label transaction-status-label--signing"
@@ -40,7 +40,7 @@ exports[`TransactionStatusLabel Component should render SIGNING if status is app
 </div>
 `;
 
-exports[`TransactionStatusLabel Component should render UNAPPROVED properly 1`] = `
+exports[`TransactionStatusLabel Component renders UNAPPROVED properly and tooltip 1`] = `
 <div>
   <div
     class="transaction-status-label transaction-status-label--unapproved transaction-status-label--unapproved"

--- a/ui/components/app/transaction-status-label/transaction-status-label.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.js
@@ -64,6 +64,7 @@ export default function TransactionStatusLabel({
   isEarliestNonce,
   className,
   statusOnly,
+  shouldShowTooltip,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   custodyStatus,
   custodyStatusDisplayText,
@@ -96,8 +97,7 @@ export default function TransactionStatusLabel({
     }
   }
   ///: END:ONLY_INCLUDE_IF
-
-  return (
+  return shouldShowTooltip ? (
     <Tooltip
       position="top"
       title={tooltipText}
@@ -110,6 +110,17 @@ export default function TransactionStatusLabel({
     >
       {statusText}
     </Tooltip>
+  ) : (
+    <div
+      data-testid="transaction-status-label"
+      className={classnames(
+        'transaction-status-label',
+        className,
+        statusToClassNameHash[statusKey],
+      )}
+    >
+      {statusText}
+    </div>
   );
 }
 
@@ -120,8 +131,13 @@ TransactionStatusLabel.propTypes = {
   error: PropTypes.object,
   isEarliestNonce: PropTypes.bool,
   statusOnly: PropTypes.bool,
+  shouldShowTooltip: PropTypes.bool,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   custodyStatus: PropTypes.string,
   custodyStatusDisplayText: PropTypes.string,
   ///: END:ONLY_INCLUDE_IF
+};
+
+TransactionStatusLabel.defaultProps = {
+  shouldShowTooltip: true,
 };


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
When we encounter a failed transaction:
- in activity list from home view, it renders as `failed`, hovering the status will render an error message
- when clicking this activity, the popup view for txn details will render `failed` as well, with no hover effect
- In the meanwhile, there's a new and more user friendly error banner showing for user when txn failed.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29338?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/14507
Figma: https://www.figma.com/design/ZzVQ6iu13C67K807Z1bg5I/Smart-Transactions-1.0?node-id=4296-25303&t=ff749RbiH6F4IUqk-0

## **Manual testing steps**

1. Render extension and test dapp
2. Trigger a failed txn from test dapp
3. Check activity for that txn
4. Check activity details by clicking item from step 3 and validate the banner, as well as hover

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="355" alt="Screenshot 2024-12-18 at 18 25 45" src="https://github.com/user-attachments/assets/76e53d88-a171-449a-a046-803472a66a02" />

<!-- [screenshots/recordings] -->

### **After**
<img width="356" alt="Screenshot 2024-12-19 at 01 54 39" src="https://github.com/user-attachments/assets/a0ce1088-f9a2-4a3a-98ab-25cdd36faa25" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
