### PR TITLE
style: make Git blame ignore specified large refactor and lint commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,7 +6,7 @@
 31175625b446cb5d18b17db23018bca8b14d280c
 
 #7730 Migrate codebase to use ESM @whymarrh
-92971d3c87fb778b5900e84bf4129f7c483ba98a Migrate codebase to use ESM
+92971d3c87fb778b5900e84bf4129f7c483ba98a
 
 #8023 Update ESLint rules for test suite @whymarrh
 4f3fc95d5062abce22d3c9cac5587269f4c98c91

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -35,10 +35,6 @@ b6ccd22d6c0ff6b9797c7aa24429f3df6d031af7
 09d81ac5f2c94d7730d2e981b4f05734858030bf
 29742b951954f1b463de331df84ff75b22a9498d
 
-#17092 Added storybook check to CI @NidhiKJha
-#### Let's discuss if this one should be removed from the list
-c5368c152b544433a2087597f0cb36b33fbd9c6a
-
 #22639 Confirmations code re-structuring @jpuri
 c4c12ecd53ee8d1c76d4329af21649ce93d5f9bd
 

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,49 @@
+# To make this work for you locally, run:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+# (if not autorun by postinstall)
+
+#6304 Folder restructure @danjm
+31175625b446cb5d18b17db23018bca8b14d280c
+
+#7730 Migrate codebase to use ESM @whymarrh
+92971d3c87fb778b5900e84bf4129f7c483ba98a Migrate codebase to use ESM
+
+#8023 Update ESLint rules for test suite @whymarrh
+4f3fc95d5062abce22d3c9cac5587269f4c98c91
+
+#8056 Enable arrow-parens ESLint rule @whymarrh
+a78cf0ef3a463c5d9d56453e2f777e08cc2dcce7
+
+#8595 [RFC] add prettier to eslint @brad-decker
+2ebf8756a4c1023e45e4bd98367f384836cb464a
+
+#9239 Fix import/order issues @whymarrh
+c1e3c229bc008ddc7ca3507e75845ed73b837e1c
+
+#9274 Update ESLint shared config to v3 @whymarrh
+b6ccd22d6c0ff6b9797c7aa24429f3df6d031af7
+
+#10358 @metamask/eslint config@5.0.0 @rekmarks
+#"It's semicolons o'clock"
+76a2a9bb8b6ea04025328d36404ac3b59121dfc8
+
+#10655 colocate tests in flat structure @brad-decker
+5a233e463457ca2ac9b3342f4cc848303a44e929
+
+#10911 remove the ui/app and ui/lib folders @brad-decker
+#(two hashes because it 's in history twice)
+09d81ac5f2c94d7730d2e981b4f05734858030bf
+29742b951954f1b463de331df84ff75b22a9498d
+
+#17092 Added storybook check to CI @NidhiKJha
+#### Let's discuss if this one should be removed from the list
+c5368c152b544433a2087597f0cb36b33fbd9c6a
+
+#22639 Confirmations code re-structuring @jpuri
+c4c12ecd53ee8d1c76d4329af21649ce93d5f9bd
+
+#22531 chore: update `sass` to v1.71.0 @davidmurdoch
+5fd2b7fc25e709ce658eab0bdee162fa566dd2d9
+
+#30440 style: apply Prettier to md, mdx, and yml files @HowardBraham
+dc7325148c1ac03f050422e07156087b53af92d2

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,6 +1,9 @@
-# To make this work for you locally, run:
+# This file is used to ignore commits when running git blame.
+#
+# It should work in Cursor and VSCode with GitLens automatically because of .vscode/settings.json
+#
+# To make this work for you everywhere locally, run:
 # git config blame.ignoreRevsFile .git-blame-ignore-revs
-# (if not autorun by postinstall)
 
 #6304 Folder restructure @danjm
 31175625b446cb5d18b17db23018bca8b14d280c

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,9 @@
     "app/*.html": "ejs"
   },
   "files.trimTrailingWhitespace": true,
+  "gitlens.advanced.blame.customArguments": [
+    "--ignore-revs-file .git-blame-ignore-revs"
+  ],
   "javascript.preferences.importModuleSpecifier": "relative",
   "json.schemas": [
     {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack": "tsx ./development/webpack/launch.ts",
     "webpack:clearcache": "./development/clear-webpack-cache.js",
     "foundryup": "tsx ./test/helpers/foundry/foundryup.ts",
-    "postinstall": "yarn webpack:clearcache && yarn foundryup",
+    "postinstall": "yarn webpack:clearcache && yarn foundryup && git config blame.ignoreRevsFile .git-blame-ignore-revs",
     "env:e2e": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' yarn",
     "start": "yarn build:dev dev --apply-lavamoat=false --snow=false",
     "start:with-state": "node ./app/scripts/start-with-wallet-state.mjs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack": "tsx ./development/webpack/launch.ts",
     "webpack:clearcache": "./development/clear-webpack-cache.js",
     "foundryup": "tsx ./test/helpers/foundry/foundryup.ts",
-    "postinstall": "yarn webpack:clearcache && yarn foundryup && git config blame.ignoreRevsFile .git-blame-ignore-revs",
+    "postinstall": "yarn webpack:clearcache && yarn foundryup",
     "env:e2e": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' yarn",
     "start": "yarn build:dev dev --apply-lavamoat=false --snow=false",
     "start:with-state": "node ./app/scripts/start-with-wallet-state.mjs",


### PR DESCRIPTION
## **Description**

@davidmurdoch requested this feature here: https://github.com/MetaMask/metamask-extension/pull/30440#pullrequestreview-2634300272

Also adds to the VSCode GitLens settings.  If a Cursor user could help with the Cursor settings, that would be much appreciated.

We should discuss:

- The inclusion of #17092, as I'm undecided about it
- Whether it's appropriate to automatically execute `git config blame.ignoreRevsFile .git-blame-ignore-revs` in `postinstall`.  It writes to the local `.git/config` file in your `metamask-extension` folder, so it's only changing that one folder.

Command to get commits with over 200 file changes
```
git log --pretty=format:"%H %s" --shortstat | awk '{if ($1 ~ /^[0-9]+$/) {num = $1 + 0; if (num > 200 && current_hash !~ /Revert/) print num " " current_hash} else current_hash = $0}' | sort -nr
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30661?quickstart=1)

## **Related issues**

David Murdoch request: https://github.com/MetaMask/metamask-extension/pull/30440#pullrequestreview-2634300272

## **Ignored PRs**

- #6304 
- #7730 
- #8023 
- #8056 
- #8595 
- #9239 
- #9274 
- #10358
- #10655
- #10911
- #17092
- #22639
- #22531
- #30440

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->