### PR TITLE
build(webpack): add `--sentry` status to webpack's `--dry-run` output

### DIFF
--- a/development/webpack/utils/cli.ts
+++ b/development/webpack/utils/cli.ts
@@ -380,6 +380,7 @@ Zip: ${args.zip}
 Snow: ${args.snow}
 LavaMoat: ${args.lavamoat}
 Lockdown: ${args.lockdown}
+Sentry: ${args.sentry}
 Manifest version: ${args.manifest_version}
 Release version: ${args.releaseVersion}
 Browsers: ${args.browser.join(', ')}


### PR DESCRIPTION
`webpack --dry-run`  logs the applied settings and then exits. The status of the `sentry` flag was missing. Now it isn't.

Before

```
~/code/metamask-extension (webpack-dry-run-sentry) $ yarn webpack --dry-run
🦊 Build Config 🦊

Environment: development
Minify: false
Watch: false
Cache: true
Progress: true
Zip: false
Snow: false
LavaMoat: false
Lockdown: false
Manifest version: 2
Release version: 0
Browsers: chrome
Devtool: source-map
Build type: main
Features: build-main, keyring-snaps
Test: false
```

After:
```
~/code/metamask-extension (webpack-dry-run-sentry) $ yarn webpack --dry-run
🦊 Build Config 🦊

Environment: development
Minify: false
Watch: false
Cache: true
Progress: true
Zip: false
Snow: false
LavaMoat: false
Lockdown: false
Sentry: false
Manifest version: 2
Release version: 0
Browsers: chrome
Devtool: source-map
Build type: main
Features: build-main, keyring-snaps
Test: false
```

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30021?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->