### PR TITLE
fix: import srp input validation

### DIFF
--- a/ui/components/multichain/multi-srp/import-srp/import-srp.test.tsx
+++ b/ui/components/multichain/multi-srp/import-srp/import-srp.test.tsx
@@ -58,6 +58,49 @@ describe('ImportSrp', () => {
     jest.restoreAllMocks();
   });
 
+  it('should not show error messages until all words are provided', async () => {
+    const render = renderWithProvider(
+      <ImportSrp onActionComplete={jest.fn()} />,
+      store,
+    );
+    const { queryByText } = render;
+
+    // Initially, no error message should be shown
+    expect(
+      queryByText('Word 1 is incorrect or misspelled.'),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByText('Secret Recovery Phrases contain 12, or 24 words'),
+    ).not.toBeInTheDocument();
+
+    // Paste a partial SRP (first 6 words)
+    const partialSrp = VALID_SECRET_RECOVERY_PHRASE.split(' ')
+      .slice(0, 6)
+      .join(' ');
+    pasteSrpIntoFirstInput(render, partialSrp);
+
+    // Still no error message should be shown
+    expect(
+      queryByText('Word 1 is incorrect or misspelled.'),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByText('Secret Recovery Phrases contain 12, or 24 words'),
+    ).not.toBeInTheDocument();
+
+    // Paste the complete SRP
+    pasteSrpIntoFirstInput(render, VALID_SECRET_RECOVERY_PHRASE);
+
+    // Now error messages should be shown if there are any issues
+    await waitFor(() => {
+      expect(
+        queryByText('Word 1 is incorrect or misspelled.'),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByText('Secret Recovery Phrases contain 12, or 24 words'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it('enables the "Import wallet" button when a valid secret recovery phrase is entered', async () => {
     const render = renderWithProvider(
       <ImportSrp onActionComplete={jest.fn()} />,

--- a/ui/components/multichain/multi-srp/import-srp/import-srp.tsx
+++ b/ui/components/multichain/multi-srp/import-srp/import-srp.tsx
@@ -145,19 +145,21 @@ export const ImportSrp = ({
         return state;
       };
 
-      const joinedDraftSrp = newDraftSrp.join(' ').trim();
-      const invalidWords = Array(newDraftSrp.length).fill(false);
-      let validationResult = validateSrp(newDraftSrp, invalidWords);
-      validationResult = validateCompleteness(validationResult, newDraftSrp);
-      validationResult = validateCase(validationResult, joinedDraftSrp);
-      validationResult = validateWords(validationResult);
-      validationResult = validateMnemonic(validationResult, joinedDraftSrp);
+      if (newDraftSrp.filter((word) => word !== '').length === numberOfWords) {
+        const joinedDraftSrp = newDraftSrp.join(' ').trim();
+        const invalidWords = Array(newDraftSrp.length).fill(false);
+        let validationResult = validateSrp(newDraftSrp, invalidWords);
+        validationResult = validateCase(validationResult, joinedDraftSrp);
+        validationResult = validateCompleteness(validationResult, newDraftSrp);
+        validationResult = validateWords(validationResult);
+        validationResult = validateMnemonic(validationResult, joinedDraftSrp);
+        setSrpError(validationResult.error);
+        setInvalidSrpWords(validationResult.words);
+      }
 
       setSecretRecoveryPhrase(newDraftSrp);
-      setSrpError(validationResult.error);
-      setInvalidSrpWords(validationResult.words);
     },
-    [t, setSrpError, setSecretRecoveryPhrase],
+    [t, setSrpError, setSecretRecoveryPhrase, numberOfWords],
   );
 
   const onSrpPaste = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes validation time of import srp input. Currently, we're showing error message after providing first word. After this change, the validation happens only after providing complete set of words.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMMULTISRP-98

## **Manual testing steps**

1. Open MM
2. Click “Import Secret Recovery Phrase”
3. Type in 1 word
4. Check if the error banner is shown
5. Delete each word in seed phrase

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="438" alt="Screenshot 2025-03-25 at 12 15 37" src="https://github.com/user-attachments/assets/3758d183-4c43-4e6a-8a49-e4b0029ffcc6" />

### **After**

<!-- [screenshots/recordings] -->
<img width="309" alt="Screenshot 2025-03-25 at 12 42 53" src="https://github.com/user-attachments/assets/60b96678-c806-491f-96b3-224067c0be76" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
