### PR TITLE
fix: replicate network change actions in rpc modal

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -252,16 +252,58 @@ export const NetworkListMenu = ({ onClose }: { onClose: () => void }) => {
     ...searchedTestNetworks,
   ].some((network) => network.rpcEndpoints.length > 1);
 
+  const handleNetworkChange = (network: NetworkConfiguration) => {
+    const allOpts = Object.keys(allNetworks).reduce((acc, chainId) => {
+      acc[chainId] = true;
+      return acc;
+    }, {} as Record<string, boolean>);
+
+    const { networkClientId } =
+      network.rpcEndpoints[network.defaultRpcEndpointIndex];
+    dispatch(setActiveNetwork(networkClientId));
+    dispatch(toggleNetworkMenu());
+    dispatch(updateCustomNonce(''));
+    dispatch(setNextNonce(''));
+    dispatch(detectNfts());
+
+    // as a user, I don't want my network selection to force update my filter when I have "All Networks" toggled on
+    // however, if I am already filtered on "Current Network", we'll want to filter by the selected network when the network changes
+    if (Object.keys(tokenNetworkFilter || {}).length <= 1) {
+      dispatch(setTokenNetworkFilter({ [network.chainId]: true }));
+    } else if (process.env.PORTFOLIO_VIEW) {
+      dispatch(setTokenNetworkFilter(allOpts));
+    }
+
+    if (permittedAccountAddresses.length > 0) {
+      dispatch(addPermittedChain(selectedTabOrigin, network.chainId));
+      if (!permittedChainIds.includes(network.chainId)) {
+        dispatch(showPermittedNetworkToast());
+      }
+    }
+    // If presently on a dapp, communicate a change to
+    // the dapp via silent switchEthereumChain that the
+    // network has changed due to user action
+    if (selectedTabOrigin && domains[selectedTabOrigin]) {
+      setNetworkClientIdForDomain(selectedTabOrigin, networkClientId);
+    }
+
+    trackEvent({
+      event: MetaMetricsEventName.NavNetworkSwitched,
+      category: MetaMetricsEventCategory.Network,
+      properties: {
+        location: 'Network Menu',
+        chain_id: currentChainId,
+        from_network: currentChainId,
+        to_network: network.chainId,
+      },
+    });
+  };
+
   // Renders a network in the network list
   const generateNetworkListItem = (network: NetworkConfiguration) => {
     const isCurrentNetwork = network.chainId === currentChainId;
     const canDeleteNetwork =
       isUnlocked && !isCurrentNetwork && network.chainId !== CHAIN_IDS.MAINNET;
-
-    const allOpts: Record<string, boolean> = {};
-    Object.keys(allNetworks).forEach((chainId) => {
-      allOpts[chainId] = true;
-    });
 
     return (
       <NetworkListItem
@@ -282,45 +324,7 @@ export const NetworkListMenu = ({ onClose }: { onClose: () => void }) => {
         selected={isCurrentNetwork && !focusSearch}
         focus={isCurrentNetwork && !focusSearch}
         onClick={() => {
-          const { networkClientId } =
-            network.rpcEndpoints[network.defaultRpcEndpointIndex];
-          dispatch(setActiveNetwork(networkClientId));
-          dispatch(toggleNetworkMenu());
-          dispatch(updateCustomNonce(''));
-          dispatch(setNextNonce(''));
-          dispatch(detectNfts());
-
-          // as a user, I don't want my network selection to force update my filter when I have "All Networks" toggled on
-          // however, if I am already filtered on "Current Network", we'll want to filter by the selected network when the network changes
-          if (Object.keys(tokenNetworkFilter || {}).length <= 1) {
-            dispatch(setTokenNetworkFilter({ [network.chainId]: true }));
-          } else if (process.env.PORTFOLIO_VIEW) {
-            dispatch(setTokenNetworkFilter(allOpts));
-          }
-
-          if (permittedAccountAddresses.length > 0) {
-            dispatch(addPermittedChain(selectedTabOrigin, network.chainId));
-            if (!permittedChainIds.includes(network.chainId)) {
-              dispatch(showPermittedNetworkToast());
-            }
-          }
-          // If presently on a dapp, communicate a change to
-          // the dapp via silent switchEthereumChain that the
-          // network has changed due to user action
-          if (selectedTabOrigin && domains[selectedTabOrigin]) {
-            setNetworkClientIdForDomain(selectedTabOrigin, networkClientId);
-          }
-
-          trackEvent({
-            event: MetaMetricsEventName.NavNetworkSwitched,
-            category: MetaMetricsEventCategory.Network,
-            properties: {
-              location: 'Network Menu',
-              chain_id: currentChainId,
-              from_network: currentChainId,
-              to_network: network.chainId,
-            },
-          });
+          handleNetworkChange(network);
         }}
         onDeleteClick={
           canDeleteNetwork
@@ -559,6 +563,7 @@ export const NetworkListMenu = ({ onClose }: { onClose: () => void }) => {
       return (
         <SelectRpcUrlModal
           networkConfiguration={networkConfigurations[editedNetwork.chainId]}
+          onNetworkChange={handleNetworkChange}
         />
       );
     }

--- a/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.test.tsx
+++ b/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.test.tsx
@@ -19,6 +19,8 @@ jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
 }));
 
+const mockOnNetworkChange = jest.fn();
+
 jest.mock('../../../../store/actions', () => ({
   updateNetwork: jest.fn(),
   setActiveNetwork: jest.fn(),
@@ -51,7 +53,10 @@ describe('SelectRpcUrlModal Component', () => {
 
   it('renders select rpc url', () => {
     const { container } = renderWithProvider(
-      <SelectRpcUrlModal networkConfiguration={networkConfiguration} />,
+      <SelectRpcUrlModal
+        networkConfiguration={networkConfiguration}
+        onNetworkChange={mockOnNetworkChange}
+      />,
       store,
     );
     expect(container).toMatchSnapshot();
@@ -59,7 +64,10 @@ describe('SelectRpcUrlModal Component', () => {
 
   it('should render the component correctly with network image and name', () => {
     const { getByRole, getByText } = renderWithProvider(
-      <SelectRpcUrlModal networkConfiguration={networkConfiguration} />,
+      <SelectRpcUrlModal
+        networkConfiguration={networkConfiguration}
+        onNetworkChange={mockOnNetworkChange}
+      />,
       store,
     );
 
@@ -77,7 +85,10 @@ describe('SelectRpcUrlModal Component', () => {
 
   it('should render all RPC endpoints and highlight the selected one', () => {
     const { getByText } = renderWithProvider(
-      <SelectRpcUrlModal networkConfiguration={networkConfiguration} />,
+      <SelectRpcUrlModal
+        networkConfiguration={networkConfiguration}
+        onNetworkChange={mockOnNetworkChange}
+      />,
       store,
     );
 
@@ -94,7 +105,10 @@ describe('SelectRpcUrlModal Component', () => {
 
   it('should dispatch the correct actions when an RPC endpoint is clicked', () => {
     const { getByText } = renderWithProvider(
-      <SelectRpcUrlModal networkConfiguration={networkConfiguration} />,
+      <SelectRpcUrlModal
+        networkConfiguration={networkConfiguration}
+        onNetworkChange={mockOnNetworkChange}
+      />,
       store,
     );
 
@@ -116,7 +130,10 @@ describe('SelectRpcUrlModal Component', () => {
 
   it('should render the selected indicator correctly for the default RPC', () => {
     const { container } = renderWithProvider(
-      <SelectRpcUrlModal networkConfiguration={networkConfiguration} />,
+      <SelectRpcUrlModal
+        networkConfiguration={networkConfiguration}
+        onNetworkChange={mockOnNetworkChange}
+      />,
       store,
     );
 
@@ -128,7 +145,10 @@ describe('SelectRpcUrlModal Component', () => {
 
   it('should render the modal with a network image', () => {
     renderWithProvider(
-      <SelectRpcUrlModal networkConfiguration={networkConfiguration} />,
+      <SelectRpcUrlModal
+        networkConfiguration={networkConfiguration}
+        onNetworkChange={mockOnNetworkChange}
+      />,
       store,
     );
 
@@ -142,9 +162,17 @@ describe('SelectRpcUrlModal Component', () => {
     );
   });
 
-  it('should handle click on RPC URL and update the network', () => {
+  it('should handle click on RPC URL and call onNetworkChange', () => {
+    const updatedNetwork = {
+      ...networkConfiguration,
+      defaultRpcEndpointIndex: 1,
+    };
+
     renderWithProvider(
-      <SelectRpcUrlModal networkConfiguration={networkConfiguration} />,
+      <SelectRpcUrlModal
+        networkConfiguration={networkConfiguration}
+        onNetworkChange={mockOnNetworkChange}
+      />,
       store,
     );
 
@@ -152,16 +180,8 @@ describe('SelectRpcUrlModal Component', () => {
       screen.getByText(stripProtocol(networkConfiguration.rpcEndpoints[1].url)),
     );
 
-    expect(mockDispatch).toHaveBeenCalledWith(
-      updateNetwork({
-        ...networkConfiguration,
-        defaultRpcEndpointIndex: 1,
-      }),
-    );
-    expect(mockDispatch).toHaveBeenCalledWith(
-      setActiveNetwork(networkConfiguration.rpcEndpoints[1].networkClientId),
-    );
+    expect(mockDispatch).toHaveBeenCalledWith(updateNetwork(updatedNetwork));
     expect(mockDispatch).toHaveBeenCalledWith(setEditedNetwork());
-    expect(mockDispatch).toHaveBeenCalledWith(toggleNetworkMenu());
+    expect(mockOnNetworkChange).toHaveBeenCalledWith(updatedNetwork);
   });
 });

--- a/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.tsx
+++ b/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.tsx
@@ -17,18 +17,15 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../shared/constants/network';
-import {
-  setActiveNetwork,
-  setEditedNetwork,
-  toggleNetworkMenu,
-  updateNetwork,
-} from '../../../../store/actions';
+import { setEditedNetwork, updateNetwork } from '../../../../store/actions';
 import RpcListItem from '../rpc-list-item';
 
 export const SelectRpcUrlModal = ({
   networkConfiguration,
+  onNetworkChange,
 }: {
   networkConfiguration: NetworkConfiguration;
+  onNetworkChange: (network: NetworkConfiguration) => void;
 }) => {
   const dispatch = useDispatch();
 
@@ -69,15 +66,13 @@ export const SelectRpcUrlModal = ({
           display={Display.Flex}
           key={rpcEndpoint.url}
           onClick={() => {
-            dispatch(
-              updateNetwork({
-                ...networkConfiguration,
-                defaultRpcEndpointIndex: index,
-              }),
-            );
-            dispatch(setActiveNetwork(rpcEndpoint.networkClientId));
+            const network = {
+              ...networkConfiguration,
+              defaultRpcEndpointIndex: index,
+            };
+            dispatch(updateNetwork(network));
             dispatch(setEditedNetwork());
-            dispatch(toggleNetworkMenu());
+            onNetworkChange(network);
           }}
           className={classnames('select-rpc-url__item', {
             'select-rpc-url__item--selected':


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The issue occurred because switching networks from the RPC selector, which is only available when there's a network with at least 2 RPCs, was not performing the same actions as switching networks from clicking the network list item directly.

I have created a handler for the actions that need to be performed and passed it down to both the network list item and the rpc selector modal, that way it ensures that the same actions occur.

A test has been added to the rpc modal to validate the new handler is being called. Tests already exist in the network list to validate that those actions are taking place, and they are still passing.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29943?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29260

## **Manual testing steps**

1. Ensure at least one of your networks has more than one RPC, so that the RPC selector appears.
2. Set any network and, in the Tokens tab, select "Current network" as the option.
3. Open the network selector and select another network by clicking in the rpc url, which will open an rpc selector modal.
4. Select any of the RPCs and check that the tokens from the new network appear and that "Current network" is still 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/3ac163d3-4f2e-4170-81f4-f3b4ccc8e3d3



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/7dc02f85-42e0-449e-a419-cc74fc936de7



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
