### PR TITLE
chore: wait at least 10 mins before showing bridge tx delay banner

### DIFF
--- a/ui/pages/bridge/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.test.tsx
@@ -1,3 +1,4 @@
+import { MINUTE } from '../../../../shared/constants/time';
 import {
   BridgeHistoryItem,
   StatusTypes,
@@ -36,8 +37,8 @@ describe('transaction-details', () => {
       expect(result).toBe(false);
     });
 
-    it('returns true when current time exceeds estimated completion time', () => {
-      const startTime = Date.now() - 61 * 1000;
+    it('returns true when current time exceeds estimated completion time by 10 minutes', () => {
+      const startTime = Date.now() - 61 * 1000 - 10 * MINUTE;
 
       const result = getIsDelayed(StatusTypes.PENDING, {
         startTime,
@@ -45,6 +46,17 @@ describe('transaction-details', () => {
       } as BridgeHistoryItem);
 
       expect(result).toBe(true);
+    });
+
+    it('returns false when current time exceeds estimated completion time, but less than 10 minutes have passed', () => {
+      const startTime = Date.now() - 61 * 1000;
+
+      const result = getIsDelayed(StatusTypes.PENDING, {
+        startTime,
+        estimatedProcessingTimeInSeconds: 60,
+      } as BridgeHistoryItem);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -63,6 +63,7 @@ import {
   AllowedBridgeChainIds,
 } from '../../../../shared/constants/bridge';
 import { getImageForChainId } from '../../../selectors/multichain';
+import { MINUTE } from '../../../../shared/constants/time';
 import TransactionDetailRow from './transaction-detail-row';
 import BridgeExplorerLinks from './bridge-explorer-links';
 import BridgeStepList from './bridge-step-list';
@@ -141,11 +142,13 @@ export const getIsDelayed = (
   status: StatusTypes,
   bridgeHistoryItem?: BridgeHistoryItem,
 ) => {
+  const tenMinutesInMs = 10 * MINUTE;
   return Boolean(
     status === StatusTypes.PENDING &&
       bridgeHistoryItem?.startTime &&
       Date.now() >
         bridgeHistoryItem.startTime +
+          tenMinutesInMs +
           bridgeHistoryItem.estimatedProcessingTimeInSeconds * 1000,
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This adds a 10-minute buffer after the tx estimated completion time, before showing the support/delay banner

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30952?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30325

## **Manual testing steps**

1. Bridge from Optimism to Arbitrum
2. Open tx details
3. Verify that the delay banner does not show up

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
