### PR TITLE
fix: flaky test `Switching between account from different networks Create a Solana account and switch to another network`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ workflows:
             - prep-build-test-flask
             - get-changed-files-with-git-diff
       - test-e2e-firefox-flask:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-flask-mv2
       - test-e2e-swap-playwright - OPTIONAL:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,6 @@ workflows:
             - prep-build-test-flask
             - get-changed-files-with-git-diff
       - test-e2e-firefox-flask:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-flask-mv2
       - test-e2e-swap-playwright - OPTIONAL:

--- a/test/e2e/flask/solana/common-solana.ts
+++ b/test/e2e/flask/solana/common-solana.ts
@@ -1696,8 +1696,8 @@ export async function withSolanaAccountSnap(
     },
     async ({ driver, mockServer }: { driver: Driver; mockServer: Mockttp }) => {
       await loginWithoutBalanceValidation(driver);
-      const headerComponen = new HeaderNavbar(driver);
-      await headerComponen.openAccountMenu();
+      const headerComponent = new HeaderNavbar(driver);
+      await headerComponent.openAccountMenu();
       const accountListPage = new AccountListPage(driver);
       if (!importAccount) {
         await accountListPage.addAccount({
@@ -1705,6 +1705,7 @@ export async function withSolanaAccountSnap(
           accountName: 'Solana 1',
         });
       }
+      await headerComponent.check_accountLabel('Solana 1');
       await test(driver, mockServer);
     },
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes a race condition when we create a Solana account and immediately switch to Solana Mainnet network. The problem is that the account is not yet loaded when we perform the network switch, making the dialog for "you need a Solana accoun" to sometimes appear, and obfuscate the next action make the test fail with the error `ElementClickInterceptedError`:

![Screenshot from 2025-03-28 07-57-49](https://github.com/user-attachments/assets/d637197b-eef0-4f90-ae22-5af20ac48c90)

Failure: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/134203/workflows/554e280c-2fa9-4dff-8652-0398b8ab80a0/jobs/4697627/tests

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31382?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci run with ff flask enabled: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/134219/workflows/52539bc9-bc6d-4d18-8fe6-fbdd51f48463/jobs/4697818

![Screenshot from 2025-03-28 08-17-21](https://github.com/user-attachments/assets/d913ad89-2b56-4d34-a35c-310c3c5a7ad2)


## **Screenshots/Recordings**
See dialog for "you need a Solana account" obfuscating the home page

![image](https://github.com/user-attachments/assets/77c9edb3-5359-4663-92c9-5a531a7752fc)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
