### PR TITLE
fix: cp-12.15.0 sort criteria by name, not symbol

### DIFF
--- a/ui/components/app/assets/asset-list/sort-control/sort-control.test.tsx
+++ b/ui/components/app/assets/asset-list/sort-control/sort-control.test.tsx
@@ -80,7 +80,7 @@ describe('SortControl', () => {
 
     expect(mockDispatch).toHaveBeenCalled();
     expect(setTokenSortConfig).toHaveBeenCalledWith({
-      key: 'symbol',
+      key: 'name',
       sortCallback: 'alphaNumeric',
       order: 'asc',
     });
@@ -89,7 +89,7 @@ describe('SortControl', () => {
       category: 'Settings',
       event: 'Token Sort Preference',
       properties: {
-        token_sort_preference: 'symbol',
+        token_sort_preference: 'name',
       },
     });
   });

--- a/ui/components/app/assets/asset-list/sort-control/sort-control.test.tsx
+++ b/ui/components/app/assets/asset-list/sort-control/sort-control.test.tsx
@@ -80,7 +80,7 @@ describe('SortControl', () => {
 
     expect(mockDispatch).toHaveBeenCalled();
     expect(setTokenSortConfig).toHaveBeenCalledWith({
-      key: 'name',
+      key: 'title',
       sortCallback: 'alphaNumeric',
       order: 'asc',
     });
@@ -89,7 +89,7 @@ describe('SortControl', () => {
       category: 'Settings',
       event: 'Token Sort Preference',
       properties: {
-        token_sort_preference: 'name',
+        token_sort_preference: 'title',
       },
     });
   });

--- a/ui/components/app/assets/asset-list/sort-control/sort-control.tsx
+++ b/ui/components/app/assets/asset-list/sort-control/sort-control.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useContext, useEffect } from 'react';
+import React, { ReactNode, useCallback, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import classnames from 'classnames';
 import { Box, Text } from '../../../../component-library';
@@ -104,24 +104,15 @@ const SortControl = ({ handleClose }: SortControlProps) => {
     [dispatch, handleClose, trackEvent],
   );
 
-  // useEffect(() => {
-  //   if (tokenSortConfig.sortCallback === 'alphaNumeric') {
-  //     dispatch(
-  //       setTokenSortConfig({
-  //         key: isEvmSelected ? 'name' : 'title',
-  //         sortCallback: 'alphaNumeric',
-  //         order: 'asc',
-  //       }),
-  //     );
-  //   }
-  // }, [dispatch, isEvmSelected, tokenSortConfig]);
   return (
     <>
       <SelectableListItem
         isSelected={
+          // TODO: consolidate name and title fields in token to avoid this switch
           tokenSortConfig?.key === 'name' || tokenSortConfig?.key === 'title'
         }
         onClick={() =>
+          // TODO: consolidate name and title fields in token to avoid this switch
           handleSort(isEvmSelected ? 'name' : 'title', 'alphaNumeric', 'asc')
         }
         testId="sortByAlphabetically"

--- a/ui/components/app/assets/asset-list/sort-control/sort-control.tsx
+++ b/ui/components/app/assets/asset-list/sort-control/sort-control.tsx
@@ -103,8 +103,8 @@ const SortControl = ({ handleClose }: SortControlProps) => {
   return (
     <>
       <SelectableListItem
-        isSelected={tokenSortConfig?.key === 'symbol'}
-        onClick={() => handleSort('symbol', 'alphaNumeric', 'asc')}
+        isSelected={tokenSortConfig?.key === 'name'}
+        onClick={() => handleSort('name', 'alphaNumeric', 'asc')}
         testId="sortByAlphabetically"
       >
         {t('sortByAlphabetically')}

--- a/ui/components/app/assets/token-list/token-list.tsx
+++ b/ui/components/app/assets/token-list/token-list.tsx
@@ -7,6 +7,7 @@ import {
   getNewTokensImported,
   getPreferences,
   getSelectedAccount,
+  getTokenSortConfig,
 } from '../../../../selectors';
 import { endTrace, TraceName } from '../../../../../shared/lib/trace';
 import { useTokenBalances as pollAndUpdateEvmBalances } from '../../../../hooks/useTokenBalances';
@@ -30,7 +31,8 @@ function TokenList({ onTokenClick }: TokenListProps) {
   const chainIdsToPoll = useSelector(getChainIdsToPoll);
   const newTokensImported = useSelector(getNewTokensImported);
   const currentNetwork = useSelector(getMultichainNetwork);
-  const { tokenSortConfig, privacyMode } = useSelector(getPreferences);
+  const { privacyMode } = useSelector(getPreferences);
+  const tokenSortConfig = useSelector(getTokenSortConfig);
   const selectedAccount = useSelector(getSelectedAccount);
   const evmBalances = useSelector((state) =>
     getTokenBalancesEvm(state, selectedAccount.address),
@@ -56,16 +58,25 @@ function TokenList({ onTokenClick }: TokenListProps) {
       },
     ]);
 
+    // TODO: consolidate name & title in token fields to avoid this switch
+    if (tokenSortConfig.sortCallback === 'alphaNumeric') {
+      return sortAssets([...filteredAssets], {
+        key: isEvm ? 'name' : 'title',
+        sortCallback: 'alphaNumeric',
+        order: 'asc',
+      });
+    }
+
     // sort filtered tokens based on the tokenSortConfig in state
     return sortAssets([...filteredAssets], tokenSortConfig);
   }, [
-    tokenSortConfig,
-    networkFilter,
-    currentNetwork,
-    selectedAccount,
-    newTokensImported,
+    isEvm,
     evmBalances,
     multichainAssets,
+    networkFilter,
+    currentNetwork.chainId,
+    tokenSortConfig,
+    newTokensImported,
   ]);
 
   useEffect(() => {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1252,6 +1252,13 @@ export function getPetnamesEnabled(state) {
   return petnamesEnabled;
 }
 
+export const getTokenSortConfig = createDeepEqualSelector(
+  getPreferences,
+  ({ tokenSortConfig }) => {
+    return tokenSortConfig;
+  },
+);
+
 /**
  * Returns an object indicating which networks
  * tokens should be shown on in the portfolio view.


### PR DESCRIPTION
## **Description**

Tweaks alphabetical sort criteria to sort by `name` not `symbol`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31171?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/31165

## **Manual testing steps**

1. Go to token view
2. Sort alphabetically
3. Ensure tokens are sorted by name, not by symbol
4. Switch networks, ensure that sorting is correct.
5. Switch between non-evm and evm networks, sorting should be correct

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/40c876d4-c1a6-48ba-aa81-2fd0fa61a974

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
