### PR TITLE
fix: critical error message visibility bug in dark mode

### DIFF
--- a/ui/css/errors.scss
+++ b/ui/css/errors.scss
@@ -3,7 +3,7 @@
   border-radius: 4px;
   border-left: var(--color-warning-default) 4px solid;
   background-color: var(--color-warning-muted);
-  color: var(--color-text-default);
+  color: inherit; // Required to inherit color set from prefers-color-scheme
   display: flex;
   padding: 12px 12px 12px 8px;
   gap: 8px;


### PR DESCRIPTION
## **Description**

This PR fixes critical error message visibility in dark mode. Previously, error messages used a hardcoded color value that didn't respect theme preferences.

The improvement changes the `color` property to `inherit` in the critical error component, ensuring proper color inheritance from the parent theme based on the user's prefers-color-scheme setting.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30570?quickstart=1)

## **Related issues**

Fixes: #30569

## **Manual testing steps**

1. Open `app/scripts/ui.js`
2. Locate the `initializeUiWithTab` function
3. Throw an error
   ```javascript
   // To test critical error display, uncomment the next line:
   throw new Error('Test Critical Error');
   ```
4. Enable dark mode in your system preferences or via dev tools (see recording)
5. Verify error message text properly inherits dark theme colors
6. Switch to light mode and verify error message remains visible

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/e2c59c38-f7ab-4755-828e-32f6696b1bbd

### **After**

https://github.com/user-attachments/assets/44fd7f34-792f-47e5-be48-7fb1c051d961

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.