### PR TITLE
fix: Use useCallback for domain input in Send flow

### DIFF
--- a/ui/components/multichain/pages/send/components/recipient-input.tsx
+++ b/ui/components/multichain/pages/send/components/recipient-input.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Label } from '../../../../component-library';
 import DomainInput from '../../../../../pages/confirmations/send/send-content/add-recipient/domain-input';
@@ -33,32 +33,65 @@ export const SendPageRecipientInput = () => {
     getIsUsingMyAccountForRecipientSearch,
   );
 
+  const onChange = useCallback(
+    (address: string) => {
+      dispatch(updateRecipientUserInput(address));
+    },
+    [dispatch],
+  );
+
+  const onValidAddressTyped = useCallback(
+    async (address: string) => {
+      dispatch(addHistoryEntry(`sendFlow - Valid address typed ${address}`));
+      await dispatch(updateRecipientUserInput(address));
+      trackEvent(
+        {
+          event: MetaMetricsEventName.sendRecipientSelected,
+          category: MetaMetricsEventCategory.Send,
+          properties: {
+            location: 'send page recipient input',
+            inputType: 'user input',
+          },
+        },
+        { excludeMetaMetricsId: false },
+      );
+      dispatch(updateRecipient({ address, nickname: '' }));
+    },
+    [dispatch, trackEvent],
+  );
+
+  const onPaste = useCallback(
+    (text: string) => {
+      dispatch(
+        addHistoryEntry(`sendFlow - User pasted ${text} into address field`),
+      );
+    },
+    [dispatch],
+  );
+
+  const scanQrCode = useCallback(() => {
+    trackEvent({
+      event: 'Used QR scanner',
+      category: MetaMetricsEventCategory.Transactions,
+      properties: {
+        action: 'Edit Screen',
+        legacy_event: true,
+      },
+    });
+    dispatch(showQrScanner());
+  }, [dispatch, trackEvent]);
+
+  const onReset = useCallback(() => {
+    dispatch(resetRecipientInput());
+  }, [dispatch]);
+
   return (
     <SendPageRow>
       <Label paddingBottom={2}>{t('to')}</Label>
       <DomainInput
         userInput={userInput}
-        onChange={(address: string) =>
-          dispatch(updateRecipientUserInput(address))
-        }
-        onValidAddressTyped={async (address: string) => {
-          dispatch(
-            addHistoryEntry(`sendFlow - Valid address typed ${address}`),
-          );
-          await dispatch(updateRecipientUserInput(address));
-          trackEvent(
-            {
-              event: MetaMetricsEventName.sendRecipientSelected,
-              category: MetaMetricsEventCategory.Send,
-              properties: {
-                location: 'send page recipient input',
-                inputType: 'user input',
-              },
-            },
-            { excludeMetaMetricsId: false },
-          );
-          dispatch(updateRecipient({ address, nickname: '' }));
-        }}
+        onChange={onChange}
+        onValidAddressTyped={onValidAddressTyped}
         internalSearch={isUsingMyAccountsForRecipientSearch}
         selectedAddress={recipient.address}
         selectedName={
@@ -66,25 +99,9 @@ export const SendPageRecipientInput = () => {
             ? shortenAddress(toChecksumHexAddress(recipient.address))
             : recipient.nickname
         }
-        onPaste={(text: string) => {
-          dispatch(
-            addHistoryEntry(
-              `sendFlow - User pasted ${text} into address field`,
-            ),
-          );
-        }}
-        onReset={() => dispatch(resetRecipientInput())}
-        scanQrCode={() => {
-          trackEvent({
-            event: 'Used QR scanner',
-            category: MetaMetricsEventCategory.Transactions,
-            properties: {
-              action: 'Edit Screen',
-              legacy_event: true,
-            },
-          });
-          dispatch(showQrScanner());
-        }}
+        onPaste={onPaste}
+        onReset={onReset}
+        scanQrCode={scanQrCode}
       />
     </SendPageRow>
   );


### PR DESCRIPTION
## **Description**

The `DomainInput` was being re-rendered because the event callbacks weren't using `useCallback`.  This PR prevents those re-renders.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30880?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to send flow
2. Ensure pasting into the domain field, typing a valid address, etc. works properly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="835" alt="SCR-20250307-stxe" src="https://github.com/user-attachments/assets/2a4ba3e3-bf43-4f18-9445-453affb1820d" />



### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
