### PR TITLE
chore: Expose extension ID to E2E tests

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -96,6 +96,7 @@ function normalizeLocalNodeOptions(localNodeOptions) {
  * @property {Bundler} bundlerServer - The bundler server.
  * @property {mockttp.Mockttp} mockServer - The mock server.
  * @property {object} manifestFlags - Flags to add to the manifest in order to change things at runtime.
+ * @property {string} extensionId - The extension ID (useful for connecting via `externally_connectable`).
  */
 
 /**
@@ -144,6 +145,7 @@ async function withFixtures(options, testSuite) {
 
   let webDriver;
   let driver;
+  let extensionId;
   let failed = false;
 
   // ganacheServer variable to be deleted once all specs are migrated to anvil
@@ -266,6 +268,7 @@ async function withFixtures(options, testSuite) {
 
     driver = (await buildWebDriver(driverOptions)).driver;
     webDriver = driver.driver;
+    extensionId = driver.extensionId;
 
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       await driver.checkBrowserForExceptions(ignoredConsoleErrors);
@@ -302,6 +305,7 @@ async function withFixtures(options, testSuite) {
       localNodes,
       mockedEndpoint,
       mockServer,
+      extensionId,
     });
 
     const errorsAndExceptions = driver.summarizeErrorsAndExceptions();


### PR DESCRIPTION
## **Description**

The E2E test setup function (`withFixtures`) has been updated to pass the extension ID to E2E tests. This will be useful in the near future for testing the new multichain API, which is exposed over `externally_connectable` and requires the extension ID to use.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30539?quickstart=1)

## **Related issues**

This was extracted from #27782

## **Manual testing steps**

N/A, this isn't used yet so there is nothing to manually test.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
