### PR TITLE
fix: decouple listNotifications from useProfileSyncing

### DIFF
--- a/ui/contexts/metamask-notifications/metamask-notifications.tsx
+++ b/ui/contexts/metamask-notifications/metamask-notifications.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useEffect, useMemo } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { useSelector } from 'react-redux';
 import { useListNotifications } from '../../hooks/metamask-notifications/useNotifications';
 import { selectIsProfileSyncingEnabled } from '../../selectors/identity/profile-syncing';
@@ -30,6 +36,7 @@ export const useMetamaskNotificationsContext = () => {
 
 export const MetamaskNotificationsProvider: React.FC = ({ children }) => {
   const isProfileSyncingEnabled = useSelector(selectIsProfileSyncingEnabled);
+  const isProfileSyncingEnabledRef = useRef(isProfileSyncingEnabled);
   const isNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );
@@ -37,6 +44,18 @@ export const MetamaskNotificationsProvider: React.FC = ({ children }) => {
   const isUnlocked = useSelector(getIsUnlocked);
   const { listNotifications, notificationsData, isLoading, error } =
     useListNotifications();
+
+  const wasProfileSyncingDisabled =
+    isProfileSyncingEnabledRef.current && !isProfileSyncingEnabled;
+
+  useEffect(() => {
+    if (wasProfileSyncingDisabled) {
+      // list notifications to update the counter
+      listNotifications();
+    }
+
+    isProfileSyncingEnabledRef.current = isProfileSyncingEnabled;
+  }, [isProfileSyncingEnabled]);
 
   const shouldFetchNotifications = useMemo(
     () => isProfileSyncingEnabled && isNotificationsEnabled,

--- a/ui/hooks/identity/useProfileSyncing/profileSyncing.test.tsx
+++ b/ui/hooks/identity/useProfileSyncing/profileSyncing.test.tsx
@@ -1,6 +1,6 @@
 import { act } from '@testing-library/react-hooks';
 import { renderHookWithProviderTyped } from '../../../../test/lib/render-helpers';
-import { MetamaskNotificationsProvider } from '../../../contexts/metamask-notifications';
+import { MetamaskIdentityProvider } from '../../../contexts/identity';
 import * as actions from '../../../store/actions';
 import {
   useDisableProfileSyncing,
@@ -37,7 +37,7 @@ describe('useDisableProfileSyncing()', () => {
       () => useDisableProfileSyncing(),
       {},
       undefined,
-      MetamaskNotificationsProvider,
+      MetamaskIdentityProvider,
     );
 
     await act(async () => {
@@ -59,7 +59,7 @@ describe('useDisableProfileSyncing()', () => {
         },
       },
       undefined,
-      MetamaskNotificationsProvider,
+      MetamaskIdentityProvider,
     );
 
     await act(async () => {

--- a/ui/hooks/identity/useProfileSyncing/profileSyncing.ts
+++ b/ui/hooks/identity/useProfileSyncing/profileSyncing.ts
@@ -1,7 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import log from 'loglevel';
-import { useMetamaskNotificationsContext } from '../../../contexts/metamask-notifications/metamask-notifications';
 import { getParticipateInMetaMetrics } from '../../../selectors';
 import { selectIsSignedIn } from '../../../selectors/identity/authentication';
 import {
@@ -55,7 +54,6 @@ export function useDisableProfileSyncing(): {
   error: string | null;
 } {
   const dispatch = useDispatch();
-  const { listNotifications } = useMetamaskNotificationsContext();
   const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
   const isSignedIn = useSelector(selectIsSignedIn);
 
@@ -72,9 +70,6 @@ export function useDisableProfileSyncing(): {
       if (!isMetaMetricsEnabled && isSignedIn) {
         await dispatch(performSignOut());
       }
-
-      // list notifications to update the counter
-      await listNotifications();
     } catch (e) {
       const errorMessage =
         e instanceof Error ? e.message : JSON.stringify(e ?? '');


### PR DESCRIPTION
## **Description**

This PR moves the notifications logic from `useProfileSyncing` to the Notifications context.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30004?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/IDENTITY-14

## **Manual testing steps**

1. Enable notifications
2. Disable profile syncing
3. Verify that the notifications counter has been updated

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
