### PR TITLE
Cherry-pick fix: not routing to home page after bridge tx submitted 

### DIFF
--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx
@@ -465,7 +465,10 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
       );
 
       // Assert
-      expect(mockHistory.push).toHaveBeenCalledWith('/');
+      expect(mockHistory.push).toHaveBeenCalledWith({
+        pathname: '/',
+        state: { stayOnHomePage: true },
+      });
     });
   });
 });

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -161,7 +161,10 @@ export default function useSubmitBridgeTransaction() {
 
     // Route user to activity tab on Home page
     await dispatch(setDefaultHomeActiveTabName('activity'));
-    history.push(DEFAULT_ROUTE);
+    history.push({
+      pathname: DEFAULT_ROUTE,
+      state: { stayOnHomePage: true },
+    });
   };
 
   return {


### PR DESCRIPTION


## **Description**

Cherry-picking https://github.com/MetaMask/metamask-extension/pull/29809 into v12.11.0 after validating that fix is working as expected. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29853?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29793

