### PR TITLE
fix: Use correct prop for Snap UI Avatar size

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/avatar.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/avatar.ts
@@ -5,5 +5,6 @@ export const avatar: UIComponentFactory<AvatarElement> = ({ element }) => ({
   element: 'SnapUIAvatar',
   props: {
     address: element.props.address,
+    size: element.props.size,
   },
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an issue where the `size` prop would not work for the Snap UI `Avatar` component. This prop was simply missed in the mapping function, this PR corrects that.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29466?quickstart=1)

## **Manual testing steps**

```ts
export const onRpcRequest: OnRpcRequestHandler = async ({
  origin,
  request,
}) => {
  switch (request.method) {
    case 'hello':
      return snap.request({
        method: 'snap_dialog',
        params: {
          type: 'confirmation',
          content: (
            <Container>
            <Box>
              <Avatar size='sm' address='bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6' />
            </Box>
          </Container>
          ),
        },
      });
    default:
      throw new Error('Method not found.');
  }
};
```