### PR TITLE
Use new utility method from chain-agnostic-permission package: `generateCaip25Caveat`

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1306,6 +1306,16 @@
         "lodash": true
       }
     },
+    "@metamask/multichain-api-middleware>@metamask/chain-agnostic-permission": {
+      "packages": {
+        "@metamask/multichain-api-middleware>@metamask/api-specs": true,
+        "@metamask/controller-utils": true,
+        "@metamask/permission-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/utils": true,
+        "lodash": true
+      }
+    },
     "@metamask/controller-utils": {
       "globals": {
         "URL": true,
@@ -1843,7 +1853,7 @@
       },
       "packages": {
         "@metamask/multichain-api-middleware>@metamask/api-specs": true,
-        "@metamask/chain-agnostic-permission": true,
+        "@metamask/multichain-api-middleware>@metamask/chain-agnostic-permission": true,
         "@metamask/controller-utils": true,
         "@metamask/eth-json-rpc-filters": true,
         "@metamask/json-rpc-engine": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1306,6 +1306,16 @@
         "lodash": true
       }
     },
+    "@metamask/multichain-api-middleware>@metamask/chain-agnostic-permission": {
+      "packages": {
+        "@metamask/multichain-api-middleware>@metamask/api-specs": true,
+        "@metamask/controller-utils": true,
+        "@metamask/permission-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/utils": true,
+        "lodash": true
+      }
+    },
     "@metamask/controller-utils": {
       "globals": {
         "URL": true,
@@ -1843,7 +1853,7 @@
       },
       "packages": {
         "@metamask/multichain-api-middleware>@metamask/api-specs": true,
-        "@metamask/chain-agnostic-permission": true,
+        "@metamask/multichain-api-middleware>@metamask/chain-agnostic-permission": true,
         "@metamask/controller-utils": true,
         "@metamask/eth-json-rpc-filters": true,
         "@metamask/json-rpc-engine": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1306,6 +1306,16 @@
         "lodash": true
       }
     },
+    "@metamask/multichain-api-middleware>@metamask/chain-agnostic-permission": {
+      "packages": {
+        "@metamask/multichain-api-middleware>@metamask/api-specs": true,
+        "@metamask/controller-utils": true,
+        "@metamask/permission-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/utils": true,
+        "lodash": true
+      }
+    },
     "@metamask/controller-utils": {
       "globals": {
         "URL": true,
@@ -1843,7 +1853,7 @@
       },
       "packages": {
         "@metamask/multichain-api-middleware>@metamask/api-specs": true,
-        "@metamask/chain-agnostic-permission": true,
+        "@metamask/multichain-api-middleware>@metamask/chain-agnostic-permission": true,
         "@metamask/controller-utils": true,
         "@metamask/eth-json-rpc-filters": true,
         "@metamask/json-rpc-engine": true,

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -1452,6 +1452,16 @@
         "lodash": true
       }
     },
