### PR TITLE
fix: unscrollable Remove Snap modal dialog

### DIFF
--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
@@ -96,14 +96,11 @@ export default function KeyringRemovalSnapWarning({
             flexDirection={FlexDirection.Column}
             gap={4}
           >
+            <BannerAlert severity={BannerAlertSeverity.Warning}>
+              {t('backupKeyringSnapReminder')}
+            </BannerAlert>
             {showConfirmation === false ? (
               <>
-                <BannerAlert
-                  severity={BannerAlertSeverity.Warning}
-                  className=""
-                >
-                  {t('backupKeyringSnapReminder')}
-                </BannerAlert>
                 <Box
                   display={Display.Flex}
                   justifyContent={JustifyContent.spaceBetween}
@@ -126,12 +123,6 @@ export default function KeyringRemovalSnapWarning({
               </>
             ) : (
               <>
-                <BannerAlert
-                  severity={BannerAlertSeverity.Warning}
-                  className=""
-                >
-                  {t('backupKeyringSnapReminder')}
-                </BannerAlert>
                 <Text>
                   {t('keyringSnapRemoveConfirmation', [
                     <Text

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
@@ -91,7 +91,11 @@ export default function KeyringRemovalSnapWarning({
           >
             {t('removeSnap')}
           </ModalHeader>
-          <ModalBody>
+          <ModalBody
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
+            gap={4}
+          >
             {showConfirmation === false ? (
               <>
                 <BannerAlert
@@ -122,49 +126,41 @@ export default function KeyringRemovalSnapWarning({
               </>
             ) : (
               <>
-                <Box
-                  display={Display.Flex}
-                  flexDirection={FlexDirection.Column}
-                  marginTop={6}
+                <BannerAlert
+                  severity={BannerAlertSeverity.Warning}
+                  className=""
                 >
-                  <BannerAlert
-                    severity={BannerAlertSeverity.Warning}
-                    className=""
-                    marginBottom={4}
-                  >
-                    {t('backupKeyringSnapReminder')}
-                  </BannerAlert>
-                  <Text marginBottom={4}>
-                    {t('keyringSnapRemoveConfirmation', [
-                      <Text
-                        key="keyringSnapRemoveConfirmation2"
-                        fontWeight={FontWeight.Bold}
-                        as="span"
-                      >
-                        {snap.manifest.proposedName}
-                      </Text>,
-                    ])}
-                  </Text>
-                  {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-                  {/* @ts-ignore TODO: fix TextField props */}
-                  <TextField
-                    marginBottom={4}
-                    value={confirmationInput}
-                    onChange={(e: { target: { value: string } }) => {
-                      setConfirmationInput(e.target.value);
-                      setConfirmedRemoval(
-                        validateConfirmationInput(e.target.value),
-                      );
-                    }}
-                    onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
-                      e.preventDefault();
-                    }}
-                    error={error}
-                    inputProps={{
-                      'data-testid': 'remove-snap-confirmation-input',
-                    }}
-                  />
-                </Box>
+                  {t('backupKeyringSnapReminder')}
+                </BannerAlert>
+                <Text>
+                  {t('keyringSnapRemoveConfirmation', [
+                    <Text
+                      key="keyringSnapRemoveConfirmation2"
+                      fontWeight={FontWeight.Bold}
+                      as="span"
+                    >
+                      {snap.manifest.proposedName}
+                    </Text>,
+                  ])}
+                </Text>
+                {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+                {/* @ts-ignore TODO: fix TextField props */}
+                <TextField
+                  value={confirmationInput}
+                  onChange={(e: { target: { value: string } }) => {
+                    setConfirmationInput(e.target.value);
+                    setConfirmedRemoval(
+                      validateConfirmationInput(e.target.value),
+                    );
+                  }}
+                  onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+                    e.preventDefault();
+                  }}
+                  error={error}
+                  inputProps={{
+                    'data-testid': 'remove-snap-confirmation-input',
+                  }}
+                />
               </>
             )}
           </ModalBody>

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
@@ -6,18 +6,18 @@ import {
   BannerAlert,
   BannerAlertSeverity,
   Box,
-  Button,
-  ButtonSize,
   ButtonVariant,
   Modal,
   ModalOverlay,
   Text,
   TextField,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
 } from '../../../component-library';
-import { ModalContent } from '../../../component-library/modal-content/deprecated';
-import { ModalHeader } from '../../../component-library/modal-header/deprecated';
+
 import {
-  BlockSize,
   Display,
   FlexDirection,
   FontWeight,
@@ -91,106 +91,105 @@ export default function KeyringRemovalSnapWarning({
           >
             {t('removeSnap')}
           </ModalHeader>
-          {showConfirmation === false ? (
-            <>
-              <BannerAlert severity={BannerAlertSeverity.Warning} className="">
-                {t('backupKeyringSnapReminder')}
-              </BannerAlert>
-              <Box
-                display={Display.Flex}
-                justifyContent={JustifyContent.spaceBetween}
-              >
-                <Text>{t('removeKeyringSnap')}</Text>
-                <InfoTooltip
-                  contentText={t('removeKeyringSnapToolTip')}
-                  position="top"
-                />
-              </Box>
-              {keyringAccounts.map((account, index) => {
-                return (
-                  <KeyringAccountListItem
-                    key={index}
-                    account={account}
-                    snapUrl={getAccountLink(account.address, chainId)}
-                  />
-                );
-              })}
-            </>
-          ) : (
-            <>
-              <Box
-                display={Display.Flex}
-                flexDirection={FlexDirection.Column}
-                marginTop={6}
-              >
+          <ModalBody>
+            {showConfirmation === false ? (
+              <>
                 <BannerAlert
                   severity={BannerAlertSeverity.Warning}
                   className=""
-                  marginBottom={4}
                 >
                   {t('backupKeyringSnapReminder')}
                 </BannerAlert>
-                <Text marginBottom={4}>
-                  {t('keyringSnapRemoveConfirmation', [
-                    <Text
-                      key="keyringSnapRemoveConfirmation2"
-                      fontWeight={FontWeight.Bold}
-                      as="span"
-                    >
-                      {snap.manifest.proposedName}
-                    </Text>,
-                  ])}
-                </Text>
-                {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-                {/* @ts-ignore TODO: fix TextField props */}
-                <TextField
-                  marginBottom={4}
-                  value={confirmationInput}
-                  onChange={(e: { target: { value: string } }) => {
-                    setConfirmationInput(e.target.value);
-                    setConfirmedRemoval(
-                      validateConfirmationInput(e.target.value),
-                    );
-                  }}
-                  onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
-                    e.preventDefault();
-                  }}
-                  error={error}
-                  inputProps={{
-                    'data-testid': 'remove-snap-confirmation-input',
-                  }}
-                />
-              </Box>
-            </>
-          )}
-          <Box width={BlockSize.Full} display={Display.Flex} gap={4}>
-            <Button
-              block
-              variant={ButtonVariant.Secondary}
-              size={ButtonSize.Lg}
-              onClick={onCancel}
-            >
-              {t('cancel')}
-            </Button>
-            <Button
-              block
-              size={ButtonSize.Lg}
-              id="popoverRemoveSnapButton"
-              danger={showConfirmation}
-              disabled={showConfirmation && !confirmedRemoval}
-              onClick={async () => {
-                if (!showConfirmation) {
-                  setShowConfirmation(true);
-                  return;
-                }
-                if (confirmedRemoval) {
-                  onSubmit();
-                }
-              }}
-            >
-              {showConfirmation ? t('removeSnap') : t('continue')}
-            </Button>
-          </Box>
+                <Box
+                  display={Display.Flex}
+                  justifyContent={JustifyContent.spaceBetween}
+                >
+                  <Text>{t('removeKeyringSnap')}</Text>
+                  <InfoTooltip
+                    contentText={t('removeKeyringSnapToolTip')}
+                    position="top"
+                  />
+                </Box>
+                {keyringAccounts.map((account, index) => {
+                  return (
+                    <KeyringAccountListItem
+                      key={index}
+                      account={account}
+                      snapUrl={getAccountLink(account.address, chainId)}
+                    />
+                  );
+                })}
+              </>
+            ) : (
+              <>
+                <Box
+                  display={Display.Flex}
+                  flexDirection={FlexDirection.Column}
+                  marginTop={6}
+                >
+                  <BannerAlert
+                    severity={BannerAlertSeverity.Warning}
+                    className=""
+                    marginBottom={4}
+                  >
+                    {t('backupKeyringSnapReminder')}
+                  </BannerAlert>
+                  <Text marginBottom={4}>
+                    {t('keyringSnapRemoveConfirmation', [
+                      <Text
+                        key="keyringSnapRemoveConfirmation2"
+                        fontWeight={FontWeight.Bold}
+                        as="span"
+                      >
+                        {snap.manifest.proposedName}
+                      </Text>,
+                    ])}
+                  </Text>
+                  {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+                  {/* @ts-ignore TODO: fix TextField props */}
+                  <TextField
+                    marginBottom={4}
+                    value={confirmationInput}
+                    onChange={(e: { target: { value: string } }) => {
+                      setConfirmationInput(e.target.value);
+                      setConfirmedRemoval(
+                        validateConfirmationInput(e.target.value),
+                      );
+                    }}
+                    onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+                      e.preventDefault();
+                    }}
+                    error={error}
+                    inputProps={{
+                      'data-testid': 'remove-snap-confirmation-input',
+                    }}
+                  />
+                </Box>
+              </>
+            )}
+          </ModalBody>
+          <ModalFooter
+            onCancel={onCancel}
+            onSubmit={async () => {
+              if (!showConfirmation) {
+                setShowConfirmation(true);
+                return;
+              }
+              if (confirmedRemoval) {
+                onSubmit();
+              }
+            }}
+            submitButtonProps={{
+              id: 'popoverRemoveSnapButton',
+              danger: showConfirmation,
+              disabled: showConfirmation && !confirmedRemoval,
+              children: showConfirmation ? t('removeSnap') : t('continue'),
+            }}
+            cancelButtonProps={{
+              variant: ButtonVariant.Secondary,
+              children: t('cancel'),
+            }}
+          />
         </ModalContent>
       </Modal>
     </>

--- a/ui/components/component-library/modal-content/modal-content.scss
+++ b/ui/components/component-library/modal-content/modal-content.scss
@@ -30,6 +30,10 @@
   &__dialog {
     --modal-content-size: var(--size, 360px);
 
+    // modal-dialog-slide-up animation may get stuck and set overflow-y to hidden
+    // Adding !important is a hack to override the style set by the animation
+    // @see {@link https://github.com/MetaMask/metamask-extension/issues/31405}
+    overflow-y: auto! important;
     max-height: 100%;
     box-shadow: var(--shadow-size-lg) var(--color-shadow-default);
 

--- a/ui/components/component-library/modal-content/modal-content.scss
+++ b/ui/components/component-library/modal-content/modal-content.scss
@@ -33,7 +33,7 @@
     // modal-dialog-slide-up animation may get stuck and set overflow-y to hidden
     // Adding !important is a hack to override the style set by the animation
     // @see {@link https://github.com/MetaMask/metamask-extension/issues/31405}
-    overflow-y: auto! important;
+    overflow-y: auto !important;
     max-height: 100%;
     box-shadow: var(--shadow-size-lg) var(--color-shadow-default);
 

--- a/ui/components/component-library/modal-content/modal-content.scss
+++ b/ui/components/component-library/modal-content/modal-content.scss
@@ -30,10 +30,6 @@
   &__dialog {
     --modal-content-size: var(--size, 360px);
 
-    // modal-dialog-slide-up animation may get stuck and set overflow-y to hidden
-    // Adding !important is a hack to override the style set by the animation
-    // @see {@link https://github.com/MetaMask/metamask-extension/issues/31405}
-    overflow-y: auto !important;
     max-height: 100%;
     box-shadow: var(--shadow-size-lg) var(--color-shadow-default);
 


### PR DESCRIPTION
## **Description**

Remove snap is unscrollable.

This is fixed by incorporating ModalBody. This PR also replaces deprecated components with current DS components

~modal-dialog-slide-up animation may get stuck causing overflow-y hidden css. As a workaround, we'll add !important to overflow-y: auto. I've created a [separate ticket](https://github.com/MetaMask/metamask-extension/issues/31405) to address the core issue which is the animation causing the unexpected overflow-y: hidden.~

Usually hidden is shown for my build:
![CleanShot 2025-03-28 at 16 00 22](https://github.com/user-attachments/assets/c7ea9e77-0963-45f8-824d-4c81b14c1d98)

I have had an instance where the same selector set overflow-y auto:
![CleanShot 2025-03-28 at 11 34 32@2x](https://github.com/user-attachments/assets/d0c63c5b-253c-4f52-9c0d-cb142d1481d7)


## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/31412
Related: https://github.com/MetaMask/metamask-extension/issues/31405 (fix core animation unexpected overflow setting) 

## **Manual testing steps**

1. Install https://metamask.github.io/snap-simple-keyring/latest/
2. Add many accounts to cause a scrollbar later (3+ accounts)
3. Go to MetaMask in popup mode or with shortened height
4. Go to Snaps > Uninstall Snaps
5. Click "Remove MetaMask Simple Snap Keyring" 
6. See Remove Snap Modal is unscrollable
7. See "mm-modal-content__dialog" element has modal-dialog-slide-up animation which overrides overflow-y with hidden value 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="320" src="https://github.com/user-attachments/assets/81a3732a-3a4e-466b-a944-368f297f8c44">
<img width="320" src="https://github.com/user-attachments/assets/53867c4f-d8ed-4f9a-99e4-9b346b33afe0">

### **After**

![CleanShot 2025-04-01 at 13 24 13](https://github.com/user-attachments/assets/7a92e24f-b122-4c3f-9c64-b6479d1a1fcb)

https://github.com/user-attachments/assets/6e3838ff-61d3-4080-8ba0-d9c454000807



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
