### PR TITLE
fix: cp-12.12.0 bring back exception if invalid address passed in eth_accounts

### DIFF
--- a/app/scripts/controllers/permissions/specifications.js
+++ b/app/scripts/controllers/permissions/specifications.js
@@ -201,7 +201,7 @@ export const unrestrictedMethods = Object.freeze([
  * @param {string[]} accounts - The accounts associated with the caveat.
  * @param {() => Record<string, import('@metamask/keyring-internal-api').InternalAccount>} getInternalAccounts -
  * Gets all AccountsController InternalAccounts.
- * TODO: Remove this function once permission refactor/factory differ work is merged into main
+ * TODO: Remove this function once the CAIP-25  permission refactor/factory differ work is merged into main
  */
 export function validateCaveatAccounts(accounts, getInternalAccounts) {
   if (!Array.isArray(accounts) || accounts.length === 0) {
@@ -238,7 +238,7 @@ export function validateCaveatAccounts(accounts, getInternalAccounts) {
  * @param {string[]} chainIdsForCaveat - The list of chain IDs to validate.
  * @param {function(string): string} findNetworkClientIdByChainId - Function to find network client ID by chain ID.
  * @throws {Error} If the chainIdsForCaveat is not a non-empty array of valid chain IDs.
- * TODO: Remove this function once permission refactor/factory differ work is merged into main
+ * TODO: Remove this function once the CAIP-25  permission refactor/factory differ work is merged into main
  */
 export function validateCaveatNetworks(
   chainIdsForCaveat,

--- a/app/scripts/controllers/permissions/specifications.js
+++ b/app/scripts/controllers/permissions/specifications.js
@@ -201,7 +201,7 @@ export const unrestrictedMethods = Object.freeze([
  * @param {string[]} accounts - The accounts associated with the caveat.
  * @param {() => Record<string, import('@metamask/keyring-internal-api').InternalAccount>} getInternalAccounts -
  * Gets all AccountsController InternalAccounts.
- * TODO: Remove this function once the CAIP-25  permission refactor/factory differ work is merged into main
+ * TODO: Remove this function once the CAIP-25 permission refactor/factory differ work is merged into main
  */
 export function validateCaveatAccounts(accounts, getInternalAccounts) {
   if (!Array.isArray(accounts) || accounts.length === 0) {
@@ -238,7 +238,7 @@ export function validateCaveatAccounts(accounts, getInternalAccounts) {
  * @param {string[]} chainIdsForCaveat - The list of chain IDs to validate.
  * @param {function(string): string} findNetworkClientIdByChainId - Function to find network client ID by chain ID.
  * @throws {Error} If the chainIdsForCaveat is not a non-empty array of valid chain IDs.
- * TODO: Remove this function once the CAIP-25  permission refactor/factory differ work is merged into main
+ * TODO: Remove this function once the CAIP-25 permission refactor/factory differ work is merged into main
  */
 export function validateCaveatNetworks(
   chainIdsForCaveat,

--- a/app/scripts/controllers/permissions/specifications.js
+++ b/app/scripts/controllers/permissions/specifications.js
@@ -192,3 +192,72 @@ export const unrestrictedMethods = Object.freeze([
   'metamaskinstitutional_openAddHardwareWallet',
   ///: END:ONLY_INCLUDE_IF
 ]);
+
+/**
+ * Validates the accounts associated with a caveat. In essence, ensures that
+ * the accounts value is an array of non-empty strings, and that each string
+ * corresponds to a PreferencesController identity.
+ *
+ * @param {string[]} accounts - The accounts associated with the caveat.
+ * @param {() => Record<string, import('@metamask/keyring-internal-api').InternalAccount>} getInternalAccounts -
+ * Gets all AccountsController InternalAccounts.
+ * TODO: Remove this function once permission refactor/factory differ work is merged into main
+ */
+export function validateCaveatAccounts(accounts, getInternalAccounts) {
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    throw new Error(
+      `${PermissionNames.eth_accounts} error: Expected non-empty array of Ethereum addresses.`,
+    );
+  }
+
+  const internalAccounts = getInternalAccounts();
+  accounts.forEach((address) => {
+    if (!address || typeof address !== 'string') {
+      throw new Error(
+        `${PermissionNames.eth_accounts} error: Expected an array of Ethereum addresses. Received: "${address}".`,
+      );
+    }
+
+    if (
+      !internalAccounts.some(
+        (internalAccount) =>
+          internalAccount.address.toLowerCase() === address.toLowerCase(),
+      )
+    ) {
+      throw new Error(
+        `${PermissionNames.eth_accounts} error: Received unrecognized address: "${address}".`,
+      );
+    }
+  });
+}
+
+/**
+ * Validates the networks associated with a caveat. Ensures that
+ * the networks value is an array of valid chain IDs.
+ *
+ * @param {string[]} chainIdsForCaveat - The list of chain IDs to validate.
+ * @param {function(string): string} findNetworkClientIdByChainId - Function to find network client ID by chain ID.
+ * @throws {Error} If the chainIdsForCaveat is not a non-empty array of valid chain IDs.
+ * TODO: Remove this function once permission refactor/factory differ work is merged into main
+ */
+export function validateCaveatNetworks(
+  chainIdsForCaveat,
+  findNetworkClientIdByChainId,
+) {
+  if (!Array.isArray(chainIdsForCaveat) || chainIdsForCaveat.length === 0) {
+    throw new Error(
+      `${PermissionNames.permittedChains} error: Expected non-empty array of chainIds.`,
+    );
+  }
+
+  chainIdsForCaveat.forEach((chainId) => {
+    try {
+      findNetworkClientIdByChainId(chainId);
+    } catch (e) {
+      console.error(e);
+      throw new Error(
+        `${PermissionNames.permittedChains} error: Received unrecognized chainId: "${chainId}". Please try adding the network first via wallet_addEthereumChain.`,
+      );
+    }
+  });
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5282,14 +5282,14 @@ export default class MetamaskController extends EventEmitter {
         (caveat) => caveat.type === CaveatTypes.restrictNetworkSwitching,
       )?.value ?? [];
 
-    if (permissions[RestrictedMethods.eth_accounts]) {
+    if (permissions[PermissionNames.permittedChains]?.caveats) {
       validateCaveatAccounts(
         requestedAccounts,
         this.accountsController.listAccounts.bind(this.accountsController),
       );
     }
 
-    if (permissions[PermissionNames.permittedChains]) {
+    if (permissions[PermissionNames.permittedChains]?.caveat) {
       validateCaveatNetworks(
         requestedChains,
         this.networkController.findNetworkClientIdByChainId.bind(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5273,7 +5273,7 @@ export default class MetamaskController extends EventEmitter {
     ]);
 
     const requestedAccounts =
-      permissions[PermissionNames.eth_accounts]?.caveats?.find(
+      permissions[RestrictedMethods.eth_accounts]?.caveats?.find(
         (caveat) => caveat.type === CaveatTypes.restrictReturnedAccounts,
       )?.value ?? [];
 
@@ -5282,14 +5282,14 @@ export default class MetamaskController extends EventEmitter {
         (caveat) => caveat.type === CaveatTypes.restrictNetworkSwitching,
       )?.value ?? [];
 
-    if (permissions[PermissionNames.permittedChains]?.caveats) {
+    if (permissions[RestrictedMethods.eth_accounts]?.caveats) {
       validateCaveatAccounts(
         requestedAccounts,
         this.accountsController.listAccounts.bind(this.accountsController),
       );
     }
 
-    if (permissions[PermissionNames.permittedChains]?.caveat) {
+    if (permissions[PermissionNames.permittedChains]?.caveats) {
       validateCaveatNetworks(
         requestedChains,
         this.networkController.findNetworkClientIdByChainId.bind(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5272,6 +5272,32 @@ export default class MetamaskController extends EventEmitter {
       PermissionNames.permittedChains,
     ]);
 
+    const requestedAccounts =
+      permissions[PermissionNames.eth_accounts]?.caveats?.find(
+        (caveat) => caveat.type === CaveatTypes.restrictReturnedAccounts,
+      )?.value ?? [];
+
+    const requestedChains =
+      permissions[PermissionNames.permittedChains]?.caveats?.find(
+        (caveat) => caveat.type === CaveatTypes.restrictNetworkSwitching,
+      )?.value ?? [];
+
+    if (permissions[RestrictedMethods.eth_accounts]) {
+      validateCaveatAccounts(
+        requestedAccounts,
+        this.accountsController.listAccounts.bind(this.accountsController),
+      );
+    }
+
+    if (permissions[PermissionNames.permittedChains]) {
+      validateCaveatNetworks(
+        requestedChains,
+        this.networkController.findNetworkClientIdByChainId.bind(
+          this.networkController,
+        ),
+      );
+    }
+
     if (!permissions[RestrictedMethods.eth_accounts]) {
       permissions[RestrictedMethods.eth_accounts] = {};
     }
@@ -5283,28 +5309,6 @@ export default class MetamaskController extends EventEmitter {
     if (isSnapId(origin)) {
       delete permissions[PermissionNames.permittedChains];
     }
-
-    const requestedChains =
-      permissions[PermissionNames.permittedChains]?.caveats?.find(
-        (caveat) => caveat.type === CaveatTypes.restrictNetworkSwitching,
-      )?.value ?? [];
-
-    const requestedAccounts =
-      permissions[PermissionNames.eth_accounts]?.caveats?.find(
-        (caveat) => caveat.type === CaveatTypes.restrictReturnedAccounts,
-      )?.value ?? [];
-
-    validateCaveatAccounts(
-      requestedAccounts,
-      this.accountsController.listAccounts.bind(this.accountsController),
-    );
-
-    validateCaveatNetworks(
-      requestedChains,
-      this.networkController.findNetworkClientIdByChainId.bind(
-        this.networkController,
-      ),
-    );
 
     const newCaveatValue = {
       requiredScopes: {},

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5298,7 +5298,7 @@ export default class MetamaskController extends EventEmitter {
       requestedAccounts,
       this.accountsController.listAccounts.bind(this.accountsController),
     );
-    console.log('i passed here');
+
     validateCaveatNetworks(
       requestedChains,
       this.networkController.findNetworkClientIdByChainId.bind(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -316,6 +316,8 @@ import {
   NOTIFICATION_NAMES,
   unrestrictedMethods,
   PermissionNames,
+  validateCaveatAccounts,
+  validateCaveatNetworks,
 } from './controllers/permissions';
 import { MetaMetricsDataDeletionController } from './controllers/metametrics-data-deletion/metametrics-data-deletion';
 import { DataDeletionService } from './services/data-deletion-service';
@@ -5291,6 +5293,18 @@ export default class MetamaskController extends EventEmitter {
       permissions[PermissionNames.eth_accounts]?.caveats?.find(
         (caveat) => caveat.type === CaveatTypes.restrictReturnedAccounts,
       )?.value ?? [];
+
+    validateCaveatAccounts(
+      requestedAccounts,
+      this.accountsController.listAccounts.bind(this.accountsController),
+    );
+    console.log('i passed here');
+    validateCaveatNetworks(
+      requestedChains,
+      this.networkController.findNetworkClientIdByChainId.bind(
+        this.networkController,
+      ),
+    );
 
     const newCaveatValue = {
       requiredScopes: {},

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1671,7 +1671,7 @@ describe('MetaMaskController', () => {
         describe('unrecognized chain id requested', () => {
           beforeEach(() => {
             PermissionSpecifications.validateCaveatAccounts.mockImplementation(
-              () => ({}),
+              () => undefined,
             );
             PermissionSpecifications.validateCaveatNetworks.mockImplementation(
               () => {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -55,6 +55,7 @@ import {
   CaveatTypes,
   EndowmentTypes,
   RestrictedEthMethods,
+  RestrictedMethods,
 } from '../../shared/constants/permissions';
 import { deferredPromise } from './lib/util';
 import { METAMASK_COOKIE_HANDLER } from './constants/stream';
@@ -1643,7 +1644,7 @@ describe('MetaMaskController', () => {
             PermissionSpecifications.validateCaveatAccounts.mockImplementation(
               () => {
                 throw new Error(
-                  `${PermissionNames.eth_accounts} error: Received unrecognized address: "${INVALID_ADDRESS}".`,
+                  `${RestrictedMethods.eth_accounts} error: Received unrecognized address: "${INVALID_ADDRESS}".`,
                 );
               },
             );
@@ -1652,7 +1653,7 @@ describe('MetaMaskController', () => {
           it('should throw exception when requesting invalid account', async () => {
             await expect(
               metamaskController.requestCaip25Approval('test.com', {
-                [PermissionNames.eth_accounts]: {
+                [RestrictedMethods.eth_accounts]: {
                   caveats: [
                     {
                       type: CaveatTypes.restrictReturnedAccounts,
@@ -1662,7 +1663,7 @@ describe('MetaMaskController', () => {
                 },
               }),
             ).rejects.toThrow(
-              `${PermissionNames.eth_accounts} error: Received unrecognized address: "${INVALID_ADDRESS}".`,
+              `${RestrictedMethods.eth_accounts} error: Received unrecognized address: "${INVALID_ADDRESS}".`,
             );
           });
         });
@@ -1684,7 +1685,7 @@ describe('MetaMaskController', () => {
           it('should throw exception when requesting invalid chain id', async () => {
             await expect(
               metamaskController.requestCaip25Approval('test.com', {
-                [PermissionNames.eth_accounts]: {
+                [RestrictedMethods.eth_accounts]: {
                   caveats: [
                     {
                       type: CaveatTypes.restrictReturnedAccounts,

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -62,6 +62,7 @@ import MetaMaskController, {
   ONE_KEY_VIA_TREZOR_MINOR_VERSION,
 } from './metamask-controller';
 import { PermissionNames } from './controllers/permissions';
+import * as PermissionSpecifications from './controllers/permissions/specifications';
 
 const { Ganache } = require('../../test/e2e/seeder/ganache');
 
@@ -115,6 +116,13 @@ const createLoggerMiddlewareMock = () => (req, res, next) => {
   }
   next();
 };
+
+jest.mock('./controllers/permissions/specifications', () => ({
+  ...jest.requireActual('./controllers/permissions/specifications'),
+  validateCaveatAccounts: jest.fn(),
+  validateCaveatNetworks: jest.fn(),
+}));
+
 jest.mock('./lib/createLoggerMiddleware', () => createLoggerMiddlewareMock);
 
 const rpcMethodMiddlewareMock = {
@@ -960,668 +968,753 @@ describe('MetaMaskController', () => {
     });
 
     describe('#requestCaip25Approval', () => {
-      it('requests approval with well formed id and origin', async () => {
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {},
-          });
-        jest
-          .spyOn(metamaskController.permissionController, 'grantPermissions')
-          .mockReturnValue({
-            [Caip25EndowmentPermissionName]: {
-              foo: 'bar',
-            },
-          });
-
-        await metamaskController.requestCaip25Approval('test.com', {});
-
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin: 'test.com',
-            requestData: expect.objectContaining({
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin: 'test.com',
-              },
-            }),
-            type: 'wallet_requestPermissions',
-          }),
-        );
-
-        const [params] =
-          metamaskController.approvalController.addAndShowApprovalRequest.mock
-            .calls[0];
-        expect(params.id).toStrictEqual(params.requestData.metadata.id);
-      });
-
-      it('requests approval from the ApprovalController for eth_accounts and permittedChains when only eth_accounts is specified in params and origin is not snapId', async () => {
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {},
-          });
-        jest
-          .spyOn(metamaskController.permissionController, 'grantPermissions')
-          .mockReturnValue({
-            [Caip25EndowmentPermissionName]: {
-              foo: 'bar',
-            },
-          });
-
-        await metamaskController.requestCaip25Approval('test.com', {
-          [PermissionNames.eth_accounts]: {
-            caveats: [
-              {
-                type: CaveatTypes.restrictReturnedAccounts,
-                value: ['foo'],
-              },
-            ],
-          },
-        });
-
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin: 'test.com',
-            requestData: {
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin: 'test.com',
-              },
-              permissions: {
-                [Caip25EndowmentPermissionName]: {
-                  caveats: [
-                    {
-                      type: Caip25CaveatType,
-                      value: {
-                        requiredScopes: {},
-                        optionalScopes: {
-                          'wallet:eip155': {
-                            accounts: ['wallet:eip155:foo'],
-                          },
-                        },
-                        isMultichainOrigin: false,
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-            type: 'wallet_requestPermissions',
-          }),
-        );
-      });
-
-      it('requests approval from the ApprovalController for eth_accounts and permittedChains when only permittedChains is specified in params and origin is not snapId', async () => {
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {},
-          });
-        jest
-          .spyOn(metamaskController.permissionController, 'grantPermissions')
-          .mockReturnValue({
-            [Caip25EndowmentPermissionName]: {
-              foo: 'bar',
-            },
-          });
-
-        await metamaskController.requestCaip25Approval('test.com', {
-          [PermissionNames.permittedChains]: {
-            caveats: [
-              {
-                type: CaveatTypes.restrictNetworkSwitching,
-                value: ['0x64'],
-              },
-            ],
-          },
-        });
-
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin: 'test.com',
-            requestData: {
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin: 'test.com',
-              },
-              permissions: {
-                [Caip25EndowmentPermissionName]: {
-                  caveats: [
-                    {
-                      type: Caip25CaveatType,
-                      value: {
-                        requiredScopes: {},
-                        optionalScopes: {
-                          'wallet:eip155': {
-                            accounts: [],
-                          },
-                          'eip155:100': {
-                            accounts: [],
-                          },
-                        },
-                        isMultichainOrigin: false,
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-            type: 'wallet_requestPermissions',
-          }),
-        );
-      });
-
-      it('requests approval from the ApprovalController for eth_accounts and permittedChains when both are specified in params and origin is not snapId', async () => {
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {},
-          });
-        jest
-          .spyOn(metamaskController.permissionController, 'grantPermissions')
-          .mockReturnValue({
-            [Caip25EndowmentPermissionName]: {
-              foo: 'bar',
-            },
-          });
-
-        await metamaskController.requestCaip25Approval('test.com', {
-          [PermissionNames.eth_accounts]: {
-            caveats: [
-              {
-                type: CaveatTypes.restrictReturnedAccounts,
-                value: ['foo'],
-              },
-            ],
-          },
-          [PermissionNames.permittedChains]: {
-            caveats: [
-              {
-                type: CaveatTypes.restrictNetworkSwitching,
-                value: ['0x64'],
-              },
-            ],
-          },
-        });
-
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin: 'test.com',
-            requestData: {
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin: 'test.com',
-              },
-              permissions: {
-                [Caip25EndowmentPermissionName]: {
-                  caveats: [
-                    {
-                      type: Caip25CaveatType,
-                      value: {
-                        requiredScopes: {},
-                        optionalScopes: {
-                          'wallet:eip155': {
-                            accounts: ['wallet:eip155:foo'],
-                          },
-                          'eip155:100': {
-                            accounts: ['eip155:100:foo'],
-                          },
-                        },
-                        isMultichainOrigin: false,
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-            type: 'wallet_requestPermissions',
-          }),
-        );
-      });
-
-      it('requests approval from the ApprovalController for only eth_accounts when only eth_accounts is specified in params and origin is snapId', async () => {
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {},
-          });
-        jest
-          .spyOn(metamaskController.permissionController, 'grantPermissions')
-          .mockReturnValue({
-            [Caip25EndowmentPermissionName]: {
-              foo: 'bar',
-            },
-          });
-
-        await metamaskController.requestCaip25Approval('npm:snap', {
-          [PermissionNames.eth_accounts]: {
-            caveats: [
-              {
-                type: CaveatTypes.restrictReturnedAccounts,
-                value: ['foo'],
-              },
-            ],
-          },
-        });
-
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin: 'npm:snap',
-            requestData: {
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin: 'npm:snap',
-              },
-              permissions: {
-                [Caip25EndowmentPermissionName]: {
-                  caveats: [
-                    {
-                      type: Caip25CaveatType,
-                      value: {
-                        requiredScopes: {},
-                        optionalScopes: {
-                          'wallet:eip155': {
-                            accounts: ['wallet:eip155:foo'],
-                          },
-                        },
-                        isMultichainOrigin: false,
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-            type: 'wallet_requestPermissions',
-          }),
-        );
-      });
-
-      it('requests approval from the ApprovalController for only eth_accounts when only permittedChains is specified in params and origin is snapId', async () => {
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {},
-          });
-        jest
-          .spyOn(metamaskController.permissionController, 'grantPermissions')
-          .mockReturnValue({
-            [Caip25EndowmentPermissionName]: {
-              foo: 'bar',
-            },
-          });
-
-        await metamaskController.requestCaip25Approval('npm:snap', {
-          [PermissionNames.permittedChains]: {
-            caveats: [
-              {
-                type: CaveatTypes.restrictNetworkSwitching,
-                value: ['0x64'],
-              },
-            ],
-          },
-        });
-
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin: 'npm:snap',
-            requestData: {
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin: 'npm:snap',
-              },
-              permissions: {
-                [Caip25EndowmentPermissionName]: {
-                  caveats: [
-                    {
-                      type: Caip25CaveatType,
-                      value: {
-                        requiredScopes: {},
-                        optionalScopes: {
-                          'wallet:eip155': {
-                            accounts: [],
-                          },
-                        },
-                        isMultichainOrigin: false,
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-            type: 'wallet_requestPermissions',
-          }),
-        );
-      });
-
-      it('requests approval from the ApprovalController for only eth_accounts when both eth_accounts and permittedChains are specified in params and origin is snapId', async () => {
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {},
-          });
-        jest
-          .spyOn(metamaskController.permissionController, 'grantPermissions')
-          .mockReturnValue({
-            [Caip25EndowmentPermissionName]: {
-              foo: 'bar',
-            },
-          });
-
-        await metamaskController.requestCaip25Approval('npm:snap', {
-          [PermissionNames.eth_accounts]: {
-            caveats: [
-              {
-                type: CaveatTypes.restrictReturnedAccounts,
-                value: ['foo'],
-              },
-            ],
-          },
-          [PermissionNames.permittedChains]: {
-            caveats: [
-              {
-                type: CaveatTypes.restrictNetworkSwitching,
-                value: ['0x64'],
-              },
-            ],
-          },
-        });
-
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin: 'npm:snap',
-            requestData: {
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin: 'npm:snap',
-              },
-              permissions: {
-                [Caip25EndowmentPermissionName]: {
-                  caveats: [
-                    {
-                      type: Caip25CaveatType,
-                      value: {
-                        requiredScopes: {},
-                        optionalScopes: {
-                          'wallet:eip155': {
-                            accounts: ['wallet:eip155:foo'],
-                          },
-                        },
-                        isMultichainOrigin: false,
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-            type: 'wallet_requestPermissions',
-          }),
-        );
-      });
-
-      it('throws an error if the eth_accounts and permittedChains approval is rejected', async () => {
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockRejectedValue(new Error('approval rejected'));
-
-        await expect(() =>
-          metamaskController.requestCaip25Approval('test.com', {
-            eth_accounts: {},
-          }),
-        ).rejects.toThrow(new Error('approval rejected'));
-      });
-
-      it('requests CAIP-25 approval with accounts and chainIds specified from `eth_accounts` and `endowment:permittedChains` permissions caveats, and isMultichainOrigin: false if origin is not snapId', async () => {
-        const origin = 'test.com';
-
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {
+      describe('valid requests', () => {
+        it('requests approval with well formed id and origin', async () => {
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {},
+            });
+          jest
+            .spyOn(metamaskController.permissionController, 'grantPermissions')
+            .mockReturnValue({
               [Caip25EndowmentPermissionName]: {
-                caveats: [
-                  {
-                    type: Caip25CaveatType,
-                    value: {
-                      requiredScopes: {},
-                      optionalScopes: {},
-                      isMultichainOrigin: false,
-                    },
-                  },
-                ],
+                foo: 'bar',
               },
-            },
-          });
+            });
 
-        await metamaskController.requestCaip25Approval('test.com', {
-          [RestrictedEthMethods.eth_accounts]: {
-            caveats: [
-              {
-                type: 'restrictReturnedAccounts',
-                value: ['0xdeadbeef'],
-              },
-            ],
-          },
-          [EndowmentTypes.permittedChains]: {
-            caveats: [
-              {
-                type: 'restrictNetworkSwitching',
-                value: ['0x1', '0x5'],
-              },
-            ],
-          },
-        });
+          await metamaskController.requestCaip25Approval('test.com', {});
 
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin,
-            requestData: {
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin,
-              },
-              permissions: {
-                [Caip25EndowmentPermissionName]: {
-                  caveats: [
-                    {
-                      type: Caip25CaveatType,
-                      value: {
-                        requiredScopes: {},
-                        optionalScopes: {
-                          'wallet:eip155': {
-                            accounts: ['wallet:eip155:0xdeadbeef'],
-                          },
-                          'eip155:1': {
-                            accounts: ['eip155:1:0xdeadbeef'],
-                          },
-                          'eip155:5': {
-                            accounts: ['eip155:5:0xdeadbeef'],
-                          },
-                        },
-                        isMultichainOrigin: false,
-                      },
-                    },
-                  ],
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin: 'test.com',
+              requestData: expect.objectContaining({
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin: 'test.com',
                 },
-              },
-            },
-            type: 'wallet_requestPermissions',
-          }),
-        );
-      });
-
-      it('requests CAIP-25 approval with approved accounts for the `wallet:eip155` scope (and no approved chainIds) with isMultichainOrigin: false if origin is snapId', async () => {
-        const origin = 'npm:snap';
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: {
-              [Caip25EndowmentPermissionName]: {
-                caveats: [
-                  {
-                    type: Caip25CaveatType,
-                    value: {
-                      requiredScopes: {},
-                      optionalScopes: {},
-                      isMultichainOrigin: false,
-                    },
-                  },
-                ],
-              },
-            },
-          });
-
-        jest
-          .spyOn(metamaskController.permissionController, 'grantPermissions')
-          .mockReturnValue({
-            [Caip25EndowmentPermissionName]: {
-              foo: 'bar',
-            },
-          });
-
-        await metamaskController.requestCaip25Approval(origin, {
-          [RestrictedEthMethods.eth_accounts]: {
-            caveats: [
-              {
-                type: 'restrictReturnedAccounts',
-                value: ['0xdeadbeef'],
-              },
-            ],
-          },
-          [EndowmentTypes.permittedChains]: {
-            caveats: [
-              {
-                type: 'restrictNetworkSwitching',
-                value: ['0x1', '0x5'],
-              },
-            ],
-          },
-        });
-
-        expect(
-          metamaskController.approvalController.addAndShowApprovalRequest,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: expect.stringMatching(/.{21}/u),
-            origin,
-            requestData: expect.objectContaining({
-              metadata: {
-                id: expect.stringMatching(/.{21}/u),
-                origin,
-              },
-              permissions: {
-                [Caip25EndowmentPermissionName]: {
-                  caveats: [
-                    {
-                      type: Caip25CaveatType,
-                      value: {
-                        requiredScopes: {},
-                        optionalScopes: {
-                          'wallet:eip155': {
-                            accounts: ['wallet:eip155:0xdeadbeef'],
-                          },
-                        },
-                        isMultichainOrigin: false,
-                      },
-                    },
-                  ],
-                },
-              },
+              }),
+              type: 'wallet_requestPermissions',
             }),
-            type: 'wallet_requestPermissions',
-          }),
-        );
-      });
+          );
 
-      it('should return sessions scopes returned from calling ApprovalController.addAndShowApprovalRequest', async () => {
-        const expectedPermissions = {
-          [Caip25EndowmentPermissionName]: {
-            caveats: [
-              {
-                type: Caip25CaveatType,
-                value: {
-                  requiredScopes: {},
-                  optionalScopes: {
-                    'wallet:eip155': {
-                      accounts: ['wallet:eip155:0xdeadbeef'],
-                    },
-                  },
-                  isMultichainOrigin: false,
-                },
+          const [params] =
+            metamaskController.approvalController.addAndShowApprovalRequest.mock
+              .calls[0];
+          expect(params.id).toStrictEqual(params.requestData.metadata.id);
+        });
+
+        it('requests approval from the ApprovalController for eth_accounts and permittedChains when only eth_accounts is specified in params and origin is not snapId', async () => {
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {},
+            });
+          jest
+            .spyOn(metamaskController.permissionController, 'grantPermissions')
+            .mockReturnValue({
+              [Caip25EndowmentPermissionName]: {
+                foo: 'bar',
               },
-            ],
-          },
-        };
+            });
 
-        jest
-          .spyOn(
-            metamaskController.approvalController,
-            'addAndShowApprovalRequest',
-          )
-          .mockResolvedValue({
-            permissions: expectedPermissions,
+          await metamaskController.requestCaip25Approval('test.com', {
+            [PermissionNames.eth_accounts]: {
+              caveats: [
+                {
+                  type: CaveatTypes.restrictReturnedAccounts,
+                  value: ['foo'],
+                },
+              ],
+            },
           });
 
-        const result = await metamaskController.requestCaip25Approval(
-          'test.com',
-          {},
-        );
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin: 'test.com',
+              requestData: {
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin: 'test.com',
+                },
+                permissions: {
+                  [Caip25EndowmentPermissionName]: {
+                    caveats: [
+                      {
+                        type: Caip25CaveatType,
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: ['wallet:eip155:foo'],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              type: 'wallet_requestPermissions',
+            }),
+          );
+        });
 
-        expect(result).toStrictEqual(expectedPermissions);
+        it('requests approval from the ApprovalController for eth_accounts and permittedChains when only permittedChains is specified in params and origin is not snapId', async () => {
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {},
+            });
+          jest
+            .spyOn(metamaskController.permissionController, 'grantPermissions')
+            .mockReturnValue({
+              [Caip25EndowmentPermissionName]: {
+                foo: 'bar',
+              },
+            });
+
+          await metamaskController.requestCaip25Approval('test.com', {
+            [PermissionNames.permittedChains]: {
+              caveats: [
+                {
+                  type: CaveatTypes.restrictNetworkSwitching,
+                  value: ['0x64'],
+                },
+              ],
+            },
+          });
+
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin: 'test.com',
+              requestData: {
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin: 'test.com',
+                },
+                permissions: {
+                  [Caip25EndowmentPermissionName]: {
+                    caveats: [
+                      {
+                        type: Caip25CaveatType,
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: [],
+                            },
+                            'eip155:100': {
+                              accounts: [],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              type: 'wallet_requestPermissions',
+            }),
+          );
+        });
+
+        it('requests approval from the ApprovalController for eth_accounts and permittedChains when both are specified in params and origin is not snapId', async () => {
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {},
+            });
+          jest
+            .spyOn(metamaskController.permissionController, 'grantPermissions')
+            .mockReturnValue({
+              [Caip25EndowmentPermissionName]: {
+                foo: 'bar',
+              },
+            });
+
+          await metamaskController.requestCaip25Approval('test.com', {
+            [PermissionNames.eth_accounts]: {
+              caveats: [
+                {
+                  type: CaveatTypes.restrictReturnedAccounts,
+                  value: ['foo'],
+                },
+              ],
+            },
+            [PermissionNames.permittedChains]: {
+              caveats: [
+                {
+                  type: CaveatTypes.restrictNetworkSwitching,
+                  value: ['0x64'],
+                },
+              ],
+            },
+          });
+
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin: 'test.com',
+              requestData: {
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin: 'test.com',
+                },
+                permissions: {
+                  [Caip25EndowmentPermissionName]: {
+                    caveats: [
+                      {
+                        type: Caip25CaveatType,
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: ['wallet:eip155:foo'],
+                            },
+                            'eip155:100': {
+                              accounts: ['eip155:100:foo'],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              type: 'wallet_requestPermissions',
+            }),
+          );
+        });
+
+        it('requests approval from the ApprovalController for only eth_accounts when only eth_accounts is specified in params and origin is snapId', async () => {
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {},
+            });
+          jest
+            .spyOn(metamaskController.permissionController, 'grantPermissions')
+            .mockReturnValue({
+              [Caip25EndowmentPermissionName]: {
+                foo: 'bar',
+              },
+            });
+
+          await metamaskController.requestCaip25Approval('npm:snap', {
+            [PermissionNames.eth_accounts]: {
+              caveats: [
+                {
+                  type: CaveatTypes.restrictReturnedAccounts,
+                  value: ['foo'],
+                },
+              ],
+            },
+          });
+
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin: 'npm:snap',
+              requestData: {
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin: 'npm:snap',
+                },
+                permissions: {
+                  [Caip25EndowmentPermissionName]: {
+                    caveats: [
+                      {
+                        type: Caip25CaveatType,
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: ['wallet:eip155:foo'],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              type: 'wallet_requestPermissions',
+            }),
+          );
+        });
+
+        it('requests approval from the ApprovalController for only eth_accounts when only permittedChains is specified in params and origin is snapId', async () => {
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {},
+            });
+          jest
+            .spyOn(metamaskController.permissionController, 'grantPermissions')
+            .mockReturnValue({
+              [Caip25EndowmentPermissionName]: {
+                foo: 'bar',
+              },
+            });
+
+          await metamaskController.requestCaip25Approval('npm:snap', {
+            [PermissionNames.permittedChains]: {
+              caveats: [
+                {
+                  type: CaveatTypes.restrictNetworkSwitching,
+                  value: ['0x64'],
+                },
+              ],
+            },
+          });
+
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin: 'npm:snap',
+              requestData: {
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin: 'npm:snap',
+                },
+                permissions: {
+                  [Caip25EndowmentPermissionName]: {
+                    caveats: [
+                      {
+                        type: Caip25CaveatType,
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: [],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              type: 'wallet_requestPermissions',
+            }),
+          );
+        });
+
+        it('requests approval from the ApprovalController for only eth_accounts when both eth_accounts and permittedChains are specified in params and origin is snapId', async () => {
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {},
+            });
+          jest
+            .spyOn(metamaskController.permissionController, 'grantPermissions')
+            .mockReturnValue({
+              [Caip25EndowmentPermissionName]: {
+                foo: 'bar',
+              },
+            });
+
+          await metamaskController.requestCaip25Approval('npm:snap', {
+            [PermissionNames.eth_accounts]: {
+              caveats: [
+                {
+                  type: CaveatTypes.restrictReturnedAccounts,
+                  value: ['foo'],
+                },
+              ],
+            },
+            [PermissionNames.permittedChains]: {
+              caveats: [
+                {
+                  type: CaveatTypes.restrictNetworkSwitching,
+                  value: ['0x64'],
+                },
+              ],
+            },
+          });
+
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin: 'npm:snap',
+              requestData: {
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin: 'npm:snap',
+                },
+                permissions: {
+                  [Caip25EndowmentPermissionName]: {
+                    caveats: [
+                      {
+                        type: Caip25CaveatType,
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: ['wallet:eip155:foo'],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              type: 'wallet_requestPermissions',
+            }),
+          );
+        });
+
+        it('throws an error if the eth_accounts and permittedChains approval is rejected', async () => {
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockRejectedValue(new Error('approval rejected'));
+
+          await expect(() =>
+            metamaskController.requestCaip25Approval('test.com', {
+              eth_accounts: {},
+            }),
+          ).rejects.toThrow(new Error('approval rejected'));
+        });
+
+        it('requests CAIP-25 approval with accounts and chainIds specified from `eth_accounts` and `endowment:permittedChains` permissions caveats, and isMultichainOrigin: false if origin is not snapId', async () => {
+          const origin = 'test.com';
+
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {
+                [Caip25EndowmentPermissionName]: {
+                  caveats: [
+                    {
+                      type: Caip25CaveatType,
+                      value: {
+                        requiredScopes: {},
+                        optionalScopes: {},
+                        isMultichainOrigin: false,
+                      },
+                    },
+                  ],
+                },
+              },
+            });
+
+          await metamaskController.requestCaip25Approval('test.com', {
+            [RestrictedEthMethods.eth_accounts]: {
+              caveats: [
+                {
+                  type: 'restrictReturnedAccounts',
+                  value: ['0xdeadbeef'],
+                },
+              ],
+            },
+            [EndowmentTypes.permittedChains]: {
+              caveats: [
+                {
+                  type: 'restrictNetworkSwitching',
+                  value: ['0x1', '0x5'],
+                },
+              ],
+            },
+          });
+
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin,
+              requestData: {
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin,
+                },
+                permissions: {
+                  [Caip25EndowmentPermissionName]: {
+                    caveats: [
+                      {
+                        type: Caip25CaveatType,
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: ['wallet:eip155:0xdeadbeef'],
+                            },
+                            'eip155:1': {
+                              accounts: ['eip155:1:0xdeadbeef'],
+                            },
+                            'eip155:5': {
+                              accounts: ['eip155:5:0xdeadbeef'],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              type: 'wallet_requestPermissions',
+            }),
+          );
+        });
+
+        it('requests CAIP-25 approval with approved accounts for the `wallet:eip155` scope (and no approved chainIds) with isMultichainOrigin: false if origin is snapId', async () => {
+          const origin = 'npm:snap';
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: {
+                [Caip25EndowmentPermissionName]: {
+                  caveats: [
+                    {
+                      type: Caip25CaveatType,
+                      value: {
+                        requiredScopes: {},
+                        optionalScopes: {},
+                        isMultichainOrigin: false,
+                      },
+                    },
+                  ],
+                },
+              },
+            });
+
+          jest
+            .spyOn(metamaskController.permissionController, 'grantPermissions')
+            .mockReturnValue({
+              [Caip25EndowmentPermissionName]: {
+                foo: 'bar',
+              },
+            });
+
+          await metamaskController.requestCaip25Approval(origin, {
+            [RestrictedEthMethods.eth_accounts]: {
+              caveats: [
+                {
+                  type: 'restrictReturnedAccounts',
+                  value: ['0xdeadbeef'],
+                },
+              ],
+            },
+            [EndowmentTypes.permittedChains]: {
+              caveats: [
+                {
+                  type: 'restrictNetworkSwitching',
+                  value: ['0x1', '0x5'],
+                },
+              ],
+            },
+          });
+
+          expect(
+            metamaskController.approvalController.addAndShowApprovalRequest,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: expect.stringMatching(/.{21}/u),
+              origin,
+              requestData: expect.objectContaining({
+                metadata: {
+                  id: expect.stringMatching(/.{21}/u),
+                  origin,
+                },
+                permissions: {
+                  [Caip25EndowmentPermissionName]: {
+                    caveats: [
+                      {
+                        type: Caip25CaveatType,
+                        value: {
+                          requiredScopes: {},
+                          optionalScopes: {
+                            'wallet:eip155': {
+                              accounts: ['wallet:eip155:0xdeadbeef'],
+                            },
+                          },
+                          isMultichainOrigin: false,
+                        },
+                      },
+                    ],
+                  },
+                },
+              }),
+              type: 'wallet_requestPermissions',
+            }),
+          );
+        });
+
+        it('should return sessions scopes returned from calling ApprovalController.addAndShowApprovalRequest', async () => {
+          const expectedPermissions = {
+            [Caip25EndowmentPermissionName]: {
+              caveats: [
+                {
+                  type: Caip25CaveatType,
+                  value: {
+                    requiredScopes: {},
+                    optionalScopes: {
+                      'wallet:eip155': {
+                        accounts: ['wallet:eip155:0xdeadbeef'],
+                      },
+                    },
+                    isMultichainOrigin: false,
+                  },
+                },
+              ],
+            },
+          };
+
+          jest
+            .spyOn(
+              metamaskController.approvalController,
+              'addAndShowApprovalRequest',
+            )
+            .mockResolvedValue({
+              permissions: expectedPermissions,
+            });
+
+          const result = await metamaskController.requestCaip25Approval(
+            'test.com',
+            {},
+          );
+
+          expect(result).toStrictEqual(expectedPermissions);
+        });
+      });
+
+      describe('invalid requests', () => {
+        const INVALID_CHAIN_HEX = '0x11';
+        const INVALID_ADDRESS = 'invalid.eth';
+
+        describe('unrecognized addresses requested', () => {
+          beforeEach(() => {
+            PermissionSpecifications.validateCaveatAccounts.mockImplementation(
+              () => {
+                throw new Error(
+                  `${PermissionNames.eth_accounts} error: Received unrecognized address: "${INVALID_ADDRESS}".`,
+                );
+              },
+            );
+          });
+
+          afterEach(() => {
+            PermissionSpecifications.validateCaveatAccounts.mockClear();
+          });
+
+          it('should throw exception when requesting invalid account', async () => {
+            await expect(
+              metamaskController.requestCaip25Approval('test.com', {
+                [PermissionNames.eth_accounts]: {
+                  caveats: [
+                    {
+                      type: CaveatTypes.restrictReturnedAccounts,
+                      value: [INVALID_ADDRESS],
+                    },
+                  ],
+                },
+              }),
+            ).rejects.toThrow(
+              `${PermissionNames.eth_accounts} error: Received unrecognized address: "${INVALID_ADDRESS}".`,
+            );
+          });
+        });
+
+        describe('unrecognized chain id requested', () => {
+          beforeEach(() => {
+            PermissionSpecifications.validateCaveatAccounts.mockImplementation(
+              () => ({}),
+            );
+            PermissionSpecifications.validateCaveatNetworks.mockImplementation(
+              () => {
+                throw new Error(
+                  `${PermissionNames.permittedChains} error: Received unrecognized chainId: "${INVALID_CHAIN_HEX}". Please try adding the network first via wallet_addEthereumChain.`,
+                );
+              },
+            );
+          });
+
+          afterEach(() => {
+            PermissionSpecifications.validateCaveatAccounts.mockClear();
+            PermissionSpecifications.validateCaveatNetworks.mockClear();
+          });
+
+          it('should throw exception when requesting invalid chain id', async () => {
+            await expect(
+              metamaskController.requestCaip25Approval('test.com', {
+                [PermissionNames.eth_accounts]: {
+                  caveats: [
+                    {
+                      type: CaveatTypes.restrictReturnedAccounts,
+                      value: ['0xdead'],
+                    },
+                  ],
+                },
+                [PermissionNames.permittedChains]: {
+                  caveats: [
+                    {
+                      type: CaveatTypes.restrictNetworkSwitching,
+                      value: [INVALID_CHAIN_HEX],
+                    },
+                  ],
+                },
+              }),
+            ).rejects.toThrow(
+              `${PermissionNames.permittedChains} error: Received unrecognized chainId: "${INVALID_CHAIN_HEX}". Please try adding the network first via wallet_addEthereumChain.`,
+            );
+          });
+        });
       });
     });
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1649,10 +1649,6 @@ describe('MetaMaskController', () => {
             );
           });
 
-          afterEach(() => {
-            PermissionSpecifications.validateCaveatAccounts.mockClear();
-          });
-
           it('should throw exception when requesting invalid account', async () => {
             await expect(
               metamaskController.requestCaip25Approval('test.com', {
@@ -1683,11 +1679,6 @@ describe('MetaMaskController', () => {
                 );
               },
             );
-          });
-
-          afterEach(() => {
-            PermissionSpecifications.validateCaveatAccounts.mockClear();
-            PermissionSpecifications.validateCaveatNetworks.mockClear();
           });
 
           it('should throw exception when requesting invalid chain id', async () => {


### PR DESCRIPTION
This commit fixes the following [issue](https://github.com/MetaMask/metamask-extension/issues/30202) which is currently a release blocker for [v12.12.0](https://github.com/MetaMask/metamask-extension/pull/30020)

The eth accounts and permitted chains caveat validation in this PR was originally removed as part of the CAIP-25 Permission Migration PR [here](https://github.com/MetaMask/metamask-extension/pull/27847/files#diff-2089a51d7dedef741fa281f38739b24373ef16a7c04901ae3fee4329e3b32ec6L251-L317), but is being restored in order to fix a regression in the API behavior. Originally, making a wallet_requestPermissions request with invalid caveat values for eth_accounts or endowment:permitted-chains would result in an immediate error returned back to the dapp specifying which value was invalid, i.e. not found in the wallet. This PR restores that behavior.
Additionally, the changes in this PR are temporary and will be removed as part of a [follow up refactor that cleans up the CAIP-25 approval/request permission flow](https://github.com/MetaMask/metamask-extension/pull/30042).

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30213?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

Unlock MM
Open test dapp console
Paste the following command
See error

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/9344d6de-2602-4a66-beff-2692f9b68241


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
