### PR TITLE
feat: Add transaction alert when sending data to EOA

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3301,6 +3301,12 @@
   "noWebcamFoundTitle": {
     "message": "Webcam not found"
   },
+  "nonContractAddressAlertDesc": {
+    "message": "You're sending call data to an address that isn't a contract. This could cause you to lose funds. Make sure you're using the correct address and network before continuing."
+  },
+  "nonContractAddressAlertTitle": {
+    "message": "Potential mistake"
+  },
   "nonce": {
     "message": "Nonce"
   },

--- a/ui/components/app/confirm/info/row/constants.ts
+++ b/ui/components/app/confirm/info/row/constants.ts
@@ -2,11 +2,11 @@ export const TEST_ADDRESS = '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1';
 
 export enum RowAlertKey {
   EstimatedFee = 'estimatedFee',
-  FirstTimeInteraction = 'firstTimeInteraction',
   SigningInWith = 'signingInWith',
   RequestFrom = 'requestFrom',
   Resimulation = 'resimulation',
   Speed = 'speed',
+  To = 'to',
 }
 
 export enum AlertActionKey {

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
@@ -61,7 +61,7 @@ export const TransactionFlowSection = () => {
         />
         {recipientAddress && (
           <ConfirmInfoAlertRow
-            alertKey={RowAlertKey.FirstTimeInteraction}
+            alertKey={RowAlertKey.To}
             label={t('to')}
             ownerId={transactionMeta.id}
             style={{

--- a/ui/pages/confirmations/hooks/alerts/transactions/NonContractAddressAlertMessage.tsx
+++ b/ui/pages/confirmations/hooks/alerts/transactions/NonContractAddressAlertMessage.tsx
@@ -1,0 +1,51 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import React from 'react';
+import { Text } from '../../../../../components/component-library';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useConfirmContext } from '../../../context/confirm';
+import { ellipsify } from '../../../send/send.utils';
+
+export const NonContractAddressAlertMessage = (
+  networkConfigurations: Record<Hex, { name: string }>,
+) => {
+  const t = useI18nContext();
+
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const networkName =
+    currentConfirmation?.chainId &&
+    networkConfigurations[currentConfirmation.chainId as Hex].name;
+  const recipientAddress = ellipsify(currentConfirmation?.txParams.to);
+
+  return (
+    <>
+      <Text
+        variant={TextVariant.bodyMd}
+        color={TextColor.textDefault}
+        data-testid="alert-modal__selected-alert"
+      >
+        {t('nonContractAddressAlertDesc')}
+      </Text>
+      <Text
+        variant={TextVariant.bodyMd}
+        color={TextColor.textDefault}
+        marginTop={2}
+        data-testid="alert-modal__selected-alert"
+      >
+        <strong>Network:</strong> {networkName}
+      </Text>
+      <Text
+        variant={TextVariant.bodyMd}
+        color={TextColor.textDefault}
+        data-testid="alert-modal__selected-alert"
+      >
+        <strong>Address:</strong> {recipientAddress}
+      </Text>
+    </>
+  );
+};

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
@@ -158,7 +158,7 @@ describe('useFirstTimeInteractionAlert', () => {
     expect(alerts).toEqual([
       {
         actions: [],
-        field: RowAlertKey.FirstTimeInteraction,
+        field: RowAlertKey.To,
         isBlocking: false,
         key: 'firstTimeInteractionTitle',
         message:

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
@@ -33,7 +33,7 @@ export function useFirstTimeInteractionAlert(): Alert[] {
     return [
       {
         actions: [],
-        field: RowAlertKey.FirstTimeInteraction,
+        field: RowAlertKey.To,
         isBlocking: false,
         key: 'firstTimeInteractionTitle',
         message: t('alertMessageFirstTimeInteraction'),

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.test.ts
@@ -1,0 +1,277 @@
+import {
+  TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { waitFor } from '@testing-library/react';
+import { useContext } from 'react';
+import { useSelector } from 'react-redux';
+import { readAddressAsContract } from '../../../../../../shared/modules/contract-utils';
+import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
+import { I18nContext } from '../../../../../contexts/i18n';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { selectPendingApprovalsForNavigation } from '../../../../../selectors';
+import { ConfirmContext } from '../../../context/confirm';
+import { useNonContractAddressAlerts } from './useNonContractAddressAlerts';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+const messageIdMock = '12345';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    id: messageIdMock,
+  }),
+}));
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn(),
+}));
+
+jest.mock('../../../../../../shared/modules/contract-utils', () => ({
+  ...jest.requireActual('../../../../../../shared/modules/contract-utils'),
+  readAddressAsContract: jest.fn(),
+}));
+
+jest.mock('./NonContractAddressAlertMessage', () => ({
+  NonContractAddressAlertMessage: () => 'NonContractAddressAlertMessage',
+}));
+
+const TRANSACTION_ID_MOCK = '123-456';
+const ACCOUNT_ADDRESS_MOCK = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+const ACCOUNT_ADDRESS_2_MOCK = '0x2e0d7e8c45221fca00d74a3609a0f7097035d09b';
+
+const TRANSACTION_META_MOCK = {
+  id: TRANSACTION_ID_MOCK,
+  chainId: '0x5',
+  networkClientId: 'testNetworkClientId',
+  status: TransactionStatus.unapproved,
+  type: TransactionType.contractInteraction,
+  txParams: {
+    from: ACCOUNT_ADDRESS_MOCK,
+    to: ACCOUNT_ADDRESS_2_MOCK,
+  },
+  time: new Date().getTime() - 10000,
+} as TransactionMeta;
+
+function runHook({
+  currentConfirmation,
+}: {
+  currentConfirmation?: TransactionMeta;
+} = {}) {
+  const state = currentConfirmation
+    ? getMockConfirmStateForTransaction(currentConfirmation as TransactionMeta)
+    : {};
+
+  const response = renderHookWithConfirmContextProvider(
+    useNonContractAddressAlerts,
+    state,
+  );
+
+  return response.result.current;
+}
+
+describe('useNonContractAddressAlerts', () => {
+  const useContextMock = useContext as jest.Mock;
+  const useSelectorMock = useSelector as jest.Mock;
+  const mockReadAddressAsContract =
+    readAddressAsContract as jest.MockedFunction<typeof readAddressAsContract>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns no alerts if no confirmation', () => {
+    const confirmation = TRANSACTION_META_MOCK;
+    useContextMock.mockImplementation((context) => {
+      if (context === ConfirmContext) {
+        return { currentConfirmation: confirmation };
+      } else if (context === I18nContext) {
+        return (translationKey: string) => translationKey;
+      }
+      return undefined;
+    });
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getNetworkConfigurationsByChainId) {
+        return {
+          '0x5': {
+            chainId: '0x5',
+            name: 'Mainnet',
+          },
+        };
+      } else if (selector === selectPendingApprovalsForNavigation) {
+        return [confirmation];
+      }
+
+      return undefined;
+    });
+
+    mockReadAddressAsContract.mockImplementation(async () => {
+      return {
+        isContractAddress: false,
+        contractCode: '',
+      };
+    });
+
+    expect(runHook()).toEqual([]);
+  });
+
+  it('returns no alerts if the transaction has no data', () => {
+    const transactionWithNoData = {
+      ...TRANSACTION_META_MOCK,
+      txParams: {
+        ...TRANSACTION_META_MOCK.txParams,
+        data: undefined,
+      },
+    };
+
+    useContextMock.mockImplementation((context) => {
+      if (context === ConfirmContext) {
+        return { currentConfirmation: transactionWithNoData };
+      } else if (context === I18nContext) {
+        return (translationKey: string) => translationKey;
+      }
+      return undefined;
+    });
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getNetworkConfigurationsByChainId) {
+        return {
+          '0x5': {
+            chainId: '0x5',
+            name: 'Mainnet',
+          },
+        };
+      } else if (selector === selectPendingApprovalsForNavigation) {
+        return [transactionWithNoData];
+      }
+
+      return undefined;
+    });
+
+    mockReadAddressAsContract.mockImplementation(async () => {
+      return {
+        isContractAddress: false,
+        contractCode: '',
+      };
+    });
+
+    expect(
+      runHook({
+        currentConfirmation: transactionWithNoData,
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns no alerts if the transaction has data but the recipient is a contract', () => {
+    const transactionWithData = {
+      ...TRANSACTION_META_MOCK,
+      txParams: {
+        ...TRANSACTION_META_MOCK.txParams,
+        data: '0xabcdef',
+      },
+    };
+
+    useContextMock.mockImplementation((context) => {
+      if (context === ConfirmContext) {
+        return { currentConfirmation: transactionWithData };
+      } else if (context === I18nContext) {
+        return (translationKey: string) => translationKey;
+      }
+      return undefined;
+    });
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getNetworkConfigurationsByChainId) {
+        return {
+          '0x5': {
+            chainId: '0x5',
+            name: 'Mainnet',
+          },
+        };
+      } else if (selector === selectPendingApprovalsForNavigation) {
+        return [transactionWithData];
+      }
+
+      return undefined;
+    });
+
+    mockReadAddressAsContract.mockImplementation(async () => {
+      return {
+        isContractAddress: true,
+        contractCode: '',
+      };
+    });
+
+    expect(
+      runHook({
+        currentConfirmation: transactionWithData,
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns alert if the transaction has data and the recipient is not a contract', async () => {
+    const transactionWithData = {
+      ...TRANSACTION_META_MOCK,
+      txParams: {
+        ...TRANSACTION_META_MOCK.txParams,
+        data: '0xabcdef',
+      },
+    };
+    useContextMock.mockImplementation((context) => {
+      if (context === ConfirmContext) {
+        return { currentConfirmation: transactionWithData };
+      } else if (context === I18nContext) {
+        return (translationKey: string) => translationKey;
+      }
+      return undefined;
+    });
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getNetworkConfigurationsByChainId) {
+        return {
+          '0x5': {
+            chainId: '0x5',
+            name: 'Mainnet',
+          },
+        };
+      } else if (selector === selectPendingApprovalsForNavigation) {
+        return [transactionWithData];
+      }
+
+      return undefined;
+    });
+
+    mockReadAddressAsContract.mockImplementation(async () => {
+      return {
+        isContractAddress: false,
+        contractCode: '',
+      };
+    });
+
+    const { result } = renderHookWithConfirmContextProvider(
+      useNonContractAddressAlerts,
+      {
+        currentConfirmation: transactionWithData,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual([
+        {
+          field: RowAlertKey.To,
+          isBlocking: false,
+          key: 'hexDataWhileInteractingWithNonContractAddress',
+          reason: 'nonContractAddressAlertTitle',
+          severity: Severity.Warning,
+          content: 'NonContractAddressAlertMessage',
+        },
+      ]);
+    });
+  });
+});

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
@@ -1,0 +1,51 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { readAddressAsContract } from '../../../../../../shared/modules/contract-utils';
+import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
+import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { useAsyncResult } from '../../../../../hooks/useAsyncResult';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useConfirmContext } from '../../../context/confirm';
+import { NonContractAddressAlertMessage } from './NonContractAddressAlertMessage';
+
+export function useNonContractAddressAlerts(): Alert[] {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
+
+  const isSendingHexData = currentConfirmation?.txParams?.data !== undefined;
+
+  const { value, pending } = useAsyncResult(async () => {
+    return await readAddressAsContract(
+      global.ethereumProvider,
+      (currentConfirmation?.txParams?.to || '0x') as Hex,
+    );
+  }, [currentConfirmation?.txParams?.to]);
+
+  const isInteractingWithNonContractAddress =
+    !pending && value?.isContractAddress === false;
+
+  const isSendingHexDataWhileInteractingWithNonContractAddress =
+    isSendingHexData && isInteractingWithNonContractAddress;
+
+  return useMemo(() => {
+    if (!isSendingHexDataWhileInteractingWithNonContractAddress) {
+      return [];
+    }
+
+    return [
+      {
+        field: RowAlertKey.To,
+        isBlocking: false,
+        key: 'hexDataWhileInteractingWithNonContractAddress',
+        reason: t('nonContractAddressAlertTitle'),
+        content: NonContractAddressAlertMessage(networkConfigurations),
+        severity: Severity.Warning,
+      },
+    ];
+  }, [isSendingHexDataWhileInteractingWithNonContractAddress]);
+}

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
@@ -18,6 +18,7 @@ import { useSigningOrSubmittingAlerts } from './alerts/transactions/useSigningOr
 import useConfirmationOriginAlerts from './alerts/useConfirmationOriginAlerts';
 import useBlockaidAlerts from './alerts/useBlockaidAlerts';
 import { useSelectedAccountAlerts } from './alerts/useSelectedAccountAlerts';
