### PR TITLE
chore: Use network-specific smart transaction feature flags

### DIFF
--- a/shared/modules/selectors/index.test.ts
+++ b/shared/modules/selectors/index.test.ts
@@ -238,6 +238,33 @@ describe('Selectors', () => {
     );
 
     jestIt(
+      'returns false if feature flag is disabled for BSC, not a HW and is BSC network with a default RPC URL',
+      () => {
+        const state = createSwapsMockStore();
+        state.metamask.swapsState.swapsFeatureFlags = {
+          ...state.metamask.swapsState.swapsFeatureFlags,
+          bsc: {
+            ...state.metamask.swapsState.swapsFeatureFlags.bsc,
+            smartTransactions: {
+              extensionActive: false,
+            },
+          },
+        };
+        const newState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            ...mockNetworkState({
+              chainId: CHAIN_IDS.BSC,
+              rpcUrl: 'https://bsc-dataseed.binance.org/',
+            }),
+          },
+        };
+        expect(getSmartTransactionsEnabled(newState)).toBe(false);
+      },
+    );
+
+    jestIt(
       'returns false if feature flag is enabled, not a HW and is BSC network with a non-default RPC URL',
       () => {
         const state = createSwapsMockStore();

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -11,6 +11,7 @@ import {
   // eslint-disable-next-line import/no-restricted-paths
 } from '../../../ui/selectors/selectors'; // TODO: Migrate shared selectors to this file.
 import { isProduction } from '../environment';
+import { getFeatureFlagsByChainId } from './feature-flags';
 import { getCurrentChainId, NetworkState } from './networks';
 
 export type SmartTransactionsMetaMaskState = {
@@ -156,10 +157,11 @@ export const getSmartTransactionsEnabled = (
   state: SmartTransactionsMetaMaskState & NetworkState,
 ): boolean => {
   const supportedAccount = accountSupportsSmartTx(state);
+  // @ts-expect-error Smart transaction selector types does not match controller state
+  const featureFlagsByChainId = getFeatureFlagsByChainId(state);
   // TODO: Create a new proxy service only for MM feature flags.
   const smartTransactionsFeatureFlagEnabled =
-    state.metamask.swapsState?.swapsFeatureFlags?.smartTransactions
-      ?.extensionActive;
+    featureFlagsByChainId?.smartTransactions?.extensionActive;
   const smartTransactionsLiveness =
     state.metamask.smartTransactionsState?.liveness;
   return Boolean(

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -398,6 +398,11 @@ export const createSwapsMockStore = () => {
               extensionReturnTxHashAsap: false,
             },
           },
+          bsc: {
+            extensionActive: true,
+            mobileActive: false,
+            smartTransactions: {},
+          },
           smartTransactions: {
             mobileActive: true,
             extensionActive: true,


### PR DESCRIPTION
## **Description**
If there are network-specific feature flags for smart transactions, they will take priority over shared smart transaction feature flags.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30094?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Turn off some feature flag which is network-specific for smart transactions (e.g. `bsc.smartTransactions.extensionActive = false`)
2. See that it's being used over a shared one (`smartTransactions.extensionActive`)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
