### PR TITLE
test: remove unnecessary delays and wait for condition with  `waitForUrlContaning`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,6 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -147,7 +146,6 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -146,6 +147,7 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/test/e2e/tests/bridge/bridge-button-opens-portfolio.spec.ts
+++ b/test/e2e/tests/bridge/bridge-button-opens-portfolio.spec.ts
@@ -10,7 +10,7 @@ describe('Click bridge button', function (this: Suite) {
         const bridgePage = new BridgePage(driver);
         await logInWithBalanceValidation(driver, ganacheServer);
         await bridgePage.navigateToBridgePage();
-        await bridgePage.verifyPortfolioTab(2);
+        await bridgePage.verifyPortfolioTab();
       },
     );
   });
@@ -25,14 +25,14 @@ describe('Click bridge button', function (this: Suite) {
         // ETH
         await bridgePage.navigateToAssetPage('ETH');
         await bridgePage.navigateToBridgePage('coin-overview');
-        await bridgePage.verifyPortfolioTab(2);
+        await bridgePage.verifyPortfolioTab();
 
         await bridgePage.reloadHome();
 
         // TST
         await bridgePage.navigateToAssetPage('TST');
         await bridgePage.navigateToBridgePage('token-overview');
-        await bridgePage.verifyPortfolioTab(3);
+        await bridgePage.verifyPortfolioTab();
       },
     );
   });

--- a/test/e2e/tests/bridge/bridge-button-routing.spec.ts
+++ b/test/e2e/tests/bridge/bridge-button-routing.spec.ts
@@ -16,7 +16,7 @@ describe('Click bridge button', function (this: Suite) {
         const bridgePage = new BridgePage(driver);
         await logInWithBalanceValidation(driver, ganacheServer);
         await bridgePage.navigateToBridgePage();
-        await bridgePage.verifySwapPage(1);
+        await bridgePage.verifySwapPage();
       },
     );
   });

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -59,7 +59,6 @@ export class BridgePage {
     });
     await this.driver.waitForUrlContaining({
       url: 'asset',
-      timeout: this.driver.timeout,
     });
   };
 
@@ -67,14 +66,12 @@ export class BridgePage {
     await this.driver.switchToWindowWithTitle('MetaMask Portfolio - Bridge');
     await this.driver.waitForUrlContaining({
       url: 'portfolio.metamask.io/bridge',
-      timeout: this.driver.timeout,
     });
   };
 
   verifySwapPage = async () => {
     await this.driver.waitForUrlContaining({
       url: 'cross-chain/swaps',
-      timeout: this.driver.timeout,
     });
   };
 }

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -1,6 +1,4 @@
-import { strict as assert } from 'assert';
 import { Mockttp } from 'mockttp';
-import { Browser } from 'selenium-webdriver';
 import FixtureBuilder from '../../fixture-builder';
 import { generateGanacheOptions } from '../../helpers';
 import {
@@ -11,15 +9,12 @@ import {
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { Driver } from '../../webdriver/driver';
-import { isManifestV3 } from '../../../../shared/modules/mv3.utils';
 import type { FeatureFlagResponse } from '../../../../shared/types/bridge';
 import {
   DEFAULT_FEATURE_FLAGS_RESPONSE,
   ETH_CONVERSION_RATE_USD,
   MOCK_CURRENCY_RATES,
 } from './constants';
-
-const IS_FIREFOX = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
 
 export class BridgePage {
   driver: Driver;
@@ -62,35 +57,28 @@ export class BridgePage {
       css: '[data-testid="multichain-token-list-button"]',
       text: symbol,
     });
-
-    await this.driver.delay(2000);
-    assert.ok((await this.driver.getCurrentUrl()).includes('asset'));
+    await this.driver.waitForUrlContaining({
+      url: 'asset',
+      timeout: this.driver.timeout,
+    });
   };
 
   verifyPortfolioTab = async (expectedHandleCount: number) => {
-    await this.driver.delay(4000);
+    await this.driver.waitUntilXWindowHandles(expectedHandleCount);
     await this.driver.switchToWindowWithTitle('MetaMask Portfolio - Bridge');
-    assert.equal(
-      (await this.driver.getAllWindowHandles()).length,
-      IS_FIREFOX || !isManifestV3
-        ? expectedHandleCount
-        : expectedHandleCount + 1,
-    );
-    assert.match(
-      await this.driver.getCurrentUrl(),
-      /^https:\/\/portfolio\.metamask\.io\/bridge/u,
-    );
+    await this.driver.waitForUrlContaining({
+      url: 'portfolio.metamask.io/bridge',
+      timeout: this.driver.timeout,
+    });
   };
 
   verifySwapPage = async (expectedHandleCount: number) => {
-    await this.driver.delay(4000);
-    assert.equal(
-      (await this.driver.getAllWindowHandles()).length,
-      IS_FIREFOX || !isManifestV3
-        ? expectedHandleCount
-        : expectedHandleCount + 1,
-    );
-    assert.match(await this.driver.getCurrentUrl(), /.+cross-chain\/swaps/u);
+    await this.driver.waitUntilXWindowHandles(expectedHandleCount);
+    await this.driver.switchToWindowWithTitle('MetaMask Portfolio - Bridge');
+    await this.driver.waitForUrlContaining({
+      url: 'cross-chain/swaps',
+      timeout: this.driver.timeout,
+    });
   };
 }
 

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -63,8 +63,7 @@ export class BridgePage {
     });
   };
 
