### PR TITLE
e2e testing: user can edit the EVM account permissions in `wallet_createSession` request#3827

### DIFF
--- a/test/e2e/flask/multichain-api/create-session.spec.ts
+++ b/test/e2e/flask/multichain-api/create-session.spec.ts
@@ -263,7 +263,7 @@ describe('Multichain API', function () {
   });
 
   describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` without any accounts requested', function () {
-    it('should automatically select first account', async function () {
+    it('should automatically select the current active account', async function () {
       await withFixtures(
         {
           title: this.test?.fullTitle(),
@@ -296,7 +296,7 @@ describe('Multichain API', function () {
           assert.strictEqual(
             isChecked,
             true,
-            'first account should be automatically selected',
+            'current active account in the wallet should be automatically selected',
           );
         },
       );
@@ -352,7 +352,7 @@ describe('Multichain API', function () {
     });
 
     describe('deselect all', function () {
-      it('should not be able to update the account permissions (at least one account is required)', async function () {
+      it('should not be able to approve the create session request without at least one account selected', async function () {
         await withFixtures(
           {
             title: this.test?.fullTitle(),
@@ -394,7 +394,7 @@ describe('Multichain API', function () {
             assert.strictEqual(
               isEnabled,
               false,
-              'should not able to update the account permissions (at least one account should be selected)',
+              'should not able to approve the create session request without at least one account should be selected',
             );
           },
         );


### PR DESCRIPTION
-- test: e2e test for user can edit the EVM account permissions in wallet_createSession request

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29400?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
