### PR TITLE
chore: update solana version

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
     "@metamask/snaps-rpc-methods": "^12.0.0",
     "@metamask/snaps-sdk": "^6.19.0",
     "@metamask/snaps-utils": "^9.0.1",
-    "@metamask/solana-wallet-snap": "^1.13.0",
+    "@metamask/solana-wallet-snap": "^1.14.0",
     "@metamask/transaction-controller": "^50.0.0",
     "@metamask/user-operation-controller": "^24.0.1",
     "@metamask/utils": "^11.1.0",

--- a/test/e2e/flask/solana/transaction-activity-list.spec.ts
+++ b/test/e2e/flask/solana/transaction-activity-list.spec.ts
@@ -39,9 +39,6 @@ describe('Transaction activity list', function (this: Suite) {
         await transactionDetails.check_transactionAmount(
           commonSolanaTxConfirmedDetailsFixture.amount,
         );
-        await transactionDetails.check_transactionNetworkFee(
-          commonSolanaTxConfirmedDetailsFixture.networkFee,
-        );
         await transactionDetails.check_transactionFromToLink(
           commonSolanaTxConfirmedDetailsFixture.fromAddress,
         );
@@ -87,9 +84,6 @@ describe.skip('Transaction activity list', function (this: Suite) {
         );
         await transactionDetails.check_transactionAmount(
           commonSolanaTxConfirmedDetailsFixture.amount,
-        );
-        await transactionDetails.check_transactionNetworkFee(
-          commonSolanaTxConfirmedDetailsFixture.networkFee,
         );
         await transactionDetails.check_transactionFromToLink(
           commonSolanaTxConfirmedDetailsFixture.fromAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6444,10 +6444,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/solana-wallet-snap@npm:^1.13.0":
-  version: 1.13.0
-  resolution: "@metamask/solana-wallet-snap@npm:1.13.0"
-  checksum: 10/f54f3149c80871b4ae5d5c26f619ebf645e580c69c87ef0eb00ed0e04285bd6108beb2814a46244ebb2af61be80247f94f9a4f996d0fb95a8a2d48d2e4ec90e2
+"@metamask/solana-wallet-snap@npm:^1.14.0":
+  version: 1.14.0
+  resolution: "@metamask/solana-wallet-snap@npm:1.14.0"
+  checksum: 10/f09baf18f259ad560877230859ebed88fb816fde8a4057794b477f72af838b202811a39133a8771561a12973755f1ca3f635095ed281656a51dfc4a68cb2bf58
   languageName: node
   linkType: hard
 
@@ -27316,7 +27316,7 @@ __metadata:
     "@metamask/snaps-rpc-methods": "npm:^12.0.0"
     "@metamask/snaps-sdk": "npm:^6.19.0"
     "@metamask/snaps-utils": "npm:^9.0.1"
-    "@metamask/solana-wallet-snap": "npm:^1.13.0"
+    "@metamask/solana-wallet-snap": "npm:^1.14.0"
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:9.1.0"
     "@metamask/test-dapp-multichain": "npm:^0.6.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

https://github.com/MetaMask/snap-solana-wallet/releases/tag/v1.14.0

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31198?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
