### PR TITLE
fix: clear transaction data after submission or cancellation

### DIFF
--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -178,6 +178,12 @@ const Footer = () => {
     (!isScrollToBottomCompleted && !isSignature) ||
     hardwareWalletRequiresConnection;
 
+  const resetTransactionState = () => {
+    dispatch(updateCustomNonce(''));
+    dispatch(setNextNonce(''));
+    dispatch(clearConfirmTransaction());
+  };
+
   const onCancel = useCallback(
     ({ location }: { location?: MetaMetricsEventLocation }) => {
       if (!currentConfirmation) {
@@ -190,9 +196,7 @@ const Footer = () => {
       dispatch(
         rejectPendingApproval(currentConfirmation.id, serializeError(error)),
       );
-      dispatch(updateCustomNonce(''));
-      dispatch(setNextNonce(''));
-      dispatch(clearConfirmTransaction());
+      resetTransactionState();
     },
     [currentConfirmation],
   );
@@ -224,9 +228,7 @@ const Footer = () => {
     } else {
       dispatch(resolvePendingApproval(currentConfirmation.id, undefined));
     }
-    dispatch(updateCustomNonce(''));
-    dispatch(setNextNonce(''));
-    dispatch(clearConfirmTransaction());
+    resetTransactionState();
   }, [currentConfirmation, customNonceValue]);
 
   const handleFooterCancel = useCallback(() => {

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -1,7 +1,9 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
 import { providerErrors, serializeError } from '@metamask/rpc-errors';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
+import { isCorrectDeveloperTransactionType } from '../../../../../../shared/lib/confirmation.utils';
 import { ConfirmAlertModal } from '../../../../../components/app/alert-system/confirm-alert-modal';
 import {
   Button,
@@ -10,13 +12,15 @@ import {
   IconName,
 } from '../../../../../components/component-library';
 import { Footer as PageFooter } from '../../../../../components/multichain/pages/page';
+import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
+import { clearConfirmTransaction } from '../../../../../ducks/confirm-transaction/confirm-transaction.duck';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import useAlerts from '../../../../../hooks/useAlerts';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import {
   doesAddressRequireLedgerHidConnection,
   getCustomNonceValue,
 } from '../../../../../selectors';
-
-import useAlerts from '../../../../../hooks/useAlerts';
 import {
   rejectPendingApproval,
   resolvePendingApproval,
@@ -26,14 +30,10 @@ import {
   ///: END:ONLY_INCLUDE_IF
   updateCustomNonce,
 } from '../../../../../store/actions';
-import { isSignatureTransactionType } from '../../../utils';
 import { useConfirmContext } from '../../../context/confirm';
-import { getConfirmationSender } from '../utils';
-import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
-import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
-import { Severity } from '../../../../../helpers/constants/design-system';
-import { isCorrectDeveloperTransactionType } from '../../../../../../shared/lib/confirmation.utils';
 import { useOriginThrottling } from '../../../hooks/useOriginThrottling';
+import { isSignatureTransactionType } from '../../../utils';
+import { getConfirmationSender } from '../utils';
 import OriginThrottleModal from './origin-throttle-modal';
 
 export type OnCancelHandler = ({
@@ -192,6 +192,7 @@ const Footer = () => {
       );
       dispatch(updateCustomNonce(''));
       dispatch(setNextNonce(''));
+      dispatch(clearConfirmTransaction());
     },
     [currentConfirmation],
   );
@@ -225,6 +226,7 @@ const Footer = () => {
     }
     dispatch(updateCustomNonce(''));
     dispatch(setNextNonce(''));
+    dispatch(clearConfirmTransaction());
   }, [currentConfirmation, customNonceValue]);
 
   const handleFooterCancel = useCallback(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30546?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29374

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
