### PR TITLE
feat: Implement the publishBatch hook for smart transactions

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -1,6 +1,7 @@
 import {
   CHAIN_IDS,
   type PublishBatchHookRequest,
+  type PublishBatchHookTransaction,
   TransactionController,
   TransactionControllerMessenger,
   TransactionMeta,
@@ -19,7 +20,6 @@ import {
   SmartTransactionHookMessenger,
   submitSmartTransactionHook,
   submitBatchSmartTransactionHook,
-  type SignedTransaction,
 } from '../../lib/transaction/smart-transactions';
 import { getTransactionById } from '../../lib/transaction/util';
 import { trace } from '../../../../shared/lib/trace';
@@ -164,7 +164,7 @@ export const TransactionControllerInit: ControllerInitFunction<
           hookControllerMessenger:
             initMessenger as SmartTransactionHookMessenger,
           flatState: getFlatState(),
-          transactions: _request.transactions as SignedTransaction[],
+          transactions: _request.transactions as PublishBatchHookTransaction[],
         }),
     },
     // @ts-expect-error Keyring controller expects TxData returned but TransactionController expects TypedTransaction
@@ -271,7 +271,7 @@ function publishBatchSmartTransactionHook({
   smartTransactionsController: SmartTransactionsController;
   hookControllerMessenger: SmartTransactionHookMessenger;
   flatState: ControllerFlatState;
-  transactions: SignedTransaction[];
+  transactions: PublishBatchHookTransaction[];
 }) {
   // UI state is required to support shared selectors to avoid duplicate logic in frontend and backend.
   // Ideally all backend logic would instead rely on messenger event / state subscriptions.
@@ -291,7 +291,7 @@ function publishBatchSmartTransactionHook({
   // Get transactionMeta based on the last transaction ID
   const lastTransaction = transactions[transactions.length - 1];
   const transactionMeta = getTransactionById(
-    lastTransaction.id,
+    lastTransaction.id ?? '',
     transactionController,
   );
 

--- a/app/scripts/controller-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/transaction-controller-messenger.ts
@@ -102,6 +102,7 @@ export function getTransactionControllerInitMessenger(
       'ApprovalController:endFlow',
       'ApprovalController:startFlow',
       'ApprovalController:updateRequestState',
+      'ApprovalController:acceptRequest',
       'NetworkController:getEIP1559Compatibility',
       'RemoteFeatureFlagController:getState',
       'SwapsController:setApproveTxId',

--- a/app/scripts/lib/transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/transaction/smart-transactions.test.ts
@@ -676,7 +676,6 @@ describe('submitBatchSmartTransactionHook', () => {
               id: '1',
               signedTx: '0x1234',
               params: {
-                from: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
                 to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
                 value: '0x0',
               },
@@ -685,7 +684,6 @@ describe('submitBatchSmartTransactionHook', () => {
               id: '2',
               signedTx: '0x5678',
               params: {
-                from: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
                 to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
                 value: '0x0',
               },

--- a/app/scripts/lib/transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/transaction/smart-transactions.test.ts
@@ -11,7 +11,10 @@ import { NetworkControllerStateChangeEvent } from '@metamask/network-controller'
 import type { SmartTransaction } from '@metamask/smart-transactions-controller/dist/types';
 import { ClientId } from '@metamask/smart-transactions-controller/dist/types';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import { submitSmartTransactionHook } from './smart-transactions';
+import {
+  submitSmartTransactionHook,
+  submitBatchSmartTransactionHook,
+} from './smart-transactions';
 import type {
   SubmitSmartTransactionRequest,
   AllowedActions,
@@ -206,7 +209,9 @@ describe('submitSmartTransactionHook', () => {
 
   it('falls back to regular transaction submit if the transaction type is "swapAndSend"', async () => {
     withRequest(async ({ request }) => {
-      request.transactionMeta.type = TransactionType.swapAndSend;
+      if (request.transactionMeta) {
+        request.transactionMeta.type = TransactionType.swapAndSend;
+      }
       const result = await submitSmartTransactionHook(request);
       expect(result).toEqual({ transactionHash: undefined });
     });
@@ -214,7 +219,9 @@ describe('submitSmartTransactionHook', () => {
 
   it('falls back to regular transaction submit if the transaction type is "swapApproval"', async () => {
     withRequest(async ({ request }) => {
-      request.transactionMeta.type = TransactionType.swapApproval;
+      if (request.transactionMeta) {
+        request.transactionMeta.type = TransactionType.swapApproval;
+      }
       const result = await submitSmartTransactionHook(request);
       expect(result).toEqual({ transactionHash: undefined });
     });
@@ -317,7 +324,7 @@ describe('submitSmartTransactionHook', () => {
         });
         const result = await submitSmartTransactionHook(request);
         expect(result).toEqual({ transactionHash: txHash });
-        const { txParams } = request.transactionMeta;
+        const { txParams } = request.transactionMeta || {};
         expect(
           request.smartTransactionsController.submitSignedTransactions,
         ).toHaveBeenCalledWith({
@@ -401,7 +408,7 @@ describe('submitSmartTransactionHook', () => {
         });
         const result = await submitSmartTransactionHook(request);
         expect(result).toEqual({ transactionHash: txHash });
-        const { txParams, chainId } = request.transactionMeta;
+        const { txParams, chainId } = request.transactionMeta || {};
         expect(
           request.transactionController.approveTransactionsWithSameNonce,
         ).toHaveBeenCalledWith(
@@ -494,7 +501,7 @@ describe('submitSmartTransactionHook', () => {
         });
         const result = await submitSmartTransactionHook(request);
         expect(result).toEqual({ transactionHash: txHash });
-        const { txParams } = request.transactionMeta;
+        const { txParams } = request.transactionMeta || {};
         expect(
           request.transactionController.approveTransactionsWithSameNonce,
         ).not.toHaveBeenCalled();
@@ -530,5 +537,253 @@ describe('submitSmartTransactionHook', () => {
         });
       },
     );
+  });
+});
+
+describe('submitBatchSmartTransactionHook', () => {
+  beforeEach(() => {
+    addRequestCallback = () => undefined;
+  });
+
+  it('does not submit a transaction that is not a smart transaction', async () => {
+    withRequest(
+      {
+        options: {
+          isSmartTransaction: false,
+        },
+      },
+      async ({ request }) => {
+        const result = await submitBatchSmartTransactionHook(request);
+        expect(result).toEqual({ results: [] });
+      },
+    );
+  });
+
+  it('throws an error if there is no uuid', async () => {
+    withRequest(async ({ request }) => {
+      request.smartTransactionsController.submitSignedTransactions = jest.fn(
+        async (_) => {
+          return { uuid: undefined };
+        },
+      );
+      await expect(submitBatchSmartTransactionHook(request)).rejects.toThrow(
+        'No smart transaction UUID',
+      );
+    });
+  });
+
+  it('throws an error if there is no transaction hash', async () => {
+    withRequest(async ({ request, messenger }) => {
+      setImmediate(() => {
+        messenger.publish('SmartTransactionsController:smartTransaction', {
+          status: 'cancelled',
+          uuid,
+          statusMetadata: {
+            minedHash: '',
+          },
+        } as SmartTransaction);
+      });
+      await expect(submitBatchSmartTransactionHook(request)).rejects.toThrow(
+        'Transaction does not have a transaction hash, there was a problem',
+      );
+    });
+  });
+
+  it('submits batch transactions from transactions array', async () => {
+    withRequest(
+      {
+        options: {
+          transactions: [
+            {
+              id: '1',
+              signedTx: '0x1234',
+              params: {
+                from: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
+                to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
+                value: '0x0',
+              },
+            },
+            {
+              id: '2',
+              signedTx: '0x5678',
+              params: {
+                from: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
+                to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
+                value: '0x0',
+              },
+            },
+          ],
+        },
+      },
+      async ({ request, messenger }) => {
+        request.smartTransactionsController.submitSignedTransactions = jest.fn(
+          async (_) => {
+            return {
+              uuid,
+              txHashes: ['hash1', 'hash2'],
+            };
+          },
+        );
+
+        setImmediate(() => {
+          messenger.publish('SmartTransactionsController:smartTransaction', {
+            status: 'pending',
+            uuid,
+            statusMetadata: {
+              minedHash: '',
+            },
+          } as SmartTransaction);
+          messenger.publish('SmartTransactionsController:smartTransaction', {
+            status: 'success',
+            uuid,
+            statusMetadata: {
+              minedHash: txHash,
+            },
+          } as SmartTransaction);
+        });
+
+        const result = await submitBatchSmartTransactionHook(request);
+
+        expect(result).toEqual({
+          results: [{ transactionHash: 'hash1' }, { transactionHash: 'hash2' }],
+        });
+
+        expect(
+          request.smartTransactionsController.submitSignedTransactions,
+        ).toHaveBeenCalledWith({
+          signedTransactions: ['0x1234', '0x5678'],
+          signedCanceledTransactions: [],
+          ...(request.transactionMeta?.txParams && {
+            txParams: request.transactionMeta.txParams,
+          }),
+          ...(request.transactionMeta && {
+            transactionMeta: request.transactionMeta,
+          }),
+        });
+      },
+    );
+  });
+
+  it('submits batch transaction and handles approval flow correctly', async () => {
+    withRequest(
+      async ({
+        request,
+        messenger,
+        startFlowSpy,
+        addRequestSpy,
+        updateRequestStateSpy,
+      }) => {
+        request.smartTransactionsController.submitSignedTransactions = jest.fn(
+          async (_) => {
+            return {
+              uuid,
+              txHashes: ['hash1', 'hash2'],
+            };
+          },
+        );
+
+        setImmediate(() => {
+          messenger.publish('SmartTransactionsController:smartTransaction', {
+            status: 'pending',
+            uuid,
+            statusMetadata: {
+              minedHash: '',
+            },
+          } as SmartTransaction);
+          messenger.publish('SmartTransactionsController:smartTransaction', {
+            status: 'success',
+            uuid,
+            statusMetadata: {
+              minedHash: txHash,
+            },
+          } as SmartTransaction);
+        });
+
+        await submitBatchSmartTransactionHook(request);
+
+        expect(startFlowSpy).toHaveBeenCalled();
+        expect(addRequestSpy).toHaveBeenCalledWith(
+          {
+            id: 'approvalId',
+            origin: 'http://localhost',
+            type: 'smartTransaction:showSmartTransactionStatusPage',
+            requestState: {
+              smartTransaction: {
+                status: 'pending',
+                uuid,
+                creationTime: expect.any(Number),
+              },
+              isDapp: true,
+              txId,
+            },
+          },
+          true,
+        );
+
+        addRequestCallback();
+
+        expect(updateRequestStateSpy).toHaveBeenCalledWith({
+          id: 'approvalId',
+          requestState: {
+            smartTransaction: {
+              uuid,
+              status: 'success',
+              statusMetadata: {
+                minedHash: txHash,
+              },
+            },
+            isDapp: true,
+            txId,
+          },
+        });
+      },
+    );
+  });
+
+  it('returns empty results array when no txHashes are returned', async () => {
+    withRequest(async ({ request, messenger }) => {
+      request.smartTransactionsController.submitSignedTransactions = jest.fn(
+        async (_) => {
+          return {
+            uuid,
+            txHashes: undefined,
+          };
+        },
+      );
+
+      setImmediate(() => {
+        messenger.publish('SmartTransactionsController:smartTransaction', {
+          status: 'success',
+          uuid,
+          statusMetadata: {
+            minedHash: txHash,
+          },
+        } as SmartTransaction);
+      });
+
+      const result = await submitBatchSmartTransactionHook(request);
+
+      expect(result).toEqual({
+        results: [],
+      });
+    });
+  });
+
+  it('handles error during transaction submission', async () => {
+    withRequest(async ({ request, endFlowSpy }) => {
+      request.smartTransactionsController.submitSignedTransactions = jest.fn(
+        async (_) => {
+          throw new Error('Submission error');
+        },
+      );
+
+      await expect(submitBatchSmartTransactionHook(request)).rejects.toThrow(
+        'Submission error',
+      );
+
+      expect(endFlowSpy).toHaveBeenCalledWith({
+        id: 'approvalId',
+      });
+    });
   });
 });

--- a/app/scripts/lib/transaction/smart-transactions.ts
+++ b/app/scripts/lib/transaction/smart-transactions.ts
@@ -59,6 +59,12 @@ export type FeatureFlags = {
   };
 };
 
+export type SignedTransaction = {
+  id: string;
+  params: TransactionParams;
+  signedTx: Hex;
+};
+
 export type SubmitSmartTransactionRequest = {
   transactionMeta: TransactionMeta;
   signedTransactionInHex?: string;
@@ -67,6 +73,7 @@ export type SubmitSmartTransactionRequest = {
   isSmartTransaction: boolean;
   controllerMessenger: SmartTransactionHookMessenger;
   featureFlags: FeatureFlags;
+  transactions?: SignedTransaction[];
 };
 
 class SmartTransactionHook {
@@ -100,6 +107,8 @@ class SmartTransactionHook {
 
   #signedTransactionInHex?: string;
 
+  #transactions?: SignedTransaction[];
+
   #txParams: TransactionParams;
 
   #shouldShowStatusPage: boolean;
@@ -113,10 +122,11 @@ class SmartTransactionHook {
       isSmartTransaction,
       controllerMessenger,
       featureFlags,
+      transactions,
     } = request;
     this.#approvalFlowId = '';
     this.#approvalFlowEnded = false;
-    this.#transactionMeta = transactionMeta;
+    this.#transactionMeta = transactionMeta as TransactionMeta;
     this.#signedTransactionInHex = signedTransactionInHex;
     this.#smartTransactionsController = smartTransactionsController;
     this.#transactionController = transactionController;
@@ -126,13 +136,16 @@ class SmartTransactionHook {
     this.#isDapp = transactionMeta.origin !== ORIGIN_METAMASK;
     this.#chainId = transactionMeta.chainId;
     this.#txParams = transactionMeta.txParams;
-    this.#shouldShowStatusPage =
-      transactionMeta.type !== TransactionType.bridge;
+    this.#transactions = transactions;
+    this.#shouldShowStatusPage = Boolean(
+      transactionMeta.type !== TransactionType.bridge ||
+        (this.#transactions && this.#transactions.length > 0),
+    );
   }
 
   async submit() {
     const isUnsupportedTransactionTypeForSmartTransaction = this
-      .#transactionMeta?.type
+      .#transactionMeta.type
       ? [
           TransactionType.swapAndSend,
           TransactionType.swapApproval,
@@ -151,10 +164,7 @@ class SmartTransactionHook {
     }
 
     if (this.#shouldShowStatusPage) {
-      const { id: approvalFlowId } = await this.#controllerMessenger.call(
-        'ApprovalController:startFlow',
-      );
-      this.#approvalFlowId = approvalFlowId;
+      await this.#startApprovalFlow();
     }
     let getFeesResponse;
     try {
@@ -174,21 +184,17 @@ class SmartTransactionHook {
       const submitTransactionResponse = await this.#signAndSubmitTransactions({
         getFeesResponse,
       });
+
       const uuid = submitTransactionResponse?.uuid;
       if (!uuid) {
         throw new Error('No smart transaction UUID');
       }
+
+      await this.#processApprovalIfNeeded(uuid);
+
       const extensionReturnTxHashAsap =
         this.#featureFlags?.smartTransactions?.extensionReturnTxHashAsap;
 
-      if (this.#shouldShowStatusPage) {
-        this.#addApprovalRequest({
-          uuid,
-        });
-        this.#addListenerToUpdateStatusPage({
-          uuid,
-        });
-      }
       let transactionHash: string | undefined | null;
       if (extensionReturnTxHashAsap && submitTransactionResponse?.txHash) {
         transactionHash = submitTransactionResponse.txHash;
@@ -197,6 +203,7 @@ class SmartTransactionHook {
           uuid,
         });
       }
+
       if (transactionHash === null) {
         throw new Error(
           'Transaction does not have a transaction hash, there was a problem',
@@ -207,6 +214,77 @@ class SmartTransactionHook {
       log.error('Error in smart transaction publish hook', error);
       this.#onApproveOrReject();
       throw error;
+    }
+  }
+
+  async submitBatch() {
+    // Will cause TransactionController to publish to the RPC provider as normal.
+    const useRegularTransactionSubmit = undefined;
+
+    if (!this.#isSmartTransaction) {
+      return useRegularTransactionSubmit;
+    }
+
+    if (this.#shouldShowStatusPage) {
+      await this.#startApprovalFlow();
+    }
+
+    try {
+      const submitTransactionResponse = await this.#signAndSubmitTransactions();
+      const uuid = submitTransactionResponse?.uuid;
+
+      if (!uuid) {
+        throw new Error('No smart transaction UUID');
+      }
+
+      await this.#processApprovalIfNeeded(uuid);
+
+      const transactionHash = await this.#waitForTransactionHash({
+        uuid,
+      });
+
+      if (transactionHash === null) {
+        throw new Error(
+          'Transaction does not have a transaction hash, there was a problem',
+        );
+      }
+
+      let submitBatchResponse;
+      if (submitTransactionResponse?.txHashes) {
+        submitBatchResponse = {
+          results: submitTransactionResponse.txHashes.map((txHash: string) => ({
+            transactionHash: txHash,
+          })),
+        };
+      } else {
+        submitBatchResponse = {
+          results: [],
+        };
+      }
+
+      return submitBatchResponse;
+    } catch (error) {
+      log.error('Error in smart transaction publish batch hook', error);
+      this.#onApproveOrReject();
+      throw error;
+    }
+  }
+
+  async #startApprovalFlow() {
+    const { id: approvalFlowId } = await this.#controllerMessenger.call(
+      'ApprovalController:startFlow',
+    );
+    this.#approvalFlowId = approvalFlowId;
+  }
+
+  async #processApprovalIfNeeded(uuid: string) {
+    if (this.#shouldShowStatusPage) {
+      this.#addApprovalRequest({
+        uuid,
+      });
+      this.#addListenerToUpdateStatusPage({
+        uuid,
+      });
     }
   }
 
@@ -312,28 +390,43 @@ class SmartTransactionHook {
   async #signAndSubmitTransactions({
     getFeesResponse,
   }: {
-    getFeesResponse: Fees;
-  }) {
-    let signedTransactions;
-    if (this.#signedTransactionInHex) {
+    getFeesResponse?: Fees;
+  } = {}) {
+    let signedTransactions: string[] = [];
+
+    if (
+      this.#transactions &&
+      Array.isArray(this.#transactions) &&
+      this.#transactions.length > 0
+    ) {
+      // Batch transaction mode - extract signed transactions from this.#transactions[].signedTx
+      signedTransactions = this.#transactions
+        .filter((tx) => tx?.signedTx)
+        .map((tx) => tx.signedTx);
+    } else if (this.#signedTransactionInHex) {
+      // Single transaction mode with pre-signed transaction
       signedTransactions = [this.#signedTransactionInHex];
-    } else {
+    } else if (getFeesResponse) {
+      // Single transaction mode requiring signing
       signedTransactions = await this.#createSignedTransactions(
         getFeesResponse.tradeTxFees?.fees ?? [],
         false,
       );
     }
+
     return await this.#smartTransactionsController.submitSignedTransactions({
       signedTransactions,
       signedCanceledTransactions: [],
       txParams: this.#txParams,
-      // TODO: Replace `any` with type - version mismatch between smart-transactions-controller and transaction-controller breaking type safety
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      transactionMeta: this.#transactionMeta as any,
+      transactionMeta: this.#transactionMeta,
     });
   }
 
   #applyFeeToTransaction(fee: Fee, isCancel: boolean): TransactionParams {
+    if (!this.#txParams) {
+      throw new Error('Transaction params are required');
+    }
+
     const unsignedTransaction = {
       ...this.#txParams,
       maxFeePerGas: `0x${decimalToHex(fee.maxFeePerGas)}`,
@@ -341,11 +434,13 @@ class SmartTransactionHook {
       gas: isCancel
         ? `0x${decimalToHex(CANCEL_GAS_LIMIT_DEC)}` // It has to be 21000 for cancel transactions, otherwise the API would reject it.
         : this.#txParams.gas,
-    };
+    } as TransactionParams;
+
     if (isCancel) {
       unsignedTransaction.to = unsignedTransaction.from;
       unsignedTransaction.data = '0x';
     }
+
     return unsignedTransaction;
   }
 
@@ -353,15 +448,21 @@ class SmartTransactionHook {
     fees: Fee[],
     isCancel: boolean,
   ): Promise<string[]> {
+    if (!this.#txParams || !this.#chainId) {
+      throw new Error('Transaction params and chainId are required');
+    }
+
     const unsignedTransactions = fees.map((fee) => {
       return this.#applyFeeToTransaction(fee, isCancel);
     });
+
     const transactionsWithChainId = unsignedTransactions.map((tx) => ({
       ...tx,
       chainId: tx.chainId || this.#chainId,
     }));
+
     return (await this.#transactionController.approveTransactionsWithSameNonce(
-      transactionsWithChainId,
+      transactionsWithChainId as (TransactionParams & { chainId: Hex })[],
       { hasNonce: true },
     )) as string[];
   }
