### PR TITLE
ci: Take DOM snapshots of all windows on failure

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1260,16 +1260,17 @@ class Driver {
         await this.driver.switchTo().window(handle);
 
         const htmlSource = await this.driver.getPageSource();
-        await fs.writeFile(`${filepathBase}-dom-${windowNumber}.html`, htmlSource);
+        await fs.writeFile(
+          `${filepathBase}-dom-${windowNumber}.html`,
+          htmlSource,
+        );
       }
     } catch (e) {
       console.error('Failed to capture DOM snapshot', e);
     }
 
-
     // We want to take a state snapshot of the app if possible, this is useful for debugging
     try {
-      const windowHandles = await this.driver.getAllWindowHandles();
       for (const handle of windowHandles) {
         await this.driver.switchTo().window(handle);
         const uiState = await this.driver.executeScript(

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1227,12 +1227,13 @@ class Driver {
 
     const filepathBase = `${artifactDir(title)}/test-failure`;
     await fs.mkdir(artifactDir(title), { recursive: true });
+
+    const windowHandles = await this.driver.getAllWindowHandles();
     // On occasion there may be a bug in the offscreen document which does
     // not render visibly to the user and therefore no screenshot can be
     // taken. In this case we skip the screenshot and log the error.
     try {
       // If there's more than one tab open, we want to iterate through all of them and take a screenshot with a unique name
-      const windowHandles = await this.driver.getAllWindowHandles();
       for (const handle of windowHandles) {
         await this.driver.switchTo().window(handle);
         const windowTitle = await this.driver.getTitle();
@@ -1252,8 +1253,19 @@ class Driver {
     } catch (e) {
       console.error('Failed to take screenshot', e);
     }
-    const htmlSource = await this.driver.getPageSource();
-    await fs.writeFile(`${filepathBase}-dom.html`, htmlSource);
+
+    try {
+      for (const handle of windowHandles) {
+        const windowNumber = windowHandles.indexOf(handle) + 1;
+        await this.driver.switchTo().window(handle);
+
+        const htmlSource = await this.driver.getPageSource();
+        await fs.writeFile(`${filepathBase}-dom-${windowNumber}.html`, htmlSource);
+      }
+    } catch (e) {
+      console.error('Failed to capture DOM snapshot', e);
+    }
+
 
     // We want to take a state snapshot of the app if possible, this is useful for debugging
     try {


### PR DESCRIPTION
## **Description**

Our e2e test tooling takes a DOM snapshot on test failure to help with debugging. Unfortunately this is not overly useful right now because the driver is always set to the last window handle when this snapshot is taken, which is typically the offscreen document (at least on Chrome). Even on Firefox where there is no offscreen document, it may end up taking a snapshot of the wrong page when there are multiple open.

The DOM snapshot step has been updated to take snapshots of all open pages, rather than just the "current" one.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/29983?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

See the DOM snapshot artifacts in CircleCI upon failure

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
