### PR TITLE
fix: runway bot cherry pick

### DIFF
--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -26,10 +26,17 @@ enum RegressionStage {
   DevelopmentMain,
   Testing,
   Beta,
-  Production
+  Production,
 }
 
-const knownBots = ["metamaskbot", "dependabot", "github-actions", "sentry-io", "devin-ai-integration"];
+const knownBots = [
+  'metamaskbot',
+  'dependabot',
+  'github-actions',
+  'sentry-io',
+  'devin-ai-integration',
+  'runway-github',
+];
 
 main().catch((error: Error): void => {
   console.error(error);
@@ -83,7 +90,10 @@ async function main(): Promise<void> {
   }
 
   // If author is not part of the MetaMask organisation
-  if (!knownBots.includes(labelable?.author) && !(await userBelongsToMetaMaskOrg(octokit, labelable?.author))) {
+  if (
+    !knownBots.includes(labelable?.author) &&
+    !(await userBelongsToMetaMaskOrg(octokit, labelable?.author))
+  ) {
     // Add external contributor label to the issue
     await addLabelToLabelable(octokit, labelable, externalContributorLabel);
   }
@@ -95,16 +105,21 @@ async function main(): Promise<void> {
 
   // If labelable's author is a bot we skip the template checks as bots don't use templates
   if (knownBots.includes(labelable.author)) {
-    console.log(`${labelable.type === LabelableType.PullRequest ? 'PR' : 'Issue'} was created by a bot (${labelable.author}). Skip template checks.`);
+    console.log(
+      `${
+        labelable.type === LabelableType.PullRequest ? 'PR' : 'Issue'
+      } was created by a bot (${labelable.author}). Skip template checks.`,
+    );
     process.exit(0); // Stop the process and exit with a success status code
   }
 
   if (labelable.type === LabelableType.Issue) {
-
     // If labelable is a flaky test report, no template is needed (we just add a link to circle.ci in the description), we skip the template checks
     const flakyTestsLabelFound = findLabel(labelable, flakyTestsLabel);
     if (flakyTestsLabelFound?.id) {
-      console.log(`Issue ${labelable?.number} was created to report a flaky test. Issue's description doesn't need to match issue template in that case as the issue's description only includes a link redirecting to circle.ci. Skip template checks.`);
+      console.log(
+        `Issue ${labelable?.number} was created to report a flaky test. Issue's description doesn't need to match issue template in that case as the issue's description only includes a link redirecting to circle.ci. Skip template checks.`,
+      );
       await removeLabelFromLabelableIfPresent(
         octokit,
         labelable,
@@ -130,7 +145,6 @@ async function main(): Promise<void> {
 
       // Add regression label to the bug report issue
       addRegressionLabelToIssue(octokit, labelable);
-
     } else {
       const errorMessage =
         "Issue body does not match any of expected templates ('general-issue.yml' or 'bug-report.yml').\n\nMake sure issue's body includes all section titles.\n\nSections titles are listed here: https://github.com/MetaMask/metamask-extension/blob/main/.github/scripts/shared/template.ts#L14-L37";
@@ -152,8 +166,7 @@ async function main(): Promise<void> {
         invalidPullRequestTemplateLabel,
       );
     } else {
-      const errorMessage =
-        `PR body does not match template ('pull-request-template.md').\n\nMake sure PR's body includes all section titles.\n\nSections titles are listed here: https://github.com/MetaMask/metamask-extension/blob/main/.github/scripts/shared/template.ts#L40-L47`;
+      const errorMessage = `PR body does not match template ('pull-request-template.md').\n\nMake sure PR's body includes all section titles.\n\nSections titles are listed here: https://github.com/MetaMask/metamask-extension/blob/main/.github/scripts/shared/template.ts#L40-L47`;
       console.log(errorMessage);
 
       // Add label to indicate PR body doesn't match template
@@ -269,7 +282,10 @@ async function addRegressionLabelToIssue(
   );
 
   // Craft regression label to add
-  const regressionLabel: Label = craftRegressionLabel(regressionStage, releaseVersion);
+  const regressionLabel: Label = craftRegressionLabel(
+    regressionStage,
+    releaseVersion,
+  );
 
   let regressionLabelFound: boolean = false;
   const regressionLabelsToBeRemoved: {
@@ -292,9 +308,7 @@ async function addRegressionLabelToIssue(
       `Issue ${issue?.number} already has ${regressionLabel.name} label.`,
     );
   } else {
-    console.log(
-      `Add ${regressionLabel.name} label to issue ${issue?.number}.`,
-    );
+    console.log(`Add ${regressionLabel.name} label to issue ${issue?.number}.`);
     await addLabelToLabelable(octokit, issue, regressionLabel);
   }
 
@@ -333,7 +347,10 @@ async function userBelongsToMetaMaskOrg(
 }
 
 // This function crafts appropriate label, corresponding to regression stage and release version.
-function craftRegressionLabel(regressionStage: RegressionStage | undefined, releaseVersion: string | undefined): Label {
+function craftRegressionLabel(
+  regressionStage: RegressionStage | undefined,
+  releaseVersion: string | undefined,
+): Label {
   switch (regressionStage) {
     case RegressionStage.DevelopmentFeature:
       return {
@@ -353,21 +370,27 @@ function craftRegressionLabel(regressionStage: RegressionStage | undefined, rele
       return {
         name: `regression-RC-${releaseVersion || '*'}`,
         color: '744C11', // orange
-        description: releaseVersion ? `Regression bug that was found in release candidate (RC) for release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-RC-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
+        description: releaseVersion
+          ? `Regression bug that was found in release candidate (RC) for release ${releaseVersion}`
+          : `TODO: Unknown release version. Please replace with correct 'regression-RC-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
       };
 
     case RegressionStage.Beta:
       return {
         name: `regression-beta-${releaseVersion || '*'}`,
         color: 'D94A83', // pink
-        description: releaseVersion ? `Regression bug that was found in beta in release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-beta-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
+        description: releaseVersion
+          ? `Regression bug that was found in beta in release ${releaseVersion}`
+          : `TODO: Unknown release version. Please replace with correct 'regression-beta-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
       };
 
     case RegressionStage.Production:
       return {
         name: `regression-prod-${releaseVersion || '*'}`,
         color: '5319E7', // violet
-        description: releaseVersion ? `Regression bug that was found in production in release ${releaseVersion}` : `TODO: Unknown release version. Please replace with correct 'regression-prod-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
+        description: releaseVersion
+          ? `Regression bug that was found in production in release ${releaseVersion}`
+          : `TODO: Unknown release version. Please replace with correct 'regression-prod-x.y.z' label, where 'x.y.z' is the number of the release where bug was found.`,
       };
 
     default:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30160?quickstart=1)

This PR fixes `.github/scripts/check-template-and-add-labels.ts`, which either expects a valid username, or a bot's name that is included in the `knownBots` array. As `runway-github` was not added to `knownBots`, this script would fail. This PR adds  `runway-github` to `knownBots` and also fixes some formatting issues.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/30159

## **Manual testing steps**

1. After merging, Runway automatic cherry picks should have CI pass successfully.

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
