### PR TITLE
fix: xchain linea bugs

### DIFF
--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -93,7 +93,8 @@ export default function useSubmitBridgeTransaction() {
           CHAIN_IDS.LINEA_GOERLI,
           CHAIN_IDS.LINEA_SEPOLIA,
         ] as Hex[]
-      ).includes(srcChainId)
+      ).includes(srcChainId) &&
+      quoteResponse?.approval
     ) {
       debugLog(
         'Delaying submitting bridge tx to make Linea confirmation more likely',

--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -161,7 +161,7 @@ export const BridgeCTAButton = ({
       variant={TextVariant.bodyMd}
       data-testid="bridge-cta-button"
       style={{ boxShadow: 'none' }}
-      onClick={() => {
+      onClick={async () => {
         if (activeQuote && isTxSubmittable && !isSubmitting) {
           try {
             // We don't need to worry about setting to false if the tx submission succeeds
@@ -179,7 +179,7 @@ export const BridgeCTAButton = ({
                   ...tradeProperties,
                 },
               });
-            submitBridgeTransaction(activeQuote);
+            await submitBridgeTransaction(activeQuote);
           } finally {
             setIsSubmitting(false);
           }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29409?quickstart=1)

This PR fixes a couple of issues and does the following:

1. Shows a loading spinner on the Bridge button after submitting
2. Does not wait 5 sec to submit a bridge tx on Linea if there is no approval tx

## **Related issues**

Fixes:

## **Manual testing steps**

Gas token

1. Start a bridge from Linea to any chain for ETH
3. Observe that you are redirected to Activity page almost instantly

ERC20
1. Start a bridge from Linea to any chain for an ERC20
2. Observe that a loading spinner shows on the button
4. Observe you are redirected to Activity page after 5 sec


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/24445f52-ddaf-4d08-b3ce-755c10b3f976


https://github.com/user-attachments/assets/ae93204d-80f6-4beb-aff5-b8274e4541e7




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
