### PR TITLE
feat(snaps):Add disabled state for Snap UI interactive components

### DIFF
--- a/ui/components/app/snaps/snap-ui-checkbox/snap-ui-checkbox.tsx
+++ b/ui/components/app/snaps/snap-ui-checkbox/snap-ui-checkbox.tsx
@@ -22,6 +22,7 @@ export type SnapUICheckboxProps = {
   label?: string;
   error?: string;
   form?: string;
+  disabled?: boolean;
 };
 
 export const SnapUICheckbox: FunctionComponent<SnapUICheckboxProps> = ({
@@ -31,6 +32,7 @@ export const SnapUICheckbox: FunctionComponent<SnapUICheckboxProps> = ({
   label,
   error,
   form,
+  disabled,
   ...props
 }) => {
   const { handleInputChange, getValue } = useSnapInterfaceContext();
@@ -65,6 +67,7 @@ export const SnapUICheckbox: FunctionComponent<SnapUICheckboxProps> = ({
           value={value}
           onLabel={label}
           offLabel={label}
+          disabled={disabled}
           {...props}
         />
       ) : (
@@ -75,6 +78,7 @@ export const SnapUICheckbox: FunctionComponent<SnapUICheckboxProps> = ({
           inputProps={{
             borderColor: BorderColor.borderMuted,
           }}
+          isDisabled={disabled}
           {...props}
         />
       )}

--- a/ui/components/app/snaps/snap-ui-dropdown/snap-ui-dropdown.tsx
+++ b/ui/components/app/snaps/snap-ui-dropdown/snap-ui-dropdown.tsx
@@ -19,6 +19,7 @@ export type SnapUIDropdownProps = {
   error?: string;
   options: { name: string; value: string }[];
   form?: string;
+  disabled?: boolean;
 };
 
 export const SnapUIDropdown: FunctionComponent<SnapUIDropdownProps> = ({
@@ -26,6 +27,7 @@ export const SnapUIDropdown: FunctionComponent<SnapUIDropdownProps> = ({
   label,
   error,
   form,
+  disabled,
   ...props
 }) => {
   const { handleInputChange, getValue } = useSnapInterfaceContext();
@@ -61,6 +63,7 @@ export const SnapUIDropdown: FunctionComponent<SnapUIDropdownProps> = ({
         style={{
           border: '1px solid var(--color-border-muted)',
         }}
+        disabled={disabled}
         {...props}
       />
       {error && (

--- a/ui/components/app/snaps/snap-ui-file-input/index.scss
+++ b/ui/components/app/snaps/snap-ui-file-input/index.scss
@@ -2,6 +2,7 @@
   &__file-input {
     &__drop-zone {
       background-color: var(--color-background-alternative);
+      cursor: pointer;
 
       .mm-icon,
       .mm-text {

--- a/ui/components/app/snaps/snap-ui-file-input/snap-ui-file-input.tsx
+++ b/ui/components/app/snaps/snap-ui-file-input/snap-ui-file-input.tsx
@@ -42,6 +42,7 @@ export type SnapUIFileInputProps = {
   compact?: boolean;
   error?: boolean;
   helpText?: string;
+  disabled?: boolean;
 };
 
 /**
@@ -65,6 +66,7 @@ export type SnapUIFileInputProps = {
  * has an error, the help text is displayed in red.
  * @param props.helpText - The help text of the file input, which is displayed
  * below the file input field.
+ * @param props.disabled - Whether the file input is disabled.
  * @returns A file input element.
  */
 export const SnapUIFileInput: FunctionComponent<SnapUIFileInputProps> = ({
@@ -75,6 +77,7 @@ export const SnapUIFileInput: FunctionComponent<SnapUIFileInputProps> = ({
   compact,
   error,
   helpText,
+  disabled,
 }) => {
   const t = useI18nContext();
   const { handleFileChange } = useSnapInterfaceContext();
@@ -126,6 +129,7 @@ export const SnapUIFileInput: FunctionComponent<SnapUIFileInputProps> = ({
         onChange={handleChange}
         accept={accept?.join(',')}
         hidden={true}
+        disabled={disabled}
       />
     </>
   );
@@ -167,6 +171,7 @@ export const SnapUIFileInput: FunctionComponent<SnapUIFileInputProps> = ({
           borderRadius={BorderRadius.MD}
           onClick={handleClick}
           ariaLabel={t('uploadFile')}
+          disabled={disabled}
         />
         {footer}
       </Box>
@@ -183,7 +188,10 @@ export const SnapUIFileInput: FunctionComponent<SnapUIFileInputProps> = ({
     >
       {header}
       <Box
-        className="snap-ui-renderer__file-input__drop-zone"
+        className={classnames('snap-ui-renderer__file-input__drop-zone', {
+          'snap-ui-snap-ui-renderer__file-input__drop-zone--disabled':
+            disabled === true,
+        })}
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.center}
@@ -197,7 +205,6 @@ export const SnapUIFileInput: FunctionComponent<SnapUIFileInputProps> = ({
         borderWidth={1}
         borderRadius={BorderRadius.MD}
         style={{
-          cursor: 'pointer',
           backgroundColor: active
             ? 'var(--color-background-default-hover)'
             : 'var(--color-background-default)',

--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -17,7 +17,7 @@ export type SnapUIInputProps = {
 
 export const SnapUIInput: FunctionComponent<
   SnapUIInputProps & FormTextFieldProps<'div'>
-> = ({ name, form, label, ...props }) => {
+> = ({ name, form, label, disabled, ...props }) => {
   const { handleInputChange, getValue, focusedInput, setCurrentFocusedInput } =
     useSnapInterfaceContext();
 
@@ -63,6 +63,7 @@ export const SnapUIInput: FunctionComponent<
       value={value}
       onChange={handleChange}
       label={label}
+      disabled={disabled}
       {...props}
     />
   );

--- a/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
+++ b/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
@@ -70,11 +70,10 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
             disabled={disabled || option.disabled}
           />
           <Text
-            className={
-              disabled || option.disabled
-                ? 'snap-ui-renderer__radio-label--disabled'
-                : ''
-            }
+            className={classnames({
+              'snap-ui-renderer__radio-label--disabled':
+                disabled || option.disabled,
+            })}
             as="label"
             htmlFor={option.name}
             variant={TextVariant.bodyMd}

--- a/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
+++ b/ui/components/app/snaps/snap-ui-radio-group/snap-ui-radio-group.tsx
@@ -15,7 +15,11 @@ import {
   Text,
 } from '../../../component-library';
 
-export type SnapUIRadioOption = { value: string; name: string };
+export type SnapUIRadioOption = {
+  value: string;
+  name: string;
+  disabled: boolean;
+};
 
 export type SnapUIRadioGroupProps = {
   name: string;
@@ -23,6 +27,7 @@ export type SnapUIRadioGroupProps = {
   error?: string;
   options: SnapUIRadioOption[];
   form?: string;
+  disabled?: boolean;
 };
 
 export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
@@ -30,6 +35,7 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
   label,
   error,
   form,
+  disabled,
   ...props
 }) => {
   const { handleInputChange, getValue } = useSnapInterfaceContext();
@@ -61,8 +67,14 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
             checked={value === option.value}
             onChange={() => handleChange(option.value)}
             style={{ margin: '0' }} // radio buttons have default margins that need to be stripped to ensure proper centering
+            disabled={disabled || option.disabled}
           />
           <Text
+            className={
+              disabled || option.disabled
+                ? 'snap-ui-renderer__radio-label--disabled'
+                : ''
+            }
             as="label"
             htmlFor={option.name}
             variant={TextVariant.bodyMd}

--- a/ui/components/app/snaps/snap-ui-renderer/components/checkbox.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/checkbox.ts
@@ -11,6 +11,7 @@ export const checkbox: UIComponentFactory<CheckboxElement> = ({
     name: element.props.name,
     label: element.props.label,
     variant: element.props.variant,
+    disabled: element.props.disabled,
     form,
   },
 });

--- a/ui/components/app/snaps/snap-ui-renderer/components/dropdown.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/dropdown.ts
@@ -12,6 +12,7 @@ export const dropdown: UIComponentFactory<DropdownElement> = ({
   const options = children.map((child) => ({
     value: child.props.value,
     name: child.props.children,
+    disabled: child.props.disabled,
   }));
 
   return {

--- a/ui/components/app/snaps/snap-ui-renderer/components/dropdown.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/dropdown.ts
@@ -19,6 +19,7 @@ export const dropdown: UIComponentFactory<DropdownElement> = ({
     props: {
       id: element.props.name,
       name: element.props.name,
+      disabled: element.props.disabled,
       form,
       options,
     },

--- a/ui/components/app/snaps/snap-ui-renderer/components/field.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/field.ts
@@ -40,6 +40,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           form,
           error: element.props.error !== undefined,
           helpText: element.props.error,
+          disabled: child.props?.disabled,
         },
       };
     }
@@ -85,6 +86,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           form,
           error: element.props.error !== undefined,
           helpText: element.props.error,
+          disabled: child.props?.disabled,
         },
         propComponents: {
           startAccessory: leftAccessoryMapped && {
@@ -119,6 +121,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           name: dropdown.props.name,
           form,
           error: element.props.error,
+          disabled: child.props?.disabled,
         },
       };
     }
@@ -137,6 +140,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           name: radioGroup.props.name,
           form,
           error: element.props.error,
+          disabled: child.props?.disabled,
         },
       };
     }
@@ -153,6 +157,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           fieldLabel: element.props.label,
           form,
           error: element.props.error,
+          disabled: child.props?.disabled,
         },
       };
     }
@@ -171,6 +176,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           label: element.props.label,
           form,
           error: element.props.error,
+          disabled: child.props?.disabled,
         },
       };
     }

--- a/ui/components/app/snaps/snap-ui-renderer/components/field.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/field.ts
@@ -40,7 +40,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           form,
           error: element.props.error !== undefined,
           helpText: element.props.error,
-          disabled: child.props?.disabled,
+          disabled: child.props.disabled,
         },
       };
     }
@@ -86,7 +86,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           form,
           error: element.props.error !== undefined,
           helpText: element.props.error,
-          disabled: child.props?.disabled,
+          disabled: child.props.disabled,
         },
         propComponents: {
           startAccessory: leftAccessoryMapped && {
@@ -121,7 +121,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           name: dropdown.props.name,
           form,
           error: element.props.error,
-          disabled: child.props?.disabled,
+          disabled: child.props.disabled,
         },
       };
     }
@@ -140,7 +140,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           name: radioGroup.props.name,
           form,
           error: element.props.error,
-          disabled: child.props?.disabled,
+          disabled: child.props.disabled,
         },
       };
     }
@@ -157,7 +157,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           fieldLabel: element.props.label,
           form,
           error: element.props.error,
-          disabled: child.props?.disabled,
+          disabled: child.props.disabled,
         },
       };
     }
@@ -176,7 +176,7 @@ export const field: UIComponentFactory<FieldElement> = ({
           label: element.props.label,
           form,
           error: element.props.error,
-          disabled: child.props?.disabled,
+          disabled: child.props.disabled,
         },
       };
     }

--- a/ui/components/app/snaps/snap-ui-renderer/components/file-input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/file-input.ts
@@ -11,6 +11,7 @@ export const fileInput: UIComponentFactory<FileInputElement> = ({
     name: element.props.name,
     accept: element.props.accept,
     compact: element.props.compact,
+    disabled: element.props.disabled,
     form,
   },
 });

--- a/ui/components/app/snaps/snap-ui-renderer/components/input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/input.ts
@@ -42,6 +42,7 @@ export const input: UIComponentFactory<InputElement> = ({ element, form }) => {
     props: {
       id: element.props.name,
       placeholder: element.props.placeholder,
+      disabled: element.props.disabled,
       ...constructInputProps(element.props),
       name: element.props.name,
       form,

--- a/ui/components/app/snaps/snap-ui-renderer/components/radioGroup.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/radioGroup.ts
@@ -12,6 +12,7 @@ export const radioGroup: UIComponentFactory<RadioGroupElement> = ({
   const options = children.map((child) => ({
     value: child.props.value,
     name: child.props.children,
+    disabled: child.props.disabled,
   }));
 
   return {
@@ -19,6 +20,7 @@ export const radioGroup: UIComponentFactory<RadioGroupElement> = ({
     props: {
       id: element.props.name,
       name: element.props.name,
+      disabled: element.props.disabled,
       form,
       options,
     },

--- a/ui/components/app/snaps/snap-ui-renderer/components/selector.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/selector.ts
@@ -15,7 +15,12 @@ export const selector: UIComponentFactory<SelectorElement> = ({
 }) => {
   const children = getJsxChildren(element) as SelectorOptionElement[];
 
-  const options = children.map((child) => child.props.value);
+  const options = children.map((child) => {
+    return {
+      value: child.props.value,
+      disabled: child.props.disabled,
+    };
+  });
 
   const optionComponents = children.map((child) =>
     mapToTemplate({
@@ -31,6 +36,7 @@ export const selector: UIComponentFactory<SelectorElement> = ({
       id: element.props.name,
       name: element.props.name,
       title: element.props.title,
+      disabled: element.props.disabled,
       form,
       options,
     },

--- a/ui/components/app/snaps/snap-ui-renderer/index.scss
+++ b/ui/components/app/snaps/snap-ui-renderer/index.scss
@@ -89,3 +89,24 @@
     }
   }
 }
+
+// Additional adjustments for interactive components disabled states
+.snap-ui-renderer, .snap-ui-renderer__content {
+  [disabled] {
+    cursor: not-allowed !important;
+  }
+
+  .mm-text-field--disabled, .toggle-button--disabled, .toggle-button--disabled *div {
+    cursor: not-allowed;
+  }
+
+  // Override DS text field component's disabled state (we deliberately do not want to adjust opacity on labels)
+  .mm-form-text-field--disabled label {
+    opacity: 1;
+  }
+}
+
+.snap-ui-snap-ui-renderer__file-input__drop-zone--disabled, .snap-ui-renderer__radio-label--disabled {
+  opacity: 0.5;
+  cursor: not-allowed !important;
+}

--- a/ui/components/app/snaps/snap-ui-renderer/index.scss
+++ b/ui/components/app/snaps/snap-ui-renderer/index.scss
@@ -91,12 +91,15 @@
 }
 
 // Additional adjustments for interactive components disabled states
-.snap-ui-renderer, .snap-ui-renderer__content {
+.snap-ui-renderer,
+.snap-ui-renderer__content {
   [disabled] {
     cursor: not-allowed !important;
   }
 
-  .mm-text-field--disabled, .toggle-button--disabled, .toggle-button--disabled *div {
+  .mm-text-field--disabled,
+  .toggle-button--disabled,
+  .toggle-button--disabled *div {
     cursor: not-allowed;
   }
 
@@ -106,7 +109,8 @@
   }
 }
 
-.snap-ui-snap-ui-renderer__file-input__drop-zone--disabled, .snap-ui-renderer__radio-label--disabled {
+.snap-ui-snap-ui-renderer__file-input__drop-zone--disabled,
+.snap-ui-renderer__radio-label--disabled {
   opacity: 0.5;
   cursor: not-allowed !important;
 }

--- a/ui/components/app/snaps/snap-ui-selector/snap-ui-selector.tsx
+++ b/ui/components/app/snaps/snap-ui-selector/snap-ui-selector.tsx
@@ -34,7 +34,7 @@ import { useSnapInterfaceContext } from '../../../../contexts/snaps';
 export type SnapUISelectorProps = {
   name: string;
   title: string;
-  options: string[];
+  options: [{ value: string; disabled: boolean }];
   optionComponents: React.ReactNode[];
   form?: string;
   label?: string;
@@ -46,12 +46,14 @@ type SelectorItemProps = {
   value: string;
   children: React.ReactNode;
   onSelect: (value: string) => void;
+  disabled?: boolean;
 };
 
 const SelectorItem: React.FunctionComponent<SelectorItemProps> = ({
   value,
   children,
   onSelect,
+  disabled,
 }) => {
   const handleClick = () => {
     onSelect(value);
@@ -79,6 +81,7 @@ const SelectorItem: React.FunctionComponent<SelectorItemProps> = ({
         minHeight: '48px',
         maxHeight: '64px',
       }}
+      disabled={disabled}
     >
       {children}
     </ButtonBase>
@@ -122,7 +125,7 @@ export const SnapUISelector: React.FunctionComponent<SnapUISelectorProps> = ({
   };
 
   const selectedOptionIndex = options.findIndex(
-    (option) => option === selectedOptionValue,
+    (option) => option.value === selectedOptionValue,
   );
 
   const selectedOption = optionComponents[selectedOptionIndex];
@@ -193,7 +196,11 @@ export const SnapUISelector: React.FunctionComponent<SnapUISelectorProps> = ({
               gap={2}
             >
               {optionComponents.map((component, index) => (
-                <SelectorItem value={options[index]} onSelect={handleSelect}>
+                <SelectorItem
+                  value={options[index].value}
+                  disabled={options[index]?.disabled}
+                  onSelect={handleSelect}
+                >
                   {component}
                 </SelectorItem>
               ))}

--- a/ui/components/ui/dropdown/dropdown.js
+++ b/ui/components/ui/dropdown/dropdown.js
@@ -35,7 +35,11 @@ const Dropdown = ({
       >
         {options.map((option) => {
           return (
-            <option key={option.value} value={option.value}>
+            <option
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+            >
               {option.name || option.value}
             </option>
           );


### PR DESCRIPTION
## **Description**
This PR integrates new Snaps UI feature for disabling interactive UI components.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29896?quickstart=1)

## **Related issues**
Fixes: https://github.com/MetaMask/metamask-extension/issues/29669

## **Related Pull Requests**
https://github.com/MetaMask/snaps/pull/3030

## **Manual testing steps**
1. Make new Snap with custom UI using interactive UI components specified in the task linked under "related issues".
2. Add flag `disabled={true}` to these components.
3. Check that components with `disabled` flag are not clickable and their styling is different (opacity 0.5).

## **Screenshots/Recordings**
### **Before**
`disabled` state was not available before, nothing to show here.

### **After**
![Screenshot 2025-01-24 at 16 35 56](https://github.com/user-attachments/assets/b7f55722-9865-4ec6-8069-6dfb2c13b354)

https://github.com/user-attachments/assets/5c8a0404-a7d6-49f1-8e8d-041daaa3b09b

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
