### PR TITLE
feat(1840): Use "decimal" format instead of "hexadecimal" format for "chain_id" event property

### DIFF
--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -28,6 +28,7 @@ import { LedgerTransportTypes } from '../../../shared/constants/hardware-wallets
 import * as Utils from '../lib/util';
 import { mockNetworkState } from '../../../test/stub/networks';
 import { flushPromises } from '../../../test/lib/timer-helpers';
+import { convertHexChainIdToDecimal } from '../../../shared/modules/network.utils';
 import MetaMetricsController, {
   AllowedActions,
   AllowedEvents,
@@ -82,7 +83,7 @@ const DEFAULT_TEST_CONTEXT = {
 };
 
 const DEFAULT_SHARED_PROPERTIES = {
-  chain_id: DEFAULT_CHAIN_ID,
+  chain_id: convertHexChainIdToDecimal(DEFAULT_CHAIN_ID),
   locale: LOCALE.replace('_', '-'),
   environment_type: 'background',
 };

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -74,6 +74,7 @@ import { ENVIRONMENT } from '../../../development/build/constants';
 ///: END:ONLY_INCLUDE_IF
 
 import { KeyringType } from '../../../shared/constants/keyring';
+import { convertHexChainIdToDecimal } from '../../../shared/modules/network.utils';
 import type {
   PreferencesControllerState,
   PreferencesControllerGetStateAction,
@@ -897,7 +898,7 @@ export default class MetaMetricsController extends BaseController<
         properties: {
           params,
           locale: this.locale,
-          chain_id: this.chainId,
+          chain_id: convertHexChainIdToDecimal(this.chainId),
           environment_type: environmentType,
         },
         context: this.#buildContext(referrer, page),
@@ -1150,12 +1151,9 @@ export default class MetaMetricsController extends BaseController<
         currency,
         category,
         locale: this.locale,
-        chain_id:
-          properties &&
-          'chain_id' in properties &&
-          typeof properties.chain_id === 'string'
-            ? properties.chain_id
-            : this.chainId,
+        chain_id: convertHexChainIdToDecimal(
+          properties?.chain_id?.toString() || this.chainId,
+        ),
         environment_type: environmentType,
         ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
         ...mmiProps,

--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../../shared/constants/security-provider';
 import { decimalToHex } from '../../../../shared/modules/conversion.utils';
 import { TransactionMetricsRequest } from '../../../../shared/types/metametrics';
+import { convertHexChainIdToDecimal } from '../../../../shared/modules/network.utils';
 import {
   handleTransactionAdded,
   handleTransactionApproved,
@@ -145,7 +146,7 @@ describe('Transaction metrics', () => {
       account_snap_version: 'snapversion',
       account_type: undefined,
       asset_type: AssetType.native,
-      chain_id: mockChainId,
+      chain_id: convertHexChainIdToDecimal(mockChainId),
       device_model: undefined,
       eip_1559_version: '0',
       gas_edit_attempted: 'none',

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -49,6 +49,7 @@ import type {
 
 import { getSnapAndHardwareInfoForMetrics } from '../snap-keyring/metrics';
 import { shouldUseRedesignForTransactions } from '../../../../shared/lib/confirmation.utils';
+import { convertHexChainIdToDecimal } from '../../../../shared/modules/network.utils';
 
 export const METRICS_STATUS_FAILED = 'failed on-chain';
 
@@ -975,7 +976,7 @@ async function buildEventFragmentProperties({
 
   /** The transaction status property is not considered sensitive and is now included in the non-anonymous event */
   let properties = {
-    chain_id: chainId,
+    chain_id: convertHexChainIdToDecimal(chainId),
     referrer,
     source,
     status,

--- a/shared/modules/network.utils.test.ts
+++ b/shared/modules/network.utils.test.ts
@@ -14,6 +14,7 @@ import {
   convertCaipToHexChainId,
   sortNetworks,
   getRpcDataByChainId,
+  convertHexChainIdToDecimal,
 } from './network.utils';
 
 describe('network utils', () => {
@@ -319,6 +320,20 @@ describe('network utils', () => {
       expect(() => getRpcDataByChainId('eip155:2', evmNetworks)).toThrow(
         'Network configuration not found for chain ID: eip155:2 (0x2)',
       );
+    });
+  });
+
+  describe('convertHexChainIdToDecimal', () => {
+    it('returns decimal value of chainID  given a string that matches a hex number formatted as a "0x"-prefixed string', () => {
+      expect(convertHexChainIdToDecimal('0x1')).toBe('1');
+      expect(convertHexChainIdToDecimal('0xa')).toBe('10');
+      expect(convertHexChainIdToDecimal('0xabc123')).toBe('11256099');
+      expect(convertHexChainIdToDecimal('0xABC123')).toBe('11256099');
+    });
+
+    it('returns chainId passed as parameter if it is a non-hex value', () => {
+      expect(convertHexChainIdToDecimal('20')).toBe('20');
+      expect(convertHexChainIdToDecimal('eip155:1')).toBe('eip155:1');
     });
   });
 });

--- a/shared/modules/network.utils.ts
+++ b/shared/modules/network.utils.ts
@@ -16,6 +16,7 @@ import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
 } from '../constants/network';
 import { MULTICHAIN_TOKEN_IMAGE_MAP } from '../constants/multichain/networks';
+import { hexToDecimal } from './conversion.utils';
 
 type RpcEndpoint = {
   name?: string;
@@ -192,4 +193,17 @@ export const getRpcDataByChainId = (
     rpcEndpoints,
     defaultRpcEndpoint,
   };
+};
+
+/**
+ * Converting a hex chainId to decimal
+ *
+ * @param chainId - The chainId to be converted
+ * @returns The chainId passed as parameter if it is a non-hex value else the corresponding decimal value.
+ */
+export const convertHexChainIdToDecimal = (chainId: string) => {
+  if (chainId.startsWith('0x')) {
+    return hexToDecimal(chainId);
+  }
+  return chainId;
 };

--- a/test/e2e/snaps/test-snap-metrics.spec.js
+++ b/test/e2e/snaps/test-snap-metrics.spec.js
@@ -239,7 +239,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
         assert.deepStrictEqual(events[1].event, 'Snap Installed');
@@ -249,7 +249,7 @@ describe('Test Snap Metrics', function () {
           version: '2.3.0',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },
@@ -327,7 +327,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
         assert.deepStrictEqual(events[1].event, 'Snap Install Rejected');
@@ -336,7 +336,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },
@@ -412,7 +412,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
         assert.deepStrictEqual(events[1].event, 'Snap Install Failed');
@@ -421,7 +421,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },
@@ -549,7 +549,7 @@ describe('Test Snap Metrics', function () {
           version: '2.3.0',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },
@@ -705,7 +705,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
         assert.deepStrictEqual(events[1].event, 'Snap Updated');
@@ -716,7 +716,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },
@@ -864,7 +864,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
         assert.deepStrictEqual(events[1].event, 'Snap Update Rejected');
@@ -873,7 +873,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },
@@ -1013,7 +1013,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
         assert.deepStrictEqual(events[1].event, 'Snap Update Failed');
@@ -1022,7 +1022,7 @@ describe('Test Snap Metrics', function () {
           origin: 'https://metamask.github.io',
           category: 'Snaps',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },

--- a/test/e2e/tests/confirmations/alerts/queued-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/alerts/queued-confirmations.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../transactions/shared';
 import ContractAddressRegistry from '../../../seeder/contract-address-registry';
 import { MOCK_META_METRICS_ID } from '../../../constants';
+import { convertHexChainIdToDecimal } from '../../../../../shared/modules/network.utils';
 
 const FixtureBuilder = require('../../../fixture-builder');
 const {
@@ -253,7 +254,10 @@ describe('Queued Confirmations', function () {
             MetaMetricsEventName.ConfirmationQueued,
           );
           assert.equal(events[0].properties.category, 'Confirmations');
-          assert.equal(events[0].properties.chain_id, '0x3e8');
+          assert.equal(
+            events[0].properties.chain_id,
+            convertHexChainIdToDecimal('0x3e8'),
+          );
           assert.equal(events[0].properties.environment_type, 'notification');
           assert.equal(events[0].properties.locale, 'en');
           assert.equal(events[0].properties.queue_size, 1);
@@ -266,7 +270,10 @@ describe('Queued Confirmations', function () {
             MetaMetricsEventName.ConfirmationQueued,
           );
           assert.equal(events[1].properties.category, 'Confirmations');
-          assert.equal(events[1].properties.chain_id, '0x3e8');
+          assert.equal(
+            events[1].properties.chain_id,
+            convertHexChainIdToDecimal('0x3e8'),
+          );
           assert.equal(events[1].properties.environment_type, 'notification');
           assert.equal(events[1].properties.locale, 'en');
           assert.equal(events[1].properties.queue_size, 1);
@@ -348,7 +355,10 @@ describe('Queued Confirmations', function () {
             MetaMetricsEventName.ConfirmationQueued,
           );
           assert.equal(events[0].properties.category, 'Confirmations');
-          assert.equal(events[0].properties.chain_id, '0x539');
+          assert.equal(
+            events[0].properties.chain_id,
+            convertHexChainIdToDecimal('0x539'),
+          );
           assert.equal(events[0].properties.environment_type, 'notification');
           assert.equal(events[0].properties.locale, 'en');
           assert.equal(events[0].properties.queue_size, 1);
@@ -361,7 +371,10 @@ describe('Queued Confirmations', function () {
             MetaMetricsEventName.ConfirmationQueued,
           );
           assert.equal(events[1].properties.category, 'Confirmations');
-          assert.equal(events[1].properties.chain_id, '0x539');
+          assert.equal(
+            events[1].properties.chain_id,
+            convertHexChainIdToDecimal('0x539'),
+          );
           assert.equal(events[1].properties.environment_type, 'notification');
           assert.equal(events[1].properties.locale, 'en');
           assert.equal(events[1].properties.queue_size, 1);

--- a/test/e2e/tests/confirmations/signatures/signature-helpers.ts
+++ b/test/e2e/tests/confirmations/signatures/signature-helpers.ts
@@ -48,7 +48,7 @@ type AssertSignatureMetricsOptions = {
 type SignatureEventProperty = {
   account_type: 'MetaMask';
   category: 'inpage_provider';
-  chain_id: '0x539';
+  chain_id: '1337';
   environment_type: 'background';
   locale: 'en';
   security_alert_reason: string;
@@ -105,7 +105,7 @@ function getSignatureEventProperty(
     account_type: 'MetaMask',
     signature_type: signatureType,
     category: 'inpage_provider',
-    chain_id: '0x539',
+    chain_id: '1337',
     environment_type: 'background',
     locale: 'en',
     security_alert_reason: securityAlertReason,
@@ -256,7 +256,7 @@ export async function assertAccountDetailsMetrics(
     signature_type: type,
     category: 'Confirmations',
     locale: 'en',
-    chain_id: '0x539',
+    chain_id: '1337',
     environment_type: 'notification',
   });
 }

--- a/test/e2e/tests/metrics/app-installed.spec.ts
+++ b/test/e2e/tests/metrics/app-installed.spec.ts
@@ -60,7 +60,7 @@ describe('App Installed Events', function () {
         assert.deepStrictEqual(events[0].properties, {
           category: 'App',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },

--- a/test/e2e/tests/metrics/nft-detection-metrics.spec.ts
+++ b/test/e2e/tests/metrics/nft-detection-metrics.spec.ts
@@ -78,14 +78,14 @@ describe('Nft detection event', function () {
           account_type: 'metamask',
           category: 'Onboarding',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'fullscreen',
         });
         assert.deepStrictEqual(events[1].properties, {
           method: 'create',
           category: 'Onboarding',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'fullscreen',
           is_profile_syncing_enabled: true,
         });
@@ -93,7 +93,7 @@ describe('Nft detection event', function () {
           nft_autodetection_enabled: true,
           category: 'Onboarding',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },

--- a/test/e2e/tests/metrics/permissions-approved.spec.js
+++ b/test/e2e/tests/metrics/permissions-approved.spec.js
@@ -65,14 +65,14 @@ describe('Permissions Approved Event', function () {
           method: 'eth_requestAccounts',
           category: 'inpage_provider',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
         assert.deepStrictEqual(events[1].properties, {
           method: 'eth_requestAccounts',
           category: 'inpage_provider',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },

--- a/test/e2e/tests/metrics/signature-approved.spec.js
+++ b/test/e2e/tests/metrics/signature-approved.spec.js
@@ -50,7 +50,7 @@ const expectedEventPropertiesBase = {
   account_type: 'MetaMask',
   category: 'inpage_provider',
   locale: 'en',
-  chain_id: '0x539',
+  chain_id: '1337',
   environment_type: 'background',
   security_alert_reason: 'validation_in_progress',
   security_alert_response: 'loading',

--- a/test/e2e/tests/metrics/swaps.spec.js
+++ b/test/e2e/tests/metrics/swaps.spec.js
@@ -1,5 +1,4 @@
 const { strict: assert } = require('assert');
-const { toHex } = require('@metamask/controller-utils');
 const FixtureBuilder = require('../../fixture-builder');
 const {
   withFixtures,
@@ -185,7 +184,7 @@ async function assertNavSwapButtonClickedEvent(reqs) {
   assert.equal(reqs[0].event, MetaMetricsEventName.NavSwapButtonClicked);
   assert.deepStrictEqual(reqs[0].properties, {
     category: MetaMetricsEventCategory.Swaps,
-    chain_id: toHex(1337),
+    chain_id: '0x539',
     environment_type: 'fullscreen',
     locale: 'en',
     location: 'Main View',
@@ -200,7 +199,7 @@ async function assertPrepareSwapPageLoadedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 8,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
 
@@ -214,7 +213,7 @@ async function assertPrepareSwapPageLoadedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 4,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
   ];
@@ -231,7 +230,7 @@ async function assertQuotesRequestedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 15,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
 
@@ -252,7 +251,7 @@ async function assertQuotesRequestedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 4,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
   ];
@@ -269,7 +268,7 @@ async function assertQuotesReceivedAndBestQuoteReviewedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 19,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
 
@@ -294,7 +293,7 @@ async function assertQuotesReceivedAndBestQuoteReviewedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 4,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
   ];
@@ -304,7 +303,7 @@ async function assertQuotesReceivedAndBestQuoteReviewedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 18,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
 
@@ -327,7 +326,7 @@ async function assertQuotesReceivedAndBestQuoteReviewedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 4,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
   ];
@@ -351,7 +350,7 @@ async function assertAllAvailableQuotesOpenedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 19,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
 
@@ -377,7 +376,7 @@ async function assertAllAvailableQuotesOpenedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 4,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
   ];
@@ -394,7 +393,7 @@ async function assertSwapStartedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 25,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
 
@@ -424,7 +423,7 @@ async function assertSwapStartedEvents(reqs) {
     (req) => Object.keys(req.properties).length === 4,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
   ];
@@ -440,7 +439,7 @@ async function assertSwapCompletedEvents(reqs) {
     (req) => req.event === MetaMetricsEventName.SwapCompleted,
     (req) => Object.keys(req.properties).length === 31,
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'background',
     (req) => req.properties?.locale === 'en',
     (req) => req.properties?.token_from === 'TESTETH',
@@ -476,7 +475,7 @@ async function assertSwapCompletedEvents(reqs) {
     (req) => req.event === MetaMetricsEventName.SwapCompleted,
     (req) => Object.keys(req.properties).length === 4,
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'background',
     (req) => req.properties?.locale === 'en',
   ];
@@ -493,7 +492,7 @@ async function assertExitedSwapsEvents(reqs) {
     (req) => Object.keys(req.properties).length === 13,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
 
@@ -512,7 +511,7 @@ async function assertExitedSwapsEvents(reqs) {
     (req) => Object.keys(req.properties).length === 4,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
   ];
@@ -527,7 +526,7 @@ async function assertExitedSwapsEvents(reqs) {
     (req) => Object.keys(req.properties).length === 10,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
 
@@ -543,7 +542,7 @@ async function assertExitedSwapsEvents(reqs) {
     (req) => Object.keys(req.properties).length === 4,
 
     (req) => req.properties?.category === MetaMetricsEventCategory.Swaps,
-    (req) => req.properties?.chain_id === toHex(1337),
+    (req) => req.properties?.chain_id === '1337',
     (req) => req.properties?.environment_type === 'fullscreen',
     (req) => req.properties?.locale === 'en',
   ];

--- a/test/e2e/tests/metrics/token-detection-metrics.spec.ts
+++ b/test/e2e/tests/metrics/token-detection-metrics.spec.ts
@@ -76,14 +76,14 @@ describe('Token detection event', function () {
           account_type: 'metamask',
           category: 'Onboarding',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'fullscreen',
         });
         assert.deepStrictEqual(events[1].properties, {
           method: 'create',
           category: 'Onboarding',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'fullscreen',
           is_profile_syncing_enabled: true,
         });
@@ -91,7 +91,7 @@ describe('Token detection event', function () {
           token_detection_enabled: true,
           category: 'Onboarding',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'background',
         });
       },

--- a/test/e2e/tests/metrics/transaction-finalized.spec.js
+++ b/test/e2e/tests/metrics/transaction-finalized.spec.js
@@ -166,7 +166,7 @@ describe('Transaction Finalized Event', function () {
               gas_price: '2',
               default_gas: '0.000021',
               default_gas_price: '2',
-              chain_id: '0x539',
+              chain_id: '1337',
               referrer: 'metamask',
               source: 'user',
               network: '1337',
@@ -191,7 +191,7 @@ describe('Transaction Finalized Event', function () {
           eventHasUserIdWithoutAnonymousId,
           (payload) =>
             isEqual(payload.properties, {
-              chain_id: '0x539',
+              chain_id: '1337',
               referrer: 'metamask',
               source: 'user',
               network: '1337',
@@ -229,7 +229,7 @@ describe('Transaction Finalized Event', function () {
                 gas_price: '2',
                 default_gas: '0.000021',
                 default_gas_price: '2',
-                chain_id: '0x539',
+                chain_id: '1337',
                 referrer: 'metamask',
                 source: 'user',
                 network: '1337',
@@ -256,7 +256,7 @@ describe('Transaction Finalized Event', function () {
           eventHasUserIdWithoutAnonymousId,
           (payload) =>
             isEqual(payload.properties, {
-              chain_id: '0x539',
+              chain_id: '1337',
               referrer: 'metamask',
               source: 'user',
               network: '1337',

--- a/test/e2e/tests/metrics/wallet-created.spec.ts
+++ b/test/e2e/tests/metrics/wallet-created.spec.ts
@@ -64,14 +64,14 @@ describe('Wallet Created Events', function () {
           account_type: 'metamask',
           category: 'Onboarding',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'fullscreen',
         });
         assert.deepStrictEqual(events[1].properties, {
           method: 'create',
           category: 'Onboarding',
           locale: 'en',
-          chain_id: '0x539',
+          chain_id: '1337',
           environment_type: 'fullscreen',
           is_profile_syncing_enabled: true,
         });

--- a/test/e2e/tests/tokens/nft/remove-nft.spec.js
+++ b/test/e2e/tests/tokens/nft/remove-nft.spec.js
@@ -11,6 +11,9 @@ const {
 } = require('../../../../../shared/constants/metametrics');
 const { CHAIN_IDS } = require('../../../../../shared/constants/network');
 const { MOCK_META_METRICS_ID } = require('../../../constants');
+const {
+  convertHexChainIdToDecimal,
+} = require('../../../../../shared/modules/network.utils');
 
 async function mockedNftRemoved(mockServer) {
   return await mockServer
@@ -85,7 +88,10 @@ describe('Remove NFT', function () {
         assert.equal(nftRemovedProperties.token_standard, 'ERC721');
         assert.equal(nftRemovedProperties.token_standard, 'ERC721');
         assert.equal(nftRemovedProperties.isSuccessful, true);
-        assert.equal(nftRemovedProperties.chain_id, CHAIN_IDS.LOCALHOST);
+        assert.equal(
+          nftRemovedProperties.chain_id,
+          convertHexChainIdToDecimal(CHAIN_IDS.LOCALHOST),
+        );
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Migrated from original PR due to conflict
https://github.com/MetaMask/metamask-extension/pull/24203.

This PR standardizes the `chain_id` event property in metrics tracking by converting hexadecimal chain IDs to decimal format. This ensures consistent data representation across our analytics platform while maintaining compatibility with all existing chain ID formats.

**Context:** 
The extension codebase currently uses multiple chain ID formats:

- Hexadecimal (e.g., "0x1" for Ethereum Mainnet)
- Decimal (e.g., "1")
- CAIP chain IDs (following the format "namespace:reference", e.g., "eip155:1")

Rather than modifying each individual event tracking call, this approach centralizes the format standardization logic, making our codebase more maintainable and our metrics more consistent.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30703?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1840

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
