### PR TITLE
fix (cherry-pick): Add transaction simulation supported networks global mock (#30507)

### DIFF
--- a/shared/constants/transaction.ts
+++ b/shared/constants/transaction.ts
@@ -199,3 +199,10 @@ export enum TokenStandard {
   /** Not a token, but rather the base asset of the selected chain. */
   none = 'NONE',
 }
+
+/**
+ * The hostname used for Ethereum Mainnet transaction simulations, and for
+ * retrieving metadata for transaction simulation supported networks.
+ */
+export const TX_SENTINEL_URL =
+  'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io';

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -16,6 +16,7 @@ const {
   SWAPS_API_V2_BASE_URL,
   TOKEN_API_BASE_URL,
 } = require('../../shared/constants/swaps');
+const { TX_SENTINEL_URL } = require('../../shared/constants/transaction');
 const { SECURITY_ALERTS_PROD_API_BASE_URL } = require('./tests/ppom/constants');
 const {
   DEFAULT_FEATURE_FLAGS_RESPONSE: BRIDGE_DEFAULT_FEATURE_FLAGS_RESPONSE,
@@ -313,6 +314,21 @@ async function setupMocking(
         },
       };
     });
+
+  // This endpoint returns metadata for "transaction simulation" supported networks.
+  await server.forGet(`${TX_SENTINEL_URL}/networks`).thenJson(200, {
+    1: {
+      name: 'Mainnet',
+      group: 'ethereum',
+      chainID: 1,
+      nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
+      network: 'ethereum-mainnet',
+      explorer: 'https://etherscan.io',
+      confirmations: true,
+      smartTransactions: true,
+      hidden: false,
+    },
+  });
 
   await server
     .forGet(`${SWAPS_API_V2_BASE_URL}/featureFlags`)

--- a/test/e2e/tests/simulation-details/simulation-details.spec.ts
+++ b/test/e2e/tests/simulation-details/simulation-details.spec.ts
@@ -1,6 +1,7 @@
 import { hexToNumber } from '@metamask/utils';
 import { Mockttp, MockttpServer } from 'mockttp';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { TX_SENTINEL_URL } from '../../../../shared/constants/transaction';
 import FixtureBuilder from '../../fixture-builder';
 import {
   createDappTransaction,
@@ -43,15 +44,6 @@ import {
 } from './mock-request-send-eth';
 import { MockRequestResponse } from './types';
 
-const TX_SENTINEL_URL =
-  'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io/';
-
-const mockNetworkRequest = async (mockServer: Mockttp) => {
-  await mockServer.forGet(`${TX_SENTINEL_URL}/networks`).thenJson(200, {
-    '1': { name: 'Mainnet', confirmations: true },
-  });
-};
-
 async function withFixturesForSimulationDetails(
   {
     title,
@@ -64,17 +56,13 @@ async function withFixturesForSimulationDetails(
   },
   test: (args: Pick<Fixtures, 'driver' | 'mockServer'>) => Promise<void>,
 ) {
-  const testSpecificMock = async (mockServer: MockttpServer) => {
-    await mockNetworkRequest(mockServer);
-    await mockRequests(mockServer);
-  };
   await withFixtures(
     {
       fixtures: new FixtureBuilder({ inputChainId })
         .withPermissionControllerConnectedToTestDapp()
         .build(),
       title,
-      testSpecificMock,
+      testSpecificMock: mockRequests,
       dapp: true,
       localNodeOptions: {
         hardfork: 'london',


### PR DESCRIPTION
Cherry-picks ff041ab to v12.13.0.

Original PR description:

## **Description**

A global mock has been added for the "supported networks" check made as part of the transaction simulations feature. This is triggered by certain types of confirmations (those that support transaction simulations), so it's triggered by a wide variety of E2E tests.

[![Open in GitHub
Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30507?quickstart=1)

## **Related issues**

Fixes #30490

## **Manual testing steps**

This should resolve the privacy snapshot related errors on CI.

You could also double-check that the mocked response is returned by running an e2e test locally that uses a confirmation that supports transaction simulation, then inspecting the network tab of the service worker dev console while the test is running, and checking the response to the
`https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io/networks` call

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---------


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30527?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
