### PR TITLE
Mms 2073 account search

### DIFF
--- a/ui/pages/bridge/prepare/components/destination-account-picker.tsx
+++ b/ui/pages/bridge/prepare/components/destination-account-picker.tsx
@@ -46,9 +46,11 @@ export const DestinationAccountPicker = ({
   const filteredAccounts = useMemo(
     () =>
       accounts.filter((account) => {
-        const matchesSearch = account.metadata.name
-          .toLowerCase()
-          .includes(searchQuery.toLowerCase());
+        const matchesSearch =
+          account.metadata.name
+            .toLowerCase()
+            .includes(searchQuery.toLowerCase()) ||
+          account.address.toLowerCase().includes(searchQuery.toLowerCase());
 
         const matchesChain = isDestinationSolana
           ? isSolanaAccount(account)


### PR DESCRIPTION
## **Description**

Fix account Search

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31135?quickstart=1)

## **Related issues**

Fixes: [mms-2063](https://consensyssoftware.atlassian.net/jira/software/projects/MMS/boards/447?assignee=624321812e101c006a8cfb7e&selectedIssue=MMS-2073)

## **Manual testing steps**

1. Go to the bridge page
2. Select solana as destination
3. unless default account and search

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


<img width="510" alt="Screenshot 2025-03-19 at 23 51 57" src="https://github.com/user-attachments/assets/fd0204e8-87d8-474d-ab42-49f10ee1f3cf" />
<img width="517" alt="Screenshot 2025-03-19 at 23 52 05" src="https://github.com/user-attachments/assets/75421087-7994-4f81-83fd-558126ad9b13" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
