### PR TITLE
pocV2: wss update token balance

### DIFF
--- a/app/scripts/controllers/web-socket-poc/init.ts
+++ b/app/scripts/controllers/web-socket-poc/init.ts
@@ -1,4 +1,5 @@
 import throttle from 'lodash/throttle';
+import log from 'loglevel';
 
 export function initSocketAndDoStuff(handler: () => void) {
   const throttledHandler = throttle(handler, 500);
@@ -12,7 +13,7 @@ export function initSocketAndDoStuff(handler: () => void) {
     );
 
     ws.onopen = () => {
-      console.log('WS: Connected to WebSocket');
+      log.log('WS: Connected to WebSocket');
       retryCount = 0; // Reset retry count on successful connection
 
       const message = {
@@ -23,10 +24,11 @@ export function initSocketAndDoStuff(handler: () => void) {
           'infura_balanceUpdates',
           {
             address: '0x3EB132069C3C4f6C8632505Fd344925645eb27C5', // account 1
-            contractAddress: [
-              '0x0000000000000000000000000000000000000000',
-              '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-            ], // POL, Bridged USDC
+            // Track all tokens if not added
+            // contractAddress: [
+            //   '0x0000000000000000000000000000000000000000',
+            //   '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+            // ], // POL, Bridged USDC
           },
         ],
       };
@@ -35,12 +37,12 @@ export function initSocketAndDoStuff(handler: () => void) {
     };
 
     ws.onmessage = (event) => {
-      console.log('WS: Received:', event.data);
+      log.log('WS: Received:', event.data);
       throttledHandler();
     };
 
     ws.onclose = () => {
-      console.log('WS: Disconnected from WebSocket');
+      log.log('WS: Disconnected from WebSocket');
       attemptReconnect();
     };
 
@@ -54,9 +56,7 @@ export function initSocketAndDoStuff(handler: () => void) {
     if (retryCount < maxRetries) {
       retryCount++;
       const retryDelay = Math.min(1000 * Math.pow(2, retryCount), 30000); // Exponential backoff with a cap
-      console.log(
-        `WS: Attempting to reconnect in ${retryDelay / 1000} seconds...`,
-      );
+      log.log(`WS: Attempting to reconnect in ${retryDelay / 1000} seconds...`);
       setTimeout(connect, retryDelay);
     } else {
       console.error('WS: Max retries reached. Could not reconnect.');

--- a/app/scripts/controllers/web-socket-poc/init.ts
+++ b/app/scripts/controllers/web-socket-poc/init.ts
@@ -1,81 +1,68 @@
-import debounce from 'lodash/debounce';
+import throttle from 'lodash/throttle';
 
 export function initSocketAndDoStuff(handler: () => void) {
-  // We don't want to fire constantly, otherwise will block UI.
-  // Maybe we can explore a Queue (AMPQ/Rabbit?) if we really need to process each response?
-  const debonucedHandler = debounce(handler, 10000);
+  const debonucedHandler = throttle(handler, 500);
+  const maxRetries = 5;
+  let retryCount = 0;
+  let ws: WebSocket;
 
-  // Can we deploy this on Polygon, this is expensive to test on ethereum.
-  // (also TXs take so much time on ethereum without speedup that the socket closed)
-  const ws = new WebSocket(
-    'wss://mainnet.dev.infura.org/ws/v3/4342f4554a734773a08d92c9136bdcfa',
-  );
+  function connect() {
+    ws = new WebSocket(
+      'wss://polygon-mainnet.dev.infura.org/ws/v3/4342f4554a734773a08d92c9136bdcfa',
+    );
 
-  ws.onopen = () => {
-    console.log('WS: Connected to WebSocket');
+    ws.onopen = () => {
+      console.log('WS: Connected to WebSocket');
+      retryCount = 0; // Reset retry count on successful connection
 
-    // This is fine for PoC, but bad in practice.
-    // A user can have many tokens, so are we meant to subscribe per address * per token * per chain?
-    const message = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'eth_subscribe',
-      params: [
-        'infura_balanceUpdates',
-        {
-          address: '0x1db3439a222c519ab44bb1144fc28167b4fa6ee6', // replace with my PoC address to test
-          contractAddress: '0x8a801c334ebac763822a0d85a595aec6da59c232', // replace with token contract address to watch
-        },
-      ],
+      const message = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_subscribe',
+        params: [
+          'infura_balanceUpdates',
+          {
+            address: '0x3EB132069C3C4f6C8632505Fd344925645eb27C5', // account 1
+            contractAddress: [
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000001010',
+              '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+            ], // POL, Bridged USDC
+          },
+        ],
+      };
+
+      ws.send(JSON.stringify(message));
     };
 
-    ws.send(JSON.stringify(message));
-  };
+    ws.onmessage = (event) => {
+      console.log('WS: Received:', event.data);
+      // debonucedHandler();
+    };
 
-  ws.onmessage = (event) => {
-    console.log('WS: Received:', event.data);
-    // Ideally we should be able to take the event data and either:
-    // 1. Target a specific token refetch
-    // 2. Do refetches required if the data contains enough information for us to inject state directly.
-    // However both of these reach require extensive work/rewiring to work (touching the library code, and adding new methods)
-    // for now, we'll just refetch all 🤷
-    debonucedHandler();
-  };
+    ws.onclose = () => {
+      console.log('WS: Disconnected from WebSocket');
+      attemptReconnect();
+    };
 
-  ws.onclose = () => {
-    console.log('WS: Disconnected from WebSocket');
-  };
+    ws.onerror = (err) => {
+      console.error('WebSocket error:', err);
+      ws.close();
+    };
+  }
 
-  ws.onerror = (err) => {
-    console.error('WebSocket error:', err);
-  };
+  function attemptReconnect() {
+    if (retryCount < maxRetries) {
+      retryCount++;
+      const retryDelay = Math.min(1000 * Math.pow(2, retryCount), 30000); // Exponential backoff with a cap
+      console.log(
+        `WS: Attempting to reconnect in ${retryDelay / 1000} seconds...`,
+      );
+      setTimeout(connect, retryDelay);
+    } else {
+      console.error('WS: Max retries reached. Could not reconnect.');
+    }
+  }
+
+  connect();
 }
-
-/**
- * DEV NOTES:
- *
- * I think we can replace the underlying PollingController with a new SubscriptionController.
- * It can keep a similar interface:
- * - startPolling becomes startSocket or startSubscription
- * - endPolling becomes closeSocket or closeSubscription
- * This controller will need to handle duplicate subscriptions, and correctly manage subscriptions.
- * - We may need a "keep alive" heartbeat if Infura closes "stale" connections on their end.
- *
- * TokenBalancePollingController becomes TokenBalanceSubscriptionController
- * - On Message Receive - it updates the token state.
- *
- * UI:
- * - Replace dispatch calls for polling with subscriptions
- * - And it works(TM), as state is automatically updated through the socket messages
- *
- * -----
- *
- * Concerns:
- * - We probably need to better handle these sockets, as currently it is only per address per token per chain
- * - An address could have hundreds of tokens on a chain (+ multichain portfolio view shows tokens on all chains)
- *   - This currently would be HUNDREDS of sockets
- *   > In the Chromium source code (Google Chrome for Linux) I can see a max of 30 per host, 256 overall
- *
- * Maybe we can use RabbitMQ (AMPQ), where our server dumps data to topics, and the client listens to topics it currently cares about?
- * - (It's been a while since I used it, but isn't this 1 connection but multiple channels?)
- */

--- a/app/scripts/controllers/web-socket-poc/init.ts
+++ b/app/scripts/controllers/web-socket-poc/init.ts
@@ -1,0 +1,81 @@
+import debounce from 'lodash/debounce';
+
+export function initSocketAndDoStuff(handler: () => void) {
+  // We don't want to fire constantly, otherwise will block UI.
+  // Maybe we can explore a Queue (AMPQ/Rabbit?) if we really need to process each response?
+  const debonucedHandler = debounce(handler, 10000);
+
+  // Can we deploy this on Polygon, this is expensive to test on ethereum.
+  // (also TXs take so much time on ethereum without speedup that the socket closed)
+  const ws = new WebSocket(
+    'wss://mainnet.dev.infura.org/ws/v3/4342f4554a734773a08d92c9136bdcfa',
+  );
+
+  ws.onopen = () => {
+    console.log('WS: Connected to WebSocket');
+
+    // This is fine for PoC, but bad in practice.
+    // A user can have many tokens, so are we meant to subscribe per address * per token * per chain?
+    const message = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_subscribe',
+      params: [
+        'infura_balanceUpdates',
+        {
+          address: '0x1db3439a222c519ab44bb1144fc28167b4fa6ee6', // replace with my PoC address to test
+          contractAddress: '0x8a801c334ebac763822a0d85a595aec6da59c232', // replace with token contract address to watch
+        },
+      ],
+    };
+
+    ws.send(JSON.stringify(message));
+  };
+
+  ws.onmessage = (event) => {
+    console.log('WS: Received:', event.data);
+    // Ideally we should be able to take the event data and either:
+    // 1. Target a specific token refetch
+    // 2. Do refetches required if the data contains enough information for us to inject state directly.
+    // However both of these reach require extensive work/rewiring to work (touching the library code, and adding new methods)
+    // for now, we'll just refetch all 🤷
+    debonucedHandler();
+  };
+
+  ws.onclose = () => {
+    console.log('WS: Disconnected from WebSocket');
+  };
+
+  ws.onerror = (err) => {
+    console.error('WebSocket error:', err);
+  };
+}
+
+/**
+ * DEV NOTES:
+ *
+ * I think we can replace the underlying PollingController with a new SubscriptionController.
+ * It can keep a similar interface:
+ * - startPolling becomes startSocket or startSubscription
+ * - endPolling becomes closeSocket or closeSubscription
+ * This controller will need to handle duplicate subscriptions, and correctly manage subscriptions.
+ * - We may need a "keep alive" heartbeat if Infura closes "stale" connections on their end.
+ *
+ * TokenBalancePollingController becomes TokenBalanceSubscriptionController
+ * - On Message Receive - it updates the token state.
+ *
+ * UI:
+ * - Replace dispatch calls for polling with subscriptions
+ * - And it works(TM), as state is automatically updated through the socket messages
+ *
+ * -----
+ *
+ * Concerns:
+ * - We probably need to better handle these sockets, as currently it is only per address per token per chain
+ * - An address could have hundreds of tokens on a chain (+ multichain portfolio view shows tokens on all chains)
+ *   - This currently would be HUNDREDS of sockets
+ *   > In the Chromium source code (Google Chrome for Linux) I can see a max of 30 per host, 256 overall
+ *
+ * Maybe we can use RabbitMQ (AMPQ), where our server dumps data to topics, and the client listens to topics it currently cares about?
+ * - (It's been a while since I used it, but isn't this 1 connection but multiple channels?)
+ */

--- a/app/scripts/controllers/web-socket-poc/init.ts
+++ b/app/scripts/controllers/web-socket-poc/init.ts
@@ -1,7 +1,7 @@
 import throttle from 'lodash/throttle';
 
 export function initSocketAndDoStuff(handler: () => void) {
-  const debonucedHandler = throttle(handler, 500);
+  const throttledHandler = throttle(handler, 500);
   const maxRetries = 5;
   let retryCount = 0;
   let ws: WebSocket;
@@ -25,7 +25,6 @@ export function initSocketAndDoStuff(handler: () => void) {
             address: '0x3EB132069C3C4f6C8632505Fd344925645eb27C5', // account 1
             contractAddress: [
               '0x0000000000000000000000000000000000000000',
-              '0x0000000000000000000000000000000000001010',
               '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
             ], // POL, Bridged USDC
           },
@@ -37,7 +36,7 @@ export function initSocketAndDoStuff(handler: () => void) {
 
     ws.onmessage = (event) => {
       console.log('WS: Received:', event.data);
-      // debonucedHandler();
+      throttledHandler();
     };
 
     ws.onclose = () => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -399,6 +399,7 @@ import {
   getCapabilities,
   processSendCalls,
 } from './lib/transaction/eip5792';
+import { initSocketAndDoStuff } from './controllers/web-socket-poc/init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -2378,6 +2379,11 @@ export default class MetamaskController extends EventEmitter {
     if (this.onboardingController.state.completedOnboarding) {
       this.postOnboardingInitialization();
     }
+
+    // Web Socket Listener
+    initSocketAndDoStuff(() => {
+      this.tokenBalancesController.updateBalancesByChainId({ chainId: '0x89' });
+    });
   }
 
   // Provides a method for getting feature flags for the multichain
@@ -4118,26 +4124,22 @@ export default class MetamaskController extends EventEmitter {
           accountTrackerController,
         ),
 
-      tokenDetectionStartPolling: tokenDetectionController.startPolling.bind(
-        tokenDetectionController,
-      ),
-      tokenDetectionStopPollingByPollingToken:
-        tokenDetectionController.stopPollingByPollingToken.bind(
-          tokenDetectionController,
-        ),
+      // eslint-disable-next-line no-empty-function, no-unused-vars
+      tokenDetectionStartPolling: (...args) => {}, // no-op,
+      // eslint-disable-next-line no-empty-function, no-unused-vars
+      tokenDetectionStopPollingByPollingToken: (...args) => {}, // no-op,
 
       tokenListStartPolling:
         tokenListController.startPolling.bind(tokenListController),
       tokenListStopPollingByPollingToken:
         tokenListController.stopPollingByPollingToken.bind(tokenListController),
 
-      tokenBalancesStartPolling: tokenBalancesController.startPolling.bind(
-        tokenBalancesController,
-      ),
-      tokenBalancesStopPollingByPollingToken:
-        tokenBalancesController.stopPollingByPollingToken.bind(
-          tokenBalancesController,
-        ),
+      // eslint-disable-next-line no-empty-function, no-unused-vars
+      tokenBalancesStartPolling: (chainIdObjs) => {
+        tokenBalancesController.updateBalancesByChainId(chainIdObjs[0]);
+      },
+      // eslint-disable-next-line no-empty-function, no-unused-vars
+      tokenBalancesStopPollingByPollingToken: (...args) => {}, // no-op,
 
       // GasFeeController
       gasFeeStartPolling: gasFeeController.startPolling.bind(gasFeeController),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2382,7 +2382,7 @@ export default class MetamaskController extends EventEmitter {
 
     // Web Socket Listener
     initSocketAndDoStuff(() => {
-      console.log('WS: Refetching tokens');
+      log.log('WS: Success - Refetching tokens');
       this.tokenBalancesController.updateBalancesByChainId({
         chainId: '0x89',
       });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2382,7 +2382,10 @@ export default class MetamaskController extends EventEmitter {
 
     // Web Socket Listener
     initSocketAndDoStuff(() => {
-      this.tokenBalancesController.updateBalancesByChainId({ chainId: '0x89' });
+      console.log('WS: Refetching tokens');
+      this.tokenBalancesController.updateBalancesByChainId({
+        chainId: '0x89',
+      });
     });
   }
 


### PR DESCRIPTION
## **Description**

Example of using WSS to refresh token balances.

FUTURE POCS:
1. Use the event result to refresh a single balance instead of updating all balances
2. Use the event result to inject state directly (bypassing any additional RPC/API calls)

<details><summary>Sketch on POC versions</summary>

![image](https://github.com/user-attachments/assets/001a5437-6f57-4abb-a738-f7625129e8a6)

</details> 

<details><summary>Architecture Updates</summary>

![image](https://github.com/user-attachments/assets/2a115ec3-f25b-4f30-9344-f9a94c4dff45)

</details> 




[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31132?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
4.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
