### PR TITLE
fix: Correct translation for `hiddenAccounts`

### DIFF
--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -2241,7 +2241,7 @@
     "message": "Шестнадцатеричные данные"
   },
   "hiddenAccounts": {
-    "message": "Скрыть счета"
+    "message": "Скрытые счета"
   },
   "hide": {
     "message": "Скрыть"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29667?quickstart=1)

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Go to main page
2. Press on account on top-center
3. Select account and click _Hide account_

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

![1](https://github.com/user-attachments/assets/fef893eb-c6cf-464f-a4d3-2cbada1b8c10)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
