### PR TITLE
chore: Remove obsolete keys

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -761,8 +761,6 @@ export default class MetamaskController extends EventEmitter {
         }),
     });
 
-    this.nftController.setApiKey(process.env.OPENSEA_KEY);
-
     const nftDetectionControllerMessenger =
       this.controllerMessenger.getRestricted({
         name: 'NftDetectionController',

--- a/builds.yml
+++ b/builds.yml
@@ -214,13 +214,9 @@ env:
   # API keys to 3rd party services
   ###
 
-  - PUBNUB_PUB_KEY: null
-  - PUBNUB_SUB_KEY: null
   - SEGMENT_HOST: null
   - SENTRY_DSN: null
   - SENTRY_DSN_DEV: null
-  - OPENSEA_KEY: null
-  - ETHERSCAN_KEY: null
   # also INFURA_PROJECT_ID below
 
   ###
@@ -318,3 +314,10 @@ env:
   # This should NEVER be enabled in production since it slows down react
   ###
   - ENABLE_WHY_DID_YOU_RENDER: false
+
+  ###
+  # Unused environment variables referenced in dependencies
+  # Unset environment variables cause a build error. These are set to `null` to tell our build
+  # system that they are intentionally unset.
+  ###
+  - ETHERSCAN_KEY: null # Used by `gridplus-sdk/dist/util.js`


### PR DESCRIPTION
## **Description**

Remove references to obsolete keys.
* PUBNUB_*: These were used for the old mobile state sync feature, which was removed a long time ago.
* ETHERSCAN_KEY: This was used for incoming transactions, but we've since switched to our own API.
* OPENSEA_KEY: We've switched to Reservoir

The `ETHERSCAN_KEY ` environment variable is still refrenced in the `gridplus-sdk` package, so it has been left in the `build.yml` file as `null` to indicate that it's intentionally unset.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29372?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
