### PR TITLE
feat: Confirmation code selector changes

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1049,10 +1049,12 @@ export function setupController(
     updateBadge,
   );
 
-  controller.controllerMessenger.subscribe(
-    METAMASK_CONTROLLER_EVENTS.QUEUED_REQUEST_STATE_CHANGE,
-    updateBadge,
-  );
+  if (process.env.EVM_MULTICHAIN_ENABLED !== true) {
+    controller.controllerMessenger.subscribe(
+      METAMASK_CONTROLLER_EVENTS.QUEUED_REQUEST_STATE_CHANGE,
+      updateBadge,
+    );
+  }
 
   controller.controllerMessenger.subscribe(
     METAMASK_CONTROLLER_EVENTS.METAMASK_NOTIFICATIONS_LIST_UPDATED,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useSupportsEIP1559.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useSupportsEIP1559.test.ts
@@ -40,4 +40,32 @@ describe('useSupportsEIP1559', () => {
 
     expect(result.current.supportsEIP1559).toMatchInlineSnapshot(`false`);
   });
+
+  it('returns true if transation is on a network supporting EIP-1559 even if current network does not support it', () => {
+    const transactionMeta = genUnapprovedContractInteractionConfirmation({
+      chainId: 'DUMMY',
+    }) as TransactionMeta;
+
+    const { result: legacyResult } = renderHookWithProvider(
+      () => useSupportsEIP1559(transactionMeta),
+      {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          selectedNetworkClientId: 'DUMMY',
+        },
+      },
+    );
+
+    expect(legacyResult.current.supportsEIP1559).toBe(false);
+
+    const { result: support1559Result } = renderHookWithProvider(
+      () => useSupportsEIP1559(transactionMeta),
+      mockState,
+    );
+    (transactionMeta.txParams as Record<string, unknown>).networkClientId =
+      '0x1';
+
+    expect(support1559Result.current.supportsEIP1559).toBe(true);
+  });
 });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useSupportsEIP1559.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useSupportsEIP1559.ts
