### PR TITLE
chore: adding storybook story for asset picker modal network component

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.stories.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.stories.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import { Provider } from 'react-redux';
+import { RpcEndpointType, NetworkConfiguration } from '@metamask/network-controller';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import configureStore from '../../../../store/store';
+import mockState from '../../../../../test/data/mock-state.json';
+import { AssetPickerModalNetwork } from './asset-picker-modal-network';
+import { Meta, StoryFn } from '@storybook/react';
+import { Button } from '../../../component-library';
+
+const networks: NetworkConfiguration[] = [
+  {
+    chainId: CHAIN_IDS.MAINNET,
+    nativeCurrency: 'ETH',
+    defaultBlockExplorerUrlIndex: 0,
+    blockExplorerUrls: ['https://explorerurl'],
+    defaultRpcEndpointIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'test1',
+        url: 'https://rpcurl',
+        type: RpcEndpointType.Custom as const,
+      },
+    ],
+    name: 'Ethereum',
+  },
+  {
+    chainId: CHAIN_IDS.OPTIMISM,
+    nativeCurrency: 'ETH',
+    defaultBlockExplorerUrlIndex: 0,
+    blockExplorerUrls: ['https://explorerurl'],
+    defaultRpcEndpointIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'test2',
+        url: 'https://rpcurl',
+        type: RpcEndpointType.Custom as const,
+      },
+    ],
+    name: 'OP Mainnet',
+  },
+  {
+    chainId: CHAIN_IDS.BSC,
+    nativeCurrency: 'BNB',
+    defaultBlockExplorerUrlIndex: 0,
+    blockExplorerUrls: ['https://explorerurl'],
+    defaultRpcEndpointIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'test3',
+        url: 'https://rpcurl',
+        type: RpcEndpointType.Custom as const,
+      },
+    ],
+    name: 'BNB Smart Chain',
+  },
+];
+
+function store() {
+  return configureStore(mockState);
+}
+
+const AssetPickerModalNetworkWithButton: StoryFn<typeof AssetPickerModalNetwork> = (args) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Provider store={store()}>
+      <Button onClick={() => setIsOpen(true)}>Open Network Modal</Button>
+      <AssetPickerModalNetwork
+        {...args}
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      />
+    </Provider>
+  );
+};
+
+const meta: Meta<typeof AssetPickerModalNetwork> = {
+  title: 'Components/Multichain/AssetPickerModalNetwork',
+  component: AssetPickerModalNetwork,
+  render: AssetPickerModalNetworkWithButton,
+  args: {
+    onNetworkChange: () => {},
+    onBack: () => {},
+  },
+};
+
+export default meta;
+const Story = {
+  args: {} as Partial<React.ComponentProps<typeof AssetPickerModalNetwork>>,
+};
+type StoryType = typeof Story & { args: Partial<React.ComponentProps<typeof AssetPickerModalNetwork>> };
+
+export const Default: StoryType = {
+  args: {
+    networks,
+  },
+};
+
+export const WithSelectedNetwork: StoryType = {
+  args: {
+    networks,
+    network: networks[0],
+  },
+};
+
+export const WithMultiSelect: StoryType = {
+  args: {
+    networks,
+    isMultiselectEnabled: true,
+    selectedChainIds: [CHAIN_IDS.MAINNET, CHAIN_IDS.OPTIMISM],
+    onMultiselectSubmit: (chainIds) => console.log('Selected chains:', chainIds),
+  },
+};
+
+export const WithCustomHeader: StoryType = {
+  args: {
+    networks,
+    header: 'Select Source Network',
+  },
+};


### PR DESCRIPTION
## **Description**

This PR adds a Storybook story for the `AssetPickerModalNetwork` component, improving coverage and making it easier to view and develop in isolation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30235?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to the [storybook build of this PR](https://diuv6g5fj9pvx.cloudfront.net/metamask-extension/13250743903/storybook-build/index.html?path=/story/components-multichain-assetpickermodalnetwork--default)
2. Navigate to `Components/Multichain/AssetPickerModalNetwork` in the Storybook sidebar
3. Test the Default story:
   - Click "Open Network Modal" button
   - Verify network list displays correctly
   - Test modal close functionality
4. Test WithSelectedNetwork story:
   - Verify Ethereum network is pre-selected
5. Test WithMultiSelect story:
   - Verify multiple networks can be selected
   - Confirm Mainnet and Optimism are pre-selected
   - Check console logs when submitting selections
6. Test WithCustomHeader story:
   - Verify custom header "Select Source Network" is displayed

## **Screenshots/Recordings**

### **Before**
N/A - New component stories

### **After**

https://github.com/user-attachments/assets/390203dc-179a-43c1-8d4e-e0fa3c5b1afa



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests (Storybook stories serve as interactive tests)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots