### PR TITLE
cherry-pick: Correct theme value for Snap UI footer buttons

### DIFF
--- a/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
+++ b/ui/components/app/snaps/snap-ui-footer-button/snap-ui-footer-button.tsx
@@ -84,6 +84,7 @@ export const SnapUIFooterButton: FunctionComponent<
         alignItems: AlignItems.center,
         flexDirection: FlexDirection.Row,
       }}
+      data-theme={null}
     >
       {isSnapAction && !hideSnapBranding && (
         <SnapIcon snapId={snapId} avatarSize={IconSize.Sm} marginRight={2} />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**

Cherry-pick https://github.com/MetaMask/metamask-extension/commit/1fbb63cc4e2c15ffc344155f8fa6e6f240d8dd74 to the RC.

The Snap UI footer buttons use the DS button which forces light theme, this does not work for the colors used in the Snap buttons, therefore we revert back to using the actually selected theme.

[![Open in GitHub
Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29434?quickstart=1)