### PR TITLE
fix: Fix `EditAccountsModal` and `EditNetworkModal` checkboxes reseting back to default on rerender

### DIFF
--- a/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
+++ b/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
@@ -60,7 +60,10 @@ export const EditAccountsModal: React.FC<EditAccountsModalProps> = ({
 
   useEffect(() => {
     setSelectedAccountAddresses(defaultSelectedAccountAddresses);
-  }, [defaultSelectedAccountAddresses]);
+  }, [
+    // TODO: Fix the source of this prop value to be the same array instance each render
+    JSON.stringify(defaultSelectedAccountAddresses),
+  ]);
 
   const selectAll = () => {
     const allNetworksAccountAddresses = accounts.map(({ address }) => address);

--- a/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
+++ b/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
@@ -52,7 +52,10 @@ export const EditNetworksModal = ({
 
   useEffect(() => {
     setSelectedChainIds(defaultSelectedChainIds);
-  }, [defaultSelectedChainIds]);
+  }, [
+    // TODO: Fix the source of this prop value to be the same array instance each render
+    JSON.stringify(defaultSelectedChainIds),
+  ]);
 
   const selectAll = () => {
     const allNetworksChainIds = allNetworks.map(({ chainId }) => chainId);


### PR DESCRIPTION
## **Description**

Fixes a bug in the `EditAccountsModal` and `EditNetworkModal` that occasionally causes any changes to the default selected checkboxes to be reset on component rerender.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29755?quickstart=1)

## **Related issues**

See: https://github.com/MetaMask/metamask-extension/pull/27847#discussion_r1917444716

## **Manual testing steps**

1. For a dapp with permissions
2. In the wallet UI, edit the dapp permissions
3. Open the edit network modal
4. Change some checkboxes to be different from what was default selected
5. Wait
6. The checkboxes should not revert back to the default selected

Do the same for the edit accounts modal

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
