### PR TITLE
fix: duplicate content in multiple pending connect confirmations

### DIFF
--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -322,6 +322,8 @@ export default class PermissionConnect extends Component {
       setSnapsInstallPrivacyWarningShownStatus,
       approvePermissionsRequest,
       snapsInstallPrivacyWarningShown,
+      origin,
+      history,
     } = this.props;
     const { selectedAccountAddresses, permissionsApproved, redirecting } =
       this.state;
@@ -366,7 +368,7 @@ export default class PermissionConnect extends Component {
                     rejectPermissionsRequest={(requestId) =>
                       this.cancelPermissionsRequest(requestId)
                     }
-                    activeTabOrigin={this.props.origin}
+                    activeTabOrigin={origin}
                     request={permissionsRequest}
                     permissionsRequestId={permissionsRequestId}
                     approveConnection={this.approveConnection}
@@ -391,7 +393,7 @@ export default class PermissionConnect extends Component {
                     selectedAccountAddresses.has(account.address),
                   )}
                   targetSubjectMetadata={targetSubjectMetadata}
-                  history={this.props.history}
+                  history={history}
                   connectPath={connectPath}
                   snapsInstallPrivacyWarningShown={
                     snapsInstallPrivacyWarningShown

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -126,9 +126,6 @@ export default class PermissionConnect extends Component {
       this.props.permissionsRequest,
     ),
     permissionsApproved: null,
-    origin: this.props.origin,
-    targetSubjectMetadata: this.props.targetSubjectMetadata || {},
-    snapsInstallPrivacyWarningShown: this.props.snapsInstallPrivacyWarningShown,
   };
 
   componentDidMount() {
@@ -180,8 +177,8 @@ export default class PermissionConnect extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { permissionsRequest, lastConnectedInfo } = this.props;
-    const { redirecting, origin } = this.state;
+    const { permissionsRequest, lastConnectedInfo, origin } = this.props;
+    const { redirecting } = this.state;
 
     if (!permissionsRequest && prevProps.permissionsRequest && !redirecting) {
       const accountsLastApprovedTime =
@@ -267,7 +264,7 @@ export default class PermissionConnect extends Component {
   }
 
   renderTopBar(permissionsRequestId) {
-    const { targetSubjectMetadata } = this.state;
+    const { targetSubjectMetadata } = this.props;
     const handleCancelFromHeader = () => {
       this.cancelPermissionsRequest(permissionsRequestId);
     };
@@ -324,13 +321,10 @@ export default class PermissionConnect extends Component {
       rejectPendingApproval,
       setSnapsInstallPrivacyWarningShownStatus,
       approvePermissionsRequest,
-    } = this.props;
-    const {
-      selectedAccountAddresses,
-      permissionsApproved,
-      redirecting,
       snapsInstallPrivacyWarningShown,
-    } = this.state;
+    } = this.props;
+    const { selectedAccountAddresses, permissionsApproved, redirecting } =
+      this.state;
 
     const isRequestingSnap = isSnapId(permissionsRequest?.metadata?.origin);
 
@@ -372,7 +366,7 @@ export default class PermissionConnect extends Component {
                     rejectPermissionsRequest={(requestId) =>
                       this.cancelPermissionsRequest(requestId)
                     }
-                    activeTabOrigin={this.state.origin}
+                    activeTabOrigin={this.props.origin}
                     request={permissionsRequest}
                     permissionsRequestId={permissionsRequestId}
                     approveConnection={this.approveConnection}


### PR DESCRIPTION
## **Description**

Fix duplicate content when there are multiple pending connect confirmations.

Caused by props being copied to state but not updated.

## **Related issues**

Fixes: #29594 

## **Manual testing steps**

See issue.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
