### PR TITLE
fix: missing non-evm account modal bottom border-radius

### DIFF
--- a/ui/components/multichain/network-list-menu/add-non-evm-account/add-non-evm-account.tsx
+++ b/ui/components/multichain/network-list-menu/add-non-evm-account/add-non-evm-account.tsx
@@ -44,7 +44,6 @@ const AddNonEvmAccountModal = ({ chainId }: { chainId: CaipChainId }) => {
       </Box>
       <Box
         className="add-non-evm-account-modal__footer"
-        backgroundColor={BackgroundColor.backgroundDefault}
         padding={4}
         width={BlockSize.Full}
       >

--- a/ui/components/multichain/network-list-menu/add-non-evm-account/add-non-evm-account.tsx
+++ b/ui/components/multichain/network-list-menu/add-non-evm-account/add-non-evm-account.tsx
@@ -12,7 +12,6 @@ import {
   ButtonPrimarySize,
 } from '../../../component-library';
 import {
-  BackgroundColor,
   BlockSize,
   Display,
   FlexDirection,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Removes .add-non-evm-account-modal__footer background-color to allow its parent background-color with border-radius applied 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31374?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![CleanShot 2025-03-27 at 17 24 13@2x](https://github.com/user-attachments/assets/f14af6b8-db9e-4359-9733-8a1c30f22447)


### **After**

![CleanShot 2025-03-27 at 17 25 53@2x](https://github.com/user-attachments/assets/26498829-0607-4eb0-8aa2-255c91bed483)


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
