### PR TITLE
perf: reduce react-router-dom unstable matcher property 

### DIFF
--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { withRouter } from 'react-router-dom';
 import { tryReverseResolveAddress } from '../../../store/actions';
 
 import {
@@ -14,6 +13,7 @@ import {
   getInternalAccounts,
 } from '../../../selectors';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
+import withOptimisedRouter from '../../../helpers/higher-order-components/withOptimisedRouter';
 import TransactionListItemDetails from './transaction-list-item-details.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -62,6 +62,6 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(TransactionListItemDetails);

--- a/ui/helpers/higher-order-components/authenticated/authenticated.container.js
+++ b/ui/helpers/higher-order-components/authenticated/authenticated.container.js
@@ -1,4 +1,6 @@
 import { connect } from 'react-redux';
+import { compose } from 'redux';
+import withOptimisedRoute from '../withOptimisedRoute';
 import Authenticated from './authenticated.component';
 
 const mapStateToProps = (state) => {
@@ -12,4 +14,7 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default connect(mapStateToProps)(Authenticated);
+export default compose(
+  withOptimisedRoute,
+  connect(mapStateToProps),
+)(Authenticated);

--- a/ui/helpers/higher-order-components/withOptimisedRoute.tsx
+++ b/ui/helpers/higher-order-components/withOptimisedRoute.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { type ComponentType } from 'react';
+import { type RouterProps } from 'react-router-dom';
+
+/**
+ * The underlying react-router-dom <Switch> component injects a
+ * `computedMatch` property in each of the Route Children.
+ * This computedMatch is unstable and causes additional re-renders.
+ *
+ * Since none of the routes use this prop, we have removed it.
+ * @param WrappedComponent
+ * @returns
+ */
+const withOptimisedRoute = (WrappedComponent: ComponentType<RouterProps>) => {
+  return (props: RouterProps & { computedMatch: unknown }) => {
+    const { computedMatch, ...rest } = props;
+    return <WrappedComponent {...rest} />;
+  };
+};
+
+export default withOptimisedRoute;

--- a/ui/helpers/higher-order-components/withOptimisedRouter.tsx
+++ b/ui/helpers/higher-order-components/withOptimisedRouter.tsx
@@ -13,7 +13,7 @@ interface WithMemoizedMatchProps {
  * @param WrappedComponent
  * @returns WrappedComponent with routing props
  */
-const withOptimisedRouterProps = (
+const withOptimisedRouter = (
   WrappedComponent: ComponentType<WithMemoizedMatchProps>,
 ) => {
   return () => {
@@ -23,4 +23,4 @@ const withOptimisedRouterProps = (
   };
 };
 
-export default withOptimisedRouterProps;
+export default withOptimisedRouter;

--- a/ui/hooks/useSegmentContext.js
+++ b/ui/hooks/useSegmentContext.js
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
 import { PATH_NAME_MAP } from '../helpers/constants/routes';
@@ -25,22 +26,35 @@ export function useSegmentContext() {
   const txData = useSelector(txDataSelector) || {};
   const confirmTransactionOrigin = txData.origin;
 
-  const referrer = confirmTransactionOrigin
-    ? {
-        url: confirmTransactionOrigin,
-      }
-    : undefined;
+  const referrer = useMemo(
+    () =>
+      confirmTransactionOrigin
+        ? {
+            url: confirmTransactionOrigin,
+          }
+        : undefined,
+    [confirmTransactionOrigin],
+  );
 
-  const page = match
-    ? {
-        path: match.path,
-        title: PATH_NAME_MAP[match.path],
-        url: match.path,
-      }
-    : undefined;
+  const page = useMemo(
+    () =>
+      match?.path
+        ? {
+            path: match.path,
+            title: PATH_NAME_MAP[match.path],
+            url: match.path,
+          }
+        : undefined,
+    [match?.path],
+  );
 
-  return {
-    page,
-    referrer,
-  };
+  const returnResult = useMemo(
+    () => ({
+      page,
+      referrer,
+    }),
+    [page, referrer],
+  );
+
+  return returnResult;
 }

--- a/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.container.js
+++ b/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.container.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { withRouter } from 'react-router-dom';
 
 import {
   goHome,
@@ -16,6 +15,7 @@ import {
 import { clearConfirmTransaction } from '../../ducks/confirm-transaction/confirm-transaction.duck';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { getNativeCurrency } from '../../ducks/metamask/metamask';
+import withOptimisedRouter from '../../helpers/higher-order-components/withOptimisedRouter';
 import ConfirmEncryptionPublicKey from './confirm-encryption-public-key.component';
 
 function mapStateToProps(state, ownProps) {
@@ -66,6 +66,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(ConfirmEncryptionPublicKey);

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -1,6 +1,5 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 
 import {
   activeTabHasPermissions,
@@ -70,6 +69,7 @@ import {
   AlertTypes,
   Web3ShimUsageAlertStates,
 } from '../../../shared/constants/alerts';
+import withOptimisedRouter from '../../helpers/higher-order-components/withOptimisedRouter';
 import Home from './home.component';
 
 const mapStateToProps = (state) => {
@@ -226,6 +226,6 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(Home);

--- a/ui/pages/lock/lock.container.js
+++ b/ui/pages/lock/lock.container.js
@@ -1,7 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { lockMetamask } from '../../store/actions';
+import withOptimisedRouter from '../../helpers/higher-order-components/withOptimisedRouter';
 import Lock from './lock.component';
 
 const mapStateToProps = (state) => {
@@ -21,6 +21,6 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(Lock);

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { Component, Suspense } from 'react';
+import React, { PureComponent, Suspense } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import IdleTimer from 'react-idle-timer';
 
@@ -135,7 +135,7 @@ const ReviewPermissions = mmLazy(() =>
 const Home = mmLazy(() => import('../home'));
 // End Lazy Routes
 
-export default class Routes extends Component {
+export default class Routes extends PureComponent {
   static propTypes = {
     currentCurrency: PropTypes.string,
     activeTabOrigin: PropTypes.string,

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -163,7 +163,7 @@ export default class Routes extends Component {
     isAccountMenuOpen: PropTypes.bool,
     toggleAccountMenu: PropTypes.func,
     isNetworkMenuOpen: PropTypes.bool,
-    toggleNetworkMenu: PropTypes.func,
+    networkMenuClose: PropTypes.func,
     accountDetailsAddress: PropTypes.string,
     isImportNftsModalOpen: PropTypes.bool.isRequired,
     hideImportNftsModal: PropTypes.func.isRequired,
@@ -179,7 +179,6 @@ export default class Routes extends Component {
     automaticallySwitchNetwork: PropTypes.func.isRequired,
     totalUnapprovedConfirmationCount: PropTypes.number.isRequired,
     currentExtensionPopupId: PropTypes.number,
-    clearEditedNetwork: PropTypes.func.isRequired,
     oldestPendingApproval: PropTypes.object,
     pendingApprovals: PropTypes.arrayOf(PropTypes.object).isRequired,
     transactionsMetadata: PropTypes.object.isRequired,
@@ -387,7 +386,6 @@ export default class Routes extends Component {
       isAccountMenuOpen,
       toggleAccountMenu,
       isNetworkMenuOpen,
-      toggleNetworkMenu,
       accountDetailsAddress,
       isImportTokensModalOpen,
       isDeprecatedNetworkModalOpen,
@@ -400,7 +398,7 @@ export default class Routes extends Component {
       hideImportTokensModal,
       hideDeprecatedNetworkModal,
       clearSwitchedNetworkDetails,
-      clearEditedNetwork,
+      networkMenuClose,
       privacyMode,
       oldestPendingApproval,
       pendingApprovals,
@@ -468,11 +466,10 @@ export default class Routes extends Component {
           [`browser-${browser}`]: browser,
         })}
         dir={textDirection}
-        onMouseUp={
-          getShowAutoNetworkSwitchTest(this.props)
-            ? () => clearSwitchedNetworkDetails()
-            : undefined
-        }
+        onMouseUp={getShowAutoNetworkSwitchTest(
+          this.props,
+          clearSwitchedNetworkDetails,
+        )}
       >
         {shouldShowNetworkDeprecationWarning ? <DeprecatedNetworks /> : null}
         <QRHardwarePopover />
@@ -483,44 +480,35 @@ export default class Routes extends Component {
         {showOnboardingHeader(location) && <OnboardingAppHeader />}
         {isAccountMenuOpen ? (
           <AccountListMenu
-            onClose={() => toggleAccountMenu()}
+            onClose={toggleAccountMenu}
             privacyMode={privacyMode}
           />
         ) : null}
         {isNetworkMenuOpen ? (
-          <NetworkListMenu
-            onClose={() => {
-              toggleNetworkMenu();
-              clearEditedNetwork();
-            }}
-          />
+          <NetworkListMenu onClose={networkMenuClose} />
         ) : null}
         <NetworkConfirmationPopover />
         {accountDetailsAddress ? (
           <AccountDetails address={accountDetailsAddress} />
         ) : null}
         {isImportNftsModalOpen ? (
-          <ImportNftsModal onClose={() => hideImportNftsModal()} />
+          <ImportNftsModal onClose={hideImportNftsModal} />
         ) : null}
 
-        {isIpfsModalOpen ? (
-          <ToggleIpfsModal onClose={() => hideIpfsModal()} />
-        ) : null}
+        {isIpfsModalOpen ? <ToggleIpfsModal onClose={hideIpfsModal} /> : null}
         {isBasicConfigurationModalOpen ? <BasicConfigurationModal /> : null}
         {isImportTokensModalOpen ? (
-          <ImportTokensModal onClose={() => hideImportTokensModal()} />
+          <ImportTokensModal onClose={hideImportTokensModal} />
         ) : null}
         {isDeprecatedNetworkModalOpen ? (
-          <DeprecatedNetworkModal
-            onClose={() => hideDeprecatedNetworkModal()}
-          />
+          <DeprecatedNetworkModal onClose={hideDeprecatedNetworkModal} />
         ) : null}
         {
           ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
           isShowKeyringSnapRemovalResultModal && (
             <KeyringSnapRemovalResult
               isOpen={isShowKeyringSnapRemovalResultModal}
-              onClose={() => hideShowKeyringSnapRemovalResultModal()}
+              onClose={hideShowKeyringSnapRemovalResultModal}
             />
           )
           ///: END:ONLY_INCLUDE_IF
@@ -540,6 +528,11 @@ export default class Routes extends Component {
 }
 
 // Will eventually delete this function
-function getShowAutoNetworkSwitchTest(props) {
-  return props.switchedNetworkDetails && !props.switchedNetworkNeverShowMessage;
+function getShowAutoNetworkSwitchTest(props, clearSwitchedNetworkDetails) {
+  const clearDetails =
+    props.switchedNetworkDetails && !props.switchedNetworkNeverShowMessage;
+  if (clearDetails) {
+    clearSwitchedNetworkDetails();
+  }
+  return undefined;
 }

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -146,7 +146,10 @@ function mapDispatchToProps(dispatch) {
     clearSwitchedNetworkDetails: () => dispatch(clearSwitchedNetworkDetails()),
     automaticallySwitchNetwork: (networkId, selectedTabOrigin) =>
       dispatch(automaticallySwitchNetwork(networkId, selectedTabOrigin)),
-    clearEditedNetwork: () => dispatch(setEditedNetwork()),
+    networkMenuClose: () => {
+      dispatch(toggleNetworkMenu());
+      dispatch(setEditedNetwork());
+    },
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     hideShowKeyringSnapRemovalResultModal: () =>
       dispatch(hideKeyringRemovalResultModal()),

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 import {
   getCurrentChainId,
@@ -52,6 +51,7 @@ import { getIsUnlocked } from '../../ducks/metamask/metamask';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../shared/constants/preferences';
 import { selectSwitchedNetworkNeverShowMessage } from '../../components/app/toast-master/selectors';
 import Routes from './routes.component';
+import withOptimisedRouterProps from './withOptimisedRouterProps';
 
 function mapStateToProps(state) {
   const { activeTab, appState } = state;
@@ -158,6 +158,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default compose(
-  withRouter,
+  withOptimisedRouterProps,
   connect(mapStateToProps, mapDispatchToProps),
 )(Routes);

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -50,8 +50,8 @@ import { getSendStage } from '../../ducks/send';
 import { getIsUnlocked } from '../../ducks/metamask/metamask';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../shared/constants/preferences';
 import { selectSwitchedNetworkNeverShowMessage } from '../../components/app/toast-master/selectors';
+import withOptimisedRouter from '../../helpers/higher-order-components/withOptimisedRouter';
 import Routes from './routes.component';
-import withOptimisedRouterProps from './withOptimisedRouterProps';
 
 function mapStateToProps(state) {
   const { activeTab, appState } = state;
@@ -158,6 +158,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default compose(
-  withOptimisedRouterProps,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(Routes);

--- a/ui/pages/routes/withOptimisedRouterProps.tsx
+++ b/ui/pages/routes/withOptimisedRouterProps.tsx
@@ -1,0 +1,26 @@
+import React, { ComponentType } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+interface WithMemoizedMatchProps {
+  history: unknown;
+  location: unknown;
+}
+
+/**
+ * This is similar to react-router-dom's `withRouter`, but drops the `match` property
+ * as it is a constantly changing prop.
+ *
+ * @param WrappedComponent
+ * @returns WrappedComponent with routing props
+ */
+const withOptimisedRouterProps = (
+  WrappedComponent: ComponentType<WithMemoizedMatchProps>,
+) => {
+  return () => {
+    const history = useHistory();
+    const location = useLocation();
+    return <WrappedComponent history={history} location={location} />;
+  };
+};
+
+export default withOptimisedRouterProps;

--- a/ui/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../../shared/constants/preferences';
 import { getPreferences } from '../../../selectors';
@@ -20,6 +19,7 @@ import {
   displayErrorInSettings,
   hideErrorInSettings,
 } from '../../../ducks/app/app';
+import withOptimisedRouter from '../../../helpers/higher-order-components/withOptimisedRouter';
 import AdvancedTab from './advanced-tab.component';
 
 export const mapStateToProps = (state) => {
@@ -87,6 +87,6 @@ export const mapDispatchToProps = (dispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(AdvancedTab);

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
@@ -1,6 +1,5 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import {
   addToAddressBook,
   showQrScanner,
@@ -13,6 +12,7 @@ import {
   resetDomainResolution,
 } from '../../../../ducks/domains';
 import { getAddressBook, getInternalAccounts } from '../../../../selectors';
+import withOptimisedRouter from '../../../../helpers/higher-order-components/withOptimisedRouter';
 import AddContact from './add-contact.component';
 
 const mapStateToProps = (state) => {
@@ -36,6 +36,6 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(AddContact);

--- a/ui/pages/settings/contact-list-tab/contact-list-tab.container.js
+++ b/ui/pages/settings/contact-list-tab/contact-list-tab.container.js
@@ -1,6 +1,5 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { getAddressBook, getInternalAccounts } from '../../../selectors';
 
 import {
@@ -8,6 +7,7 @@ import {
   CONTACT_EDIT_ROUTE,
   CONTACT_VIEW_ROUTE,
 } from '../../../helpers/constants/routes';
+import withOptimisedRouter from '../../../helpers/higher-order-components/withOptimisedRouter';
 import ContactListTab from './contact-list-tab.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -35,4 +35,7 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-export default compose(withRouter, connect(mapStateToProps))(ContactListTab);
+export default compose(
+  withOptimisedRouter,
+  connect(mapStateToProps),
+)(ContactListTab);

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
@@ -1,6 +1,5 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import {
   getAddressBook,
   getAddressBookEntry,
@@ -16,6 +15,7 @@ import {
   addToAddressBook,
   removeFromAddressBook,
 } from '../../../../store/actions';
+import withOptimisedRouter from '../../../../helpers/higher-order-components/withOptimisedRouter';
 import EditContact from './edit-contact.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -56,6 +56,6 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(EditContact);

--- a/ui/pages/settings/contact-list-tab/view-contact/view-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/view-contact/view-contact.container.js
@@ -1,6 +1,5 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import {
   getAddressBookEntry,
   getInternalAccountByAddress,
@@ -10,6 +9,7 @@ import {
   CONTACT_LIST_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { toChecksumHexAddress } from '../../../../../shared/modules/hexstring-utils';
+import withOptimisedRouter from '../../../../helpers/higher-order-components/withOptimisedRouter';
 import ViewContact from './view-contact.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -37,4 +37,7 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-export default compose(withRouter, connect(mapStateToProps))(ViewContact);
+export default compose(
+  withOptimisedRouter,
+  connect(mapStateToProps),
+)(ViewContact);

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.ts
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.ts
@@ -1,6 +1,5 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import {
   ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   setBitcoinSupportEnabled,
@@ -29,6 +28,7 @@ import type {
   MetaMaskReduxDispatch,
   MetaMaskReduxState,
 } from '../../../store/store';
+import withOptimisedRouter from '../../../helpers/higher-order-components/withOptimisedRouter';
 import ExperimentalTab from './experimental-tab.component';
 
 const mapStateToProps = (state: MetaMaskReduxState) => {
@@ -72,6 +72,6 @@ const mapDispatchToProps = (dispatch: MetaMaskReduxDispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(ExperimentalTab);

--- a/ui/pages/settings/security-tab/security-tab.container.js
+++ b/ui/pages/settings/security-tab/security-tab.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 import {
   setIncomingTransactionsPreferences,
@@ -29,6 +28,7 @@ import {
 } from '../../../selectors/selectors';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/selectors/networks';
 import { openBasicFunctionalityModal } from '../../../ducks/app/app';
+import withOptimisedRouter from '../../../helpers/higher-order-components/withOptimisedRouter';
 import SecurityTab from './security-tab.component';
 
 const mapStateToProps = (state) => {
@@ -123,6 +123,6 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(SecurityTab);

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -1,6 +1,5 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import {
   getAddressBookEntryOrAccountName,
   getSettingsPageSnapsIds,
@@ -39,6 +38,7 @@ import { getProviderConfig } from '../../../shared/modules/selectors/networks';
 import { toggleNetworkMenu } from '../../store/actions';
 import { getSnapName } from '../../helpers/utils/util';
 import { decodeSnapIdFromPathname } from '../../helpers/utils/snaps';
+import withOptimisedRouter from '../../helpers/higher-order-components/withOptimisedRouter';
 import Settings from './settings.component';
 
 const ROUTES_TO_I18N_KEYS = {
@@ -143,6 +143,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps),
 )(Settings);

--- a/ui/pages/unlock-page/unlock-page.container.js
+++ b/ui/pages/unlock-page/unlock-page.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
@@ -14,6 +13,7 @@ import {
   markPasswordForgotten,
   forceUpdateMetamaskState,
 } from '../../store/actions';
+import withOptimisedRouter from '../../helpers/higher-order-components/withOptimisedRouter';
 import UnlockPage from './unlock-page.component';
 
 const mapStateToProps = (state) => {
@@ -68,6 +68,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 };
 
 export default compose(
-  withRouter,
+  withOptimisedRouter,
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
 )(UnlockPage);

--- a/ui/selectors/approvals.ts
+++ b/ui/selectors/approvals.ts
@@ -54,9 +54,10 @@ export function getApprovalFlows(state: ApprovalsMetaMaskState) {
   return state.metamask.approvalFlows;
 }
 
-export function getPendingApprovals(state: ApprovalsMetaMaskState) {
-  return Object.values(state.metamask.pendingApprovals ?? {});
-}
+export const getPendingApprovals = createSelector(
+  (state: ApprovalsMetaMaskState) => state.metamask.pendingApprovals,
+  (pendingApprovals) => Object.values(pendingApprovals ?? {}),
+);
 
 export function pendingApprovalsSortedSelector(state: ApprovalsMetaMaskState) {
   return getPendingApprovals(state).sort((a1, a2) => a1.time - a2.time);


### PR DESCRIPTION
## **Description**

The `matcher` property in React Router DOM is unstable and causes both our `<Routes>` component and the `trackEvent()` function to constantly re-render.

We have optimised both instances which have reduced some component render cycles.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31024?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
