### PR TITLE
feat: reject pending confirmations for origin when permissions are revoked for it

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.test.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.test.ts
@@ -21,6 +21,7 @@ const createMockedHandler = () => {
   const next = jest.fn();
   const end = jest.fn();
   const revokePermissionsForOrigin = jest.fn();
+  const rejectApprovalRequestsForOrigin = jest.fn();
 
   const response: PendingJsonRpcResponse<Json> = {
     jsonrpc: '2.0' as const,
@@ -29,6 +30,7 @@ const createMockedHandler = () => {
   const handler = (request: JsonRpcRequest<Json[]>) =>
     revokePermissionsHandler.implementation(request, response, next, end, {
       revokePermissionsForOrigin,
+      rejectApprovalRequestsForOrigin,
     });
 
   return {
@@ -36,6 +38,7 @@ const createMockedHandler = () => {
     next,
     end,
     revokePermissionsForOrigin,
+    rejectApprovalRequestsForOrigin,
     handler,
   };
 };
@@ -139,6 +142,21 @@ describe('revokePermissionsHandler', () => {
     expect(revokePermissionsForOrigin).toHaveBeenCalledWith([
       'otherPermission',
     ]);
+  });
+
+  it('calls function rejectApprovalRequestsForOrigin to reject pending confirmations', () => {
+    const { handler, rejectApprovalRequestsForOrigin } = createMockedHandler();
+
+    handler({
+      ...baseRequest,
+      params: [
+        {
+          [Caip25EndowmentPermissionName]: {},
+          otherPermission: {},
+        },
+      ],
+    });
+    expect(rejectApprovalRequestsForOrigin).toHaveBeenCalled();
   });
 
   it('returns null', () => {

--- a/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.ts
@@ -18,6 +18,7 @@ export const revokePermissionsHandler = {
   implementation: revokePermissionsImplementation,
   hookNames: {
     revokePermissionsForOrigin: true,
+    rejectApprovalRequestsForOrigin: true,
     updateCaveat: true,
   },
 };
@@ -31,6 +32,7 @@ export const revokePermissionsHandler = {
  * @param end - JsonRpcEngine end() callback
  * @param options - Method hooks passed to the method implementation
  * @param options.revokePermissionsForOrigin - A hook that revokes given permission keys for an origin
+ * @param options.rejectApprovalRequestsForOrigin - A hook that rejects pending confirmation for an origin
  * @returns A promise that resolves to nothing
  */
 function revokePermissionsImplementation(
@@ -40,8 +42,10 @@ function revokePermissionsImplementation(
   end: JsonRpcEngineEndCallback,
   {
     revokePermissionsForOrigin,
+    rejectApprovalRequestsForOrigin,
   }: {
     revokePermissionsForOrigin: (permissionKeys: string[]) => void;
+    rejectApprovalRequestsForOrigin: () => void;
   },
 ) {
   const { params } = req;
@@ -78,6 +82,7 @@ function revokePermissionsImplementation(
   }
 
   revokePermissionsForOrigin(relevantPermissionKeys);
+  rejectApprovalRequestsForOrigin();
 
   res.result = null;
 


### PR DESCRIPTION
## **Description**

reject pending confirmations for origin when permissions are revoked for it

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4443

## **Manual testing steps**

1. Enable EVM multichain locally
2. Go to test dapp and create a confirmation
3. Revoke permissions, check that pending confirmation is rejected

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/bd9c1993-20df-4c1e-91b9-1378e8c09562

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
