### PR TITLE
fix: Use same address shortening logic when resolving domains

### DIFF
--- a/test/e2e/snaps/test-snap-namelookup.spec.ts
+++ b/test/e2e/snaps/test-snap-namelookup.spec.ts
@@ -35,7 +35,7 @@ describe('Name lookup', function () {
         await sendTokenPage.fillRecipient('metamask.domain');
         await sendTokenPage.check_ensAddressResolution(
           'metamask.domain',
-          '0xc0ff...4979',
+          '0xc0ffe...54979',
         );
       },
     );

--- a/test/e2e/tests/transaction/ens.spec.ts
+++ b/test/e2e/tests/transaction/ens.spec.ts
@@ -12,9 +12,7 @@ import { mockMultiNetworkBalancePolling } from '../../mock-balance-polling/mock-
 describe('ENS', function (this: Suite) {
   const sampleAddress: string = '1111111111111111111111111111111111111111';
 
-  // Having 2 versions of the address is a bug(#25286)
-  const shortSampleAddress = '0x1111...1111';
-  const shortSampleAddresV2 = '0x11111...11111';
+  const shortSampleAddress = '0x11111...11111';
   const chainId = 1;
 
   // ENS Contract Addresses and Function Signatures
@@ -108,7 +106,7 @@ describe('ENS', function (this: Suite) {
         // Verify the resolved ENS address can be used as the recipient address
         await sendToPage.check_ensAddressAsRecipient(
           sampleEnsDomain,
-          shortSampleAddresV2,
+          shortSampleAddress,
         );
       },
     );

--- a/ui/components/multichain/pages/send/components/domain-input-resolution-cell.tsx
+++ b/ui/components/multichain/pages/send/components/domain-input-resolution-cell.tsx
@@ -20,8 +20,8 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
-import { ellipsify } from '../../../../../pages/confirmations/send/send.utils';
 import Tooltip from '../../../../ui/tooltip';
+import { shortenAddress } from '../../../../../helpers/utils/util';
 
 type DomainInputResolutionCellArgs = {
   address: string;
@@ -144,7 +144,7 @@ export const DomainInputResolutionCell = ({
             <Confusable asText input={domainName} />
           )}
         </Box>
-        <Text color={TextColor.textAlternative}>{ellipsify(address)}</Text>
+        <Text color={TextColor.textAlternative}>{shortenAddress(address)}</Text>
         <Box
           className="multichain-send-page__recipient__item__subtitle"
           data-testid="multichain-send-page__recipient__item__subtitle"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`DomainInputResolutionCell` was not using `shortenAddress` which resulted in some confusion when comparing to other elements on the same screen. This PR corrects that.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31282?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25286

## **Manual testing steps**

1. Go to the send flow
2. Type in an ENS name
3. See that it is truncated using the same amount of characters as everywhere else
