### PR TITLE
fix: Fix MMI LavaMoat policy update

### DIFF
--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -175,6 +175,12 @@ jobs:
           path: lavamoat/browserify/flask
           key: cache-flask-${{ needs.prepare.outputs.COMMIT_SHA }}
           fail-on-cache-miss: true
+      - name: Restore MMI application policy
+        uses: actions/cache/restore@v4
+        with:
+          path: lavamoat/browserify/mmi
+          key: cache-mmi-${{ needs.prepare.outputs.COMMIT_SHA }}
+          fail-on-cache-miss: true
       - name: Check whether there are policy changes
         id: policy-changes
         run: |


### PR DESCRIPTION
## **Description**

The LavaMoat update workflow was recently changed to re-enable updates for the MMI LavaMoat policy (#30106), but in that change we missed a step. The updated MMI policy was not restored from cache. This has now been corrected.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30117?quickstart=1)

## **Related issues**

The MMI policy updates should work correctly once this is merged. Can't test from this PR, as they run from the context of the default branch.

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
