### PR TITLE
test: Use test-dapp for transaction insights E2E

### DIFF
--- a/test/e2e/snaps/test-snap-txinsights.spec.js
+++ b/test/e2e/snaps/test-snap-txinsights.spec.js
@@ -1,4 +1,9 @@
-const { withFixtures, unlockWallet, WINDOW_TITLES, openDapp } = require('../helpers');
+const {
+  withFixtures,
+  unlockWallet,
+  WINDOW_TITLES,
+  openDapp,
+} = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -7,7 +12,9 @@ describe('Test Snap TxInsights', function () {
     await withFixtures(
       {
         dapp: true,
-        fixtures: new FixtureBuilder().withPermissionControllerConnectedToTestDapp().build(),
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
         title: this.test.fullTitle(),
       },
       async ({ driver }) => {
@@ -72,6 +79,10 @@ describe('Test Snap TxInsights', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
         // click send tx
+        const sendTransactionButton = await driver.findElement(
+          '#maliciousERC20TransferButton',
+        );
+        await driver.scrollToElement(sendTransactionButton);
         await driver.clickElement('#maliciousERC20TransferButton');
 
         // delay added for rendering (deflake)

--- a/test/e2e/snaps/test-snap-txinsights.spec.js
+++ b/test/e2e/snaps/test-snap-txinsights.spec.js
@@ -1,4 +1,4 @@
-const { withFixtures, unlockWallet, WINDOW_TITLES } = require('../helpers');
+const { withFixtures, unlockWallet, WINDOW_TITLES, openDapp } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -6,7 +6,8 @@ describe('Test Snap TxInsights', function () {
   it('tests tx insights functionality', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        dapp: true,
+        fixtures: new FixtureBuilder().withPermissionControllerConnectedToTestDapp().build(),
         title: this.test.fullTitle(),
       },
       async ({ driver }) => {
@@ -61,30 +62,17 @@ describe('Test Snap TxInsights', function () {
           tag: 'button',
         });
 
-        // switch to test-snaps page and get accounts
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
-
-        // click get accounts
-        await driver.clickElement('#getAccounts');
-
-        // switch back to MetaMask window
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-
-        // wait for and click next and wait for window to close
-        await driver.waitForSelector({
-          text: 'Connect',
-          tag: 'button',
-        });
-        await driver.clickElementAndWaitForWindowToClose({
-          text: 'Connect',
-          tag: 'button',
-        });
-
         // switch to test-snaps page
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
 
+        // open the test-dapp page
+        await openDapp(driver);
+
+        // switch back to test-dapp window
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+
         // click send tx
-        await driver.clickElement('#sendInsights');
+        await driver.clickElement('#maliciousERC20TransferButton');
 
         // delay added for rendering (deflake)
         await driver.delay(2000);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Use the test-dapp for the transaction used when testing the transaction insights feature. This prevents an issue in an open PR where the payloads used in the test-snaps page was disallowed. It also sets us up to run this E2E test on multiple different transaction types.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30909?quickstart=1)


