### PR TITLE
fix: flaky tests `Confirmation Redesign Token Send ERC1155 Wallet initiated...`

### DIFF
--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -151,3 +151,27 @@ export async function mockSignatureRejectedWithDecoding(
 export async function mockPermitDecoding(mockServer: Mockttp) {
   return [await createMockSignatureDecodingEvent(mockServer)];
 }
+
+export async function mockedSourcifyTokenSend(mockServer: Mockttp) {
+  return await mockServer
+    .forGet('https://www.4byte.directory/api/v1/signatures/')
+    .withQuery({ hex_signature: '0xa9059cbb' })
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [
+          {
+            bytes_signature: '©\u0005»',
+            created_at: '2016-07-09T03:58:28.234977Z',
+            hex_signature: '0xa9059cbb',
+            id: 145,
+            text_signature: 'transfer(address,uint256)',
+          },
+        ],
+      },
+    }));
+}

--- a/test/e2e/tests/confirmations/transactions/erc20-token-send-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc20-token-send-redesign.spec.ts
@@ -20,6 +20,7 @@ import { TestSuiteArguments } from './shared';
 const { SMART_CONTRACTS } = require('../../../seeder/smart-contracts');
 
 describe('Confirmation Redesign ERC20 Token Send', function () {
+  this.timeout(200000); // This test is very long, so we need an unusually high timeout
   describe('Wallet initiated', async function () {
     it('Sends a type 0 transaction (Legacy)', async function () {
       await withTransactionEnvelopeTypeFixtures(

--- a/test/e2e/tests/confirmations/transactions/erc20-token-send-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc20-token-send-redesign.spec.ts
@@ -14,13 +14,15 @@ import SendTokenPage from '../../../page-objects/pages/send/send-token-page';
 import TestDapp from '../../../page-objects/pages/test-dapp';
 import ContractAddressRegistry from '../../../seeder/contract-address-registry';
 import { Driver } from '../../../webdriver/driver';
-import { withTransactionEnvelopeTypeFixtures } from '../helpers';
+import {
+  mockedSourcifyTokenSend,
+  withTransactionEnvelopeTypeFixtures,
+} from '../helpers';
 import { TestSuiteArguments } from './shared';
 
 const { SMART_CONTRACTS } = require('../../../seeder/smart-contracts');
 
 describe('Confirmation Redesign ERC20 Token Send', function () {
-  this.timeout(200000); // This test is very long, so we need an unusually high timeout
   describe('Wallet initiated', async function () {
     it('Sends a type 0 transaction (Legacy)', async function () {
       await withTransactionEnvelopeTypeFixtures(
@@ -88,30 +90,6 @@ describe('Confirmation Redesign ERC20 Token Send', function () {
 
 async function mocks(server: Mockttp) {
   return [await mockedSourcifyTokenSend(server)];
-}
-
-export async function mockedSourcifyTokenSend(mockServer: Mockttp) {
-  return await mockServer
-    .forGet('https://www.4byte.directory/api/v1/signatures/')
-    .withQuery({ hex_signature: '0xa9059cbb' })
-    .always()
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {
-        count: 1,
-        next: null,
-        previous: null,
-        results: [
-          {
-            bytes_signature: '©\u0005»',
-            created_at: '2016-07-09T03:58:28.234977Z',
-            hex_signature: '0xa9059cbb',
-            id: 145,
-            text_signature: 'transfer(address,uint256)',
-          },
-        ],
-      },
-    }));
 }
 
 async function createWalletInitiatedTransactionAndAssertDetails(

--- a/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
@@ -25,6 +25,7 @@ const { SMART_CONTRACTS } = require('../../../seeder/smart-contracts');
 const TOKEN_RECIPIENT_ADDRESS = '0x2f318C334780961FB129D2a6c30D0763d9a5C970';
 
 describe('Confirmation Redesign Token Send', function () {
+  this.timeout(200000); // This test is very long, so we need an unusually high timeout
   describe('ERC721', function () {
     describe('Wallet initiated', async function () {
       it('Sends a type 0 transaction (Legacy)', async function () {

--- a/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
@@ -25,7 +25,6 @@ const { SMART_CONTRACTS } = require('../../../seeder/smart-contracts');
 const TOKEN_RECIPIENT_ADDRESS = '0x2f318C334780961FB129D2a6c30D0763d9a5C970';
 
 describe('Confirmation Redesign Token Send', function () {
-  this.timeout(200000); // This test is very long, so we need an unusually high timeout
   describe('ERC721', function () {
     describe('Wallet initiated', async function () {
       it('Sends a type 0 transaction (Legacy)', async function () {

--- a/test/e2e/tests/tokens/custom-token-send-transfer.spec.ts
+++ b/test/e2e/tests/tokens/custom-token-send-transfer.spec.ts
@@ -1,5 +1,5 @@
 import { Mockttp } from 'mockttp';
-import { mockedSourcifyTokenSend } from '../confirmations/transactions/erc20-token-send-redesign.spec';
+import { mockedSourcifyTokenSend } from '../confirmations/helpers';
 import {
   withFixtures,
   openDapp,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The `Confirmation Redesign Token Send ERC1155 Wallet initiated.` and `Confirmation Redesign ERC20 Token Send Wallet initiated Sends a type 0 transaction (Legacy)`  contain multiple specs which take sometimes longer than `80000`, making the spec fail

![Screenshot from 2025-02-21 10-10-10](https://github.com/user-attachments/assets/b2d03622-4de6-4075-96c0-15d1aac7b313)

![Screenshot from 2025-02-21 10-17-32](https://github.com/user-attachments/assets/ebcfcf5c-de33-48f5-9276-ab36809f8beb)

[Update]

- The root cause of  `Confirmation Redesign Token Send ERC1155 Wallet initiated.`  is because it's a long test, so we add a greater timeout
- The root cause of `Confirmation Redesign ERC20 Token Send Wallet initiated Sends a type 0 transaction (Legacy)` is that whenever we imported `mockedSourcifyTokenSend` from another spec file, that import caused to run the specs in those spec files too :exploding_head: that's why it took more than 80000, as we were running 2 spec files at the same context timeout. This has been fixed by moving the `mockedSourcifyTokenSend` to the helpers file.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30481?quickstart=1)

## **Related issues**

Fixes: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/126566/workflows/f9651772-3b7b-4da7-9db8-0f8f768c41c6/jobs/4570990/tests#failed-test-0

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
See how running the `test/e2e/tests/tokens/custom-token-send-transfer.spec.ts` triggers first  all the `erc20-token-send-redesign` tests

So instead of seeing this `Transfer custom tokens @no-mmi...` we see this `Confirmation Redesign ERC20 Token Send`


![Screenshot from 2025-02-21 12-11-04](https://github.com/user-attachments/assets/bb658bea-6dad-4655-a8db-988d71cb4ddb)


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
