### PR TITLE
chore: Support building backport prod build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ workflows:
             branches:
               ignore:
                 - master
+                # Backport branch created for v12.12.1
+                - stable-v12.12.x
           requires:
             - prep-deps
       - prep-build:
@@ -243,7 +245,10 @@ workflows:
       - job-publish-release:
           filters:
             branches:
-              only: master
+              only:
+              - master
+              # Backport branch created for v12.12.1
+              - stable-v12.12.x
           requires:
             - prep-deps
             - prep-build
@@ -385,7 +390,7 @@ jobs:
           condition:
             not:
               matches:
-                pattern: /^master$/
+                pattern: /^master|stable-v12\.12\.x$/
                 value: << pipeline.git.branch >>
           steps:
             - run:
@@ -394,7 +399,7 @@ jobs:
       - when:
           condition:
             matches:
-              pattern: /^master$/
+              pattern: /^master|stable-v12\.12\.x$/
               value: << pipeline.git.branch >>
           steps:
             - run:
@@ -422,7 +427,7 @@ jobs:
           condition:
             not:
               matches:
-                pattern: /^master$/
+                pattern: /^master|stable-v12\.12\.x$/
                 value: << pipeline.git.branch >>
           steps:
             - run:
@@ -431,7 +436,7 @@ jobs:
       - when:
           condition:
             matches:
-              pattern: /^master$/
+              pattern: /^master|stable-v12\.12\.x$/
               value: << pipeline.git.branch >>
           steps:
             - run:
@@ -465,7 +470,7 @@ jobs:
           condition:
             not:
               matches:
-                pattern: /^master$/
+                pattern: /^master|stable-v12\.12\.x$/
                 value: << pipeline.git.branch >>
           steps:
             - run:
@@ -474,7 +479,7 @@ jobs:
       - when:
           condition:
             matches:
-              pattern: /^master$/
+              pattern: /^master|stable-v12\.12\.x$/
               value: << pipeline.git.branch >>
           steps:
             - run:
@@ -506,7 +511,7 @@ jobs:
           condition:
             not:
               matches:
-                pattern: /^master$/
+                pattern: /^master|stable-v12\.12\.x$/
                 value: << pipeline.git.branch >>
           steps:
             - run:
@@ -515,7 +520,7 @@ jobs:
       - when:
           condition:
             matches:
-              pattern: /^master$/
+              pattern: /^master|stable-v12\.12\.x$/
               value: << pipeline.git.branch >>
           steps:
             - run:


### PR DESCRIPTION
## **Description**

The CircleCI configuration has been updated to treat the branch v12.12.x the same as `master`, allowing us to create a backport build for v12.12.1.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31113?quickstart=1)

## **Related issues**

This is intended to support https://github.com/MetaMask/metamask-extension/pull/31108

## **Manual testing steps**

No easy way to test this ahead of time unfortunately.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
