### PR TITLE
fix: fix e2e decimal failure in Swap-Send ERC20 to non-contract address

### DIFF
--- a/test/e2e/tests/swap-send/swap-send-erc20.spec.ts
+++ b/test/e2e/tests/swap-send/swap-send-erc20.spec.ts
@@ -39,10 +39,7 @@ describe('Swap-Send ERC20', function () {
             4000,
           );
 
-          await swapSendPage.verifyMaxButtonClick(
-            ['TST', 'TST'],
-            ['10.0000', '10.0000'],
-          );
+          await swapSendPage.verifyMaxButtonClick(['TST', 'TST'], ['10', '10']);
 
           await swapSendPage.fillAmountInput('10');
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix e2e decimal error in firefox, similar as https://github.com/MetaMask/metamask-extension/pull/30203

From @seaona's suggestion: 
> In v125, the 2 decimals are not displayed with values which are "rounded", like  $50 . This makes the expect fail for FF, as we are looking for $50.00 .

Pipeline: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/127352/workflows/2aeff087-6ca5-4b6f-a113-68e15500b06b/jobs/4586524
<img width="1271" alt="Screenshot 2025-02-26 at 18 21 35" src="https://github.com/user-attachments/assets/5aab9cd8-1eab-4f13-b983-e33e015e67f5" />


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30588?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
