### PR TITLE
refactor: Expose E2E Chrome driver extension ID

### DIFF
--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -109,6 +109,7 @@ class ChromeDriver {
 
     return {
       driver,
+      extensionId,
       extensionUrl: `chrome-extension://${extensionId}`,
     };
   }


### PR DESCRIPTION
## **Description**

The `extensionId` property was accidentally omitted by the ChromeDriver builder. This was an old mistake, made in #7690. You can see this property is expected in `test/e2e/webdriver/index.js`, though in practice we don't use this `extensionId` for anything right now.

This was fixed so that we could use the `extensionId` in the future if necessary. This was extracted from #27782, which used this ID in some API spec e2e test helpers.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30444?quickstart=1)

## **Related issues**

Extracted from #27782

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
