### PR TITLE
fix: fetch quotes when dest asset is native

### DIFF
--- a/ui/ducks/bridge/bridge.ts
+++ b/ui/ducks/bridge/bridge.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { type Hex, type CaipChainId } from '@metamask/utils';
+import { zeroAddress } from 'ethereumjs-util';
 import {
   type BridgeToken,
   ChainId,
@@ -94,6 +95,7 @@ const bridgeSlice = createSlice({
           balance: payload.balance ?? '0',
           string: payload.string ?? '0',
           chainId: formatChainIdToCaip(payload.chainId),
+          address: payload.address || zeroAddress(),
         };
       } else {
         state.toToken = payload;

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -138,11 +138,6 @@ export const getTokenExchangeRate = async (request: {
     tokenAddress,
   );
   if (chainId === MultichainNetworks.SOLANA) {
-    console.log(
-      '=====getTokenExchangeRate solana',
-      exchangeRates,
-      tokenAddress,
-    );
     return exchangeRates?.[tokenAddress];
   }
   // The exchange rate can be checksummed or not, so we need to check both


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This fixes the bug in which quotes are not fetched when the destination is a native asset. This was due to the token address being empty, which was causing validation to fail

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30749?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMS-2033

## **Manual testing steps**

1. Go to Bridge page (EVM or solana)
2. Select native asset for both src and dest
3. Quotes should be fetched

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
