### PR TITLE
chore: Cherry pick 241c9d8 (#29285) to v12.10.0

### DIFF
--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -104,10 +104,10 @@ export const SENTRY_BACKGROUND_STATE = {
       },
       destTokens: {},
       destTopAssets: [],
-      destTokensLoadingStatus: false,
+      destTokensLoadingStatus: true,
       srcTokens: {},
       srcTopAssets: [],
-      srcTokensLoadingStatus: false,
+      srcTokensLoadingStatus: true,
       quoteRequest: {
         walletAddress: false,
         srcTokenAddress: true,

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -76,8 +76,6 @@
       "srcTokens": {},
       "srcTopAssets": {},
       "destTokens": {},
-      "destTokensLoadingStatus": "undefined",
-      "srcTokensLoadingStatus": "undefined",
       "destTopAssets": {},
       "quoteRequest": {
         "srcTokenAddress": "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
Cherry picks 241c9d8 (#29285) to v12.10.0

Fixes sentry tests for bridge token loading status in Firefox