### PR TITLE
fix(snaps): Add missing controller names to `ControllersToInitialize`

### DIFF
--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -1,3 +1,4 @@
+import { get, noop } from 'lodash';
 import {
   getPPOMControllerMessenger,
   getPPOMControllerInitMessenger,
@@ -26,18 +27,23 @@ import {
 export const CONTROLLER_MESSENGERS = {
   CronjobController: {
     getMessenger: getCronjobControllerMessenger,
+    getInitMessenger: noop,
   },
   ExecutionService: {
     getMessenger: getExecutionServiceMessenger,
+    getInitMessenger: noop,
   },
   MultichainAssetsController: {
     getMessenger: getMultichainAssetsControllerMessenger,
+    getInitMessenger: noop,
   },
   MultichainBalancesController: {
     getMessenger: getMultichainBalancesControllerMessenger,
+    getInitMessenger: noop,
   },
   MultichainTransactionsController: {
     getMessenger: getMultichainTransactionsControllerMessenger,
+    getInitMessenger: noop,
   },
   RateLimitController: {
     getMessenger: getRateLimitControllerMessenger,
@@ -45,6 +51,7 @@ export const CONTROLLER_MESSENGERS = {
   },
   SnapsRegistry: {
     getMessenger: getSnapsRegistryMessenger,
+    getInitMessenger: noop,
   },
   SnapController: {
     getMessenger: getSnapControllerMessenger,
@@ -52,9 +59,11 @@ export const CONTROLLER_MESSENGERS = {
   },
   SnapInsightsController: {
     getMessenger: getSnapInsightsControllerMessenger,
+    getInitMessenger: noop,
   },
   SnapInterfaceController: {
     getMessenger: getSnapInterfaceControllerMessenger,
+    getInitMessenger: noop,
   },
   PPOMController: {
     getMessenger: getPPOMControllerMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -1,4 +1,4 @@
-import { get, noop } from 'lodash';
+import { noop } from 'lodash';
 import {
   getPPOMControllerMessenger,
   getPPOMControllerInitMessenger,

--- a/app/scripts/controller-init/multichain/multichain-assets-controller-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-assets-controller-init.test.ts
@@ -20,6 +20,7 @@ function buildInitRequestMock(): jest.Mocked<
     controllerMessenger: getMultichainAssetsControllerMessenger(
       baseControllerMessenger,
     ),
+    initMessenger: undefined,
   };
 }
 

--- a/app/scripts/controller-init/multichain/multichain-balances-controller-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-balances-controller-init.test.ts
@@ -20,6 +20,7 @@ function buildInitRequestMock(): jest.Mocked<
     controllerMessenger: getMultichainBalancesControllerMessenger(
       baseControllerMessenger,
     ),
+    initMessenger: undefined,
   };
 }
 

--- a/app/scripts/controller-init/multichain/multichain-transactions-controller-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-transactions-controller-init.test.ts
@@ -20,6 +20,7 @@ function buildInitRequestMock(): jest.Mocked<
     controllerMessenger: getMultichainTransactionsControllerMessenger(
       baseControllerMessenger,
     ),
+    initMessenger: undefined,
   };
 }
 

--- a/app/scripts/controller-init/snaps/cronjob-controller-init.test.ts
+++ b/app/scripts/controller-init/snaps/cronjob-controller-init.test.ts
@@ -21,6 +21,7 @@ function getInitRequestMock(): jest.Mocked<
   const requestMock = {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getCronjobControllerMessenger(baseMessenger),
+    initMessenger: undefined,
   };
 
   return requestMock;

--- a/app/scripts/controller-init/snaps/execution-service-init.test.ts
+++ b/app/scripts/controller-init/snaps/execution-service-init.test.ts
@@ -24,6 +24,7 @@ function getInitRequestMock(): jest.Mocked<
   const requestMock = {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getExecutionServiceMessenger(baseMessenger),
+    initMessenger: undefined,
   };
 
   return requestMock;

--- a/app/scripts/controller-init/snaps/snap-insights-controller-init.test.ts
+++ b/app/scripts/controller-init/snaps/snap-insights-controller-init.test.ts
@@ -18,6 +18,7 @@ function getInitRequestMock(): jest.Mocked<
   const requestMock = {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getSnapInsightsControllerMessenger(baseMessenger),
+    initMessenger: undefined,
   };
 
   return requestMock;

--- a/app/scripts/controller-init/snaps/snap-interface-controller-init.test.ts
+++ b/app/scripts/controller-init/snaps/snap-interface-controller-init.test.ts
@@ -18,6 +18,7 @@ function getInitRequestMock(): jest.Mocked<
   const requestMock = {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getSnapInterfaceControllerMessenger(baseMessenger),
+    initMessenger: undefined,
   };
 
   return requestMock;

--- a/app/scripts/controller-init/snaps/snaps-registry-init.test.ts
+++ b/app/scripts/controller-init/snaps/snaps-registry-init.test.ts
@@ -18,6 +18,7 @@ function getInitRequestMock(): jest.Mocked<
   const requestMock = {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getSnapsRegistryMessenger(baseMessenger),
+    initMessenger: undefined,
   };
 
   return requestMock;

--- a/app/scripts/controller-init/types.ts
+++ b/app/scripts/controller-init/types.ts
@@ -167,7 +167,7 @@ export type ControllerInitRequest<
        * Required initialization messenger instance.
        * Generated using the callback specified in `getInitMessengerCallback`.
        */
-      initMessenger: InitMessengerType;
+      initMessenger?: InitMessengerType;
     }
   : unknown);
 

