### PR TITLE
chore: add integration test to check nonce editing is disabled when stx is on

### DIFF
--- a/test/integration/confirmations/transactions/erc20-approve.test.tsx
+++ b/test/integration/confirmations/transactions/erc20-approve.test.tsx
@@ -1,3 +1,4 @@
+import { mock } from 'node:test';
 import { ApprovalType } from '@metamask/controller-utils';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -10,6 +11,8 @@ import { integrationTestRender } from '../../../lib/render-helpers';
 import { createTestProviderTools } from '../../../stub/provider';
 import mockMetaMaskState from '../../data/integration-init-state.json';
 import { createMockImplementation, mock4byte } from '../../helpers';
+import { ENVIRONMENT } from '../../../../development/build/constants';
+import smartTransactionStatusPage from '../../../../ui/pages/confirmations/confirmation/templates/smart-transaction-status-page';
 import { getUnapprovedApproveTransaction } from './transactionDataHelpers';
 
 jest.mock('../../../../ui/store/background-connection', () => ({
@@ -400,5 +403,69 @@ describe('ERC20 Approve Confirmation', () => {
     expect(dataSection).toContainElement(approveDataParams2);
     expect(approveDataParams2).toHaveTextContent('Param #2');
     expect(approveDataParams2).toHaveTextContent('1');
+  });
+
+  it('disables nonce editing when STX is on', async () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.TESTING;
+    const mockedMetaMaskState =
+      getMetaMaskStateWithUnapprovedApproveTransaction({
+        showAdvanceDetails: true,
+      });
+
+    await act(async () => {
+      await integrationTestRender({
+        preloadedState: mockedMetaMaskState,
+        backgroundConnection: backgroundConnectionMocked,
+      });
+    });
+
+    const approveDetails = await screen.findByTestId(
+      'confirmation__approve-details',
+    );
+    expect(approveDetails).toBeInTheDocument();
+
+    const approveDetailsNonce = await screen.findByTestId(
+      'advanced-details-nonce-section',
+    );
+    expect(approveDetailsNonce).toBeInTheDocument();
+
+    expect(
+      await screen.queryByTestId('edit-nonce-icon'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('enables nonce editing when STX is off', async () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.TESTING;
+    const mockedMetaMaskState =
+      getMetaMaskStateWithUnapprovedApproveTransaction({
+        showAdvanceDetails: true,
+      });
+
+    const mockedState = {
+      ...mockedMetaMaskState,
+      preferences: {
+        ...mockedMetaMaskState.preferences,
+        smartTransactionsOptInStatus: false,
+      },
+    };
+
+    await act(async () => {
+      await integrationTestRender({
+        preloadedState: mockedState,
+        backgroundConnection: backgroundConnectionMocked,
+      });
+    });
+
+    const approveDetails = await screen.findByTestId(
+      'confirmation__approve-details',
+    );
+    expect(approveDetails).toBeInTheDocument();
+
+    const approveDetailsNonce = await screen.findByTestId(
+      'advanced-details-nonce-section',
+    );
+    expect(approveDetailsNonce).toBeInTheDocument();
+
+    expect(await screen.findByTestId('edit-nonce-icon')).toBeInTheDocument();
   });
 });

--- a/test/integration/confirmations/transactions/erc20-approve.test.tsx
+++ b/test/integration/confirmations/transactions/erc20-approve.test.tsx
@@ -1,4 +1,3 @@
-import { mock } from 'node:test';
 import { ApprovalType } from '@metamask/controller-utils';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -12,7 +11,6 @@ import { createTestProviderTools } from '../../../stub/provider';
 import mockMetaMaskState from '../../data/integration-init-state.json';
 import { createMockImplementation, mock4byte } from '../../helpers';
 import { ENVIRONMENT } from '../../../../development/build/constants';
-import smartTransactionStatusPage from '../../../../ui/pages/confirmations/confirmation/templates/smart-transaction-status-page';
 import { getUnapprovedApproveTransaction } from './transactionDataHelpers';
 
 jest.mock('../../../../ui/store/background-connection', () => ({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30260?quickstart=1)

## **Related issues**

Fixes: [#4183](https://github.com/MetaMask/MetaMask-planning/issues/4183)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
