### PR TITLE
fix(30348): profile sync can now be searched in settings

### DIFF
--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -330,11 +330,20 @@ const SETTINGS_CONSTANTS = [
     route: `${SECURITY_ROUTE}#dataCollectionForMarketing`,
     icon: 'fa fa-lock',
   },
+  // securityAndPrivacy settingsRefs[20]
   {
     tabMessage: (t) => t('securityAndPrivacy'),
     sectionMessage: (t) => t('deleteMetaMetricsData'),
     descriptionMessage: (t) => t('deleteMetaMetricsDataDescription'),
     route: `${SECURITY_ROUTE}#delete-metametrics-data`,
+    icon: 'fa fa-lock',
+  },
+  // securityAndPrivacy settingsRefs[21]
+  {
+    tabMessage: (t) => t('securityAndPrivacy'),
+    sectionMessage: (t) => t('profileSync'),
+    descriptionMessage: (t) => t('profileSyncDescription'),
+    route: `${SECURITY_ROUTE}#profile-sync`,
     icon: 'fa fa-lock',
   },
   {

--- a/ui/helpers/utils/settings-search.test.js
+++ b/ui/helpers/utils/settings-search.test.js
@@ -173,7 +173,7 @@ describe('Settings Search Utils', () => {
     it('returns "Security & privacy" section count', () => {
       expect(
         getNumberOfSettingRoutesInTab(t, t('securityAndPrivacy')),
-      ).toStrictEqual(21);
+      ).toStrictEqual(22);
     });
 
     it('returns "Network" section count', () => {

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -203,6 +203,7 @@ exports[`Security Tab should match snapshot 1`] = `
     </span>
     <div
       class="settings-page__content-padded"
+      data-testid="profile-sync"
     >
       <div
         class="mm-box"

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -1163,7 +1163,11 @@ export default class SecurityTab extends PureComponent {
           {this.context.t('privacy')}
         </span>
 
-        <div className="settings-page__content-padded">
+        <div
+          ref={this.settingsRefs[21]}
+          className="settings-page__content-padded"
+          data-testid="profile-sync"
+        >
           <ProfileSyncToggle />
         </div>
 


### PR DESCRIPTION
## **Description**

**Issue:** Profile sync cannot be searched within our settings

**Solution:** Added necessary logic to support search for profile settings

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30687?quickstart=1)

## **Related issues**

Fixes: [#30348](https://github.com/MetaMask/metamask-extension/issues/30348)

## **Manual testing steps**

1. Go to settings page
2. Search Profile Sync
3. Test different variations of the word profile sync 

## **Screenshots/Recordings**

![search](https://github.com/user-attachments/assets/9d03e53b-9fb9-48fb-98e5-d7782b7c06c2)

| Before  | After  |
|:---:|:---:|
|![before_welcome](https://github.com/user-attachments/assets/d466dfe2-5008-4740-80e6-3fad5d68d863)|![after_welcome](https://github.com/user-attachments/assets/80384c00-3785-41c1-b04d-c35755cf1d40)|


### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
