### PR TITLE
fix: #30115: Hide import key error

### DIFF
--- a/ui/components/multichain/import-account/private-key.js
+++ b/ui/components/multichain/import-account/private-key.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   FormTextField,
   TextFieldSize,
   TextFieldType,
 } from '../../component-library';
+import { hideWarning } from '../../../store/actions';
 
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import * as actions from '../../../store/actions';
@@ -20,6 +21,14 @@ export default function PrivateKeyImportView({
   const dispatch = useDispatch();
   const [privateKey, setPrivateKey] = useState('');
   const [showPrivateKey, setShowPrivateKey] = useState(false);
+
+  // Since MetaMask still uses a global warning state,
+  // hide the "invalid" warning when the private key import view is unmounted
+  useEffect(() => {
+    return () => {
+      dispatch(hideWarning());
+    };
+  }, [dispatch]);
 
   const warning = useSelector((state) => state.appState.warning);
 

--- a/ui/components/multichain/import-account/private-key.js
+++ b/ui/components/multichain/import-account/private-key.js
@@ -9,7 +9,6 @@ import {
 import { hideWarning } from '../../../store/actions';
 
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import * as actions from '../../../store/actions';
 import ShowHideToggle from '../../ui/show-hide-toggle';
 import BottomButtons from './bottom-buttons';
 
@@ -31,12 +30,6 @@ export default function PrivateKeyImportView({
   }, [dispatch]);
 
   const warning = useSelector((state) => state.appState.warning);
-
-  useEffect(() => {
-    return () => {
-      dispatch(actions.hideWarning());
-    };
-  }, [dispatch]);
 
   function handleKeyPress(event) {
     if (privateKey !== '' && event.key === 'Enter') {


### PR DESCRIPTION
## **Description**

Some parts of the extension still use a gross global warning state that persists throughout the app.  Ugh.  This removes the state warning when importing a key and backing out of the import.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31129?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30115

## **Manual testing steps**

1. Go to the Account Menu -> choose Import
2. Enter a bad key -> see error
3. Press "Cancel", then choose Import again
4. Don't see error.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/d8d87015-4212-46a5-8abe-ec34462f9ace





## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
