### PR TITLE
fix: NFT full page stretched image; remove badgeWrapperClassname prop

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-full-image.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-full-image.test.js.snap
@@ -41,7 +41,7 @@ exports[`NFT full image should match snapshot 1`] = `
           class="mm-box multichain-page-content fade-in visible mm-box--padding-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--width-full mm-box--height-full"
         >
           <div
-            class="mm-box mm-box--padding-top-4 mm-box--display-flex mm-box--justify-content-center"
+            class="mm-box mm-box--padding-bottom-12 mm-box--display-flex mm-box--justify-content-center"
           >
             <div
               class="mm-box"
@@ -54,7 +54,7 @@ exports[`NFT full image should match snapshot 1`] = `
                   data-testid="nft-item"
                 >
                   <div
-                    class="mm-box mm-badge-wrapper nft-item__badge-wrapper badge-wrapper mm-box--display-block"
+                    class="mm-box mm-badge-wrapper nft-item__badge-wrapper mm-box--display-block"
                   >
                     <div
                       class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"

--- a/ui/components/app/assets/nfts/nft-details/index.scss
+++ b/ui/components/app/assets/nfts/nft-details/index.scss
@@ -27,10 +27,6 @@ $spacer-break-small: 16px;
   }
 }
 
-.badge-wrapper {
-  height: 70vh;
-}
-
 .fade-in {
   opacity: 0;
   transition: opacity 0.3s ease;

--- a/ui/components/app/assets/nfts/nft-details/nft-full-image.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-full-image.tsx
@@ -75,7 +75,7 @@ export default function NftFullImage() {
           <Box
             display={Display.Flex}
             justifyContent={JustifyContent.center}
-            paddingTop={4}
+            paddingBottom={12}
           >
             <Box>
               <NftItem
@@ -86,7 +86,6 @@ export default function NftFullImage() {
                 networkName={currentChain.nickname ?? ''}
                 networkSrc={currentChain.rpcPrefs?.imageUrl}
                 isIpfsURL={isIpfsURL}
-                badgeWrapperClassname="badge-wrapper"
               />
             </Box>
           </Box>

--- a/ui/components/multichain/nft-item/nft-item.tsx
+++ b/ui/components/multichain/nft-item/nft-item.tsx
@@ -41,7 +41,6 @@ type NftItemProps = {
   detailView?: boolean;
   clickable?: boolean;
   privacyMode?: boolean;
-  badgeWrapperClassname?: string;
 };
 
 export const NftItem = ({
@@ -55,7 +54,6 @@ export const NftItem = ({
   clickable,
   privacyMode,
   isIpfsURL,
-  badgeWrapperClassname = '',
 }: NftItemProps) => {
   const testNetworkBackgroundColor = useSelector(getTestNetworkBackgroundColor);
   const isIpfsEnabled = useSelector(getIpfsGateway);
@@ -114,13 +112,9 @@ export const NftItem = ({
         onClick={onClick}
       >
         <BadgeWrapper
-          className={classnames(
-            'nft-item__badge-wrapper',
-            badgeWrapperClassname,
-            {
-              'nft-item__badge-wrapper__clickable': Boolean(clickable),
-            },
-          )}
+          className={classnames('nft-item__badge-wrapper', {
+            'nft-item__badge-wrapper__clickable': Boolean(clickable),
+          })}
           anchorElementShape={BadgeWrapperAnchorElementShape.circular}
           positionObj={{ top: -4, right: -4 }}
           display={Display.Block}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes stretched NFT background in NFT Full Image page. Includes:
- Removes fixed height 70vh
- Removes badgeWrapperClassname prop

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31082?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/31081

## **Manual testing steps**

1. Go to NFT tab
2. Click on NFT
3. Click on NFT Image to expand full screen
4. Observe image


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![CleanShot 2025-03-18 at 11 13 12@2x](https://github.com/user-attachments/assets/786fe58d-e18e-4928-8c32-76264333b968)

### **After**

(Note padding bottom to container will be added in https://github.com/MetaMask/metamask-extension/pull/31058)

![CleanShot 2025-03-18 at 11 08 36@2x](https://github.com/user-attachments/assets/3a7776e7-ddf6-41aa-ac21-df3dd8235968)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
