### PR TITLE
Multichain API E2E Test: wallet_notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -480,7 +480,7 @@
     "@metamask/preferences-controller": "^15.0.1",
     "@metamask/test-bundler": "^1.0.0",
     "@metamask/test-dapp": "8.13.0",
-    "@metamask/test-dapp-multichain": "^0.5.0",
+    "@metamask/test-dapp-multichain": "^0.6.0",
     "@octokit/core": "^3.6.0",
     "@open-rpc/meta-schema": "^1.14.6",
     "@open-rpc/mock-server": "^1.7.5",

--- a/test/e2e/flask/multichain-api/notify.spec.ts
+++ b/test/e2e/flask/multichain-api/notify.spec.ts
@@ -1,85 +1,65 @@
 import { strict as assert } from 'assert';
-import {
-  ACCOUNT_1,
-  largeDelayMs,
-  WINDOW_TITLES,
-  withFixtures,
-} from '../../helpers';
+import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';
 import {
-  initCreateSessionScopes,
   DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
   openMultichainDappAndConnectWalletWithExternallyConnectable,
-  addAccountInWalletAndAuthorize,
 } from './testHelpers';
 
-describe('Multichain API', function () {
-  describe('Calling `eth_subscribe` on a particular network event', function () {
-    it('Should receive a notification through the Multichain API for the event app subscribed to', async function () {
-      await withFixtures(
-        {
-          title: this.test?.fullTitle(),
-          fixtures: new FixtureBuilder()
-            .withNetworkControllerTripleGanache()
-            .build(),
-          ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
-        },
-        async ({
+describe('Calling `eth_subscribe` on a particular network event', function () {
+  it('Should receive a notification through the Multichain API for the event app subscribed to', async function () {
+    await withFixtures(
+      {
+        title: this.test?.fullTitle(),
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDappMultichain()
+          .build(),
+        ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+      },
+      async ({
+        driver,
+        extensionId,
+      }: {
+        driver: Driver;
+        extensionId: string;
+      }) => {
+        await openMultichainDappAndConnectWalletWithExternallyConnectable(
           driver,
           extensionId,
-        }: {
-          driver: Driver;
-          extensionId: string;
-        }) => {
-          await openMultichainDappAndConnectWalletWithExternallyConnectable(
-            driver,
-            extensionId,
-          );
-          const SCOPE = 'eip155:1337';
-          await initCreateSessionScopes(driver, [SCOPE], [ACCOUNT_1]);
-          await addAccountInWalletAndAuthorize(driver);
-          await driver.clickElement({ text: 'Connect', tag: 'button' });
-          await driver.delay(largeDelayMs);
-          await driver.switchToWindowWithTitle(
-            WINDOW_TITLES.MultichainTestDApp,
-          );
+        );
+        const SCOPE = 'eip155:1337';
 
-          await driver.clickElementSafe(
-            `[data-testid="${SCOPE}-eth_subscribe-option"]`,
-          );
+        await driver.clickElementSafe(
+          `[data-testid="${SCOPE}-eth_subscribe-option"]`,
+        );
+        await driver.clickElementSafe(
+          `[data-testid="invoke-method-${SCOPE}-btn"]`,
+        );
 
-          await driver.clickElementSafe(
-            `[data-testid="invoke-method-${SCOPE}-btn"]`,
-          );
+        const walletNotifyNotificationWebElement = await driver.findElement(
+          '#wallet-notify-result-0',
+        );
+        const resultSummaries = await driver.findElements('.result-summary');
 
-          const walletNotifyNotificationWebElement = await driver.findElement(
-            '#wallet-notify-result-0',
-          );
+        /**
+         * Currently we don't have `data-testid` setup for the desired result, so we click on all available results
+         * to make the complete text available and later evaluate if scopes match.
+         */
+        resultSummaries.forEach(async (element) => await element.click());
 
-          assert.ok(walletNotifyNotificationWebElement);
+        const parsedNotificationResult = JSON.parse(
+          await walletNotifyNotificationWebElement.getText(),
+        );
 
-          const resultSummaries = await driver.findElements('.result-summary');
+        const resultScope = parsedNotificationResult.params.scope;
 
-          /**
-           * Currently we don't have `data-testid` setup for the desired result, so we click on all available results
-           * to make the complete text available and later evaluate if scopes match.
-           */
-          resultSummaries.forEach(async (element) => await element.click());
-
-          const parsedNotificationResult = JSON.parse(
-            await walletNotifyNotificationWebElement.getText(),
-          );
-
-          const resultScope = parsedNotificationResult.params.scope;
-
-          assert.strictEqual(
-            parsedNotificationResult.params.scope,
-            SCOPE,
-            `received notification should come from the subscribed event and scope. Expected scope: ${SCOPE}, Actual scope: ${resultScope}`,
-          );
-        },
-      );
-    });
+        assert.strictEqual(
+          parsedNotificationResult.params.scope,
+          SCOPE,
+          `received notification should come from the subscribed event and scope. Expected scope: ${SCOPE}, Actual scope: ${resultScope}`,
+        );
+      },
+    );
   });
 });

--- a/test/e2e/flask/multichain-api/notify.spec.ts
+++ b/test/e2e/flask/multichain-api/notify.spec.ts
@@ -1,0 +1,85 @@
+import { strict as assert } from 'assert';
+import {
+  ACCOUNT_1,
+  largeDelayMs,
+  WINDOW_TITLES,
+  withFixtures,
+} from '../../helpers';
+import { Driver } from '../../webdriver/driver';
+import FixtureBuilder from '../../fixture-builder';
+import {
+  initCreateSessionScopes,
+  DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+  openMultichainDappAndConnectWalletWithExternallyConnectable,
+  addAccountInWalletAndAuthorize,
+} from './testHelpers';
+
+describe('Multichain API', function () {
+  describe('Calling `eth_subscribe` on a particular network event', function () {
+    it('Should receive a notification through the Multichain API for the event app subscribed to', async function () {
+      await withFixtures(
+        {
+          title: this.test?.fullTitle(),
+          fixtures: new FixtureBuilder()
+            .withNetworkControllerTripleGanache()
+            .build(),
+          ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+        },
+        async ({
+          driver,
+          extensionId,
+        }: {
+          driver: Driver;
+          extensionId: string;
+        }) => {
+          await openMultichainDappAndConnectWalletWithExternallyConnectable(
+            driver,
+            extensionId,
+          );
+          const SCOPE = 'eip155:1337';
+          await initCreateSessionScopes(driver, [SCOPE], [ACCOUNT_1]);
+          await addAccountInWalletAndAuthorize(driver);
+          await driver.clickElement({ text: 'Connect', tag: 'button' });
+          await driver.delay(largeDelayMs);
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.MultichainTestDApp,
+          );
+
+          await driver.clickElementSafe(
+            `[data-testid="${SCOPE}-eth_subscribe-option"]`,
+          );
+
+          await driver.clickElementSafe(
+            `[data-testid="invoke-method-${SCOPE}-btn"]`,
+          );
+
+          const walletNotifyNotificationWebElement = await driver.findElement(
+            '#wallet-notify-result-0',
+          );
+
+          assert.ok(walletNotifyNotificationWebElement);
+
+          const resultSummaries = await driver.findElements('.result-summary');
+
+          /**
+           * Currently we don't have `data-testid` setup for the desired result, so we click on all available results
+           * to make the complete text available and later evaluate if scopes match.
+           */
+          resultSummaries.forEach(async (element) => await element.click());
+
+          const parsedNotificationResult = JSON.parse(
+            await walletNotifyNotificationWebElement.getText(),
+          );
+
+          const resultScope = parsedNotificationResult.params.scope;
+
+          assert.strictEqual(
+            parsedNotificationResult.params.scope,
+            SCOPE,
+            `received notification should come from the subscribed event and scope. Expected scope: ${SCOPE}, Actual scope: ${resultScope}`,
+          );
+        },
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6535,10 +6535,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/test-dapp-multichain@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@metamask/test-dapp-multichain@npm:0.5.0"
-  checksum: 10/8579e133d76de699bbebd5ea41ca323d87bac01f105816be28f68e7f9c3dc6ca4181abddbc06c222d8507976a48699c3c1f888c518561cf5deda414e06e25958
+"@metamask/test-dapp-multichain@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@metamask/test-dapp-multichain@npm:0.6.0"
+  checksum: 10/23bb60422fa3986a648e487562697e7ca57dc97ac9ff693eeac391e673e5ebd838ad3a54160af8dbb195ab3eba497bf2a3767d76693bbbf6044ab6cdbd59b254
   languageName: node
   linkType: hard
 
@@ -26943,7 +26943,7 @@ __metadata:
     "@metamask/solana-wallet-snap": "npm:^1.0.4"
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:8.13.0"
-    "@metamask/test-dapp-multichain": "npm:^0.5.0"
+    "@metamask/test-dapp-multichain": "npm:^0.6.0"
     "@metamask/transaction-controller": "npm:^42.1.0"
     "@metamask/user-operation-controller": "npm:^21.0.0"
     "@metamask/utils": "npm:^10.0.1"


### PR DESCRIPTION
-- test: multichain test dapp e2e test for wallet_notify

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29623?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
