### PR TITLE
fix: Display mailto links properly in Snaps link warning

### DIFF
--- a/ui/components/app/snaps/snap-link-warning/snap-link-warning.js
+++ b/ui/components/app/snaps/snap-link-warning/snap-link-warning.js
@@ -35,8 +35,10 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 export default function SnapLinkWarning({ isOpen, onClose, url }) {
   const t = useI18nContext();
 
-  const parsedUrl = url && new URL(url);
-  const urlParts = parsedUrl && url.split(parsedUrl.host);
+  const parsedUrl = new URL(url);
+  const isHTTPS = parsedUrl.protocol === 'https:';
+  const urlParts = url.split(parsedUrl.host);
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -85,17 +87,21 @@ export default function SnapLinkWarning({ isOpen, onClose, url }) {
             paddingLeft={4}
             width={BlockSize.Full}
           >
-            {parsedUrl && (
-              <Text
-                ellipsis
-                style={{ overflow: 'hidden' }}
-                color={TextColor.primaryDefault}
-              >
-                {urlParts[0]}
-                <b>{parsedUrl.host}</b>
-                {urlParts[1]}
-              </Text>
-            )}
+            <Text
+              ellipsis
+              style={{ overflow: 'hidden' }}
+              color={TextColor.primaryDefault}
+            >
+              {isHTTPS ? (
+                <>
+                  {urlParts[0]}
+                  <b>{parsedUrl.host}</b>
+                  {urlParts[1]}
+                </>
+              ) : (
+                url
+              )}
+            </Text>
             <Icon
               name={IconName.Export}
               color={IconColor.iconAlternative}

--- a/ui/components/app/snaps/snap-link-warning/snap-link-warning.js
+++ b/ui/components/app/snaps/snap-link-warning/snap-link-warning.js
@@ -60,6 +60,13 @@ const SnapLinkDisplay = ({ url }) => {
   );
 };
 
+SnapLinkDisplay.propTypes = {
+  /**
+   * The URL to display
+   */
+  url: PropTypes.string,
+};
+
 export default function SnapLinkWarning({ isOpen, onClose, url }) {
   const t = useI18nContext();
 

--- a/ui/components/app/snaps/snap-link-warning/snap-link-warning.js
+++ b/ui/components/app/snaps/snap-link-warning/snap-link-warning.js
@@ -32,12 +32,36 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
-export default function SnapLinkWarning({ isOpen, onClose, url }) {
-  const t = useI18nContext();
-
+const SnapLinkDisplay = ({ url }) => {
   const parsedUrl = new URL(url);
   const isHTTPS = parsedUrl.protocol === 'https:';
-  const urlParts = url.split(parsedUrl.host);
+
+  // If the link is HTTPS we split on the host to highlight it
+  if (isHTTPS) {
+    const urlParts = url.split(parsedUrl.host);
+
+    return (
+      <>
+        {urlParts[0]}
+        <b>{parsedUrl.host}</b>
+        {urlParts[1]}
+      </>
+    );
+  }
+
+  // Otherwise highlight anything beyond the protocol
+  const urlParts = url.split(parsedUrl.protocol);
+
+  return (
+    <>
+      {parsedUrl.protocol}
+      <b>{urlParts[1]}</b>
+    </>
+  );
+};
+
+export default function SnapLinkWarning({ isOpen, onClose, url }) {
+  const t = useI18nContext();
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -92,15 +116,7 @@ export default function SnapLinkWarning({ isOpen, onClose, url }) {
               style={{ overflow: 'hidden' }}
               color={TextColor.primaryDefault}
             >
-              {isHTTPS ? (
-                <>
-                  {urlParts[0]}
-                  <b>{parsedUrl.host}</b>
-                  {urlParts[1]}
-                </>
-              ) : (
-                url
-              )}
+              <SnapLinkDisplay url={url} />
             </Text>
             <Icon
               name={IconName.Export}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a formatting issue when displaying mailto links in the `SnapLinkWarning`. This was broken due to parsing the `mailto:` link in the same way as HTTPS and assumptions made about the output of that parsing.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30000?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29977

## **Manual testing steps**

See the attached ticket

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See the attached ticket

### **After**

![image](https://github.com/user-attachments/assets/03dcf5d2-2d38-438f-b575-85c197f26961)

