### PR TITLE
fix: validation of EIP-7702 signatures with odd-length chain ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "@metamask/snaps-sdk": "^6.21.0",
     "@metamask/snaps-utils": "^9.1.0",
     "@metamask/solana-wallet-snap": "^1.15.1",
-    "@metamask/transaction-controller": "^52.2.0",
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@52.2.0-preview-ed8163d",
     "@metamask/user-operation-controller": "^24.0.1",
     "@metamask/utils": "^11.1.0",
     "@ngraveio/bc-ur": "^1.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6594,9 +6594,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^52.2.0":
-  version: 52.2.0
-  resolution: "@metamask/transaction-controller@npm:52.2.0"
+"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@52.2.0-preview-ed8163d":
+  version: 52.2.0-preview-ed8163d
+  resolution: "@metamask-previews/transaction-controller@npm:52.2.0-preview-ed8163d"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -6626,7 +6626,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^23.0.0
     "@metamask/network-controller": ^23.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 10/2a2b08c5d19410a69cf3fd29819d7928e91c3d9fe59b1b29a12ff62ddebacadcb3dc4710e54860571230f95ed17c57fc6876d85fcfbc6d6b21e22d868a47cb92
+  checksum: 10/3de7c48aa6a58f897bb670914d03b59cb4a9d249dec5363edae69b3da15955e07dee3af8f8b78baab187fec9b61e94d03a888d72a7c0bba5f64713aa242644a0
   languageName: node
   linkType: hard
 
@@ -27386,7 +27386,7 @@ __metadata:
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:9.2.0"
     "@metamask/test-dapp-multichain": "npm:^0.6.0"
-    "@metamask/transaction-controller": "npm:^52.2.0"
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@52.2.0-preview-ed8163d"
     "@metamask/user-operation-controller": "npm:^24.0.1"
     "@metamask/utils": "npm:^11.1.0"
     "@ngraveio/bc-ur": "npm:^1.1.12"


### PR DESCRIPTION
## **Description**

Bump `@metamask/transaction-controller` to pad chain IDs when validating signature.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31389?quickstart=1)

## **Related issues**

Fixes: [#31338](https://github.com/MetaMask/metamask-extension/issues/31388)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
