### PR TITLE
fix: Correct theme value for Snap UI footer buttons

### DIFF
--- a/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
+++ b/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
@@ -87,6 +87,7 @@ export const SnapUIFooterButton: FunctionComponent<
         alignItems: AlignItems.center,
         flexDirection: FlexDirection.Row,
       }}
+      data-theme={null}
     >
       {isSnapAction && !hideSnapBranding && !loading && (
         <SnapIcon snapId={snapId} avatarSize={IconSize.Sm} marginRight={2} />

--- a/ui/components/app/snaps/snap-ui-renderer/index.scss
+++ b/ui/components/app/snaps/snap-ui-renderer/index.scss
@@ -13,7 +13,6 @@
     & > *:first-child {
       gap: 16px;
       margin: 16px;
-      overflow-y: hidden;
     }
   }
 

--- a/ui/components/app/snaps/snap-ui-renderer/index.scss
+++ b/ui/components/app/snaps/snap-ui-renderer/index.scss
@@ -13,6 +13,7 @@
     & > *:first-child {
       gap: 16px;
       margin: 16px;
+      overflow-y: hidden;
     }
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Snap UI footer buttons use the DS button which forces light theme, this does not work for the colors used in the Snap buttons, therefore we revert back to using the actually selected theme.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29434?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29388

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Image](https://github.com/user-attachments/assets/fb14d5c1-44f9-473a-81bf-6f0f01c46686)

### **After**

![image](https://github.com/user-attachments/assets/c9f08368-58f5-43b3-a129-fe7689572242)

