### PR TITLE
fix: Ensure SRP backup reminder only displays when on HDKey account

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2889,7 +2889,8 @@ export function getShouldShowSeedPhraseReminder(state) {
     state.metamask;
 
   const currentKeyring = getCurrentKeyring(state);
-  const isNativeAccount = currentKeyring.type === KeyringType.hdKeyTree;
+  const isNativeAccount =
+    currentKeyring?.type && currentKeyring.type === KeyringType.hdKeyTree;
 
   // if there is no account, we don't need to show the seed phrase reminder
   const accountBalance = getSelectedInternalAccount(state)

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2888,16 +2888,21 @@ export function getShouldShowSeedPhraseReminder(state) {
   const { tokens, seedPhraseBackedUp, dismissSeedBackUpReminder } =
     state.metamask;
 
+  const currentKeyring = getCurrentKeyring(state);
+  const isNativeAccount = currentKeyring.type === KeyringType.hdKeyTree;
+
   // if there is no account, we don't need to show the seed phrase reminder
   const accountBalance = getSelectedInternalAccount(state)
     ? getCurrentEthBalance(state)
     : 0;
 
-  return (
+  const showMessage =
     seedPhraseBackedUp === false &&
     (parseInt(accountBalance, 16) > 0 || tokens.length > 0) &&
-    dismissSeedBackUpReminder === false
-  );
+    dismissSeedBackUpReminder === false &&
+    isNativeAccount;
+
+  return showMessage;
 }
 
 export function getUnconnectedAccounts(state, activeTab) {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -296,6 +296,46 @@ describe('Selectors', () => {
     });
   });
 
+  describe('#getShouldShowSeedPhraseReminder', () => {
+    it('returns true if the account is a native account', () => {
+      const state = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          seedPhraseBackedUp: false,
+        },
+      };
+      expect(selectors.getShouldShowSeedPhraseReminder(state)).toBe(true);
+    });
+
+    it('returns false if the account is not native', () => {
+      const state = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          seedPhraseBackedUp: false,
+          internalAccounts: {
+            ...mockState.metamask.internalAccounts,
+            accounts: {
+              ...mockState.metamask.internalAccounts.accounts,
+              'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3': {
+                ...mockState.metamask.internalAccounts.accounts[
+                  'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3'
+                ],
+                metadata: {
+                  keyring: {
+                    type: KeyringType.imported,
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      expect(selectors.getShouldShowSeedPhraseReminder(state)).toBe(false);
+    });
+  });
+
   describe('#getNetworkToAutomaticallySwitchTo', () => {
     const SELECTED_ORIGIN = 'https://portfolio.metamask.io';
     const SELECTED_ORIGIN_NETWORK_ID = NETWORK_TYPES.LINEA_SEPOLIA;


### PR DESCRIPTION


## **Description**

Ensures that the SRP backup reminder only displays if the user is on HD keyring, so will not display if the user is on hardware wallet or imported wallet


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29857?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create a new wallet and do _NOT_ backup SRP
2. Finish onboarding, see SRP reminder
3. Import a new account, do _NOT_ see SRP reminder
4. Add hardware wallet account, do _NOT_ see SRP reminder

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