--- a/app/scripts/controller-init/types.ts
+++ b/app/scripts/controller-init/types.ts
@@ -161,15 +161,13 @@ export type ControllerInitRequest<
     message: string,
     url?: string,
   ) => Promise<void>;
-} & (InitMessengerType extends BaseRestrictedControllerMessenger
-  ? {
-      /**
-       * Required initialization messenger instance.
-       * Generated using the callback specified in `getInitMessengerCallback`.
-       */
-      initMessenger?: InitMessengerType;
-    }
-  : unknown);
+
+  /**
+   * Required initialization messenger instance.
+   * Generated using the callback specified in `getInitMessengerCallback`.
+   */
+  initMessenger: InitMessengerType;
+};
 
 /**
  * A single background API method available to the UI.

--- a/app/scripts/controller-init/utils.ts
+++ b/app/scripts/controller-init/utils.ts
@@ -1,4 +1,4 @@
-import { createProjectLogger } from '@metamask/utils';
+import { createProjectLogger, hasProperty } from '@metamask/utils';
 import {
   BaseControllerMessenger,
   BaseRestrictedControllerMessenger,
@@ -53,7 +53,9 @@ export type ControllersToInitialize =
 type InitFunction<Name extends ControllersToInitialize> =
   ControllerInitFunction<
     ControllerByName[Name],
+    // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getMessenger']>,
+    // @ts-expect-error TODO: Allow for undefined getInitMessenger
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getInitMessenger']>
   >;
 
@@ -114,8 +116,12 @@ export function initControllers({
     const controllerMessengerCallback =
       messengerCallbacks?.getMessenger as ControllerMessengerCallback;
 
-    const initMessengerCallback =
-      messengerCallbacks?.getInitMessenger as ControllerMessengerCallback;
+    const initMessengerCallback = hasProperty(
+      messengerCallbacks,
+      'getInitMessenger',
+    )
+      ? (messengerCallbacks?.getInitMessenger as ControllerMessengerCallback)
+      : undefined;
 
     const controllerMessenger = controllerMessengerCallback?.(
       baseControllerMessenger,

--- a/app/scripts/controller-init/utils.ts
+++ b/app/scripts/controller-init/utils.ts
@@ -36,7 +36,11 @@ type ControllerMessengerCallback = (
   BaseControllerMessenger: BaseControllerMessenger,
 ) => BaseRestrictedControllerMessenger;
 
-type ControllersToInitialize = 'PPOMController' | 'TransactionController';
+type ControllersToInitialize =
+  | 'PPOMController'
+  | 'TransactionController'
+  | 'RateLimitController'
+  | 'SnapController';
 
 type InitFunction<Name extends ControllersToInitialize> =
   ControllerInitFunction<
@@ -101,7 +105,6 @@ export function initControllers({
     const messengerCallbacks = CONTROLLER_MESSENGERS[controllerName];
 
     const controllerMessengerCallback =
-      // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
       messengerCallbacks?.getMessenger as ControllerMessengerCallback;
 
     const initMessengerCallback =
@@ -124,7 +127,6 @@ export function initControllers({
     // Instead of suppressing all type errors, we'll be specific about the controllerMessenger mismatch
     const result = initFunction({
       ...finalInitRequest,
-      // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
       controllerMessenger: finalInitRequest.controllerMessenger,
     });
 
@@ -144,8 +146,8 @@ export function initControllers({
     const memStateKey =
       memStateKeyRaw === null ? undefined : memStateKeyRaw ?? controllerName;
 
-    partialControllersByName[controllerName] = controller as Controller &
-      undefined;
+    // @ts-expect-error: Union too complex.
+    partialControllersByName[controllerName] = controller;
 
     controllerApi = {
       ...controllerApi,

--- a/app/scripts/controller-init/utils.ts
+++ b/app/scripts/controller-init/utils.ts
@@ -122,7 +122,7 @@ export function initControllers({
       baseControllerMessenger,
     );
 
-    const initMessenger = initMessengerCallback(baseControllerMessenger);
+    const initMessenger = initMessengerCallback?.(baseControllerMessenger);
 
     const finalInitRequest: BaseControllerInitRequest = {
       ...initRequest,

--- a/app/scripts/controller-init/utils.ts
+++ b/app/scripts/controller-init/utils.ts
@@ -123,8 +123,6 @@ export function initControllers({
       initMessenger,
     };
 
-    // TODO: Remove @ts-expect-error once base-controller version mismatch is resolved
-    // Instead of suppressing all type errors, we'll be specific about the controllerMessenger mismatch
     const result = initFunction({
       ...finalInitRequest,
       controllerMessenger: finalInitRequest.controllerMessenger,

--- a/app/scripts/controller-init/utils.ts
+++ b/app/scripts/controller-init/utils.ts
@@ -1,4 +1,4 @@
-import { createProjectLogger, hasProperty } from '@metamask/utils';
+import { createProjectLogger } from '@metamask/utils';
 import {
   BaseControllerMessenger,
   BaseRestrictedControllerMessenger,
@@ -29,7 +29,7 @@ export type InitControllersResult = {
 
 type BaseControllerInitRequest = ControllerInitRequest<
   BaseRestrictedControllerMessenger,
-  BaseRestrictedControllerMessenger
+  BaseRestrictedControllerMessenger | void
 >;
 
 type ControllerMessengerCallback = (
@@ -115,18 +115,13 @@ export function initControllers({
     const controllerMessengerCallback =
       messengerCallbacks?.getMessenger as ControllerMessengerCallback;
 
-    const initMessengerCallback = hasProperty(
-      messengerCallbacks,
-      'getInitMessenger',
-    )
-      ? (messengerCallbacks?.getInitMessenger as ControllerMessengerCallback)
-      : undefined;
+    const initMessengerCallback = messengerCallbacks?.getInitMessenger;
 
     const controllerMessenger = controllerMessengerCallback?.(
       baseControllerMessenger,
     );
 
-    const initMessenger = initMessengerCallback?.(baseControllerMessenger);
+    const initMessenger = initMessengerCallback(baseControllerMessenger);
 
     const finalInitRequest: BaseControllerInitRequest = {
       ...initRequest,

--- a/app/scripts/controller-init/utils.ts
+++ b/app/scripts/controller-init/utils.ts
@@ -55,7 +55,6 @@ type InitFunction<Name extends ControllersToInitialize> =
     ControllerByName[Name],
     // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getMessenger']>,
-    // @ts-expect-error TODO: Allow for undefined getInitMessenger
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getInitMessenger']>
   >;
 

--- a/app/scripts/controller-init/utils.ts
+++ b/app/scripts/controller-init/utils.ts
@@ -115,7 +115,8 @@ export function initControllers({
     const controllerMessengerCallback =
       messengerCallbacks?.getMessenger as ControllerMessengerCallback;
 
-    const initMessengerCallback = messengerCallbacks?.getInitMessenger;
+    const initMessengerCallback =
+      messengerCallbacks?.getInitMessenger as ControllerMessengerCallback;
 
     const controllerMessenger = controllerMessengerCallback?.(
       baseControllerMessenger,

--- a/app/scripts/controller-init/utils.ts
+++ b/app/scripts/controller-init/utils.ts
@@ -36,16 +36,23 @@ type ControllerMessengerCallback = (
   BaseControllerMessenger: BaseControllerMessenger,
 ) => BaseRestrictedControllerMessenger;
 
-type ControllersToInitialize =
-  | 'PPOMController'
-  | 'TransactionController'
+export type ControllersToInitialize =
+  | 'CronjobController'
+  | 'ExecutionService'
+  | 'MultichainAssetsController'
+  | 'MultichainBalancesController'
+  | 'MultichainTransactionsController'
   | 'RateLimitController'
-  | 'SnapController';
+  | 'SnapsRegistry'
+  | 'SnapController'
+  | 'SnapInsightsController'
+  | 'SnapInterfaceController'
+  | 'PPOMController'
+  | 'TransactionController';
 
 type InitFunction<Name extends ControllersToInitialize> =
   ControllerInitFunction<
     ControllerByName[Name],
-    // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getMessenger']>,
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getInitMessenger']>
   >;


### PR DESCRIPTION
## **Description**

This adds the missing controller names to `ControllersToInitialize`, types might need an update later has they don't fully support not having an `initMessenger`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30301?quickstart=1)

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
