### PR TITLE
feat: Remove tooltip and connection badge from Connection Menu

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -167,6 +167,7 @@ env:
   - BLOCKAID_FILE_CDN: static.cx.metamask.io/api/v1/confirmations/ppom
   # Blockaid public key for verifying signatures of data files downloaded from CDN
   - BLOCKAID_PUBLIC_KEY: 066ad3e8af5583385e312c156d238055215d5f25247c1e91055afa756cb98a88
+  - REMOVE_GNS: ''
 
   - ENABLE_MV3: true
   # These are exclusively used for MV3

--- a/ui/components/multichain/connected-site-menu/__snapshots__/connected-site-menu.test.js.snap
+++ b/ui/components/multichain/connected-site-menu/__snapshots__/connected-site-menu.test.js.snap
@@ -18,15 +18,10 @@ exports[`Connected Site Menu should render the site menu in connected state 1`] 
         <div
           class="mm-box mm-badge-wrapper mm-box--display-inline-block"
         >
-          <div
-            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
-          >
-            <img
-              alt="Uniswap logo"
-              class="mm-avatar-favicon__image"
-              src="https://uniswap.org/favicon.ico"
-            />
-          </div>
+          <span
+            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-icon-default"
+            style="mask-image: url('./images/icons/global.svg');"
+          />
           <div
             class="mm-box mm-badge-wrapper__badge-container"
             style="bottom: -1px; right: -4px; z-index: 1;"
