### PR TITLE
chore: show max network fee tooltip

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2896,9 +2896,6 @@
   "networkFee": {
     "message": "Network fee"
   },
-  "networkFees": {
-    "message": "Network fees"
-  },
   "networkIsBusy": {
     "message": "Network is busy. Gas prices are high and estimates are less accurate."
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2215,11 +2215,14 @@
   "holdToRevealUnlockedLabel": {
     "message": "hold to reveal circle unlocked"
   },
+  "howNetworkFeesWork": {
+    "message": "How network fees work"
+  },
+  "howNetworkFeesWorkExplanation": {
+    "message": "Estimated fee required to process the transaction. The max fee is $1."
+  },
   "howQuotesWork": {
     "message": "How quotes work"
-  },
-  "howQuotesWorkExplanation": {
-    "message": "This quote has the best return of the quotes we searched. This is based on the swap rate, which includes bridging fees and a $1% MetaMask fee, minus gas fees. Gas fees depend on how busy the network is and how complex the transaction is."
   },
   "id": {
     "message": "ID"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2224,6 +2224,9 @@
   "howQuotesWork": {
     "message": "How quotes work"
   },
+  "howQuotesWorkExplanation": {
+    "message": "This quote has the best return of the quotes we searched. This is based on the swap rate, which includes bridging fees and a $1% MetaMask fee, minus gas fees. Gas fees depend on how busy the network is and how complex the transaction is."
+  },
   "id": {
     "message": "ID"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2215,9 +2215,6 @@
   "holdToRevealUnlockedLabel": {
     "message": "hold to reveal circle unlocked"
   },
-  "howNetworkFeesWork": {
-    "message": "How network fees work"
-  },
   "howNetworkFeesWorkExplanation": {
     "message": "Estimated fee required to process the transaction. The max fee is $1."
   },

--- a/ui/pages/bridge/quotes/__snapshots__/bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/bridge-quote-card.test.tsx.snap
@@ -101,17 +101,25 @@ exports[`BridgeQuoteCard should render the recommended quote 1`] = `
           class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-alternative-soft"
           style="white-space: nowrap;"
         >
-          Network fees
+          Network fee
         </p>
         <div
           class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
         >
-          <p
-            class="mm-box mm-text mm-text--body-md"
-            style="white-space: nowrap; overflow: visible;"
+          <div
+            class="mm-box"
           >
-            $2.52 - $2.52
-          </p>
+            <div
+              class="mm-box mm-box--display-flex"
+            >
+              <p
+                class="mm-box mm-text mm-text--body-md"
+                style="white-space: nowrap; overflow: visible; text-decoration: underline; cursor: pointer;"
+              >
+                $2.52
+              </p>
+            </div>
+          </div>
           <span
             class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative-soft"
             style="mask-image: url('./images/icons/swap-vertical.svg'); cursor: pointer;"
@@ -257,17 +265,25 @@ exports[`BridgeQuoteCard should render the recommended quote while loading new q
           class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-alternative-soft"
           style="white-space: nowrap;"
         >
-          Network fees
+          Network fee
         </p>
         <div
           class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
         >
-          <p
-            class="mm-box mm-text mm-text--body-md"
-            style="white-space: nowrap; overflow: visible;"
+          <div
+            class="mm-box"
           >
-            $2.52 - $2.52
-          </p>
+            <div
+              class="mm-box mm-box--display-flex"
+            >
+              <p
+                class="mm-box mm-text mm-text--body-md"
+                style="white-space: nowrap; overflow: visible; text-decoration: underline; cursor: pointer;"
+              >
+                $2.52
+              </p>
+            </div>
+          </div>
           <span
             class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative-soft"
             style="mask-image: url('./images/icons/swap-vertical.svg'); cursor: pointer;"

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -189,7 +189,7 @@ export const BridgeQuoteCard = () => {
                     : TextColor.textAlternativeSoft
                 }
               >
-                {t('networkFees')}
+                {t('networkFee')}
               </Text>
               <Row gap={1}>
                 <Text
@@ -210,14 +210,6 @@ export const BridgeQuoteCard = () => {
                               activeQuote.totalNetworkFee?.amount,
                             )
                           : undefined
-                      } - ${
-                        activeQuote.totalMaxNetworkFee?.valueInCurrency
-                          ? formatTokenAmount(
-                              locale,
-                              activeQuote.totalMaxNetworkFee?.amount,
-                              ticker,
-                            )
-                          : undefined
                       }`
                     : // Network fee in display currency
                       `${
@@ -229,17 +221,6 @@ export const BridgeQuoteCard = () => {
                         formatTokenAmount(
                           locale,
                           activeQuote.totalNetworkFee?.amount,
-                        )
-                      } - ${
-                        formatCurrencyAmount(
-                          activeQuote.totalMaxNetworkFee?.valueInCurrency,
-                          currency,
-                          2,
-                        ) ??
-                        formatTokenAmount(
-                          locale,
-                          activeQuote.totalMaxNetworkFee?.amount,
-                          ticker,
                         )
                       }`}
                 </Text>

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -71,35 +71,6 @@ export const BridgeQuoteCard = () => {
   const [shouldShowNetworkFeesInGasToken, setShouldShowNetworkFeesInGasToken] =
     useState(false);
 
-  const networkFee = shouldShowNetworkFeesInGasToken
-    ? //  Network fee in gas token amounts
-      `${
-        activeQuote.totalNetworkFee?.valueInCurrency
-          ? formatTokenAmount(
-              locale,
-              activeQuote.totalNetworkFee?.amount,
-              ticker,
-            )
-          : undefined
-      }`
-    : // Network fee in display currency
-      `${
-        formatCurrencyAmount(
-          activeQuote.totalNetworkFee?.valueInCurrency,
-          currency,
-          2,
-        ) ??
-        formatTokenAmount(locale, activeQuote.totalNetworkFee?.amount, ticker)
-      }`;
-
-  const maxNetworkFee = shouldShowNetworkFeesInGasToken
-    ? formatTokenAmount(locale, activeQuote.totalMaxNetworkFee.amount, ticker)
-    : formatCurrencyAmount(
-        activeQuote.totalMaxNetworkFee.valueInCurrency,
-        currency,
-        2,
-      );
-
   return (
     <>
       <BridgeQuotesModal
@@ -239,11 +210,46 @@ export const BridgeQuoteCard = () => {
                           : undefined
                       }
                     >
-                      {networkFee}
+                      {shouldShowNetworkFeesInGasToken
+                        ? //  Network fee in gas token amounts
+                          `${
+                            activeQuote?.totalNetworkFee?.valueInCurrency
+                              ? formatTokenAmount(
+                                  locale,
+                                  activeQuote?.totalNetworkFee?.amount,
+                                  ticker,
+                                )
+                              : undefined
+                          }`
+                        : // Network fee in display currency
+                          `${
+                            formatCurrencyAmount(
+                              activeQuote?.totalNetworkFee?.valueInCurrency,
+                              currency,
+                              2,
+                            ) ??
+                            formatTokenAmount(
+                              locale,
+                              activeQuote?.totalNetworkFee?.amount,
+                              ticker,
+                            )
+                          }`}
                     </Text>
                   }
                 >
-                  {t('howNetworkFeesWorkExplanation', [maxNetworkFee])}
+                  {t('howNetworkFeesWorkExplanation', [
+                    shouldShowNetworkFeesInGasToken
+                      ? formatTokenAmount(
+                          locale,
+                          activeQuote?.totalMaxNetworkFee.amount,
+                          ticker,
+                        )
+                      : formatCurrencyAmount(
+                          activeQuote?.totalMaxNetworkFee.valueInCurrency,
+                          currency,
+                          2,
+                        ),
+                  ])}
                 </Tooltip>
 
                 <Icon

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -71,6 +71,35 @@ export const BridgeQuoteCard = () => {
   const [shouldShowNetworkFeesInGasToken, setShouldShowNetworkFeesInGasToken] =
     useState(false);
 
+  const networkFee = shouldShowNetworkFeesInGasToken
+    ? //  Network fee in gas token amounts
+      `${
+        activeQuote.totalNetworkFee?.valueInCurrency
+          ? formatTokenAmount(
+              locale,
+              activeQuote.totalNetworkFee?.amount,
+              ticker,
+            )
+          : undefined
+      }`
+    : // Network fee in display currency
+      `${
+        formatCurrencyAmount(
+          activeQuote.totalNetworkFee?.valueInCurrency,
+          currency,
+          2,
+        ) ??
+        formatTokenAmount(locale, activeQuote.totalNetworkFee?.amount, ticker)
+      }`;
+
+  const maxNetworkFee = shouldShowNetworkFeesInGasToken
+    ? formatTokenAmount(locale, activeQuote.totalMaxNetworkFee.amount, ticker)
+    : formatCurrencyAmount(
+        activeQuote.totalMaxNetworkFee.valueInCurrency,
+        currency,
+        2,
+      );
+
   return (
     <>
       <BridgeQuotesModal
@@ -192,38 +221,32 @@ export const BridgeQuoteCard = () => {
                 {t('networkFee')}
               </Text>
               <Row gap={1}>
-                <Text
-                  style={{
-                    whiteSpace: 'nowrap',
-                    overflow: 'visible',
-                  }}
-                  color={
-                    isEstimatedReturnLow ? TextColor.warningDefault : undefined
+                <Tooltip
+                  title={t('howQuotesWork')}
+                  position={PopoverPosition.TopStart}
+                  offset={[-16, 16]}
+                  iconName={IconName.Question}
+                  triggerElement={
+                    <Text
+                      style={{
+                        whiteSpace: 'nowrap',
+                        overflow: 'visible',
+                        textDecoration: 'underline',
+                        cursor: 'pointer',
+                      }}
+                      color={
+                        isEstimatedReturnLow
+                          ? TextColor.warningDefault
+                          : undefined
+                      }
+                    >
+                      {networkFee}
+                    </Text>
                   }
                 >
-                  {shouldShowNetworkFeesInGasToken
-                    ? //  Network fee in gas token amounts
-                      `${
-                        activeQuote.totalNetworkFee?.valueInCurrency
-                          ? formatTokenAmount(
-                              locale,
-                              activeQuote.totalNetworkFee?.amount,
-                            )
-                          : undefined
-                      }`
-                    : // Network fee in display currency
-                      `${
-                        formatCurrencyAmount(
-                          activeQuote.totalNetworkFee?.valueInCurrency,
-                          currency,
-                          2,
-                        ) ??
-                        formatTokenAmount(
-                          locale,
-                          activeQuote.totalNetworkFee?.amount,
-                        )
-                      }`}
-                </Text>
+                  {t('howNetworkFeesWorkExplanation', [maxNetworkFee])}
+                </Tooltip>
+
                 <Icon
                   style={{ cursor: 'pointer' }}
                   color={

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -222,7 +222,6 @@ export const BridgeQuoteCard = () => {
               </Text>
               <Row gap={1}>
                 <Tooltip
-                  title={t('howQuotesWork')}
                   position={PopoverPosition.TopStart}
                   offset={[-16, 16]}
                   iconName={IconName.Question}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30208?quickstart=1)

This PR moves the max fee for a bridge tx into a tooltip.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to bridge
2. Enter in your from and to tokens and amounts
3. See network fee
4. Hover over it for the max

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


### **After**

<!-- [screenshots/recordings] -->

![Screenshot 2025-02-07 at 10 47 48 AM](https://github.com/user-attachments/assets/c6057808-f9c8-4566-87d7-845d652fdc9f)



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
