### PR TITLE
fix(3932): Fix User traits changed during onboarding are never sent to Segment

### DIFF
--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -541,6 +541,24 @@ describe('MetaMetricsController', function () {
   });
 
   describe('setParticipateInMetaMetrics', function () {
+    it('should set dataCollectionForMarketing to false if not provided to update the value in userTraits', async function () {
+      await withController(
+        {
+          options: {
+            state: {
+              participateInMetaMetrics: false,
+              dataCollectionForMarketing: null,
+            },
+          },
+        },
+        async ({ controller }) => {
+          await controller.setParticipateInMetaMetrics(true);
+          expect(controller.state.dataCollectionForMarketing).toStrictEqual(
+            false,
+          );
+        },
+      );
+    });
     it('should update the value of participateInMetaMetrics', async function () {
       await withController(
         {

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -807,7 +807,14 @@ export default class MetaMetricsController extends BaseController<
     participateInMetaMetrics: boolean,
   ): Promise<string | null> {
     const { metaMetricsId: existingMetaMetricsId } = this.state;
-
+    if (
+      participateInMetaMetrics &&
+      this.state.dataCollectionForMarketing === null
+    ) {
+      this.update((state) => {
+        state.dataCollectionForMarketing = false;
+      });
+    }
     const metaMetricsId =
       participateInMetaMetrics && !existingMetaMetricsId
         ? this.generateMetaMetricsId()
@@ -1238,7 +1245,6 @@ export default class MetaMetricsController extends BaseController<
         metamaskState.preferences.tokenNetworkFilter || {},
       ),
     };
-
     if (!previousUserTraits) {
       this.update((state) => {
         state.previousUserTraits = currentTraits;
@@ -1246,6 +1252,11 @@ export default class MetaMetricsController extends BaseController<
       return currentTraits;
     }
 
+    console.log(
+      'previousUserTraits',
+      this.state.participateInMetaMetrics,
+      this.state.dataCollectionForMarketing,
+    );
     if (previousUserTraits && !isEqual(previousUserTraits, currentTraits)) {
       const updates = pickBy(currentTraits, (v, k) => {
         // @ts-expect-error It's okay that `k` may not be a key of `previousUserTraits`, because we assume `isEqual` can handle it

--- a/test/e2e/page-objects/flows/onboarding.flow.ts
+++ b/test/e2e/page-objects/flows/onboarding.flow.ts
@@ -17,17 +17,20 @@ import { E2E_SRP } from '../../default-fixture';
  * @param [options.password] - The password to create. Defaults to WALLET_PASSWORD.
  * @param [options.participateInMetaMetrics] - Whether to participate in MetaMetrics. Defaults to false.
  * @param [options.needNavigateToNewPage] - Indicates whether to navigate to a new page before starting the onboarding flow. Defaults to true.
+ * @param [options.dataCollectionForMarketing] - Whether to opt in to data collection for marketing. Defaults to false.
  */
 export const createNewWalletOnboardingFlow = async ({
   driver,
   password = WALLET_PASSWORD,
   participateInMetaMetrics = false,
   needNavigateToNewPage = true,
+  dataCollectionForMarketing = false,
 }: {
   driver: Driver;
   password?: string;
   participateInMetaMetrics?: boolean;
   needNavigateToNewPage?: boolean;
+  dataCollectionForMarketing?: boolean;
 }): Promise<void> => {
   console.log('Starting the creation of a new wallet onboarding flow');
   if (needNavigateToNewPage) {
@@ -40,6 +43,9 @@ export const createNewWalletOnboardingFlow = async ({
 
   const onboardingMetricsPage = new OnboardingMetricsPage(driver);
   await onboardingMetricsPage.check_pageIsLoaded();
+  if (dataCollectionForMarketing) {
+    await onboardingMetricsPage.clickDataCollectionForMarketingCheckbox();
+  }
   if (participateInMetaMetrics) {
     await onboardingMetricsPage.clickIAgreeButton();
   } else {
@@ -109,17 +115,20 @@ export const importSRPOnboardingFlow = async ({
  * @param [options.password] - The password to use. Defaults to WALLET_PASSWORD.
  * @param [options.participateInMetaMetrics] - Whether to participate in MetaMetrics. Defaults to false.
  * @param [options.needNavigateToNewPage] - Indicates whether to navigate to a new page before starting the onboarding flow. Defaults to true.
+ * @param [options.dataCollectionForMarketing] - Whether to opt in to data collection for marketing. Defaults to false.
  */
 export const completeCreateNewWalletOnboardingFlow = async ({
   driver,
   password = WALLET_PASSWORD,
   participateInMetaMetrics = false,
   needNavigateToNewPage = true,
+  dataCollectionForMarketing = false,
 }: {
   driver: Driver;
   password?: string;
   participateInMetaMetrics?: boolean;
   needNavigateToNewPage?: boolean;
+  dataCollectionForMarketing?: boolean;
 }): Promise<void> => {
   console.log('start to complete create new wallet onboarding flow ');
   await createNewWalletOnboardingFlow({
@@ -127,6 +136,7 @@ export const completeCreateNewWalletOnboardingFlow = async ({
     password,
     participateInMetaMetrics,
     needNavigateToNewPage,
+    dataCollectionForMarketing,
   });
   const onboardingCompletePage = new OnboardingCompletePage(driver);
   await onboardingCompletePage.check_pageIsLoaded();

--- a/test/e2e/page-objects/pages/onboarding/onboarding-metrics-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-metrics-page.ts
@@ -5,6 +5,9 @@ class OnboardingMetricsPage {
 
   private readonly iAgreeButton = '[data-testid="metametrics-i-agree"]';
 
+  private readonly dataCollectionForMarketingCheckbox =
+    '[data-testid="metametrics-data-collection-checkbox"]';
+
   private readonly metametricsMessage = {
     text: 'Help us improve MetaMask',
     tag: 'h2',
@@ -38,6 +41,10 @@ class OnboardingMetricsPage {
 
   async clickIAgreeButton(): Promise<void> {
     await this.driver.clickElementAndWaitToDisappear(this.iAgreeButton);
+  }
+
+  async clickDataCollectionForMarketingCheckbox(): Promise<void> {
+    await this.driver.clickElement(this.dataCollectionForMarketingCheckbox);
   }
 }
 

--- a/test/e2e/page-objects/pages/settings/security-and-privacy-settings.ts
+++ b/test/e2e/page-objects/pages/settings/security-and-privacy-settings.ts
@@ -1,0 +1,52 @@
+import { Driver } from '../../../webdriver/driver';
+import HeaderNavbar from '../header-navbar';
+import SettingsPage from './settings-page';
+
+class SecurityAndPrivacySettings {
+  private readonly driver: Driver;
+
+  private readonly securityAndPrivacySettingsPageTitle = {
+    text: 'Security & privacy',
+    tag: 'h4',
+  };
+
+  private readonly participateInMetaMetricsToggle =
+    '[data-testid="participate-in-meta-metrics-toggle"]';
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  async check_pageIsLoaded(): Promise<void> {
+    try {
+      await this.driver.waitForSelector(
+        this.securityAndPrivacySettingsPageTitle,
+      );
+    } catch (e) {
+      console.log(
+        'Timeout while waiting for Security and Privacy settings page to be loaded',
+        e,
+      );
+      throw e;
+    }
+    console.log('Security and Privacy settings page is loaded');
+  }
+
+  async navigateToPage() {
+    const headerNavbar = new HeaderNavbar(this.driver);
+    await headerNavbar.openSettingsPage();
+    const settingsPage = new SettingsPage(this.driver);
+    await settingsPage.check_pageIsLoaded();
+    await settingsPage.goToPrivacySettings();
+    await this.check_pageIsLoaded();
+  }
+
+  async toggleParticipateInMetaMetrics(): Promise<void> {
+    console.log(
+      'Toggle participate in meta metrics in Security and Privacy settings page',
+    );
+    await this.driver.clickElement(this.participateInMetaMetricsToggle);
+  }
+}
+
+export default SecurityAndPrivacySettings;

--- a/test/e2e/tests/metrics/metametrics-persistence.spec.js
+++ b/test/e2e/tests/metrics/metametrics-persistence.spec.js
@@ -49,7 +49,7 @@ describe('MetaMetrics ID persistence', function () {
 
         // toggle off
         await driver.clickElement(
-          '[data-testid="participateInMetaMetrics"] .toggle-button',
+          '[data-testid="participate-in-meta-metrics-toggle-button"]',
         );
 
         // wait for state to update
@@ -65,7 +65,7 @@ describe('MetaMetrics ID persistence', function () {
 
         // toggle back on
         await driver.clickElement(
-          '[data-testid="participateInMetaMetrics"] .toggle-button',
+          '[data-testid="participate-in-meta-metrics-toggle-button"]',
         );
 
         // wait for state to update

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -1,0 +1,165 @@
+import { strict as assert } from 'assert';
+import { Mockttp } from 'mockttp';
+import { getEventPayloads, withFixtures } from '../../helpers';
+import FixtureBuilder from '../../fixture-builder';
+import {
+  completeCreateNewWalletOnboardingFlow,
+  createNewWalletOnboardingFlow,
+} from '../../page-objects/flows/onboarding.flow';
+import SecurityAndPrivacySettings from '../../page-objects/pages/settings/security-and-privacy-settings';
+import { MOCK_META_METRICS_ID } from '../../constants';
+
+async function mockSegment(mockServer: Mockttp) {
+  return [
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'identify' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+  ];
+}
+
+describe('segment-user-traits', function () {
+  it('send identify event with traits during onboarding if user has opted in to participate in meta metrics and data collection', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true })
+          .withMetaMetricsController({
+            metaMetricsId: MOCK_META_METRICS_ID,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await createNewWalletOnboardingFlow({
+          driver,
+          participateInMetaMetrics: true,
+          dataCollectionForMarketing: true,
+        });
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(events[0].traits.has_marketing_consent, true);
+      },
+    );
+  });
+
+  it('send identify event with traits during onboarding if user has opted in to participate in meta metrics but not data collection', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true })
+          .withMetaMetricsController({
+            metaMetricsId: MOCK_META_METRICS_ID,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await createNewWalletOnboardingFlow({
+          driver,
+          participateInMetaMetrics: true,
+          dataCollectionForMarketing: false,
+        });
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(events[0].traits.has_marketing_consent, false);
+      },
+    );
+  });
+
+  it('will not send identify event with traits during onboarding if user has opted out of meta metrics and data collection', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true })
+          .withMetaMetricsController({
+            metaMetricsId: MOCK_META_METRICS_ID,
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await createNewWalletOnboardingFlow({
+          driver,
+          participateInMetaMetrics: false,
+          dataCollectionForMarketing: false,
+        });
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 0);
+      },
+    );
+  });
+
+  it('send identify event with traits after changing in privacy settings if user has opted out of meta metrics and data collection during onboarding', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true })
+          .withMetaMetricsController({
+            metaMetricsId: MOCK_META_METRICS_ID,
+            participateInMetaMetrics: false,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        let events = [];
+        await completeCreateNewWalletOnboardingFlow({
+          driver,
+          participateInMetaMetrics: false,
+        });
+        events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 0);
+        const securityAndPrivacySettings = new SecurityAndPrivacySettings(
+          driver,
+        );
+        await securityAndPrivacySettings.navigateToPage();
+        await securityAndPrivacySettings.toggleParticipateInMetaMetrics();
+        events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(events[0].traits.has_marketing_consent, false);
+      },
+    );
+  });
+
+  it('stop sending identify event with traits after opt out meta metrics in privacy settings if user has opted in to participate in meta metrics and data collection during onboarding', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true })
+          .withMetaMetricsController({
+            metaMetricsId: MOCK_META_METRICS_ID,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        let events = [];
+        await completeCreateNewWalletOnboardingFlow({
+          driver,
+          participateInMetaMetrics: true,
+          dataCollectionForMarketing: true,
+        });
+        events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+        const securityAndPrivacySettings = new SecurityAndPrivacySettings(
+          driver,
+        );
+        await securityAndPrivacySettings.navigateToPage();
+        await securityAndPrivacySettings.toggleParticipateInMetaMetrics();
+        events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+      },
+    );
+  });
+});

--- a/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.js.snap
+++ b/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.js.snap
@@ -101,6 +101,7 @@ exports[`Onboarding Metametrics Component should match snapshot 1`] = `
     </ul>
     <label
       class="mm-box mm-text mm-checkbox mm-text--body-md mm-box--padding-bottom-3 mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
+      data-testid="metametrics-data-collection-checkbox"
       for="metametrics-opt-in"
     >
       <span
@@ -256,6 +257,7 @@ exports[`Onboarding Metametrics Component should match snapshot after new policy
     </ul>
     <label
       class="mm-box mm-text mm-checkbox mm-text--body-md mm-box--padding-bottom-3 mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
+      data-testid="metametrics-data-collection-checkbox"
       for="metametrics-opt-in"
     >
       <span

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -101,7 +101,6 @@ export default function OnboardingMetametrics() {
 
   const onCancel = async () => {
     await dispatch(setParticipateInMetaMetrics(false));
-    await dispatch(setDataCollectionForMarketing(false));
     history.push(nextRoute);
   };
 
@@ -196,6 +195,7 @@ export default function OnboardingMetametrics() {
       </ul>
       <Checkbox
         id="metametrics-opt-in"
+        data-testid="metametrics-data-collection-checkbox"
         isChecked={dataCollectionForMarketing}
         onClick={() =>
           dispatch(setDataCollectionForMarketing(!dataCollectionForMarketing))

--- a/ui/pages/onboarding-flow/metametrics/metametrics.test.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.test.js
@@ -10,10 +10,7 @@ import {
   // TODO: Remove restricted import
   // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../app/_locales/en/messages.json';
-import {
-  setParticipateInMetaMetrics,
-  setDataCollectionForMarketing,
-} from '../../../store/actions';
+import { setParticipateInMetaMetrics } from '../../../store/actions';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import OnboardingMetametrics from './metametrics';
 
@@ -110,24 +107,6 @@ describe('Onboarding Metametrics Component', () => {
 
     await waitFor(() => {
       expect(setParticipateInMetaMetrics).toHaveBeenCalledWith(false);
-      expect(mockPushHistory).toHaveBeenCalledWith(
-        ONBOARDING_CREATE_PASSWORD_ROUTE,
-      );
-    });
-  });
-
-  it('should set setDataCollectionForMarketing to false when clicking cancel', async () => {
-    const { queryByText } = renderWithProvider(
-      <OnboardingMetametrics />,
-      mockStore,
-    );
-
-    const confirmCancel = queryByText(noThanks.message);
-
-    fireEvent.click(confirmCancel);
-
-    await waitFor(() => {
-      expect(setDataCollectionForMarketing).toHaveBeenCalledWith(false);
       expect(mockPushHistory).toHaveBeenCalledWith(
         ONBOARDING_CREATE_PASSWORD_ROUTE,
       );

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -1442,7 +1442,7 @@ exports[`Security Tab should match snapshot 1`] = `
           </div>
           <div
             class="settings-page__content-item-col"
-            data-testid="participateInMetaMetrics"
+            data-testid="participate-in-meta-metrics-toggle"
           >
             <label
               class="toggle-button toggle-button--off"
@@ -1469,7 +1469,7 @@ exports[`Security Tab should match snapshot 1`] = `
                   />
                 </div>
                 <input
-                  data-testid="toggleButton"
+                  data-testid="participate-in-meta-metrics-toggle-button"
                   style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
                   type="checkbox"
                   value="false"

--- a/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.test.tsx
+++ b/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.test.tsx
@@ -67,7 +67,7 @@ describe('MetametricsToggle', () => {
         />
       </Provider>,
     );
-    fireEvent.click(getByTestId('toggleButton'));
+    fireEvent.click(getByTestId('participate-in-meta-metrics-toggle-button'));
     expect(enableMetametricsMock).toHaveBeenCalled();
   });
 
@@ -82,7 +82,7 @@ describe('MetametricsToggle', () => {
         />
       </Provider>,
     );
-    fireEvent.click(getByTestId('toggleButton'));
+    fireEvent.click(getByTestId('participate-in-meta-metrics-toggle-button'));
     expect(disableMetametricsMock).toHaveBeenCalled();
   });
 });

--- a/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.tsx
+++ b/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.tsx
@@ -101,14 +101,14 @@ const MetametricsToggle = ({
 
         <div
           className="settings-page__content-item-col"
-          data-testid="participateInMetaMetrics"
+          data-testid="participate-in-meta-metrics-toggle"
         >
           <ToggleButton
             value={participateInMetaMetrics}
             onToggle={handleUseParticipateInMetaMetrics}
             offLabel={t('off')}
             onLabel={t('on')}
-            dataTestId="toggleButton"
+            dataTestId="participate-in-meta-metrics-toggle-button"
           />
         </div>
       </Box>

--- a/ui/pages/settings/security-tab/security-tab.test.js
+++ b/ui/pages/settings/security-tab/security-tab.test.js
@@ -131,7 +131,9 @@ describe('Security Tab', () => {
   });
 
   it('toggles metaMetrics', async () => {
-    expect(await toggleCheckbox('participateInMetaMetrics', false)).toBe(true);
+    expect(
+      await toggleCheckbox('participate-in-meta-metrics-toggle', false),
+    ).toBe(true);
   });
 
   it('toggles SRP Quiz', async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
User traits are not logged during onboarding (including the initial values, and any changes made during onboarding).
After following the steps https://github.com/MetaMask/MetaMask-planning/issues/3932#issuecomment-2604742483, The data changes are as follows:
- initialize the extension with default state
 `{participateInMetaMetrics : null, dataCollectionForMarketing: null}`
- during onboarding, when we change `participateInMetaMetrics` to false by clicking "No thanks", and state is `{participateInMetaMetrics : false, dataCollectionForMarketing: null}`
- after onboarding, user navigates to privacy settings, and toggle on "Participate in MetaMetrics", state is `{participateInMetaMetrics : true, dataCollectionForMarketing: null}`

=> the state of `dataCollectionForMarketing` is not changed from this action, hence the batch request will not include unchanged value `dataCollectionForMarketing`, which means `has_marketing_consent` is not going to be included in first identify call to segment.

Hence the solution is to modify the value of `dataCollectionForMarketing` to false in the state and the difference of state will be picked up and included in `traits` sent to segment in identify call.

You can find some e2e tests covering the situation in `test/e2e/tests/metrics/segment-user-traits.spec.ts`
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29865?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3932

## **Manual testing steps**

- Install the MetaMask extension
- Must use production build, or build with SEGMENT_WRITE_KEY and SEGMENT_HOST set
- See here for more information on how to set these in a dev build: https://github.com/MetaMask/metamask-extension/tree/main/development#debugging-with-the-mock-segment-api
- Open dev tools for the background process (background.html / service worker)
- In the dev tools networks tab, filter for Segment requests
- For a production build, filter to segment. For a dev build, filter to whatever you set for SEGMENT_HOST
- Proceed through onboarding, opting out of metametrics and marketing data consent
- After onboarding, go to privacy settings and enable "Participate in metametrics"
- You should see a request with `type: "identify"` to Segment, it comes with traits of `{has_marketing_consent : true, is_metrics_opted_in: false}`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://www.loom.com/share/9375153003c44231a65a685305ec1828?sid=c58f98f0-6fba-400f-8f96-8e53c316879f
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
