### PR TITLE
feat: Add clear functionality to SRP import error banner

### DIFF
--- a/ui/components/multichain/multi-srp/import-srp/import-srp.test.tsx
+++ b/ui/components/multichain/multi-srp/import-srp/import-srp.test.tsx
@@ -229,9 +229,9 @@ describe('ImportSrp', () => {
 
     // Verify all input fields are cleared
     for (let i = 0; i < 12; i++) {
-      const input = getByTestId(`import-srp__srp-word-${i}`).querySelector(
-        'input',
-      );
+      const input = getByTestId(
+        `import-multi-srp__srp-word-${i}`,
+      ).querySelector('input');
       expect(input).toHaveValue('');
     }
 

--- a/ui/components/multichain/multi-srp/import-srp/import-srp.test.tsx
+++ b/ui/components/multichain/multi-srp/import-srp/import-srp.test.tsx
@@ -204,6 +204,41 @@ describe('ImportSrp', () => {
     expect(mockClearClipboard).toHaveBeenCalled();
   });
 
+  it('clears the SRP input fields and error message when Clear button is clicked', async () => {
+    const onActionComplete = jest.fn();
+    const render = renderWithProvider(
+      <ImportSrp onActionComplete={onActionComplete} />,
+      store,
+    );
+    const { getByText, queryByTestId, getByTestId } = render;
+
+    // Input an invalid SRP to trigger error
+    const invalidSRP = VALID_SECRET_RECOVERY_PHRASE.replace('input', 'inptu');
+    pasteSrpIntoFirstInput(render, invalidSRP);
+
+    // Verify error message is shown
+    const bannerAlert = await waitFor(() => getByTestId('bannerAlert'));
+    expect(bannerAlert).toBeInTheDocument();
+
+    // Click Clear button
+    const clearButton = getByText('Clear');
+    fireEvent.click(clearButton);
+
+    // Verify error message is cleared
+    expect(queryByTestId('bannerAlert')).not.toBeInTheDocument();
+
+    // Verify all input fields are cleared
+    for (let i = 0; i < 12; i++) {
+      const input = getByTestId(`import-srp__srp-word-${i}`).querySelector(
+        'input',
+      );
+      expect(input).toHaveValue('');
+    }
+
+    // Verify Import wallet button is disabled
+    expect(getByText('Import wallet')).not.toBeEnabled();
+  });
+
   it('logs an error and not call onActionComplete on import failure', async () => {
     (actions.importMnemonicToVault as jest.Mock).mockImplementation(() =>
       jest.fn().mockRejectedValue(new Error('error')),

--- a/ui/components/multichain/multi-srp/import-srp/import-srp.tsx
+++ b/ui/components/multichain/multi-srp/import-srp/import-srp.tsx
@@ -280,7 +280,7 @@ export const ImportSrp = ({
         <BannerAlert
           severity={BannerAlertSeverity.Danger}
           description={srpError}
-          actionButtonLabel={'Clear'}
+          actionButtonLabel={t('clear')}
           actionButtonOnClick={() => {
             onSrpChange(Array(defaultNumberOfWords).fill(''));
             setSrpError('');

--- a/ui/components/multichain/multi-srp/import-srp/import-srp.tsx
+++ b/ui/components/multichain/multi-srp/import-srp/import-srp.tsx
@@ -280,6 +280,12 @@ export const ImportSrp = ({
         <BannerAlert
           severity={BannerAlertSeverity.Danger}
           description={srpError}
+          actionButtonLabel={'Clear'}
+          actionButtonOnClick={() => {
+            onSrpChange(Array(defaultNumberOfWords).fill(''));
+            setSrpError('');
+          }}
+          data-testid="bannerAlert"
         />
       ) : null}
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Adds an option to clear the SRP input and error message, so user can easily paste another SRP.

## **Related issues**



## **Manual testing steps**

1. Go to Import SRP page
2. Paste SRP that has been already imported (you can try to import the same SRP 2nd time)
3. Error message should appear with a "Clear" option

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="315" alt="Screenshot 2025-03-07 at 12 22 56" src="https://github.com/user-attachments/assets/88b014bd-8db4-48ae-8e0f-44efadbfc040" />

### **After**
<img width="321" alt="Screenshot 2025-03-07 at 12 29 37" src="https://github.com/user-attachments/assets/7600a976-01db-4589-b0b5-f595d0f5ae91" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
