### PR TITLE
fix: fix sentry error related to auto import

### DIFF
--- a/ui/components/app/assets/util/importAllDetectedTokens.test.ts
+++ b/ui/components/app/assets/util/importAllDetectedTokens.test.ts
@@ -1,14 +1,12 @@
 import { NetworkConfiguration } from '@metamask/network-controller';
-import { importAllDetectedTokens } from './importAllDetectedTokens';
 import { Token } from '../types';
+import { importAllDetectedTokens } from './importAllDetectedTokens';
 
 describe('importAllDetectedTokens with PORTFOLIO_VIEW true', () => {
   let addImportedTokensMock: jest.Mock;
   let trackTokenAddedEventMock: jest.Mock;
-  let originalPortfolioView: string | undefined;
 
   beforeEach(() => {
-    originalPortfolioView = process.env.PORTFOLIO_VIEW;
     process.env.PORTFOLIO_VIEW = 'true';
     addImportedTokensMock = jest.fn(() => Promise.resolve());
     trackTokenAddedEventMock = jest.fn();

--- a/ui/components/app/assets/util/importAllDetectedTokens.test.ts
+++ b/ui/components/app/assets/util/importAllDetectedTokens.test.ts
@@ -1,0 +1,192 @@
+import { NetworkConfiguration } from '@metamask/network-controller';
+import { importAllDetectedTokens } from './importAllDetectedTokens';
+import { Token } from '../types';
+
+describe('importAllDetectedTokens with PORTFOLIO_VIEW true', () => {
+  let addImportedTokensMock: jest.Mock;
+  let trackTokenAddedEventMock: jest.Mock;
+  let originalPortfolioView: string | undefined;
+
+  beforeEach(() => {
+    originalPortfolioView = process.env.PORTFOLIO_VIEW;
+    process.env.PORTFOLIO_VIEW = 'true';
+    addImportedTokensMock = jest.fn(() => Promise.resolve());
+    trackTokenAddedEventMock = jest.fn();
+  });
+
+  it('should process multichain tokens when not on current network', async () => {
+    const isOnCurrentNetwork = false;
+    const detectedTokensMultichain = {
+      '0x1': [{ symbol: 'ABC' }, { symbol: 'DEF' }],
+      '0x2': [{ symbol: 'GHI' }],
+    } as unknown as Record<string, Token[]>;
+
+    const allNetworks = {
+      '0x1': {
+        chainId: 'chain-1',
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'net-1' }],
+      },
+      '0x2': {
+        chainId: 'chain-2',
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'net-2' }],
+      },
+    } as unknown as Record<string, NetworkConfiguration>;
+
+    const networkClientId = 'default-net';
+    const currentChainId = 'current-chain';
+    const detectedTokens: Token[] = [];
+
+    await importAllDetectedTokens(
+      isOnCurrentNetwork,
+      detectedTokensMultichain,
+      allNetworks,
+      networkClientId,
+      currentChainId,
+      detectedTokens,
+      addImportedTokensMock,
+      trackTokenAddedEventMock,
+    );
+
+    expect(addImportedTokensMock).toHaveBeenCalledTimes(2);
+    expect(addImportedTokensMock).toHaveBeenCalledWith(
+      detectedTokensMultichain['0x1'],
+      'net-1',
+    );
+    expect(addImportedTokensMock).toHaveBeenCalledWith(
+      detectedTokensMultichain['0x2'],
+      'net-2',
+    );
+
+    expect(trackTokenAddedEventMock).toHaveBeenCalledTimes(3);
+    expect(trackTokenAddedEventMock).toHaveBeenCalledWith(
+      { symbol: 'ABC' },
+      'chain-1',
+    );
+    expect(trackTokenAddedEventMock).toHaveBeenCalledWith(
+      { symbol: 'DEF' },
+      'chain-1',
+    );
+    expect(trackTokenAddedEventMock).toHaveBeenCalledWith(
+      { symbol: 'GHI' },
+      'chain-2',
+    );
+  });
+
+  it('should process single-chain tokens when on current network', async () => {
+    const isOnCurrentNetwork = true;
+    const detectedTokensMultichain = {
+      '0x1': [{ symbol: 'ABC' }],
+    } as unknown as Record<string, Token[]>;
+
+    const allNetworks = {
+      '0x1': {
+        chainId: 'chain-1',
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'net-1' }],
+      },
+    } as unknown as Record<string, NetworkConfiguration>;
+
+    const networkClientId = 'default-net';
+    const currentChainId = 'current-chain';
+    const detectedTokens: Token[] = [
+      { symbol: 'XYZ' },
+      { symbol: 'LMN' },
+    ] as unknown as Token[];
+
+    await importAllDetectedTokens(
+      isOnCurrentNetwork,
+      detectedTokensMultichain,
+      allNetworks,
+      networkClientId,
+      currentChainId,
+      detectedTokens,
+      addImportedTokensMock,
+      trackTokenAddedEventMock,
+    );
+
+    expect(addImportedTokensMock).toHaveBeenCalledTimes(1);
+    expect(addImportedTokensMock).toHaveBeenCalledWith(
+      detectedTokens,
+      networkClientId,
+    );
+
+    expect(trackTokenAddedEventMock).toHaveBeenCalledTimes(2);
+    expect(trackTokenAddedEventMock).toHaveBeenCalledWith(
+      { symbol: 'XYZ' },
+      currentChainId,
+    );
+    expect(trackTokenAddedEventMock).toHaveBeenCalledWith(
+      { symbol: 'LMN' },
+      currentChainId,
+    );
+  });
+
+  it('should do nothing if no tokens are detected', async () => {
+    const isOnCurrentNetwork = true;
+    const detectedTokensMultichain = {};
+    const allNetworks = {};
+
+    const networkClientId = 'default-net';
+    const currentChainId = 'current-chain';
+    const detectedTokens: Token[] = [];
+
+    await importAllDetectedTokens(
+      isOnCurrentNetwork,
+      detectedTokensMultichain,
+      allNetworks,
+      networkClientId,
+      currentChainId,
+      detectedTokens,
+      addImportedTokensMock,
+      trackTokenAddedEventMock,
+    );
+
+    expect(addImportedTokensMock).not.toHaveBeenCalled();
+    expect(trackTokenAddedEventMock).not.toHaveBeenCalled();
+  });
+
+  it('should skip tokens for a network when chain configuration is missing', async () => {
+    const isOnCurrentNetwork = false;
+    const detectedTokensMultichain = {
+      '0x1': [{ symbol: 'ABC' }],
+      '0x2': [{ symbol: 'GHI' }],
+    } as unknown as Record<string, Token[]>;
+
+    const allNetworks = {
+      '0x1': {
+        chainId: 'chain-1',
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ networkClientId: 'net-1' }],
+      },
+    } as unknown as Record<string, NetworkConfiguration>;
+
+    const networkClientId = 'default-net';
+    const currentChainId = 'current-chain';
+    const detectedTokens: Token[] = [];
+
+    await importAllDetectedTokens(
+      isOnCurrentNetwork,
+      detectedTokensMultichain,
+      allNetworks,
+      networkClientId,
+      currentChainId,
+      detectedTokens,
+      addImportedTokensMock,
+      trackTokenAddedEventMock,
+    );
+
+    expect(addImportedTokensMock).toHaveBeenCalledTimes(1);
+    expect(addImportedTokensMock).toHaveBeenCalledWith(
+      detectedTokensMultichain['0x1'],
+      'net-1',
+    );
+
+    expect(trackTokenAddedEventMock).toHaveBeenCalledTimes(1);
+    expect(trackTokenAddedEventMock).toHaveBeenCalledWith(
+      { symbol: 'ABC' },
+      'chain-1',
+    );
+  });
+});

