### PR TITLE
Add eslint-plugin-react-perf eslint package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ const tsconfig = ts.parseJsonConfigFileContent(config, ts.sys, './');
 module.exports = {
   root: true,
   // Suggested addition from the storybook 6.5 update
-  extends: ['plugin:storybook/recommended'],
+  extends: ['plugin:storybook/recommended', 'plugin:react-perf/recommended'],
   // Ignore files which are also in .prettierignore
   ignorePatterns: readFileSync('.prettierignore', 'utf8').trim().split('\n'),
   // eslint's parser, esprima, is not compatible with ESM, so use the babel parser instead

--- a/package.json
+++ b/package.json
@@ -555,6 +555,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-react-perf": "^3.3.3",
     "eslint-plugin-storybook": "^0.6.15",
     "eta": "^3.2.0",
     "ethers": "5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19126,6 +19126,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-react-perf@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "eslint-plugin-react-perf@npm:3.3.3"
+  peerDependencies:
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+  checksum: 10/fc3446aa785714a1d6d06a52c0e6a28ca41c498185f0d3d7154c312d3d8b74059cb5c6ece4b2babb5cc0b3ad350870c84c098122c30a4d70098b58b819da555f
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react@npm:^7.23.1":
   version: 7.30.1
   resolution: "eslint-plugin-react@npm:7.30.1"
@@ -27489,6 +27498,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-react: "npm:^7.23.1"
     eslint-plugin-react-hooks: "npm:^4.2.0"
+    eslint-plugin-react-perf: "npm:^3.3.3"
     eslint-plugin-storybook: "npm:^0.6.15"
     eta: "npm:^3.2.0"
     eth-chainlist: "npm:~0.0.498"


### PR DESCRIPTION
Adds the `eslint-plugin-react-perf` library as a linting rule.  First run....not great :/ 

<img width="369" alt="SCR-20250314-kewf" src="https://github.com/user-attachments/assets/8c3e171c-302d-4756-bb9d-d59395ce9c95" />

This should be a warning, not an error, before merge.

Unfortunately `lint:fix` doesn't fix the issues. FML.


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31014?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
