### PR TITLE
fix spelling issues

### DIFF
--- a/.circleci/scripts/git-diff-default-branch.ts
+++ b/.circleci/scripts/git-diff-default-branch.ts
@@ -119,7 +119,7 @@ function writePrBodyToFile(prBody: string) {
 async function storeGitDiffOutputAndPrBody() {
   try {
     // Create the directory
-    // This is done first because our CirleCI config requires that this directory is present,
+    // This is done first because our CircleCI config requires that this directory is present,
     // even if we want to skip this step.
     fs.mkdirSync(CHANGED_FILES_DIR, { recursive: true });
 

--- a/.circleci/scripts/show-changelog.awk
+++ b/.circleci/scripts/show-changelog.awk
@@ -1,7 +1,7 @@
 # DESCRIPTION
 #
 # This script will print out all of the CHANGELOG.md lines for a given version
-# with the assumption that the CHANGELOG.md files looks something along the
+# with the assumption that the CHANGELOG.md files look something along the
 # lines of:
 #
 # ```


### PR DESCRIPTION
`CirleCI`  -  `CircleCI`

`looks`  -  `look`