### PR TITLE
fix: Avoid nonce flicker when transaction is submitted

### DIFF
--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -125,20 +125,8 @@ describe('ConfirmFooter', () => {
       // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .mockImplementation(() => ({} as any));
-    const updateCustomNonceSpy = jest
-      .spyOn(Actions, 'updateCustomNonce')
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({} as any));
-    const setNextNonceSpy = jest
-      .spyOn(Actions, 'setNextNonce')
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({} as any));
     fireEvent.click(cancelButton);
     expect(rejectSpy).toHaveBeenCalled();
-    expect(updateCustomNonceSpy).toHaveBeenCalledWith('');
-    expect(setNextNonceSpy).toHaveBeenCalledWith('');
   });
 
   it('invoke required actions when submit button is clicked', () => {
@@ -149,20 +137,8 @@ describe('ConfirmFooter', () => {
       // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .mockImplementation(() => ({} as any));
-    const updateCustomNonceSpy = jest
-      .spyOn(Actions, 'updateCustomNonce')
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({} as any));
-    const setNextNonceSpy = jest
-      .spyOn(Actions, 'setNextNonce')
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({} as any));
     fireEvent.click(submitButton);
     expect(resolveSpy).toHaveBeenCalled();
-    expect(updateCustomNonceSpy).toHaveBeenCalledWith('');
-    expect(setNextNonceSpy).toHaveBeenCalledWith('');
   });
 
   it('displays a danger "Confirm" button there are danger alerts', async () => {

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -20,11 +20,9 @@ import useAlerts from '../../../../../hooks/useAlerts';
 import {
   rejectPendingApproval,
   resolvePendingApproval,
-  setNextNonce,
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   updateAndApproveTx,
   ///: END:ONLY_INCLUDE_IF
-  updateCustomNonce,
 } from '../../../../../store/actions';
 import { isSignatureTransactionType } from '../../../utils';
 import { useConfirmContext } from '../../../context/confirm';

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -186,8 +186,6 @@ const Footer = () => {
       dispatch(
         rejectPendingApproval(currentConfirmation.id, serializeError(error)),
       );
-      dispatch(updateCustomNonce(''));
-      dispatch(setNextNonce(''));
     },
     [currentConfirmation],
   );
@@ -219,8 +217,6 @@ const Footer = () => {
     } else {
       dispatch(resolvePendingApproval(currentConfirmation.id, undefined));
     }
-    dispatch(updateCustomNonce(''));
-    dispatch(setNextNonce(''));
   }, [currentConfirmation, customNonceValue]);
 
   const onFooterCancel = useCallback(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Submitting or cancelling a transaction was clearing the custom nonce field before the confirmation popup had time to close. This PR fixes that.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30193?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4140

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/fc803f67-cb8a-4bda-bbaa-745036fae9e3

https://github.com/user-attachments/assets/95a679f8-acba-4155-82a1-d1b536e1c5d8

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
