### PR TITLE
ci: skip type imports when checking circular dependencies

### DIFF
--- a/.madgerc
+++ b/.madgerc
@@ -1,4 +1,17 @@
 {
+  "excludeRegExp": [
+    "/.[^/]*\/test\/.[^/]*/u",
+    "/.[^/]*\/tests\/.[^/]*/u",
+    "/.[^/]*\/[^/]*.test.[^/]*/u",
+    "/.[^/]*\/[^/]*.spec.[^/]*/u",
+    "/.[^/]*\/stories\/.[^/]*/u",
+    "/.[^/]*\/storybook\/.[^/]*/u",
+    "/.[^/]*\/[^/]*.stories.[^/]*/u"
+  ],
+  "circular": true,
+  "extensions": ["js", "jsx", "ts", "tsx"],
+  "tsConfig": "tsconfig.json",
+  "webpackConfig": "webpack.config.js",
   "detectiveOptions": {
     "es6": {
       "skipTypeImports": true

--- a/.madgerc
+++ b/.madgerc
@@ -8,8 +8,7 @@
     "/.[^/]*\/storybook\/.[^/]*/u",
     "/.[^/]*\/[^/]*.stories.[^/]*/u"
   ],
-  "circular": true,
-  "extensions": ["js", "jsx", "ts", "tsx"],
+  "fileExtensions": ["js", "jsx", "ts", "tsx"],
   "tsConfig": "tsconfig.json",
   "webpackConfig": "webpack.config.js",
   "detectiveOptions": {

--- a/development/circular-deps.jsonc
+++ b/development/circular-deps.jsonc
@@ -16,19 +16,6 @@
     "app/scripts/controllers/bridge-status/validators.ts"
   ],
   [
-    "app/scripts/controllers/bridge/bridge-controller.ts",
-    "app/scripts/controllers/bridge/types.ts"
-  ],
-  [
-    "app/scripts/controllers/swaps/index.ts",
-    "app/scripts/controllers/swaps/swaps.constants.ts",
-    "app/scripts/controllers/swaps/swaps.types.ts"
-  ],
-  [
-    "app/scripts/controllers/swaps/swaps.constants.ts",
-    "app/scripts/controllers/swaps/swaps.types.ts"
-  ],
-  [
     "app/scripts/lib/transaction/metrics.ts",
     "shared/modules/metametrics.ts"
   ],
@@ -151,51 +138,16 @@
   ],
   [
     "ui/components/component-library/avatar-account/avatar-account.tsx",
-    "ui/components/component-library/avatar-account/avatar-account.types.ts",
     "ui/components/component-library/avatar-account/index.ts",
-    "ui/components/component-library/avatar-base/avatar-base.types.ts",
+    "ui/components/component-library/avatar-base/avatar-base.tsx",
+    "ui/components/component-library/avatar-base/index.ts",
     "ui/components/component-library/index.ts",
     "ui/components/component-library/text/index.ts",
     "ui/components/component-library/text/text.tsx"
   ],
   [
     "ui/components/component-library/badge-wrapper/badge-wrapper.tsx",
-    "ui/components/component-library/badge-wrapper/badge-wrapper.types.ts",
     "ui/components/component-library/badge-wrapper/index.ts",
-    "ui/components/component-library/index.ts"
-  ],
-  [
-    "ui/components/component-library/badge-wrapper/badge-wrapper.tsx",
-    "ui/components/component-library/badge-wrapper/index.ts",
-    "ui/components/component-library/index.ts"
-  ],
-  [
-    "ui/components/component-library/banner-alert/banner-alert.tsx",
-    "ui/components/component-library/banner-alert/banner-alert.types.ts",
-    "ui/components/component-library/banner-alert/index.ts",
-    "ui/components/component-library/banner-base/banner-base.types.ts",
-    "ui/components/component-library/button-base/button-base.tsx",
-    "ui/components/component-library/button-base/index.ts",
-    "ui/components/component-library/button-link/button-link.tsx",
-    "ui/components/component-library/button-link/index.ts",
-    "ui/components/component-library/index.ts"
-  ],
-  [
-    "ui/components/component-library/banner-alert/banner-alert.tsx",
-    "ui/components/component-library/banner-alert/banner-alert.types.ts",
-    "ui/components/component-library/banner-alert/index.ts",
-    "ui/components/component-library/banner-base/banner-base.types.ts",
-    "ui/components/component-library/button-icon/button-icon.tsx",
-    "ui/components/component-library/button-icon/index.ts",
-    "ui/components/component-library/index.ts"
-  ],
-  [
-    "ui/components/component-library/banner-alert/banner-alert.tsx",
-    "ui/components/component-library/banner-alert/banner-alert.types.ts",
-    "ui/components/component-library/banner-alert/index.ts",
-    "ui/components/component-library/banner-base/banner-base.types.ts",
-    "ui/components/component-library/button-link/button-link.tsx",
-    "ui/components/component-library/button-link/index.ts",
     "ui/components/component-library/index.ts"
   ],
   [
@@ -213,6 +165,21 @@
   [
     "ui/components/component-library/banner-tip/banner-tip.tsx",
     "ui/components/component-library/banner-tip/index.ts",
+    "ui/components/component-library/index.ts"
+  ],
+  [
+    "ui/components/component-library/button-base/button-base.tsx",
+    "ui/components/component-library/button-base/index.ts",
+    "ui/components/component-library/index.ts"
+  ],
+  [
+    "ui/components/component-library/button-icon/button-icon.tsx",
+    "ui/components/component-library/button-icon/index.ts",
+    "ui/components/component-library/index.ts"
+  ],
+  [
+    "ui/components/component-library/button-link/button-link.tsx",
+    "ui/components/component-library/button-link/index.ts",
     "ui/components/component-library/index.ts"
   ],
   [

--- a/development/circular-deps.ts
+++ b/development/circular-deps.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 
-import fs from 'fs';
+import fs, { readFileSync } from 'fs';
 import madge from 'madge';
 import fg from 'fast-glob';
 
@@ -88,26 +88,7 @@ function normalizeJson(cycles: CircularDeps): CircularDeps {
 }
 
 // Common madge configuration
-const MADGE_CONFIG = {
-  circular: true,
-  extensions: ['js', 'jsx', 'ts', 'tsx'],
-  excludeRegExp: IGNORE_PATTERNS.map(globToRegExp),
-  tsConfig: 'tsconfig.json',
-  webpackConfig: 'webpack.config.js',
-  detectiveOptions: {
-    es6: {
-      skipTypeImports: true,
-    },
-    ts: {
-      skipTypeImports: true,
-      skipAsyncImports: true,
-    },
-    tsx: {
-      skipTypeImports: true,
-      skipAsyncImports: true,
-    },
-  },
-};
+const MADGE_CONFIG = JSON.parse(readFileSync('.madgerc', 'utf-8'));
 
 async function getMadgeCircularDeps(): Promise<CircularDeps> {
   console.log('Running madge to detect circular dependencies...');

--- a/development/circular-deps.ts
+++ b/development/circular-deps.ts
@@ -94,6 +94,19 @@ const MADGE_CONFIG = {
   excludeRegExp: IGNORE_PATTERNS.map(globToRegExp),
   tsConfig: 'tsconfig.json',
   webpackConfig: 'webpack.config.js',
+  detectiveOptions: {
+    es6: {
+      skipTypeImports: true,
+    },
+    ts: {
+      skipTypeImports: true,
+      skipAsyncImports: true,
+    },
+    tsx: {
+      skipTypeImports: true,
+      skipAsyncImports: true,
+    },
+  },
 };
 
 async function getMadgeCircularDeps(): Promise<CircularDeps> {

--- a/development/circular-deps.ts
+++ b/development/circular-deps.ts
@@ -51,18 +51,6 @@ const ENTRYPOINT_PATTERNS = [
   'ui/**/*', // UI components and styles
 ];
 
-// Converts a glob pattern to a RegExp pattern
-function globToRegExp(pattern: string): RegExp {
-  return new RegExp(
-    pattern
-      // Convert '**' to '.*' to match any characters.
-      .replace(/\*\*/gu, '.*')
-      // Convert '*' to '[^/]*' to match any characters except directory separators.
-      .replace(/\*/gu, '[^/]*'),
-    'u',
-  );
-}
-
 /**
  * Circular dependencies are represented as an array of arrays, where each
  * inner array represents a cycle of dependencies.


### PR DESCRIPTION
Skip type imports when checking circular dependencies.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30080?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->