### PR TITLE
fix: Bug in transaction flow component for 1155 token

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransferRecipient.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransferRecipient.ts
@@ -12,7 +12,9 @@ export function useTransferRecipient() {
   const transactionData = useTokenTransactionData();
   const transactionType = transactionMetadata?.type;
   const transactionTo = transactionMetadata?.txParams?.to;
-  const transferTo = transactionData?.args?._to as string | undefined;
+  const transferTo =
+    (transactionData?.args?._to as string | undefined) ||
+    transactionData?.args?.to;
 
   return transactionType === TransactionType.simpleSend
     ? transactionTo


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

There has been a [recent change to stop relying on transaction decoding third parties](https://github.com/MetaMask/metamask-extension/pull/29341). The parsed transaction data now varies depending on the ABIs, and for some ERC1155 tokens the `._to` argument is expressed as simply `.to`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29775?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="320" alt="Screenshot 2025-01-17 at 10 03 10" src="https://github.com/user-attachments/assets/ef3c39a1-0002-48a8-a64b-5479a2122dc5" />


### **After**

<!-- [screenshots/recordings] -->

<img width="320" alt="Screenshot 2025-01-17 at 10 05 45" src="https://github.com/user-attachments/assets/0b95a3bc-420a-4150-908b-bed6cbb20206" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
