### PR TITLE
test: pin Firefox version temporarily to 134 until artifacts `tar.bz2` are available again (or a fix is provided)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,11 +146,11 @@ workflows:
           requires:
             - prep-build-test
             - get-changed-files-with-git-diff
-      - test-e2e-firefox:
-          <<: *main_master_rc_only
-          requires:
-            - prep-build-test-mv2
-            - get-changed-files-with-git-diff
+      # - test-e2e-firefox:
+      #     <<: *main_master_rc_only
+      #     requires:
+      #       - prep-build-test-mv2
+      #       - get-changed-files-with-git-diff
       - test-e2e-chrome-rpc:
           requires:
             - prep-build-test
@@ -167,10 +167,10 @@ workflows:
           requires:
             - prep-build-test-flask
             - get-changed-files-with-git-diff
-      - test-e2e-firefox-flask:
-          <<: *main_master_rc_only
-          requires:
-            - prep-build-test-flask-mv2
+      # - test-e2e-firefox-flask:
+      #     <<: *main_master_rc_only
+      #     requires:
+      #       - prep-build-test-flask-mv2
       - test-e2e-swap-playwright - OPTIONAL:
           requires:
             - prep-build
@@ -210,9 +210,9 @@ workflows:
             - test-mozilla-lint-flask-mv2
             - test-e2e-chrome
             - test-e2e-chrome-multiple-providers
-            - test-e2e-firefox
+            #- test-e2e-firefox
             - test-e2e-chrome-flask
-            - test-e2e-firefox-flask
+            # - test-e2e-firefox-flask
             - test-e2e-chrome-vault-decryption
             - test-e2e-chrome-webpack
       - benchmark:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,11 +146,11 @@ workflows:
           requires:
             - prep-build-test
             - get-changed-files-with-git-diff
-      # - test-e2e-firefox:
-      #     <<: *main_master_rc_only
-      #     requires:
-      #       - prep-build-test-mv2
-      #       - get-changed-files-with-git-diff
+      - test-e2e-firefox:
+          <<: *main_master_rc_only
+          requires:
+            - prep-build-test-mv2
+            - get-changed-files-with-git-diff
       - test-e2e-chrome-rpc:
           requires:
             - prep-build-test
@@ -167,10 +167,10 @@ workflows:
           requires:
             - prep-build-test-flask
             - get-changed-files-with-git-diff
-      # - test-e2e-firefox-flask:
-      #     <<: *main_master_rc_only
-      #     requires:
-      #       - prep-build-test-flask-mv2
+      - test-e2e-firefox-flask:
+          <<: *main_master_rc_only
+          requires:
+            - prep-build-test-flask-mv2
       - test-e2e-swap-playwright - OPTIONAL:
           requires:
             - prep-build
@@ -210,9 +210,9 @@ workflows:
             - test-mozilla-lint-flask-mv2
             - test-e2e-chrome
             - test-e2e-chrome-multiple-providers
-            #- test-e2e-firefox
+            - test-e2e-firefox
             - test-e2e-chrome-flask
-            # - test-e2e-firefox-flask
+            - test-e2e-firefox-flask
             - test-e2e-chrome-vault-decryption
             - test-e2e-chrome-webpack
       - benchmark:

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -63,6 +63,10 @@ class FirefoxDriver {
       parseInt(proxyServerURL.port, 10),
     );
 
+    // Temporarily lock to version 134 until fix provided by Firefox/Selenium
+    // See issue https://github.com/MetaMask/MetaMask-planning/issues/4122
+    options.setBrowserVersion('134');
+
     options.setAcceptInsecureCerts(true);
     options.setPreference('browser.download.folderList', 2);
     options.setPreference(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Firefox specs started failing with the error:

```
<failure message="Unable to obtain browser driver.
        For more information on how to install drivers see
        https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/driver_location/. Error: Error executing command for /home/circleci/project/node_modules/selenium-webdriver/bin/linux/selenium-manager with --browser,firefox,--output,json,--browser-path,/opt/firefox/firefox: Unsuccessful response (404 Not Found) for URL https://ftp.mozilla.org/pub/firefox/releases/135.0/linux-x86_64/en-US/firefox-135.0.tar.bz2
  (Ran on CircleCI Node 0 of 24, Job test-e2e-firefox)" type="Error"><![CDATA[Error: Unable to obtain browser driver.
```
The problem is that the artifact ending with `tar.bz2` is not in present in the version 135.0, whereas it was always in previous versions, which we relied on.

https://ftp.mozilla.org/pub/firefox/releases/135.0/linux-x86_64/en-US/

![image](https://github.com/user-attachments/assets/e4f4166d-b703-4bf6-a979-d1d3aca2347c)



From @itsyoboieltr :
`It seems like firefox changed the way their releases work, so selenium cannot get the tar.`

Context: https://consensys.slack.com/archives/CTQAGKY5V/p1738664570174839

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30112?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**
I re-enabled FF specs and tested this in [another branch](https://github.com/MetaMask/metamask-extension/pull/30122):

1. Check ci, how FF tests started running normally [here](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/122355/workflows/f1806a6c-b9ef-4a27-8291-fc6c71f0c519/jobs/4518553)

I canceled the job once I saw that the browser was successfully downloaded and specs started running


## **Screenshots/Recordings**

![Screenshot from 2025-02-05 08-23-28](https://github.com/user-attachments/assets/f1d65d15-218e-4db2-a34c-327ce6f5dfdb)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
