### PR TITLE
fix: Disable CSP override feature that is breaking sites

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -47,8 +47,6 @@ import {
   FakeTrezorBridge,
 } from '../../test/stub/keyring-bridge';
 import { getCurrentChainId } from '../../shared/modules/selectors/networks';
-import { addNonceToCsp } from '../../shared/modules/add-nonce-to-csp';
-import { checkURLForProviderInjection } from '../../shared/modules/provider-injection';
 import { PersistenceManager } from './lib/stores/persistence-manager';
 import ExtensionStore from './lib/stores/extension-store';
 import ReadOnlyNetworkStore from './lib/stores/read-only-network-store';
@@ -356,40 +354,6 @@ function maybeDetectPhishing(theController) {
   );
 }
 
-/**
- * Overrides the Content-Security-Policy (CSP) header by adding a nonce to the `script-src` directive.
- * This is a workaround for [Bug #1446231](https://bugzilla.mozilla.org/show_bug.cgi?id=1446231),
- * which involves overriding the page CSP for inline script nodes injected by extension content scripts.
- */
-function overrideContentSecurityPolicyHeader() {
-  // The extension url is unique per install on Firefox, so we can safely add it as a nonce to the CSP header
-  const nonce = btoa(browser.runtime.getURL('/'));
-  browser.webRequest.onHeadersReceived.addListener(
-    ({ responseHeaders, url }) => {
-      // Check whether inpage.js is going to be injected into the page or not.
-      // There is no reason to modify the headers if we are not injecting inpage.js.
-      const isInjected = checkURLForProviderInjection(new URL(url));
-
-      // Check if the user has enabled the overrideContentSecurityPolicyHeader preference
-      const isEnabled =
-        controller.preferencesController.state
-          .overrideContentSecurityPolicyHeader;
-
-      if (isInjected && isEnabled) {
-        for (const header of responseHeaders) {
-          if (header.name.toLowerCase() === 'content-security-policy') {
-            header.value = addNonceToCsp(header.value, nonce);
-          }
-        }
-      }
-
-      return { responseHeaders };
-    },
-    { types: ['main_frame', 'sub_frame'], urls: ['http://*/*', 'https://*/*'] },
-    ['blocking', 'responseHeaders'],
-  );
-}
-
 // These are set after initialization
 let connectRemote;
 let connectExternalExtension;
@@ -537,11 +501,6 @@ async function initialize() {
 
     if (!isManifestV3) {
       await loadPhishingWarningPage();
-      // Workaround for Bug #1446231 to override page CSP for inline script nodes injected by extension content scripts
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1446231
-      if (isFirefox) {
-        overrideContentSecurityPolicyHeader();
-      }
     }
     await sendReadyMessageToTabs();
     log.info('MetaMask initialization complete.');

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -29,10 +29,6 @@ import {
   getNumberOfSettingRoutesInTab,
   handleSettingsRefs,
 } from '../../../helpers/utils/settings-search';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { getPlatform } from '../../../../app/scripts/lib/util';
-import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 
 export default class AdvancedTab extends PureComponent {
   static contextTypes = {
@@ -60,8 +56,6 @@ export default class AdvancedTab extends PureComponent {
     backupUserData: PropTypes.func.isRequired,
     showExtensionInFullSizeView: PropTypes.bool,
     setShowExtensionInFullSizeView: PropTypes.func.isRequired,
-    overrideContentSecurityPolicyHeader: PropTypes.bool,
-    setOverrideContentSecurityPolicyHeader: PropTypes.func.isRequired,
   };
 
   state = {
@@ -553,42 +547,6 @@ export default class AdvancedTab extends PureComponent {
     );
   }
 
-  renderOverrideContentSecurityPolicyHeader() {
-    const { t } = this.context;
-    const {
-      overrideContentSecurityPolicyHeader,
-      setOverrideContentSecurityPolicyHeader,
-    } = this.props;
-
-    return (
-      <Box
-        ref={this.settingsRefs[11]}
-        className="settings-page__content-row"
-        data-testid="advanced-setting-override-content-security-policy-header"
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
-        gap={4}
-      >
-        <div className="settings-page__content-item">
-          <span>{t('overrideContentSecurityPolicyHeader')}</span>
-          <div className="settings-page__content-description">
-            {t('overrideContentSecurityPolicyHeaderDescription')}
-          </div>
-        </div>
-
-        <div className="settings-page__content-item-col">
-          <ToggleButton
-            value={overrideContentSecurityPolicyHeader}
-            onToggle={(value) => setOverrideContentSecurityPolicyHeader(!value)}
-            offLabel={t('off')}
-            onLabel={t('on')}
-          />
-        </div>
-      </Box>
-    );
-  }
-
   render() {
     const { errorInSettings } = this.props;
     // When adding/removing/editing the order of renders, double-check the order of the settingsRefs. This affects settings-search.js
@@ -607,9 +565,6 @@ export default class AdvancedTab extends PureComponent {
         {this.renderAutoLockTimeLimit()}
         {this.renderUserDataBackup()}
         {this.renderDismissSeedBackupReminderControl()}
-        {getPlatform() === PLATFORM_FIREFOX
-          ? this.renderOverrideContentSecurityPolicyHeader()
-          : null}
       </div>
     );
   }

--- a/ui/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.container.js
@@ -7,7 +7,6 @@ import {
   backupUserData,
   setAutoLockTimeLimit,
   setDismissSeedBackUpReminder,
-  setOverrideContentSecurityPolicyHeader,
   setFeatureFlag,
   setShowExtensionInFullSizeView,
   setShowFiatConversionOnTestnetsPreference,
@@ -27,11 +26,8 @@ export const mapStateToProps = (state) => {
     appState: { errorInSettings },
     metamask,
   } = state;
-  const {
-    featureFlags: { sendHexData } = {},
-    dismissSeedBackUpReminder,
-    overrideContentSecurityPolicyHeader,
-  } = metamask;
+  const { featureFlags: { sendHexData } = {}, dismissSeedBackUpReminder } =
+    metamask;
   const {
     showFiatInTestnets,
     showTestNetworks,
@@ -48,7 +44,6 @@ export const mapStateToProps = (state) => {
     smartTransactionsEnabled: getSmartTransactionsPreferenceEnabled(state),
     autoLockTimeLimit,
     dismissSeedBackUpReminder,
-    overrideContentSecurityPolicyHeader,
   };
 };
 
@@ -79,9 +74,6 @@ export const mapDispatchToProps = (dispatch) => {
     },
     setDismissSeedBackUpReminder: (value) => {
       return dispatch(setDismissSeedBackUpReminder(value));
-    },
-    setOverrideContentSecurityPolicyHeader: (value) => {
-      return dispatch(setOverrideContentSecurityPolicyHeader(value));
     },
   };
 };


### PR DESCRIPTION
## **Description**

The CSP override feature has been temporarily disabled. The CSP override state itself is still in place, as are some related utility functions. But the code responsible for actually performing the CSP override has been removed, and the settings page toggle for this feature has been removed.

We should follow up with a longer-term fix; either complete removal, or fix the feature but default it to off (and migrate existing users to start with this disabled).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31107?quickstart=1)

## **Related issues**

Fixes #31094

## **Manual testing steps**

1. Check that the settings page renders correctly without this toggle
2. Test sites referenced in #31094 to ensure they don't fail anymore

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/8e8ee155-99cf-4625-97fa-5b093bfdf3e2



### **After**

https://github.com/user-attachments/assets/b3d20ffa-04e0-457e-b9f1-eef6266e7d48

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
