### PR TITLE
fix: flaky test `Settings - general tab validate "मानक हिन्दी" language on tooltips`

### DIFF
--- a/test/e2e/tests/settings/change-language.spec.ts
+++ b/test/e2e/tests/settings/change-language.spec.ts
@@ -12,8 +12,12 @@ import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 const selectors = {
-  labelSpanish: { tag: 'p', text: 'Idioma actual' },
-  currentLanguageLabel: { tag: 'p', text: 'Current language' },
+  currentLanguageDansk: { tag: 'p', text: 'Nuværende sprog' },
+  currentLanguageDeutsch: { tag: 'p', text: 'Aktuelle Sprache' },
+  currentLanguageEnglish: { tag: 'p', text: 'Current language' },
+  currentLanguageMagyar: { tag: 'p', text: 'Aktuális nyelv' },
+  currentLanguageSpanish: { tag: 'p', text: 'Idioma actual' },
+  currentLanguageवर्तमान: { tag: 'p', text: 'वर्तमान भाषा'},
   advanceText: { text: 'Avanceret', tag: 'div' },
   waterText: '[placeholder="Søg"]',
   headerTextDansk: { text: 'Indstillinger', tag: 'h3' },
@@ -41,7 +45,7 @@ describe('Settings - general tab', function (this: Suite) {
         // Change language to Spanish and validate that the word has changed correctly
         await generalSettings.changeLanguage('Español');
         const isLanguageLabelChanged = await driver.isElementPresent(
-          selectors.labelSpanish,
+          selectors.currentLanguageSpanish,
         );
         assert.equal(isLanguageLabelChanged, true, 'Language did not change');
 
@@ -49,7 +53,7 @@ describe('Settings - general tab', function (this: Suite) {
         await driver.refresh();
         await generalSettings.check_pageIsLoaded();
         assert.equal(
-          await driver.isElementPresent(selectors.labelSpanish),
+          await driver.isElementPresent(selectors.currentLanguageSpanish),
           true,
           'Language did not change after refresh',
         );
@@ -57,7 +61,7 @@ describe('Settings - general tab', function (this: Suite) {
         // Change language back to English and validate that the word has changed correctly
         await generalSettings.changeLanguage('English');
         const isLabelTextChanged = await driver.isElementPresent(
-          selectors.currentLanguageLabel,
+          selectors.currentLanguageEnglish,
         );
         assert.equal(isLabelTextChanged, true, 'Language did not change');
       },
@@ -78,6 +82,11 @@ describe('Settings - general tab', function (this: Suite) {
 
         // Select "Dansk" language
         await generalSettings.changeLanguage('Dansk');
+        const isLanguageLabelChanged = await driver.isElementPresent(
+          selectors.currentLanguageDansk,
+        );
+        assert.equal(isLanguageLabelChanged, true, 'Language did not change');
+
         await driver.clickElement(selectors.advanceText);
         const advancedSettings = new AdvancedSettings(driver);
         await advancedSettings.check_pageIsLoaded();
@@ -129,6 +138,11 @@ describe('Settings - general tab', function (this: Suite) {
 
         // Select "Deutsch" language
         await generalSettings.changeLanguage('Deutsch');
+        const isLanguageLabelChanged = await driver.isElementPresent(
+          selectors.currentLanguageDeutsch,
+        );
+        assert.equal(isLanguageLabelChanged, true, 'Language did not change');
+
         await new SettingsPage(driver).closeSettingsPage();
 
         const homepage = new Homepage(driver);
@@ -170,6 +184,12 @@ describe('Settings - general tab', function (this: Suite) {
 
         // Select "मानक हिन्दी" language
         await generalSettings.changeLanguage('मानक हिन्दी');
+
+        const  isLabelTextChanged = await driver.isElementPresent(
+          selectors.currentLanguageवर्तमान,
+        );
+        assert.equal(isLabelTextChanged, true, 'Language did not change');
+
         await new SettingsPage(driver).closeSettingsPage();
         const homepage = new Homepage(driver);
         await homepage.check_pageIsLoaded();
@@ -212,6 +232,11 @@ describe('Settings - general tab', function (this: Suite) {
 
         // Select "Magyar" language
         await generalSettings.changeLanguage('Magyar');
+        const  isLabelTextChanged = await driver.isElementPresent(
+          selectors.currentLanguageMagyar,
+        );
+        assert.equal(isLabelTextChanged, true, 'Language did not change');
+
         await new SettingsPage(driver).closeSettingsPage();
         const homepage = new Homepage(driver);
         await homepage.check_pageIsLoaded();

--- a/test/e2e/tests/settings/change-language.spec.ts
+++ b/test/e2e/tests/settings/change-language.spec.ts
@@ -17,7 +17,7 @@ const selectors = {
   currentLanguageEnglish: { tag: 'p', text: 'Current language' },
   currentLanguageMagyar: { tag: 'p', text: 'Aktuális nyelv' },
   currentLanguageSpanish: { tag: 'p', text: 'Idioma actual' },
-  currentLanguageवर्तमान: { tag: 'p', text: 'वर्तमान भाषा'},
+  currentLanguageवर्तमान: { tag: 'p', text: 'वर्तमान भाषा' },
   advanceText: { text: 'Avanceret', tag: 'div' },
   waterText: '[placeholder="Søg"]',
   headerTextDansk: { text: 'Indstillinger', tag: 'h3' },
@@ -185,7 +185,7 @@ describe('Settings - general tab', function (this: Suite) {
         // Select "मानक हिन्दी" language
         await generalSettings.changeLanguage('मानक हिन्दी');
 
-        const  isLabelTextChanged = await driver.isElementPresent(
+        const isLabelTextChanged = await driver.isElementPresent(
           selectors.currentLanguageवर्तमान,
         );
         assert.equal(isLabelTextChanged, true, 'Language did not change');
@@ -232,7 +232,7 @@ describe('Settings - general tab', function (this: Suite) {
 
         // Select "Magyar" language
         await generalSettings.changeLanguage('Magyar');
-        const  isLabelTextChanged = await driver.isElementPresent(
+        const isLabelTextChanged = await driver.isElementPresent(
           selectors.currentLanguageMagyar,
         );
         assert.equal(isLabelTextChanged, true, 'Language did not change');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In some of the change language specs, we change the language and immediately click the close settings button. This action can have no effect, if we click before the language is changes, as then there's a re-render and we are still in the settings page.

We need to wait until the language has been changed before proceeding with the next action. For that, we add a check to make sure the language has changed, every time we perform a `changeLanguage` action.

![Screenshot from 2025-03-28 10-16-42](https://github.com/user-attachments/assets/bbded9ee-533e-4b34-bbdf-e7b05b3fa81f)


ci failure: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/134139/workflows/c284f602-6903-4a81-a0ac-48a05f987ee7/jobs/4696447/tests

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31384?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
See in the failure artifacts, how after clicking close settings, we still remain in the settings page. The click was performed but took no effect, as after that the page was re-rendered with the new language.
Then we try to look for an element from the home page but that can't be found as we are still in settings


![image](https://github.com/user-attachments/assets/016d8cd0-13a4-4658-8979-e1d599e6a289)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
