### PR TITLE
e2e testing: accounts requested in `wallet_createSession`#3822

### DIFF
--- a/test/e2e/flask/multichain-api/create-session.spec.ts
+++ b/test/e2e/flask/multichain-api/create-session.spec.ts
@@ -186,69 +186,71 @@ describe('Multichain API', function () {
     );
   });
 
-  describe('With requested EVM scope that match the user’s enabled networks, edit selection in wallet UI', function () {
-    it('should change result according to changed network & accounts', async function () {
-      await withFixtures(
-        {
-          title: this.test?.fullTitle(),
-          fixtures: new FixtureBuilder()
-            .withPopularNetworks()
-            .withPreferencesControllerAdditionalAccountIdentities()
-            .build(),
-          ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
-        },
-        async ({
-          driver,
-          extensionId,
-        }: {
-          driver: Driver;
-          extensionId: string;
-        }) => {
-          const requestScopesToNetworkMap = {
-            'eip155:1': 'Ethereum Mainnet',
-            'eip155:10': 'OP Mainnet',
-          };
-
-          const requestScopes = Object.keys(requestScopesToNetworkMap);
-
-          await openMultichainDappAndConnectWalletWithExternallyConnectable(
+  describe('Call `wallet_createSession`', function () {
+    describe('With requested EVM scope that match the user’s enabled networks, edit selection in wallet UI', function () {
+      it('should change result according to changed network & accounts', async function () {
+        await withFixtures(
+          {
+            title: this.test?.fullTitle(),
+            fixtures: new FixtureBuilder()
+              .withPopularNetworks()
+              .withPreferencesControllerAdditionalAccountIdentities()
+              .build(),
+            ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+          },
+          async ({
             driver,
             extensionId,
-          );
+          }: {
+            driver: Driver;
+            extensionId: string;
+          }) => {
+            const requestScopesToNetworkMap = {
+              'eip155:1': 'Ethereum Mainnet',
+              'eip155:10': 'OP Mainnet',
+            };
 
-          await addAccountsToCreateSessionForm(driver, [
-            DEFAULT_FIXTURE_ACCOUNT,
-            '',
-          ]);
-          await initCreateSessionScopes(driver, requestScopes);
+            const requestScopes = Object.keys(requestScopesToNetworkMap);
 
-          await addAccountInWalletAndAuthorize(driver);
-          await uncheckNetworksExceptMainnet(driver);
+            await openMultichainDappAndConnectWalletWithExternallyConnectable(
+              driver,
+              extensionId,
+            );
 
-          await driver.clickElement({ text: 'Connect', tag: 'button' });
-          await driver.switchToWindowWithTitle(
-            WINDOW_TITLES.MultichainTestDApp,
-          );
-
-          const getSessionScopesResult = await getSessionScopes(driver);
-
-          assert.strictEqual(
-            getSessionScopesResult.sessionScopes['eip155:10'],
-            undefined,
-          );
-
-          assert.ok(getSessionScopesResult.sessionScopes['eip155:1']);
-
-          assert.deepEqual(
-            getSessionScopesResult.sessionScopes['eip155:1'].accounts,
-            getExpectedSessionScope('eip155:1', [
+            await addAccountsToCreateSessionForm(driver, [
               DEFAULT_FIXTURE_ACCOUNT,
-              SECOND_INJECTED_ACCOUNT,
-            ]).accounts,
-            `Should add account ${SECOND_INJECTED_ACCOUNT} to scope`,
-          );
-        },
-      );
+              '',
+            ]);
+            await initCreateSessionScopes(driver, requestScopes);
+
+            await addAccountInWalletAndAuthorize(driver);
+            await uncheckNetworksExceptMainnet(driver);
+
+            await driver.clickElement({ text: 'Connect', tag: 'button' });
+            await driver.switchToWindowWithTitle(
+              WINDOW_TITLES.MultichainTestDApp,
+            );
+
+            const getSessionScopesResult = await getSessionScopes(driver);
+
+            assert.strictEqual(
+              getSessionScopesResult.sessionScopes['eip155:10'],
+              undefined,
+            );
+
+            assert.ok(getSessionScopesResult.sessionScopes['eip155:1']);
+
+            assert.deepEqual(
+              getSessionScopesResult.sessionScopes['eip155:1'].accounts,
+              getExpectedSessionScope('eip155:1', [
+                DEFAULT_FIXTURE_ACCOUNT,
+                SECOND_INJECTED_ACCOUNT,
+              ]).accounts,
+              `Should add account ${SECOND_INJECTED_ACCOUNT} to scope`,
+            );
+          },
+        );
+      });
     });
   });
 });

--- a/test/e2e/flask/multichain-api/create-session.spec.ts
+++ b/test/e2e/flask/multichain-api/create-session.spec.ts
@@ -5,7 +5,6 @@ import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';
 import { DEFAULT_FIXTURE_ACCOUNT } from '../../constants';
 import {
-  confirmAndSwitchFocusToDapp,
   initCreateSessionScopes,
   DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
   getSessionScopes,
@@ -48,7 +47,12 @@ describe('Multichain API', function () {
             'eip155:1',
             ...scopesToIgnore,
           ]);
-          await confirmAndSwitchFocusToDapp(driver);
+
+          await driver.clickElement({ text: 'Connect', tag: 'button' });
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.MultichainTestDApp,
+          );
+
           const getSessionScopesResult = await getSessionScopes(driver);
 
           for (const scope of scopesToIgnore) {
@@ -100,7 +104,11 @@ describe('Multichain API', function () {
           ]);
 
           await initCreateSessionScopes(driver, [REQUEST_SCOPE]);
-          await confirmAndSwitchFocusToDapp(driver);
+
+          await driver.clickElement({ text: 'Connect', tag: 'button' });
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.MultichainTestDApp,
+          );
 
           const getSessionScopesResult = await getSessionScopes(driver);
           /**

--- a/test/e2e/flask/multichain-api/create-session.spec.ts
+++ b/test/e2e/flask/multichain-api/create-session.spec.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'assert';
+import { By } from 'selenium-webdriver';
 import { largeDelayMs, WINDOW_TITLES, withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';
@@ -10,9 +11,8 @@ import {
   getSessionScopes,
   openMultichainDappAndConnectWalletWithExternallyConnectable,
   getExpectedSessionScope,
-  addRequestAccountsToCreateSession,
-  assertOnlyRequestedNetworksAreSelected,
-  addAndAuthorizeAccount,
+  addAccountsToCreateSessionForm,
+  addAccountInWalletAndAuthorize,
   uncheckNetworksExceptMainnet,
 } from './testHelpers';
 
@@ -62,12 +62,15 @@ describe('Multichain API', function () {
     });
   });
 
-  describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that match the user’s enabled networks', function () {
-    it('should only select the specified EVM scopes requested by the user, and session scope contain valid accounts only', async function () {
+  describe('Call `wallet_createSession` with EVM scopes that match the user’s enabled networks, and eip155 scoped accounts', function () {
+    it('should ignore requested accounts that do not match accounts in the wallet and and pre-select matching requested accounts in the permission confirmation screen', async function () {
       await withFixtures(
         {
           title: this.test?.fullTitle(),
-          fixtures: new FixtureBuilder().withPopularNetworks().build(),
+          fixtures: new FixtureBuilder()
+            .withPopularNetworks()
+            .withTrezorAccount()
+            .build(),
           ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
         },
         async ({
@@ -77,66 +80,113 @@ describe('Multichain API', function () {
           driver: Driver;
           extensionId: string;
         }) => {
-          const INVALID_ACCOUNT = '0x9999999999999999999999999999999999999999';
-          const requestScopesToNetworkMap = {
-            'eip155:1': 'Ethereum Mainnet',
-            'eip155:42161': 'Arbitrum One',
-            'eip155:10': 'OP Mainnet',
-          };
-
-          const requestScopes = Object.keys(requestScopesToNetworkMap);
-          const networksToRequest = Object.values(requestScopesToNetworkMap);
+          const REQUEST_SCOPE = 'eip155:1';
+          /**
+           * check {@link FixtureBuilder.withTrezorAccount} for second injected account address.
+           */
+          const SECOND_ACCOUNT_IN_WALLET =
+            '0xf68464152d7289d7ea9a2bec2e0035c45188223c';
+          const ACCOUNT_NOT_IN_WALLET =
+            '0x9999999999999999999999999999999999999999';
 
           await openMultichainDappAndConnectWalletWithExternallyConnectable(
             driver,
             extensionId,
           );
 
-          await addRequestAccountsToCreateSession(driver, [
-            DEFAULT_FIXTURE_ACCOUNT,
-            INVALID_ACCOUNT,
+          await addAccountsToCreateSessionForm(driver, [
+            SECOND_ACCOUNT_IN_WALLET,
+            ACCOUNT_NOT_IN_WALLET,
           ]);
 
-          await initCreateSessionScopes(driver, requestScopes);
-
-          // navigate to network selection screen
-          const editButtons = await driver.findElements('[data-testid="edit"]');
-          await editButtons[1].click();
-          await driver.delay(largeDelayMs);
-
-          await assertOnlyRequestedNetworksAreSelected(
-            driver,
-            networksToRequest,
-          );
-
-          // proceed with network selection confirm
-          await driver.clickElement(
-            '[data-testid="connect-more-chains-button"]',
-          );
+          await initCreateSessionScopes(driver, [REQUEST_SCOPE]);
           await confirmAndSwitchFocusToDapp(driver);
 
           const getSessionScopesResult = await getSessionScopes(driver);
-          for (const scope of requestScopes) {
-            /**
-             * Accounts in scope should not include invalid account {@link INVALID_ACCOUNT}, only the valid accounts.
-             */
-            const expectedSessionScope = getExpectedSessionScope(scope, [
-              DEFAULT_FIXTURE_ACCOUNT,
-            ]);
-            const result = getSessionScopesResult.sessionScopes[scope].accounts;
+          /**
+           * Accounts in scope should not include invalid account {@link ACCOUNT_NOT_IN_WALLET}, only the valid accounts.
+           */
+          const expectedSessionScope = getExpectedSessionScope(REQUEST_SCOPE, [
+            SECOND_ACCOUNT_IN_WALLET,
+          ]);
+          const result =
+            getSessionScopesResult.sessionScopes[REQUEST_SCOPE].accounts;
 
-            assert.deepEqual(
-              expectedSessionScope.accounts,
-              result,
-              `${expectedSessionScope.accounts} does not match accounts in scope ${result}`,
-            );
-          }
+          assert.deepEqual(
+            expectedSessionScope.accounts,
+            result,
+            `${expectedSessionScope.accounts} does not match accounts in scope ${result}`,
+          );
         },
       );
     });
   });
 
