### PR TITLE
fix: cherrypick-v12.14.0 bridge page

### DIFF
--- a/ui/hooks/bridge/useLatestBalance.ts
+++ b/ui/hooks/bridge/useLatestBalance.ts
@@ -36,7 +36,8 @@ const useLatestBalance = (
   const nonEvmBalancesByAccountId = useMultichainSelector(
     getMultichainBalances,
   );
-  const nonEvmBalances = nonEvmBalancesByAccountId[id];
+
+  const nonEvmBalances = nonEvmBalancesByAccountId?.[id];
 
   const value = useAsyncResult<Numeric | undefined>(async () => {
     if (


### PR DESCRIPTION
## **Description**

When the users does not have a non Evm account, the bridge cannot calculated the users balance.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30671?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30662

## **Manual testing steps**

1. Build the App
2. Go to the brige page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**



### **After**

<img width="679" alt="Screenshot 2025-03-03 at 10 00 26" src="https://github.com/user-attachments/assets/144d091f-f73e-4270-9cc1-85275fdd9574" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
