### PR TITLE
feat: mmassets-543

### DIFF
--- a/ui/components/ui/currency-display/__snapshots__/currency-display.component.test.js.snap
+++ b/ui/components/ui/currency-display/__snapshots__/currency-display.component.test.js.snap
@@ -46,3 +46,34 @@ exports[`CurrencyDisplay Component should render text with a prefix 1`] = `
   </div>
 </div>
 `;
+
+exports[`CurrencyDisplay Component should render with title (tooltip) 1`] = `
+<div>
+  <div
+    class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
+    title="$123.45"
+  >
+    <span
+      class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
+      data-testid="account-value-and-suffix"
+    >
+      $123.45
+    </span>
+  </div>
+</div>
+`;
+
+exports[`CurrencyDisplay Component should render without title (tooltip) 1`] = `
+<div>
+  <div
+    class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
+  >
+    <span
+      class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
+      data-testid="account-value-and-suffix"
+    >
+      ••••••
+    </span>
+  </div>
+</div>
+`;

--- a/ui/components/ui/currency-display/currency-display.component.js
+++ b/ui/components/ui/currency-display/currency-display.component.js
@@ -53,7 +53,7 @@ export default function CurrencyDisplay({
       className={classnames('currency-display-component', className)}
       data-testid={dataTestId}
       style={style}
-      title={(!hideTitle && title) || null}
+      title={(!hideTitle && !privacyMode && title) || null}
       display={Display.Flex}
       alignItems={AlignItems.center}
       flexWrap={FlexWrap.Wrap}

--- a/ui/components/ui/currency-display/currency-display.component.test.js
+++ b/ui/components/ui/currency-display/currency-display.component.test.js
@@ -27,7 +27,6 @@ describe('CurrencyDisplay Component', () => {
     expect(container).toMatchSnapshot();
   });
 
-
   it('should render without title (tooltip)', () => {
     const props = {
       displayValue: '$123.45',

--- a/ui/components/ui/currency-display/currency-display.component.test.js
+++ b/ui/components/ui/currency-display/currency-display.component.test.js
@@ -24,7 +24,33 @@ describe('CurrencyDisplay Component', () => {
       <CurrencyDisplay {...props} />,
       mockStore,
     );
+    expect(container).toMatchSnapshot();
+  });
 
+
+  it('should render without title (tooltip)', () => {
+    const props = {
+      displayValue: '$123.45',
+      privacyMode: true,
+    };
+
+    const { container } = renderWithProvider(
+      <CurrencyDisplay {...props} />,
+      mockStore,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with title (tooltip)', () => {
+    const props = {
+      displayValue: '$123.45',
+      privacyMode: false,
+    };
+
+    const { container } = renderWithProvider(
+      <CurrencyDisplay {...props} />,
+      mockStore,
+    );
     expect(container).toMatchSnapshot();
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Bug fix: Do not show users' balance tool-tip when in privacy mode.
<!--

-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30133?quickstart=1)

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/29236
https://consensyssoftware.atlassian.net/browse/MMASSETS-534


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/73160957-5fe8-4ec3-a599-94e67e5cb36d)

### **After**

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/85763a84-0207-4f48-8367-c84962069e5b" />

## **Pre-merge author checklist**

- [ x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ x] I've completed the PR template to the best of my ability
- [ x] I’ve included tests if applicable
- [ x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
