### PR TITLE
feat: convert non-evm amounts to fiat

### DIFF
--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -11,7 +11,9 @@ import { BigNumber } from 'bignumber.js';
 import { calcTokenAmount } from '@metamask/notification-services-controller/push-services';
 import {
   MultichainNetworks,
+  ///: BEGIN:ONLY_INCLUDE_IF(solana-swaps)
   MULTICHAIN_PROVIDER_CONFIGS,
+  ///: END:ONLY_INCLUDE_IF
 } from '../../../shared/constants/multichain/networks';
 import {
   getIsBridgeEnabled,

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -13,6 +13,7 @@ import { getTransaction1559GasFeeEstimates } from '../../pages/swaps/swaps.util'
 import { fetchTokenExchangeRates as fetchTokenExchangeRatesUtil } from '../../helpers/utils/util';
 import { formatChainIdToHex } from '../../../shared/modules/bridge-utils/caip-formatters';
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
+import fetchWithCache from '../../../shared/lib/fetch-with-cache';
 
 type GasFeeEstimate = {
   suggestedMaxPriorityFeePerGas: string;
@@ -79,9 +80,24 @@ const fetchTokenExchangeRates = async (
   currency: string,
   ...tokenAddresses: string[]
 ) => {
-  // TODO fetch exchange rates for solana
   if (chainId === MultichainNetworks.SOLANA) {
-    return {};
+    const queryParams = new URLSearchParams({
+      assetIds: tokenAddresses,
+      includeMarketData: true,
+      vsCurrency: currency,
+    });
+    const url = `https://price.api.cx.metamask.io/v3/spot-prices?${queryParams}`;
+    const exchangeRates = await fetchWithCache({
+      url,
+      fetchOptions: {
+        method: 'GET',
+        headers: 'metamask',
+      },
+      cacheOptions: { cacheRefreshTime: 0 },
+      functionName: 'fetchTokenExchangeRates',
+    });
+
+    return exchangeRates;
   }
 
   const exchangeRates = await fetchTokenExchangeRatesUtil(
@@ -112,6 +128,9 @@ export const getTokenExchangeRate = async (request: {
     currency,
     tokenAddress,
   );
+  if (chainId === MultichainNetworks.SOLANA) {
+    return exchangeRates?.[tokenAddress];
+  }
   // The exchange rate can be checksummed or not, so we need to check both
   const exchangeRate =
     exchangeRates?.[toChecksumAddress(tokenAddress)] ??

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -82,8 +82,8 @@ const fetchTokenExchangeRates = async (
 ) => {
   if (chainId === MultichainNetworks.SOLANA) {
     const queryParams = new URLSearchParams({
-      assetIds: tokenAddresses,
-      includeMarketData: true,
+      assetIds: tokenAddresses.join(','),
+      includeMarketData: 'true',
       vsCurrency: currency,
     });
     const url = `https://price.api.cx.metamask.io/v3/spot-prices?${queryParams}`;

--- a/ui/hooks/bridge/useBridgeExchangeRates.ts
+++ b/ui/hooks/bridge/useBridgeExchangeRates.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { isStrictHexString } from '@metamask/utils';
 import {
   getBridgeQuotes,
   getQuoteRequest,
@@ -43,7 +44,7 @@ export const useBridgeExchangeRates = () => {
 
   // Fetch exchange rates for selected src token if not found in marketData
   useEffect(() => {
-    if (fromChainId && fromTokenAddress) {
+    if (fromChainId && fromTokenAddress && isStrictHexString(fromChainId)) {
       const exchangeRate = exchangeRateFromMarketData(
         fromChainId,
         fromTokenAddress,

--- a/ui/hooks/bridge/useBridgeExchangeRates.ts
+++ b/ui/hooks/bridge/useBridgeExchangeRates.ts
@@ -7,18 +7,19 @@ import {
 } from '../../ducks/bridge/selectors';
 import { getMarketData, getParticipateInMetaMetrics } from '../../selectors';
 import { getCurrentCurrency } from '../../ducks/metamask/metamask';
-import { getCurrentChainId } from '../../../shared/modules/selectors/networks';
 import {
   setDestTokenExchangeRates,
   setDestTokenUsdExchangeRates,
   setSrcTokenExchangeRates,
 } from '../../ducks/bridge/bridge';
 import { exchangeRateFromMarketData } from '../../ducks/bridge/utils';
+import { useMultichainSelector } from '../useMultichainSelector';
+import { getMultichainCurrentChainId } from '../../selectors/multichain';
 
 export const useBridgeExchangeRates = () => {
   const { srcTokenAddress, destTokenAddress } = useSelector(getQuoteRequest);
   const { activeQuote } = useSelector(getBridgeQuotes);
-  const chainId = useSelector(getCurrentChainId);
+  const chainId = useMultichainSelector(getMultichainCurrentChainId);
   const toChain = useSelector(getToChain);
   const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This enables looking up non-evm exchange rate data for converting token amounts


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30568?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Select non-evm account
2. Open bridge experience and select token
3. Enter an amount
4. Converted amount should appear under input field

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
