### PR TITLE
chore: clarifying comments for some github actions

### DIFF
--- a/.github/workflows/test-lint-changelog.yml
+++ b/.github/workflows/test-lint-changelog.yml
@@ -15,9 +15,13 @@ jobs:
         uses: metamask/github-tools/.github/actions/setup-environment@main
 
       - name: Validate changelog
+        # For a `pull_request` event, the branch is `github.head_ref``.
+        # For a `push` event, the branch is `github.ref_name`.
         if: ${{ !startsWith(github.head_ref || github.ref_name, 'Version-v') }}
         run: yarn lint:changelog
 
       - name: Validate release candidate changelog
+        # For a `pull_request` event, the branch is `github.head_ref``.
+        # For a `push` event, the branch is `github.ref_name`.
         if: ${{ startsWith(github.head_ref || github.ref_name, 'Version-v') }}
         run: .circleci/scripts/validate-changelog-in-rc.sh

--- a/.github/workflows/wait-for-circleci-workflow-status.yml
+++ b/.github/workflows/wait-for-circleci-workflow-status.yml
@@ -12,14 +12,15 @@ jobs:
         env:
           OWNER: ${{ github.repository_owner }}
           REPOSITORY: ${{ github.event.repository.name }}
+          # For a `pull_request` event, the branch is `github.head_ref``.
+          # For a `push` event, the branch is `github.ref_name`.
           BRANCH: ${{ github.head_ref || github.ref_name }}
-          # For a `push` event, the HEAD commit hash is `github.sha`.
-          # For a `pull_request` event, `github.sha` is instead the base branch commit hash. The
-          # HEAD commit hash is `pull_request.head.sha`.
+          # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
+          # For a `push` event, the head commit hash is `github.sha`.
           HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          pipeline_id=$(curl --silent "https://circleci.com/api/v2/project/gh/$OWNER/$REPOSITORY/pipeline?branch=$BRANCH" | jq -r ".items | map(select(.vcs.revision == \"${HEAD_COMMIT_HASH}\" )) | first | .id")
-          echo "Waiting for pipeline '${pipeline_id}' for commit hash '${HEAD_COMMIT_HASH}'"
+          pipeline_id=$(curl --silent "https://circleci.com/api/v2/project/gh/$OWNER/$REPOSITORY/pipeline?branch=$BRANCH" | jq --arg head_commit_hash "${HEAD_COMMIT_HASH}" -r '.items | map(select(.vcs.revision == $head_commit_hash)) | first | .id')
+          echo "Waiting for pipeline '${pipeline_id}', commit hash '${HEAD_COMMIT_HASH}'"
           workflow_status=$(curl --silent "https://circleci.com/api/v2/pipeline/$pipeline_id/workflow" | jq -r ".items[0].status")
 
           if [ "$workflow_status" == "running" ]; then


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29642?quickstart=1)

This small PR adds some clarifying comments for some GitHub Actions, namely:

```
# For a `pull_request` event, the branch is `github.head_ref``.
# For a `push` event, the branch is `github.ref_name`.
```

to make sure the contributor is aware which variable corresponds to which event.

No functional changes, only cosmetic.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Everything should work the same as before

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