@@ -372,4 +473,11 @@ export const submitSmartTransactionHook = (
 ) => {
   const smartTransactionHook = new SmartTransactionHook(request);
   return smartTransactionHook.submit();
+};
+
+export const submitBatchSmartTransactionHook = (
+  request: SubmitSmartTransactionRequest,
+) => {
+  const smartTransactionHook = new SmartTransactionHook(request);
+  return smartTransactionHook.submitBatch();
 };

--- a/app/scripts/lib/transaction/smart-transactions.ts
+++ b/app/scripts/lib/transaction/smart-transactions.ts
@@ -13,6 +13,7 @@ import {
   TransactionMeta,
   TransactionParams,
   TransactionType,
+  type PublishBatchHookTransaction,
 } from '@metamask/transaction-controller';
 import log from 'loglevel';
 import { RestrictedMessenger } from '@metamask/base-controller';
@@ -60,12 +61,6 @@ export type FeatureFlags = {
   };
 };
 
-export type SignedTransaction = {
-  id: string;
-  params: TransactionParams;
-  signedTx: Hex;
-};
-
 export type SubmitSmartTransactionRequest = {
   transactionMeta: TransactionMeta;
   signedTransactionInHex?: string;
@@ -74,7 +69,7 @@ export type SubmitSmartTransactionRequest = {
   isSmartTransaction: boolean;
   controllerMessenger: SmartTransactionHookMessenger;
   featureFlags: FeatureFlags;
-  transactions?: SignedTransaction[];
+  transactions?: PublishBatchHookTransaction[];
 };
 
 class SmartTransactionHook {
@@ -111,7 +106,7 @@ class SmartTransactionHook {
 
   #signedTransactionInHex?: string;
 
-  #transactions?: SignedTransaction[];
+  #transactions?: PublishBatchHookTransaction[];
 
   #txParams: TransactionParams;
 

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -208,7 +208,7 @@ async function addUserOperationWithController(
   };
 }
 
-function getTransactionById(
+export function getTransactionById(
   transactionId: string,
   transactionController: TransactionController,
 ) {


### PR DESCRIPTION
## **Description**
This PR implements the publishBatch hook for smart transactions, which will be used when submitting multiple transactions at once, e.g. when a user choose their gas token for a transaction.

We can test this end to end once UI for the Transaction Confirmation page is merged. Then we might need to do some final tweaks if needed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31267?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Once the UI on the Transaction Confirmation page is ready (e.g. when you do a Send transaction), you will be able to choose a gas token to be used for transaction fees

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
