### PR TITLE
chore: Swap blockstream for mempool.space as Bitcoin block explorer

### DIFF
--- a/shared/constants/multichain/networks.ts
+++ b/shared/constants/multichain/networks.ts
@@ -62,12 +62,12 @@ export const MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP: Record<
   MultichainBlockExplorerFormatUrls
 > = {
   [MultichainNetworks.BITCOIN]: {
-    url: 'https://mempool.space/',
+    url: 'https://mempool.space',
     address: 'https://mempool.space/address/{address}',
     transaction: 'https://mempool.space/tx/{txId}',
   },
   [MultichainNetworks.BITCOIN_TESTNET]: {
-    url: 'https://mempool.space/',
+    url: 'https://mempool.space',
     address: 'https://mempool.space/testnet/address/{address}',
     transaction: 'https://mempool.space/testnet/tx/{txId}',
   },

--- a/shared/constants/multichain/networks.ts
+++ b/shared/constants/multichain/networks.ts
@@ -62,14 +62,14 @@ export const MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP: Record<
   MultichainBlockExplorerFormatUrls
 > = {
   [MultichainNetworks.BITCOIN]: {
-    url: 'https://blockstream.info',
-    address: 'https://blockstream.info/address/{address}',
-    transaction: 'https://blockstream.info/tx/{txId}',
+    url: 'https://mempool.space/',
+    address: 'https://mempool.space/address/{address}',
+    transaction: 'https://mempool.space/tx/{txId}',
   },
   [MultichainNetworks.BITCOIN_TESTNET]: {
-    url: 'https://blockstream.info',
-    address: 'https://blockstream.info/testnet/address/{address}',
-    transaction: 'https://blockstream.info/testnet/tx/{txId}',
+    url: 'https://mempool.space/',
+    address: 'https://mempool.space/testnet/address/{address}',
+    transaction: 'https://mempool.space/testnet/tx/{txId}',
   },
 
   [MultichainNetworks.SOLANA]: {

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
@@ -46,7 +46,7 @@ const mockNonEvmNetwork = {
   network: {
     chainId: MultichainNetworks.BITCOIN,
     rpcPrefs: {
-      blockExplorerUrl: 'https://blockstream.info',
+      blockExplorerUrl: 'https://mempool.space/',
     },
   },
 };

--- a/ui/components/app/multichain-transaction-details-modal/helpers.ts
+++ b/ui/components/app/multichain-transaction-details-modal/helpers.ts
@@ -15,8 +15,8 @@ import {
 /**
  * Creates a transaction URL for block explorer based on network type
  * Different networks have different URL patterns:
- * Bitcoin Mainnet: https://blockstream.info/tx/{txId}
- * Bitcoin Testnet: https://blockstream.info/testnet/tx/{txId}
+ * Bitcoin Mainnet: https://mempool.space/tx/{txId}
+ * Bitcoin Testnet: https://mempool.space/testnet/tx/{txId}
  * Solana Mainnet: https://explorer.solana.com/tx/{txId}
  * Solana Devnet: https://explorer.solana.com/tx/{txId}?cluster=devnet
  *
@@ -39,8 +39,8 @@ export const getTransactionUrl = (txId: string, chainId: string): string => {
 /**
  * Creates an address URL for block explorer based on network type
  * Different networks have different URL patterns:
- * Bitcoin Mainnet: https://blockstream.info/address/{address}
- * Bitcoin Testnet: https://blockstream.info/testnet/address/{address}
+ * Bitcoin Mainnet: https://mempool.space/address/{address}
+ * Bitcoin Testnet: https://mempool.space/testnet/address/{address}
  * Solana Mainnet: https://explorer.solana.com/address/{address}
  * Solana Devnet: https://explorer.solana.com/address/{address}?cluster=devnet
  *

--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
@@ -218,7 +218,7 @@ describe('MultichainTransactionDetailsModal', () => {
     const chainId = MultichainNetworks.BITCOIN;
 
     expect(getTransactionUrl(txId, chainId)).toBe(
-      `https://blockstream.info/tx/${txId}`,
+      `https://mempool.space/tx/${txId}`,
     );
   });
 
@@ -228,7 +228,7 @@ describe('MultichainTransactionDetailsModal', () => {
     const chainId = MultichainNetworks.BITCOIN_TESTNET;
 
     expect(getTransactionUrl(txId, chainId)).toBe(
-      `https://blockstream.info/testnet/tx/${txId}`,
+      `https://mempool.space/testnet/tx/${txId}`,
     );
   });
 
@@ -275,7 +275,7 @@ describe('MultichainTransactionDetailsModal', () => {
     const chainId = MultichainNetworks.BITCOIN;
 
     expect(getAddressUrl(address, chainId)).toBe(
-      `https://blockstream.info/address/${address}`,
+      `https://mempool.space/address/${address}`,
     );
   });
 
@@ -284,7 +284,7 @@ describe('MultichainTransactionDetailsModal', () => {
     const chainId = MultichainNetworks.BITCOIN_TESTNET;
 
     expect(getAddressUrl(address, chainId)).toBe(
-      `https://blockstream.info/testnet/address/${address}`,
+      `https://mempool.space/testnet/address/${address}`,
     );
   });
 

--- a/ui/helpers/utils/multichain/blockExplorer.test.ts
+++ b/ui/helpers/utils/multichain/blockExplorer.test.ts
@@ -72,7 +72,7 @@ describe('Block Explorer Tests', () => {
 
     it('returns the correct account URL for Binance Smart Chain', () => {
       const address = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
-      const expectedUrl = `https://blockstream.info/address/${address}`;
+      const expectedUrl = `https://mempool.space/address/${address}`;
 
       const result = getMultichainAccountUrl(address, mockNonEvmNetwork);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This is a small patch PR that swaps the dedicated block explorer for Bitcoin accounts from blockstream.info to mempool.space

currently Bitcoin accounts are not supported on Metamask extension so I was unable to test this feature but I see now reason why it would not work since all that changed was the values in a mapping. This is already in [effect on mobile](https://github.com/MetaMask/metamask-mobile/pull/14013/files#diff-7b86186720b7137ba4c84733615d2ed00adf9971df578825b28ea9017e15b141R48-R57) and working quite well. 

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/881

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
