### PR TITLE
fix(29226): fix error for undefined unitInput for sending NFT

### DIFF
--- a/ui/components/ui/unit-input/unit-input.component.js
+++ b/ui/components/ui/unit-input/unit-input.component.js
@@ -95,7 +95,7 @@ export default class UnitInput extends PureComponent {
     }
 
     this.props.onBlur && this.props.onBlur(value);
-    this.unitInput.scrollTo && this.unitInput.scrollTo(0, 0);
+    this.unitInput?.scrollTo?.(0, 0);
   };
 
   handleChange = (event) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
When switching to another non-ERC721 NFT in send flow, it is possible that the input is undefined when rendered. As we didn't need to use `scrollTo` for this input (introduced [here](https://github.com/MetaMask/metamask-extension/pull/25307/files#diff-5b53d7ec060521a384c4dff7468398b01e302ac17511f243b79a5dd1d1cb69d3)) , putting a conditional running is sufficient. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29386?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29226

## **Manual testing steps**

1. Go to NFT
2. Pick a non ERC721 NFT to send
3. Should not see errors in console when in the sending form

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/98268028-fcb1-419e-8638-bb3cbc482b3c


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/830f40c3-0601-4eab-971f-eb69f253c084

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
