### PR TITLE
fix: oldestPendingApproval and transactionsMetadata PropTypes in the …

### DIFF
--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -194,9 +194,9 @@ export default class Routes extends Component {
     totalUnapprovedConfirmationCount: PropTypes.number.isRequired,
     currentExtensionPopupId: PropTypes.number,
     clearEditedNetwork: PropTypes.func.isRequired,
-    oldestPendingApproval: PropTypes.object.isRequired,
+    oldestPendingApproval: PropTypes.object,
     pendingApprovals: PropTypes.arrayOf(PropTypes.object).isRequired,
-    transactionsMetadata: PropTypes.arrayOf(PropTypes.object).isRequired,
+    transactionsMetadata: PropTypes.object,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isShowKeyringSnapRemovalResultModal: PropTypes.bool.isRequired,
     hideShowKeyringSnapRemovalResultModal: PropTypes.func.isRequired,


### PR DESCRIPTION
…routes file


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There are two relatively new proptypes warnings that I included below. This is because `transactionsMetadata` is in fact an object, not an array of objects, and oldestPendingApproval can be undefined.

These PropTypes were introduced in https://github.com/MetaMask/metamask-extension/pull/28301.

This PR updates both PropTypes definitions to avoid any more warnings.

```
Warning: Failed prop type: The prop `oldestPendingApproval` is marked as required in `Routes`, but its value is `undefined`.
    in Routes (created by Connect(Routes))
    in Connect(Routes) (created by Context.Consumer)
    in withRouter(Connect(Routes)) (at pages/index.js:57)
    in MetamaskNotificationsProvider (at pages/index.js:56)
    in MetamaskIdentityProvider (at pages/index.js:55)
    in AssetPollingProvider (at pages/index.js:54)
    in LegacyI18nProvider (at pages/index.js:53)
    in I18nProvider (at pages/index.js:52)
    in LegacyMetaMetricsProvider (at pages/index.js:51)
    in MetaMetricsProvider (at pages/index.js:50)
    in RenderedRoute (created by Routes)
    in Routes (created by CompatRouter)
    in Router (created by CompatRouter)
    in CompatRouter (at pages/index.js:49)
    in Router (created by HashRouter)
    in HashRouter (at pages/index.js:48)
    in Provider (at pages/index.js:47)
    in Index (at ui/index.js:213)
Warning: Failed prop type: Invalid prop `transactionsMetadata` of type `object` supplied to `Routes`, expected an array.
    in Routes (created by Connect(Routes))
    in Connect(Routes) (created by Context.Consumer)
    in withRouter(Connect(Routes)) (at pages/index.js:57)
    in MetamaskNotificationsProvider (at pages/index.js:56)
    in MetamaskIdentityProvider (at pages/index.js:55)
    in AssetPollingProvider (at pages/index.js:54)
    in LegacyI18nProvider (at pages/index.js:53)
    in I18nProvider (at pages/index.js:52)
    in LegacyMetaMetricsProvider (at pages/index.js:51)
    in MetaMetricsProvider (at pages/index.js:50)
    in RenderedRoute (created by Routes)
    in Routes (created by CompatRouter)
    in Router (created by CompatRouter)
    in CompatRouter (at pages/index.js:49)
    in Router (created by HashRouter)
    in HashRouter (at pages/index.js:48)
    in Provider (at pages/index.js:47)
    in Index (at ui/index.js:213)
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29689?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
