### PR TITLE
fix (cherry-pick): add Runway to CLA Allowlist (#30302)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla.html'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],metamaskbot,crowdin-bot'
+          allowlist: 'dependabot[bot],metamaskbot,crowdin-bot,runway-github[bot]'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
Cherry picks f7f2769ad37 to v12.12

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30302?quickstart=1)

This PR adds `runway-github[bot]` to the CLA allowlist, as this github action [recently failed on the v12.12.0 release branch](https://github.com/MetaMask/metamask-extension/actions/runs/13304016671/job/37176762833), presumably because it was missing.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/actions/runs/13304016671/job/37176762833

## **Manual testing steps**

1. After merging, CLA signature should pass, even if Runway automations contribute to a release.

## **Screenshots/Recordings**

Not applicable

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
