### PR TITLE
fix: only show valid notification accounts

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1376,7 +1376,7 @@ export default class MetamaskController extends EventEmitter {
       this.controllerMessenger.getRestricted({
         name: 'NotificationServicesController',
         allowedActions: [
-          'KeyringController:getAccounts',
+          'KeyringController:withKeyring',
           'KeyringController:getState',
           'AuthenticationController:getBearerToken',
           'AuthenticationController:isSignedIn',

--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
     "@metamask/multichain-transactions-controller": "^0.7.1",
     "@metamask/name-controller": "^8.0.3",
     "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A22.1.1#~/.yarn/patches/@metamask-network-controller-npm-22.1.1-09b6510f1e.patch",
-    "@metamask/notification-services-controller": "^1.0.0",
+    "@metamask/notification-services-controller": "npm:@metamask-previews/notification-services-controller@3.0.0-preview-c2a9ad3c",
     "@metamask/object-multiplex": "^2.0.0",
     "@metamask/obs-store": "^9.0.0",
     "@metamask/permission-controller": "^11.0.6",

--- a/ui/pages/notifications-settings/notifications-settings.tsx
+++ b/ui/pages/notifications-settings/notifications-settings.tsx
@@ -25,12 +25,30 @@ import { Content, Header } from '../../components/multichain/pages/page';
 import {
   selectIsMetamaskNotificationsEnabled,
   getIsUpdatingMetamaskNotifications,
+  getValidNotificationAccounts,
 } from '../../selectors/metamask-notifications/metamask-notifications';
 import { getInternalAccounts } from '../../selectors';
 import { useAccountSettingsProps } from '../../hooks/metamask-notifications/useSwitchNotifications';
 import { NotificationsSettingsAllowNotifications } from './notifications-settings-allow-notifications';
 import { NotificationsSettingsTypes } from './notifications-settings-types';
 import { NotificationsSettingsPerAccount } from './notifications-settings-per-account';
+
+function useNotificationAccounts() {
+  const accountAddresses = useSelector(getValidNotificationAccounts);
+  const internalAcconuts = useSelector(getInternalAccounts);
+  const accounts = useMemo(() => {
+    return accountAddresses
+      .map((addr) => {
+        const account = internalAcconuts.find(
+          (a) => a.address.toLowerCase() === addr.toLowerCase(),
+        );
+        return account;
+      })
+      .filter(<T,>(val: T | undefined): val is T => Boolean(val));
+  }, [accountAddresses, internalAcconuts]);
+
+  return accounts;
+}
 
 export default function NotificationsSettings() {
   const history = useHistory();
@@ -44,7 +62,7 @@ export default function NotificationsSettings() {
   const isUpdatingMetamaskNotifications = useSelector(
     getIsUpdatingMetamaskNotifications,
   );
-  const accounts = useSelector(getInternalAccounts);
+  const accounts = useNotificationAccounts();
 
   // States
   const [loadingAllowNotifications, setLoadingAllowNotifications] =

--- a/ui/selectors/metamask-notifications/metamask-notifications.test.ts
+++ b/ui/selectors/metamask-notifications/metamask-notifications.test.ts
@@ -5,6 +5,7 @@ import {
   getMetamaskNotificationsReadList,
   getMetamaskNotificationsUnreadCount,
   selectIsFeatureAnnouncementsEnabled,
+  getValidNotificationAccounts,
 } from './metamask-notifications';
 
 type Notification = NotificationServicesController.Types.INotification;
@@ -59,5 +60,10 @@ describe('Metamask Notifications Selectors', () => {
 
   it('should select the isFeatureAnnouncementsEnabled state', () => {
     expect(selectIsFeatureAnnouncementsEnabled(mockState)).toBe(true);
+  });
+
+  it('should select the valid accounts that can enable notifications', () => {
+    const state = { ...mockState, subscriptionAccountsSeen: ['0x1111'] };
+    expect(getValidNotificationAccounts(state)).toStrictEqual(['0x1111']);
   });
 });

--- a/ui/selectors/metamask-notifications/metamask-notifications.ts
+++ b/ui/selectors/metamask-notifications/metamask-notifications.ts
@@ -270,3 +270,8 @@ export const getIsCheckingAccountsPresence = createSelector(
   [getMetamask],
   (metamask) => metamask.isCheckingAccountsPresence,
 );
+
+export const getValidNotificationAccounts = createSelector(
+  [getMetamask],
+  (metamask) => metamask.subscriptionAccountsSeen,
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5912,22 +5912,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/notification-services-controller@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/notification-services-controller@npm:1.0.0"
+"@metamask/notification-services-controller@npm:@metamask-previews/notification-services-controller@3.0.0-preview-c2a9ad3c":
+  version: 3.0.0-preview-c2a9ad3c
+  resolution: "@metamask-previews/notification-services-controller@npm:3.0.0-preview-c2a9ad3c"
   dependencies:
     "@contentful/rich-text-html-renderer": "npm:^16.5.2"
     "@metamask/base-controller": "npm:^8.0.0"
-    "@metamask/controller-utils": "npm:^11.5.0"
+    "@metamask/controller-utils": "npm:^11.6.0"
     "@metamask/utils": "npm:^11.2.0"
     bignumber.js: "npm:^9.1.2"
     firebase: "npm:^11.2.0"
     loglevel: "npm:^1.8.1"
     uuid: "npm:^8.3.2"
   peerDependencies:
-    "@metamask/keyring-controller": ^19.0.0
-    "@metamask/profile-sync-controller": ^8.0.0
-  checksum: 10/9cb7cee622ee8485d4424dcf42ffbd4c932572c2c21dc723d6e3e5204fb24f37c01a9080a1826bfd9cfea986233e757cb0630004512415ee966b3110db80f3e9
+    "@metamask/keyring-controller": ^21.0.0
+    "@metamask/profile-sync-controller": ^10.0.0
+  checksum: 10/1beee6d7f82a0f5fa63a749b55bea82df3478ebf952a0b4dcf84dd582728efad328ecc5c9ac110ef0480e458f039633591904f9ae8ea86ca56b72656f90de4e1
   languageName: node
   linkType: hard
 
@@ -27345,7 +27345,7 @@ __metadata:
     "@metamask/multichain-transactions-controller": "npm:^0.7.1"
     "@metamask/name-controller": "npm:^8.0.3"
     "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A22.1.1#~/.yarn/patches/@metamask-network-controller-npm-22.1.1-09b6510f1e.patch"
-    "@metamask/notification-services-controller": "npm:^1.0.0"
+    "@metamask/notification-services-controller": "npm:@metamask-previews/notification-services-controller@3.0.0-preview-c2a9ad3c"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/obs-store": "npm:^9.0.0"
     "@metamask/permission-controller": "npm:^11.0.6"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31116?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30766

## **Manual testing steps**

1. Add a solana account and an internal account
2. Enable notifications
3. Visit notification settings page
4. You should not see the solana or internal account in the notification settings.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
