### PR TITLE
feat: add EIP-7702 revoke flow

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -90,6 +90,9 @@
   "accountDetails": {
     "message": "Account details"
   },
+  "accountDetailsRevokeDelegationButton": {
+    "message": " Switch back to regular account"
+  },
   "accountIdenticon": {
     "message": "Account identicon"
   },
@@ -1033,7 +1036,10 @@
     "message": "Type"
   },
   "confirmAccountTypeSmartContract": {
-    "message": "Smart contract account"
+    "message": "Smart account"
+  },
+  "confirmAccountTypeStandard": {
+    "message": "Standard account"
   },
   "confirmAlertModalAcknowledgeMultiple": {
     "message": "I have acknowledged the alerts and still want to proceed"
@@ -1077,6 +1083,9 @@
   "confirmTitleDescPermitSignature": {
     "message": "This site wants permission to spend your tokens."
   },
+  "confirmTitleDescRevokeDelegation": {
+    "message": "This site is requesting to switch back to a standard account."
+  },
   "confirmTitleDescSIWESignature": {
     "message": "A site wants you to sign in to prove you own this account."
   },
@@ -1088,6 +1097,9 @@
   },
   "confirmTitleRevokeApproveTransaction": {
     "message": "Remove permission"
+  },
+  "confirmTitleRevokeDelegation": {
+    "message": "Reset account"
   },
   "confirmTitleSIWESignature": {
     "message": "Sign-in request"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -90,6 +90,9 @@
   "accountDetails": {
     "message": "Account details"
   },
+  "accountDetailsRevokeDelegationButton": {
+    "message": " Switch back to regular account"
+  },
   "accountIdenticon": {
     "message": "Account identicon"
   },
@@ -1033,7 +1036,10 @@
     "message": "Type"
   },
   "confirmAccountTypeSmartContract": {
-    "message": "Smart contract account"
+    "message": "Smart account"
+  },
+  "confirmAccountTypeStandard": {
+    "message": "Standard account"
   },
   "confirmAlertModalAcknowledgeMultiple": {
     "message": "I have acknowledged the alerts and still want to proceed"
@@ -1077,6 +1083,9 @@
   "confirmTitleDescPermitSignature": {
     "message": "This site wants permission to spend your tokens."
   },
+  "confirmTitleDescRevokeDelegation": {
+    "message": "This site is requesting to switch back to a standard account."
+  },
   "confirmTitleDescSIWESignature": {
     "message": "A site wants you to sign in to prove you own this account."
   },
@@ -1088,6 +1097,9 @@
   },
   "confirmTitleRevokeApproveTransaction": {
     "message": "Remove permission"
+  },
+  "confirmTitleRevokeDelegation": {
+    "message": "Reset account"
   },
   "confirmTitleSIWESignature": {
     "message": "Sign-in request"

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3438,6 +3438,7 @@ export default class MetamaskController extends EventEmitter {
       getOpenMetamaskTabsIds: this.getOpenMetamaskTabsIds,
       markNotificationPopupAsAutomaticallyClosed: () =>
         this.notificationManager.markAsAutomaticallyClosed(),
+      getCode: this.getCode.bind(this),
 
       // primary keyring management
       addNewAccount: this.addNewAccount.bind(this),
@@ -7616,6 +7617,16 @@ export default class MetamaskController extends EventEmitter {
     rejectAllApprovals({
       approvalController: this.approvalController,
       deleteInterface,
+    });
+  }
+
+  async getCode(address, networkClientId) {
+    const { provider } =
+      this.networkController.getNetworkClientById(networkClientId);
+
+    return await provider.request({
+      method: 'eth_getCode',
+      params: [address],
     });
   }
 

--- a/shared/lib/confirmation.utils.ts
+++ b/shared/lib/confirmation.utils.ts
@@ -14,6 +14,7 @@ const REDESIGN_USER_TRANSACTION_TYPES = [
   TransactionType.batch,
   TransactionType.contractInteraction,
   TransactionType.deployContract,
+  TransactionType.revokeDelegation,
   TransactionType.tokenMethodApprove,
   TransactionType.tokenMethodIncreaseAllowance,
   TransactionType.tokenMethodSetApprovalForAll,

--- a/ui/__mocks__/actions.js
+++ b/ui/__mocks__/actions.js
@@ -10,6 +10,7 @@ const {
 
 const ERC20_TOKEN_1_MOCK = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'; // WBTC
 const ERC20_TOKEN_2_MOCK = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'; // USDC
+const UPGRADED_ACCOUNT_MOCK = '0x9d0ba4ddac06032527b140912ec808ab9451b788';
 const ERC721_TOKEN_MOCK = '0x06012c8cf97bead5deae237070f9587f8e7a266d'; // CryptoKitties
 
 const TOKEN_DETAILS_MOCK = {
@@ -50,7 +51,7 @@ module.exports = {
   },
 
   // eslint-disable-next-line no-empty-function
-  trackMetaMetricsEvent: () => {},
+  trackMetaMetricsEvent: () => { },
 
   decodeTransactionData: async (request) => {
     const { contractAddress } = request;
@@ -64,5 +65,13 @@ module.exports = {
     }
 
     return undefined;
+  },
+
+  getCode: async (address) => {
+    if (address === UPGRADED_ACCOUNT_MOCK) {
+      return '0x1234';
+    }
+
+    return '0x';
   },
 };

--- a/ui/__mocks__/actions.js
+++ b/ui/__mocks__/actions.js
@@ -51,7 +51,9 @@ module.exports = {
   },
 
   // eslint-disable-next-line no-empty-function
-  trackMetaMetricsEvent: () => { },
+  trackMetaMetricsEvent: () => {
+    // Intentionally empty
+  },
 
   decodeTransactionData: async (request) => {
     const { contractAddress } = request;

--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -15,11 +15,15 @@ import {
   Box,
   ButtonSecondary,
   ButtonSecondarySize,
+  Text,
 } from '../../component-library';
 import {
   AlignItems,
+  BackgroundColor,
+  BorderRadius,
   Display,
   FlexDirection,
+  TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -30,12 +34,73 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
+import { useEIP7702Account } from '../../../pages/confirmations/hooks/useEIP7702Account';
+
+function SmartAccountPill() {
+  const { isUpgraded } = useEIP7702Account();
+
+  if (!isUpgraded) {
+    return null;
+  }
+
+  return (
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      backgroundColor={BackgroundColor.backgroundAlternative}
+      alignItems={AlignItems.center}
+      borderRadius={BorderRadius.pill}
+      margin={4}
+      style={{
+        padding: '0px 8px',
+        flexShrink: 1,
+        flexBasis: 'auto',
+        minWidth: 0,
+      }}
+    >
+      <Text
+        ellipsis
+        variant={TextVariant.bodyMd}
+        color={TextColor.textAlternativeSoft}
+      >
+        Smart account
+      </Text>
+    </Box>
+  );
+}
+
+function DowngradeAccountButton({ address, onClose }) {
+  const { downgradeAccount, isUpgraded } = useEIP7702Account({
+    onRedirect: onClose,
+  });
+
+  const handleClick = useCallback(() => {
+    downgradeAccount(address);
+  }, [address, downgradeAccount]);
+
+  if (!isUpgraded) {
+    return null;
+  }
+
+  return (
+    <ButtonSecondary
+      block
+      size={ButtonSecondarySize.Lg}
+      variant={TextVariant.bodyMd}
+      marginBottom={4}
+      onClick={handleClick}
+    >
+      Switch back to regular account
+    </ButtonSecondary>
+  );
+}
 
 export const AccountDetailsDisplay = ({
   accounts,
   accountName,
   address,
   onExportClick,
+  onClose,
 }) => {
   const dispatch = useDispatch();
   const trackEvent = useContext(MetaMetricsContext);
@@ -71,7 +136,9 @@ export const AccountDetailsDisplay = ({
         }}
         accounts={accounts}
       />
+      <SmartAccountPill />
       <QrCodeView Qr={{ data: address }} />
+      <DowngradeAccountButton address={address} onClose={onClose} />
       {exportPrivateKeyFeatureEnabled ? (
         <ButtonSecondary
           block
@@ -113,4 +180,19 @@ AccountDetailsDisplay.propTypes = {
    * Executes upon Export button click
    */
   onExportClick: PropTypes.func.isRequired,
+  /**
+   * Executes when closing the modal
+   */
+  onClose: PropTypes.func.isRequired,
+};
+
+DowngradeAccountButton.propTypes = {
+  /**
+   * Current address
+   */
+  address: PropTypes.string.isRequired,
+  /**
+   * Executes when closing the modal
+   */
+  onClose: PropTypes.func.isRequired,
 };

--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -35,11 +35,17 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import { useEIP7702Account } from '../../../pages/confirmations/hooks/useEIP7702Account';
+import { useAsyncResult } from '../../../hooks/useAsyncResult';
 
-function SmartAccountPill() {
+function SmartAccountPill({ address }) {
   const { isUpgraded } = useEIP7702Account();
 
-  if (!isUpgraded) {
+  const { value: isAccountUpgraded } = useAsyncResult(
+    () => isUpgraded(address),
+    [address],
+  );
+
+  if (!isAccountUpgraded) {
     return null;
   }
 
@@ -74,11 +80,16 @@ function DowngradeAccountButton({ address, onClose }) {
     onRedirect: onClose,
   });
 
-  const handleClick = useCallback(() => {
-    downgradeAccount(address);
+  const { value: isAccountUpgraded } = useAsyncResult(
+    () => isUpgraded(address),
+    [address],
+  );
+
+  const handleClick = useCallback(async () => {
+    await downgradeAccount(address);
   }, [address, downgradeAccount]);
 
-  if (!isUpgraded) {
+  if (!isAccountUpgraded) {
     return null;
   }
 
@@ -184,6 +195,13 @@ AccountDetailsDisplay.propTypes = {
    * Executes when closing the modal
    */
   onClose: PropTypes.func.isRequired,
+};
+
+SmartAccountPill.propTypes = {
+  /**
+   * Current address
+   */
+  address: PropTypes.string.isRequired,
 };
 
 DowngradeAccountButton.propTypes = {

--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -147,7 +147,7 @@ export const AccountDetailsDisplay = ({
         }}
         accounts={accounts}
       />
-      <SmartAccountPill />
+      <SmartAccountPill address={address} />
       <QrCodeView Qr={{ data: address }} />
       <DowngradeAccountButton address={address} onClose={onClose} />
       {exportPrivateKeyFeatureEnabled ? (

--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -38,6 +38,7 @@ import { useEIP7702Account } from '../../../pages/confirmations/hooks/useEIP7702
 import { useAsyncResult } from '../../../hooks/useAsyncResult';
 
 function SmartAccountPill({ address }) {
+  const t = useI18nContext();
   const { isUpgraded } = useEIP7702Account();
 
   const { value: isAccountUpgraded } = useAsyncResult(
@@ -69,13 +70,15 @@ function SmartAccountPill({ address }) {
         variant={TextVariant.bodyMd}
         color={TextColor.textAlternativeSoft}
       >
-        Smart account
+        {t('confirmAccountTypeSmartContract')}
       </Text>
     </Box>
   );
 }
 
 function DowngradeAccountButton({ address, onClose }) {
+  const t = useI18nContext();
+
   const { downgradeAccount, isUpgraded } = useEIP7702Account({
     onRedirect: onClose,
   });
@@ -101,7 +104,7 @@ function DowngradeAccountButton({ address, onClose }) {
       marginBottom={4}
       onClick={handleClick}
     >
-      Switch back to regular account
+      {t('accountDetailsRevokeDelegationButton')}
     </ButtonSecondary>
   );
 }

--- a/ui/components/multichain/account-details/account-details-display.test.js
+++ b/ui/components/multichain/account-details/account-details-display.test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { act } from '@testing-library/react';
+import { useEIP7702Account } from '../../../pages/confirmations/hooks/useEIP7702Account';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import configureStore from '../../../store/store';
+import mockState from '../../../../test/data/mock-state.json';
+import { AccountDetailsDisplay } from './account-details-display';
+
+jest.mock('../../../pages/confirmations/hooks/useEIP7702Account', () => ({
+  useEIP7702Account: jest.fn(),
+}));
+
+const ADDRESS_MOCK = Object.values(
+  mockState.metamask.internalAccounts.accounts,
+)[0].address;
+
+function renderComponent() {
+  return renderWithProvider(
+    <AccountDetailsDisplay accounts={[]} address={ADDRESS_MOCK} />,
+    configureStore(mockState),
+  );
+}
+
+describe('AccountDetailsDisplay', () => {
+  const useEIP7702AccountMock = jest.mocked(useEIP7702Account);
+  const isUpgradedMock = jest.fn();
+  const downgradeAccountMock = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useEIP7702AccountMock.mockReturnValue({
+      isUpgraded: isUpgradedMock,
+      downgradeAccount: downgradeAccountMock,
+    });
+  });
+
+  it('renders smart account pill if account is upgraded', async () => {
+    isUpgradedMock.mockResolvedValue(true);
+    const { getByText } = renderComponent();
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(getByText('Smart account')).toBeInTheDocument();
+  });
+
+  it('does not render smart account pill if account is not upgraded', async () => {
+    isUpgradedMock.mockResolvedValue(false);
+    const { queryByText } = renderComponent();
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(queryByText('Smart account')).toBeNull();
+  });
+
+  it('renders downgrade button if account is upgraded', async () => {
+    isUpgradedMock.mockResolvedValue(true);
+    const { getByText } = renderComponent();
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(getByText('Switch back to regular account')).toBeInTheDocument();
+  });
+
+  it('does not render downgrade button if account is not upgraded', async () => {
+    isUpgradedMock.mockResolvedValue(false);
+    const { queryByText } = renderComponent();
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(queryByText('Switch back to regular account')).toBeNull();
+  });
+
+  it('adds transaction on downgrade button click', async () => {
+    isUpgradedMock.mockResolvedValue(true);
+    const { queryByText } = renderComponent();
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    await act(async () => {
+      queryByText('Switch back to regular account').click();
+    });
+
+    expect(downgradeAccountMock).toHaveBeenCalledTimes(1);
+    expect(downgradeAccountMock).toHaveBeenCalledWith(ADDRESS_MOCK);
+  });
+});

--- a/ui/components/multichain/account-details/account-details-display.test.tsx
+++ b/ui/components/multichain/account-details/account-details-display.test.tsx
@@ -16,7 +16,17 @@ const ADDRESS_MOCK = Object.values(
 
 function renderComponent() {
   return renderWithProvider(
-    <AccountDetailsDisplay accounts={[]} address={ADDRESS_MOCK} />,
+    <AccountDetailsDisplay
+      accounts={[]}
+      accountName={''}
+      address={ADDRESS_MOCK}
+      onExportClick={() => {
+        // Intentionally empty
+      }}
+      onClose={() => {
+        // Intentionally empty
+      }}
+    />,
     configureStore(mockState),
   );
 }
@@ -87,7 +97,7 @@ describe('AccountDetailsDisplay', () => {
     });
 
     await act(async () => {
-      queryByText('Switch back to regular account').click();
+      queryByText('Switch back to regular account')?.click();
     });
 
     expect(downgradeAccountMock).toHaveBeenCalledTimes(1);

--- a/ui/components/multichain/account-details/account-details.js
+++ b/ui/components/multichain/account-details/account-details.js
@@ -139,6 +139,7 @@ export const AccountDetails = ({ address }) => {
                 accountName={name}
                 address={address}
                 onExportClick={() => setAttemptingExport(true)}
+                onClose={onClose}
               />
             )}
           </ModalBody>

--- a/ui/components/multichain/account-details/account-details.stories.js
+++ b/ui/components/multichain/account-details/account-details.stories.js
@@ -2,6 +2,8 @@ import React from 'react';
 import testData from '../../../../.storybook/test-data';
 import { AccountDetails } from '.';
 
+const UPGRADED_ACCOUNT_MOCK = '0x9d0ba4ddac06032527b140912ec808ab9451b788';
+
 const { address } = Object.values(
   testData.metamask.internalAccounts.accounts,
 )[1];
@@ -20,3 +22,11 @@ export default {
 };
 
 export const DefaultStory = (args) => <AccountDetails {...args} />;
+
+DefaultStory.storyName = 'Default';
+
+export const UpgradedAccountStory = (args) => (
+  <AccountDetails {...args} address={UPGRADED_ACCOUNT_MOCK} />
+);
+
+UpgradedAccountStory.storyName = 'Upgraded Account';

--- a/ui/helpers/utils/transactions.util.js
+++ b/ui/helpers/utils/transactions.util.js
@@ -135,7 +135,8 @@ export function getTransactionTypeTitle(t, type, nativeCurrency = 'ETH') {
       return t('sendingNativeAsset', [nativeCurrency]);
     }
     case TransactionType.contractInteraction:
-    case TransactionType.batch: {
+    case TransactionType.batch:
+    case TransactionType.revokeDelegation: {
       return t('contractInteraction');
     }
     case TransactionType.deployContract: {

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -345,7 +345,8 @@ export function useTransactionDisplayData(transactionGroup) {
     subtitleContainsOrigin = true;
   } else if (
     type === TransactionType.contractInteraction ||
-    type === TransactionType.batch
+    type === TransactionType.batch ||
+    type === TransactionType.revokeDelegation
   ) {
     category = TransactionGroupCategory.interaction;
     const transactionTypeTitle = getTransactionTypeTitle(t, type);

--- a/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
@@ -7,17 +7,21 @@ import {
 } from '../../../../../../../components/app/confirm/info/row';
 import { useConfirmContext } from '../../../../../context/confirm';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
-import { useIsUpgradeTransaction } from '../../hooks/useIsUpgradeTransaction';
+import {
+  useIsDowngradeTransaction,
+  useIsUpgradeTransaction,
+} from '../../hooks/useIsUpgradeTransaction';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 
 export function TransactionAccountDetails() {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const isUpgrade = useIsUpgradeTransaction();
+  const isDowngrade = useIsDowngradeTransaction();
   const { chainId, txParams } = currentConfirmation;
   const { from } = txParams;
 
-  if (!isUpgrade) {
+  if (!isUpgrade && !isDowngrade) {
     return null;
   }
 
@@ -26,9 +30,21 @@ export function TransactionAccountDetails() {
       <ConfirmInfoRow label={t('account')}>
         <ConfirmInfoRowAddress chainId={chainId} address={from} />
       </ConfirmInfoRow>
-      <ConfirmInfoRow label={t('confirmAccountType')}>
-        <ConfirmInfoRowText text={t('confirmAccountTypeSmartContract')} />
-      </ConfirmInfoRow>
+      {isUpgrade && (
+        <ConfirmInfoRow label={t('confirmAccountType')}>
+          <ConfirmInfoRowText text={t('confirmAccountTypeSmartContract')} />
+        </ConfirmInfoRow>
+      )}
+      {isDowngrade && (
+        <>
+          <ConfirmInfoRow label="Current Type">
+            <ConfirmInfoRowText text={t('confirmAccountTypeSmartContract')} />
+          </ConfirmInfoRow>
+          <ConfirmInfoRow label="New Type">
+            <ConfirmInfoRowText text="Standard account" />
+          </ConfirmInfoRow>
+        </>
+      )}
     </ConfirmInfoSection>
   );
 }

--- a/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
@@ -41,7 +41,7 @@ export function TransactionAccountDetails() {
             <ConfirmInfoRowText text={t('confirmAccountTypeSmartContract')} />
           </ConfirmInfoRow>
           <ConfirmInfoRow label="New Type">
-            <ConfirmInfoRowText text="Standard account" />
+            <ConfirmInfoRowText text={t('confirmAccountTypeStandard')} />
           </ConfirmInfoRow>
         </>
       )}

--- a/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transasction-account-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transasction-account-details.test.tsx
@@ -40,13 +40,13 @@ describe('TransactionAccountDetails', () => {
       authorizationList: [{ address: DELEGATION_MOCK }],
     });
 
-    expect(getByText('Smart contract account')).toBeInTheDocument();
+    expect(getByText('Smart account')).toBeInTheDocument();
   });
 
   it('does not render if no authorization list', () => {
     const { queryByText } = render({});
 
     expect(queryByText('0x12345...67890')).toBeNull();
-    expect(queryByText('Smart contract account')).toBeNull();
+    expect(queryByText('Smart account')).toBeNull();
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useIsUpgradeTransaction.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useIsUpgradeTransaction.test.ts
@@ -2,9 +2,13 @@ import { AuthorizationList } from '@metamask/transaction-controller';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../../test/data/confirmations/contract-interaction';
 import { getMockConfirmStateForTransaction } from '../../../../../../../test/data/confirmations/helper';
 import { renderHookWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
-import { useIsUpgradeTransaction } from './useIsUpgradeTransaction';
+import { EIP_7702_REVOKE_ADDRESS } from '../../../../hooks/useEIP7702Account';
+import {
+  useIsDowngradeTransaction,
+  useIsUpgradeTransaction,
+} from './useIsUpgradeTransaction';
 
-function runHook(authorizationList?: AuthorizationList) {
+function runUpgradeHook(authorizationList?: AuthorizationList) {
   const transaction = genUnapprovedContractInteractionConfirmation({
     authorizationList,
   });
@@ -19,18 +23,59 @@ function runHook(authorizationList?: AuthorizationList) {
   return result.current as boolean;
 }
 
+function runDowngradeHook(authorizationList?: AuthorizationList) {
+  const transaction = genUnapprovedContractInteractionConfirmation({
+    authorizationList,
+  });
+
+  const state = getMockConfirmStateForTransaction(transaction);
+
+  const { result } = renderHookWithConfirmContextProvider(
+    useIsDowngradeTransaction,
+    state,
+  );
+
+  return result.current as boolean;
+}
+
 describe('useIsUpgradeTransaction', () => {
-  it('returns true if authorizationList is not empty', async () => {
-    const result = runHook([{ address: '0x123' }]);
+  it('returns true if authorization address is not empty', async () => {
+    const result = runUpgradeHook([{ address: '0x123' }]);
     expect(result).toBe(true);
   });
 
   // @ts-expect-error This is missing from the Mocha type definitions
   it.each([undefined, null, []] as const)(
-    'returns false if authorizationList is %s',
+    'returns false if authorization address is %s',
     async (authorizationList: never) => {
-      const result = runHook(authorizationList);
+      const result = runUpgradeHook(authorizationList);
       expect(result).toBe(false);
     },
   );
+
+  it('returns false if authorization address is zero address', async () => {
+    const result = runUpgradeHook([{ address: EIP_7702_REVOKE_ADDRESS }]);
+    expect(result).toBe(false);
+  });
+});
+
+describe('useIsDowngradeTransaction', () => {
+  it('returns true if authorization address is zero address', async () => {
+    const result = runDowngradeHook([{ address: EIP_7702_REVOKE_ADDRESS }]);
+    expect(result).toBe(true);
+  });
+
+  // @ts-expect-error This is missing from the Mocha type definitions
+  it.each([undefined, null, []] as const)(
+    'returns false if authorization address is %s',
+    async (authorizationList: never) => {
+      const result = runDowngradeHook(authorizationList);
+      expect(result).toBe(false);
+    },
+  );
+
+  it('returns false if authorization address is other address', async () => {
+    const result = runDowngradeHook([{ address: '0x123' }]);
+    expect(result).toBe(false);
+  });
 });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useIsUpgradeTransaction.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useIsUpgradeTransaction.ts
@@ -1,10 +1,31 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 import { useConfirmContext } from '../../../../context/confirm';
+import { EIP_7702_REVOKE_ADDRESS } from '../../../../hooks/useEIP7702Account';
 
 export function useIsUpgradeTransaction(): boolean {
+  const authorizationAddress = useTransactionAuthorizationAddress();
+
+  return (
+    Boolean(authorizationAddress) &&
+    authorizationAddress !== EIP_7702_REVOKE_ADDRESS
+  );
+}
+
+export function useIsDowngradeTransaction(): boolean {
+  const authorizationAddress = useTransactionAuthorizationAddress();
+
+  return (
+    Boolean(authorizationAddress) &&
+    authorizationAddress === EIP_7702_REVOKE_ADDRESS
+  );
+}
+
+function useTransactionAuthorizationAddress(): Hex | undefined {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { txParams } = currentConfirmation ?? {};
   const { authorizationList } = txParams ?? {};
+  const authorization = authorizationList?.[0];
 
-  return Boolean(authorizationList?.length);
+  return authorization?.address;
 }

--- a/ui/pages/confirmations/components/confirm/info/info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.tsx
@@ -25,6 +25,7 @@ const Info = () => {
       [TransactionType.contractInteraction]: () => BaseTransactionInfo,
       [TransactionType.deployContract]: () => BaseTransactionInfo,
       [TransactionType.personalSign]: () => PersonalSignInfo,
+      [TransactionType.revokeDelegation]: () => BaseTransactionInfo,
       [TransactionType.simpleSend]: () => NativeTransferInfo,
       [TransactionType.signTypedData]: () => {
         const { version } =

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -96,7 +96,7 @@ const getTitle = (
       }
       return t('confirmTitleSignature');
     case TransactionType.revokeDelegation:
-      return 'Revert';
+      return t('confirmTitleRevokeDelegation');
     case TransactionType.signTypedData:
       if (primaryType === TypedSignSignaturePrimaryTypes.PERMIT) {
         if (tokenStandard === TokenStandard.ERC721) {
@@ -159,7 +159,7 @@ const getDescription = (
       }
       return t('confirmTitleDescSign');
     case TransactionType.revokeDelegation:
-      return 'Test';
+      return t('confirmTitleDescRevokeDelegation');
     case TransactionType.signTypedData:
       if (primaryType === TypedSignSignaturePrimaryTypes.PERMIT) {
         if (tokenStandard === TokenStandard.ERC721) {

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -95,6 +95,8 @@ const getTitle = (
         return t('confirmTitleSIWESignature');
       }
       return t('confirmTitleSignature');
+    case TransactionType.revokeDelegation:
+      return 'Revert';
     case TransactionType.signTypedData:
       if (primaryType === TypedSignSignaturePrimaryTypes.PERMIT) {
         if (tokenStandard === TokenStandard.ERC721) {
@@ -156,6 +158,8 @@ const getDescription = (
         return t('confirmTitleDescSIWESignature');
       }
       return t('confirmTitleDescSign');
+    case TransactionType.revokeDelegation:
+      return 'Test';
     case TransactionType.signTypedData:
       if (primaryType === TypedSignSignaturePrimaryTypes.PERMIT) {
         if (tokenStandard === TokenStandard.ERC721) {

--- a/ui/pages/confirmations/hooks/useEIP7702Account.test.ts
+++ b/ui/pages/confirmations/hooks/useEIP7702Account.test.ts
@@ -1,0 +1,157 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../test/data/confirmations/contract-interaction';
+import { getMockConfirmStateForTransaction } from '../../../../test/data/confirmations/helper';
+import {
+  EIP_7702_REVOKE_ADDRESS,
+  useEIP7702Account,
+} from './useEIP7702Account';
+import {
+  addTransactionAndRouteToConfirmationPage,
+  getCode,
+} from '../../../store/actions';
+import { act } from '@testing-library/react';
+import { renderHookWithProvider } from '../../../../test/lib/render-helpers';
+import { TransactionEnvelopeType } from '@metamask/transaction-controller';
+import { ThunkAction } from 'redux-thunk';
+import { useConfirmationNavigation } from './useConfirmationNavigation';
+import { ApprovalRequest } from '@metamask/approval-controller';
+import { flushPromises } from '../../../../test/lib/timer-helpers';
+import { useDispatch } from 'react-redux';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../store/actions', () => ({
+  ...jest.requireActual('../../../store/actions'),
+  addTransactionAndRouteToConfirmationPage: jest.fn(),
+  getCode: jest.fn(),
+}));
+
+jest.mock('./useConfirmationNavigation', () => ({
+  useConfirmationNavigation: jest.fn(),
+}));
+
+const ADDRESS_MOCK = '0x1234';
+const CODE_MOCK = '0xabcd';
+const TRANSACTION_ID_MOCK = '1234-5678';
+
+function runHook({ onRedirect }: { onRedirect?: () => void } = {}) {
+  const { result } = renderHookWithProvider(
+    () => useEIP7702Account({ onRedirect }),
+    {},
+  );
+  return result.current;
+}
+
+describe('useEIP7702Account', () => {
+  const addTransactionAndRouteToConfirmationPageMock = jest.mocked(
+    addTransactionAndRouteToConfirmationPage,
+  );
+
+  const useDispatchMock = jest.mocked(useDispatch);
+  const getCodeMock = jest.mocked(getCode);
+  const useConfirmationNavigationMock = jest.mocked(useConfirmationNavigation);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    addTransactionAndRouteToConfirmationPageMock.mockReturnValue({
+      type: 'MockAction',
+    } as unknown as ReturnType<typeof addTransactionAndRouteToConfirmationPageMock>);
+
+    useConfirmationNavigationMock.mockReturnValue({
+      confirmations: [],
+      navigateToId: jest.fn(),
+    } as unknown as ReturnType<typeof useConfirmationNavigationMock>);
+
+    useDispatchMock.mockReturnValue(jest.fn());
+  });
+
+  describe('isUpgraded', () => {
+    it('returns true if account has code', async () => {
+      getCodeMock.mockResolvedValue(CODE_MOCK);
+      const result = await runHook().isUpgraded(ADDRESS_MOCK);
+      expect(result).toBe(true);
+    });
+
+    // @ts-expect-error This function is missing from the Mocha type definitions
+    it.each([undefined, '', '0x'])(
+      'returns false if code is %s',
+      async (code: string) => {
+        getCodeMock.mockResolvedValue(code);
+        const result = await runHook().isUpgraded(ADDRESS_MOCK);
+        expect(result).toBe(false);
+      },
+    );
+  });
+
+  describe('downgradeAccount', () => {
+    it('adds transaction', async () => {
+      const { downgradeAccount } = runHook();
+
+      await downgradeAccount(ADDRESS_MOCK);
+
+      expect(addTransactionAndRouteToConfirmationPageMock).toHaveBeenCalledWith(
+        {
+          authorizationList: [
+            {
+              address: EIP_7702_REVOKE_ADDRESS,
+            },
+          ],
+          from: ADDRESS_MOCK,
+          to: ADDRESS_MOCK,
+          type: TransactionEnvelopeType.setCode,
+        },
+      );
+    });
+
+    it('navigates to confirmation', async () => {
+      const navigateToIdMock = jest.fn();
+
+      useConfirmationNavigationMock.mockReturnValue({
+        confirmations: [{ id: TRANSACTION_ID_MOCK }],
+        navigateToId: navigateToIdMock,
+      } as unknown as ReturnType<typeof useConfirmationNavigationMock>);
+
+      useDispatchMock.mockReturnValue(
+        jest.fn().mockResolvedValue({
+          id: TRANSACTION_ID_MOCK,
+        }),
+      );
+
+      const { downgradeAccount } = runHook();
+
+      await act(async () => {
+        await downgradeAccount(ADDRESS_MOCK);
+      });
+
+      expect(navigateToIdMock).toHaveBeenCalledTimes(1);
+      expect(navigateToIdMock).toHaveBeenCalledWith(TRANSACTION_ID_MOCK);
+    });
+
+    it('calls onRedirect', async () => {
+      const onRedirect = jest.fn();
+
+      useConfirmationNavigationMock.mockReturnValue({
+        confirmations: [{ id: TRANSACTION_ID_MOCK }],
+        navigateToId: jest.fn(),
+      } as unknown as ReturnType<typeof useConfirmationNavigationMock>);
+
+      useDispatchMock.mockReturnValue(
+        jest.fn().mockResolvedValue({
+          id: TRANSACTION_ID_MOCK,
+        }),
+      );
+
+      const { downgradeAccount } = runHook({ onRedirect });
+
+      await act(async () => {
+        await downgradeAccount(ADDRESS_MOCK);
+      });
+
+      expect(onRedirect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/ui/pages/confirmations/hooks/useEIP7702Account.test.ts
+++ b/ui/pages/confirmations/hooks/useEIP7702Account.test.ts
@@ -1,5 +1,8 @@
 import { act } from '@testing-library/react';
-import { TransactionEnvelopeType } from '@metamask/transaction-controller';
+import {
+  TransactionEnvelopeType,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { useDispatch } from 'react-redux';
 import {
   addTransactionAndRouteToConfirmationPage,
@@ -97,6 +100,9 @@ describe('useEIP7702Account', () => {
           from: ADDRESS_MOCK,
           to: ADDRESS_MOCK,
           type: TransactionEnvelopeType.setCode,
+        },
+        {
+          type: TransactionType.revokeDelegation,
         },
       );
     });

--- a/ui/pages/confirmations/hooks/useEIP7702Account.test.ts
+++ b/ui/pages/confirmations/hooks/useEIP7702Account.test.ts
@@ -1,22 +1,16 @@
-import { renderHook } from '@testing-library/react-hooks';
-import { genUnapprovedContractInteractionConfirmation } from '../../../../test/data/confirmations/contract-interaction';
-import { getMockConfirmStateForTransaction } from '../../../../test/data/confirmations/helper';
-import {
-  EIP_7702_REVOKE_ADDRESS,
-  useEIP7702Account,
-} from './useEIP7702Account';
+import { act } from '@testing-library/react';
+import { TransactionEnvelopeType } from '@metamask/transaction-controller';
+import { useDispatch } from 'react-redux';
 import {
   addTransactionAndRouteToConfirmationPage,
   getCode,
 } from '../../../store/actions';
-import { act } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers';
-import { TransactionEnvelopeType } from '@metamask/transaction-controller';
-import { ThunkAction } from 'redux-thunk';
 import { useConfirmationNavigation } from './useConfirmationNavigation';
-import { ApprovalRequest } from '@metamask/approval-controller';
-import { flushPromises } from '../../../../test/lib/timer-helpers';
-import { useDispatch } from 'react-redux';
+import {
+  EIP_7702_REVOKE_ADDRESS,
+  useEIP7702Account,
+} from './useEIP7702Account';
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),

--- a/ui/pages/confirmations/hooks/useEIP7702Account.ts
+++ b/ui/pages/confirmations/hooks/useEIP7702Account.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  addTransactionAndRouteToConfirmationPage,
+  getCode,
+} from '../../../store/actions';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  TransactionEnvelopeType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import { useConfirmationNavigation } from './useConfirmationNavigation';
+import { getSelectedNetworkClientId } from '../../../../shared/modules/selectors/networks';
+import { Hex } from '@metamask/utils';
+
+export const EIP_7702_REVOKE_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+export function useEIP7702Account({
+  onRedirect,
+}: { onRedirect?: () => void } = {}) {
+  const dispatch = useDispatch();
+  const [transactionId, setTransactionId] = useState<string | undefined>();
+  const { confirmations, navigateToId } = useConfirmationNavigation();
+  const globalNetworkClientId = useSelector(getSelectedNetworkClientId);
+
+  const isRedirectPending = confirmations.some(
+    (conf) => conf.id === transactionId,
+  );
+
+  const downgradeAccount = useCallback(
+    async (address: Hex) => {
+      const transactionMeta = (await dispatch(
+        addTransactionAndRouteToConfirmationPage({
+          authorizationList: [
+            {
+              address: EIP_7702_REVOKE_ADDRESS,
+            },
+          ],
+          from: address,
+          to: address,
+          type: TransactionEnvelopeType.setCode,
+        }),
+      )) as unknown as TransactionMeta;
+
+      setTransactionId(transactionMeta?.id);
+    },
+    [dispatch],
+  );
+
+  const isUpgraded = useCallback(
+    async (address: Hex) => {
+      const code = await getCode(address, globalNetworkClientId);
+      return code?.length > 2;
+    },
+    [globalNetworkClientId],
+  );
+
+  useEffect(() => {
+    if (isRedirectPending) {
+      navigateToId(transactionId);
+      onRedirect?.();
+    }
+  }, [isRedirectPending, navigateToId, transactionId, onRedirect]);
+
+  return { isUpgraded, downgradeAccount };
+}

--- a/ui/pages/confirmations/hooks/useEIP7702Account.ts
+++ b/ui/pages/confirmations/hooks/useEIP7702Account.ts
@@ -12,7 +12,8 @@ import { useConfirmationNavigation } from './useConfirmationNavigation';
 import { getSelectedNetworkClientId } from '../../../../shared/modules/selectors/networks';
 import { Hex } from '@metamask/utils';
 
-export const EIP_7702_REVOKE_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const EIP_7702_REVOKE_ADDRESS =
+  '0x0000000000000000000000000000000000000000';
 
 export function useEIP7702Account({
   onRedirect,

--- a/ui/pages/confirmations/hooks/useEIP7702Account.ts
+++ b/ui/pages/confirmations/hooks/useEIP7702Account.ts
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   TransactionEnvelopeType,
   TransactionMeta,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import { useConfirmationNavigation } from './useConfirmationNavigation';
 import { getSelectedNetworkClientId } from '../../../../shared/modules/selectors/networks';
@@ -30,16 +31,21 @@ export function useEIP7702Account({
   const downgradeAccount = useCallback(
     async (address: Hex) => {
       const transactionMeta = (await dispatch(
-        addTransactionAndRouteToConfirmationPage({
-          authorizationList: [
-            {
-              address: EIP_7702_REVOKE_ADDRESS,
-            },
-          ],
-          from: address,
-          to: address,
-          type: TransactionEnvelopeType.setCode,
-        }),
+        addTransactionAndRouteToConfirmationPage(
+          {
+            authorizationList: [
+              {
+                address: EIP_7702_REVOKE_ADDRESS,
+              },
+            ],
+            from: address,
+            to: address,
+            type: TransactionEnvelopeType.setCode,
+          },
+          {
+            type: TransactionType.revokeDelegation,
+          },
+        ),
       )) as unknown as TransactionMeta;
 
       setTransactionId(transactionMeta?.id);

--- a/ui/pages/confirmations/hooks/useEIP7702Account.ts
+++ b/ui/pages/confirmations/hooks/useEIP7702Account.ts
@@ -1,17 +1,17 @@
 import { useCallback, useEffect, useState } from 'react';
-import {
-  addTransactionAndRouteToConfirmationPage,
-  getCode,
-} from '../../../store/actions';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   TransactionEnvelopeType,
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { useConfirmationNavigation } from './useConfirmationNavigation';
-import { getSelectedNetworkClientId } from '../../../../shared/modules/selectors/networks';
 import { Hex } from '@metamask/utils';
+import {
+  addTransactionAndRouteToConfirmationPage,
+  getCode,
+} from '../../../store/actions';
+import { getSelectedNetworkClientId } from '../../../../shared/modules/selectors/networks';
+import { useConfirmationNavigation } from './useConfirmationNavigation';
 
 export const EIP_7702_REVOKE_ADDRESS =
   '0x0000000000000000000000000000000000000000';

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6084,3 +6084,10 @@ export async function disableAccountUpgradeForChain(chainId: string) {
     chainId,
   ]);
 }
+
+export async function getCode(address: Hex, networkClientId: string) {
+  return await submitRequestToBackground<string>('getCode', [
+    address,
+    networkClientId,
+  ]);
+}


### PR DESCRIPTION
## **Description**

Add an EIP-7702 revoke flow to downgrade the user's EOA to a standard account.

Specifically:

- Add `getCode` action and associated background API.
- Support `TransactionType.revokeDelegation` in confirmations including custom title and description.
- Add account type pill to `AccountDetailsDisplay`.
- Add revoke button to `AccountDetailsDisplay`.
- Add `useIsDowngradeTransaction` hook to identify if transaction will revoke delegation.
- Add `useEIP7702Account` hook to identify if account is upgraded, and trigger revert transaction.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/30969?quickstart=1)

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="351" alt="Account Details" src="https://github.com/user-attachments/assets/732d3068-4413-4895-be81-9ac37649c20d" />

<img width="352" alt="Confirmation" src="https://github.com/user-attachments/assets/10f92b29-219d-49b0-b10d-da175b662264" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
