### PR TITLE
fix: Anvil running on Windows

### DIFF
--- a/test/e2e/seeder/anvil.ts
+++ b/test/e2e/seeder/anvil.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { delimiter, join } from 'path';
 import { execSync } from 'child_process';
 import { createAnvil, Anvil as AnvilType } from '@viem/anvil';
 import { createAnvilClients } from './anvil-clients';
@@ -63,7 +63,7 @@ export class Anvil {
     const anvilBinaryDir = join(process.cwd(), 'node_modules', '.bin');
 
     // Prepend the anvil binary directory to the PATH environment variable
-    process.env.PATH = `${anvilBinaryDir}:${process.env.PATH}`;
+    process.env.PATH = `${anvilBinaryDir}${delimiter}${process.env.PATH}`;
 
     // Verify that the anvil binary is accessible
     try {


### PR DESCRIPTION
## **Description**

Fixes the following Anvil path problem on Windows

`'anvil' is not recognized as an internal or external command, operable program or batch file.`

The issue was that the delimiter between parts of the `PATH` is `:` on *nix and `;` on Windows.  Changed it to `path.delimiter`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31345?quickstart=1)

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->