### PR TITLE
fix: Remove scroll to bottom requirement for signatures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,7 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -152,6 +153,7 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff
@@ -172,6 +174,7 @@ workflows:
             - prep-build-test-flask
             - get-changed-files-with-git-diff
       - test-e2e-firefox-flask:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-flask-mv2
       - test-e2e-swap-playwright - OPTIONAL:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,6 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -153,7 +152,6 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff
@@ -174,7 +172,6 @@ workflows:
             - prep-build-test-flask
             - get-changed-files-with-git-diff
       - test-e2e-firefox-flask:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-flask-mv2
       - test-e2e-swap-playwright - OPTIONAL:

--- a/test/e2e/snaps/test-snap-ethprovider.spec.js
+++ b/test/e2e/snaps/test-snap-ethprovider.spec.js
@@ -143,7 +143,6 @@ describe('Test Snap ethereum_provider', function () {
         await driver.clickElement('#signTypedDataButton');
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await driver.clickElementSafe('.confirm-scroll-to-bottom__button');
         await driver.clickElementAndWaitForWindowToClose({
           text: 'Confirm',
           tag: 'button',

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -707,12 +707,15 @@ class Driver {
   async clickElementSafe(rawLocator, timeout = 1000) {
     try {
       const locator = this.buildLocator(rawLocator);
-
       const elements = await this.driver.wait(
         until.elementsLocated(locator),
         timeout,
       );
 
+      await Promise.all([
+        this.driver.wait(until.elementIsVisible(elements[0]), timeout),
+        this.driver.wait(until.elementIsEnabled(elements[0]), timeout),
+      ]);
       await elements[0].click();
     } catch (e) {
       console.log(`Element ${rawLocator} not found (${e})`);

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -116,20 +116,6 @@ describe('ConfirmFooter', () => {
       const confirmButton = getByText('Confirm');
       expect(confirmButton).toBeDisabled();
     });
-
-    it('when the confirmation is a Permit with the transaction simulation setting disabled', () => {
-      jest.spyOn(confirmContext, 'useConfirmContext').mockReturnValue({
-        currentConfirmation: permitSignatureMsg,
-        isScrollToBottomCompleted: false,
-        setIsScrollToBottomCompleted: () => undefined,
-      });
-      const mockStatePermit =
-        getMockTypedSignConfirmStateForRequest(permitSignatureMsg);
-      const { getByText } = render(mockStatePermit);
-
-      const confirmButton = getByText('Confirm');
-      expect(confirmButton).toBeDisabled();
-    });
   });
 
   it('invoke required actions when cancel button is clicked', () => {

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -1,7 +1,4 @@
-import {
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import { providerErrors, serializeError } from '@metamask/rpc-errors';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -32,12 +29,7 @@ import {
   ///: END:ONLY_INCLUDE_IF
   updateCustomNonce,
 } from '../../../../../store/actions';
-import { selectUseTransactionSimulations } from '../../../selectors/preferences';
-
-import {
-  isPermitSignatureRequest,
-  isSIWESignatureRequest,
-} from '../../../utils';
+import { isSignatureTransactionType } from '../../../utils';
 import { useConfirmContext } from '../../../context/confirm';
 import { getConfirmationSender } from '../utils';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
@@ -167,9 +159,7 @@ const Footer = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
   const customNonceValue = useSelector(getCustomNonceValue);
-  const useTransactionSimulations = useSelector(
-    selectUseTransactionSimulations,
-  );
+
   const { currentConfirmation, isScrollToBottomCompleted } =
     useConfirmContext();
   const { from } = getConfirmationSender(currentConfirmation);
@@ -187,17 +177,10 @@ const Footer = () => {
     return false;
   });
 
-  const isSIWE = isSIWESignatureRequest(currentConfirmation);
-  const isPermit = isPermitSignatureRequest(currentConfirmation);
-  const isPermitSimulationShown = isPermit && useTransactionSimulations;
-  const isPersonalSign =
-    currentConfirmation?.type === TransactionType.personalSign;
+  const isSignature = isSignatureTransactionType(currentConfirmation);
 
   const isConfirmDisabled =
-    (!isScrollToBottomCompleted &&
-      !isSIWE &&
-      !isPermitSimulationShown &&
-      !isPersonalSign) ||
+    (!isScrollToBottomCompleted && !isSignature) ||
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
     mmiSubmitDisabled ||
     ///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#29808

Removes scroll to bottom requirement on signatures
Improves the clickElementSafe function