### PR TITLE
fix: don't reject valid bridge statuses of failed with empty token obj

### DIFF
--- a/app/scripts/controllers/bridge-status/validators.test.ts
+++ b/app/scripts/controllers/bridge-status/validators.test.ts
@@ -204,6 +204,16 @@ const BridgeTxStatusResponses = {
     isExpectedToken: true,
     bridge: 'across',
   },
+  STATUS_FAILED_VALID: {
+    status: 'FAILED',
+    bridge: 'across',
+    srcChain: {
+      chainId: 42161,
+      txHash:
+        '0x4c57876fad21fb5149af5a58a4aba2ca9d6b212014505dd733b75667ca4f0f2b',
+      token: {},
+    },
+  },
 };
 
 describe('validators', () => {
@@ -249,6 +259,11 @@ describe('validators', () => {
         input: BridgeTxStatusResponses.STATUS_COMPLETE_VALID_MISSING_FIELDS,
         expected: true,
         description: 'complete bridge status with missing fields',
+      },
+      {
+        input: BridgeTxStatusResponses.STATUS_FAILED_VALID,
+        expected: true,
+        description: 'valid failed bridge status',
       },
       {
         input: undefined,

--- a/app/scripts/controllers/bridge-status/validators.ts
+++ b/app/scripts/controllers/bridge-status/validators.ts
@@ -87,7 +87,9 @@ const srcChainStatusValidators = [
     property: 'token',
     type: 'object|undefined',
     validator: (v: unknown): v is object | undefined =>
-      v === undefined || assetValidator(v),
+      v === undefined ||
+      (v && typeof v === 'object' && Object.keys(v).length === 0) ||
+      assetValidator(v),
   },
 ];
 

--- a/shared/types/bridge-status.ts
+++ b/shared/types/bridge-status.ts
@@ -48,7 +48,7 @@ export type SrcChainStatus = {
   chainId: ChainId;
   txHash?: string; // might be undefined if this is a smart transaction (STX)
   amount?: string;
-  token?: Asset;
+  token?: Record<string, never> | Asset;
 };
 
 export type DestChainStatus = {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29901?quickstart=1)

This PR fixes a case where a valid Bridge status API response of a Failed tx was being rejected by the response validators.

Since these Failed responses were being rejected, the client will continue to poll since it still thinks the tx is Pending.

## **Related issues**

Fixes:

## **Manual testing steps**

It's not that easy to trigger a Failed status from the Bridge API. 

Instead you can run the tests and confirm that they pass given the data object from this example url: https://bridge.dev-api.cx.metamask.io/getTxStatus?bridgeId=lifi&srcTxHash=0x0473533d91fff15fa47fbef663c632b531612e2ad0ef92c65005051f715f7425&bridge=across&srcChainId=42161&destChainId=10&refuel=false&requestId=141abf51-de4c-4017-855a-1aad583e5352

The updated validators should pass.

`yarn jest app/scripts/controllers/bridge-status/validators.test.ts`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
