### PR TITLE
fix: Hide non-zero hex data alert for contract deployment confirmations

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
@@ -35,7 +35,7 @@ export function useNonContractAddressAlerts(): Alert[] {
     !pending && value?.isContractAddress === false;
 
   const isContractDeploymentTx =
-    currentConfirmation.type === TransactionType.deployContract;
+    currentConfirmation?.type === TransactionType.deployContract;
 
   const isSendingHexDataWhileInteractingWithNonContractAddress =
     isSendingHexData &&

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -31,8 +34,13 @@ export function useNonContractAddressAlerts(): Alert[] {
   const isInteractingWithNonContractAddress =
     !pending && value?.isContractAddress === false;
 
+  const isContractDeploymentTx =
+    currentConfirmation.type === TransactionType.deployContract;
+
   const isSendingHexDataWhileInteractingWithNonContractAddress =
-    isSendingHexData && isInteractingWithNonContractAddress;
+    isSendingHexData &&
+    isInteractingWithNonContractAddress &&
+    !isContractDeploymentTx;
 
   return useMemo(() => {
     if (!isSendingHexDataWhileInteractingWithNonContractAddress) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Previously, the non-zero hex data alert could be visible by the user if another alert was triggered for contract deployments. This PR hides it for this case.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30474?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30359

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
