### PR TITLE
fix(e2e): test-artifacts/undefined folder

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -23,8 +23,6 @@ const PAGES = {
   POPUP: 'popup',
 };
 
-const artifactDir = (title) => `./test-artifacts/${this.browser}/${title}`;
-
 /**
  * Temporary workaround to patch selenium's element handle API with methods
  * that match the playwright API for Elements
@@ -669,13 +667,24 @@ class Driver {
     throw new Error('Element did not stop moving within the timeout period');
   }
 
-  /** @param {string} title - The title of the window or tab the screenshot is being taken in */
-  async takeScreenshot(title) {
-    const filepathBase = `${artifactDir(title)}/test-screenshot`;
-    await fs.mkdir(artifactDir(title), { recursive: true });
+  /**
+   * @param {string} testTitle - The title of the test
+   */
+  #getArtifactDir(testTitle) {
+    return `./test-artifacts/${this.browser}/${testTitle}`;
+  }
+
+  /**
+   * @param {string} testTitle - The title of the test
+   * @param {string} screenshotTitle - The title of the screenshot
+   * @returns {Promise<void>} Promise that resolves when the screenshot is taken
+   */
+  async takeScreenshot(testTitle, screenshotTitle) {
+    const artifactDir = this.#getArtifactDir(testTitle);
+    await fs.mkdir(artifactDir, { recursive: true });
 
     const screenshot = await this.driver.takeScreenshot();
-    await fs.writeFile(`${filepathBase}-screenshot.png`, screenshot, {
+    await fs.writeFile(`${artifactDir}/${screenshotTitle}.png`, screenshot, {
       encoding: 'base64',
     });
   }
@@ -1230,16 +1239,16 @@ class Driver {
 
   // Error handling
 
-  async verboseReportOnFailure(title, error) {
+  async verboseReportOnFailure(testTitle, error) {
     console.error(
-      `Failure on testcase: '${title}', for more information see the ${
+      `Failure on testcase: '${testTitle}', for more information see the ${
         process.env.CIRCLECI ? 'artifacts tab in CI' : 'test-artifacts folder'
       }\n`,
     );
     console.error(`${error}\n`);
 
-    const filepathBase = `${artifactDir(title)}/test-failure`;
-    await fs.mkdir(artifactDir(title), { recursive: true });
+    const filepathBase = `${this.#getArtifactDir(testTitle)}/test-failure`;
+    await fs.mkdir(this.#getArtifactDir(testTitle), { recursive: true });
 
     const windowHandles = await this.driver.getAllWindowHandles();
     // On occasion there may be a bug in the offscreen document which does
@@ -1251,16 +1260,10 @@ class Driver {
         await this.driver.switchTo().window(handle);
         const windowTitle = await this.driver.getTitle();
         if (windowTitle !== 'MetaMask Offscreen Page') {
-          const screenshot = await this.driver.takeScreenshot();
-          await fs.writeFile(
-            `${filepathBase}-screenshot-${
-              windowHandles.indexOf(handle) + 1
-            }.png`,
-            screenshot,
-            {
-              encoding: 'base64',
-            },
-          );
+          const screenshotTitle = `test-failure-screenshot-${
+            windowHandles.indexOf(handle) + 1
+          }`;
+          await this.takeScreenshot(testTitle, screenshotTitle);
         }
       }
     } catch (e) {


### PR DESCRIPTION
## **Description**

There was a bug introduced in #26845 where E2E test failures would create folders named `test-artifacts/undefined` in some situations (see _Before_ screenshot).

This happened because the `artifactDir` function was referencing `this.browser` outside of the scope where it was defined.  I moved the function so that it's in scope now.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30591?quickstart=1)

## **Related issues**

Fixes: bug introduced in #26845

## **Manual testing steps**

1. Create a deliberate failure in an E2E test
2. Run the E2E test
3. Check folder output

## **Screenshots/Recordings**
### **Before**

![before](https://github.com/user-attachments/assets/28f339ce-b4c0-44c9-a6c4-5449c537a25a)

### **After**

![after](https://github.com/user-attachments/assets/c88bb043-161a-4d58-bb2a-01fcd65dc071)

<!--## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->