### PR TITLE
chore: Temporarily store MMI policy validation/update

### DIFF
--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -92,7 +92,7 @@ jobs:
       matrix:
         # Ensure this is synchronized with the list below in the "commit-updated-policies" job
         # and with the build type list in `builds.yml`
-        build-type: [main, beta, flask]
+        build-type: [main, beta, flask, mmi]
     name: Update LavaMoat ${{ matrix.build-type }} application policy
     runs-on: ubuntu-latest
     needs:
@@ -154,7 +154,7 @@ jobs:
           path: lavamoat/build-system
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
           fail-on-cache-miss: true
-      # One restore step per build type: [main, beta, flask]
+      # One restore step per build type: [main, beta, flask, mmi]
       # Ensure this is synchronized with the list above in the "update-lavamoat-webapp-policy" job
       # and with the build type list in `builds.yml`
       - name: Restore main application policy

--- a/.github/workflows/validate-lavamoat-policy-webapp.yml
+++ b/.github/workflows/validate-lavamoat-policy-webapp.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build-type: [main, beta, flask]
+        build-type: [main, beta, flask, mmi]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -5062,7 +5062,7 @@
         "react": true
       }
     },
-    "@storybook/addon-knobs>qs": {
+    "browserify>url>qs": {
       "packages": {
         "string.prototype.matchall>side-channel": true
       }
@@ -5849,7 +5849,7 @@
     "browserify>url": {
       "packages": {
         "browserify>punycode": true,
-        "@storybook/addon-knobs>qs": true
+        "browserify>url>qs": true
       }
     },
     "react-focus-lock>use-callback-ref": {


### PR DESCRIPTION
## **Description**

Recently we removed all CI steps related to MMI, in preparation for removing MMI. However, the lack of policy validation for the MMI LavaMoat policy has led to churn/conflicts from local updates to the policy.

The CI config has been updated to restore MMI LavaMoat policy validation/updates temporarily. We expect we'll be able to delete this again very soon, but it is easiest to keep this until we're ready to delete the MMI build type.
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30106?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
