### PR TITLE
Add Polkadot Asset Hub chain

### DIFF
--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -175,6 +175,8 @@ export const CHAIN_IDS = {
   INK: '0xdef1',
   MODE_SEPOLIA: '0x397',
   MODE: '0x868b',
+  ASSET_HUB: '0x190f1b43',
+  ASSET_HUB_WESTEND: '0x190f1b45',
 } as const;
 
 export const CHAINLIST_CHAIN_IDS_MAP = {
@@ -1023,11 +1025,21 @@ export const ETHERSCAN_SUPPORTED_NETWORKS = {
     domain: 'gnosisscan.io',
     subdomain: `${defaultEtherscanSubdomainPrefix}-gnosis`,
   },
+  [CHAIN_IDS.ASSET_HUB_WESTEND]: {
+    domain: 'polkadot.io',
+    subdomain: `${defaultEtherscanSubdomainPrefix}-asset-hub-westend`,
+  },
+  [CHAIN_IDS.ASSET_HUB]: {
+    domain: 'polkadot.io',
+    subdomain: `${defaultEtherscanSubdomainPrefix}-asset-hub`,
+  },
 };
 
 export const CHAIN_ID_TO_GAS_LIMIT_BUFFER_MAP = {
   [CHAIN_IDS.OPTIMISM]: 1,
   [CHAIN_IDS.OPTIMISM_TESTNET]: 1,
+  [CHAIN_IDS.ASSET_HUB_WESTEND]: 1,
+  [CHAIN_IDS.ASSET_HUB]: 1,
 };
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add Polkadot Asset Hub (mainnet) and Asset Hub Westend (testnet) to the network `CHAIN_IDS` constant.
And set the `CHAIN_ID_TO_GAS_LIMIT_BUFFER_MAP` gas limit buffer multipliers for these chains to 1.

These chains do not need the default 1.5x multiplier, that also happen to break the gas estimation that encode additional gas information in the lowest digits (Polkadot uses 2 dimensionals weights for gas computation time and proof of validity size)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30321?quickstart=1)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
