### PR TITLE
chore: adding storybook story for snap install warning component

### DIFF
--- a/ui/components/app/snaps/snap-install-warning/snap-install-warning.stories.tsx
+++ b/ui/components/app/snaps/snap-install-warning/snap-install-warning.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Button } from '../../../component-library';
+import SnapInstallWarning from '.';
+
+const meta: Meta<typeof SnapInstallWarning> = {
+  title: 'Components/App/Snaps/SnapInstallWarning',
+  component: SnapInstallWarning,
+  argTypes: {
+    onCancel: {
+      action: 'onCancel',
+    },
+    onSubmit: {
+      action: 'onSubmit',
+    },
+    snapName: {
+      control: 'text',
+    },
+    warnings: {
+      control: 'object',
+    },
+  },
+  args: {
+    snapName: 'Test Snap',
+    warnings: [
+      {
+        id: '1',
+        permissionName: 'snap_getBip32PublicKey',
+        warningMessageSubject: 'BTC',
+      },
+      {
+        id: '2',
+        permissionName: 'snap_getBip44Entropy',
+        warningMessageSubject: 'ETH',
+      },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SnapInstallWarning>;
+
+export const Default: Story = {
+  render:(args) => {
+  const [showWarning, setShowWarning] = useState(false);
+
+  const handleOpen = () => {
+    setShowWarning(true);
+  };
+
+  return (
+    <div>
+      <Button onClick={handleOpen}>Open Warning Modal</Button>
+      {showWarning && (
+        <SnapInstallWarning
+          {...args}
+          onCancel={() => setShowWarning(false)}
+          onSubmit={() => setShowWarning(false)}
+        />
+      )}
+    </div>
+  );
+  },
+};


### PR DESCRIPTION
## **Description**

This PR adds a Storybook story for the `SnapInstallWarning` component, improving coverage and making it easier to view and develop in isolation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30237?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to the latest [build of storybook in this PR](https://diuv6g5fj9pvx.cloudfront.net/metamask-extension/13251457556/storybook-build/index.html?path=/story/components-app-snaps-snapinstallwarning--default)
2. Navigate to Components/App/Snaps/SnapInstallWarning
3. Click "Open Warning Modal"
4. Verify that the `SnapInstallWarning` renders

## **Screenshots/Recordings**

### **Before**
N/A - New component stories

### **After**

https://github.com/user-attachments/assets/587c5cbd-aee4-472e-8524-3c3a642734ba

Known issue with the local provider in storybook

<img width="438" alt="Screenshot 2025-02-10 at 2 07 30 PM" src="https://github.com/user-attachments/assets/659f5e14-52af-4a65-a17b-e171db99161e" />


## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests through Storybook stories
- [x] I've documented my code using TypeScript types and story documentation
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots
