### PR TITLE
fix(30190): fix flaky tests for user traits

### DIFF
--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -164,7 +164,6 @@ describe('Segment User Traits', function () {
 
         const privacySettings = new PrivacySettings(driver);
         await privacySettings.check_pageIsLoaded();
-        await privacySettings.toggleParticipateInMetaMetrics();
         await privacySettings.toggleDataCollectionForMarketing();
         events = await getEventPayloads(driver, mockedEndpoints);
         assert.equal(events.length, 1);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix "Segment User Traits sends identify event when user opts in both metrics and data in privacy settings after opting out during onboarding". The detailed log can be find in ci https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/123710/workflows/7819ab4b-9730-43a2-b231-b2ca9d30a036/jobs/4542393/tests.

The reason is in original test, we toggle "participate in metametrics" and then immediately "Data collection for marketing", there's a race condition that the segment request is sent before 2nd toggle, hence when we assert the events after 2nd toggle we would get different response back. 

The fix is to remove "participate in metametrics" toggle, lucky for us, when we toggle  "Data collection for marketing", the first one will be toggled on too. So we can guarantee the event is captured with only 1 click. 


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30346?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30190

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
The report of running the test locally 20 times, failed on attempt no.14
[before.txt](https://github.com/user-attachments/files/18807136/before.txt)
<!-- [screenshots/recordings] -->

### **After**
The report of running the test locally 50 times, all success
[after.txt](https://github.com/user-attachments/files/18807132/after.txt)
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
