### PR TITLE
fix: cp-12.14.0 color inheritance

### DIFF
--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -17,10 +17,7 @@ body {
 
 html {
   min-height: 500px;
-}
 
-html,
-body {
   @include design-system.screen-sm-max {
     &:not([data-theme]) {
       background-color: var(--color-background-default);
@@ -36,6 +33,10 @@ body {
     &:not([data-theme]) {
       color: var(--brand-colors-white);
       background-color: var(--brand-colors-grey-grey900);
+
+      body {
+        color: var(--brand-colors-white);
+      }
     }
 
     @include design-system.screen-sm-max {


### PR DESCRIPTION
## **Description**

This PR addresses an issue introduced in PR #30408 where elements using `color: inherit` incorrectly inherit `var(--brand-colors-white)` in light mode. The previous PR fixed error page text visibility in dark mode but inadvertently created contrast and readability issues in light mode.

The issue stems from changes in the CSS cascade and selector structure in `ui/css/base-styles.scss`, specifically how color is applied to the `body` element within the dark mode media query. This fix ensures proper color inheritance based on the current theme while maintaining the dark mode improvements.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30650
Related to: #30408 (original dark mode error page fix)

## **Manual testing steps**

1. Set your system to light mode
2. Verify text using `color: inherit` appears with proper contrast (dark text on light background) in more menu and send screens
3. Switch to dark mode and verify text is still visible (light text on dark background)
4. Test the error page in both modes to ensure it maintains proper text visibility (testing steps in #30408)
5. Test components using `color: inherit` in both modes to verify correct inheritance

## **Screenshots/Recordings**

### **Before**

<img src="https://github.com/user-attachments/assets/62fb3bdb-11a3-4273-889e-ad03c8968b3b" width="250"/><img src="https://github.com/user-attachments/assets/d37f846b-c5c1-46e5-b24c-25e57d68db5a" width="250"/>

### **After**

Colors are correctly inheriting theme level design tokens again

https://github.com/user-attachments/assets/f99c1f96-619b-4325-bc68-6cd722277aa9

Error page still works as expected

https://github.com/user-attachments/assets/ca17a98c-37e8-4e48-98b6-4967ef8f5bc0

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

