### PR TITLE
fix: Fix attribution generation

### DIFF
--- a/development/generate-attributions.sh
+++ b/development/generate-attributions.sh
@@ -23,6 +23,9 @@ main() {
   # `plugin-allow-scripts.cjs` defined in the .yarnrc file
   export PATH="${SCRIPT_DIRECTORY}/generate-attributions/node_modules/.bin:${PATH}"
 
+  # Unset the root postinstall script to prevent it from installing devDependencies
+  node ./unset-postinstall.js
+
   # Switching to the project directory explicitly, so that we can use paths
   # relative to the project root irrespective of where this script was run.
   cd "${PROJECT_DIRECTORY}"
@@ -47,7 +50,7 @@ main() {
   if [ -z "${CI:-}" ]; then
     # If not running in CI, restore the allow-scripts plugin and development dependencies.
     cd "${PROJECT_DIRECTORY}"
-    git checkout -- .yarnrc.yml .yarn
+    git checkout -- .yarnrc.yml .yarn package.json
     yarn
   fi
 }

--- a/development/generate-attributions/unset-postinstall.js
+++ b/development/generate-attributions/unset-postinstall.js
@@ -4,15 +4,22 @@ const { readFile, writeFile } = require('node:fs/promises');
 const rootDirectory = path.resolve(__dirname, '..', '..');
 const packageJsonPath = path.join(rootDirectory, 'package.json');
 
+/**
+ * Unset the root `postinstall` script.
+ *
+ * This is used when generating attributions, to prevent development dependencies from being used
+ * or installed during `postinstall`.
+ */
 async function main() {
-  const packageJsonContents = await readFile(packageJsonPath, { encoding: 'utf8' });
+  const packageJsonContents = await readFile(packageJsonPath, {
+    encoding: 'utf8',
+  });
   const packageJson = JSON.parse(packageJsonContents);
   delete packageJson.scripts.postinstall;
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 }
 
-main()
-  .catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-  })
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/development/generate-attributions/unset-postinstall.js
+++ b/development/generate-attributions/unset-postinstall.js
@@ -1,0 +1,18 @@
+const path = require('node:path');
+const { readFile, writeFile } = require('node:fs/promises');
+
+const rootDirectory = path.resolve(__dirname, '..', '..');
+const packageJsonPath = path.join(rootDirectory, 'package.json');
+
+async function main() {
+  const packageJsonContents = await readFile(packageJsonPath, { encoding: 'utf8' });
+  const packageJson = JSON.parse(packageJsonContents);
+  delete packageJson.scripts.postinstall;
+  await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })


### PR DESCRIPTION
## **Description**

Attribution generation is currently broken because the root `postinstall` script uses `tsx`, but attribution generation uses a focused production-only install that omits development dependencies like `tsx`. Beyond that, the foundry installation is something we don't want when generating attributions, even if it did work.

The attribution generation script has been updated to unset the root `postinstall` script prior to installation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30498?quickstart=1)

## **Related issues**

Fixes #30497

## **Manual testing steps**

Run `yarn attributions:generate`

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
