### PR TITLE
Issue #29847: Removed and edited the code for useExternalServices check for isDecodeSignatureRequestEnabled

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1973,7 +1973,6 @@ export default class MetamaskController extends EventEmitter {
       trace,
       decodingApiUrl: process.env.DECODING_API_URL,
       isDecodeSignatureRequestEnabled: () =>
-        this.preferencesController.state.useExternalServices === true &&
         this.preferencesController.state.useTransactionSimulations,
     });
 


### PR DESCRIPTION
## **Description**

This pull request removes the useExternalServices check from the isDecodeSignatureRequestEnabled function in the metamask-controller.

## Reason for the change

The decoder API is an internal service and does not interact with any external services. As a result, the useExternalServices check is unnecessary.

## improvement/solution?

- Updated the isDecodeSignatureRequestEnabled function to only check the useTransactionSimulations state.
- This ensures the function logic aligns with the intended design, improving maintainability and reducing unnecessary checks.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29909?quickstart=1)

## **Related issues**

Fixes: #29847


## **Manual testing steps**

1. Open MetaMask and navigate to the relevant settings page.
2. Enable/disable Transaction Simulations in the preferences.
3. Observe if the decoder functionality behaves as expected.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2025-01-23 221420](https://github.com/user-attachments/assets/d4863bdf-1119-46e9-a06c-f26458f94f1e)


### **After**

![Screenshot 2025-01-23 221336](https://github.com/user-attachments/assets/2e2fb6f8-5d34-49d7-b58f-e88e279d68a5)


## **Pre-merge author checklist**

- [ x ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ x ] I've completed the PR template to the best of my ability
- [ x ] I’ve included tests if applicable
- [ x ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ x ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ x ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ x ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
