### PR TITLE
chore: rename migration 151 to 146.1

### DIFF
--- a/app/scripts/migrations/146.1.test.ts
+++ b/app/scripts/migrations/146.1.test.ts
@@ -1,7 +1,7 @@
-import { migrate } from './151';
+import { migrate } from './146.1';
 
-const expectedVersion = 151;
-const previousVersion = expectedVersion - 1;
+const expectedVersion = 146.1;
+const previousVersion = 146;
 
 describe(`migration #${expectedVersion}`, () => {
   it('does nothing if state.NetworkController has no networkConfigurationsByChainId property', async () => {

--- a/app/scripts/migrations/146.1.ts
+++ b/app/scripts/migrations/146.1.ts
@@ -6,7 +6,7 @@ type VersionedData = {
   data: Record<string, unknown>;
 };
 
-export const version = 151;
+export const version = 146.1;
 
 /**
  * This migration sets the selectedNetworkClientId to mainnet if the current selectedNetworkClientId does not exist in the networkConfigurationsByChainId object.

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -172,11 +172,11 @@ const migrations = [
   require('./144'),
   require('./145'),
   require('./146'),
+  require('./146.1'),
   require('./147'),
   require('./148'),
   require('./149'),
   require('./150'),
-  require('./151'),
 ];
 
 export default migrations;


### PR DESCRIPTION
## **Description**

Renamed to more easily backport to v12.14.2

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31304?quickstart=1)

## **Related issues**

This is a suggested change for https://github.com/MetaMask/metamask-extension/pull/31298

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