+import { useNonContractAddressAlerts } from './alerts/transactions/useNonContractAddressAlerts';
 
 function useSignatureAlerts(): Alert[] {
   const accountMismatchAlerts = useAccountMismatchAlerts();
@@ -43,6 +44,7 @@ function useTransactionAlerts(): Alert[] {
   const signingOrSubmittingAlerts = useSigningOrSubmittingAlerts();
   ///: END:ONLY_INCLUDE_IF
   const queuedConfirmationsAlerts = useQueuedConfirmationsAlerts();
+  const nonContractAddressAlerts = useNonContractAddressAlerts();
 
   return useMemo(
     () => [
@@ -59,6 +61,7 @@ function useTransactionAlerts(): Alert[] {
       ...signingOrSubmittingAlerts,
       ///: END:ONLY_INCLUDE_IF
       ...queuedConfirmationsAlerts,
+      ...nonContractAddressAlerts,
     ],
     [
       gasEstimateFailedAlerts,
@@ -74,6 +77,7 @@ function useTransactionAlerts(): Alert[] {
       signingOrSubmittingAlerts,
       ///: END:ONLY_INCLUDE_IF
       queuedConfirmationsAlerts,
+      nonContractAddressAlerts,
     ],
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds new alert for when the user sends a "simple send" native asset transaction with hex data to an EOA account.

This intends to alert the user when they think they are doing a contract interaction but perhaps trigger the confirmation on the wrong network, in which the recipient address is in fact an EOA.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30141?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2926

## **Manual testing steps**

```javascript
// 1. Switch to the chain you want to broadcast the message on.
// 2. Open the browser console, paste this code and execute it.
// 3. Confirm the transaction on MetaMask.

const ON_CHAIN_MESSAGE = `Why, let the stricken deer go weep,
The hart ungallèd play.
For some must watch while some must sleep.
So runs the world away.`;

async function connectMetaMask() {
  try {
    const accounts = await window.ethereum.request({
      method: 'eth_requestAccounts',
    });
    console.log('Connected account:', accounts[0]);
    return accounts[0];
  } catch (error) {
    console.error('User rejected the request:', error);
    throw error;
  }
}

function stringToHex(str) {
  const encoder = new TextEncoder();
  const bytes = encoder.encode(str);
  return '0x' + Array.from(bytes).map(byte => byte.toString(16).padStart(2, '0')).join('');
}

async function createTransactionWithHexData() {
  try {
    const fromAddress = await connectMetaMask();
    const hexData = stringToHex(ON_CHAIN_MESSAGE);

    const transactionParameters = {
      to: fromAddress,
      from: fromAddress,
      value: '0x0', // Optional: Amount of ETH to send
      data: hexData,
    };

    const txHash = await window.ethereum.request({
      method: 'eth_sendTransaction',
      params: [transactionParameters],
    });

    console.log('Transaction hash:', txHash);
    return txHash;
  } catch (error) {
    console.error('Error creating transaction:', error);
  }
}

createTransactionWithHexData();
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="320" alt="Screenshot 2025-02-05 at 16 43 59" src="https://github.com/user-attachments/assets/ab07fb62-d7cf-494e-808c-fdba5376a2a9" />
<img width="320" alt="Screenshot 2025-02-05 at 16 44 02" src="https://github.com/user-attachments/assets/671216ce-8e57-4b3f-a751-0e583fee0533" />
<img width="320" alt="Screenshot 2025-02-05 at 16 44 05" src="https://github.com/user-attachments/assets/38a7725b-3e05-4adf-b042-9291277028a9" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
