### PR TITLE
fix: fixes bridging label showing for solana swap

### DIFF
--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -14,6 +14,7 @@ import {
   getBridgeQuotes,
   getFromChain,
   getToChain,
+  getIsBridgeTx,
 } from '../../../ducks/bridge/selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -61,6 +62,7 @@ export const MultichainBridgeQuoteCard = () => {
   const fromChain = useSelector(getFromChain);
   const toChain = useSelector(getToChain);
   const locale = useSelector(getIntlLocale);
+  const isBridgeTx = useSelector(getIsBridgeTx);
 
   const [showAllQuotes, setShowAllQuotes] = useState(false);
 
@@ -123,32 +125,34 @@ export const MultichainBridgeQuoteCard = () => {
               </Text>
             </Row>
 
-            {/* Bridging */}
-            <Row justifyContent={JustifyContent.spaceBetween}>
-              <Text
-                variant={TextVariant.bodyMd}
-                color={TextColor.textAlternative}
-              >
-                {t('multichainQuoteCardBridgingLabel')}
-              </Text>
-              <Row gap={1}>
-                <AvatarNetwork
-                  name={fromChain?.name ?? ''}
-                  src={getNetworkImage(activeQuote.quote.srcChainId)}
-                  size={AvatarNetworkSize.Xs}
-                  backgroundColor={BackgroundColor.transparent}
-                />
-                <Text>{getNetworkName(activeQuote.quote.srcChainId)}</Text>
-                <Icon name={IconName.Arrow2Right} size={IconSize.Xs} />
-                <AvatarNetwork
-                  name={toChain?.name ?? ''}
-                  src={getNetworkImage(activeQuote.quote.destChainId)}
-                  size={AvatarNetworkSize.Xs}
-                  backgroundColor={BackgroundColor.transparent}
-                />
-                <Text>{getNetworkName(activeQuote.quote.destChainId)}</Text>
+            {/* Bridging - Only show when it's a bridge transaction */}
+            {isBridgeTx && (
+              <Row justifyContent={JustifyContent.spaceBetween}>
+                <Text
+                  variant={TextVariant.bodyMd}
+                  color={TextColor.textAlternative}
+                >
+                  {t('multichainQuoteCardBridgingLabel')}
+                </Text>
+                <Row gap={1}>
+                  <AvatarNetwork
+                    name={fromChain?.name ?? ''}
+                    src={getNetworkImage(activeQuote.quote.srcChainId)}
+                    size={AvatarNetworkSize.Xs}
+                    backgroundColor={BackgroundColor.transparent}
+                  />
+                  <Text>{getNetworkName(activeQuote.quote.srcChainId)}</Text>
+                  <Icon name={IconName.Arrow2Right} size={IconSize.Xs} />
+                  <AvatarNetwork
+                    name={toChain?.name ?? ''}
+                    src={getNetworkImage(activeQuote.quote.destChainId)}
+                    size={AvatarNetworkSize.Xs}
+                    backgroundColor={BackgroundColor.transparent}
+                  />
+                  <Text>{getNetworkName(activeQuote.quote.destChainId)}</Text>
+                </Row>
               </Row>
-            </Row>
+            )}
 
             {/* Network Fee */}
             <Row justifyContent={JustifyContent.spaceBetween}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30756?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to the swap experience with a Solana account.
2. Generate a swap quote by filling out all necessary information.
3. The Bridge label should be absent from the Quote card.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
