### PR TITLE
fix: remove obsolete `{AppState,Nft,Preferences}Controller` state  properties

### DIFF
--- a/app/scripts/migrations/148.test.ts
+++ b/app/scripts/migrations/148.test.ts
@@ -1,0 +1,224 @@
+import { migrate, version } from './148';
+
+const oldVersion = 148;
+
+describe(`migration #${version}`, () => {
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  describe(`migration #${version}`, () => {
+    describe('removes the transactionSecurityCheckEnabled preference from the PreferencesController', () => {
+      it('removes the transactionSecurityCheckEnabled preference if it is set', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            PreferencesController: {
+              preferences: {
+                transactionSecurityCheckEnabled: true,
+              },
+            },
+          },
+        };
+        const expectedData = {
+          PreferencesController: {
+            preferences: {},
+          },
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+
+      it('does nothing to other PreferencesController state if there is not a transactionSecurityCheckEnabled preference', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            PreferencesController: {
+              existingPreference: true,
+            },
+          },
+        };
+        const expectedData = {
+          PreferencesController: {
+            existingPreference: true,
+          },
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+    });
+
+    describe('removes the useRequestQueue preference from the PreferencesController', () => {
+      it('removes the useRequestQueue preference if it is set', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            PreferencesController: {
+              preferences: {
+                useRequestQueue: true,
+              },
+            },
+          },
+        };
+        const expectedData = {
+          PreferencesController: {
+            preferences: {},
+          },
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+
+      it('does nothing to other PreferencesController state if there is not a useRequestQueue preference', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            PreferencesController: {
+              existingPreference: true,
+            },
+          },
+        };
+        const expectedData = {
+          PreferencesController: {
+            existingPreference: true,
+          },
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+    });
+
+    describe('removes the collectibles property from the NftController', () => {
+      it('removes the collectibles property if it is set', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            NftController: {
+              collectibles: true,
+            },
+          },
+        };
+        const expectedData = {
+          NftController: {},
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+
+      it('it does nothing to other state if the collectibles property is not set', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            NftController: {
+              existingProperty: true,
+            },
+          },
+        };
+        const expectedData = {
+          NftController: {
+            existingProperty: true,
+          },
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+    });
+
+    describe('removes the collectibleContracts property from the NftController', () => {
+      it('removes the collectibleContracts property if it is set', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            NftController: {
+              collectibleContracts: true,
+            },
+          },
+        };
+        const expectedData = {
+          NftController: {},
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+
+      it('it does nothing to other state if the collectibleContracts property is not set', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            NftController: {
+              existingProperty: true,
+            },
+          },
+        };
+        const expectedData = {
+          NftController: {
+            existingProperty: true,
+          },
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+    });
+
+    describe('removes the enableEIP1559V2NoticeDismissed property from the AppStateController', () => {
+      it('removes the enableEIP1559V2NoticeDismissed property if it is set', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            AppStateController: {
+              enableEIP1559V2NoticeDismissed: true,
+            },
+          },
+        };
+        const expectedData = {
+          AppStateController: {},
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+
+      it('it does nothing to other state if the enableEIP1559V2NoticeDismissed property is not set', async () => {
+        const oldStorage = {
+          meta: { version: oldVersion },
+          data: {
+            AppStateController: {
+              existingProperty: true,
+            },
+          },
+        };
+        const expectedData = {
+          AppStateController: {
+            existingProperty: true,
+          },
+        };
+
+        const newStorage = await migrate(oldStorage);
+
+        expect(newStorage.data).toStrictEqual(expectedData);
+      });
+    });
+  });
+});

