### PR TITLE
fix: default network selection logic in connection flow

### DIFF
--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -94,18 +94,22 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
       network.chainId === currentlySelectedNetworkChainId,
   );
 
-  const selectedNetworksList = selectedTestNetwork
+  const defaultSelectedNetworkList = selectedTestNetwork
     ? [...nonTestNetworks, selectedTestNetwork].map(({ chainId }) => chainId)
     : nonTestNetworks.map(({ chainId }) => chainId);
 
+  const allNetworksList = [...nonTestNetworks, ...testNetworks].map(
+    ({ chainId }) => chainId,
+  );
+
   const supportedRequestedChainIds = requestedChainIds.filter((chainId) =>
-    selectedNetworksList.includes(chainId),
+    allNetworksList.includes(chainId),
   );
 
   const defaultSelectedChainIds =
     supportedRequestedChainIds.length > 0
       ? supportedRequestedChainIds
-      : selectedNetworksList;
+      : defaultSelectedNetworkList;
 
   const [selectedChainIds, setSelectedChainIds] = useState(
     defaultSelectedChainIds,


### PR DESCRIPTION
Fixes a small gap left by [this fix](https://github.com/MetaMask/metamask-extension/pull/29988)

BEFORE:
https://github.com/user-attachments/assets/80d59554-83a6-47eb-906e-a06e99ae6158


AFTER:
https://github.com/user-attachments/assets/453a5bca-f975-4e9a-9028-2fa1f8980046

