### PR TITLE
cherry-pick: Solana RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "@metamask/snaps-rpc-methods": "^11.12.0",
     "@metamask/snaps-sdk": "^6.18.0",
     "@metamask/snaps-utils": "^9.0.0",
-    "@metamask/solana-wallet-snap": "^1.10.0",
+    "@metamask/solana-wallet-snap": "^1.11.0",
     "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A45.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-45.0.0-010fef9da6.patch",
     "@metamask/user-operation-controller": "^24.0.1",
     "@metamask/utils": "^11.1.0",

--- a/test/data/mock-accounts.ts
+++ b/test/data/mock-accounts.ts
@@ -78,7 +78,7 @@ export const MOCK_ACCOUNT_BIP122_P2WPKH_TESTNET: InternalAccount = {
 
 export const MOCK_ACCOUNT_SOLANA_MAINNET: InternalAccount = {
   id: 'a3f9c2d4-6b8e-4d3a-9b2e-7f4b8e1a9c3d',
-  address: '3yZe7d5m8V9x2Q1w4u6t8b9n7k5j3h2g1f4d6s8a9p7q2r5t8v',
+  address: '8A4AptCThfbuknsbteHgGKXczfJpfjuVA9SLTSGaaLGC',
   options: {},
   methods: [SolMethod.SendAndConfirmTransaction],
   scopes: [SolScope.Mainnet],
@@ -96,4 +96,5 @@ export const MOCK_ACCOUNTS = {
   [MOCK_ACCOUNT_ERC4337.id]: MOCK_ACCOUNT_ERC4337,
   [MOCK_ACCOUNT_BIP122_P2WPKH.id]: MOCK_ACCOUNT_BIP122_P2WPKH,
   [MOCK_ACCOUNT_BIP122_P2WPKH_TESTNET.id]: MOCK_ACCOUNT_BIP122_P2WPKH_TESTNET,
+  [MOCK_ACCOUNT_SOLANA_MAINNET.id]: MOCK_ACCOUNT_SOLANA_MAINNET,
 };

--- a/ui/components/app/transaction-list/transaction-list.test.js
+++ b/ui/components/app/transaction-list/transaction-list.test.js
@@ -3,7 +3,10 @@ import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
-import { MOCK_ACCOUNT_BIP122_P2WPKH } from '../../../../test/data/mock-accounts';
+import {
+  MOCK_ACCOUNT_BIP122_P2WPKH,
+  MOCK_ACCOUNT_SOLANA_MAINNET,
+} from '../../../../test/data/mock-accounts';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
@@ -55,6 +58,135 @@ const btcState = {
       selectedAccount: MOCK_ACCOUNT_BIP122_P2WPKH.id,
     },
     selectedAddress: MOCK_ACCOUNT_BIP122_P2WPKH.address,
+    completedOnboarding: true,
+    transactions: [],
+  },
+};
+
+const solanaSwapState = {
+  metamask: {
+    ...mockState.metamask,
+    nonEvmTransactions: {
+      [MOCK_ACCOUNT_SOLANA_MAINNET.id]: {
+        transactions: [
+          {
+            id: '2pfnv4drhnitfzCFKxiRoJMzFQpG7wZ9mpRQVk7xm5TQ27g6FZH95HVF6KgwQBS872yGtyhuq57jXXS1y29ub11',
+            timestamp: 1740480781,
+            chain: MultichainNetworks.SOLANA,
+            status: 'confirmed',
+            type: 'swap',
+            from: [
+              {
+                address: '8kR2HTHzPtTJuzpFZ8jtGCQ9TpahPaWbZfTNRs2GJdxq',
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'SOL',
+                  amount: '0.000073111',
+                },
+              },
+              {
+                address: MOCK_ACCOUNT_SOLANA_MAINNET.address,
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'SOL',
+                  amount: '0.01',
+                },
+              },
+              {
+                address: 'HUCjBnmd4FoUjCCMYQ9xFz1ce1r8vWAd8uMhUQakE2FR',
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'BONK',
+                  amount: '2583.728601',
+                },
+              },
+              {
+                address: '3msVd34R5KxonDzyNSV5nT19UtUeJ2RF1NaQhvVPNLxL',
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'SOL',
+                  amount: '0.000073111',
+                },
+              },
+            ],
+            to: [
+              {
+                address: 'CebN5WGQ4jvEPvsVU4EoHEpgzq1VV7AbicfhtW4xC9iM',
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'SOL',
+                  amount: '0.000000723',
+                },
+              },
+              {
+                address: 'HUCjBnmd4FoUjCCMYQ9xFz1ce1r8vWAd8uMhUQakE2FR',
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'SOL',
+                  amount: '0.00007238',
+                },
+              },
+              {
+                address: MOCK_ACCOUNT_SOLANA_MAINNET.address,
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'BONK',
+                  amount: '2583.72',
+                },
+              },
+              {
+                address: '3msVd34R5KxonDzyNSV5nT19UtUeJ2RF1NaQhvVPNLxL',
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'SOL',
+                  amount: '0.01',
+                },
+              },
+            ],
+            fees: [
+              {
+                type: 'base',
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'SOL',
+                  amount: '0.000005',
+                },
+              },
+              {
+                type: 'priority',
+                asset: {
+                  fungible: true,
+                  type: '',
+                  unit: 'SOL',
+                  amount: '0.000069798',
+                },
+              },
+            ],
+            events: [{ status: 'confirmed', timestamp: 1740480781 }],
+          },
+        ],
+        next: null,
+        lastUpdated: expect.any(Number),
+      },
+    },
+    internalAccounts: {
+      ...mockState.metamask.internalAccounts,
+      accounts: {
+        ...mockState.metamask.internalAccounts.accounts,
+        [MOCK_ACCOUNT_SOLANA_MAINNET.id]: MOCK_ACCOUNT_SOLANA_MAINNET,
+      },
+      selectedAccount: MOCK_ACCOUNT_SOLANA_MAINNET.id,
+    },
+    selectedAddress: MOCK_ACCOUNT_SOLANA_MAINNET.address,
     completedOnboarding: true,
     transactions: [],
   },
