### PR TITLE
chore: Bump `@metamask/snaps-rpc-methods` from `^11.9.0` to `^11.9.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,7 +345,7 @@
     "@metamask/smart-transactions-controller": "^16.0.1",
     "@metamask/snaps-controllers": "^9.17.0",
     "@metamask/snaps-execution-environments": "^6.12.0",
-    "@metamask/snaps-rpc-methods": "^11.9.0",
+    "@metamask/snaps-rpc-methods": "^11.9.1",
     "@metamask/snaps-sdk": "^6.15.0",
     "@metamask/snaps-utils": "^8.8.0",
     "@metamask/solana-wallet-snap": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6398,6 +6398,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-rpc-methods@npm:^11.9.1":
+  version: 11.9.1
+  resolution: "@metamask/snaps-rpc-methods@npm:11.9.1"
+  dependencies:
+    "@metamask/key-tree": "npm:^10.0.2"
+    "@metamask/permission-controller": "npm:^11.0.5"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-sdk": "npm:^6.15.0"
+    "@metamask/snaps-utils": "npm:^8.8.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.0.1"
+    "@noble/hashes": "npm:^1.3.1"
+    luxon: "npm:^3.5.0"
+  checksum: 10/bd39c232ad96999573dbb79e4c99cea54b2f1a4a94426c81500dc362e5d27eafa8986304f6ee11601a6b3410b95199a1c547f6be4adc12bc0efe910e10299972
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-sdk@npm:^6.15.0":
   version: 6.15.0
   resolution: "@metamask/snaps-sdk@npm:6.15.0"
@@ -26729,7 +26746,7 @@ __metadata:
     "@metamask/smart-transactions-controller": "npm:^16.0.1"
     "@metamask/snaps-controllers": "npm:^9.17.0"
     "@metamask/snaps-execution-environments": "npm:^6.12.0"
-    "@metamask/snaps-rpc-methods": "npm:^11.9.0"
+    "@metamask/snaps-rpc-methods": "npm:^11.9.1"
     "@metamask/snaps-sdk": "npm:^6.15.0"
     "@metamask/snaps-utils": "npm:^8.8.0"
     "@metamask/solana-wallet-snap": "npm:^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6381,24 +6381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^11.9.0":
-  version: 11.9.0
-  resolution: "@metamask/snaps-rpc-methods@npm:11.9.0"
-  dependencies:
-    "@metamask/key-tree": "npm:^10.0.2"
-    "@metamask/permission-controller": "npm:^11.0.5"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-sdk": "npm:^6.15.0"
-    "@metamask/snaps-utils": "npm:^8.8.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.0.1"
-    "@noble/hashes": "npm:^1.3.1"
-    luxon: "npm:^3.5.0"
-  checksum: 10/44d47d3d8dcaa349863f2df2622c6fedc15e56e77d00ee97caadf3cebef6ddca06c8d4fa199b196a067bbdce59ec9a867446c133658b098216746bc23e7245f8
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-rpc-methods@npm:^11.9.1":
+"@metamask/snaps-rpc-methods@npm:^11.9.0, @metamask/snaps-rpc-methods@npm:^11.9.1":
   version: 11.9.1
   resolution: "@metamask/snaps-rpc-methods@npm:11.9.1"
   dependencies:


### PR DESCRIPTION
## **Description**

This bumps `@metamask/snaps-rpc-methods` from `^11.9.0` to `^11.9.1`, which fixes some bugs and improves error messages related to state management.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29805?quickstart=1)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
