### PR TITLE
chore: Skip failing flask e2e tests

### DIFF
--- a/test/e2e/flask/solana/check-balance.spec.ts
+++ b/test/e2e/flask/solana/check-balance.spec.ts
@@ -4,7 +4,9 @@ import { withSolanaAccountSnap } from './common-solana';
 
 describe('Check balance', function (this: Suite) {
   this.timeout(300000);
-  it('Just created Solana account shows 0 SOL when native token is enabled', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('Just created Solana account shows 0 SOL when native token is enabled', async function () {
     await withSolanaAccountSnap(
       {
         title: this.test?.fullTitle(),
@@ -17,7 +19,9 @@ describe('Check balance', function (this: Suite) {
       },
     );
   });
-  it('Just created Solana account shows 0 USD when native token is not enabled', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('Just created Solana account shows 0 USD when native token is not enabled', async function () {
     await withSolanaAccountSnap(
       {
         title: this.test?.fullTitle(),
@@ -30,7 +34,9 @@ describe('Check balance', function (this: Suite) {
       },
     );
   });
-  it('For a non 0 balance account - USD balance', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('For a non 0 balance account - USD balance', async function () {
     await withSolanaAccountSnap(
       {
         title: this.test?.fullTitle(),
@@ -43,7 +49,9 @@ describe('Check balance', function (this: Suite) {
       },
     );
   });
-  it('For a non 0 balance account - SOL balance', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('For a non 0 balance account - SOL balance', async function () {
     await withSolanaAccountSnap(
       {
         title: this.test?.fullTitle(),

--- a/test/e2e/flask/solana/send-flow.spec.ts
+++ b/test/e2e/flask/solana/send-flow.spec.ts
@@ -9,7 +9,9 @@ import { withSolanaAccountSnap } from './common-solana';
 
 const commonSolanaAddress = 'GYP1hGem9HBkYKEWNUQUxEwfmu4hhjuujRgGnj5LrHna';
 describe('Send flow', function (this: Suite) {
-  it('with some field validation', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('with some field validation', async function () {
     this.timeout(120000);
     await withSolanaAccountSnap(
       {
@@ -61,7 +63,9 @@ describe('Send flow', function (this: Suite) {
   });
 });
 describe('Send full flow of USD', function (this: Suite) {
-  it('with a positive balance account', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('with a positive balance account', async function () {
     this.timeout(120000);
     await withSolanaAccountSnap(
       {
@@ -193,7 +197,9 @@ describe('Send full flow of USD', function (this: Suite) {
   });
 });
 describe('Send full flow of SOL', function (this: Suite) {
-  it('with a positive balance account', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('with a positive balance account', async function () {
     this.timeout(120000);
     await withSolanaAccountSnap(
       {
@@ -318,7 +324,9 @@ describe('Send full flow of SOL', function (this: Suite) {
   });
 });
 describe('Send flow', function (this: Suite) {
-  it('and Transaction fails', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('and Transaction fails', async function () {
     this.timeout(120000); // there is a bug open for this big timeout https://consensyssoftware.atlassian.net/browse/SOL-90
     await withSolanaAccountSnap(
       {
@@ -383,7 +391,9 @@ describe('Send flow', function (this: Suite) {
   });
 });
 describe('Send flow', function (this: Suite) {
-  it('and Transaction Simulation fails', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('and Transaction Simulation fails', async function () {
     this.timeout(120000); // there is a bug open for this big timeout https://consensyssoftware.atlassian.net/browse/SOL-90
     await withSolanaAccountSnap(
       {

--- a/test/e2e/flask/solana/send-spl-token.spec.ts
+++ b/test/e2e/flask/solana/send-spl-token.spec.ts
@@ -8,7 +8,9 @@ import { commonSolanaAddress, withSolanaAccountSnap } from './common-solana';
 
 const splTokenName = 'PKIN';
 describe('Send flow', function (this: Suite) {
-  it('user with more than 1 token in the token list', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('user with more than 1 token in the token list', async function () {
     this.timeout(120000);
     await withSolanaAccountSnap(
       {
@@ -135,7 +137,9 @@ describe('Send flow', function (this: Suite) {
   });
 });
 describe('Send flow', function (this: Suite) {
-  it('and send transaction fails', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('and send transaction fails', async function () {
     this.timeout(120000); // there is a bug open for this big timeout https://consensyssoftware.atlassian.net/browse/SOL-90
     await withSolanaAccountSnap(
       {
@@ -204,7 +208,9 @@ describe('Send flow', function (this: Suite) {
 });
 
 describe('Send flow', function (this: Suite) {
-  it('and Transaction simulation fails', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('and Transaction simulation fails', async function () {
     this.timeout(120000); // there is a bug open for this big timeout https://consensyssoftware.atlassian.net/browse/SOL-90
     await withSolanaAccountSnap(
       {

--- a/test/e2e/flask/solana/transaction-activity-list.spec.ts
+++ b/test/e2e/flask/solana/transaction-activity-list.spec.ts
@@ -9,7 +9,9 @@ import {
 } from './common-solana';
 
 describe('Transaction activity list', function (this: Suite) {
-  it('user can see activity list and a confirmed transaction details', async function () {
+  // Temporarily disabled on Mar 26, 2025 because of CI failures.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('user can see activity list and a confirmed transaction details', async function () {
     this.timeout(120000);
     await withSolanaAccountSnap(
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Temporarily skips failing e2e tests that are affecting CI on all Extension branches and blocking releases `v12.14.2` and `v12.15.0`.

This commit will be reverted once a fix for the tests is merged. This fix is currently in the works here: https://github.com/MetaMask/metamask-extension/pull/31319.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31325?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