@@ -181,5 +313,21 @@ describe('TransactionList', () => {
         'Please switch to Linea Mainnet network to view transactions',
       ),
     ).toBeNull();
+  });
+
+  it('renders TransactionList component and shows a Solana Swap Tx in the activity list', () => {
+    const { getByText, getByRole, getByTestId } = render(solanaSwapState);
+
+    expect(getByText('Confirmed')).toBeInTheDocument();
+    expect(getByText('Swap SOL to BONK')).toBeInTheDocument();
+
+    expect(getByTestId('activity-list-item')).toBeInTheDocument();
+
+    expect(getByText('-0.01 SOL')).toBeInTheDocument();
+
+    const viewOnExplorerBtn = getByRole('button', {
+      name: 'View on block explorer',
+    });
+    expect(viewOnExplorerBtn).toBeInTheDocument();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6422,10 +6422,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/solana-wallet-snap@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@metamask/solana-wallet-snap@npm:1.10.0"
-  checksum: 10/d7a1538fad9adf92f78334b5422aba81182bb70d06ddc3319b10df563f742d9df53ac2b7d501191fc2cb3ced8b405fe39e764c2d33e81fdc1596ff027e0e40f6
+"@metamask/solana-wallet-snap@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "@metamask/solana-wallet-snap@npm:1.11.0"
+  checksum: 10/2d6e9a0ed37805a48cedbf3f7ff039223270e1e54abf0a942696356bdfb6c5623df56fe52cee8763a0cf35eacda23aab9810dcf61e5bb5ce64f2144c3075f63d
   languageName: node
   linkType: hard
 
@@ -27307,7 +27307,7 @@ __metadata:
     "@metamask/snaps-rpc-methods": "npm:^11.12.0"
     "@metamask/snaps-sdk": "npm:^6.18.0"
     "@metamask/snaps-utils": "npm:^9.0.0"
-    "@metamask/solana-wallet-snap": "npm:^1.10.0"
+    "@metamask/solana-wallet-snap": "npm:^1.11.0"
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:9.0.0"
     "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A45.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-45.0.0-010fef9da6.patch"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

* Non-EVM swap transactions on activity list
* Solana version update

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30866?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
