### PR TITLE
fix: cp-12.15.0 Prevent fullscreen UI from opening every startup

### DIFF
--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -187,8 +187,6 @@ const registerInPageContentScript = async () => {
 chrome.runtime.onInstalled.addListener(function (details) {
   if (details.reason === 'install') {
     chrome.storage.session.set({ isFirstTimeInstall: true });
-  } else if (details.reason === 'update') {
-    chrome.storage.session.set({ isFirstTimeInstall: false });
   }
 });
 

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -184,10 +184,17 @@ const registerInPageContentScript = async () => {
   }
 };
 
-// On MV3 builds we must listen for this event in `app-init`, otherwise we found that the listener
-// is never called.
-// For MV2 builds, the listener is added in `background.js` instead.
-chrome.runtime.onInstalled.addListener(function (details) {
+/**
+ * `onInstalled` event handler.
+ *
+ * On MV3 builds we must listen for this event in `app-init`, otherwise we found that the listener
+ * is never called.
+ * For MV2 builds, the listener is added in `background.js` instead.
+ *
+ * @param {object} details - Event details.
+ * @param {string} details.reason - The reason that this event was dispatched.
+ */
+function onInstalledListener(details) {
   if (details.reason === 'install') {
     // This condition is for when `background.js` was loaded before the `onInstalled` listener was
     // called.
@@ -200,7 +207,10 @@ chrome.runtime.onInstalled.addListener(function (details) {
     } else {
       globalThis.__metamaskWasJustInstalled = true;
     }
+    chrome.runtime.onInstalled.removeListener(onInstalledListener);
   }
-});
+}
+
+chrome.runtime.onInstalled.addListener(onInstalledListener);
 
 registerInPageContentScript();

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -186,7 +186,11 @@ const registerInPageContentScript = async () => {
 
 chrome.runtime.onInstalled.addListener(function (details) {
   if (details.reason === 'install') {
-    chrome.storage.session.set({ isFirstTimeInstall: true });
+    if (globalThis.__metamaskTriggerOnInstall) {
+      globalThis.__metamaskTriggerOnInstall();
+    } else {
+      globalThis.__metamaskWasJustInstalled = true;
+    }
   }
 });
 

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -184,10 +184,19 @@ const registerInPageContentScript = async () => {
   }
 };
 
+// On MV3 builds we must listen for this event in `app-init`, otherwise we found that the listener
+// is never called.
+// For MV2 builds, the listener is added in `background.js` instead.
 chrome.runtime.onInstalled.addListener(function (details) {
   if (details.reason === 'install') {
+    // This condition is for when `background.js` was loaded before the `onInstalled` listener was
+    // called.
     if (globalThis.__metamaskTriggerOnInstall) {
       globalThis.__metamaskTriggerOnInstall();
+      // Delete just to clean up global namespace
+      delete globalThis.__metamaskTriggerOnInstall;
+      // This condition is for when the `onInstalled` listener in `app-init` was called before
+      // `background.js` was loaded.
     } else {
       globalThis.__metamaskWasJustInstalled = true;
     }

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -6,6 +6,8 @@ let scriptsLoadInitiated = false;
 const { chrome } = globalThis;
 const testMode = process.env.IN_TEST;
 
+globalThis.stateHooks = globalThis.stateHooks || {};
+
 const loadTimeLogs = [];
 // eslint-disable-next-line import/unambiguous
 function tryImport(...fileNames) {
@@ -198,14 +200,14 @@ function onInstalledListener(details) {
   if (details.reason === 'install') {
     // This condition is for when `background.js` was loaded before the `onInstalled` listener was
     // called.
-    if (globalThis.__metamaskTriggerOnInstall) {
-      globalThis.__metamaskTriggerOnInstall();
+    if (globalThis.stateHooks.metamaskTriggerOnInstall) {
+      globalThis.stateHooks.metamaskTriggerOnInstall();
       // Delete just to clean up global namespace
-      delete globalThis.__metamaskTriggerOnInstall;
+      delete globalThis.stateHooks.metamaskTriggerOnInstall;
       // This condition is for when the `onInstalled` listener in `app-init` was called before
       // `background.js` was loaded.
     } else {
-      globalThis.__metamaskWasJustInstalled = true;
+      globalThis.stateHooks.metamaskWasJustInstalled = true;
     }
     chrome.runtime.onInstalled.removeListener(onInstalledListener);
   }

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -193,8 +193,7 @@ const registerInPageContentScript = async () => {
  * is never called.
  * For MV2 builds, the listener is added in `background.js` instead.
  *
- * @param {object} details - Event details.
- * @param {string} details.reason - The reason that this event was dispatched.
+ * @param {chrome.runtime.InstalledDetails} details - Event details.
  */
 function onInstalledListener(details) {
   if (details.reason === 'install') {

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -6,6 +6,9 @@ let scriptsLoadInitiated = false;
 const { chrome } = globalThis;
 const testMode = process.env.IN_TEST;
 
+/**
+ * @type {globalThis.stateHooks}
+ */
 globalThis.stateHooks = globalThis.stateHooks || {};
 
 const loadTimeLogs = [];

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1290,7 +1290,7 @@ const addAppInstalledEvent = () => {
 function onInstall() {
   log.debug('First install detected');
   addAppInstalledEvent();
-  if (!process.env.METAMASK_DEBUG) {
+  if (!process.env.IN_TEST && !process.env.METAMASK_DEBUG) {
     // If storeAlreadyExisted is true then this is a fresh installation
     // and an app installed event should be tracked.
     addAppInstalledEvent();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1289,15 +1289,13 @@ const addAppInstalledEvent = () => {
  */
 function onInstall() {
   log.debug('First install detected');
-  if (process.env.IN_TEST) {
-    addAppInstalledEvent();
-  } else if (!process.env.METAMASK_DEBUG) {
+  addAppInstalledEvent();
+  if (!process.env.METAMASK_DEBUG) {
     // If storeAlreadyExisted is true then this is a fresh installation
     // and an app installed event should be tracked.
     addAppInstalledEvent();
     platform.openExtensionInBrowser();
   }
-  onNavigateToTab();
 }
 
 function onNavigateToTab() {
@@ -1328,6 +1326,7 @@ function setupSentryGetStateGlobal(store) {
 }
 
 async function initBackground() {
+  onNavigateToTab();
   try {
     await initialize();
     if (process.env.IN_TEST) {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1291,9 +1291,6 @@ function onInstall() {
   log.debug('First install detected');
   addAppInstalledEvent();
   if (!process.env.IN_TEST && !process.env.METAMASK_DEBUG) {
-    // If storeAlreadyExisted is true then this is a fresh installation
-    // and an app installed event should be tracked.
-    addAppInstalledEvent();
     platform.openExtensionInBrowser();
   }
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -141,15 +141,25 @@ const PHISHING_WARNING_PAGE_TIMEOUT = ONE_SECOND_IN_MILLISECONDS;
 // Event emitter for state persistence
 export const statePersistenceEvents = new EventEmitter();
 
-// On MV3 builds we must listen for this event in `app-init`, otherwise we found that the listener
-// is never called.
-// There is no `app-init` file on MV2 builds, so we add a listener here instead.
 if (!isManifestV3) {
-  browser.runtime.onInstalled.addListener(function (details) {
+  /**
+   * `onInstalled` event handler.
+   *
+   * On MV3 builds we must listen for this event in `app-init`, otherwise we found that the listener
+   * is never called.
+   * There is no `app-init` file on MV2 builds, so we add a listener here instead.
+   *
+   * @param {object} details - Event details.
+   * @param {string} details.reason - The reason that this event was dispatched.
+   */
+  const onInstalledListener = (details) => {
     if (details.reason === 'install') {
       onInstall();
+      browser.runtime.onInstalled.removeListener(onInstalledListener);
     }
-  });
+  };
+
+  browser.runtime.onInstalled.addListener(onInstalledListener);
 
   // This condition is for when the `onInstalled` listener in `app-init` was called before
   // `background.js` was loaded.

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -149,8 +149,7 @@ if (!isManifestV3) {
    * is never called.
    * There is no `app-init` file on MV2 builds, so we add a listener here instead.
    *
-   * @param {object} details - Event details.
-   * @param {string} details.reason - The reason that this event was dispatched.
+   * @param {import('webextension-polyfill').Runtime.OnInstalledDetailsType} details - Event details.
    */
   const onInstalledListener = (details) => {
     if (details.reason === 'install') {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -163,14 +163,14 @@ if (!isManifestV3) {
 
   // This condition is for when the `onInstalled` listener in `app-init` was called before
   // `background.js` was loaded.
-} else if (globalThis.__metamaskWasJustInstalled) {
+} else if (globalThis.stateHooks.metamaskWasJustInstalled) {
   onInstall();
   // Delete just to clean up global namespace
-  delete globalThis.__metamaskWasJustInstalled;
+  delete globalThis.stateHooks.metamaskWasJustInstalled;
   // This condition is for when `background.js` was loaded before the `onInstalled` listener was
   // called.
 } else {
-  globalThis.__metamaskTriggerOnInstall = () => onInstall();
+  globalThis.stateHooks.metamaskTriggerOnInstall = () => onInstall();
 }
 
 /**

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -263,8 +263,15 @@ export declare global {
 
   var stateHooks: StateHooks;
 
-  // Used in `app-init.js` and `background.js` to trigger install event
+  /**
+   * This is set in `app-init.js` to communicate that MetaMask was just installed, and is read in
+   * `background.js`.
+   */
   var __metamaskWasJustInstalled: boolean | undefined;
+  /**
+   * This is set in `background.js` so that `app-init.js` can trigger "on install" actions when
+   * the `onInstalled` listener is called.
+   */
   var __metamaskTriggerOnInstall: (() => void) | undefined;
 
   namespace jest {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -263,6 +263,10 @@ export declare global {
 
   var stateHooks: StateHooks;
 
+  // Used in `app-init.js` and `background.js` to trigger install event
+  var __metamaskWasJustInstalled: boolean | undefined;
+  var __metamaskTriggerOnInstall: (() => void) | undefined;
+
   namespace jest {
     // The interface is being used for declaration merging, which is an acceptable exception to this rule.
     // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -250,6 +250,16 @@ type StateHooks = {
   metamaskGetState?: () => Promise<any>;
   throwTestBackgroundError?: (msg?: string) => Promise<void>;
   throwTestError?: (msg?: string) => void;
+  /**
+   * This is set in `app-init.js` to communicate that MetaMask was just installed, and is read in
+   * `background.js`.
+   */
+  metamaskWasJustInstalled?: boolean;
+  /**
+   * This is set in `background.js` so that `app-init.js` can trigger "on install" actions when
+   * the `onInstalled` listener is called.
+   */
+  metamaskTriggerOnInstall?: () => void;
 };
 
 export declare global {
@@ -262,17 +272,6 @@ export declare global {
   var ethereumProvider: Provider;
 
   var stateHooks: StateHooks;
-
-  /**
-   * This is set in `app-init.js` to communicate that MetaMask was just installed, and is read in
-   * `background.js`.
-   */
-  var __metamaskWasJustInstalled: boolean | undefined;
-  /**
-   * This is set in `background.js` so that `app-init.js` can trigger "on install" actions when
-   * the `onInstalled` listener is called.
-   */
-  var __metamaskTriggerOnInstall: (() => void) | undefined;
 
   namespace jest {
     // The interface is being used for declaration merging, which is an acceptable exception to this rule.


### PR DESCRIPTION
## **Description**

Prevent tab from opening upon every browser startup.

A [recent PR](https://github.com/MetaMask/metamask-extension/pull/29826) updated the logic for how we determine whether the extension was just installed or not; we used to check state, but now we use the `runtime.onInstalled` event instead to store a flag in session storage indicating whether the extension was just installed.

Unfortunately this PR had a couple of bugs; the condition using this flag was accidentally reversed, and the read from session storage was never successful because of a race condition (the write had not finished yet).

To address both problems, the logic for detecting first install was refactored to use a global variable instead of session storage. Globals can be accessed and written synchronously, preventing any possibility of a race condition.

The solution was complicated by the fact that MV3 builds must add an `onInstalled` listener in the root service worker module, otherwise the listener is never called (we tested this experimentally). It was also unclear whether the listener would always run before or after the `background.js` script loading, and we need to trigger an action in `background.js` on install. But we've accounted for both possibilities in this solution.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31332?quickstart=1)

## **Related issues**

Fixes: #30924

## **Manual testing steps**

* Create a production-like build (`yarn dist` and `yarn dist:mv2`), or download the builds from the `metamaskbot` comment
* Test that the window opens only on first install, not on later browser restarts.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