--- a/ui/components/app/assets/util/importAllDetectedTokens.ts
+++ b/ui/components/app/assets/util/importAllDetectedTokens.ts
@@ -17,11 +17,13 @@ export const importAllDetectedTokens = async (
   trackTokenAddedEvent: (importedToken: Token, chainId: string) => void,
 ) => {
   // TODO add event for MetaMetricsEventName.TokenAdded
-
   if (process.env.PORTFOLIO_VIEW && !isOnCurrentNetwork) {
     const importPromises = Object.entries(detectedTokensMultichain).map(
       async ([networkId, tokens]) => {
         const chainConfig = allNetworks[networkId];
+        if (!chainConfig) {
+          return;
+        }
         const { defaultRpcEndpointIndex } = chainConfig;
         const { networkClientId: networkInstanceId } =
           chainConfig.rpcEndpoints[defaultRpcEndpointIndex];


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR addresses an issue where the auto-import functionality attempts to trigger a token import on a network that hasn’t been added to the configuration. This scenario occurs when a network is present in allDetectedTokens but does not have a corresponding entry in our network configurations, causing the error when destructuring defaultRpcEndpointIndex from an undefined value.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30743?quickstart=1)

## **Related issues**

Fixes: #30412 

## **Manual testing steps**

1. replace the result of this line [here](https://github.com/MetaMask/metamask-extension/blob/c9d7dd1e323bff8d7dc6ea1781b0bb4ce573759e/ui/components/app/assets/util/importAllDetectedTokens.ts#L24) by undefined 
2. check the console

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
