### PR TITLE
fix: Misdefined types related to `Bridge{,Status}Controller` state

### DIFF
--- a/app/scripts/controllers/bridge-status/bridge-status-controller.test.ts
+++ b/app/scripts/controllers/bridge-status/bridge-status-controller.test.ts
@@ -2,7 +2,7 @@ import { flushPromises } from '../../../../test/lib/timer-helpers';
 import { Numeric } from '../../../../shared/modules/Numeric';
 import BridgeStatusController from './bridge-status-controller';
 import { BridgeStatusControllerMessenger } from './types';
-import { DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE } from './constants';
+import { DEFAULT_BRIDGE_STATUS_STATE } from './constants';
 import * as bridgeStatusUtils from './utils';
 import {
   MockStatusResponse,
@@ -11,7 +11,7 @@ import {
 } from './mocks';
 
 const EMPTY_INIT_STATE = {
-  bridgeStatusState: DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
+  bridgeStatusState: { ...DEFAULT_BRIDGE_STATUS_STATE },
 };
 
 const getMessengerMock = ({

--- a/app/scripts/controllers/bridge-status/bridge-status-controller.ts
+++ b/app/scripts/controllers/bridge-status/bridge-status-controller.ts
@@ -6,19 +6,18 @@ import {
   StatusTypes,
   BridgeStatusControllerState,
   StartPollingForBridgeTxStatusArgsSerialized,
+  BridgeStatusState,
 } from '../../../../shared/types/bridge-status';
 import { decimalToPrefixedHex } from '../../../../shared/modules/conversion.utils';
 import {
   BRIDGE_STATUS_CONTROLLER_NAME,
-  DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
+  DEFAULT_BRIDGE_STATUS_STATE,
   REFRESH_INTERVAL_MS,
 } from './constants';
 import { BridgeStatusControllerMessenger } from './types';
 import { fetchBridgeTxStatus, getStatusRequestWithSrcTxHash } from './utils';
 
-const metadata: StateMetadata<{
-  bridgeStatusState: BridgeStatusControllerState;
-}> = {
+const metadata: StateMetadata<BridgeStatusControllerState> = {
   // We want to persist the bridge status state so that we can show the proper data for the Activity list
   // basically match the behavior of TransactionController
   bridgeStatusState: {
@@ -36,7 +35,7 @@ export type FetchBridgeTxStatusArgs = {
 };
 export default class BridgeStatusController extends StaticIntervalPollingController<BridgeStatusPollingInput>()<
   typeof BRIDGE_STATUS_CONTROLLER_NAME,
-  { bridgeStatusState: BridgeStatusControllerState },
+  BridgeStatusControllerState,
   BridgeStatusControllerMessenger
 > {
   #pollingTokensByTxMetaId: Record<SrcTxMetaId, string> = {};
@@ -46,9 +45,7 @@ export default class BridgeStatusController extends StaticIntervalPollingControl
     state,
   }: {
     messenger: BridgeStatusControllerMessenger;
-    state?: Partial<{
-      bridgeStatusState: BridgeStatusControllerState;
-    }>;
+    state?: { bridgeStatusState?: Partial<BridgeStatusState> };
   }) {
     super({
       name: BRIDGE_STATUS_CONTROLLER_NAME,
@@ -58,7 +55,7 @@ export default class BridgeStatusController extends StaticIntervalPollingControl
       state: {
         ...state,
         bridgeStatusState: {
-          ...DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
+          ...DEFAULT_BRIDGE_STATUS_STATE,
           ...state?.bridgeStatusState,
         },
       },
@@ -86,7 +83,7 @@ export default class BridgeStatusController extends StaticIntervalPollingControl
   resetState = () => {
     this.update((_state) => {
       _state.bridgeStatusState = {
-        ...DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
+        ...DEFAULT_BRIDGE_STATUS_STATE,
       };
     });
   };
@@ -102,7 +99,7 @@ export default class BridgeStatusController extends StaticIntervalPollingControl
     if (ignoreNetwork) {
       this.update((_state) => {
         _state.bridgeStatusState = {
-          ...DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
+          ...DEFAULT_BRIDGE_STATUS_STATE,
         };
       });
     } else {

--- a/app/scripts/controllers/bridge-status/constants.ts
+++ b/app/scripts/controllers/bridge-status/constants.ts
@@ -1,10 +1,13 @@
-import { BridgeStatusControllerState } from '../../../../shared/types/bridge-status';
+import { BridgeStatusState } from '../../../../shared/types/bridge-status';
 
 export const REFRESH_INTERVAL_MS = 10 * 1000;
 
 export const BRIDGE_STATUS_CONTROLLER_NAME = 'BridgeStatusController';
 
-export const DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE: BridgeStatusControllerState =
-  {
-    txHistory: {},
-  };
+export const DEFAULT_BRIDGE_STATUS_STATE: BridgeStatusState = {
+  txHistory: {},
+};
+
+export const DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE = {
+  bridgeStatusState: { ...DEFAULT_BRIDGE_STATUS_STATE },
+};

--- a/app/scripts/controllers/bridge-status/types.ts
+++ b/app/scripts/controllers/bridge-status/types.ts
@@ -32,13 +32,13 @@ type BridgeStatusControllerActions =
   | BridgeStatusControllerAction<BridgeStatusAction.WIPE_BRIDGE_STATUS>
   | ControllerGetStateAction<
       typeof BRIDGE_STATUS_CONTROLLER_NAME,
-      { bridgeStatusState: BridgeStatusControllerState }
+      BridgeStatusControllerState
     >;
 
 // Events
 export type BridgeStatusControllerStateChangeEvent = ControllerStateChangeEvent<
   typeof BRIDGE_STATUS_CONTROLLER_NAME,
-  { bridgeStatusState: BridgeStatusControllerState }
+  BridgeStatusControllerState
 >;
 
 export type BridgeStatusControllerBridgeTransactionCompleteEvent = {

--- a/app/scripts/controllers/bridge-status/types.ts
+++ b/app/scripts/controllers/bridge-status/types.ts
@@ -32,13 +32,13 @@ type BridgeStatusControllerActions =
   | BridgeStatusControllerAction<BridgeStatusAction.WIPE_BRIDGE_STATUS>
   | ControllerGetStateAction<
       typeof BRIDGE_STATUS_CONTROLLER_NAME,
-      BridgeStatusControllerState
+      { bridgeStatusState: BridgeStatusControllerState }
     >;
 
 // Events
 export type BridgeStatusControllerStateChangeEvent = ControllerStateChangeEvent<
   typeof BRIDGE_STATUS_CONTROLLER_NAME,
-  BridgeStatusControllerState
+  { bridgeStatusState: BridgeStatusControllerState }
 >;
 
 export type BridgeStatusControllerBridgeTransactionCompleteEvent = {

--- a/app/scripts/controllers/bridge/bridge-controller.test.ts
+++ b/app/scripts/controllers/bridge/bridge-controller.test.ts
@@ -14,10 +14,10 @@ import { type QuoteResponse } from '../../../../shared/types/bridge';
 import { decimalToHex } from '../../../../shared/modules/conversion.utils';
 import BridgeController from './bridge-controller';
 import { BridgeControllerMessenger } from './types';
-import { DEFAULT_BRIDGE_CONTROLLER_STATE } from './constants';
+import { DEFAULT_BRIDGE_STATE } from './constants';
 
 const EMPTY_INIT_STATE = {
-  bridgeState: DEFAULT_BRIDGE_CONTROLLER_STATE,
+  bridgeState: { ...DEFAULT_BRIDGE_STATE },
 };
 
 const messengerMock = {
@@ -157,10 +157,9 @@ describe('BridgeController', function () {
     expect(bridgeController.state.bridgeState).toStrictEqual(
       expect.objectContaining({
         bridgeFeatureFlags: expectedFeatureFlagsResponse,
-        quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
-        quotesLastFetched: DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched,
-        quotesLoadingStatus:
-          DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus,
+        quotes: DEFAULT_BRIDGE_STATE.quotes,
+        quotesLastFetched: DEFAULT_BRIDGE_STATE.quotesLastFetched,
+        quotesLoadingStatus: DEFAULT_BRIDGE_STATE.quotesLoadingStatus,
       }),
     );
   });
@@ -300,10 +299,9 @@ describe('BridgeController', function () {
     expect(bridgeController.state.bridgeState).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, walletAddress: undefined },
-        quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
-        quotesLastFetched: DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched,
-        quotesLoadingStatus:
-          DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus,
+        quotes: DEFAULT_BRIDGE_STATE.quotes,
+        quotesLastFetched: DEFAULT_BRIDGE_STATE.quotesLastFetched,
+        quotesLoadingStatus: DEFAULT_BRIDGE_STATE.quotesLoadingStatus,
       }),
     );
 
@@ -450,11 +448,10 @@ describe('BridgeController', function () {
     expect(bridgeController.state.bridgeState).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, walletAddress: undefined },
-        quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
-        quotesLastFetched: DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched,
+        quotes: DEFAULT_BRIDGE_STATE.quotes,
+        quotesLastFetched: DEFAULT_BRIDGE_STATE.quotesLastFetched,
         quotesInitialLoadTime: undefined,
-        quotesLoadingStatus:
-          DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus,
+        quotesLoadingStatus: DEFAULT_BRIDGE_STATE.quotesLoadingStatus,
       }),
     );
 
@@ -544,10 +541,9 @@ describe('BridgeController', function () {
           destChainId: 10,
           destTokenAddress: '0x123',
         },
-        quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
-        quotesLastFetched: DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched,
-        quotesLoadingStatus:
-          DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus,
+        quotes: DEFAULT_BRIDGE_STATE.quotes,
+        quotesLastFetched: DEFAULT_BRIDGE_STATE.quotesLastFetched,
+        quotesLoadingStatus: DEFAULT_BRIDGE_STATE.quotesLoadingStatus,
       }),
     );
   });
@@ -645,10 +641,9 @@ describe('BridgeController', function () {
       expect(bridgeController.state.bridgeState).toStrictEqual(
         expect.objectContaining({
           quoteRequest: { ...quoteRequest, walletAddress: undefined },
-          quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
-          quotesLastFetched: DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched,
-          quotesLoadingStatus:
-            DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus,
+          quotes: DEFAULT_BRIDGE_STATE.quotes,
+          quotesLastFetched: DEFAULT_BRIDGE_STATE.quotesLastFetched,
+          quotesLoadingStatus: DEFAULT_BRIDGE_STATE.quotesLoadingStatus,
         }),
       );
 

--- a/app/scripts/controllers/bridge/bridge-controller.ts
+++ b/app/scripts/controllers/bridge/bridge-controller.ts
@@ -31,12 +31,12 @@ import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { REFRESH_INTERVAL_MS } from '../../../../shared/constants/bridge';
 import {
   BRIDGE_CONTROLLER_NAME,
-  DEFAULT_BRIDGE_CONTROLLER_STATE,
+  DEFAULT_BRIDGE_STATE,
   METABRIDGE_CHAIN_TO_ADDRESS_MAP,
 } from './constants';
 import type { BridgeControllerMessenger } from './types';
 
-const metadata: StateMetadata<{ bridgeState: BridgeControllerState }> = {
+const metadata: StateMetadata<BridgeControllerState> = {
   bridgeState: {
     persist: false,
     anonymous: false,
@@ -53,7 +53,7 @@ type BridgePollingInput = {
 
 export default class BridgeController extends StaticIntervalPollingController<BridgePollingInput>()<
   typeof BRIDGE_CONTROLLER_NAME,
-  { bridgeState: BridgeControllerState },
+  BridgeControllerState,
   BridgeControllerMessenger
 > {
   #abortController: AbortController | undefined;
@@ -80,7 +80,7 @@ export default class BridgeController extends StaticIntervalPollingController<Br
       metadata,
       messenger,
       state: {
-        bridgeState: DEFAULT_BRIDGE_CONTROLLER_STATE,
+        bridgeState: { ...DEFAULT_BRIDGE_STATE },
       },
     });
 
@@ -120,7 +120,7 @@ export default class BridgeController extends StaticIntervalPollingController<Br
 
     const { bridgeState } = this.state;
     const updatedQuoteRequest = {
-      ...DEFAULT_BRIDGE_CONTROLLER_STATE.quoteRequest,
+      ...DEFAULT_BRIDGE_STATE.quoteRequest,
       ...paramsToUpdate,
     };
 
@@ -128,14 +128,12 @@ export default class BridgeController extends StaticIntervalPollingController<Br
       _state.bridgeState = {
         ...bridgeState,
         quoteRequest: updatedQuoteRequest,
-        quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
-        quotesLastFetched: DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched,
-        quotesLoadingStatus:
-          DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus,
-        quoteFetchError: DEFAULT_BRIDGE_CONTROLLER_STATE.quoteFetchError,
-        quotesRefreshCount: DEFAULT_BRIDGE_CONTROLLER_STATE.quotesRefreshCount,
-        quotesInitialLoadTime:
-          DEFAULT_BRIDGE_CONTROLLER_STATE.quotesInitialLoadTime,
+        quotes: DEFAULT_BRIDGE_STATE.quotes,
+        quotesLastFetched: DEFAULT_BRIDGE_STATE.quotesLastFetched,
+        quotesLoadingStatus: DEFAULT_BRIDGE_STATE.quotesLoadingStatus,
+        quoteFetchError: DEFAULT_BRIDGE_STATE.quoteFetchError,
+        quotesRefreshCount: DEFAULT_BRIDGE_STATE.quotesRefreshCount,
+        quotesInitialLoadTime: DEFAULT_BRIDGE_STATE.quotesInitialLoadTime,
       };
     });
 
@@ -185,7 +183,7 @@ export default class BridgeController extends StaticIntervalPollingController<Br
 
     this.update((_state) => {
       _state.bridgeState = {
-        ...DEFAULT_BRIDGE_CONTROLLER_STATE,
+        ...DEFAULT_BRIDGE_STATE,
         quotes: [],
         bridgeFeatureFlags: _state.bridgeState.bridgeFeatureFlags,
       };
@@ -218,7 +216,7 @@ export default class BridgeController extends StaticIntervalPollingController<Br
         ...bridgeState,
         quotesLoadingStatus: RequestStatus.LOADING,
         quoteRequest: updatedQuoteRequest,
-        quoteFetchError: DEFAULT_BRIDGE_CONTROLLER_STATE.quoteFetchError,
+        quoteFetchError: DEFAULT_BRIDGE_STATE.quoteFetchError,
       };
     });
 

--- a/app/scripts/controllers/bridge/constants.ts
+++ b/app/scripts/controllers/bridge/constants.ts
@@ -8,10 +8,10 @@ import {
 } from '../../../../shared/constants/bridge';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { BridgeFeatureFlagsKey } from '../../../../shared/types/bridge';
-import type { BridgeControllerState } from '../../../../shared/types/bridge';
+import type { BridgeState } from '../../../../shared/types/bridge';
 
 export const BRIDGE_CONTROLLER_NAME = 'BridgeController';
-export const DEFAULT_BRIDGE_CONTROLLER_STATE: BridgeControllerState = {
+export const DEFAULT_BRIDGE_STATE: BridgeState = {
   bridgeFeatureFlags: {
     [BridgeFeatureFlagsKey.EXTENSION_CONFIG]: {
       refreshRate: REFRESH_INTERVAL_MS,
@@ -31,6 +31,10 @@ export const DEFAULT_BRIDGE_CONTROLLER_STATE: BridgeControllerState = {
   quotesLoadingStatus: undefined,
   quoteFetchError: undefined,
   quotesRefreshCount: 0,
+};
+
+export const DEFAULT_BRIDGE_CONTROLLER_STATE = {
+  bridgeState: { ...DEFAULT_BRIDGE_STATE },
 };
 
 export const METABRIDGE_CHAIN_TO_ADDRESS_MAP: Record<Hex, string> = {

--- a/app/scripts/controllers/bridge/types.ts
+++ b/app/scripts/controllers/bridge/types.ts
@@ -29,7 +29,7 @@ type BridgeControllerActions =
 
 type BridgeControllerEvents = ControllerStateChangeEvent<
   typeof BRIDGE_CONTROLLER_NAME,
-  { bridgeState: BridgeControllerState }
+  BridgeControllerState
 >;
 
 type AllowedActions =

--- a/app/scripts/controllers/bridge/types.ts
+++ b/app/scripts/controllers/bridge/types.ts
@@ -29,13 +29,13 @@ type BridgeControllerActions =
 
 type BridgeControllerEvents = ControllerStateChangeEvent<
   typeof BRIDGE_CONTROLLER_NAME,
-  BridgeControllerState
+  { bridgeState: BridgeControllerState }
 >;
 
 type AllowedActions =
-  | AccountsControllerGetSelectedAccountAction['type']
-  | NetworkControllerGetSelectedNetworkClientAction['type']
-  | NetworkControllerFindNetworkClientIdByChainIdAction['type'];
+  | AccountsControllerGetSelectedAccountAction
+  | NetworkControllerGetSelectedNetworkClientAction
+  | NetworkControllerFindNetworkClientIdByChainIdAction;
 type AllowedEvents = never;
 
 /**
@@ -43,11 +43,8 @@ type AllowedEvents = never;
  */
 export type BridgeControllerMessenger = RestrictedControllerMessenger<
   typeof BRIDGE_CONTROLLER_NAME,
-  | BridgeControllerActions
-  | AccountsControllerGetSelectedAccountAction
-  | NetworkControllerGetSelectedNetworkClientAction
-  | NetworkControllerFindNetworkClientIdByChainIdAction,
-  BridgeControllerEvents,
-  AllowedActions,
-  AllowedEvents
+  BridgeControllerActions | AllowedActions,
+  BridgeControllerEvents | AllowedEvents,
+  AllowedActions['type'],
+  AllowedEvents['type']
 >;

--- a/shared/types/bridge-status.ts
+++ b/shared/types/bridge-status.ts
@@ -228,14 +228,18 @@ export type StartPollingForBridgeTxStatusArgsSerialized = Omit<
 
 export type SourceChainTxMetaId = string;
 
-export type BridgeStatusControllerState = {
+export type BridgeStatusState = {
   txHistory: Record<SourceChainTxMetaId, BridgeHistoryItem>;
 };
-export type BridgeStatusAppState = ProviderConfigState & {
-  metamask: {
-    bridgeStatusState: BridgeStatusControllerState;
-  };
+
+export type BridgeStatusControllerState = {
+  bridgeStatusState: BridgeStatusState;
 };
+
+export type BridgeStatusAppState = ProviderConfigState & {
+  metamask: BridgeStatusControllerState;
+};
+
 export type MetricsBackgroundState = BridgeStatusAppState['metamask'] &
   SmartTransactionsMetaMaskState['metamask'] &
   NetworkState['metamask'] &

--- a/shared/types/bridge.ts
+++ b/shared/types/bridge.ts
@@ -186,7 +186,7 @@ export enum BridgeBackgroundAction {
   RESET_STATE = 'resetState',
   GET_BRIDGE_ERC20_ALLOWANCE = 'getBridgeERC20Allowance',
 }
-export type BridgeControllerState = {
+export type BridgeState = {
   bridgeFeatureFlags: BridgeFeatureFlags;
   quoteRequest: Partial<QuoteRequest>;
   quotes: (QuoteResponse & L1GasFees)[];
@@ -195,4 +195,8 @@ export type BridgeControllerState = {
   quotesLoadingStatus?: RequestStatus;
   quoteFetchError?: string;
   quotesRefreshCount: number;
+};
+
+export type BridgeControllerState = {
+  bridgeState: BridgeState;
 };

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -3,8 +3,8 @@ import { CHAIN_IDS, CURRENCY_SYMBOLS } from '../../shared/constants/network';
 import { KeyringType } from '../../shared/constants/keyring';
 import { ETH_EOA_METHODS } from '../../shared/constants/eth-methods';
 import { mockNetworkState } from '../stub/networks';
-import { DEFAULT_BRIDGE_CONTROLLER_STATE } from '../../app/scripts/controllers/bridge/constants';
-import { DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE } from '../../app/scripts/controllers/bridge-status/constants';
+import { DEFAULT_BRIDGE_STATE } from '../../app/scripts/controllers/bridge/constants';
+import { DEFAULT_BRIDGE_STATUS_STATE } from '../../app/scripts/controllers/bridge-status/constants';
 import { BRIDGE_PREFERRED_GAS_ESTIMATE } from '../../shared/constants/bridge';
 import { mockTokenData } from '../data/bridge/mock-token-data';
 
@@ -759,7 +759,7 @@ export const createBridgeMockStore = (
       ...mockTokenData,
       ...metamaskStateOverrides,
       bridgeState: {
-        ...DEFAULT_BRIDGE_CONTROLLER_STATE,
+        ...DEFAULT_BRIDGE_STATE,
         bridgeFeatureFlags: {
           ...featureFlagOverrides,
           extensionConfig: {
@@ -771,7 +771,7 @@ export const createBridgeMockStore = (
         ...bridgeStateOverrides,
       },
       bridgeStatusState: {
-        ...DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
+        ...DEFAULT_BRIDGE_STATUS_STATE,
         ...bridgeStatusStateOverrides,
       },
     },

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -61,7 +61,8 @@ import {
 import type { BridgeState } from './bridge';
 
 type BridgeAppState = {
-  metamask: { bridgeState: BridgeControllerState } & NetworkState & {
+  metamask: BridgeControllerState &
+    NetworkState & {
       useExternalServices: boolean;
       currencyRates: {
         [currency: string]: {


### PR DESCRIPTION
## **Description**

- The first commit (https://github.com/MetaMask/metamask-extension/pull/29443/commits/6fcb2af8f5e03085591509c511a41f37b0290d4a) fixes errors in the messenger types for `Bridge{,Status}Controller`.
- The second commit (https://github.com/MetaMask/metamask-extension/pull/29443/commits/d7368f548d1e35bbc0dc5d555c335bd1472720f4) is optional, but strongly recommended. Under the `BaseController` API with which the `Bridge{,Status}Controller` are defined, `BridgeControllerState` and `BridgeStatusControllerState` should be considered as reserved keywords.
  - The current set of types violates guidelines: https://github.com/MetaMask/core/blob/main/docs/writing-controllers.md#define-and-export-a-type-for-the-controllers-state.
  - Deviating from this convention breeds confusion and silently-failing errors as per the examples fixed in the first commit.
  - This also affects downstream consumers and dependent modules of the bridge controllers, as the expected functionality for the reserved keywords is not fulfilled.
  - The type expressions `{ bridgeState: BridgeControllerState }`, `{ bridgeStatusState: BridgeStatusControllerState }` are being used redundantly and should be de-duplicated. However, defining these types using anything other than the reserved keywords will cause further unnecessary confusion.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29443?quickstart=1)

## **Related issues**

- Supersedes https://github.com/MetaMask/metamask-extension/pull/28971

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
