### PR TITLE
fix: show correct notification accounts

### DIFF
--- a/ui/pages/notifications-settings/notifications-settings.tsx
+++ b/ui/pages/notifications-settings/notifications-settings.tsx
@@ -25,12 +25,30 @@ import { Content, Header } from '../../components/multichain/pages/page';
 import {
   selectIsMetamaskNotificationsEnabled,
   getIsUpdatingMetamaskNotifications,
+  getValidNotificationAccounts,
 } from '../../selectors/metamask-notifications/metamask-notifications';
 import { getInternalAccounts } from '../../selectors';
 import { useAccountSettingsProps } from '../../hooks/metamask-notifications/useSwitchNotifications';
 import { NotificationsSettingsAllowNotifications } from './notifications-settings-allow-notifications';
 import { NotificationsSettingsTypes } from './notifications-settings-types';
 import { NotificationsSettingsPerAccount } from './notifications-settings-per-account';
+
+function useNotificationAccounts() {
+  const accountAddresses = useSelector(getValidNotificationAccounts);
+  const internalAcconuts = useSelector(getInternalAccounts);
+  const accounts = useMemo(() => {
+    return accountAddresses
+      .map((addr) => {
+        const account = internalAcconuts.find(
+          (a) => a.address.toLowerCase() === addr.toLowerCase(),
+        );
+        return account;
+      })
+      .filter(<T,>(val: T | undefined): val is T => Boolean(val));
+  }, [accountAddresses, internalAcconuts]);
+
+  return accounts;
+}
 
 export default function NotificationsSettings() {
   const history = useHistory();
@@ -44,7 +62,7 @@ export default function NotificationsSettings() {
   const isUpdatingMetamaskNotifications = useSelector(
     getIsUpdatingMetamaskNotifications,
   );
-  const accounts = useSelector(getInternalAccounts);
+  const accounts = useNotificationAccounts();
 
   // States
   const [loadingAllowNotifications, setLoadingAllowNotifications] =

--- a/ui/selectors/metamask-notifications/metamask-notifications.test.ts
+++ b/ui/selectors/metamask-notifications/metamask-notifications.test.ts
@@ -5,6 +5,7 @@ import {
   getMetamaskNotificationsReadList,
   getMetamaskNotificationsUnreadCount,
   selectIsFeatureAnnouncementsEnabled,
+  getValidNotificationAccounts,
 } from './metamask-notifications';
 
 type Notification = NotificationServicesController.Types.INotification;
@@ -59,5 +60,10 @@ describe('Metamask Notifications Selectors', () => {
 
   it('should select the isFeatureAnnouncementsEnabled state', () => {
     expect(selectIsFeatureAnnouncementsEnabled(mockState)).toBe(true);
+  });
+
+  it('should select the valid accounts that can enable notifications', () => {
+    const state = { ...mockState, subscriptionAccountsSeen: ['0x1111'] };
+    expect(getValidNotificationAccounts(state)).toStrictEqual(['0x1111']);
   });
 });

--- a/ui/selectors/metamask-notifications/metamask-notifications.ts
+++ b/ui/selectors/metamask-notifications/metamask-notifications.ts
@@ -270,3 +270,8 @@ export const getIsCheckingAccountsPresence = createSelector(
   [getMetamask],
   (metamask) => metamask.isCheckingAccountsPresence,
 );
+
+export const getValidNotificationAccounts = createSelector(
+  [getMetamask],
+  (metamask) => metamask.subscriptionAccountsSeen,
+);


### PR DESCRIPTION
## **Description**

This filters the list of notification accounts to accounts that we are able to create notifications for (accounts on the main HD keyring)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31174?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30766

## **Manual testing steps**

1. Add a solana account and an internal account
2. Enable notifications
3. Visit notification settings page
4. You should not see the solana or internal account in the notification settings.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
