### PR TITLE
fix: Fix bundle size diffs

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -22,9 +22,10 @@ jobs:
       - name: Get merge base commit hash
         id: get-merge-base
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          merge_base="$(git merge-base "origin/${BASE_REF}" HEAD)"
+          merge_base="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")"
           echo "MERGE_BASE=${merge_base}" >> "$GITHUB_OUTPUT"
           echo "Merge base is '${merge_base}'"
 


### PR DESCRIPTION
## **Description**

Fix bundle size diffs that are included in `metamaskbot` comments.

The diffs were incorrect because the "merge base" commit was wrong. The merge base commit is the commit we're comparing the branch against. We were calculating this using `git merge-base origin/main HEAD`, which locally does give the correct answer. But in GitHub Actions, HEAD was not set to the tip of the branch. Instead it was a new commit generated during the checkout step, representing the target branch merged into the current branch.

This resulted in the "merge base" always being the tip of `main` (at the time of this workflow run). This in turn resulted in the "bundle diff" including changes that were already made on `main`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29862?quickstart=1)

## **Related issues**

Fixes #29858.

## **Manual testing steps**

I created a second draft PR to add diagnostic logs for testing this: https://github.com/MetaMask/metamask-extension/pull/29859

You can see an example of these logs here: https://github.com/MetaMask/metamask-extension/actions/runs/12917863547/job/36025202434?pr=29859

Note that the `HEAD` resolves to a totally different commit than the real head of the branch (which is accessible as `pull_request.head.sha`), resulting in a different merge base.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
