### PR TITLE
fix: overflow of title/description in Snap `Card` component

### DIFF
--- a/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
+++ b/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
@@ -33,7 +33,12 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
       justifyContent={JustifyContent.spaceBetween}
       alignItems={AlignItems.center}
     >
-      <Box display={Display.Flex} gap={4} alignItems={AlignItems.center}>
+      <Box
+        display={Display.Flex}
+        gap={4}
+        alignItems={AlignItems.center}
+        style={{ overflow: 'hidden' }}
+      >
         {image && (
           <SnapUIImage
             width="32px"


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? Text overflow was not properly working for the title & description section of the `Card` snap component.
2. What is the improvement/solution? Add a constraint to the parent container.

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/2815

## **Manual testing steps**

1. Build the extension
2. Trigger a snap dialog with the example code in the issue
3. Observe the below changes.

## **Screenshots/Recordings**

### **Before**

[See issue link](https://github.com/MetaMask/snaps/issues/2815)

### **After**

<img width="380" alt="Screenshot 2025-01-21 at 6 49 00 PM" src="https://github.com/user-attachments/assets/e3486c52-803d-4936-87b1-9117a788c854" />

<img width="380" alt="Screenshot 2025-01-21 at 6 48 00 PM" src="https://github.com/user-attachments/assets/2371cd8c-be2d-49e2-9214-66302eff1c13" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
