### PR TITLE
fix(30583): broken gha check template and labels

### DIFF
--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -265,7 +265,7 @@ function extractReleaseVersionFromBugReportIssueBody(
 }
 
 // This function adds the "needs-triage" label to the issue if it doesn't have it
-function addNeedsTriageLabelToIssue(
+async function addNeedsTriageLabelToIssue(
   octokit: InstanceType<typeof GitHub>,
   issue: Labelable,
 ): Promise<void> {


### PR DESCRIPTION
## **Description**
broken gha check template and labels

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30584?quickstart=1)

## **Related issues**

Fixes: #30583 

## **Manual testing steps**

1. Open PR
2. See failure in GHA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
