### PR TITLE
feat: new styles for account badge status

### DIFF
--- a/ui/components/multichain/badge-status/badge-status.tsx
+++ b/ui/components/multichain/badge-status/badge-status.tsx
@@ -53,8 +53,8 @@ export const BadgeStatus: React.FC<BadgeStatusProps> = ({
         <BadgeWrapper
           positionObj={
             isConnectedAndNotActive
-              ? { bottom: 2, right: 5 }
-              : { bottom: -1, right: 2 }
+              ? { bottom: 0, right: 8 }
+              : { bottom: -1, right: 7 }
           }
           badge={
             <Box

--- a/ui/components/multichain/badge-status/badge-status.tsx
+++ b/ui/components/multichain/badge-status/badge-status.tsx
@@ -28,6 +28,7 @@ export const BadgeStatus: React.FC<BadgeStatusProps> = ({
   badgeBorderColor = BorderColor.borderMuted,
   address,
   isConnectedAndNotActive = false,
+  isDisconnected = false,
   text,
   ...props
 }): JSX.Element => {
@@ -61,6 +62,7 @@ export const BadgeStatus: React.FC<BadgeStatusProps> = ({
               className={classNames('multichain-badge-status__badge', {
                 'multichain-badge-status__badge-not-connected':
                   isConnectedAndNotActive,
+                'multichain-badge-status__badge-disconnected': isDisconnected,
               })}
               backgroundColor={badgeBackgroundColor}
               borderRadius={BorderRadius.full}

--- a/ui/components/multichain/badge-status/badge-status.types.tsx
+++ b/ui/components/multichain/badge-status/badge-status.types.tsx
@@ -29,4 +29,8 @@ export interface BadgeStatusProps extends StyleUtilityProps {
    * Address for AvatarAccount
    */
   address: string;
+  /**
+   * To determine if the connection is disconnected
+   */
+  isDisconnected: boolean;
 }

--- a/ui/components/multichain/badge-status/index.scss
+++ b/ui/components/multichain/badge-status/index.scss
@@ -17,6 +17,10 @@
     width: 8px;
   }
 
+  &__badge-disconnected {
+    display: none;
+  }
+
   &__badge-not-connected::after {
     content: '';
     position: absolute;

--- a/ui/components/multichain/badge-status/index.scss
+++ b/ui/components/multichain/badge-status/index.scss
@@ -2,8 +2,8 @@
   padding: 0;
 
   &__badge {
-    height: 16px;
-    width: 16px;
+    height: 12px;
+    width: 12px;
     z-index: 1;
   }
 
@@ -13,8 +13,8 @@
   }
 
   &__badge-not-connected {
-    height: 10px;
-    width: 10px;
+    height: 8px;
+    width: 8px;
   }
 
   &__badge-not-connected::after {

--- a/ui/components/multichain/connected-status/connected-status.tsx
+++ b/ui/components/multichain/connected-status/connected-status.tsx
@@ -75,6 +75,7 @@ export const ConnectedStatus: React.FC<ConnectedStatusProps> = ({
       badgeBorderColor={badgeBorderColor}
       text={tooltipText}
       isConnectedAndNotActive={connectedAndNotActive}
+      isDisconnected={status === STATUS_NOT_CONNECTED}
     />
   );
 };


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30564?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3766


## **Manual testing steps**

1. Go to uniswap
2. Create three accounts, connect two of them
3. Check the status of the accounts in the "Select an account" menu 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2025-02-25 at 13 56 12](https://github.com/user-attachments/assets/1c5fb02f-308e-4918-9f2d-fe7ae23df926)


### **After**

<img width="310" alt="Screenshot 2025-02-25 at 20 11 11" src="https://github.com/user-attachments/assets/29676e71-65ed-4ada-b8d8-ce63d598a0bb" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