-  verifyPortfolioTab = async (expectedHandleCount: number) => {
-    await this.driver.waitUntilXWindowHandles(expectedHandleCount);
+  verifyPortfolioTab = async () => {
     await this.driver.switchToWindowWithTitle('MetaMask Portfolio - Bridge');
     await this.driver.waitForUrlContaining({
       url: 'portfolio.metamask.io/bridge',
@@ -72,8 +71,7 @@ export class BridgePage {
     });
   };
 
-  verifySwapPage = async (expectedHandleCount: number) => {
-    await this.driver.waitUntilXWindowHandles(expectedHandleCount);
+  verifySwapPage = async () => {
     await this.driver.waitForUrlContaining({
       url: 'cross-chain/swaps',
       timeout: this.driver.timeout,

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -74,7 +74,6 @@ export class BridgePage {
 
   verifySwapPage = async (expectedHandleCount: number) => {
     await this.driver.waitUntilXWindowHandles(expectedHandleCount);
-    await this.driver.switchToWindowWithTitle('MetaMask Portfolio - Bridge');
     await this.driver.waitForUrlContaining({
       url: 'cross-chain/swaps',
       timeout: this.driver.timeout,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1174,7 +1174,7 @@ class Driver {
    * @throws {Error} Throws an error if the URL does not include the substring within the timeout period.
    */
   async waitForUrlContaining({ url, timeout = this.timeout }) {
-  await this.driver.wait(until.urlContains(url), timeout);
+    await this.driver.wait(until.urlContains(url), timeout);
   }
 
   /**

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1174,7 +1174,7 @@ class Driver {
    * @throws {Error} Throws an error if the URL does not include the substring within the timeout period.
    */
   async waitForUrlContaining({ url, timeout = this.timeout }) {
-    return await this.driver.wait(until.urlContains(url), timeout);
+  await this.driver.wait(until.urlContains(url), timeout);
   }
 
   /**

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1169,7 +1169,7 @@ class Driver {
    *
    * @param {object} options - Parameters for the function.
    * @param {string} options.url - Substring to wait for in the URL.
-   * @param {number} options.timeout - optional timeout period, defaults to `this.timeout`.
+   * @param {number} [options.timeout]  - optional timeout period, defaults to `this.timeout`.
    * @returns {Promise<void>} Promise that resolves once the URL includes the substring.
    * @throws {Error} Throws an error if the URL does not include the substring within the timeout period.
    */

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1165,6 +1165,19 @@ class Driver {
   }
 
   /**
+   * Waits until the current URL includes the specified substring.
+   *
+   * @param {object} options - Parameters for the function.
+   * @param {string} options.url - Substring to wait for in the URL.
+   * @param {int} options.timeout - optional timeout period, defaults to this.timeout.
+   * @returns {Promise<void>} Promise that resolves once the URL includes the substring.
+   * @throws {Error} Throws an error if the URL does not include the substring within the timeout period.
+   */
+  async waitForUrlContaining({ url, timeout = this.timeout }) {
+    return await this.driver.wait(until.urlContains(url), timeout);
+  }
+
+  /**
    * Closes the current window tab in the browser session
    *
    *  @returns {Promise<void>} promise resolving after closing the current window

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1169,7 +1169,7 @@ class Driver {
    *
    * @param {object} options - Parameters for the function.
    * @param {string} options.url - Substring to wait for in the URL.
-   * @param {int} options.timeout - optional timeout period, defaults to this.timeout.
+   * @param {number} options.timeout - optional timeout period, defaults to `this.timeout`.
    * @returns {Promise<void>} Promise that resolves once the URL includes the substring.
    * @throws {Error} Throws an error if the URL does not include the substring within the timeout period.
    */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Just a small enhancement to remove some unnecessary delays in bridge specs.
This PR adds a new function in the driver `waitForUrlContaning`, which just checks for a substring, instead of the exact match with the `waitForUrl`. We can now use this and remove the hardcoded delays 


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30265?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
