### PR TITLE
fix: flaky test `Full-size View Setting opens the extension in popup view when opened from a dapp after enabling it in Advanced Settings`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,6 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -147,7 +146,6 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -146,6 +147,7 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/test/e2e/tests/settings/full-size-view-settings.spec.js
+++ b/test/e2e/tests/settings/full-size-view-settings.spec.js
@@ -21,7 +21,6 @@ describe('Full-size View Setting', function () {
       {
         dapp: true,
         fixtures: new FixtureBuilder()
-          .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
         title: this.test.fullTitle(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In this spec we are testing the settings full-size view. The test is flaky as uses `.withNetworkControllerOnMainnet()` and it's sometimes stuck in the loading Mainnet screen network. However, using Mainnet is not relevant for this spec, so we can just remove the fixture.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30466?quickstart=1)

## **Related issues**

Fixes: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/125900/workflows/79c96ac1-2270-40ad-8691-43c12d5ba98a/jobs/4561370/tests

## **Manual testing steps**

1. Check webpack e2e ci job https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/126364/workflows/88b110fc-517c-4f82-9b54-469a244573b1/jobs/4567218

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/fb68072b-a4ff-4c24-bb61-c30e3d2d854c)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
