### PR TITLE
fix: Prevent rerenders of the AccountListItem

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta)
@@ -163,10 +163,12 @@ const AccountListItem = ({
     formattedTokensWithBalancesPerChain,
   );
   // cross chain agg balance
-  const mappedOrderedTokenList = accountTotalFiatBalances.orderedTokenList.map(
-    (item) => ({
-      avatarValue: item.iconUrl,
-    }),
+  const mappedOrderedTokenList = useMemo(
+    () =>
+      accountTotalFiatBalances.orderedTokenList.map((item) => ({
+        avatarValue: item.iconUrl,
+      })),
+    [accountTotalFiatBalances.orderedTokenList],
   );
   let balanceToTranslate;
   if (isEvmNetwork) {

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -261,7 +261,7 @@ const AccountListItem = ({
         // Without this check, the account will be selected after
         // the account options menu closes
         if (!accountOptionsMenuOpen) {
-          onClick?.();
+          onClick?.(account);
         }
       }}
     >
@@ -340,7 +340,7 @@ const AccountListItem = ({
                 as="button"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onClick?.();
+                  onClick?.(account);
                 }}
                 variant={TextVariant.bodyMdMedium}
                 className="multichain-account-list-item__account-name__button"

--- a/ui/components/multichain/account-list-menu/account-list-menu.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.tsx
@@ -346,28 +346,26 @@ export const AccountListMenu = ({
   }
 
   const onAccountListItemItemClicked = useCallback(
-    (address: string) => {
-      return () => {
-        onClose();
-        trackEvent({
-          category: MetaMetricsEventCategory.Navigation,
-          event: MetaMetricsEventName.NavAccountSwitched,
-          properties: {
-            location: 'Main Menu',
-          },
-        });
-        endTrace({
-          name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[
-            defaultHomeActiveTabName
-          ],
-        });
-        trace({
-          name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[
-            defaultHomeActiveTabName
-          ],
-        });
-        dispatch(setSelectedAccount(address));
-      };
+    (account: MergedInternalAccount) => {
+      onClose();
+      trackEvent({
+        category: MetaMetricsEventCategory.Navigation,
+        event: MetaMetricsEventName.NavAccountSwitched,
+        properties: {
+          location: 'Main Menu',
+        },
+      });
+      endTrace({
+        name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[
+          defaultHomeActiveTabName
+        ],
+      });
+      trace({
+        name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[
+          defaultHomeActiveTabName
+        ],
+      });
+      dispatch(setSelectedAccount(account.address));
     },
     [dispatch, onClose, trackEvent, defaultHomeActiveTabName],
   );
@@ -393,7 +391,7 @@ export const AccountListMenu = ({
           key={account.address}
         >
           <AccountListItem
-            onClick={onAccountListItemItemClicked(account.address)}
+            onClick={onAccountListItemItemClicked}
             account={account}
             key={account.address}
             selected={selectedAccount.address === account.address}

--- a/ui/components/multichain/account-list-menu/account-list-menu.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.tsx
@@ -312,19 +312,23 @@ export const AccountListMenu = ({
   );
   ///: END:ONLY_INCLUDE_IF
 
-  let searchResults: MergedInternalAccount[] = filteredUpdatedAccountList;
-  if (searchQuery) {
-    const fuse = new Fuse(filteredAccounts, {
-      threshold: 0.2,
-      location: 0,
-      distance: 100,
-      maxPatternLength: 32,
-      minMatchCharLength: 1,
-      keys: ['metadata.name', 'address'],
-    });
-    fuse.setCollection(filteredAccounts);
-    searchResults = fuse.search(searchQuery);
-  }
+  const searchResults: MergedInternalAccount[] = useMemo(() => {
+    let _searchResults: MergedInternalAccount[] = filteredUpdatedAccountList;
+    if (searchQuery) {
+      const fuse = new Fuse(filteredAccounts, {
+        threshold: 0.2,
+        location: 0,
+        distance: 100,
+        maxPatternLength: 32,
+        minMatchCharLength: 1,
+        keys: ['metadata.name', 'address'],
+      });
+      fuse.setCollection(filteredAccounts);
+      _searchResults = fuse.search(searchQuery);
+    }
+
+    return _searchResults;
+  }, [filteredAccounts, filteredUpdatedAccountList, searchQuery]);
 
   const title = useMemo(
     () => getActionTitle(t as (text: string) => string, actionMode),
@@ -342,7 +346,7 @@ export const AccountListMenu = ({
   }
 
   const onAccountListItemItemClicked = useCallback(
-    (account) => {
+    (address: string) => {
       return () => {
         onClose();
         trackEvent({
@@ -362,11 +366,61 @@ export const AccountListMenu = ({
             defaultHomeActiveTabName
           ],
         });
-        dispatch(setSelectedAccount(account.address));
+        dispatch(setSelectedAccount(address));
       };
     },
-    [dispatch, onClose, trackEvent],
+    [dispatch, onClose, trackEvent, defaultHomeActiveTabName],
   );
+
+  const accountListItems = useMemo(() => {
+    return searchResults.map((account) => {
+      const connectedSite = connectedSites[account.address]?.find(
+        ({ origin }) => origin === currentTabOrigin,
+      );
+
+      const hideAccountListItem = searchQuery.length === 0 && account.hidden;
+
+      /* NOTE: Hidden account will be displayed only in the search list */
+
+      return (
+        <Box
+          className={
+            account.hidden
+              ? 'multichain-account-menu-popover__list--menu-item-hidden'
+              : 'multichain-account-menu-popover__list--menu-item'
+          }
+          display={hideAccountListItem ? Display.None : Display.Block}
+          key={account.address}
+        >
+          <AccountListItem
+            onClick={onAccountListItemItemClicked(account.address)}
+            account={account}
+            key={account.address}
+            selected={selectedAccount.address === account.address}
+            closeMenu={onClose}
+            connectedAvatar={connectedSite?.iconUrl}
+            menuType={AccountListItemMenuTypes.Account}
+            isPinned={Boolean(account.pinned)}
+            isHidden={Boolean(account.hidden)}
+            currentTabOrigin={currentTabOrigin}
+            isActive={Boolean(account.active)}
+            privacyMode={privacyMode}
+            {...accountListItemProps}
+          />
+        </Box>
+      );
+    });
+  }, [
+    searchResults,
+    connectedSites,
+    currentTabOrigin,
+    privacyMode,
+    accountListItemProps,
+    selectedAccount,
+    onClose,
+    onAccountListItemItemClicked,
+    searchQuery,
+  ]);
 
   return (
     <Modal isOpen onClose={onClose}>
@@ -713,9 +767,8 @@ export const AccountListMenu = ({
                     size: Size.SM,
                   }}
                   inputProps={{ autoFocus: true }}
-                  // TODO: These props are required in the TextFieldSearch component. These should be optional
-                  endAccessory
-                  className
+                  endAccessory={null}
+                  className=""
                 />
               </Box>
             ) : null}
@@ -731,44 +784,7 @@ export const AccountListMenu = ({
                   {t('noAccountsFound')}
                 </Text>
               ) : null}
-              {searchResults.map((account) => {
-                const connectedSite = connectedSites[account.address]?.find(
-                  ({ origin }) => origin === currentTabOrigin,
-                );
-
-                const hideAccountListItem =
-                  searchQuery.length === 0 && account.hidden;
-
-                /* NOTE: Hidden account will be displayed only in the search list */
-
-                return (
-                  <Box
-                    className={
-                      account.hidden
-                        ? 'multichain-account-menu-popover__list--menu-item-hidden'
-                        : 'multichain-account-menu-popover__list--menu-item'
-                    }
-                    display={hideAccountListItem ? Display.None : Display.Block}
-                    key={account.address}
-                  >
-                    <AccountListItem
-                      onClick={onAccountListItemItemClicked(account)}
-                      account={account}
-                      key={account.address}
-                      selected={selectedAccount.address === account.address}
-                      closeMenu={onClose}
-                      connectedAvatar={connectedSite?.iconUrl}
-                      menuType={AccountListItemMenuTypes.Account}
-                      isPinned={Boolean(account.pinned)}
-                      isHidden={Boolean(account.hidden)}
-                      currentTabOrigin={currentTabOrigin}
-                      isActive={Boolean(account.active)}
-                      privacyMode={privacyMode}
-                      {...accountListItemProps}
-                    />
-                  </Box>
-                );
-              })}
+              {accountListItems}
             </Box>
             {/* Hidden Accounts, this component shows hidden accounts in account list Item*/}
             {hiddenAddresses.length > 0 ? (

--- a/ui/components/multichain/pages/send/components/account-picker.tsx
+++ b/ui/components/multichain/pages/send/components/account-picker.tsx
@@ -16,6 +16,8 @@ import { AccountListMenu } from '../../..';
 import { SEND_STAGES, getSendStage } from '../../../../../ducks/send';
 import { SendPageRow } from './send-page-row';
 
+const AccountListItemProps = { showOptions: false };
+
 export const SendPageAccountPicker = () => {
   const t = useContext(I18nContext);
   const internalAccount = useSelector(getSelectedInternalAccount);
@@ -24,7 +26,6 @@ export const SendPageAccountPicker = () => {
 
   const sendStage = useSelector(getSendStage);
   const disabled = SEND_STAGES.EDIT === sendStage;
-  const accountListItemProps = { showOptions: false };
   const onAccountListMenuClose = useCallback(() => {
     setShowAccountPicker(false);
   }, []);
@@ -64,7 +65,7 @@ export const SendPageAccountPicker = () => {
       />
       {showAccountPicker ? (
         <AccountListMenu
-          accountListItemProps={accountListItemProps}
+          accountListItemProps={AccountListItemProps}
           showAccountCreation={false}
           onClose={onAccountListMenuClose}
           allowedAccountTypes={[EthAccountType.Eoa, EthAccountType.Erc4337]}

--- a/ui/components/multichain/pages/send/components/your-accounts.tsx
+++ b/ui/components/multichain/pages/send/components/your-accounts.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { EthAccountType, KeyringAccountType } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -18,6 +18,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../../../shared/constants/metametrics';
 import { SendPageRow } from './send-page-row';
+import { MergedInternalAccount } from '../../../../../selectors/selectors.types';
 
 type SendPageYourAccountsProps = {
   allowedAccountTypes?: KeyringAccountType[];
@@ -40,6 +41,35 @@ export const SendPageYourAccounts = ({
   }, [accounts]);
   const selectedAccount = useSelector(getSelectedInternalAccount);
 
+  const onClick = useCallback(
+    (account: MergedInternalAccount) => {
+      dispatch(
+        addHistoryEntry(
+          `sendFlow - User clicked recipient from my accounts. address: ${account.address}, nickname ${account.metadata.name}`,
+        ),
+      );
+      trackEvent(
+        {
+          event: MetaMetricsEventName.sendRecipientSelected,
+          category: MetaMetricsEventCategory.Send,
+          properties: {
+            location: 'my accounts',
+            inputType: 'click',
+          },
+        },
+        { excludeMetaMetricsId: false },
+      );
+      dispatch(
+        updateRecipient({
+          address: account.address,
+          nickname: account.metadata.name,
+        }),
+      );
+      dispatch(updateRecipientUserInput(account.address));
+    },
+    [dispatch, trackEvent],
+  );
+
   return (
     <SendPageRow>
       {/* TODO: Replace `any` with type */}
@@ -51,31 +81,7 @@ export const SendPageYourAccounts = ({
           key={account.address}
           isPinned={Boolean(account.pinned)}
           shouldScrollToWhenSelected={false}
-          onClick={() => {
-            dispatch(
-              addHistoryEntry(
-                `sendFlow - User clicked recipient from my accounts. address: ${account.address}, nickname ${account.name}`,
-              ),
-            );
-            trackEvent(
-              {
-                event: MetaMetricsEventName.sendRecipientSelected,
-                category: MetaMetricsEventCategory.Send,
-                properties: {
-                  location: 'my accounts',
-                  inputType: 'click',
-                },
-              },
-              { excludeMetaMetricsId: false },
-            );
-            dispatch(
-              updateRecipient({
-                address: account.address,
-                nickname: account.name,
-              }),
-            );
-            dispatch(updateRecipientUserInput(account.address));
-          }}
+          onClick={onClick}
         />
       ))}
     </SendPageRow>

--- a/ui/components/multichain/pages/send/components/your-accounts.tsx
+++ b/ui/components/multichain/pages/send/components/your-accounts.tsx
@@ -17,8 +17,8 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../../../shared/constants/metametrics';
-import { SendPageRow } from './send-page-row';
 import { MergedInternalAccount } from '../../../../../selectors/selectors.types';
+import { SendPageRow } from './send-page-row';
 
 type SendPageYourAccountsProps = {
   allowedAccountTypes?: KeyringAccountType[];

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -483,7 +483,7 @@ export default class Routes extends Component {
         {showOnboardingHeader(location) && <OnboardingAppHeader />}
         {isAccountMenuOpen ? (
           <AccountListMenu
-            onClose={() => toggleAccountMenu()}
+            onClose={toggleAccountMenu}
             privacyMode={privacyMode}
           />
         ) : null}

--- a/ui/selectors/accounts.test.ts
+++ b/ui/selectors/accounts.test.ts
@@ -34,6 +34,12 @@ describe('Accounts Selectors', () => {
         Object.values(mockState.metamask.internalAccounts.accounts),
       );
     });
+
+    it('returns the same object', () => {
+      const result1 = getInternalAccounts(mockState as AccountsState);
+      const result2 = getInternalAccounts(mockState as AccountsState);
+      expect(result1 === result2).toBe(true);
+    });
   });
 
   describe('#getSelectedInternalAccount', () => {

--- a/ui/selectors/accounts.ts
+++ b/ui/selectors/accounts.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { AccountsControllerState } from '@metamask/accounts-controller';
+import { createSelector } from 'reselect';
 import {
   isBtcMainnetAddress,
   isBtcTestnetAddress,
@@ -26,9 +27,11 @@ export function isSolanaAccount(account: InternalAccount) {
   return Boolean(account && account.type === DataAccount);
 }
 
-export function getInternalAccounts(state: AccountsState) {
-  return Object.values(state.metamask.internalAccounts.accounts);
-}
+export const getInternalAccounts = createSelector(
+  (state: AccountsState) =>
+    Object.values(state.metamask.internalAccounts.accounts),
+  (accounts) => accounts,
+);
 
 export function getSelectedInternalAccount(state: AccountsState) {
   const accountId = state.metamask.internalAccounts.selectedAccount;

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -376,7 +376,7 @@ export function getAccountTypeForKeyring(keyring) {
 /**
  * Get MetaMask accounts, including account name and balance.
  */
-export const getMetaMaskAccounts = createSelector(
+export const getMetaMaskAccounts = createDeepEqualSelector(
   getInternalAccounts,
   getMetaMaskAccountBalances,
   getMetaMaskCachedBalances,
@@ -501,7 +501,7 @@ export const getSelectedEvmInternalAccount = createSelector(
  * @param accounts - The object containing the accounts.
  * @returns The array of internal accounts sorted by keyring.
  */
-export const getInternalAccountsSortedByKeyring = createSelector(
+export const getInternalAccountsSortedByKeyring = createDeepEqualSelector(
   getMetaMaskKeyrings,
   getMetaMaskAccounts,
   (keyrings, accounts) => {
@@ -797,7 +797,7 @@ function getNativeTokenInfo(state, chainId) {
  *
  * @returns {InternalAccountWithBalance} An array of internal accounts with balance
  */
-export const getMetaMaskAccountsOrdered = createSelector(
+export const getMetaMaskAccountsOrdered = createDeepEqualSelector(
   getInternalAccountsSortedByKeyring,
   getMetaMaskAccounts,
   (internalAccounts, accounts) => {


### PR DESCRIPTION
## **Description**

The AccountListMenu has been been flagged as slow in the past, so I've memoized some selectors and child elements to make the menu render much, much less.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30873?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check out `main` branch 
2. Start the extension with the `ENABLE_WHY_DID_YOU_RENDER` flag on
3. Open the Account List Menu
4. See *loads* of rerendering of the `AccountListItem` due to 4 props changing (onClick, closeMenu, etc)
5. Checkout this branch PR
6. Start the extension with the `ENABLE_WHY_DID_YOU_RENDER` flag on
7. Open the Account List Menu
8. See 0 re-renders of the `AccountListItem`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
