### PR TITLE
fix: flaky test `Swaps - notifications tests notifications for slippage`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,6 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff

--- a/test/e2e/tests/swaps/swaps-notifications.spec.ts
+++ b/test/e2e/tests/swaps/swaps-notifications.spec.ts
@@ -167,6 +167,7 @@ describe('Swaps - notifications', function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),
+        testSpecificMock: mockSwapsTransactionQuote,
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The problem is that we are missing the fetch trades mock, and that request  is redirected to the catch-all mock returning a 200 with empty data.
Then, when the wallet tries to parse the data we get teh JSON error.

This happens ocasionally if there's "time" for that request to happen and the wallet tries to parse the JSON response, within the test run.

![Screenshot from 2025-03-28 08-11-59](https://github.com/user-attachments/assets/0f426e16-3b5b-42f1-b886-f89e501b7fd5)


Circle ci error: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/134207/workflows/69597d81-ae63-41b1-b655-50d85e31b59b/jobs/4697734/tests

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31383?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci run https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/134223/workflows/9c61c340-c4b3-49c8-8590-d1e2f783f124/jobs/4697845

![Screenshot from 2025-03-28 08-34-05](https://github.com/user-attachments/assets/006cedfe-b110-4487-9000-98ca42fd46fd)



## **Screenshots/Recordings**
See the error fetching quotes behind the modal, which makes the test fail due to the console error.

![Screenshot from 2025-03-28 08-08-06](https://github.com/user-attachments/assets/3e9f6335-73f4-46f2-9fae-a33da46e872f)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
