### PR TITLE
fix: reapply the fix for seeing you received when bridge tx not finished

### DIFF
--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -410,24 +410,27 @@ const CrossChainSwapTxDetails = () => {
                 </Box>
               }
             />
-            <TransactionDetailRow
-              title={t('bridgeTxDetailsYouReceived')}
-              value={
-                <Box
-                  display={Display.Flex}
-                  gap={1}
-                  alignItems={AlignItems.center}
-                  flexWrap={FlexWrap.Wrap}
-                  justifyContent={JustifyContent.flexEnd}
-                >
-                  {t('bridgeTxDetailsTokenAmountOnChain', [
-                    bridgeAmountReceived,
-                    bridgeHistoryItem?.quote.destAsset.symbol,
-                  ])}
-                  {destNetworkIconName}
-                </Box>
-              }
-            />
+            {bridgeAmountReceived &&
+              bridgeHistoryItem?.quote.destAsset.symbol && (
+                <TransactionDetailRow
+                  title={t('bridgeTxDetailsYouReceived')}
+                  value={
+                    <Box
+                      display={Display.Flex}
+                      gap={1}
+                      alignItems={AlignItems.center}
+                      flexWrap={FlexWrap.Wrap}
+                      justifyContent={JustifyContent.flexEnd}
+                    >
+                      {t('bridgeTxDetailsTokenAmountOnChain', [
+                        bridgeAmountReceived,
+                        bridgeHistoryItem?.quote.destAsset.symbol,
+                      ])}
+                      {destNetworkIconName}
+                    </Box>
+                  }
+                />
+              )}
             <TransactionDetailRow
               title={t('bridgeTxDetailsTotalGasFee')}
               value={


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29933?quickstart=1)

This PR reapplies the fixes from #29411.

This PR fixes an issue where the "You Received" row in the Activity item for a bridge tx would be partially filled in. Now we just hide it until the bridge tx completes and we have all the necessary data to display the row properly.

## **Related issues**

Reapplies the fixes from #29411

## **Manual testing steps**

1. Start a bridge tx
1. Get navigated to Activity list
1. Click on bridge tx
1. Observe that "You received" is not present until the bridge is completed.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/8536e6c7-34c1-49a3-a692-7e7acbcf5994



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
