### PR TITLE
Allow creation of blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Request a new feature
     url: https://community.metamask.io/c/feature-requests-ideas/


### PR DESCRIPTION
I think most of our current templates require way too much content to be filled in (that just becomes noise) compared to the actual context needed for most issues