### PR TITLE
cherry-pick c9d7dd1 (#30614) in v12.14.0

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -341,20 +341,33 @@ export const NetworkListMenu = ({ onClose }: { onClose: () => void }) => {
     setActionMode(ACTION_MODE.ADD_NON_EVM_ACCOUNT);
   };
 
+  const getMultichainNetworkConfigurationOrThrow = (chainId: CaipChainId) => {
+    const network = multichainNetworks[chainId];
+    if (!network) {
+      throw new Error(
+        `Network configuration not found for chainId: ${chainId}`,
+      );
+    }
+    return network;
+  };
+
   const handleNetworkChange = async (chainId: CaipChainId) => {
-    const { isEvm } = multichainNetworks[chainId];
-    if (isEvm) {
+    const currentChain =
+      getMultichainNetworkConfigurationOrThrow(currentChainId);
+    const chain = getMultichainNetworkConfigurationOrThrow(chainId);
+
+    if (chain.isEvm) {
       handleEvmNetworkChange(chainId);
     } else {
       await handleNonEvmNetworkChange(chainId);
     }
 
-    const [chainIdToTrack, currentChainIdToTrack] = isEvm
-      ? [
-          convertCaipToHexChainId(chainId),
-          convertCaipToHexChainId(currentChainId),
-        ]
-      : [chainId, currentChainId];
+    const chainIdToTrack = chain.isEvm
+      ? convertCaipToHexChainId(chainId)
+      : chainId;
+    const currentChainIdToTrack = currentChain.isEvm
+      ? convertCaipToHexChainId(currentChainId)
+      : currentChainId;
 
     trackEvent({
       event: MetaMetricsEventName.NavNetworkSwitched,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution? -->

[![Open in GitHub
Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30614?quickstart=1)

Fix Caip <> Hex conversion error for network switching event

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/858

## **Manual testing steps**

1. Switch from Solana to Ethereum or other EVM network
2. See the error in the logs

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2025-02-27 at 11 27
24](https://github.com/user-attachments/assets/5dbcf7a7-1dda-4628-8c7e-9fbfa03cb898)

### **After**

The error should not be logged

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
