### PR TITLE
fix: auth & user storage when switching srp with forgot password flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@metamask/post-message-stream": "^9.0.0",
     "@metamask/ppom-validator": "0.36.0",
     "@metamask/preinstalled-example-snap": "^0.3.0",
-    "@metamask/profile-sync-controller": "^10.0.0",
+    "@metamask/profile-sync-controller": "^10.1.0",
     "@metamask/providers": "^20.0.0",
     "@metamask/queued-request-controller": "^7.0.1",
     "@metamask/rate-limit-controller": "^6.0.3",

--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -5,6 +5,7 @@ import TextField from '../../ui/text-field';
 import { ButtonVariant, Button, Checkbox } from '../../component-library';
 import SrpInput from '../srp-input';
 import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
+import { useSignOut } from '../../../hooks/identity/useAuthentication';
 
 export default function CreateNewVault({
   disabled = false,
@@ -18,6 +19,8 @@ export default function CreateNewVault({
   const [passwordError, setPasswordError] = useState('');
   const [seedPhrase, setSeedPhrase] = useState('');
   const [termsChecked, setTermsChecked] = useState(false);
+
+  const { signOut } = useSignOut();
 
   const t = useI18nContext();
 
@@ -73,9 +76,10 @@ export default function CreateNewVault({
         return;
       }
 
+      await signOut();
       await onSubmit(password, seedPhrase);
     },
-    [isValid, onSubmit, password, seedPhrase],
+    [isValid, onSubmit, password, seedPhrase, signOut],
   );
 
   const toggleTermsCheck = useCallback(() => {

--- a/ui/components/app/create-new-vault/create-new-vault.test.js
+++ b/ui/components/app/create-new-vault/create-new-vault.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
@@ -13,6 +13,13 @@ const store = configureStore({
     ...mockState.metamask,
   },
 });
+
+const mockSignOut = jest.fn();
+jest.mock('../../../hooks/identity/useAuthentication', () => ({
+  useSignOut: () => ({
+    signOut: mockSignOut,
+  }),
+}));
 
 describe('CreateNewVault', () => {
   it('renders CreateNewVault component and shows Secret Recovery Phrase text', () => {
@@ -120,7 +127,7 @@ describe('CreateNewVault', () => {
     expect(submitButton).toBeDisabled();
   });
 
-  it('should valid', () => {
+  it('should sign out the user and submit successfully when password and confirm password match', () => {
     const props = {
       onSubmit: jest.fn(),
       submitText: 'Submit',
@@ -158,7 +165,10 @@ describe('CreateNewVault', () => {
 
     fireEvent.click(submitButton);
 
-    expect(props.onSubmit).toHaveBeenCalledWith(password, TEST_SEED);
+    waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalled();
+      expect(props.onSubmit).toHaveBeenCalledWith(password, TEST_SEED);
+    });
   });
 });
 

--- a/ui/pages/keychains/restore-vault.stories.tsx
+++ b/ui/pages/keychains/restore-vault.stories.tsx
@@ -8,6 +8,8 @@ const mockStore = configureStore([]);
 const store = mockStore({
   appState: {
     isLoading: false,
+    isSignedIn: true,
+    sessionData: undefined,
   },
 });
 

--- a/ui/pages/keychains/restore-vault.stories.tsx
+++ b/ui/pages/keychains/restore-vault.stories.tsx
@@ -8,9 +8,11 @@ const mockStore = configureStore([]);
 const store = mockStore({
   appState: {
     isLoading: false,
+  },
+  metamask: {
     isSignedIn: true,
     sessionData: undefined,
-  },
+  }
 });
 
 const meta: Meta<typeof RestoreVaultPage> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6108,9 +6108,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/profile-sync-controller@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@metamask/profile-sync-controller@npm:10.0.0"
+"@metamask/profile-sync-controller@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "@metamask/profile-sync-controller@npm:10.1.0"
   dependencies:
     "@metamask/base-controller": "npm:^8.0.0"
     "@metamask/keyring-api": "npm:^17.2.0"
@@ -6130,7 +6130,7 @@ __metadata:
     "@metamask/providers": ^18.1.0
     "@metamask/snaps-controllers": ^9.19.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/107f751488dafa3017a9cb75f808b27fc9864c25cdc6b7a50557f646982465c6812cbb09c00f62b01cc343c88d52ff5558378a23b2480df4ddb7589c72ee09a8
+  checksum: 10/09dfc1eb6a12c2e109b795f0b7dbd196fec5126996e7b39729f901802fbaf19fc41f1f8a7ff5ccb4f70d86a8e8e021667bbc4bcc3f8e593601376631e45419e1
   languageName: node
   linkType: hard
 
@@ -27369,7 +27369,7 @@ __metadata:
     "@metamask/ppom-validator": "npm:0.36.0"
     "@metamask/preferences-controller": "npm:^15.0.2"
     "@metamask/preinstalled-example-snap": "npm:^0.3.0"
-    "@metamask/profile-sync-controller": "npm:^10.0.0"
+    "@metamask/profile-sync-controller": "npm:^10.1.0"
     "@metamask/providers": "npm:^20.0.0"
     "@metamask/queued-request-controller": "npm:^7.0.1"
     "@metamask/rate-limit-controller": "npm:^6.0.3"


### PR DESCRIPTION
## **Description**

We found out some users were using the “forgot password” flow to switch from SRP X to SRP Y. Some users are blasting this functionality by sometimes doing it once every 1 or 2 minutes.
Changing from SRP X to SRP Y by doing the vault restore flow is currently not supported by auth & user storage. 

This PR fixes that.

More information can be found in [this document](https://www.notion.so/consensys/Post-mortem-vault-restore-flow-auth-user-storage-errors-discrepancies-1b5fc61a326e80aa8d95e61409c7d7a5?showMoveTo=true&saveParent=true)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31011?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/IDENTITY-60

## **Manual testing steps**

1. Import SRP 1
2. Finish onboarding
3. Lock wallet et click forgot password
4. Input SRP 2
5. Verify that there's a new call to `/login` in the network tab
6. Verify that account syncing works correctly
7. Verify that you can
    1. Turn off basic functionality
    2. Turn it back on
    3. Re-enable profile syncing successfuly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
