### PR TITLE
fix: fix undici audit (5.28.4 -> 5.28.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,8 @@
     "tslib@npm:^2.3.0": "~2.6.0",
     "tslib@npm:^2.3.1": "~2.6.0",
     "tslib@npm:^2.4.0": "~2.6.0",
-    "tslib@npm:^2.6.2": "~2.6.0"
+    "tslib@npm:^2.6.2": "~2.6.0",
+    "undici@npm:5.28.4": "5.28.5"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36255,12 +36255,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:5.28.4":
-  version: 5.28.4
-  resolution: "undici@npm:5.28.4"
+"undici@npm:5.28.5":
+  version: 5.28.5
+  resolution: "undici@npm:5.28.5"
   dependencies:
     "@fastify/busboy": "npm:^2.0.0"
-  checksum: 10/a666a9f5ac4270c659fafc33d78b6b5039a0adbae3e28f934774c85dcc66ea91da907896f12b414bd6f578508b44d5dc206fa636afa0e49a4e1c9e99831ff065
+  checksum: 10/459cd84ab75fe90d696fa2634a8b5b23f9e1080b27236c6809bd74e51862be85df6d95b4a8fed3ee42554495008cb3c05f1bc9d4a1807478f433cca567003d70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

```console
$ yarn audit
└─ undici
   ├─ ID: 1101610
   ├─ Issue: Use of Insufficiently Random Values in undici
   ├─ URL: https://github.com/advisories/GHSA-c76h-2ccp-4975
   ├─ Severity: moderate
   ├─ Vulnerable Versions: >=4.5.0 <5.28.5
   │
   ├─ Tree Versions
   │  └─ 5.28.4
   │
   └─ Dependents
      └─ @firebase/auth-compat@npm:0.5.6 [35f05]
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29914?quickstart=1)

## **Related issues**

Fixes: https://github.com/advisories/GHSA-c76h-2ccp-4975

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
