### PR TITLE
refactor(snaps e2e): Refactor E2E tests to reduce duplication

### DIFF
--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -3,8 +3,6 @@ import { Driver } from '../webdriver/driver';
 import { loginWithoutBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
 import { withFixtures, WINDOW_TITLES } from '../helpers';
-import SnapInstall from '../page-objects/pages/dialog/snap-install';
-import SnapInstallWarning from '../page-objects/pages/dialog/snap-install-warning';
 
 describe('Test Snap bip-32', function () {
   it('tests various functions of bip-32', async function () {
@@ -17,36 +15,10 @@ describe('Test Snap bip-32', function () {
         await loginWithoutBalanceValidation(driver);
 
         const testSnaps = new TestSnaps(driver);
-        const snapInstall = new SnapInstall(driver);
-        const snapInstallWarning = new SnapInstallWarning(driver);
 
-        // navigate to test snaps page and connect wait for page to load
+        // Navigate to `test-snaps` page, and install the Snap.
         await testSnaps.openPage();
-
-        // find, scroll and click connect to the bip32 snap
-        await testSnaps.clickConnectBip32();
-
-        // switch to metamask extension and click connect
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await snapInstall.check_pageIsLoaded();
-        await snapInstall.clickNextButton();
-
-        // click confirm
-        await snapInstall.clickConfirmButton();
-
-        // wait for permissions popover, click checkboxes and confirm
-        await snapInstallWarning.check_pageIsLoaded();
-        await snapInstallWarning.clickCheckboxPermission();
-        await snapInstallWarning.clickConfirmButton();
-
-        // wait for and click OK and wait for window to close
-        await snapInstall.clickNextButton();
-
-        // switch back to test-snaps window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
-
-        // wait for npm installation success
-        await testSnaps.waitForReconnectButton();
+        await testSnaps.installSnap('#connectbip32', true);
 
         // scroll to and click get public key
         await testSnaps.clickGetPublicKeyButton();
@@ -71,7 +43,7 @@ describe('Test Snap bip-32', function () {
 
         // hit 'approve' on the signature confirmation and wait for window to close
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await snapInstall.clickApproveButton();
+        await testSnaps.snapInstall.clickApproveButton();
 
         // switch back to the test-snaps window
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
@@ -91,7 +63,7 @@ describe('Test Snap bip-32', function () {
         // switch to dialog window
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        await snapInstall.clickApproveButton();
+        await testSnaps.snapInstall.clickApproveButton();
 
         // switch back to test-snaps window
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
@@ -108,7 +80,7 @@ describe('Test Snap bip-32', function () {
         // switch to dialog window
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        await snapInstall.clickApproveButton();
+        await testSnaps.snapInstall.clickApproveButton();
 
         // switch back to test-snaps window
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -3,8 +3,6 @@ import { Driver } from '../webdriver/driver';
 import { loginWithoutBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
 import { withFixtures, WINDOW_TITLES } from '../helpers';
-import SnapInstall from '../page-objects/pages/dialog/snap-install';
-import SnapInstallWarning from '../page-objects/pages/dialog/snap-install-warning';
 
 describe('Test Snap bip-44', function () {
   it('can pop up bip-44 snap and get private key result', async function () {
@@ -17,36 +15,10 @@ describe('Test Snap bip-44', function () {
         await loginWithoutBalanceValidation(driver);
 
         const testSnaps = new TestSnaps(driver);
-        const snapInstall = new SnapInstall(driver);
-        const snapInstallWarning = new SnapInstallWarning(driver);
 
-        // navigate to test snaps page and connect wait for page to load
+        // Navigate to `test-snaps` page, and install the Snap.
         await testSnaps.openPage();
-
-        // find and scroll to the bip44 snap
-        await testSnaps.clickConnectBip44();
-
-        // switch to metamask extension and click connect and approve
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await snapInstall.check_pageIsLoaded();
-        await snapInstall.clickNextButton();
-
-        // click confirm
-        await snapInstall.clickConfirmButton();
-
-        // deal with permissions popover, click checkboxes and confirm
-        await snapInstallWarning.check_pageIsLoaded();
-        await snapInstallWarning.clickCheckboxPermission();
-        await snapInstallWarning.clickConfirmButton();
-
-        // wait for and click ok and wait for window to close
-        await snapInstall.clickNextButton();
-
-        // switch back to test-snaps window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
-
-        // wait for npm installation success
-        await testSnaps.waitForReconnectBip44Button();
+        await testSnaps.installSnap('#connectbip44', true);
 
         // find and click bip44 test
         await testSnaps.clickPublicKeyBip44Button();
@@ -64,7 +36,7 @@ describe('Test Snap bip-44', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // wait for and click approve and wait for window to close
-        await snapInstall.clickApproveButton();
+        await testSnaps.snapInstall.clickApproveButton();
 
         // switch back to test-snaps page
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);

--- a/test/e2e/snaps/test-snap-homepage.spec.ts
+++ b/test/e2e/snaps/test-snap-homepage.spec.ts
@@ -22,8 +22,7 @@ describe('Test Snap Homepage', function (this: Suite) {
         const snapListPage = new SnapListPage(driver);
 
         await testSnaps.openPage();
-        await testSnaps.clickConnectHomePage();
-        await testSnaps.completeSnapInstallConfirmation();
+        await testSnaps.installSnap('#connecthomepage');
 
         // switch to metamask page and open the three dots menu
         await driver.switchToWindowWithTitle(

--- a/test/e2e/tests/confirmations/navigation.spec.ts
+++ b/test/e2e/tests/confirmations/navigation.spec.ts
@@ -135,8 +135,7 @@ describe('Confirmation Navigation', function (this: Suite) {
 
         const testSnaps = new TestSnaps(driver);
         await testSnaps.openPage();
-        await testSnaps.clickConnectDialogsSnapButton();
-        await testSnaps.completeSnapInstallConfirmation();
+        await testSnaps.installSnap('#connectdialogs');
         await testSnaps.clickDialogsSnapConfirmationButton();
 
         const testDapp = new TestDapp(driver);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The E2E tests for Snaps contained a lot of duplication for installing Snaps. I've moved the installation logic to a more generic `installSnap` function in the `TestSnaps` page object, which accepts a selector to install a Snap on the `test-snaps` page. This means we can remove logic for installing specific Snaps.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30638?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

n/a

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
