### PR TITLE
Add release date automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,9 @@ workflows:
               only: main
           requires:
             - prep-build-ts-migration-dashboard
+      - fetch-release-dates: # Pe052
+          requires:
+            - prep-deps
 
   rerun-from-failed:
     when:
@@ -1196,3 +1199,14 @@ jobs:
       - run:
           name: All Tests Passed
           command: echo 'whew - everything passed!'
+
+  fetch-release-dates: # Pe052
+    executor: node-browsers-medium
+    steps:
+      - checkout
+      - run: sudo corepack enable
+      - attach_workspace:
+          at: .
+      - run:
+          name: Fetch release dates from Runway
+          command: node .circleci/scripts/fetch-release-dates.js

--- a/.circleci/scripts/fetch-release-dates.js
+++ b/.circleci/scripts/fetch-release-dates.js
@@ -1,0 +1,69 @@
+const { Client } = require('@notionhq/client');
+const { Octokit } = require('@octokit/rest');
+const fetch = require('node-fetch');
+
+// Initialize Notion client
+const notion = new Client({ auth: process.env.NOTION_API_KEY });
+
+// Initialize Octokit client
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+// Fetch release dates from Runway
+async function fetchReleaseDatesFromRunway() {
+  const response = await fetch('https://runway.example.com/api/releases');
+  const data = await response.json();
+  return data;
+}
+
+// Update Notion with release dates
+async function updateNotion(releaseDates) {
+  for (const release of releaseDates) {
+    await notion.pages.update({
+      page_id: release.notionPageId,
+      properties: {
+        'Cut Date': {
+          date: {
+            start: release.cutDate,
+          },
+        },
+        'Validated Date': {
+          date: {
+            start: release.validatedDate,
+          },
+        },
+        'Rollout Started Date': {
+          date: {
+            start: release.rolloutStartedDate,
+          },
+        },
+        'Rollout Completed Date': {
+          date: {
+            start: release.rolloutCompletedDate,
+          },
+        },
+      },
+    });
+  }
+}
+
+// Update GitHub Project Board with release dates
+async function updateGitHubProjectBoard(releaseDates) {
+  for (const release of releaseDates) {
+    await octokit.projects.updateCard({
+      card_id: release.githubCardId,
+      note: `Cut Date: ${release.cutDate}\nValidated Date: ${release.validatedDate}\nRollout Started Date: ${release.rolloutStartedDate}\nRollout Completed Date: ${release.rolloutCompletedDate}`,
+    });
+  }
+}
+
+// Main function to fetch release dates and update Notion and GitHub Project Board
+async function main() {
+  const releaseDates = await fetchReleaseDatesFromRunway();
+  await updateNotion(releaseDates);
+  await updateGitHubProjectBoard(releaseDates);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/workflows/runway.yml
+++ b/.github/workflows/runway.yml
@@ -69,3 +69,7 @@ jobs:
         with:
           name: metamask-flask-firefox-${{ steps.get-build-version.outputs.BUILD_VERSION }}-flask.0
           path: metamask-flask-firefox-${{ steps.get-build-version.outputs.BUILD_VERSION }}-flask.0.zip
+
+      - name: Fetch release dates from Runway
+        run: node .circleci/scripts/fetch-release-dates.js
+

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "attributions:generate": "./development/generate-attributions.sh",
     "ci-rerun-from-failed": "tsx .circleci/scripts/rerun-ci-workflow-from-failed.ts",
     "git-diff-default-branch": "tsx .circleci/scripts/git-diff-default-branch.ts",
-    "validate-e2e-page-object-usage": "tsx .github/scripts/validate-e2e-page-object-usage.ts"
+    "validate-e2e-page-object-usage": "tsx .github/scripts/validate-e2e-page-object-usage.ts",
+    "fetch-release-dates": "node .circleci/scripts/fetch-release-dates.js" // Pa17f
   },
   "resolutions": {
     "chokidar": "^3.6.0",
@@ -443,7 +444,9 @@
     "unicode-confusables": "^0.1.1",
     "uri-js": "^4.4.1",
     "uuid": "^8.3.2",
-    "zxcvbn": "^4.4.2"
+    "zxcvbn": "^4.4.2",
+    "@notionhq/client": "^2.0.0", // Pe952
+    "@octokit/rest": "^18.0.0" // Pe952
   },
   "devDependencies": {
     "@actions/core": "^1.10.0",


### PR DESCRIPTION
Related to #30334

Implement automation for fetching release dates from Runway and updating Notion and GitHub Project Board.

* **Dependencies**: Add `@notionhq/client` and `@octokit/rest` to `package.json`.
* **Scripts**: Add a script to `package.json` to fetch release dates from Runway and update Notion and GitHub Project Board.
* **CircleCI Configuration**: Add a new job in `.circleci/config.yml` to fetch release dates from Runway and update Notion and GitHub Project Board. Add this job to the `test_and_release` workflow.
* **GitHub Workflow**: Add steps in `.github/workflows/runway.yml` to fetch release dates from Runway and update Notion and GitHub Project Board.
* **Script Implementation**: Add `fetch-release-dates.js` in `.circleci/scripts/` to fetch release dates from Runway, update Notion with release dates, and update GitHub Project Board with release dates.

