### PR TITLE
chore(CI): Add hints whether webapp policy files diffs differ

### DIFF
--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -197,11 +197,33 @@ jobs:
           git config --global user.email 'metamaskbot@users.noreply.github.com'
           git commit -am "Update LavaMoat policies"
           git push
+      ## Yes, it would be nice to use the local diff before the commit is made, but we need to include potential multiple updates in the history of the PR
+      - name: Compare policy changes
+        run: |
+          if [[ $HAS_CHANGES == 'true' ]]
+          then
+            git fetch origin ${{ github.base_ref }}
+            main_diff=$(git diff origin/${{ github.base_ref }} lavamoat/browserify/main/policy.json | md5sum | cut -d' ' -f1)
+            for folder in lavamoat/browserify/*/; do
+              if [ "$folder" != "lavamoat/browserify/main/" ]; then
+                file="${folder}policy.json"
+                if [ -f "$file" ]; then
+                  diff=$(git diff origin/${{ github.base_ref }} "$file" | md5sum | cut -d' ' -f1)
+                  if [ "$diff" = "$main_diff" ]; then
+                    echo "✅ ${folder}policy.json changes match main/policy.json policy changes"
+                  else
+                    echo "👀 ${folder}policy.json changes **differ from** main/policy.json policy changes"
+                  fi
+                fi
+              fi
+            done > does_diff_diff.txt
+          fi
+      ## Note the use of `cat -` to include the file contents and the echo in the comment
       - name: Post comment
         run: |
           if [[ $HAS_CHANGES == 'true' ]]
           then
-            echo -e 'Policies updated.  \n👀 Please review the diff for suspicious new powers.  \n\n🧠 Learn how: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff' |  gh pr comment "${PR_NUMBER}" --body-file -
+            echo -e 'Policies updated.  \n👀 Please review the diff for suspicious new powers.  \n\n🧠 Learn how: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff \n\n' | cat - does_diff_diff.txt |  gh pr comment "${PR_NUMBER}" --body-file -
           else
             gh pr comment "${PR_NUMBER}" --body 'No policy changes'
           fi


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a helpful hint to the policy update message highlighting whether you only need to review main/policy.js or multiple (if the policy updates differently across build variants)

The result should look something like this:

```
✔️ lavamoat/browserify/beta/policy.json changes match main policy changes
✔️ lavamoat/browserify/flask/policy.json changes match main policy changes
✔️ lavamoat/browserify/mmi/policy.json changes match main policy changes
```
or
```
❌ lavamoat/browserify/beta/policy.json changes **differ from** main policy changes
✔️ lavamoat/browserify/flask/policy.json changes match main policy changes
✔️ lavamoat/browserify/mmi/policy.json changes match main policy changes
```

I've tested the bash script, but I've yet to test the action as a whole. I'll need to branch off of this and make a fake PR I think. Will link here when ready.

update:
I didn't succeed testing it on a branch without messing up the code for MMI and I don't think it's worth the effort. Worst case, I'd need to fix the script if it fails. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29657?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
