### PR TITLE
fix: Apply proper border radius to `SnapUICard` image

### DIFF
--- a/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
+++ b/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
@@ -44,7 +44,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
             width="32px"
             height="32px"
             value={image}
-            style={{ borderRadius: '999px' }}
+            borderRadius="999px"
           />
         )}
         <Box


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an issue where border-radius wouldn't be properly applied to the image in a `SnapUICard` following a recent change to `SnapUIImage`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29941?quickstart=1)

## **Manual testing steps**

```ts
import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
import { Box, Card } from '@metamask/snaps-sdk/jsx';

/**
 * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
 *
 * @param args - The request handler args as object.
 * @param args.origin - The origin of the request, e.g., the website that
 * invoked the snap.
 * @param args.request - A validated JSON-RPC request object.
 * @returns The result of `snap_dialog`.
 * @throws If the request method is not valid for this snap.
 */
export const onRpcRequest: OnRpcRequestHandler = async ({
  origin,
  request,
}) => {
  switch (request.method) {
    case 'hello':
      return snap.request({
        method: 'snap_dialog',
        params: {
          type: 'confirmation',
          content: (
            <Box>
              <Card
                image={`
                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
                    <rect x="0" y="0" width="500" height="500" style="fill: rgb(255, 0, 0); stroke: rgb(0, 0, 0);"></rect>
                  </svg>`}
                title="Title"
                description="Description"
                value="$1200"
                extra="0.12 ETH"
              />
            </Box>
          ),
        },
      });
    default:
      throw new Error('Method not found.');
  }
};

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/541bfd8c-6199-49f6-a0a9-412a2240d263)


### **After**

![image](https://github.com/user-attachments/assets/522b8861-712e-4f48-b535-b7236d853bd2)
