### PR TITLE
fix (cherry-pick): validate EIP-5792 requests using PPOM (#31231)

### DIFF
--- a/.yarn/patches/@metamask-transaction-controller-npm-50.0.0-6e65889240.patch
+++ b/.yarn/patches/@metamask-transaction-controller-npm-50.0.0-6e65889240.patch
@@ -78,6 +78,234 @@ index 3ecb211958f31624677c0db41c0e87b2cdb4cf76..92d1d34182a3b319253ee11cef27e385
          txMeta: transactionMeta,
      });
  }, _TransactionController_deleteTransaction = function _TransactionController_deleteTransaction(transactionId) {
+diff --git a/dist/index.d.cts b/dist/index.d.cts
+index ddb051c3fa6b160ee45c3b3c5968cdf6fef33f37..4d51b296f1c8668e31ce19b3c30b6e2a84f7fb15 100644
+--- a/dist/index.d.cts
++++ b/dist/index.d.cts
+@@ -1,6 +1,6 @@
+ export type { MethodData, Result, TransactionControllerActions, TransactionControllerEvents, TransactionControllerGetStateAction, TransactionControllerIncomingTransactionsReceivedEvent, TransactionControllerPostTransactionBalanceUpdatedEvent, TransactionControllerSpeedupTransactionAddedEvent, TransactionControllerState, TransactionControllerStateChangeEvent, TransactionControllerTransactionApprovedEvent, TransactionControllerTransactionConfirmedEvent, TransactionControllerTransactionDroppedEvent, TransactionControllerTransactionFailedEvent, TransactionControllerTransactionFinishedEvent, TransactionControllerTransactionNewSwapApprovalEvent, TransactionControllerTransactionNewSwapEvent, TransactionControllerTransactionPublishingSkipped, TransactionControllerTransactionRejectedEvent, TransactionControllerTransactionStatusUpdatedEvent, TransactionControllerTransactionSubmittedEvent, TransactionControllerUnapprovedTransactionAddedEvent, TransactionControllerMessenger, TransactionControllerOptions, } from "./TransactionController.cjs";
+ export { CANCEL_RATE, SPEED_UP_RATE, TransactionController, } from "./TransactionController.cjs";
+-export type { Authorization, AuthorizationList, BatchTransactionParams, DappSuggestedGasFees, DefaultGasEstimates, FeeMarketEIP1559Values, FeeMarketGasFeeEstimateForLevel, FeeMarketGasFeeEstimates, GasFeeEstimates, GasPriceGasFeeEstimates, GasPriceValue, InferTransactionTypeResult, LegacyGasFeeEstimates, Log, NestedTransactionMetadata, SavedGasFees, SecurityAlertResponse, SecurityProviderRequest, SendFlowHistoryEntry, SimulationBalanceChange, SimulationData, SimulationError, SimulationToken, SimulationTokenBalanceChange, TransactionBatchRequest, TransactionBatchResult, TransactionError, TransactionHistory, TransactionHistoryEntry, TransactionMeta, TransactionParams, TransactionReceipt, } from "./types.cjs";
++export type { Authorization, AuthorizationList, BatchTransactionParams, DappSuggestedGasFees, DefaultGasEstimates, FeeMarketEIP1559Values, FeeMarketGasFeeEstimateForLevel, FeeMarketGasFeeEstimates, GasFeeEstimates, GasPriceGasFeeEstimates, GasPriceValue, InferTransactionTypeResult, LegacyGasFeeEstimates, Log, NestedTransactionMetadata, SavedGasFees, SecurityAlertResponse, SecurityProviderRequest, SendFlowHistoryEntry, SimulationBalanceChange, SimulationData, SimulationError, SimulationToken, SimulationTokenBalanceChange, TransactionBatchRequest, TransactionBatchResult, TransactionError, TransactionHistory, TransactionHistoryEntry, TransactionMeta, TransactionParams, TransactionReceipt, ValidateSecurityRequest, } from "./types.cjs";
+ export { GasFeeEstimateLevel, GasFeeEstimateType, SimulationErrorCode, SimulationTokenStandard, TransactionEnvelopeType, TransactionStatus, TransactionType, UserFeeLevel, WalletDevice, } from "./types.cjs";
+ export { DISPLAYED_TRANSACTION_HISTORY_PATHS, MAX_TRANSACTION_HISTORY_LENGTH, } from "./utils/history.cjs";
+ export { determineTransactionType } from "./utils/transaction-type.cjs";
+diff --git a/dist/index.d.mts b/dist/index.d.mts
+index 8e85dcca513f6f8879b3c217a65c34537ad25634..21a816f052d5ca2c55dc471613e14b2b2d7c86c0 100644
+--- a/dist/index.d.mts
++++ b/dist/index.d.mts
+@@ -1,6 +1,6 @@
+ export type { MethodData, Result, TransactionControllerActions, TransactionControllerEvents, TransactionControllerGetStateAction, TransactionControllerIncomingTransactionsReceivedEvent, TransactionControllerPostTransactionBalanceUpdatedEvent, TransactionControllerSpeedupTransactionAddedEvent, TransactionControllerState, TransactionControllerStateChangeEvent, TransactionControllerTransactionApprovedEvent, TransactionControllerTransactionConfirmedEvent, TransactionControllerTransactionDroppedEvent, TransactionControllerTransactionFailedEvent, TransactionControllerTransactionFinishedEvent, TransactionControllerTransactionNewSwapApprovalEvent, TransactionControllerTransactionNewSwapEvent, TransactionControllerTransactionPublishingSkipped, TransactionControllerTransactionRejectedEvent, TransactionControllerTransactionStatusUpdatedEvent, TransactionControllerTransactionSubmittedEvent, TransactionControllerUnapprovedTransactionAddedEvent, TransactionControllerMessenger, TransactionControllerOptions, } from "./TransactionController.mjs";
+ export { CANCEL_RATE, SPEED_UP_RATE, TransactionController, } from "./TransactionController.mjs";
+-export type { Authorization, AuthorizationList, BatchTransactionParams, DappSuggestedGasFees, DefaultGasEstimates, FeeMarketEIP1559Values, FeeMarketGasFeeEstimateForLevel, FeeMarketGasFeeEstimates, GasFeeEstimates, GasPriceGasFeeEstimates, GasPriceValue, InferTransactionTypeResult, LegacyGasFeeEstimates, Log, NestedTransactionMetadata, SavedGasFees, SecurityAlertResponse, SecurityProviderRequest, SendFlowHistoryEntry, SimulationBalanceChange, SimulationData, SimulationError, SimulationToken, SimulationTokenBalanceChange, TransactionBatchRequest, TransactionBatchResult, TransactionError, TransactionHistory, TransactionHistoryEntry, TransactionMeta, TransactionParams, TransactionReceipt, } from "./types.mjs";
++export type { Authorization, AuthorizationList, BatchTransactionParams, DappSuggestedGasFees, DefaultGasEstimates, FeeMarketEIP1559Values, FeeMarketGasFeeEstimateForLevel, FeeMarketGasFeeEstimates, GasFeeEstimates, GasPriceGasFeeEstimates, GasPriceValue, InferTransactionTypeResult, LegacyGasFeeEstimates, Log, NestedTransactionMetadata, SavedGasFees, SecurityAlertResponse, SecurityProviderRequest, SendFlowHistoryEntry, SimulationBalanceChange, SimulationData, SimulationError, SimulationToken, SimulationTokenBalanceChange, TransactionBatchRequest, TransactionBatchResult, TransactionError, TransactionHistory, TransactionHistoryEntry, TransactionMeta, TransactionParams, TransactionReceipt, ValidateSecurityRequest, } from "./types.mjs";
+ export { GasFeeEstimateLevel, GasFeeEstimateType, SimulationErrorCode, SimulationTokenStandard, TransactionEnvelopeType, TransactionStatus, TransactionType, UserFeeLevel, WalletDevice, } from "./types.mjs";
+ export { DISPLAYED_TRANSACTION_HISTORY_PATHS, MAX_TRANSACTION_HISTORY_LENGTH, } from "./utils/history.mjs";
+ export { determineTransactionType } from "./utils/transaction-type.mjs";
+diff --git a/dist/types.d.cts b/dist/types.d.cts
+index 693e50b14e0ceea7fd3e3a0184986b639d7f0647..df27da562cd642b3e9b2847524131b12e6651a11 100644
+--- a/dist/types.d.cts
++++ b/dist/types.d.cts
+@@ -918,10 +918,11 @@ export type TransactionError = {
+  * Type for security alert response from transaction validator.
+  */
+ export type SecurityAlertResponse = {
+-    reason: string;
+     features?: string[];
+-    result_type: string;
+     providerRequestsCount?: Record<string, number>;
++    reason: string;
++    result_type: string;
++    securityAlertId?: string;
+ };
+ /** Alternate priority levels for which values are provided in gas fee estimates. */
+ export declare enum GasFeeEstimateLevel {
+@@ -1185,8 +1186,17 @@ export type TransactionBatchRequest = {
+     origin?: string;
+     /** Whether an approval request should be created to require confirmation from the user. */
+     requireApproval?: boolean;
++    /** Security alert ID to persist on the transaction. */
++    securityAlertId?: string;
+     /** Transactions to be submitted as part of the batch. */
+     transactions: TransactionBatchSingleRequest[];
++    /**
++     * Callback to trigger security validation in the client.
++     *
++     * @param request - The JSON-RPC request to validate.
++     * @param chainId - The chain ID of the transaction batch.
++     */
++    validateSecurity?: (request: ValidateSecurityRequest, chainId: Hex) => Promise<void>;
+ };
+ /**
+  * Result from submitting a transaction batch.
+@@ -1195,5 +1205,16 @@ export type TransactionBatchResult = {
+     /** ID of the batch to locate related transactions. */
+     batchId: Hex;
+ };
++/**
++ * Request to validate security of a transaction in the client.
++ */
++export type ValidateSecurityRequest = {
++    /** JSON-RPC method to validate. */
++    method: string;
++    /** Parameters of the JSON-RPC method to validate. */
++    params: unknown[];
++    /** Optional EIP-7702 delegation to mock for the transaction sender. */
++    delegationMock?: Hex;
++};
+ export {};
+ //# sourceMappingURL=types.d.cts.map
+\ No newline at end of file
+diff --git a/dist/types.d.mts b/dist/types.d.mts
+index 450a27115a5f0d3ed3f719de6e98b14410e4de81..73084cf88c1c498671771ef560bf175d4aca8a82 100644
+--- a/dist/types.d.mts
++++ b/dist/types.d.mts
+@@ -918,10 +918,11 @@ export type TransactionError = {
+  * Type for security alert response from transaction validator.
+  */
+ export type SecurityAlertResponse = {
+-    reason: string;
+     features?: string[];
+-    result_type: string;
+     providerRequestsCount?: Record<string, number>;
++    reason: string;
++    result_type: string;
++    securityAlertId?: string;
+ };
+ /** Alternate priority levels for which values are provided in gas fee estimates. */
+ export declare enum GasFeeEstimateLevel {
+@@ -1185,8 +1186,17 @@ export type TransactionBatchRequest = {
+     origin?: string;
+     /** Whether an approval request should be created to require confirmation from the user. */
+     requireApproval?: boolean;
++    /** Security alert ID to persist on the transaction. */
++    securityAlertId?: string;
+     /** Transactions to be submitted as part of the batch. */
+     transactions: TransactionBatchSingleRequest[];
++    /**
++     * Callback to trigger security validation in the client.
++     *
++     * @param request - The JSON-RPC request to validate.
++     * @param chainId - The chain ID of the transaction batch.
++     */
++    validateSecurity?: (request: ValidateSecurityRequest, chainId: Hex) => Promise<void>;
+ };
+ /**
+  * Result from submitting a transaction batch.
+@@ -1195,5 +1205,16 @@ export type TransactionBatchResult = {
+     /** ID of the batch to locate related transactions. */
+     batchId: Hex;
+ };
++/**
++ * Request to validate security of a transaction in the client.
++ */
++export type ValidateSecurityRequest = {
++    /** JSON-RPC method to validate. */
++    method: string;
++    /** Parameters of the JSON-RPC method to validate. */
++    params: unknown[];
++    /** Optional EIP-7702 delegation to mock for the transaction sender. */
++    delegationMock?: Hex;
++};
+ export {};
+ //# sourceMappingURL=types.d.mts.map
+\ No newline at end of file
+diff --git a/dist/utils/batch.cjs b/dist/utils/batch.cjs
+index f2f3931df247fc8798f020900b32710b086b25dd..f1d677c80c5ffe77443ceeeaea8f3034d95c318d 100644
+--- a/dist/utils/batch.cjs
++++ b/dist/utils/batch.cjs
+@@ -25,7 +25,7 @@ async function addTransactionBatch(request) {
+         request: userRequest,
+         sizeLimit,
+     });
+-    const { batchId: batchIdOverride, from, networkClientId, requireApproval, transactions, } = userRequest;
++    const { batchId: batchIdOverride, from, networkClientId, requireApproval, securityAlertId, transactions, validateSecurity, } = userRequest;
+     log('Adding', userRequest);
+     const chainId = getChainId(networkClientId);
+     const ethQuery = request.getEthQuery(networkClientId);
+@@ -57,13 +57,34 @@ async function addTransactionBatch(request) {
+         txParams.type = types_1.TransactionEnvelopeType.setCode;
+         txParams.authorizationList = [{ address: upgradeContractAddress }];
+     }
++    if (validateSecurity) {
++        const securityRequest = {
++            method: 'eth_sendTransaction',
++            params: [
++                {
++                    ...txParams,
++                    authorizationList: undefined,
++                    type: types_1.TransactionEnvelopeType.feeMarket,
++                },
++            ],
++            delegationMock: txParams.authorizationList?.[0]?.address,
++        };
++        log('Security request', securityRequest);
++        validateSecurity(securityRequest, chainId).catch((error) => {
++            log('Security validation failed', error);
++        });
++    }
+     log('Adding batch transaction', txParams, networkClientId);
+     const batchId = batchIdOverride ?? generateBatchId();
++    const securityAlertResponse = securityAlertId
++        ? { securityAlertId }
++        : undefined;
+     const { result } = await addTransaction(txParams, {
+         batchId,
+         nestedTransactions,
+         networkClientId,
+         requireApproval,
++        securityAlertResponse,
+         type: types_1.TransactionType.batch,
+     });
+     // Wait for the transaction to be published.
+diff --git a/dist/utils/batch.mjs b/dist/utils/batch.mjs
+index c1a98754a78717ae716043c68bef3af10a5d5fc3..ae130ff924e6cc60a9aebf3450d08b8f0e3b3608 100644
+--- a/dist/utils/batch.mjs
++++ b/dist/utils/batch.mjs
+@@ -22,7 +22,7 @@ export async function addTransactionBatch(request) {
+         request: userRequest,
+         sizeLimit,
+     });
+-    const { batchId: batchIdOverride, from, networkClientId, requireApproval, transactions, } = userRequest;
++    const { batchId: batchIdOverride, from, networkClientId, requireApproval, securityAlertId, transactions, validateSecurity, } = userRequest;
+     log('Adding', userRequest);
+     const chainId = getChainId(networkClientId);
+     const ethQuery = request.getEthQuery(networkClientId);
+@@ -54,13 +54,34 @@ export async function addTransactionBatch(request) {
+         txParams.type = TransactionEnvelopeType.setCode;
+         txParams.authorizationList = [{ address: upgradeContractAddress }];
+     }
++    if (validateSecurity) {
++        const securityRequest = {
++            method: 'eth_sendTransaction',
++            params: [
++                {
++                    ...txParams,
++                    authorizationList: undefined,
++                    type: TransactionEnvelopeType.feeMarket,
++                },
++            ],
++            delegationMock: txParams.authorizationList?.[0]?.address,
++        };
++        log('Security request', securityRequest);
++        validateSecurity(securityRequest, chainId).catch((error) => {
++            log('Security validation failed', error);
++        });
++    }
+     log('Adding batch transaction', txParams, networkClientId);
+     const batchId = batchIdOverride ?? generateBatchId();
++    const securityAlertResponse = securityAlertId
++        ? { securityAlertId }
++        : undefined;
+     const { result } = await addTransaction(txParams, {
+         batchId,
+         nestedTransactions,
+         networkClientId,
+         requireApproval,
++        securityAlertResponse,
+         type: TransactionType.batch,
+     });
+     // Wait for the transaction to be published.
 diff --git a/dist/utils/feature-flags.cjs b/dist/utils/feature-flags.cjs
 index f5997a25468c27acb6f82f131906d87be0233b44..af10348ec8c726f99b64e67b8c78948e990a0a0b 100644
 --- a/dist/utils/feature-flags.cjs

--- a/app/scripts/lib/transaction/eip5792.test.ts
+++ b/app/scripts/lib/transaction/eip5792.test.ts
@@ -86,6 +86,10 @@ describe('EIP-5792', () => {
 
   let getDisabledAccountUpgradeChainsMock: jest.MockedFn<() => Hex[]>;
 
+  let validateSecurityMock: jest.MockedFunction<
+    Parameters<typeof processSendCalls>[0]['validateSecurity']
+  >;
+
   let messenger: EIP5792Messenger;
 
   beforeEach(() => {
@@ -95,6 +99,7 @@ describe('EIP-5792', () => {
     getTransactionControllerStateMock = jest.fn();
     getNetworkClientByIdMock = jest.fn();
     getDisabledAccountUpgradeChainsMock = jest.fn();
+    validateSecurityMock = jest.fn();
 
     messenger = new Messenger();
 
@@ -117,6 +122,7 @@ describe('EIP-5792', () => {
     addTransactionBatchMock.mockResolvedValue({
       batchId: BATCH_ID_MOCK,
     });
+
     getDisabledAccountUpgradeChainsMock.mockReturnValue([]);
   });
 
@@ -126,6 +132,7 @@ describe('EIP-5792', () => {
         {
           addTransactionBatch: addTransactionBatchMock,
           getDisabledAccountUpgradeChains: getDisabledAccountUpgradeChainsMock,
+          validateSecurity: validateSecurityMock,
         },
         messenger,
         SEND_CALLS_MOCK,
@@ -136,7 +143,9 @@ describe('EIP-5792', () => {
         from: SEND_CALLS_MOCK.from,
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         origin: ORIGIN_MOCK,
+        securityAlertId: expect.any(String),
         transactions: [{ params: SEND_CALLS_MOCK.calls[0] }],
+        validateSecurity: expect.any(Function),
       });
     });
 
@@ -147,6 +156,7 @@ describe('EIP-5792', () => {
             addTransactionBatch: addTransactionBatchMock,
             getDisabledAccountUpgradeChains:
               getDisabledAccountUpgradeChainsMock,
+            validateSecurity: validateSecurityMock,
           },
           messenger,
           SEND_CALLS_MOCK,
@@ -162,6 +172,7 @@ describe('EIP-5792', () => {
             addTransactionBatch: addTransactionBatchMock,
             getDisabledAccountUpgradeChains:
               getDisabledAccountUpgradeChainsMock,
+            validateSecurity: validateSecurityMock,
           },
           messenger,
           { ...SEND_CALLS_MOCK, version: '2.0' },
@@ -177,6 +188,7 @@ describe('EIP-5792', () => {
             addTransactionBatch: addTransactionBatchMock,
             getDisabledAccountUpgradeChains:
               getDisabledAccountUpgradeChainsMock,
+            validateSecurity: validateSecurityMock,
           },
           messenger,
           { ...SEND_CALLS_MOCK, chainId: CHAIN_ID_2_MOCK },
@@ -196,6 +208,7 @@ describe('EIP-5792', () => {
             addTransactionBatch: addTransactionBatchMock,
             getDisabledAccountUpgradeChains:
               getDisabledAccountUpgradeChainsMock,
+            validateSecurity: validateSecurityMock,
           },
           messenger,
           SEND_CALLS_MOCK,
@@ -213,6 +226,7 @@ describe('EIP-5792', () => {
             addTransactionBatch: addTransactionBatchMock,
             getDisabledAccountUpgradeChains:
               getDisabledAccountUpgradeChainsMock,
+            validateSecurity: validateSecurityMock,
           },
           messenger,
           {
@@ -235,6 +249,7 @@ describe('EIP-5792', () => {
             addTransactionBatch: addTransactionBatchMock,
             getDisabledAccountUpgradeChains:
               getDisabledAccountUpgradeChainsMock,
+            validateSecurity: validateSecurityMock,
           },
           messenger,
           {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -345,7 +345,6 @@ import { METAMASK_COOKIE_HANDLER } from './constants/stream';
 // Notification controllers
 import { createTxVerificationMiddleware } from './lib/tx-verification/tx-verification-middleware';
 import {
-  generateSecurityAlertId,
   updateSecurityAlertResponse,
   validateRequestWithPPOM,
 } from './lib/ppom/ppom-util';

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -344,7 +344,11 @@ import { METAMASK_COOKIE_HANDLER } from './constants/stream';
 
 // Notification controllers
 import { createTxVerificationMiddleware } from './lib/tx-verification/tx-verification-middleware';
-import { updateSecurityAlertResponse } from './lib/ppom/ppom-util';
+import {
+  generateSecurityAlertId,
+  updateSecurityAlertResponse,
+  validateRequestWithPPOM,
+} from './lib/ppom/ppom-util';
 import createEvmMethodsToNonEvmAccountReqFilterMiddleware from './lib/createEvmMethodsToNonEvmAccountReqFilterMiddleware';
 import { isEthAddress } from './lib/multichain/address';
 
@@ -2159,6 +2163,15 @@ export default class MetamaskController extends EventEmitter {
             this.preferencesController.getDisabledAccountUpgradeChains.bind(
               this.preferencesController,
             ),
+          validateSecurity: (securityAlertId, request, chainId) =>
+            validateRequestWithPPOM({
+              chainId,
+              ppomController: this.ppomController,
+              request,
+              securityAlertId,
+              updateSecurityAlertResponse:
+                this.updateSecurityAlertResponse.bind(this),
+            }),
         },
         this.controllerMessenger,
       ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6589,7 +6589,7 @@ __metadata:
 
 "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A50.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-50.0.0-6e65889240.patch":
   version: 50.0.0
-  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A50.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-50.0.0-6e65889240.patch::version=50.0.0&hash=83ca22"
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A50.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-50.0.0-6e65889240.patch::version=50.0.0&hash=46660b"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -6619,7 +6619,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^22.0.0
     "@metamask/network-controller": ^22.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 10/aab8e4e157b93a0def4cb2e6603b9f494a5c725cffb94e356b1b590265d7843c4d0f7237ee1d7acc083d31eaaa4ac38fbdd401906ba1e66bb0432ecd81163e72
+  checksum: 10/b5b270ff4614a1f3ec0515f1d81d83854fd23ed73e629f9c536f0c3110574486f36c00f7262a10cec5eb6afa4b9e45c264cc78b8d8cb6b46e4185e4f9da102b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Cherry-pick of #31231 for `12.15.0`.

Using patch as `@metamask/transaction-controller` release includes unrelated changes.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31291?quickstart=1)

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
