### PR TITLE
feat: Conditionally disable nonce editing when smart transactions are…

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/advanced-details/advanced-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/advanced-details/advanced-details.tsx
@@ -1,7 +1,7 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { TransactionMeta } from '@metamask/transaction-controller';
-
+import { getIsSmartTransaction } from '../../../../../../../../shared/modules/selectors';
 import {
   ConfirmInfoRow,
   ConfirmInfoRowText,
@@ -17,8 +17,8 @@ import {
   showModal,
   updateCustomNonce,
 } from '../../../../../../../store/actions';
-import { selectConfirmationAdvancedDetailsOpen } from '../../../../../selectors/preferences';
 import { useConfirmContext } from '../../../../../context/confirm';
+import { selectConfirmationAdvancedDetailsOpen } from '../../../../../selectors/preferences';
 import { isSignatureTransactionType } from '../../../../../utils';
 import { TransactionData } from '../transaction-data/transaction-data';
 
@@ -53,6 +53,7 @@ const NonceDetails = () => {
     );
 
   const displayedNonce = customNonceValue || nextNonce;
+  const isSmartTransactionsEnabled = useSelector(getIsSmartTransaction);
 
   return (
     <ConfirmInfoSection data-testid="advanced-details-nonce-section">
@@ -63,7 +64,9 @@ const NonceDetails = () => {
         <ConfirmInfoRowText
           data-testid="advanced-details-displayed-nonce"
           text={`${displayedNonce}`}
-          onEditClick={() => openEditNonceModal()}
+          onEditClick={
+            isSmartTransactionsEnabled ? undefined : () => openEditNonceModal()
+          }
           editIconClassName="edit-nonce-btn"
           editIconDataTestId="edit-nonce-icon"
         />


### PR DESCRIPTION
… enabled


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We [recently enabled custom nonce editing in all redesigned flows](https://github.com/MetaMask/metamask-extension/pull/29627/), independently of the custom nonce editing settings toggle. This toggle was still used in the legacy flows that are no longer visible by the user, and it will be removed soon in an upcoming PR.

This resulted in nonce editing being available for smart transactions which is not needed as the user should never need to manipulate nonces of smart transactions. This PR fixes this by removing that option to the user.

If smart transactions are enabled but the transaction is on a chain that doesn't currently support smart transactions, the nonce is still editable.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29891?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29841

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