@@ -60,15 +55,10 @@ exports[`Connected Site Menu should render the site menu in not connected state 
         <div
           class="mm-box mm-badge-wrapper mm-box--display-inline-block"
         >
-          <div
-            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
-          >
-            <img
-              alt="Uniswap logo"
-              class="mm-avatar-favicon__image"
-              src="https://uniswap.org/favicon.ico"
-            />
-          </div>
+          <span
+            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-icon-default"
+            style="mask-image: url('./images/icons/global.svg');"
+          />
           <div
             class="mm-box mm-badge-wrapper__badge-container"
             style="bottom: -1px; right: -4px; z-index: 1;"
@@ -102,15 +92,10 @@ exports[`Connected Site Menu should render the site menu in not connected to cur
         <div
           class="mm-box mm-badge-wrapper mm-box--display-inline-block"
         >
-          <div
-            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
-          >
-            <img
-              alt="Uniswap logo"
-              class="mm-avatar-favicon__image"
-              src="https://uniswap.org/favicon.ico"
-            />
-          </div>
+          <span
+            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-icon-default"
+            style="mask-image: url('./images/icons/global.svg');"
+          />
           <div
             class="mm-box mm-badge-wrapper__badge-container"
             style="bottom: -1px; right: -2px; z-index: 1;"

--- a/ui/components/multichain/connected-site-menu/connected-site-menu.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.js
@@ -27,6 +27,7 @@ import {
 } from '../../component-library';
 import {
   getOriginOfCurrentTab,
+  getPermittedAccountsByOrigin,
   getSelectedInternalAccount,
   getSubjectMetadata,
 } from '../../../selectors';
@@ -45,22 +46,25 @@ export const ConnectedSiteMenu = ({
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const subjectMetadata = useSelector(getSubjectMetadata);
   const connectedOrigin = useSelector(getOriginOfCurrentTab);
+  const permittedAccountsByOrigin = useSelector(getPermittedAccountsByOrigin);
+  const currentTabHasNoAccounts =
+    !permittedAccountsByOrigin[connectedOrigin]?.length;
   const connectedSubjectsMetadata = subjectMetadata[connectedOrigin];
   const isConnectedtoOtherAccountOrSnap =
     status === STATUS_CONNECTED_TO_ANOTHER_ACCOUNT ||
     status === STATUS_CONNECTED_TO_SNAP;
 
-  const iconElement = connectedSubjectsMetadata?.iconUrl ? (
-    <AvatarFavicon
-      name={connectedSubjectsMetadata.name}
-      size={Size.SM}
-      src={connectedSubjectsMetadata.iconUrl}
-    />
-  ) : (
+  const iconElement = currentTabHasNoAccounts ? (
     <Icon
       name={IconName.Global}
       size={IconSize.Sm}
       color={IconColor.iconDefault}
+    />
+  ) : (
+    <AvatarFavicon
+      name={connectedSubjectsMetadata.name}
+      size={Size.SM}
+      src={connectedSubjectsMetadata.iconUrl}
     />
   );
   return (

--- a/ui/components/multichain/connected-site-menu/connected-site-menu.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.js
@@ -49,6 +49,20 @@ export const ConnectedSiteMenu = ({
   const isConnectedtoOtherAccountOrSnap =
     status === STATUS_CONNECTED_TO_ANOTHER_ACCOUNT ||
     status === STATUS_CONNECTED_TO_SNAP;
+
+  const iconElement = connectedSubjectsMetadata?.iconUrl ? (
+    <AvatarFavicon
+      name={connectedSubjectsMetadata.name}
+      size={Size.SM}
+      src={connectedSubjectsMetadata.iconUrl}
+    />
+  ) : (
+    <Icon
+      name={IconName.Global}
+      size={IconSize.Sm}
+      color={IconColor.iconDefault}
+    />
+  );
   return (
     <Box
       className={classNames(
@@ -63,52 +77,44 @@ export const ConnectedSiteMenu = ({
       justifyContent={JustifyContent.center}
       backgroundColor={BackgroundColor.backgroundDefault}
     >
-      <Tooltip
-        title={
-          status === STATUS_NOT_CONNECTED
-            ? t('statusNotConnectedAccount')
-            : `${selectedAccount?.metadata.name} ${text}`
-        }
-        data-testid="multichain-connected-site-menu__tooltip"
-        position="bottom"
-      >
-        <BadgeWrapper
-          positionObj={
-            isConnectedtoOtherAccountOrSnap
-              ? { bottom: -1, right: -2, zIndex: 1 }
-              : { bottom: -1, right: -4, zIndex: 1 }
+      {process.env.REMOVE_GNS ? (
+        iconElement
+      ) : (
+        <Tooltip
+          title={
+            status === STATUS_NOT_CONNECTED
+              ? t('statusNotConnectedAccount')
+              : `${selectedAccount?.metadata.name} ${text}`
           }
-          badge={
-            <Box
-              backgroundColor={globalMenuColor}
-              className={classNames('multichain-connected-site-menu__badge', {
-                'not-connected': isConnectedtoOtherAccountOrSnap,
-              })}
-              borderRadius={BorderRadius.full}
-              borderColor={
-                isConnectedtoOtherAccountOrSnap
-                  ? BorderColor.successDefault
-                  : BorderColor.backgroundDefault
-              }
-              borderWidth={2}
-            />
-          }
+          data-testid="multichain-connected-site-menu__tooltip"
+          position="bottom"
         >
-          {connectedSubjectsMetadata?.iconUrl ? (
-            <AvatarFavicon
-              name={connectedSubjectsMetadata.name}
-              size={Size.SM}
-              src={connectedSubjectsMetadata.iconUrl}
-            />
-          ) : (
-            <Icon
-              name={IconName.Global}
-              size={IconSize.Sm}
-              color={IconColor.iconDefault}
-            />
-          )}
-        </BadgeWrapper>
-      </Tooltip>
+          <BadgeWrapper
+            positionObj={
+              isConnectedtoOtherAccountOrSnap
+                ? { bottom: -1, right: -2, zIndex: 1 }
+                : { bottom: -1, right: -4, zIndex: 1 }
+            }
+            badge={
+              <Box
+                backgroundColor={globalMenuColor}
+                className={classNames('multichain-connected-site-menu__badge', {
+                  'not-connected': isConnectedtoOtherAccountOrSnap,
+                })}
+                borderRadius={BorderRadius.full}
+                borderColor={
+                  isConnectedtoOtherAccountOrSnap
+                    ? BorderColor.successDefault
+                    : BorderColor.backgroundDefault
+                }
+                borderWidth={2}
+              />
+            }
+          >
+            {iconElement}
+          </BadgeWrapper>
+        </Tooltip>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
This PR is to remove the connection badge and tooltip from connection menu in header

## **Related issues**

Fixes: [https://github.com/MetaMask/MetaMask-planning/issues/4178](https://github.com/MetaMask/MetaMask-planning/issues/4178)

## **Manual testing steps**

1. Run extension with `REMOVE_GNS=1 yarn start`
2. In the popup view in header, connection menu should not show any tooltip or badge on hover
3. When not connected, it should render the globe icon
4. for connected state, it should show the dapp icon

## **Screenshots/Recordings**


### **Before**


### **After**

#### When not connected

![Screenshot 2025-02-10 at 2 38 22 PM](https://github.com/user-attachments/assets/46b27c5c-adfc-4661-a589-3580fa708982)


#### When connected

![Screenshot 2025-02-10 at 2 37 41 PM](https://github.com/user-attachments/assets/f839bf3f-dfc5-4cd6-93b7-88301bf1df21)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
