### PR TITLE
chore: adding storybook story for unconnected account alert component

### DIFF
--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.stories.tsx
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.stories.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import type { Meta, StoryObj } from '@storybook/react';
+import testData from '../../../../../.storybook/test-data';
+import UnconnectedAccountAlert from './unconnected-account-alert';
+
+const mockState = {
+  ...testData,
+  metamask: {
+    ...testData.metamask,
+    unconnectedAccount: {
+      state: 'IDLE',
+    },
+  },
+  activeTab: {
+    id: 113,
+    title: 'E2E Test Dapp',
+    origin: 'https://metamask.github.io',
+    protocol: 'https:',
+    url: 'https://metamask.github.io/test-dapp/',
+  },
+};
+
+const store = configureStore({
+  reducer: (state = mockState) => state,
+  preloadedState: mockState,
+});
+
+const meta = {
+  title: 'Components/App/Alerts/UnconnectedAccountAlert',
+  component: UnconnectedAccountAlert,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <Story />
+      </Provider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Alert shown when the selected account is not connected to the current dapp',
+      },
+    },
+  },
+} satisfies Meta<typeof UnconnectedAccountAlert>;
+
+export default meta;
+type Story = StoryObj<typeof UnconnectedAccountAlert>;
+
+export const DefaultStory: Story = {
+  name: 'Default',
+};


### PR DESCRIPTION
## **Description**

This PR adds a Storybook story for the `UnconnectedAccountAlert` component, improving coverage and making it easier to view and develop in isolation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30239?quickstart=1)


## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to the latest storybook build in this PR
2. Navigate to `Components/App/Alerts/UnconnectedAccountAlert` in the sidebar
3. Verify the `UnconnectedAccountAlert` component renders correctly in the Default story

## **Screenshots/Recordings**

### **Before**
N/A - New component story

### **After**

https://github.com/user-attachments/assets/aeca8e3a-41b5-4628-b529-2dc130dcb6a4


## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests through Storybook stories
- [x] I've documented my code through component documentation and stories
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots