### PR TITLE
fix: #30215 - Fix tab color accessibility

### DIFF
--- a/ui/components/ui/tabs/tab/index.scss
+++ b/ui/components/ui/tabs/tab/index.scss
@@ -1,6 +1,6 @@
 .tab {
   border-bottom: 2px solid var(--color-border-muted);
-  color: var(--color-text-muted);
+  color: var(--color-text-alternative);
   font-weight: 500;
 
   button {


### PR DESCRIPTION


## **Description**

Fixes unselected tab color such that it will pass accessibility tests.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31212?quickstart=1)

## **Related issues**

Fixes:  https://github.com/MetaMask/metamask-extension/issues/30215

## **Manual testing steps**

1. Look at unselected tabs.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1014" alt="SCR-20250321-lzlw" src="https://github.com/user-attachments/assets/04e9582d-75cc-41fd-8b91-c08abdc1038a" />




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
