### PR TITLE
fix: Revert "fix: Remove scroll to bottom requirement for signatures"

### DIFF
--- a/test/e2e/snaps/test-snap-ethprovider.spec.js
+++ b/test/e2e/snaps/test-snap-ethprovider.spec.js
@@ -143,6 +143,7 @@ describe('Test Snap ethereum_provider', function () {
         await driver.clickElement('#signTypedDataButton');
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.clickElementSafe('.confirm-scroll-to-bottom__button');
         await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
           tag: 'button',

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -707,15 +707,12 @@ class Driver {
   async clickElementSafe(rawLocator, timeout = 1000) {
     try {
       const locator = this.buildLocator(rawLocator);
+
       const elements = await this.driver.wait(
         until.elementsLocated(locator),
         timeout,
       );
 
-      await Promise.all([
-        this.driver.wait(until.elementIsVisible(elements[0]), timeout),
-        this.driver.wait(until.elementIsEnabled(elements[0]), timeout),
-      ]);
       await elements[0].click();
     } catch (e) {
       console.log(`Element ${rawLocator} not found (${e})`);

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -116,6 +116,20 @@ describe('ConfirmFooter', () => {
       const confirmButton = getByText('Confirm');
       expect(confirmButton).toBeDisabled();
     });
+
+    it('when the confirmation is a Permit with the transaction simulation setting disabled', () => {
+      jest.spyOn(confirmContext, 'useConfirmContext').mockReturnValue({
+        currentConfirmation: permitSignatureMsg,
+        isScrollToBottomCompleted: false,
+        setIsScrollToBottomCompleted: () => undefined,
+      });
+      const mockStatePermit =
+        getMockTypedSignConfirmStateForRequest(permitSignatureMsg);
+      const { getByText } = render(mockStatePermit);
+
+      const confirmButton = getByText('Confirm');
+      expect(confirmButton).toBeDisabled();
+    });
   });
 
   it('invoke required actions when cancel button is clicked', () => {

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { providerErrors, serializeError } from '@metamask/rpc-errors';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -29,7 +32,12 @@ import {
   ///: END:ONLY_INCLUDE_IF
   updateCustomNonce,
 } from '../../../../../store/actions';
-import { isSignatureTransactionType } from '../../../utils';
+import { selectUseTransactionSimulations } from '../../../selectors/preferences';
+
+import {
+  isPermitSignatureRequest,
+  isSIWESignatureRequest,
+} from '../../../utils';
 import { useConfirmContext } from '../../../context/confirm';
 import { getConfirmationSender } from '../utils';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
@@ -159,7 +167,9 @@ const Footer = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
   const customNonceValue = useSelector(getCustomNonceValue);
-
+  const useTransactionSimulations = useSelector(
+    selectUseTransactionSimulations,
+  );
   const { currentConfirmation, isScrollToBottomCompleted } =
     useConfirmContext();
   const { from } = getConfirmationSender(currentConfirmation);
@@ -177,10 +187,17 @@ const Footer = () => {
     return false;
   });
 
-  const isSignature = isSignatureTransactionType(currentConfirmation);
+  const isSIWE = isSIWESignatureRequest(currentConfirmation);
+  const isPermit = isPermitSignatureRequest(currentConfirmation);
+  const isPermitSimulationShown = isPermit && useTransactionSimulations;
+  const isPersonalSign =
+    currentConfirmation?.type === TransactionType.personalSign;
 
   const isConfirmDisabled =
-    (!isScrollToBottomCompleted && !isSignature) ||
+    (!isScrollToBottomCompleted &&
+      !isSIWE &&
+      !isPermitSimulationShown &&
+      !isPersonalSign) ||
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
     mmiSubmitDisabled ||
     ///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#29784 to address CI failures on `main` caused by that PR