### PR TITLE
chore: Disable CSP test

### DIFF
--- a/test/e2e/tests/content-security-policy/content-security-policy.spec.ts
+++ b/test/e2e/tests/content-security-policy/content-security-policy.spec.ts
@@ -6,7 +6,8 @@ import TestDapp from '../../page-objects/pages/test-dapp';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 describe('Content-Security-Policy', function (this: Suite) {
-  it('opening a restricted website should still load the extension', async function () {
+  // TODO: Re-enable this after fixing the CSP override feature. See #31094
+  it.skip('opening a restricted website should still load the extension', async function () {
     await withFixtures(
       {
         dapp: true,


### PR DESCRIPTION
## **Description**

Disable CSP test that was intended to verify that the CSP override feature was working correctly. That feature was disabled temporarily in #31107 until we can resolve a newly discovered bug.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31122?quickstart=1)

## **Related issues**

Relates to #31107

## **Manual testing steps**

N/A

## **Screenshots/Recordings**
N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