@@ -5,17 +5,16 @@ import {
 import { useSelector } from 'react-redux';
 import { isLegacyTransaction } from '../../../../../../helpers/utils/transactions.util';
 import { checkNetworkAndAccountSupports1559 } from '../../../../../../selectors';
-import { getSelectedNetworkClientId } from '../../../../../../../shared/modules/selectors/networks';
 
 export function useSupportsEIP1559(transactionMeta: TransactionMeta) {
+  const { networkClientId, txParams } = transactionMeta ?? {};
+
   const isLegacyTxn =
-    transactionMeta?.txParams?.type === TransactionEnvelopeType.legacy ||
+    txParams?.type === TransactionEnvelopeType.legacy ||
     isLegacyTransaction(transactionMeta);
 
-  const selectedNetworkClientId = useSelector(getSelectedNetworkClientId);
-
   const networkAndAccountSupports1559 = useSelector((state) =>
-    checkNetworkAndAccountSupports1559(state, selectedNetworkClientId),
+    checkNetworkAndAccountSupports1559(state, networkClientId),
   );
 
   const supportsEIP1559 = networkAndAccountSupports1559 && !isLegacyTxn;

--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
@@ -158,15 +158,6 @@ describe('useCurrentConfirmation', () => {
     expect(currentConfirmation).toBeUndefined();
   });
 
-  it('returns undefined if transaction has incorrect chain ID', () => {
-    const currentConfirmation = runHook({
-      pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.Transaction }],
-      transaction: { ...TRANSACTION_MOCK, chainId: '0x123' },
-    });
-
-    expect(currentConfirmation).toBeUndefined();
-  });
-
   it('returns undefined if transaction is not unapproved', () => {
     const currentConfirmation = runHook({
       pendingApprovals: [{ ...APPROVAL_MOCK, type: ApprovalType.Transaction }],

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -25,10 +25,7 @@ import {
   subtractHexes,
   sumHexes,
 } from '../../shared/modules/conversion.utils';
-import {
-  getProviderConfig,
-  getCurrentChainId,
-} from '../../shared/modules/selectors/networks';
+import { getProviderConfig } from '../../shared/modules/selectors/networks';
 import { getAveragePriceEstimateInHexWEI } from './custom-gas';
 import {
   checkNetworkAndAccountSupports1559,
@@ -52,14 +49,12 @@ export const unconfirmedTransactionsListSelector = createSelector(
   unapprovedDecryptMsgsSelector,
   unapprovedEncryptionPublicKeyMsgsSelector,
   unapprovedTypedMessagesSelector,
-  getCurrentChainId,
   (
     unapprovedTxs = {},
     unapprovedPersonalMsgs = {},
     unapprovedDecryptMsgs = {},
     unapprovedEncryptionPublicKeyMsgs = {},
     unapprovedTypedMessages = {},
-    chainId,
   ) =>
     txHelper(
       unapprovedTxs,
@@ -67,7 +62,6 @@ export const unconfirmedTransactionsListSelector = createSelector(
       unapprovedDecryptMsgs,
       unapprovedEncryptionPublicKeyMsgs,
       unapprovedTypedMessages,
-      chainId,
     ) || [],
 );
 
@@ -77,36 +71,19 @@ export const unconfirmedTransactionsHashSelector = createSelector(
   unapprovedDecryptMsgsSelector,
   unapprovedEncryptionPublicKeyMsgsSelector,
   unapprovedTypedMessagesSelector,
-  getCurrentChainId,
   (
     unapprovedTxs = {},
     unapprovedPersonalMsgs = {},
     unapprovedDecryptMsgs = {},
     unapprovedEncryptionPublicKeyMsgs = {},
     unapprovedTypedMessages = {},
-    chainId,
-  ) => {
-    const filteredUnapprovedTxs = Object.keys(unapprovedTxs).reduce(
-      (acc, address) => {
-        const transactions = { ...acc };
-
-        if (unapprovedTxs[address].chainId === chainId) {
-          transactions[address] = unapprovedTxs[address];
-        }
-
-        return transactions;
-      },
-      {},
-    );
-
-    return {
-      ...filteredUnapprovedTxs,
-      ...unapprovedPersonalMsgs,
-      ...unapprovedDecryptMsgs,
-      ...unapprovedEncryptionPublicKeyMsgs,
-      ...unapprovedTypedMessages,
-    };
-  },
+  ) => ({
+    ...unapprovedTxs,
+    ...unapprovedPersonalMsgs,
+    ...unapprovedDecryptMsgs,
+    ...unapprovedEncryptionPublicKeyMsgs,
+    ...unapprovedTypedMessages,
+  }),
 );
 
 export const unconfirmedMessagesHashSelector = createSelector(

--- a/ui/selectors/confirm-transaction.test.js
+++ b/ui/selectors/confirm-transaction.test.js
@@ -1,6 +1,13 @@
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { CHAIN_IDS } from '../../shared/constants/network';
 import { mockNetworkState } from '../../test/stub/networks';
-import { conversionRateSelector } from './confirm-transaction';
+import {
+  conversionRateSelector,
+  unconfirmedTransactionsHashSelector,
+} from './confirm-transaction';
 
 describe('Confirm Transaction Selector', () => {
   describe('conversionRateSelector', () => {
@@ -16,6 +23,52 @@ describe('Confirm Transaction Selector', () => {
         },
       };
       expect(conversionRateSelector(state)).toStrictEqual(556.12);
+    });
+  });
+
+  describe('unconfirmedTransactionsHashSelector', () => {
+    it('returns transactions from all networks', () => {
+      const state = {
+        metamask: {
+          incomingTransactionsPreferences: true,
+          transactions: [
+            {
+              id: 1,
+              chainId: '0x1',
+              status: TransactionStatus.unapproved,
+              type: TransactionType.incoming,
+              txParams: { to: '0xSelectedAddress' },
+            },
+            {
+              id: 2,
+              chainId: '0x2',
+              status: TransactionStatus.unapproved,
+              type: TransactionType.incoming,
+              txParams: { to: '0xOtherAddress' },
+            },
+            {
+              id: 3,
+              chainId: '0x3',
+              status: TransactionStatus.unapproved,
+              type: TransactionType.outgoing,
+              txParams: { to: '0xSelectedAddress' },
+            },
+            {
+              id: 4,
+              chainId: '0x1',
+              status: TransactionStatus.unapproved,
+              type: TransactionType.incoming,
+              txParams: { to: '0xSelectedAddress' },
+            },
+          ],
+        },
+      };
+      expect(unconfirmedTransactionsHashSelector(state)).toStrictEqual({
+        1: state.metamask.transactions[0],
+        2: state.metamask.transactions[1],
+        3: state.metamask.transactions[2],
+        4: state.metamask.transactions[3],
+      });
     });
   });
 });

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -108,7 +108,6 @@ export const incomingTxListSelectorAllChains = createDeepEqualSelector(
 export const getUnapprovedTransactions = createDeepEqualSelector(
   (state) => {
     const transactions = getTransactions(state);
-    console.log('===========================', transactions);
     return filterAndShapeUnapprovedTransactions(transactions);
   },
   (transactions) => transactions,

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -107,8 +107,9 @@ export const incomingTxListSelectorAllChains = createDeepEqualSelector(
 
 export const getUnapprovedTransactions = createDeepEqualSelector(
   (state) => {
-    const currentNetworkTransactions = getCurrentNetworkTransactions(state);
-    return filterAndShapeUnapprovedTransactions(currentNetworkTransactions);
+    const transactions = getTransactions(state);
+    console.log('===========================', transactions);
+    return filterAndShapeUnapprovedTransactions(transactions);
   },
   (transactions) => transactions,
 );

--- a/ui/selectors/transactions.test.js
+++ b/ui/selectors/transactions.test.js
@@ -26,6 +26,7 @@ import {
   smartTransactionsListSelector,
   getTransactions,
   getAllNetworkTransactions,
+  getUnapprovedTransactions,
   incomingTxListSelectorAllChains,
   selectedAddressTxListSelectorAllChain,
   transactionSubSelectorAllChains,
@@ -1782,6 +1783,73 @@ describe('Transaction Selectors', () => {
     it('returns an empty array if there are no transactions', () => {
       const results = getTransactions({});
       expect(results).toStrictEqual([]);
+    });
+  });
+
+  describe('getUnapprovedTransactions', () => {
+    it('returns confirmations from all networks', () => {
+      const state = {
+        metamask: {
+          incomingTransactionsPreferences: true,
+          transactions: [
+            {
+              id: 1,
+              chainId: '0x1',
+              status: TransactionStatus.unapproved,
+              type: TransactionType.incoming,
+              txParams: { to: '0xSelectedAddress' },
+            },
+            {
+              id: 2,
+              chainId: '0x2',
+              status: TransactionStatus.unapproved,
+              type: TransactionType.incoming,
+              txParams: { to: '0xOtherAddress' },
+            },
+            {
+              id: 3,
+              chainId: '0x3',
+              status: TransactionStatus.unapproved,
+              type: TransactionType.outgoing,
+              txParams: { to: '0xSelectedAddress' },
+            },
+            {
+              id: 4,
+              chainId: '0x1',
+              status: TransactionStatus.unapproved,
+              type: TransactionType.incoming,
+              txParams: { to: '0xSelectedAddress' },
+            },
+          ],
+          internalAccounts: {
+            accounts: {
+              'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3': {
+                address: '0xSelectedAddress',
+                id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+                metadata: {
+                  name: 'Test Account',
+                  keyring: {
+                    type: 'HD Key Tree',
+                  },
+                },
+                options: {},
+                methods: ETH_EOA_METHODS,
+                type: EthAccountType.Eoa,
+              },
+            },
+            selectedAccount: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+          },
+        },
+      };
+
+      const result = getUnapprovedTransactions(state);
+
+      expect(result).toStrictEqual({
+        1: state.metamask.transactions[0],
+        2: state.metamask.transactions[1],
+        3: state.metamask.transactions[2],
+        4: state.metamask.transactions[3],
+      });
     });
   });
 });


### PR DESCRIPTION
## **Description**

Changes in confirmation selectors to support multiple chains. The changes will not be visible in UI currently due to QueuingController.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4465

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
