### PR TITLE
fix: broken test in firefox `Bridge tests Execute various bridge transactions`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,6 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -143,7 +142,6 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -142,6 +143,7 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/test/e2e/tests/bridge/bridge-cross-chain-swap.spec.ts
+++ b/test/e2e/tests/bridge/bridge-cross-chain-swap.spec.ts
@@ -50,6 +50,7 @@ describe('Bridge tests', function (this: Suite) {
   ) {
     // Navigate to Bridge page
     const homePage = new HomePage(driver);
+    await homePage.check_expectedBalanceIsDisplayed();
     await homePage.startBridgeFlow();
 
     const bridgePage = new BridgeQuotePage(driver);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `Bridge tests Execute various bridge transactions` test is broken in firefox, as whenever we land into the home page and click on the bridge button, that redirects us to the portfolio view, instead of the inside Bridge page from metamask.

The logic for that button is that, whenever we are on a supported network, we go to the inside Bridge page, and if we are not, then we go to the portfolio view.

It seems due to some timing issue in Firefox (usually a slower browser), we clicked on the button before the chainId was set, so the network was falling back to an unsupported one, and we were redirected to the Portfolio page


https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/133847/workflows/1acba6c3-fd6e-4e3c-97a4-635021fb3e88/jobs/4690513/tests#failed-test-0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31348?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

Successful FF job run here https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/133870/workflows/0fabcde6-39bc-44f3-83b0-1366210461a3/jobs/4690919

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/4a371079-70d8-479a-8cca-e54e5eb4e8f2




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
