### PR TITLE
ci: log name of page when benchmarking

### DIFF
--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -33,6 +33,7 @@ async function measurePage(pageName) {
     {
       fixtures: new FixtureBuilder().build(),
       disableServerMochaToBackground: true,
+      title: `Profile page load of "${pageName}" page`,
     },
     async ({ driver }) => {
       await driver.delay(tinyDelayMs);


### PR DESCRIPTION
The `benchmark` CI job logged "undefined". This annoyed me. So I fixed it.

Before:
```
ChromeDriver was started successfully.

DevTools listening on ws://127.0.0.1:46589/devtools/browser/c1061c0a-ab0a-4389-9aaf-b445f668a840

Executing testcase: undefined


Success on testcase: undefined
```

After:
```
ChromeDriver was started successfully.

DevTools listening on ws://127.0.0.1:46589/devtools/browser/c1061c0a-ab0a-4389-9aaf-b445f668a840

Executing testcase: 'Profile page load of "home" page'


Success on testcase: 'Profile page load of "home" page'
```

<!--

## **Description**


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31012?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**

### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->