### PR TITLE
fix: not re-load the whole confirmation when spending cap is changed

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/approve/approve.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/approve.tsx
@@ -2,7 +2,7 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useConfirmContext } from '../../../../context/confirm';
 import { useAssetDetails } from '../../../../hooks/useAssetDetails';
 import { AdvancedDetails } from '../shared/advanced-details/advanced-details';
@@ -18,6 +18,7 @@ import { RevokeStaticSimulation } from './revoke-static-simulation/revoke-static
 import { SpendingCap } from './spending-cap/spending-cap';
 
 const ApproveInfo = () => {
+  const [initialPending, setInitialPending] = useState<boolean>(true);
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
 
@@ -38,7 +39,16 @@ const ApproveInfo = () => {
     decimals || '0',
   );
 
+  // initialPending is introduced so that entire component does not go into loading state
+  // each time spending cap is updated.
+  useEffect(() => {
+    if (!pending) {
+      setInitialPending(false);
+    }
+  }, [pending]);
+
   const showRevokeVariant =
+    !pending &&
     spendingCap === '0' &&
     transactionMeta.type === TransactionType.tokenMethodApprove;
 
@@ -46,17 +56,13 @@ const ApproveInfo = () => {
     return null;
   }
 
-  if (pending) {
+  if (initialPending) {
     return <ConfirmLoader />;
   }
 
   return (
     <>
-      {showRevokeVariant ? (
-        <RevokeStaticSimulation />
-      ) : (
-        <ApproveStaticSimulation />
-      )}
+      <ApproveStaticSimulation />
       {showRevokeVariant ? <RevokeDetails /> : <ApproveDetails />}
       {!isNFT && !showRevokeVariant && (
         <SpendingCap

--- a/ui/pages/confirmations/components/confirm/info/approve/approve.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/approve.tsx
@@ -62,7 +62,11 @@ const ApproveInfo = () => {
 
   return (
     <>
-      <ApproveStaticSimulation />
+      {showRevokeVariant ? (
+        <RevokeStaticSimulation />
+      ) : (
+        <ApproveStaticSimulation />
+      )}
       {showRevokeVariant ? <RevokeDetails /> : <ApproveDetails />}
       {!isNFT && !showRevokeVariant && (
         <SpendingCap

--- a/ui/pages/confirmations/components/confirm/info/approve/spending-cap/spending-cap.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/spending-cap/spending-cap.tsx
@@ -95,21 +95,21 @@ export const SpendingCap = ({
     decimals || '0',
   );
 
-  if (pending) {
-    return <Container isLoading />;
-  }
-
   return (
     <ConfirmInfoSection data-testid="confirmation__approve-spending-cap-section">
       <ConfirmInfoRow label={t('accountBalance')}>
         <ConfirmInfoRowText text={`${accountBalance} ${tokenSymbol || ''}`} />
       </ConfirmInfoRow>
 
-      <SpendingCapGroup
-        tokenSymbol={tokenSymbol || ''}
-        decimals={decimals || '0'}
-        setIsOpenEditSpendingCapModal={setIsOpenEditSpendingCapModal}
-      />
+      {pending ? (
+        <Container isLoading />
+      ) : (
+        <SpendingCapGroup
+          tokenSymbol={tokenSymbol || ''}
+          decimals={decimals || '0'}
+          setIsOpenEditSpendingCapModal={setIsOpenEditSpendingCapModal}
+        />
+      )}
     </ConfirmInfoSection>
   );
 };

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -2,7 +2,7 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import React, { memo, useEffect, useMemo, useState } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 
 import { TokenStandard } from '../../../../../../shared/constants/transaction';
 import GeneralAlert from '../../../../../components/app/alert-system/general-alert/general-alert';

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -2,7 +2,7 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import React, { memo, useMemo } from 'react';
+import React, { memo, useEffect, useMemo, useState } from 'react';
 
 import { TokenStandard } from '../../../../../../shared/constants/transaction';
 import GeneralAlert from '../../../../../components/app/alert-system/general-alert/general-alert';
@@ -61,14 +61,9 @@ const getTitle = (
   isNFT?: boolean,
   customSpendingCap?: string,
   isRevokeSetApprovalForAll?: boolean,
-  pending?: boolean,
   primaryType?: keyof typeof TypedSignSignaturePrimaryTypes,
   tokenStandard?: string,
 ) => {
-  if (pending) {
-    return '';
-  }
-
   switch (confirmation?.type) {
     case TransactionType.contractInteraction:
       return t('confirmTitleTransaction');
@@ -113,14 +108,9 @@ const getDescription = (
   isNFT?: boolean,
   customSpendingCap?: string,
   isRevokeSetApprovalForAll?: boolean,
-  pending?: boolean,
   primaryType?: keyof typeof TypedSignSignaturePrimaryTypes,
   tokenStandard?: string,
 ) => {
-  if (pending) {
-    return '';
-  }
-
   switch (confirmation?.type) {
     case TransactionType.contractInteraction:
       return '';
@@ -163,6 +153,8 @@ const getDescription = (
 const ConfirmTitle: React.FC = memo(() => {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
 
   const { isNFT } = useIsNFT(currentConfirmation as TransactionMeta);
 
@@ -187,53 +179,60 @@ const ConfirmTitle: React.FC = memo(() => {
     revokePending = decodedResponse.pending;
   }
 
-  const title = useMemo(
-    () =>
+  useEffect(() => {
+    // if use is making any change to transaction like changing spending cap - pending is again set to true
+    // condition below ensures that title is not reset each time pending is true
+    // so that there is no flickering on the page
+    if (spendingCapPending || revokePending) {
+      return;
+    }
+    setTitle(
       getTitle(
         t as IntlFunction,
         currentConfirmation,
         isNFT,
         customSpendingCap,
         isRevokeSetApprovalForAll,
-        spendingCapPending || revokePending,
         primaryType,
         tokenStandard,
       ),
-    [
-      currentConfirmation,
-      isNFT,
-      customSpendingCap,
-      isRevokeSetApprovalForAll,
-      spendingCapPending,
-      revokePending,
-      primaryType,
-      tokenStandard,
-    ],
-  );
+    );
+  }, [
+    currentConfirmation,
+    isNFT,
+    customSpendingCap,
+    isRevokeSetApprovalForAll,
+    spendingCapPending,
+    revokePending,
+    primaryType,
+    tokenStandard,
+  ]);
 
-  const description = useMemo(
-    () =>
+  useEffect(() => {
+    if (spendingCapPending || revokePending) {
+      return;
+    }
+    setDescription(
       getDescription(
         t as IntlFunction,
         currentConfirmation,
         isNFT,
         customSpendingCap,
         isRevokeSetApprovalForAll,
-        spendingCapPending || revokePending,
         primaryType,
         tokenStandard,
       ),
-    [
-      currentConfirmation,
-      isNFT,
-      customSpendingCap,
-      isRevokeSetApprovalForAll,
-      spendingCapPending,
-      revokePending,
-      primaryType,
-      tokenStandard,
-    ],
-  );
+    );
+  }, [
+    currentConfirmation,
+    isNFT,
+    customSpendingCap,
+    isRevokeSetApprovalForAll,
+    spendingCapPending,
+    revokePending,
+    primaryType,
+    tokenStandard,
+  ]);
 
   if (!currentConfirmation) {
     return null;


### PR DESCRIPTION
## **Description**

Currently almost whole of confirmation page re-loads when updating spending cap. This PR makes fix to load only specific sections when spending cap is updated.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3819

## **Manual testing steps**

1. Go to test dapp
2. Create spending cap request
3. Update spending cap - only specific section of the page should re-loas

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/61942cb9-2b93-445d-81c5-37789076cb88

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