+    "@metamask/multichain-api-middleware>@metamask/chain-agnostic-permission": {
+      "packages": {
+        "@metamask/multichain-api-middleware>@metamask/api-specs": true,
+        "@metamask/controller-utils": true,
+        "@metamask/permission-controller": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/utils": true,
+        "lodash": true
+      }
+    },
     "@metamask/controller-utils": {
       "globals": {
         "URL": true,
@@ -1989,7 +1999,7 @@
       },
       "packages": {
         "@metamask/multichain-api-middleware>@metamask/api-specs": true,
-        "@metamask/chain-agnostic-permission": true,
+        "@metamask/multichain-api-middleware>@metamask/chain-agnostic-permission": true,
         "@metamask/controller-utils": true,
         "@metamask/eth-json-rpc-filters": true,
         "@metamask/json-rpc-engine": true,

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@metamask/base-controller": "^8.0.0",
     "@metamask/bitcoin-wallet-snap": "^0.9.0",
     "@metamask/browser-passworder": "^4.3.0",
-    "@metamask/chain-agnostic-permission": "npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-6bd2731f",
+    "@metamask/chain-agnostic-permission": "^0.3.0",
     "@metamask/contract-metadata": "^2.5.0",
     "@metamask/controller-utils": "^11.4.0",
     "@metamask/design-tokens": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@metamask/base-controller": "^8.0.0",
     "@metamask/bitcoin-wallet-snap": "^0.9.0",
     "@metamask/browser-passworder": "^4.3.0",
-    "@metamask/chain-agnostic-permission": "npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-8c3b89c",
+    "@metamask/chain-agnostic-permission": "npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-6bd2731f",
     "@metamask/contract-metadata": "^2.5.0",
     "@metamask/controller-utils": "^11.4.0",
     "@metamask/design-tokens": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@metamask/base-controller": "^8.0.0",
     "@metamask/bitcoin-wallet-snap": "^0.9.0",
     "@metamask/browser-passworder": "^4.3.0",
-    "@metamask/chain-agnostic-permission": "^0.2.0",
+    "@metamask/chain-agnostic-permission": "npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-8c3b89c",
     "@metamask/contract-metadata": "^2.5.0",
     "@metamask/controller-utils": "^11.4.0",
     "@metamask/design-tokens": "^5.0.0",

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -5,6 +5,7 @@ import type {
 import { RpcEndpointType } from '@metamask/network-controller';
 import { capitalize, pick } from 'lodash';
 import { Hex } from '@metamask/utils';
+import { hexToDecimal } from '../modules/conversion.utils';
 import { MultichainNetworks } from './multichain/networks';
 
 /**
@@ -544,6 +545,13 @@ export const TEST_CHAINS: Hex[] = [
   CHAIN_IDS.LINEA_SEPOLIA,
   CHAIN_IDS.LOCALHOST,
   CHAIN_IDS.MEGAETH_TESTNET,
+];
+
+export const CAIP_FORMATTED_TEST_CHAINS = [
+  `eip155:${hexToDecimal(CHAIN_IDS.SEPOLIA)}`,
+  `eip155:${hexToDecimal(CHAIN_IDS.LINEA_SEPOLIA)}`,
+  `eip155:${hexToDecimal(CHAIN_IDS.LOCALHOST)}`,
+  `eip155:${hexToDecimal(CHAIN_IDS.MEGAETH_TESTNET)}`,
 ];
 
 export const MAINNET_CHAINS = [

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -4,7 +4,7 @@ import type {
 } from '@metamask/network-controller';
 import { RpcEndpointType } from '@metamask/network-controller';
 import { capitalize, pick } from 'lodash';
-import { Hex } from '@metamask/utils';
+import { CaipChainId, Hex } from '@metamask/utils';
 import { hexToDecimal } from '../modules/conversion.utils';
 import { MultichainNetworks } from './multichain/networks';
 
@@ -547,12 +547,12 @@ export const TEST_CHAINS: Hex[] = [
   CHAIN_IDS.MEGAETH_TESTNET,
 ];
 
-export const CAIP_FORMATTED_TEST_CHAINS = [
-  `eip155:${hexToDecimal(CHAIN_IDS.SEPOLIA)}`,
-  `eip155:${hexToDecimal(CHAIN_IDS.LINEA_SEPOLIA)}`,
-  `eip155:${hexToDecimal(CHAIN_IDS.LOCALHOST)}`,
-  `eip155:${hexToDecimal(CHAIN_IDS.MEGAETH_TESTNET)}`,
-];
+// export const CAIP_FORMATTED_TEST_CHAINS: CaipChainId[] = [
+//   `eip155:${hexToDecimal(CHAIN_IDS.SEPOLIA)}`,
+//   `eip155:${hexToDecimal(CHAIN_IDS.LINEA_SEPOLIA)}`,
+//   `eip155:${hexToDecimal(CHAIN_IDS.LOCALHOST)}`,
+//   `eip155:${hexToDecimal(CHAIN_IDS.MEGAETH_TESTNET)}`,
+// ];
 
 export const MAINNET_CHAINS = [
   { chainId: CHAIN_IDS.MAINNET, rpcUrl: MAINNET_RPC_URL },

--- a/shared/modules/selectors/networks.ts
+++ b/shared/modules/selectors/networks.ts
@@ -6,6 +6,8 @@ import {
 import { createSelector } from 'reselect';
 import { NetworkStatus } from '../../constants/network';
 import { createDeepEqualSelector } from './util';
+import { parseCaipChainId } from '@metamask/utils';
+import { hexToDecimal } from '../conversion.utils';
 
 export type NetworkState = {
   metamask: InternalNetworkState;
@@ -79,8 +81,20 @@ export const getConsolidatedNetworkConfigurations = createDeepEqualSelector(
     networkConfigurationsByChainId,
     multichainNetworkConfigurationsByChainId,
   ) => {
+    const caipFormattedEvmNetworkConfigurations: Record<
+      string,
+      NetworkConfiguration
+    > = {};
+
+    Object.entries(networkConfigurationsByChainId).forEach(
+      ([chainId, network]) => {
+        const caipChainId = `eip155:${hexToDecimal(chainId)}`;
+        caipFormattedEvmNetworkConfigurations[caipChainId] = network;
+      },
+    );
+
     return {
-      ...networkConfigurationsByChainId,
+      ...caipFormattedEvmNetworkConfigurations,
       ...multichainNetworkConfigurationsByChainId,
     };
   },

--- a/test/e2e/flask/multichain-api/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/wallet_createSession.spec.ts
@@ -59,7 +59,7 @@ describeBrowserOnly(Browser.CHROME, 'Multichain API', function () {
     });
   });
 
-  describe('Call `wallet_createSession` with EVM scopes that match the user’s enabled networks, and eip155 scoped accounts', function () {
+  describe.only('Call `wallet_createSession` with EVM scopes that match the user’s enabled networks, and eip155 scoped accounts', function () {
     it('should ignore requested accounts that do not match accounts in the wallet and and pre-select matching requested accounts in the permission confirmation screen', async function () {
       await withFixtures(
         {

--- a/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
+++ b/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
@@ -1,5 +1,10 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { CaipAccountId } from '@metamask/utils';
+import {
+  CaipAccountAddress,
+  CaipAccountId,
+  CaipNamespace,
+  CaipReference,
+} from '@metamask/utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   Modal,
@@ -39,7 +44,13 @@ import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 
 type EditAccountsModalProps = {
-  accounts: MergedInternalAccount[];
+  accounts: {
+    internalAccount: MergedInternalAccount;
+    address: CaipAccountAddress;
+    namespace: CaipNamespace;
+    reference: CaipReference;
+    caipAccountId: CaipAccountId;
+  }[];
   defaultSelectedAccountAddresses: CaipAccountId[];
   onClose: () => void;
   onSubmit: (addresses: CaipAccountId[]) => void;
@@ -67,7 +78,9 @@ export const EditAccountsModal: React.FC<EditAccountsModalProps> = ({
   ]);
 
   const selectAll = () => {
-    const allNetworksAccountAddresses = accounts.map(({ address }) => address);
+    const allNetworksAccountAddresses = accounts.map(
+      ({ caipAccountId }) => caipAccountId,
+    );
     setSelectedAccountAddresses(allNetworksAccountAddresses);
   };
 
@@ -75,13 +88,15 @@ export const EditAccountsModal: React.FC<EditAccountsModalProps> = ({
     setSelectedAccountAddresses([]);
   };
 
-  const handleAccountClick = (address: string) => {
-    if (selectedAccountAddresses.includes(address)) {
+  const handleAccountClick = (caipAccountId: CaipAccountId) => {
+    if (selectedAccountAddresses.includes(caipAccountId)) {
       setSelectedAccountAddresses(
-        selectedAccountAddresses.filter((_address) => _address !== address),
+        selectedAccountAddresses.filter(
+          (_caipAccountId) => _caipAccountId !== caipAccountId,
+        ),
       );
     } else {
-      setSelectedAccountAddresses([...selectedAccountAddresses, address]);
+      setSelectedAccountAddresses([...selectedAccountAddresses, caipAccountId]);
     }
   };
 
@@ -137,17 +152,17 @@ export const EditAccountsModal: React.FC<EditAccountsModalProps> = ({
 
               {accounts.map((account) => (
                 <AccountListItem
-                  onClick={() => handleAccountClick(account.address)}
-                  account={account}
-                  key={account.address}
-                  isPinned={Boolean(account.pinned)}
+                  onClick={() => handleAccountClick(account.caipAccountId)}
+                  account={account.internalAccount}
+                  key={account.caipAccountId}
+                  isPinned={Boolean(account.internalAccount.pinned)}
                   startAccessory={
                     <Checkbox
                       isChecked={selectedAccountAddresses.some(
                         (selectedAccountAddress) =>
                           isEqualCaseInsensitive(
                             selectedAccountAddress,
-                            account.address,
+                            account.caipAccountId,
                           ),
                       )}
                     />

--- a/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
+++ b/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
@@ -1,10 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import {
-  CaipAccountAddress,
-  CaipAccountId,
-  CaipNamespace,
-  CaipReference,
-} from '@metamask/utils';
+import { CaipAccountId } from '@metamask/utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   Modal,
@@ -46,9 +41,6 @@ import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils'
 type EditAccountsModalProps = {
   accounts: {
     internalAccount: MergedInternalAccount;
-    address: CaipAccountAddress;
-    namespace: CaipNamespace;
-    reference: CaipReference;
     caipAccountId: CaipAccountId;
   }[];
   defaultSelectedAccountAddresses: CaipAccountId[];

--- a/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
+++ b/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
+import { CaipAccountId } from '@metamask/utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   Modal,
@@ -39,9 +40,9 @@ import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils'
 
 type EditAccountsModalProps = {
   accounts: MergedInternalAccount[];
-  defaultSelectedAccountAddresses: string[];
+  defaultSelectedAccountAddresses: CaipAccountId[];
   onClose: () => void;
-  onSubmit: (addresses: string[]) => void;
+  onSubmit: (addresses: CaipAccountId[]) => void;
 };
 
 export const EditAccountsModal: React.FC<EditAccountsModalProps> = ({

--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { CaipAccountId, Hex } from '@metamask/utils';
+import { CaipAccountId, CaipChainId, Hex } from '@metamask/utils';
 import {
   BackgroundColor,
   BorderColor,
@@ -27,6 +27,7 @@ import { SiteCellConnectionListItem } from './site-cell-connection-list-item';
 type Network = {
   name: string;
   chainId: string;
+  caipChainId: CaipChainId;
 };
 
 type SiteCellProps = {
@@ -34,9 +35,9 @@ type SiteCellProps = {
   testNetworks: Network[];
   accounts: MergedInternalAccount[];
   onSelectAccountAddresses: (addresses: CaipAccountId[]) => void;
-  onSelectChainIds: (chainIds: Hex[]) => void;
+  onSelectChainIds: (chainIds: CaipChainId[]) => void;
   selectedAccountAddresses: CaipAccountId[];
-  selectedChainIds: string[];
+  selectedChainIds: CaipChainId[];
   isConnectFlow?: boolean;
   hideAllToasts?: () => void;
 };
@@ -64,8 +65,8 @@ export const SiteCell: React.FC<SiteCellProps> = ({
       isEqualCaseInsensitive(selectedAccountAddress, address),
     ),
   );
-  const selectedNetworks = allNetworks.filter(({ chainId }) =>
-    selectedChainIds.includes(chainId),
+  const selectedNetworks = allNetworks.filter(({ caipChainId }) =>
+    selectedChainIds.includes(caipChainId),
   );
 
   const selectedChainIdsLength = selectedChainIds.length;

--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Hex } from '@metamask/utils';
+import { CaipAccountId, Hex } from '@metamask/utils';
 import {
   BackgroundColor,
   BorderColor,
@@ -33,9 +33,9 @@ type SiteCellProps = {
   nonTestNetworks: Network[];
   testNetworks: Network[];
   accounts: MergedInternalAccount[];
-  onSelectAccountAddresses: (addresses: string[]) => void;
+  onSelectAccountAddresses: (addresses: CaipAccountId[]) => void;
   onSelectChainIds: (chainIds: Hex[]) => void;
-  selectedAccountAddresses: string[];
+  selectedAccountAddresses: CaipAccountId[];
   selectedChainIds: string[];
   isConnectFlow?: boolean;
   hideAllToasts?: () => void;

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -67,6 +67,8 @@ import {
   getRequestedAccounts,
   getFilteredNetworks,
   getRequestedChainIds,
+  getAllAccounts,
+  getAllChainIds,
 } from './utils';
 
 export type ConnectPageRequest = {
@@ -103,15 +105,23 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
   const requestedCaip25CaveatValue = getRequestedCaip25CaveatValue(
     request.permissions,
   );
-  const requestedAccounts = getRequestedAccounts(requestedCaip25CaveatValue);
-  const requestedChainIds = getRequestedChainIds(requestedCaip25CaveatValue);
+  const requestedAccounts = getAllAccounts(requestedCaip25CaveatValue);
+  const requestedChainIds = getAllChainIds(requestedCaip25CaveatValue);
 
   const networkConfigurations = useSelector(
     getConsolidatedNetworkConfigurations,
   );
-  const filteredNetworkConfigurations = getFilteredNetworks(
-    networkConfigurations,
-    requestedCaip25CaveatValue,
+  console.log('networkConfigurations', networkConfigurations);
+
+  // const filteredNetworkConfigurations = getFilteredNetworks(
+  //   networkConfigurations,
+  //   requestedCaip25CaveatValue,
+  // );
+
+  const filteredNetworkConfigurations = Object.fromEntries(
+    Object.entries(networkConfigurations).filter(([chainId]) =>
+      requestedChainIds.includes(chainId),
+    ),
   );
 
   const [nonTestNetworks, testNetworks] = useMemo(
@@ -172,9 +182,10 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
     requestedCaip25CaveatValue,
   );
 
+  // This needs to be enhanced for new types
   const supportedRequestedAccounts = requestedAccounts.filter((account) =>
     filteredAccounts.find(({ address }) =>
-      isEqualCaseInsensitive(address, account),
+      isEqualCaseInsensitive(address, account.address),
     ),
   );
 
@@ -185,10 +196,12 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
     ? [currentAccount.address]
     : [filteredAccounts[0]?.address].filter(Boolean);
 
+  // We need a default per requested namespace
   const defaultAccountsAddresses =
     supportedRequestedAccounts.length > 0
       ? supportedRequestedAccounts
       : currentAccountAddress;
+
   const [selectedAccountAddresses, setSelectedAccountAddresses] = useState(
     defaultAccountsAddresses,
   );

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -1,8 +1,9 @@
 import React, { useContext, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { NetworkConfiguration } from '@metamask/network-controller';
-import { Hex } from '@metamask/utils';
 import { isEqualCaseInsensitive } from '@metamask/controller-utils';
+import { generateCaip25Caveat } from '@metamask/chain-agnostic-permission';
+
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getSelectedInternalAccount,
@@ -60,7 +61,6 @@ import {
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { MergedInternalAccount } from '../../../selectors/selectors.types';
 import {
-  getCaip25PermissionsResponse,
   PermissionsRequest,
   getRequestedCaip25CaveatValue,
   getFilteredAccounts,
@@ -198,11 +198,10 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
       ...request,
       permissions: {
         ...request.permissions,
-        ...getCaip25PermissionsResponse(
+        ...generateCaip25Caveat(
           requestedCaip25CaveatValue,
-          selectedAccountAddresses as Hex[],
-          // TODO: Fix this when proper adapter is available
           // @ts-expect-error Fix with request types formatted with adapter
+          selectedAccountAddresses,
           selectedChainIds,
         ),
       },

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -236,7 +236,6 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
     defaultAccountsAddresses,
   );
 
-  // TODO accounts should be CaipAccountId[] now
   const onConfirm = () => {
     const _request = {
       ...request,
@@ -245,6 +244,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
         ...generateCaip25Caveat(
           requestedCaip25CaveatValue,
           selectedAccountAddresses,
+          // TODO chainIds should be CaipChainId[] now
           selectedChainIds,
         ),
       },

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -200,7 +200,6 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
         ...request.permissions,
         ...generateCaip25Caveat(
           requestedCaip25CaveatValue,
-          // @ts-expect-error Fix with request types formatted with adapter
           selectedAccountAddresses,
           selectedChainIds,
         ),

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -193,6 +193,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
     defaultAccountsAddresses,
   );
 
+  // TODO accounts should be CaipAccountId[] now
   const onConfirm = () => {
     const _request = {
       ...request,

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -12,6 +12,7 @@ import {
   CaipChainId,
   CaipNamespace,
   CaipReference,
+  KnownCaipNamespace,
   parseCaipChainId,
 } from '@metamask/utils';
 
@@ -211,6 +212,8 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
       address: account.address,
       namespace,
       reference,
+      caipAccountId:
+        `${namespace}:${reference}:${account.address}` as CaipAccountId,
     };
   });
 
@@ -248,6 +251,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
       address: CaipAccountAddress;
       namespace: CaipNamespace;
       reference: CaipReference;
+      caipAccountId: CaipAccountId;
     }[],
   );
 
@@ -305,8 +309,13 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
   );
 
   const defaultCaip10AccountAddresses = defaultAccounts.map(
-    ({ address, namespace, reference }) =>
-      `${namespace}:${reference}:${address}` as CaipAccountId,
+    ({ address, namespace, reference }) => {
+      if (namespace === KnownCaipNamespace.Eip155 && reference === '0') {
+        // this is very hacky, but it works for now
+        return `${namespace}:1:${address}` as CaipAccountId;
+      }
+      return `${namespace}:${reference}:${address}` as CaipAccountId;
+    },
   );
 
   const [selectedCaip10AccountAddresses, setSelectedCaip10AccountAddresses] =
@@ -328,19 +337,19 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
     approveConnection(_request);
   };
 
-  const selectedAccounts = defaultAccounts.filter(
-    (
-      account,
-    ): account is {
-      internalAccount: MergedInternalAccount;
-      address: CaipAccountAddress;
-      namespace: CaipNamespace;
-      reference: CaipReference;
-    } =>
-      selectedCaip10AccountAddresses.some((selectedCaip10AccountAddress) =>
-        isEqualCaseInsensitive(selectedCaip10AccountAddress, account.address),
-      ),
-  );
+  // const defaultAccounts = defaultAccounts.filter(
+  //   (
+  //     account,
+  //   ): account is {
+  //     internalAccount: MergedInternalAccount;
+  //     address: CaipAccountAddress;
+  //     namespace: CaipNamespace;
+  //     reference: CaipReference;
+  //   } =>
+  //     selectedCaip10AccountAddresses.some((selectedCaip10AccountAddress) =>
+  //       isEqualCaseInsensitive(selectedCaip10AccountAddress, account.address),
+  //     ),
+  // );
 
   const title = transformOriginToTitle(targetSubjectMetadata.origin);
 
@@ -455,14 +464,14 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
                   scrollbarColor: 'var(--color-icon-muted) transparent',
                 }}
               >
-                {selectedAccounts.map((account) => (
+                {defaultAccounts.map((account) => (
                   <AccountListItem
                     account={account.internalAccount}
                     key={account.address}
                     selected={false}
                   />
                 ))}
-                {selectedAccounts.length === 0 && (
+                {defaultAccounts.length === 0 && (
                   <Box
                     className="connect-page__accounts-empty"
                     display={Display.Flex}
@@ -479,7 +488,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
                   </Box>
                 )}
               </Box>
-              {selectedAccounts.length > 0 && (
+              {defaultAccounts.length > 0 && (
                 <Box
                   marginTop={4}
                   display={Display.Flex}
@@ -495,9 +504,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
               )}
               {showEditAccountsModal && (
                 <EditAccountsModal
-                  accounts={defaultAccounts.map(
-                    ({ internalAccount }) => internalAccount,
-                  )}
+                  accounts={defaultAccounts}
                   defaultSelectedAccountAddresses={
                     selectedCaip10AccountAddresses
                   }

--- a/ui/pages/permissions-connect/connect-page/utils.ts
+++ b/ui/pages/permissions-connect/connect-page/utils.ts
@@ -1,4 +1,4 @@
-import { Hex } from '@metamask/utils';
+import { Hex, parseCaipAccountId } from '@metamask/utils';
 import {
   Caip25CaveatType,
   Caip25CaveatValue,
@@ -131,6 +131,34 @@ export function getRequestedAccounts(
     .filter(Boolean);
 
   return [...requiredNonEvmAccounts, ...optionalNonEvmAccounts].filter(Boolean);
+}
+
+/**
+ * Gets a list of unique accounts from the given CAIP-25 caveat value.
+ *
+ * @param requestedCaip25CaveatValue - CAIP-25 request values.
+ * @returns Accounts available for requesting.
+ */
+export function getAllAccounts(requestedCaip25CaveatValue: Caip25CaveatValue) {
+  const requiredAccounts = Object.values(
+    requestedCaip25CaveatValue.requiredScopes,
+  )
+    .flatMap((scope) => scope.accounts)
+    .map((account) => ({
+      address: parseCaipAccountId(account).address,
+      chainId: parseCaipAccountId(account).chainId,
+    }));
+
+  const optionalAccounts = Object.values(
+    requestedCaip25CaveatValue.optionalScopes,
+  )
+    .flatMap((scope) => scope.accounts)
+    .map((account) => ({
+      address: parseCaipAccountId(account).address,
+      chainId: parseCaipAccountId(account).chainId,
+    }));
+
+  return [...requiredAccounts, ...optionalAccounts];
 }
 
 /**

--- a/ui/pages/permissions-connect/connect-page/utils.ts
+++ b/ui/pages/permissions-connect/connect-page/utils.ts
@@ -6,7 +6,6 @@ import {
   setEthAccounts,
   setPermittedEthChainIds,
 } from '@metamask/chain-agnostic-permission';
-import { isEvmAccountType } from '@metamask/keyring-api';
 import { NetworkConfiguration } from '@metamask/network-controller';
 import { MergedInternalAccount } from '../../../selectors/selectors.types';
 

--- a/ui/pages/permissions-connect/connect-page/utils.ts
+++ b/ui/pages/permissions-connect/connect-page/utils.ts
@@ -5,6 +5,7 @@ import {
   Hex,
   parseCaipAccountId,
   CaipAccountId,
+  parseCaipChainId,
 } from '@metamask/utils';
 import {
   Caip25CaveatType,
@@ -81,169 +82,6 @@ export function getCaip25PermissionsResponse(
 }
 
 /**
- * Filters and returns accounts available for selection based on the scope requested.
- *
- * @param accounts - All available accounts.
- * @param requestedNamespaces - The namespaces requested.
- * @returns Accounts available for selection.
- */
-export function getFilteredAccounts(
-  accounts: {
-    internalAccount: MergedInternalAccount;
-    address: CaipAccountAddress;
-    namespace: CaipNamespace;
-    reference: CaipReference;
-    caipAccountId: CaipAccountId;
-  }[],
-  requestedNamespaces: CaipNamespace[],
-): {
-  internalAccount: MergedInternalAccount;
-  address: CaipAccountAddress;
-  namespace: CaipNamespace;
-  reference: CaipReference;
-  caipAccountId: CaipAccountId;
-}[] {
-  const filteredAccounts = accounts.filter((account) => {
-    return requestedNamespaces.includes(account.namespace);
-  });
-
-  return filteredAccounts;
-
-  //   const evmScopesAreRequested = Array.from(requestedScopes).some(
-  //     (scope) => scope.startsWith('eip155:') || scope.startsWith('wallet:eip155'),
-  //   );
-
-  //   const filteredAccounts = accounts.filter((account) => {
-  //     const hasUniversalEipScope =
-  //       hasEipRequests && account.scopes.includes('eip155:0');
-
-  //     if (hasUniversalEipScope) {
-  //       return true;
-  //     }
-  //     /*
-  //     [
-  //     {
-  //         "type": "solana:data-account",
-  //         "id": "705449e6-e9e4-41b0-a2ef-d56689fd6b6a",
-  //         "address": "43gdHDjZKnum4iZ2snLih2fu9FGWytHeFu9Fv2j91dCb",
-  //         "options": {
-  //             "scope": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-  //             "entropySource": "01JNSCFB61ZBXCHWCBT0CNZSHW",
-  //             "imported": false
-  //         },
-  //         "methods": [
-  //             "signAndSendTransaction",
-  //             "signTransaction",
-  //             "signMessage",
-  //             "signIn"
-  //         ],
-  //         "scopes": [
-  //             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-  //             "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
-  //             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
-  //         ],
-  //         "metadata": {
-  //             "name": "Solana Account 1",
-  //             "importTime": 1741642143176,
-  //             "keyring": {
-  //                 "type": "Snap Keyring"
-  //             },
-  //             "snap": {
-  //                 "id": "npm:@metamask/solana-wallet-snap",
-  //                 "name": "Solana",
-  //                 "enabled": true
-  //             },
-  //             "lastSelected": 1742928117271
-  //         },
-  //         "balance": "0",
-  //         "pinned": false,
-  //         "hidden": false,
-  //         "active": false
-  //     },
-  //     {
-  //         "type": "solana:data-account",
-  //         "id": "cd709c6e-4a32-454b-bfe7-02e26024d0b3",
-  //         "address": "BUDhihG2wwL7aCmnQyv5g7Mw4Rqo8oiEhgJVDdSdW9b4",
-  //         "options": {
-  //             "scope": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-  //             "entropySource": "01JNSCFB61ZBXCHWCBT0CNZSHW",
-  //             "imported": false
-  //         },
-  //         "methods": [
-  //             "signAndSendTransaction",
-  //             "signTransaction",
-  //             "signMessage",
-  //             "signIn"
-  //         ],
-  //         "scopes": [
-  //             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-  //             "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
-  //             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
-  //         ],
-  //         "metadata": {
-  //             "name": "Solana Account 2",
-  //             "importTime": 1741728982744,
-  //             "keyring": {
-  //                 "type": "Snap Keyring"
-  //             },
-  //             "snap": {
-  //                 "id": "npm:@metamask/solana-wallet-snap",
-  //                 "name": "Solana",
-  //                 "enabled": true
-  //             },
-  //             "lastSelected": 1742928115471
-  //         },
-  //         "balance": "0",
-  //         "pinned": false,
-  //         "hidden": false,
-  //         "active": false
-  //     }
-  // ]
-  //     */
-
-  //     return account.scopes.some((accountScope) =>
-  //       requestedScopes.has(accountScope),
-  //     );
-
-  // return filteredAccounts.map((internalAccount: MergedInternalAccount) => {
-  //   const { namespace, reference } = parseCaipChainId(
-  //     internalAccount.scopes[0],
-  //   );
-  //   return {
-  //     address: internalAccount.address,
-  //     namespace,
-  //     reference,
-  //   };
-  // });
-}
-
-/**
- * Find and return available requested accounts.
- *
- * @param requestedCaip25CaveatValue - CAIP-25 request values.
- * @returns Accounts available for requesting.
- */
-export function getRequestedAccounts(
-  requestedCaip25CaveatValue: Caip25CaveatValue,
-) {
-  const requiredNonEvmAccounts = Object.values(
-    requestedCaip25CaveatValue.requiredScopes,
-  )
-    .flatMap((scope) => scope.accounts)
-    .map((account) => account.split(':').pop() ?? '')
-    .filter(Boolean);
-
-  const optionalNonEvmAccounts = Object.values(
-    requestedCaip25CaveatValue.optionalScopes,
-  )
-    .flatMap((scope) => scope.accounts)
-    .map((account) => account.split(':').pop() ?? '')
-    .filter(Boolean);
-
-  return [...requiredNonEvmAccounts, ...optionalNonEvmAccounts].filter(Boolean);
-}
-
-/**
  * Gets a list of unique accounts from the given CAIP-25 caveat value.
  *
  * @param requestedCaip25CaveatValue - CAIP-25 request values.
@@ -254,27 +92,13 @@ export function getAllRequestedAccounts(
 ) {
   const requiredAccounts = Object.values(
     requestedCaip25CaveatValue.requiredScopes,
-  )
-    .flatMap((scope) => scope.accounts)
-    .map((account) => ({
-      address: parseCaipAccountId(account).address,
-      namespace: parseCaipAccountId(account).chain.namespace,
-      reference: parseCaipAccountId(account).chain.reference,
-      fullCaipAccountId: account,
-    }));
+  ).flatMap((scope) => scope.accounts);
 
   const optionalAccounts = Object.values(
     requestedCaip25CaveatValue.optionalScopes,
-  )
-    .flatMap((scope) => scope.accounts)
-    .map((account) => ({
-      address: parseCaipAccountId(account).address,
-      namespace: parseCaipAccountId(account).chain.namespace,
-      reference: parseCaipAccountId(account).chain.reference,
-      fullCaipAccountId: account,
-    }));
+  ).flatMap((scope) => scope.accounts);
 
-  return [...requiredAccounts, ...optionalAccounts];
+  return new Set([...requiredAccounts, ...optionalAccounts]);
 }
 
 /**
@@ -322,15 +146,6 @@ export function getFilteredNetworks(
   networks: Record<string, NetworkConfiguration>,
   requestedCaip25CaveatValue: Caip25CaveatValue,
 ): Record<string, NetworkConfiguration> {
-  // This ensures backwards compatability
-  // if (
-  //   !requestedCaip25CaveatValue ||
-  //   (!requestedCaip25CaveatValue.requiredScopes &&
-  //     !requestedCaip25CaveatValue.optionalScopes)
-  // ) {
-  //   return networks;
-  // }
-
   const filteredNetworks: Record<string, NetworkConfiguration> = {};
   const allScopes = {
     ...(requestedCaip25CaveatValue.requiredScopes || {}),
@@ -354,51 +169,58 @@ export function getFilteredNetworks(
   return filteredNetworks;
 }
 
-// We need at least one default per requested namespace
-// if there are more explicitly requested accounts, use those instead
-// for that namespace
+
+/**
+ * Gets the default accounts for the requested namespaces.
+ * We need at least one default per requested namespace
+ * if there are more explicitly requested accounts, use those instead
+ * for that namespace
+ *
+ * @param requestedNamespaces - The namespaces requested.
+ * @param supportedRequestedAccounts - The supported requested accounts.
+ * @param allAccounts - All available accounts.
+ */
 export function getDefaultAccounts(
   requestedNamespaces: CaipNamespace[],
   supportedRequestedAccounts: {
     internalAccount: MergedInternalAccount;
-    address: CaipAccountAddress;
-    namespace: CaipNamespace;
-    reference: CaipReference;
     caipAccountId: CaipAccountId;
   }[],
   allAccounts: {
     internalAccount: MergedInternalAccount;
-    address: CaipAccountAddress;
-    namespace: CaipNamespace;
-    reference: CaipReference;
     caipAccountId: CaipAccountId;
   }[],
 ): {
   internalAccount: MergedInternalAccount;
-  address: CaipAccountAddress;
-  namespace: CaipNamespace;
-  reference: CaipReference;
   caipAccountId: CaipAccountId;
 }[] {
   const defaultAccounts: {
     internalAccount: MergedInternalAccount;
-    address: CaipAccountAddress;
-    namespace: CaipNamespace;
-    reference: CaipReference;
     caipAccountId: CaipAccountId;
   }[] = [];
 
   supportedRequestedAccounts.forEach((account) => {
-    if (requestedNamespaces.includes(account.namespace)) {
+    const { namespace } = parseCaipChainId(account.caipAccountId);
+    if (requestedNamespaces.includes(namespace)) {
       defaultAccounts.push(account);
     }
   });
 
   requestedNamespaces.forEach((namespace) => {
-    if (!defaultAccounts.find((account) => account.namespace === namespace)) {
-      const defaultAccountForNamespace = allAccounts.find(
-        (account) => account.namespace === namespace,
-      );
+    if (
+      !defaultAccounts.find((account) => {
+        const { namespace: accountNamespace } = parseCaipChainId(
+          account.caipAccountId,
+        );
+        return accountNamespace === namespace;
+      })
+    ) {
+      const defaultAccountForNamespace = allAccounts.find((account) => {
+        const { namespace: accountNamespace } = parseCaipChainId(
+          account.caipAccountId,
+        );
+        return accountNamespace === namespace;
+      });
       if (defaultAccountForNamespace) {
         defaultAccounts.push(defaultAccountForNamespace);
       }

--- a/ui/pages/permissions-connect/connect-page/utils.ts
+++ b/ui/pages/permissions-connect/connect-page/utils.ts
@@ -1,5 +1,6 @@
 import {
   CaipAccountAddress,
+  CaipAccountId,
   CaipNamespace,
   CaipReference,
   Hex,
@@ -88,125 +89,129 @@ export function getCaip25PermissionsResponse(
  * @returns Accounts available for selection.
  */
 export function getFilteredAccounts(
-  accounts: MergedInternalAccount[],
-  requestedCaip25CaveatValue: Caip25CaveatValue,
+  accounts: {
+    address: CaipAccountAddress;
+    namespace: CaipNamespace;
+    reference: CaipReference;
+  }[],
+  requestedNamespaces: CaipNamespace[],
 ): {
   address: CaipAccountAddress;
   namespace: CaipNamespace;
   reference: CaipReference;
 }[] {
-  const requestedScopes = new Set([
-    ...Object.keys(requestedCaip25CaveatValue.requiredScopes),
-    ...Object.keys(requestedCaip25CaveatValue.optionalScopes),
-  ]);
-
-  const hasEipRequests = Array.from(requestedScopes).some(
-    (scope) => scope.startsWith('eip155:') || scope.startsWith('wallet:eip155'),
-  );
-
   const filteredAccounts = accounts.filter((account) => {
-    const hasUniversalEipScope =
-      hasEipRequests && account.scopes.includes('eip155:0');
-
-    if (hasUniversalEipScope) {
-      return true;
-    }
-    /*
-    [
-    {
-        "type": "solana:data-account",
-        "id": "705449e6-e9e4-41b0-a2ef-d56689fd6b6a",
-        "address": "43gdHDjZKnum4iZ2snLih2fu9FGWytHeFu9Fv2j91dCb",
-        "options": {
-            "scope": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-            "entropySource": "01JNSCFB61ZBXCHWCBT0CNZSHW",
-            "imported": false
-        },
-        "methods": [
-            "signAndSendTransaction",
-            "signTransaction",
-            "signMessage",
-            "signIn"
-        ],
-        "scopes": [
-            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-            "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
-            "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
-        ],
-        "metadata": {
-            "name": "Solana Account 1",
-            "importTime": 1741642143176,
-            "keyring": {
-                "type": "Snap Keyring"
-            },
-            "snap": {
-                "id": "npm:@metamask/solana-wallet-snap",
-                "name": "Solana",
-                "enabled": true
-            },
-            "lastSelected": 1742928117271
-        },
-        "balance": "0",
-        "pinned": false,
-        "hidden": false,
-        "active": false
-    },
-    {
-        "type": "solana:data-account",
-        "id": "cd709c6e-4a32-454b-bfe7-02e26024d0b3",
-        "address": "BUDhihG2wwL7aCmnQyv5g7Mw4Rqo8oiEhgJVDdSdW9b4",
-        "options": {
-            "scope": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-            "entropySource": "01JNSCFB61ZBXCHWCBT0CNZSHW",
-            "imported": false
-        },
-        "methods": [
-            "signAndSendTransaction",
-            "signTransaction",
-            "signMessage",
-            "signIn"
-        ],
-        "scopes": [
-            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-            "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
-            "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
-        ],
-        "metadata": {
-            "name": "Solana Account 2",
-            "importTime": 1741728982744,
-            "keyring": {
-                "type": "Snap Keyring"
-            },
-            "snap": {
-                "id": "npm:@metamask/solana-wallet-snap",
-                "name": "Solana",
-                "enabled": true
-            },
-            "lastSelected": 1742928115471
-        },
-        "balance": "0",
-        "pinned": false,
-        "hidden": false,
-        "active": false
-    }
-]
-    */
-
-    return account.scopes.some((accountScope) =>
-      requestedScopes.has(accountScope),
-    );
+    return requestedNamespaces.includes(account.namespace);
   });
 
-  return filteredAccounts.map((internalAccount: MergedInternalAccount) => {
-    const { namespace, reference } = parseCaipChainId(
-      internalAccount.scopes[0],
-    );
-    return {
-      address: internalAccount.address,
-      namespace,
-      reference,
-    };
-  });
+  return filteredAccounts;
+
+  //   const evmScopesAreRequested = Array.from(requestedScopes).some(
+  //     (scope) => scope.startsWith('eip155:') || scope.startsWith('wallet:eip155'),
+  //   );
+
+  //   const filteredAccounts = accounts.filter((account) => {
+  //     const hasUniversalEipScope =
+  //       hasEipRequests && account.scopes.includes('eip155:0');
+
+  //     if (hasUniversalEipScope) {
+  //       return true;
+  //     }
+  //     /*
+  //     [
+  //     {
+  //         "type": "solana:data-account",
+  //         "id": "705449e6-e9e4-41b0-a2ef-d56689fd6b6a",
+  //         "address": "43gdHDjZKnum4iZ2snLih2fu9FGWytHeFu9Fv2j91dCb",
+  //         "options": {
+  //             "scope": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  //             "entropySource": "01JNSCFB61ZBXCHWCBT0CNZSHW",
+  //             "imported": false
+  //         },
+  //         "methods": [
+  //             "signAndSendTransaction",
+  //             "signTransaction",
+  //             "signMessage",
+  //             "signIn"
+  //         ],
+  //         "scopes": [
+  //             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  //             "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
+  //             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
+  //         ],
+  //         "metadata": {
+  //             "name": "Solana Account 1",
+  //             "importTime": 1741642143176,
+  //             "keyring": {
+  //                 "type": "Snap Keyring"
+  //             },
+  //             "snap": {
+  //                 "id": "npm:@metamask/solana-wallet-snap",
+  //                 "name": "Solana",
+  //                 "enabled": true
+  //             },
+  //             "lastSelected": 1742928117271
+  //         },
+  //         "balance": "0",
+  //         "pinned": false,
+  //         "hidden": false,
+  //         "active": false
+  //     },
+  //     {
+  //         "type": "solana:data-account",
+  //         "id": "cd709c6e-4a32-454b-bfe7-02e26024d0b3",
+  //         "address": "BUDhihG2wwL7aCmnQyv5g7Mw4Rqo8oiEhgJVDdSdW9b4",
+  //         "options": {
+  //             "scope": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  //             "entropySource": "01JNSCFB61ZBXCHWCBT0CNZSHW",
+  //             "imported": false
+  //         },
+  //         "methods": [
+  //             "signAndSendTransaction",
+  //             "signTransaction",
+  //             "signMessage",
+  //             "signIn"
+  //         ],
+  //         "scopes": [
+  //             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  //             "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
+  //             "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
+  //         ],
+  //         "metadata": {
+  //             "name": "Solana Account 2",
+  //             "importTime": 1741728982744,
+  //             "keyring": {
+  //                 "type": "Snap Keyring"
+  //             },
+  //             "snap": {
+  //                 "id": "npm:@metamask/solana-wallet-snap",
+  //                 "name": "Solana",
+  //                 "enabled": true
+  //             },
+  //             "lastSelected": 1742928115471
+  //         },
+  //         "balance": "0",
+  //         "pinned": false,
+  //         "hidden": false,
+  //         "active": false
+  //     }
+  // ]
+  //     */
+
+  //     return account.scopes.some((accountScope) =>
+  //       requestedScopes.has(accountScope),
+  //     );
+
+  // return filteredAccounts.map((internalAccount: MergedInternalAccount) => {
+  //   const { namespace, reference } = parseCaipChainId(
+  //     internalAccount.scopes[0],
+  //   );
+  //   return {
+  //     address: internalAccount.address,
+  //     namespace,
+  //     reference,
+  //   };
+  // });
 }
 
 /**
@@ -309,13 +314,13 @@ export function getFilteredNetworks(
   requestedCaip25CaveatValue: Caip25CaveatValue,
 ): Record<string, NetworkConfiguration> {
   // This ensures backwards compatability
-  if (
-    !requestedCaip25CaveatValue ||
-    (!requestedCaip25CaveatValue.requiredScopes &&
-      !requestedCaip25CaveatValue.optionalScopes)
-  ) {
-    return networks;
-  }
+  // if (
+  //   !requestedCaip25CaveatValue ||
+  //   (!requestedCaip25CaveatValue.requiredScopes &&
+  //     !requestedCaip25CaveatValue.optionalScopes)
+  // ) {
+  //   return networks;
+  // }
 
   const filteredNetworks: Record<string, NetworkConfiguration> = {};
   const allScopes = {
@@ -338,4 +343,49 @@ export function getFilteredNetworks(
   });
 
   return filteredNetworks;
+}
+
+// We need at least one default per requested namespace
+// if there are more explicitly requested accounts, use those instead
+// for that namespace
+export function getDefaultAccounts(
+  requestedNamespaces: CaipNamespace[],
+  supportedRequestedAccounts: {
+    address: CaipAccountAddress;
+    namespace: CaipNamespace;
+    reference: CaipReference;
+  }[],
+  allAccounts: {
+    address: CaipAccountAddress;
+    namespace: CaipNamespace;
+    reference: CaipReference;
+  }[],
+): CaipAccountId[] {
+  const defaultAccounts: {
+    address: CaipAccountAddress;
+    namespace: CaipNamespace;
+    reference: CaipReference;
+  }[] = [];
+
+  supportedRequestedAccounts.forEach((account) => {
+    if (requestedNamespaces.includes(account.namespace)) {
+      defaultAccounts.push(account);
+    }
+  });
+
+  requestedNamespaces.forEach((namespace) => {
+    if (!defaultAccounts.find((account) => account.namespace === namespace)) {
+      const defaultAccountForNamespace = allAccounts.find(
+        (account) => account.namespace === namespace,
+      );
+      if (defaultAccountForNamespace) {
+        defaultAccounts.push(defaultAccountForNamespace);
+      }
+    }
+  });
+
+  return defaultAccounts.map(
+    ({ address, namespace, reference }) =>
+      `${namespace}:${reference}:${address}` as CaipAccountId,
+  );
 }

--- a/ui/pages/permissions-connect/connect-page/utils.ts
+++ b/ui/pages/permissions-connect/connect-page/utils.ts
@@ -1,11 +1,9 @@
 import {
   CaipAccountAddress,
-  CaipAccountId,
   CaipNamespace,
   CaipReference,
   Hex,
   parseCaipAccountId,
-  parseCaipChainId,
 } from '@metamask/utils';
 import {
   Caip25CaveatType,
@@ -85,7 +83,7 @@ export function getCaip25PermissionsResponse(
  * Filters and returns accounts available for selection based on the scope requested.
  *
  * @param accounts - All available accounts.
- * @param requestedCaip25CaveatValue - CAIP-25 request values.
+ * @param requestedNamespaces - The namespaces requested.
  * @returns Accounts available for selection.
  */
 export function getFilteredAccounts(

--- a/ui/pages/permissions-connect/connect-page/utils.ts
+++ b/ui/pages/permissions-connect/connect-page/utils.ts
@@ -90,12 +90,14 @@ export function getCaip25PermissionsResponse(
  */
 export function getFilteredAccounts(
   accounts: {
+    internalAccount: MergedInternalAccount;
     address: CaipAccountAddress;
     namespace: CaipNamespace;
     reference: CaipReference;
   }[],
   requestedNamespaces: CaipNamespace[],
 ): {
+  internalAccount: MergedInternalAccount;
   address: CaipAccountAddress;
   namespace: CaipNamespace;
   reference: CaipReference;
@@ -246,7 +248,9 @@ export function getRequestedAccounts(
  * @param requestedCaip25CaveatValue - CAIP-25 request values.
  * @returns Accounts available for requesting.
  */
-export function getAllAccounts(requestedCaip25CaveatValue: Caip25CaveatValue) {
+export function getAllRequestedAccounts(
+  requestedCaip25CaveatValue: Caip25CaveatValue,
+) {
   const requiredAccounts = Object.values(
     requestedCaip25CaveatValue.requiredScopes,
   )
@@ -293,7 +297,9 @@ export function getRequestedChainIds(caveatValue: Caip25CaveatValue): string[] {
   });
 }
 
-export function getAllChainIds(requestedCaip25CaveatValue: Caip25CaveatValue) {
+export function getAllRequestedChainIds(
+  requestedCaip25CaveatValue: Caip25CaveatValue,
+) {
   const allScopes = [
     ...Object.keys(requestedCaip25CaveatValue.requiredScopes),
     ...Object.keys(requestedCaip25CaveatValue.optionalScopes),
@@ -351,17 +357,25 @@ export function getFilteredNetworks(
 export function getDefaultAccounts(
   requestedNamespaces: CaipNamespace[],
   supportedRequestedAccounts: {
+    internalAccount: MergedInternalAccount;
     address: CaipAccountAddress;
     namespace: CaipNamespace;
     reference: CaipReference;
   }[],
   allAccounts: {
+    internalAccount: MergedInternalAccount;
     address: CaipAccountAddress;
     namespace: CaipNamespace;
     reference: CaipReference;
   }[],
-): CaipAccountId[] {
+): {
+  internalAccount: MergedInternalAccount;
+  address: CaipAccountAddress;
+  namespace: CaipNamespace;
+  reference: CaipReference;
+}[] {
   const defaultAccounts: {
+    internalAccount: MergedInternalAccount;
     address: CaipAccountAddress;
     namespace: CaipNamespace;
     reference: CaipReference;
@@ -384,8 +398,5 @@ export function getDefaultAccounts(
     }
   });
 
-  return defaultAccounts.map(
-    ({ address, namespace, reference }) =>
-      `${namespace}:${reference}:${address}` as CaipAccountId,
-  );
+  return defaultAccounts;
 }

--- a/ui/pages/permissions-connect/connect-page/utils.ts
+++ b/ui/pages/permissions-connect/connect-page/utils.ts
@@ -4,6 +4,7 @@ import {
   CaipReference,
   Hex,
   parseCaipAccountId,
+  CaipAccountId,
 } from '@metamask/utils';
 import {
   Caip25CaveatType,
@@ -92,6 +93,7 @@ export function getFilteredAccounts(
     address: CaipAccountAddress;
     namespace: CaipNamespace;
     reference: CaipReference;
+    caipAccountId: CaipAccountId;
   }[],
   requestedNamespaces: CaipNamespace[],
 ): {
@@ -99,6 +101,7 @@ export function getFilteredAccounts(
   address: CaipAccountAddress;
   namespace: CaipNamespace;
   reference: CaipReference;
+  caipAccountId: CaipAccountId;
 }[] {
   const filteredAccounts = accounts.filter((account) => {
     return requestedNamespaces.includes(account.namespace);
@@ -257,6 +260,7 @@ export function getAllRequestedAccounts(
       address: parseCaipAccountId(account).address,
       namespace: parseCaipAccountId(account).chain.namespace,
       reference: parseCaipAccountId(account).chain.reference,
+      fullCaipAccountId: account,
     }));
 
   const optionalAccounts = Object.values(
@@ -267,6 +271,7 @@ export function getAllRequestedAccounts(
       address: parseCaipAccountId(account).address,
       namespace: parseCaipAccountId(account).chain.namespace,
       reference: parseCaipAccountId(account).chain.reference,
+      fullCaipAccountId: account,
     }));
 
   return [...requiredAccounts, ...optionalAccounts];
@@ -359,24 +364,28 @@ export function getDefaultAccounts(
     address: CaipAccountAddress;
     namespace: CaipNamespace;
     reference: CaipReference;
+    caipAccountId: CaipAccountId;
   }[],
   allAccounts: {
     internalAccount: MergedInternalAccount;
     address: CaipAccountAddress;
     namespace: CaipNamespace;
     reference: CaipReference;
+    caipAccountId: CaipAccountId;
   }[],
 ): {
   internalAccount: MergedInternalAccount;
   address: CaipAccountAddress;
   namespace: CaipNamespace;
   reference: CaipReference;
+  caipAccountId: CaipAccountId;
 }[] {
   const defaultAccounts: {
     internalAccount: MergedInternalAccount;
     address: CaipAccountAddress;
     namespace: CaipNamespace;
     reference: CaipReference;
+    caipAccountId: CaipAccountId;
   }[] = [];
 
   supportedRequestedAccounts.forEach((account) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5080,9 +5080,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/chain-agnostic-permission@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@metamask/chain-agnostic-permission@npm:0.1.0"
+"@metamask/chain-agnostic-permission@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/chain-agnostic-permission@npm:0.2.0"
   dependencies:
     "@metamask/api-specs": "npm:^0.10.12"
     "@metamask/controller-utils": "npm:^11.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5065,9 +5065,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/chain-agnostic-permission@npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-8c3b89c":
-  version: 0.2.0-preview-8c3b89c
-  resolution: "@metamask-previews/chain-agnostic-permission@npm:0.2.0-preview-8c3b89c"
+"@metamask/chain-agnostic-permission@npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-6bd2731f":
+  version: 0.2.0-preview-6bd2731f
+  resolution: "@metamask-previews/chain-agnostic-permission@npm:0.2.0-preview-6bd2731f"
   dependencies:
     "@metamask/api-specs": "npm:^0.10.12"
     "@metamask/controller-utils": "npm:^11.6.0"
@@ -5076,7 +5076,7 @@ __metadata:
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.2.0"
     lodash: "npm:^4.17.21"
-  checksum: 10/65117397887a5d5fb6f8eb942006ed62966955c650e6fc4ead2f0a66db466be50709bcb1f6654e780471a79b48a334d347e70b5cad680bdea2e130c686c1a71a
+  checksum: 10/089bc653e00598f3a64039dc601c4b0cb7757661371326b28f361ff456140ef0ae83ef59af3175f5cd0b6ff8d2433c2f710636c761bb82c441662676f8232a73
   languageName: node
   linkType: hard
 
@@ -27303,7 +27303,7 @@ __metadata:
     "@metamask/bitcoin-wallet-snap": "npm:^0.9.0"
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^3.0.0"
-    "@metamask/chain-agnostic-permission": "npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-8c3b89c"
+    "@metamask/chain-agnostic-permission": "npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-6bd2731f"
     "@metamask/contract-metadata": "npm:^2.5.0"
     "@metamask/controller-utils": "npm:^11.4.0"
     "@metamask/design-tokens": "npm:^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5281,18 +5281,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-infura@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "@metamask/eth-json-rpc-infura@npm:10.1.0"
-  dependencies:
-    "@metamask/eth-json-rpc-provider": "npm:^4.1.7"
-    "@metamask/json-rpc-engine": "npm:^10.0.2"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.0.1"
-  checksum: 10/e3305d8a2535c3dd0e4b127fb6d01e70245f394b05c6fe81030a9043ad6fd4b8d904e00830236f88cb80b09fa6490ea22e7abaa8230a4fd4912436d0738ee702
-  languageName: node
-  linkType: hard
-
 "@metamask/eth-json-rpc-middleware@npm:^15.0.1, @metamask/eth-json-rpc-middleware@npm:^15.1.0":
   version: 15.3.0
   resolution: "@metamask/eth-json-rpc-middleware@npm:15.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5065,21 +5065,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/chain-agnostic-permission@npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-6bd2731f":
-  version: 0.2.0-preview-6bd2731f
-  resolution: "@metamask-previews/chain-agnostic-permission@npm:0.2.0-preview-6bd2731f"
-  dependencies:
-    "@metamask/api-specs": "npm:^0.10.12"
-    "@metamask/controller-utils": "npm:^11.6.0"
-    "@metamask/network-controller": "npm:^23.1.0"
-    "@metamask/permission-controller": "npm:^11.0.6"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.2.0"
-    lodash: "npm:^4.17.21"
-  checksum: 10/089bc653e00598f3a64039dc601c4b0cb7757661371326b28f361ff456140ef0ae83ef59af3175f5cd0b6ff8d2433c2f710636c761bb82c441662676f8232a73
-  languageName: node
-  linkType: hard
-
 "@metamask/chain-agnostic-permission@npm:^0.2.0":
   version: 0.2.0
   resolution: "@metamask/chain-agnostic-permission@npm:0.2.0"
@@ -5092,6 +5077,21 @@ __metadata:
     "@metamask/utils": "npm:^11.2.0"
     lodash: "npm:^4.17.21"
   checksum: 10/b3121bdbcc2a14d44802ad1799045b4a01c99047fa2675a639b3ebed51a1b30eba071b5a8d8cbf5a045204670a4ef159c44560036013f54a368a6e80071dd5df
+  languageName: node
+  linkType: hard
+
+"@metamask/chain-agnostic-permission@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@metamask/chain-agnostic-permission@npm:0.3.0"
+  dependencies:
+    "@metamask/api-specs": "npm:^0.10.12"
+    "@metamask/controller-utils": "npm:^11.6.0"
+    "@metamask/network-controller": "npm:^23.1.0"
+    "@metamask/permission-controller": "npm:^11.0.6"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.2.0"
+    lodash: "npm:^4.17.21"
+  checksum: 10/872cd804ba64ee78b7f28fd78d864680672911b567b36be3b5046b8164aaf9088aed937ffc983ca1986ba16a3892c471de0870bc00f94f9d87c634a568fb5a78
   languageName: node
   linkType: hard
 
@@ -27303,7 +27303,7 @@ __metadata:
     "@metamask/bitcoin-wallet-snap": "npm:^0.9.0"
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^3.0.0"
-    "@metamask/chain-agnostic-permission": "npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-6bd2731f"
+    "@metamask/chain-agnostic-permission": "npm:^0.3.0"
     "@metamask/contract-metadata": "npm:^2.5.0"
     "@metamask/controller-utils": "npm:^11.4.0"
     "@metamask/design-tokens": "npm:^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5065,9 +5065,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/chain-agnostic-permission@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@metamask/chain-agnostic-permission@npm:0.2.0"
+"@metamask/chain-agnostic-permission@npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-8c3b89c":
+  version: 0.2.0-preview-8c3b89c
+  resolution: "@metamask-previews/chain-agnostic-permission@npm:0.2.0-preview-8c3b89c"
+  dependencies:
+    "@metamask/api-specs": "npm:^0.10.12"
+    "@metamask/controller-utils": "npm:^11.6.0"
+    "@metamask/network-controller": "npm:^23.1.0"
+    "@metamask/permission-controller": "npm:^11.0.6"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.2.0"
+    lodash: "npm:^4.17.21"
+  checksum: 10/65117397887a5d5fb6f8eb942006ed62966955c650e6fc4ead2f0a66db466be50709bcb1f6654e780471a79b48a334d347e70b5cad680bdea2e130c686c1a71a
+  languageName: node
+  linkType: hard
+
+"@metamask/chain-agnostic-permission@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@metamask/chain-agnostic-permission@npm:0.1.0"
   dependencies:
     "@metamask/api-specs": "npm:^0.10.12"
     "@metamask/controller-utils": "npm:^11.6.0"
@@ -5255,6 +5270,18 @@ __metadata:
   linkType: hard
 
 "@metamask/eth-json-rpc-infura@npm:^10.0.0, @metamask/eth-json-rpc-infura@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "@metamask/eth-json-rpc-infura@npm:10.1.0"
+  dependencies:
+    "@metamask/eth-json-rpc-provider": "npm:^4.1.7"
+    "@metamask/json-rpc-engine": "npm:^10.0.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.0.1"
+  checksum: 10/e3305d8a2535c3dd0e4b127fb6d01e70245f394b05c6fe81030a9043ad6fd4b8d904e00830236f88cb80b09fa6490ea22e7abaa8230a4fd4912436d0738ee702
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-infura@npm:^10.1.0":
   version: 10.1.0
   resolution: "@metamask/eth-json-rpc-infura@npm:10.1.0"
   dependencies:
@@ -27288,7 +27315,7 @@ __metadata:
     "@metamask/bitcoin-wallet-snap": "npm:^0.9.0"
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^3.0.0"
-    "@metamask/chain-agnostic-permission": "npm:^0.2.0"
+    "@metamask/chain-agnostic-permission": "npm:@metamask-previews/chain-agnostic-permission@0.2.0-preview-8c3b89c"
     "@metamask/contract-metadata": "npm:^2.5.0"
     "@metamask/controller-utils": "npm:^11.4.0"
     "@metamask/design-tokens": "npm:^5.0.0"


### PR DESCRIPTION
See this core PR where I've adapted some of the helpers to be more chain-agnostic: https://github.com/MetaMask/core/pull/5536

## Before:

https://github.com/user-attachments/assets/835cfdca-2a6b-4bb0-a48d-f7f0a7eb9f8a



## After:
https://github.com/user-attachments/assets/a881bc5f-b2e2-4d77-ae4c-3d2dce970b36

