### PR TITLE
fix: POL gas fee is reused after switching to a new network

### DIFF
--- a/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.test.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.test.tsx
@@ -3,8 +3,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   getNativeCurrency,
   getConversionRate,
-  getGasFeeEstimates,
   getCurrentCurrency,
+  getGasFeeControllerEstimates,
 } from '../../../../../../../ducks/metamask/metamask';
 import { getUsedSwapsGasPrice } from '../../../../../../../ducks/swaps/swaps';
 import {
@@ -28,7 +28,7 @@ describe('useEthFeeData', () => {
     getConversionRate: 2000,
     getCurrentCurrency: 'USD',
     checkNetworkAndAccountSupports1559: true,
-    getGasFeeEstimates: {
+    getGasFeeControllerEstimates: {
       medium: { suggestedMaxFeePerGas: '20' },
       gasPrice: null, // assume fallback every time
     } as Record<string, unknown>,
@@ -52,8 +52,8 @@ describe('useEthFeeData', () => {
           return mockState.getCurrentCurrency;
         case checkNetworkAndAccountSupports1559:
           return mockState.checkNetworkAndAccountSupports1559;
-        case getGasFeeEstimates:
-          return mockState.getGasFeeEstimates;
+        case getGasFeeControllerEstimates:
+          return mockState.getGasFeeControllerEstimates;
         case getCurrentChainId:
           return mockState.getCurrentChainId;
         case getIsSwapsChain:
@@ -91,7 +91,7 @@ describe('useEthFeeData', () => {
 
   it('should return both empty strings if gas fee is not available', () => {
     const gasLimit = 21000;
-    mockState.getGasFeeEstimates = {};
+    mockState.getGasFeeControllerEstimates = {};
 
     const { result } = renderHook(() => useEthFeeData(gasLimit));
 

--- a/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.tsx
+++ b/ui/components/multichain/pages/send/components/quote-card/hooks/useEthFeeData.tsx
@@ -11,7 +11,6 @@ import {
 import { EtherDenomination } from '../../../../../../../../shared/constants/common';
 import {
   checkNetworkAndAccountSupports1559,
-  getCurrentNetwork,
   getIsSwapsChain,
 } from '../../../../../../../selectors/selectors';
 import { getCurrentChainId } from '../../../../../../../../shared/modules/selectors/networks';
@@ -20,7 +19,6 @@ import {
   getUsedSwapsGasPrice,
 } from '../../../../../../../ducks/swaps/swaps';
 import { formatCurrency } from '../../../../../../../helpers/utils/confirm-tx.util';
-import { useGasFeeEstimates } from '../../../../../../../hooks/useGasFeeEstimates';
 import { toFixedNoTrailingZeros } from './utils';
 
 export default function useEthFeeData(gasLimit = 0) {
@@ -39,10 +37,8 @@ export default function useEthFeeData(gasLimit = 0) {
   const gasFee1559 = medium?.suggestedMaxFeePerGas;
 
   const chainId = useSelector(getCurrentChainId);
-  const network = useSelector(getCurrentNetwork);
   const isSwapsChain = useSelector(getIsSwapsChain);
 
-  useGasFeeEstimates(network?.id);
   const gasPriceNon1559 = useSelector(getUsedSwapsGasPrice);
 
   useEffect(() => {

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -327,7 +327,7 @@ function getGasFeeControllerEstimateTypeByChainId(state, chainId) {
   return state.metamask.gasFeeEstimatesByChainId?.[chainId]?.gasEstimateType;
 }
 
-function getGasFeeControllerEstimates(state) {
+export function getGasFeeControllerEstimates(state) {
   return state.metamask.gasFeeEstimates;
 }
 

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -22,6 +22,7 @@ import reduceMetamask, {
   getSendToAccounts,
   isNotEIP1559Network,
   getCurrentCurrency,
+  getGasFeeControllerEstimates,
 } from './metamask';
 
 jest.mock('@metamask/transaction-controller', () => ({
@@ -530,6 +531,20 @@ describe('MetaMask Reducers', () => {
         gasFeeControllerEstimates: GAS_FEE_CONTROLLER_ESTIMATES_MOCK,
         transactionGasFeeEstimates: TRANSACTION_ESTIMATES_MOCK,
       });
+    });
+  });
+
+  describe('getGasFeeControllerEstimates', () => {
+    it('returns GasFeeController estimate', () => {
+      const state = {
+        metamask: {
+          gasFeeEstimates: GAS_FEE_CONTROLLER_ESTIMATES_MOCK,
+        },
+      };
+
+      expect(getGasFeeControllerEstimates(state)).toStrictEqual(
+        GAS_FEE_CONTROLLER_ESTIMATES_MOCK,
+      );
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30417?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29374

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
