### PR TITLE
chore: ignore babel audit failure temporarily

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -54,6 +54,10 @@ npmAuditIgnoreAdvisories:
   # We are ignoring this on March 11, 2025 to unblock CI, we will follow with a proper fix or confirmation this does not affect our users
   - 1102472
 
+  # Issue: Issue: Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups
+  # We are ignoring this on March 12, 2025 to unblock CI, we will follow with a proper fix or confirmation this does not affect our users
+  - 1103026
+
   # Temp fix for https://github.com/MetaMask/metamask-extension/pull/16920 for the sake of 11.7.1 hotfix
   # This will be removed in this ticket https://github.com/MetaMask/metamask-extension/issues/22299
   - 'ts-custom-error (deprecation)'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Temporarily ignoring babel failure to unblock ci

![Screenshot from 2025-03-12 18-52-00](https://github.com/user-attachments/assets/8d0f060f-a548-4afc-a542-54a100b18b88)


After:
![Screenshot from 2025-03-12 18-52-28](https://github.com/user-attachments/assets/aae2438f-678b-4ac5-bf91-0dd6f004a892)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30946?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check github action

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
