### PR TITLE
chore: replace local `isSnapId` definition with `isSnapId` from `@metamask/snaps-utils`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -146,12 +146,13 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import {
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   getLocalizedSnapManifest,
   stripSnapPrefix,
+  ///: END:ONLY_INCLUDE_IF
+  isSnapId,
 } from '@metamask/snaps-utils';
-///: END:ONLY_INCLUDE_IF
 
 import { Interface } from '@ethersproject/abi';
 import { abiERC1155, abiERC721 } from '@metamask/metamask-eth-abis';
@@ -245,8 +246,6 @@ import {
 } from '../../shared/lib/transactions-controller-utils';
 import { getProviderConfig } from '../../shared/modules/selectors/networks';
 import { endTrace, trace } from '../../shared/lib/trace';
-// eslint-disable-next-line import/no-restricted-paths
-import { isSnapId } from '../../ui/helpers/utils/snaps';
 import { BridgeStatusAction } from '../../shared/types/bridge-status';
 import { ENVIRONMENT } from '../../development/build/constants';
 import fetchWithCache from '../../shared/lib/fetch-with-cache';

--- a/ui/components/app/confirm/info/row/url.tsx
+++ b/ui/components/app/confirm/info/row/url.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { isSnapId } from '@metamask/snaps-utils';
 import {
   Box,
   Icon,
@@ -18,7 +19,6 @@ import {
 } from '../../../../../helpers/constants/design-system';
 import SnapAuthorshipPill from '../../../snaps/snap-authorship-pill';
 import { SnapMetadataModal } from '../../../snaps/snap-metadata-modal';
-import { isSnapId } from '../../../../../helpers/utils/snaps';
 
 export type ConfirmInfoRowUrlProps = {
   url: string;

--- a/ui/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/components/app/connected-sites-list/connected-sites-list.component.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { isSnapId } from '@metamask/snaps-utils';
 import Button from '../../ui/button';
 import { AvatarFavicon, IconSize } from '../../component-library';
 import { stripHttpsSchemeWithoutPort } from '../../../helpers/utils/util';
 import SiteOrigin from '../../ui/site-origin';
 import { Size } from '../../../helpers/constants/design-system';
-import { isSnapId } from '../../../helpers/utils/snaps';
 import { SnapIcon } from '../snaps/snap-icon';
 
 export default class ConnectedSitesList extends Component {

--- a/ui/components/app/snaps/snap-metadata-modal/snap-metadata-modal.js
+++ b/ui/components/app/snaps/snap-metadata-modal/snap-metadata-modal.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { getSnapPrefix, stripSnapPrefix } from '@metamask/snaps-utils';
+import {
+  getSnapPrefix,
+  isSnapId,
+  stripSnapPrefix,
+} from '@metamask/snaps-utils';
 import {
   getSnap,
   getSnapRegistryData,
@@ -39,7 +43,6 @@ import { ShowMore } from '../show-more';
 import SnapExternalPill from '../snap-version/snap-external-pill';
 import { useSafeWebsite } from '../../../../hooks/snaps/useSafeWebsite';
 import Tooltip from '../../../ui/tooltip';
-import { isSnapId } from '../../../../helpers/utils/snaps';
 import { SnapIcon } from '../snap-icon';
 
 export const SnapMetadataModal = ({ snapId, isOpen, onClose }) => {

--- a/ui/components/multichain/pages/permissions-page/permissions-page.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { isSnapId } from '@metamask/snaps-utils';
 import { Content, Header, Page } from '../page';
 import {
   Box,
@@ -26,7 +27,6 @@ import {
   REVIEW_PERMISSIONS,
 } from '../../../../helpers/constants/routes';
 import { getConnectedSitesListWithNetworkInfo } from '../../../../selectors';
-import { isSnapId } from '../../../../helpers/utils/snaps';
 import { ConnectionListItem } from './connection-list-item';
 
 export const PermissionsPage = () => {

--- a/ui/helpers/utils/snaps.ts
+++ b/ui/helpers/utils/snaps.ts
@@ -1,20 +1,4 @@
-import { SnapId } from '@metamask/snaps-sdk';
 import { isProduction } from '../../../shared/modules/environment';
-
-/**
- * Check if the given value is a valid snap ID.
- *
- * NOTE: This function is a duplicate oF a yet to be released version in @metamask/snaps-utils.
- *
- * @param value - The value to check.
- * @returns `true` if the value is a valid snap ID, and `false` otherwise.
- */
-export function isSnapId(value: unknown): value is SnapId {
-  return (
-    (typeof value === 'string' || value instanceof String) &&
-    (value.startsWith('local:') || value.startsWith('npm:'))
-  );
-}
 
 /**
  * Decode a snap ID fron a pathname.

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { TransactionType } from '@metamask/transaction-controller';
 
+import { isSnapId } from '@metamask/snaps-utils';
 import {
   getMockConfirmState,
   getMockPersonalSignConfirmState,
@@ -13,7 +14,6 @@ import {
   signatureRequestSIWE,
   unapprovedPersonalSignMsg,
 } from '../../../../../../../test/data/confirmations/personal_sign';
-import * as snapUtils from '../../../../../../helpers/utils/snaps';
 import { SignatureRequestType } from '../../../../types/confirm';
 import * as utils from '../../../../utils';
 import PersonalSignInfo from './personal-sign';
@@ -43,12 +43,9 @@ jest.mock('../../../../../../../node_modules/@metamask/snaps-utils', () => {
     ...originalUtils,
     stripSnapPrefix: jest.fn().mockReturnValue('@metamask/examplesnap'),
     getSnapPrefix: jest.fn().mockReturnValue('npm:'),
+    isSnapId: jest.fn(),
   };
 });
-
-jest.mock('../../../../../../helpers/utils/snaps', () => ({
-  isSnapId: jest.fn(),
-}));
 
 describe('PersonalSignInfo', () => {
   it('renders correctly for personal sign request', () => {
@@ -149,7 +146,7 @@ describe('PersonalSignInfo', () => {
       getMockPersonalSignConfirmStateForRequest(signatureRequestSIWE);
 
     (utils.isSIWESignatureRequest as jest.Mock).mockReturnValue(false);
-    (snapUtils.isSnapId as unknown as jest.Mock).mockReturnValue(true);
+    (isSnapId as unknown as jest.Mock).mockReturnValue(true);
 
     const mockStore = configureMockStore([])(state);
     const { queryByText, getByText } = renderWithConfirmContextProvider(
@@ -171,7 +168,7 @@ describe('PersonalSignInfo', () => {
     const state =
       getMockPersonalSignConfirmStateForRequest(signatureRequestSIWE);
     (utils.isSIWESignatureRequest as jest.Mock).mockReturnValue(false);
-    (snapUtils.isSnapId as unknown as jest.Mock).mockReturnValue(true);
+    (isSnapId as unknown as jest.Mock).mockReturnValue(true);
 
     const mockStore = configureMockStore([])(state);
     const { getByText, queryByText } = renderWithConfirmContextProvider(

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
+import { isSnapId } from '@metamask/snaps-utils';
 import {
   ConfirmInfoRowText,
   ConfirmInfoRowUrl,
@@ -27,7 +28,6 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../../helpers/constants/design-system';
-import { isSnapId } from '../../../../../../helpers/utils/snaps';
 import {
   hexToText,
   sanitizeString,

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/typed-sign-v1.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/typed-sign-v1.test.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { TransactionType } from '@metamask/transaction-controller';
 
+import { isSnapId } from '@metamask/snaps-utils';
 import { renderWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
 import { getMockTypedSignConfirmStateForRequest } from '../../../../../../../test/data/confirmations/helper';
 import { unapprovedTypedSignMsgV1 } from '../../../../../../../test/data/confirmations/typed_sign';
-import * as snapUtils from '../../../../../../helpers/utils/snaps';
 import TypedSignInfoV1 from './typed-sign-v1';
 
 jest.mock(
@@ -25,12 +25,9 @@ jest.mock('../../../../../../../node_modules/@metamask/snaps-utils', () => {
     ...originalUtils,
     stripSnapPrefix: jest.fn().mockReturnValue('@metamask/examplesnap'),
     getSnapPrefix: jest.fn().mockReturnValue('npm:'),
+    isSnapId: jest.fn(),
   };
 });
-
-jest.mock('../../../../../../helpers/utils/snaps', () => ({
-  isSnapId: jest.fn(),
-}));
 
 describe('TypedSignInfo', () => {
   it('correctly renders typed sign data request', () => {
@@ -65,7 +62,7 @@ describe('TypedSignInfo', () => {
       type: TransactionType.signTypedData,
       chainId: '0x5',
     });
-    (snapUtils.isSnapId as unknown as jest.Mock).mockReturnValue(true);
+    (isSnapId as unknown as jest.Mock).mockReturnValue(true);
     const mockStore = configureMockStore([])(mockState);
     const { queryByText } = renderWithConfirmContextProvider(
       <TypedSignInfoV1 />,
@@ -88,7 +85,7 @@ describe('TypedSignInfo', () => {
       type: TransactionType.signTypedData,
       chainId: '0x5',
     });
-    (snapUtils.isSnapId as unknown as jest.Mock).mockReturnValue(false);
+    (isSnapId as unknown as jest.Mock).mockReturnValue(false);
     const mockStore = configureMockStore([])(mockState);
     const { queryByText } = renderWithConfirmContextProvider(
       <TypedSignInfoV1 />,

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/typed-sign-v1.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/typed-sign-v1.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isSnapId } from '@metamask/snaps-utils';
 import { ConfirmInfoAlertRow } from '../../../../../../components/app/confirm/info/row/alert-row/alert-row';
 import {
   ConfirmInfoRow,
@@ -14,7 +15,6 @@ import {
 import { useConfirmContext } from '../../../../context/confirm';
 import { ConfirmInfoRowTypedSignDataV1 } from '../../row/typed-sign-data-v1/typedSignDataV1';
 import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
-import { isSnapId } from '../../../../../../helpers/utils/snaps';
 import { SigningInWithRow } from '../shared/sign-in-with-row/sign-in-with-row';
 
 const TypedSignV1Info: React.FC = () => {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.test.tsx
@@ -5,6 +5,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 
+import { isSnapId } from '@metamask/snaps-utils';
 import {
   getMockConfirmStateForTransaction,
   getMockTypedSignConfirmState,
@@ -17,7 +18,6 @@ import {
   unapprovedTypedSignMsgV4,
 } from '../../../../../../../test/data/confirmations/typed_sign';
 import { renderWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
-import * as snapUtils from '../../../../../../helpers/utils/snaps';
 import TypedSignInfo from './typed-sign';
 
 jest.mock(
@@ -44,12 +44,9 @@ jest.mock('../../../../../../../node_modules/@metamask/snaps-utils', () => {
     ...originalUtils,
     stripSnapPrefix: jest.fn().mockReturnValue('@metamask/examplesnap'),
     getSnapPrefix: jest.fn().mockReturnValue('npm:'),
+    isSnapId: jest.fn(),
   };
 });
-
-jest.mock('../../../../../../helpers/utils/snaps', () => ({
-  isSnapId: jest.fn(),
-}));
 
 describe('TypedSignInfo', () => {
   it('renders origin for typed sign data request', () => {
@@ -153,7 +150,7 @@ describe('TypedSignInfo', () => {
       type: TransactionType.signTypedData,
       chainId: '0x5',
     });
-    (snapUtils.isSnapId as unknown as jest.Mock).mockReturnValue(true);
+    (isSnapId as unknown as jest.Mock).mockReturnValue(true);
     const mockStore = configureMockStore([])(mockState);
     const { queryByText } = renderWithConfirmContextProvider(
       <TypedSignInfo />,
@@ -177,7 +174,7 @@ describe('TypedSignInfo', () => {
       type: TransactionType.signTypedData,
       chainId: '0x5',
     });
-    (snapUtils.isSnapId as unknown as jest.Mock).mockReturnValue(false);
+    (isSnapId as unknown as jest.Mock).mockReturnValue(false);
     const mockStore = configureMockStore([])(mockState);
     const { queryByText } = renderWithConfirmContextProvider(
       <TypedSignInfo />,

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { isValidAddress } from 'ethereumjs-util';
 
+import { isSnapId } from '@metamask/snaps-utils';
 import { ConfirmInfoAlertRow } from '../../../../../../components/app/confirm/info/row/alert-row/alert-row';
 import { parseTypedDataMessage } from '../../../../../../../shared/modules/transaction.utils';
 import { RowAlertKey } from '../../../../../../components/app/confirm/info/row/constants';
@@ -21,7 +22,6 @@ import {
 import { useConfirmContext } from '../../../../context/confirm';
 import { useTypesSignSimulationEnabledInfo } from '../../../../hooks/useTypesSignSimulationEnabledInfo';
 import { ConfirmInfoRowTypedSignData } from '../../row/typed-sign-data/typedSignData';
-import { isSnapId } from '../../../../../../helpers/utils/snaps';
 import { SigningInWithRow } from '../shared/sign-in-with-row/sign-in-with-row';
 import { TypedSignV4Simulation } from './typed-sign-v4-simulation';
 

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { providerErrors, serializeError } from '@metamask/rpc-errors';
 import { SubjectType } from '@metamask/permission-controller';
+import { isSnapId } from '@metamask/snaps-utils';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { isEthAddress } from '../../../app/scripts/lib/multichain/address';
@@ -19,7 +20,6 @@ import {
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { PermissionNames } from '../../../app/scripts/controllers/permissions';
-import { isSnapId } from '../../helpers/utils/snaps';
 import ChooseAccount from './choose-account';
 import PermissionsRedirect from './redirect';
 import SnapsConnect from './snaps/snaps-connect';

--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { isSnapId } from '@metamask/snaps-utils';
 import { PageContainerFooter } from '../../../../components/ui/page-container';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import SnapInstallWarning from '../../../../components/app/snaps/snap-install-warning';
@@ -34,7 +35,6 @@ import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
 import { getSnapMetadata, getSnapsMetadata } from '../../../../selectors';
 import { getSnapName } from '../../../../helpers/utils/util';
 import PermissionConnectHeader from '../../../../components/app/permission-connect-header';
-import { isSnapId } from '../../../../helpers/utils/snaps';
 
 export default function SnapInstall({
   request,

--- a/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import { isSnapId } from '@metamask/snaps-utils';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { Box, IconSize, Text } from '../../../../components/component-library';
 import {
@@ -26,7 +27,6 @@ import {
   getSnapMetadata,
 } from '../../../../selectors';
 import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
-import { isSnapId } from '../../../../helpers/utils/snaps';
 import { SnapIcon } from '../../../../components/app/snaps/snap-icon';
 
 export default function SnapsConnect({

--- a/ui/pages/snaps/snap-view/snap-settings.js
+++ b/ui/pages/snaps/snap-view/snap-settings.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import semver from 'semver';
+import { isSnapId } from '@metamask/snaps-utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   BackgroundColor,
@@ -51,7 +52,6 @@ import { DelineatorType } from '../../../helpers/constants/snaps';
 import SnapUpdateAlert from '../../../components/app/snaps/snap-update-alert';
 import { CONNECT_ROUTE } from '../../../helpers/constants/routes';
 import { ShowMore } from '../../../components/app/snaps/show-more';
-import { isSnapId } from '../../../helpers/utils/snaps';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { KeyringSnapRemovalResultStatus } from './constants';
 ///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? Deduplication of code
2. What is the improvement/solution? Using the `isSnapId` function from the `@metamask/snaps-utils` package.

## **Related issues**

Fixes: #29280 

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
