### PR TITLE
fix: missing smart transaction messenger actions

### DIFF
--- a/app/scripts/controller-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/transaction-controller-messenger.ts
@@ -87,6 +87,10 @@ export function getTransactionControllerInitMessenger(
       'SmartTransactionsController:smartTransaction',
     ],
     allowedActions: [
+      'ApprovalController:addRequest',
+      'ApprovalController:endFlow',
+      'ApprovalController:startFlow',
+      'ApprovalController:updateRequestState',
       'NetworkController:getEIP1559Compatibility',
       'SwapsController:setApproveTxId',
       'SwapsController:setTradeTxId',


### PR DESCRIPTION
## **Description**

Fix smart transactions by adding additional messenger actions to the `TransactionController` init messenger which is used by the smart transaction publish hook.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29913?quickstart=1)

## **Related issues**

## **Manual testing steps**

Send smart transaction.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
