### PR TITLE
fix: `test-e2e-chrome-vault-decryption` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,11 @@ workflows:
           requires:
             - prep-build
       - test-e2e-chrome-vault-decryption:
+          filters:
+            branches:
+              only:
+                - main
+                - /^Version-v(\d+)[.](\d+)[.](\d+)/
           requires:
             - prep-build
       - validate-source-maps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,11 +175,6 @@ workflows:
           requires:
             - prep-build
       - test-e2e-chrome-vault-decryption:
-          filters:
-            branches:
-              only:
-                - main
-                - /^Version-v(\d+)[.](\d+)[.](\d+)/
           requires:
             - prep-build
       - validate-source-maps:

--- a/test/e2e/vault-decryption-chrome.spec.ts
+++ b/test/e2e/vault-decryption-chrome.spec.ts
@@ -168,6 +168,7 @@ describe('Vault Decryptor Page', function () {
         // we cannot use the customized driver functions as there is no socket for window communications in prod builds
         await driver.switchToWindowByTitleWithoutSocket(WINDOW_TITLES.ExtensionInFullScreenView);
 
+        // switch to MetaMask window and create a new vault through onboarding flow
         await completeCreateNewWalletOnboardingFlowWithCustomSettings({
           driver,
           password: WALLET_PASSWORD,
@@ -224,6 +225,7 @@ describe('Vault Decryptor Page', function () {
         // we cannot use the customized driver functions as there is no socket for window communications in prod builds
         await driver.switchToWindowByTitleWithoutSocket(WINDOW_TITLES.ExtensionInFullScreenView);
 
+        // switch to MetaMask window and create a new vault through onboarding flow
         await completeCreateNewWalletOnboardingFlowWithCustomSettings({
           driver,
           password: WALLET_PASSWORD,

--- a/test/e2e/vault-decryption-chrome.spec.ts
+++ b/test/e2e/vault-decryption-chrome.spec.ts
@@ -155,6 +155,34 @@ async function closePopoverIfPresent(driver: Driver) {
   await driver.clickElementSafe(nftAutodetection);
 }
 
+async function switchToMetaMaskWindowWithoutSocket(driver) {
+  const windowHandles = await driver.driver.getAllWindowHandles();
+
+  // switch to MetaMask window and create a new vault through onboarding flow
+  let metaMaskWindowFound = false;
+
+  // Iterate through each window handle
+  for (let handle of windowHandles) {
+      // Switch to the window
+      await driver.driver.switchTo().window(handle);
+
+      // Get the window title
+      let title = await driver.driver.getTitle();
+      console.log(`Window Handle: ${handle}, Title: ${title}`);
+
+      // Check if the title matches "MetaMask"
+      if (title === "MetaMask") {
+        metaMaskWindowFound = true;
+        console.log("Switched to MetaMask window");
+        break;
+      }
+  }
+  // If MetaMask window is not found, throw an error
+  if (!metaMaskWindowFound) {
+    throw new Error("MetaMask window not found");
+  }
+}
+
 describe('Vault Decryptor Page', function () {
   it('is able to decrypt the vault uploading the log file in the vault-decryptor webapp', async function () {
     await withFixtures(
@@ -166,10 +194,8 @@ describe('Vault Decryptor Page', function () {
         await driver.waitUntilXWindowHandles(2);
 
         // we cannot use the customized driver functions as there is no socket for window communications in prod builds
-        const windowHandles = await driver.driver.getAllWindowHandles();
+        await switchToMetaMaskWindowWithoutSocket(driver);
 
-        // switch to MetaMask window and create a new vault through onboarding flow
-        await driver.driver.switchTo().window(windowHandles[2]);
         await completeCreateNewWalletOnboardingFlowWithCustomSettings({
           driver,
           password: WALLET_PASSWORD,
@@ -224,10 +250,8 @@ describe('Vault Decryptor Page', function () {
         await driver.waitUntilXWindowHandles(2);
 
         // we cannot use the customized driver functions as there is no socket for window communications in prod builds
-        const windowHandles = await driver.driver.getAllWindowHandles();
+        await switchToMetaMaskWindowWithoutSocket(driver);
 
-        // switch to MetaMask window and create a new vault through onboarding flow
-        await driver.driver.switchTo().window(windowHandles[2]);
         await completeCreateNewWalletOnboardingFlowWithCustomSettings({
           driver,
           password: WALLET_PASSWORD,

--- a/test/e2e/vault-decryption-chrome.spec.ts
+++ b/test/e2e/vault-decryption-chrome.spec.ts
@@ -157,8 +157,6 @@ async function closePopoverIfPresent(driver: Driver) {
 
 async function switchToMetaMaskWindowWithoutSocket(driver) {
   const windowHandles = await driver.driver.getAllWindowHandles();
-
-  // switch to MetaMask window and create a new vault through onboarding flow
   let metaMaskWindowFound = false;
 
   // Iterate through each window handle
@@ -171,15 +169,15 @@ async function switchToMetaMaskWindowWithoutSocket(driver) {
       console.log(`Window Handle: ${handle}, Title: ${title}`);
 
       // Check if the title matches "MetaMask"
-      if (title === "MetaMask") {
+      if (title === 'MetaMask') {
         metaMaskWindowFound = true;
-        console.log("Switched to MetaMask window");
+        console.log('Switched to MetaMask window');
         break;
       }
   }
   // If MetaMask window is not found, throw an error
   if (!metaMaskWindowFound) {
-    throw new Error("MetaMask window not found");
+    throw new Error('MetaMask window not found');
   }
 }
 

--- a/test/e2e/vault-decryption-chrome.spec.ts
+++ b/test/e2e/vault-decryption-chrome.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import level from 'level';
 import { Driver } from './webdriver/driver';
-import { withFixtures, WALLET_PASSWORD } from './helpers';
+import { WALLET_PASSWORD, WINDOW_TITLES, withFixtures } from './helpers';
 import HeaderNavbar from './page-objects/pages/header-navbar';
 import HomePage from './page-objects/pages/home/homepage';
 import PrivacySettings from './page-objects/pages/settings/privacy-settings';
@@ -155,32 +155,6 @@ async function closePopoverIfPresent(driver: Driver) {
   await driver.clickElementSafe(nftAutodetection);
 }
 
-async function switchToMetaMaskWindowWithoutSocket(driver) {
-  const windowHandles = await driver.driver.getAllWindowHandles();
-  let metaMaskWindowFound = false;
-
-  // Iterate through each window handle
-  for (let handle of windowHandles) {
-      // Switch to the window
-      await driver.driver.switchTo().window(handle);
-
-      // Get the window title
-      let title = await driver.driver.getTitle();
-      console.log(`Window Handle: ${handle}, Title: ${title}`);
-
-      // Check if the title matches "MetaMask"
-      if (title === 'MetaMask') {
-        metaMaskWindowFound = true;
-        console.log('Switched to MetaMask window');
-        break;
-      }
-  }
-  // If MetaMask window is not found, throw an error
-  if (!metaMaskWindowFound) {
-    throw new Error('MetaMask window not found');
-  }
-}
-
 describe('Vault Decryptor Page', function () {
   it('is able to decrypt the vault uploading the log file in the vault-decryptor webapp', async function () {
     await withFixtures(
@@ -192,7 +166,7 @@ describe('Vault Decryptor Page', function () {
         await driver.waitUntilXWindowHandles(2);
 
         // we cannot use the customized driver functions as there is no socket for window communications in prod builds
-        await switchToMetaMaskWindowWithoutSocket(driver);
+        await driver.switchToWindowByTitleWithoutSocket(WINDOW_TITLES.ExtensionInFullScreenView);
 
         await completeCreateNewWalletOnboardingFlowWithCustomSettings({
           driver,
@@ -248,7 +222,7 @@ describe('Vault Decryptor Page', function () {
         await driver.waitUntilXWindowHandles(2);
 
         // we cannot use the customized driver functions as there is no socket for window communications in prod builds
-        await switchToMetaMaskWindowWithoutSocket(driver);
+        await driver.switchToWindowByTitleWithoutSocket(WINDOW_TITLES.ExtensionInFullScreenView);
 
         await completeCreateNewWalletOnboardingFlowWithCustomSettings({
           driver,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1278,6 +1278,46 @@ class Driver {
     }
   }
 
+  /**
+   * Switches to a window by its title without using the background socket.
+   * To be used in specs that run against production builds.
+   *
+   * @param {string} title - The target window title to switch to
+   * @returns {Promise<void>}
+   * @throws {Error} Will throw an error if the target window is not found
+   */
+  async switchToWindowByTitleWithoutSocket(title) {
+    const windowHandles = await this.driver.getAllWindowHandles();
+    let targetWindowFound = false;
+
+    // Iterate through each window handle
+    for (const handle of windowHandles) {
+      await this.driver.switchTo().window(handle);
+      let currentTitle = await this.driver.getTitle();
+
+      // Wait 25 x 200ms = 5 seconds for the title to match the target title
+      for (let i = 0; i < 25; i++) {
+        if (currentTitle === title) {
+          targetWindowFound = true;
+          console.log(`Switched to ${title} window`);
+          break;
+        }
+        await this.driver.sleep(200);
+        currentTitle = await this.driver.getTitle();
+      }
+
+      // If the target window is found, break out of the outer loop
+      if (targetWindowFound) {
+        break;
+      }
+    }
+
+    // If target window is not found, throw an error
+    if (!targetWindowFound) {
+      throw new Error(`${title} window not found`);
+    }
+  }
+
   // Error handling
 
   async verboseReportOnFailure(testTitle, error) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Vault Decryptor spec is flaky. The problem is that whenever we started the spec, we wait until the MetaMask full window was open and then switch to it, just by switching to the last open window (broken assumption: last window is the MetaMask full width one). The reason for not using the regular driver methods, (switch by title) was because we there's no socket for windows in the prod build.
This behavior was stable, but after this [PR was merged](https://github.com/MetaMask/metamask-extension/pull/30970) this changed.

Now the window handles we get in the array are sometimes unordered (the MetaMask full width is not the 3rd one but sometimes the 2nd, and the offscreen is the 3rd -- see video below).

The fix is to make the switch to MetaMask deterministic, by switching to each window handle and getting the window title and check if it matches the full width one.

https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/134516/workflows/ec495927-6baf-4324-86ff-b65786197dad/jobs/4703080/steps

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31425?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. successful ci run here: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/134537/workflows/7095dd73-ff37-4a6f-b35a-b3e0e7fe9bc6/jobs/4703479

## **Screenshots/Recordings**

You can see how the error says it doesn't find the title, but in the artifacts we do see it, meaning we are not focused on the correct window

![Screenshot from 2025-03-31 09-01-27](https://github.com/user-attachments/assets/1d996911-76df-47fa-a2db-7488ebadb8d0)

See the order of the windows on a failed test:
1. Dom1: chrome Extension page
2. Dom2: MetaMask full width
3. Dom3: MetaMAsk offscreen

And in our spec we assumed the MetaMask full witdth was always at the last position of the array,


https://github.com/user-attachments/assets/67180246-a464-4d1f-8c9e-6fa391f7736d



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