--- a/app/scripts/migrations/148.ts
+++ b/app/scripts/migrations/148.ts
@@ -1,0 +1,65 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 148;
+
+/**
+ * This migration deletes properties from state which have been removed in
+ * previous commits.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly
+ * what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by
+ * controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (
+    hasProperty(state, 'AppStateController') &&
+    isObject(state.AppStateController)
+  ) {
+    // Removed in
+    // See: https://metamask.sentry.io/issues/5975849508/events/7b2c1e15e40b4b94b08030f8b5470f36/
+    delete state.AppStateController.enableEIP1559V2NoticeDismissed;
+  }
+
+  if (hasProperty(state, 'NftController') && isObject(state.NftController)) {
+    // See: https://metamask.sentry.io/issues/5975849508/events/7b2c1e15e40b4b94b08030f8b5470f36/
+    delete state.NftController.collectibles;
+    // See: https://metamask.sentry.io/issues/5975849508/events/7b2c1e15e40b4b94b08030f8b5470f36/
+    delete state.NftController.collectibleContracts;
+  }
+
+  if (
+    hasProperty(state, 'PreferencesController') &&
+    isObject(state.PreferencesController) &&
+    hasProperty(state.PreferencesController, 'preferences') &&
+    isObject(state.PreferencesController.preferences)
+  ) {
+    // Removed in https://github.com/MetaMask/metamask-extension/pull/23460
+    // See: https://metamask.sentry.io/issues/6312710272/events/e9f738648e874c7ab7bc974a79c0a048/
+    delete state.PreferencesController.preferences
+      .transactionSecurityCheckEnabled;
+    // Removed in https://github.com/MetaMask/metamask-extension/pull/29301
+    // See: https://metamask.sentry.io/issues/6043753318/events/b610fbc6125d439190845caeba805eb1/
+    delete state.PreferencesController.preferences.useRequestQueue;
+  }
+
+  return state;
+}

--- a/app/scripts/migrations/148.ts
+++ b/app/scripts/migrations/148.ts
@@ -34,7 +34,6 @@ function transformState(state: Record<string, unknown>) {
     hasProperty(state, 'AppStateController') &&
     isObject(state.AppStateController)
   ) {
-    // Removed in
     // See: https://metamask.sentry.io/issues/5975849508/events/7b2c1e15e40b4b94b08030f8b5470f36/
     delete state.AppStateController.enableEIP1559V2NoticeDismissed;
   }

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -173,6 +173,7 @@ const migrations = [
   require('./145'),
   require('./146'),
   require('./147'),
+  require('./148'),
 ];
 
 export default migrations;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There are several kinds of errors in Sentry which indicate that there are properties in controller state we are attempting to persist that do not have corresponding metadata. This indicates that these properties were removed at some point from the controller's state but no migration was added that removed them from the persisted wallet state. In many cases, at the time of removal, such a migration was not needed because the controller in question inherited from BaseController v1. We have made a targeted effort over the past few years to migrate all controllers to BaseController v2, however, and so it matters now that every property have corresponding metadata or else are removed from state. We don't want these errors to show up in Sentry because they create noise, so this commit removes these properties from state.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31160?quickstart=1)

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/30506
https://github.com/MetaMask/metamask-extension/issues/26818
https://github.com/MetaMask/metamask-extension/issues/30065
https://github.com/MetaMask/metamask-extension/issues/30561

## **Manual testing steps**

* Create a dev build from v12.13.1
* Install the dev build from the `dist/chrome` directory and proceed
through onboarding
* Run this command in the background console: 
```javascript

chrome.storage.local.get(null, (state) => {
  state.data.NftController.collectibles = {};
  state.data.NftController.collectibleContracts = {};
  state.data.AppStateController.enableEIP1559V2NoticeDismissed = true;
  state.data.PreferencesController.preferences.transactionSecurityCheckEnabled = true;
  state.data.PreferencesController.preferences.useRequestQueue = true;
  chrome.storage.local.set(state, () => chrome.runtime.reload());
});

```
  * You should see a console error in the background
* Disable the extension
* Switch to this branch and create a dev build
* Enable and reload the extension
* You should see in the console that migration 12.14.0 has run without
error
  * You can run `chrome.storage.local.get(console.log)` to check that the`NftController`, `AppStateController` and `PreferencesController` states are now valid
  * There is no longer a console error upon reload

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