-  describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that match the user’s enabled networks, edit selection in wallet UI', function () {
+  it('should only select the specified EVM scopes requested by the user', async function () {
+    await withFixtures(
+      {
+        title: this.test?.fullTitle(),
+        fixtures: new FixtureBuilder().withPopularNetworks().build(),
+        ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+      },
+      async ({
+        driver,
+        extensionId,
+      }: {
+        driver: Driver;
+        extensionId: string;
+      }) => {
+        const requestScopesToNetworkMap = {
+          'eip155:1': 'Ethereum Mainnet',
+          'eip155:42161': 'Arbitrum One',
+          'eip155:10': 'OP Mainnet',
+        };
+
+        const requestScopes = Object.keys(requestScopesToNetworkMap);
+        const networksToRequest = Object.values(requestScopesToNetworkMap);
+
+        await openMultichainDappAndConnectWalletWithExternallyConnectable(
+          driver,
+          extensionId,
+        );
+
+        await initCreateSessionScopes(driver, requestScopes);
+
+        // navigate to network selection screen
+        const editButtons = await driver.findElements('[data-testid="edit"]');
+        await editButtons[1].click();
+        await driver.delay(largeDelayMs);
+
+        const networkListItems = await driver.findElements(
+          '.multichain-network-list-item',
+        );
+
+        for (const item of networkListItems) {
+          const network = await item.getText();
+          const checkbox = await item.findElement(
+            By.css('input[type="checkbox"]'),
+          );
+          const isChecked = await checkbox.isSelected();
+
+          if (networksToRequest.includes(network)) {
+            assert.strictEqual(
+              isChecked,
+              true,
+              `Expected ${network} to be selected.`,
+            );
+          } else {
+            assert.strictEqual(
+              isChecked,
+              false,
+              `Expected ${network} to NOT be selected.`,
+            );
+          }
+        }
+      },
+    );
+  });
+
+  describe('With requested EVM scope that match the user’s enabled networks, edit selection in wallet UI', function () {
     it('should change result according to changed network & accounts', async function () {
       await withFixtures(
         {
@@ -166,13 +216,13 @@ describe('Multichain API', function () {
             extensionId,
           );
 
-          await addRequestAccountsToCreateSession(driver, [
+          await addAccountsToCreateSessionForm(driver, [
             DEFAULT_FIXTURE_ACCOUNT,
             '',
           ]);
           await initCreateSessionScopes(driver, requestScopes);
 
-          await addAndAuthorizeAccount(driver);
+          await addAccountInWalletAndAuthorize(driver);
           await uncheckNetworksExceptMainnet(driver);
 
           await driver.clickElement({ text: 'Connect', tag: 'button' });

--- a/test/e2e/flask/multichain-api/create-session.spec.ts
+++ b/test/e2e/flask/multichain-api/create-session.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { WINDOW_TITLES, withFixtures } from '../../helpers';
+import { largeDelayMs, WINDOW_TITLES, withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';
 import { DEFAULT_FIXTURE_ACCOUNT } from '../../constants';
@@ -17,6 +17,11 @@ import {
 } from './testHelpers';
 
 describe('Multichain API', function () {
+  /**
+   * check {@link FixtureBuilder.withPreferencesControllerAdditionalAccountIdentities} for second injected account address.
+   */
+  const SECOND_INJECTED_ACCOUNT = '0x09781764c08de8ca82e156bbf156a3ca217c7950';
+
   describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that does NOT match one of the user’s enabled networks', function () {
     it("the specified EVM scopes that do not match the user's configured networks should be treated as if they were not requested", async function () {
       await withFixtures(
@@ -94,11 +99,20 @@ describe('Multichain API', function () {
 
           await initCreateSessionScopes(driver, requestScopes);
 
+          // navigate to network selection screen
+          const editButtons = await driver.findElements('[data-testid="edit"]');
+          await editButtons[1].click();
+          await driver.delay(largeDelayMs);
+
           await assertOnlyRequestedNetworksAreSelected(
             driver,
             networksToRequest,
           );
 
+          // proceed with network selection confirm
+          await driver.clickElement(
+            '[data-testid="connect-more-chains-button"]',
+          );
           await confirmAndSwitchFocusToDapp(driver);
 
           const getSessionScopesResult = await getSessionScopes(driver);
@@ -157,7 +171,6 @@ describe('Multichain API', function () {
             '',
           ]);
           await initCreateSessionScopes(driver, requestScopes);
-          await driver.clickElement({ text: 'Update', tag: 'button' });
 
           await addAndAuthorizeAccount(driver);
           await uncheckNetworksExceptMainnet(driver);
@@ -180,9 +193,9 @@ describe('Multichain API', function () {
             getSessionScopesResult.sessionScopes['eip155:1'].accounts,
             getExpectedSessionScope('eip155:1', [
               DEFAULT_FIXTURE_ACCOUNT,
-              '0x09781764c08de8ca82e156bbf156a3ca217c7950',
+              SECOND_INJECTED_ACCOUNT,
             ]).accounts,
-            'Should add account 0x09781764c08de8ca82e156bbf156a3ca217c7950 to scope',
+            `Should add account ${SECOND_INJECTED_ACCOUNT} to scope`,
           );
         },
       );

--- a/test/e2e/flask/multichain-api/create-session.spec.ts
+++ b/test/e2e/flask/multichain-api/create-session.spec.ts
@@ -1,12 +1,19 @@
 import { strict as assert } from 'assert';
-import { withFixtures } from '../../helpers';
+import { WINDOW_TITLES, withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';
+import { DEFAULT_FIXTURE_ACCOUNT } from '../../constants';
 import {
-  createSessionScopes,
+  confirmAndSwitchFocusToDapp,
+  initCreateSessionScopes,
   DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
   getSessionScopes,
   openMultichainDappAndConnectWalletWithExternallyConnectable,
+  getExpectedSessionScope,
+  addRequestAccountsToCreateSession,
+  assertOnlyRequestedNetworksAreSelected,
+  addAndAuthorizeAccount,
+  uncheckNetworksExceptMainnet,
 } from './testHelpers';
 
 describe('Multichain API', function () {
@@ -32,8 +39,11 @@ describe('Multichain API', function () {
             driver,
             extensionId,
           );
-          await createSessionScopes(driver, ['eip155:1', ...scopesToIgnore]);
-
+          await initCreateSessionScopes(driver, [
+            'eip155:1',
+            ...scopesToIgnore,
+          ]);
+          await confirmAndSwitchFocusToDapp(driver);
           const getSessionScopesResult = await getSessionScopes(driver);
 
           for (const scope of scopesToIgnore) {
@@ -42,6 +52,138 @@ describe('Multichain API', function () {
               undefined,
             );
           }
+        },
+      );
+    });
+  });
+
+  describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that match the user’s enabled networks', function () {
+    it('should only select the specified EVM scopes requested by the user, and session scope contain valid accounts only', async function () {
+      await withFixtures(
+        {
+          title: this.test?.fullTitle(),
+          fixtures: new FixtureBuilder().withPopularNetworks().build(),
+          ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+        },
+        async ({
+          driver,
+          extensionId,
+        }: {
+          driver: Driver;
+          extensionId: string;
+        }) => {
+          const INVALID_ACCOUNT = '0x9999999999999999999999999999999999999999';
+          const requestScopesToNetworkMap = {
+            'eip155:1': 'Ethereum Mainnet',
+            'eip155:42161': 'Arbitrum One',
+            'eip155:10': 'OP Mainnet',
+          };
+
+          const requestScopes = Object.keys(requestScopesToNetworkMap);
+          const networksToRequest = Object.values(requestScopesToNetworkMap);
+
+          await openMultichainDappAndConnectWalletWithExternallyConnectable(
+            driver,
+            extensionId,
+          );
+
+          await addRequestAccountsToCreateSession(driver, [
+            DEFAULT_FIXTURE_ACCOUNT,
+            INVALID_ACCOUNT,
+          ]);
+
+          await initCreateSessionScopes(driver, requestScopes);
+
+          await assertOnlyRequestedNetworksAreSelected(
+            driver,
+            networksToRequest,
+          );
+
+          await confirmAndSwitchFocusToDapp(driver);
+
+          const getSessionScopesResult = await getSessionScopes(driver);
+          for (const scope of requestScopes) {
+            /**
+             * Accounts in scope should not include invalid account {@link INVALID_ACCOUNT}, only the valid accounts.
+             */
+            const expectedSessionScope = getExpectedSessionScope(scope, [
+              DEFAULT_FIXTURE_ACCOUNT,
+            ]);
+            const result = getSessionScopesResult.sessionScopes[scope].accounts;
+
+            assert.deepEqual(
+              expectedSessionScope.accounts,
+              result,
+              `${expectedSessionScope.accounts} does not match accounts in scope ${result}`,
+            );
+          }
+        },
+      );
+    });
+  });
+
+  describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that match the user’s enabled networks, edit selection in wallet UI', function () {
+    it('should change result according to changed network & accounts', async function () {
+      await withFixtures(
+        {
+          title: this.test?.fullTitle(),
+          fixtures: new FixtureBuilder()
+            .withPopularNetworks()
+            .withPreferencesControllerAdditionalAccountIdentities()
+            .build(),
+          ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+        },
+        async ({
+          driver,
+          extensionId,
+        }: {
+          driver: Driver;
+          extensionId: string;
+        }) => {
+          const requestScopesToNetworkMap = {
+            'eip155:1': 'Ethereum Mainnet',
+            'eip155:10': 'OP Mainnet',
+          };
+
+          const requestScopes = Object.keys(requestScopesToNetworkMap);
+
+          await openMultichainDappAndConnectWalletWithExternallyConnectable(
+            driver,
+            extensionId,
+          );
+
+          await addRequestAccountsToCreateSession(driver, [
+            DEFAULT_FIXTURE_ACCOUNT,
+            '',
+          ]);
+          await initCreateSessionScopes(driver, requestScopes);
+          await driver.clickElement({ text: 'Update', tag: 'button' });
+
+          await addAndAuthorizeAccount(driver);
+          await uncheckNetworksExceptMainnet(driver);
+
+          await driver.clickElement({ text: 'Connect', tag: 'button' });
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.MultichainTestDApp,
+          );
+
+          const getSessionScopesResult = await getSessionScopes(driver);
+
+          assert.strictEqual(
+            getSessionScopesResult.sessionScopes['eip155:10'],
+            undefined,
+          );
+
+          assert.ok(getSessionScopesResult.sessionScopes['eip155:1']);
+
+          assert.deepEqual(
+            getSessionScopesResult.sessionScopes['eip155:1'].accounts,
+            getExpectedSessionScope('eip155:1', [
+              DEFAULT_FIXTURE_ACCOUNT,
+              '0x09781764c08de8ca82e156bbf156a3ca217c7950',
+            ]).accounts,
+            'Should add account 0x09781764c08de8ca82e156bbf156a3ca217c7950 to scope',
+          );
         },
       );
     });

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -70,18 +70,6 @@ export async function initCreateSessionScopes(
 }
 
 /**
- * Confirms wallet operation and switches focus to multichain test dapp
- *
- * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
- */
-export async function confirmAndSwitchFocusToDapp(
-  driver: Driver,
-): Promise<void> {
-  await driver.clickElement({ text: 'Connect', tag: 'button' });
-  await driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
-}
-
-/**
  * Retrieves permitted session scopes by using test driver to interact with web dapp.
  *
  * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import { strict as assert } from 'assert';
 import { By } from 'selenium-webdriver';
 import {
   KnownRpcMethods,
@@ -105,12 +104,12 @@ export async function getSessionScopes(
 }
 
 /**
- * Use dapp UI to send custom addresses to request scope for.
+ * Use dapp UI to add account addresses to `wallet_createSession` request.
  *
  * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
- * @param accounts - The addresses to get session scope for.
+ * @param accounts - The addresses to add to the create session request.
  */
-export async function addRequestAccountsToCreateSession(
+export async function addAccountsToCreateSessionForm(
   driver: Driver,
   accounts: [string, string],
 ): Promise<void> {
@@ -155,7 +154,9 @@ export const getExpectedSessionScope = (scope: string, accounts: string[]) => ({
   accounts: accounts.map((acc) => `${scope}:${acc.toLowerCase()}`),
 });
 
-export const addAndAuthorizeAccount = async (driver: Driver): Promise<void> => {
+export const addAccountInWalletAndAuthorize = async (
+  driver: Driver,
+): Promise<void> => {
   const editButtons = await driver.findElements('[data-testid="edit"]');
   await editButtons[0].click();
   await driver.clickElement({ text: 'New account', tag: 'button' });
@@ -204,39 +205,4 @@ export const uncheckNetworksExceptMainnet = async (
     }
   }
   await driver.clickElement({ text: 'Update', tag: 'button' });
-};
-
-/**
- * Will assert only the requested networks are selected, and all other are not.
- *
- * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
- * @param networkList - list of networks to assert selection for.
- */
-export const assertOnlyRequestedNetworksAreSelected = async (
-  driver: Driver,
-  networkList: string[],
-) => {
-  const networkListItems = await driver.findElements(
-    '.multichain-network-list-item',
-  );
-
-  for (const item of networkListItems) {
-    const network = await item.getText();
-    const checkbox = await item.findElement(By.css('input[type="checkbox"]'));
-    const isChecked = await checkbox.isSelected();
-
-    if (networkList.includes(network)) {
-      assert.strictEqual(
-        isChecked,
-        true,
-        `Expected ${network} to be selected.`,
-      );
-    } else {
-      assert.strictEqual(
-        isChecked,
-        false,
-        `Expected ${network} to NOT be selected.`,
-      );
-    }
-  }
 };

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -68,10 +68,6 @@ export async function initCreateSessionScopes(
   await driver.clickElement({ text: 'wallet_createSession', tag: 'span' });
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
   await driver.delay(largeDelayMs);
-
-  const editButtons = await driver.findElements('[data-testid="edit"]');
-  await editButtons[1].click();
-  await driver.delay(largeDelayMs);
 }
 
 /**
@@ -82,7 +78,6 @@ export async function initCreateSessionScopes(
 export async function confirmAndSwitchFocusToDapp(
   driver: Driver,
 ): Promise<void> {
-  await driver.clickElement('[data-testid="connect-more-chains-button"]');
   await driver.clickElement({ text: 'Connect', tag: 'button' });
   await driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
 }

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -1,9 +1,16 @@
 import * as path from 'path';
-import { KnownRpcMethods, KnownNotifications } from '@metamask/multichain';
+import { strict as assert } from 'assert';
+import { By } from 'selenium-webdriver';
+import {
+  KnownRpcMethods,
+  KnownNotifications,
+  NormalizedScopeObject,
+} from '@metamask/multichain';
 import {
   DAPP_URL,
   largeDelayMs,
   openDapp,
+  regularDelayMs,
   unlockWallet,
   WINDOW_TITLES,
 } from '../../helpers';
@@ -45,12 +52,12 @@ export async function openMultichainDappAndConnectWalletWithExternallyConnectabl
 }
 
 /**
- * Sends a request to wallet extension to create session for the passed scopes.
+ * Initiates a request to wallet extension to create session for the passed scopes.
  *
  * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
  * @param scopes - scopes to create session for.
  */
-export async function createSessionScopes(
+export async function initCreateSessionScopes(
   driver: Driver,
   scopes: string[],
 ): Promise<void> {
@@ -65,7 +72,16 @@ export async function createSessionScopes(
   const editButtons = await driver.findElements('[data-testid="edit"]');
   await editButtons[1].click();
   await driver.delay(largeDelayMs);
+}
 
+/**
+ * Confirms wallet operation and switches focus to multichain test dapp
+ *
+ * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
+ */
+export async function confirmAndSwitchFocusToDapp(
+  driver: Driver,
+): Promise<void> {
   await driver.clickElement('[data-testid="connect-more-chains-button"]');
   await driver.clickElement({ text: 'Connect', tag: 'button' });
   await driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
@@ -79,7 +95,7 @@ export async function createSessionScopes(
  */
 export async function getSessionScopes(
   driver: Driver,
-): Promise<{ sessionScopes: Record<string, unknown> }> {
+): Promise<{ sessionScopes: Record<string, NormalizedScopeObject> }> {
   await driver.clickElement({ text: 'wallet_getSession', tag: 'span' });
 
   const completeResultSummary = await driver.findElements('.result-summary');
@@ -94,6 +110,44 @@ export async function getSessionScopes(
 }
 
 /**
+ * Use dapp UI to send custom addresses to request scope for.
+ *
+ * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
+ * @param accounts - The addresses to get session scope for.
+ */
+export async function addRequestAccountsToCreateSession(
+  driver: Driver,
+  accounts: [string, string],
+): Promise<void> {
+  const label = await driver.findElement({
+    tag: 'label',
+    text: 'Address',
+  });
+  const addressInput0 = await driver.findNestedElement(
+    label,
+    'input[type=text]',
+  );
+
+  // @ts-expect-error Driver.findNestedElement injects `fill` method onto returned element, but typescript compiler will not let us access this method without a complaint, so we override it.
+  addressInput0.fill(accounts[0]);
+  await driver.clickElement({ text: '+', tag: 'button' });
+  await driver.delay(largeDelayMs);
+
+  const allLabels = await driver.findElements({
+    tag: 'label',
+    text: 'Address',
+  });
+
+  const addressInput1 = await driver.findNestedElement(
+    allLabels[1],
+    'input[type=text]',
+  );
+
+  // @ts-expect-error refer above comment
+  addressInput1.fill(accounts[1]);
+}
+
+/**
  * Retrieves the expected session scope for a given set of addresses.
  *
  * @param scope - The session scope.
@@ -105,3 +159,89 @@ export const getExpectedSessionScope = (scope: string, accounts: string[]) => ({
   notifications: KnownNotifications.eip155,
   accounts: accounts.map((acc) => `${scope}:${acc.toLowerCase()}`),
 });
+
+export const addAndAuthorizeAccount = async (driver: Driver): Promise<void> => {
+  const editButtons = await driver.findElements('[data-testid="edit"]');
+  await editButtons[0].click();
+  await driver.clickElement({ text: 'New account', tag: 'button' });
+  await driver.clickElement({ text: 'Add account', tag: 'button' });
+  await driver.delay(regularDelayMs);
+
+  /**
+   * this needs to be called again, as previous element is stale and will not be found in current frame
+   */
+  const freshEditButtons = await driver.findElements('[data-testid="edit"]');
+  await freshEditButtons[0].click();
+  await driver.delay(regularDelayMs);
+
+  const checkboxes = await driver.findElements('input[type="checkbox" i]');
+  await checkboxes[0].click(); // select all checkbox
+  await driver.delay(regularDelayMs);
+
+  await driver.clickElement({ text: 'Update', tag: 'button' });
+};
+
+/**
+ * Deselect all networks but Ethereum Mainnet through extension UI.
+ *
+ * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
+ */
+export const uncheckNetworksExceptMainnet = async (
+  driver: Driver,
+): Promise<void> => {
+  const editButtons = await driver.findElements('[data-testid="edit"]');
+  await editButtons[1].click();
+  await driver.delay(regularDelayMs);
+
+  const networkListItems = await driver.findElements(
+    '.multichain-network-list-item',
+  );
+
+  for (const item of networkListItems) {
+    const network = await item.getText();
+    const checkbox = await item.findElement(By.css('input[type="checkbox"]'));
+    const isChecked = await checkbox.isSelected();
+
+    // we make sure to uncheck every other previously selected network other than Ethereum Mainnet
+    if (isChecked && !network.includes('Ethereum Mainnet')) {
+      await checkbox.click();
+      await driver.delay(regularDelayMs);
+    }
+  }
+  await driver.clickElement({ text: 'Update', tag: 'button' });
+};
+
+/**
+ * Will assert only the requested networks are selected, and all other are not.
+ *
+ * @param driver - E2E test driver {@link Driver}, wrapping the Selenium WebDriver.
+ * @param networkList - list of networks to assert selection for.
+ */
+export const assertOnlyRequestedNetworksAreSelected = async (
+  driver: Driver,
+  networkList: string[],
+) => {
+  const networkListItems = await driver.findElements(
+    '.multichain-network-list-item',
+  );
+
+  for (const item of networkListItems) {
+    const network = await item.getText();
+    const checkbox = await item.findElement(By.css('input[type="checkbox"]'));
+    const isChecked = await checkbox.isSelected();
+
+    if (networkList.includes(network)) {
+      assert.strictEqual(
+        isChecked,
+        true,
+        `Expected ${network} to be selected.`,
+      );
+    } else {
+      assert.strictEqual(
+        isChecked,
+        false,
+        `Expected ${network} to NOT be selected.`,
+      );
+    }
+  }
+};


### PR DESCRIPTION
test: add [e2e test for accounts requested in wallet_createSession](https://app.zenhub.com/workspaces/wallet-api-platform-63bee08a4e3b9d001108416e/issues/gh/metamask/metamask-planning/3822)