### PR TITLE
test: Add E2E test for first install

### DIFF
--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -67,11 +67,19 @@ jobs:
       matrix-index: ${{ matrix.index }}
       matrix-total: ${{ strategy.job-total }}
 
+  test-e2e-firefox-dist:
+    uses: ./.github/workflows/run-e2e.yml
+    with:
+      test-suite-name: test-e2e-firefox-dist
+      build-artifact: build-dist-mv2-browserify
+      test-command: yarn test:e2e:firefox:dist
+
   test-e2e-firefox-report:
     needs:
       - test-e2e-firefox-browserify
       - test-e2e-firefox-webpack
       - test-e2e-firefox-flask
+      - test-e2e-firefox-dist
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -73,6 +73,7 @@ jobs:
       test-suite-name: test-e2e-firefox-dist
       build-artifact: build-dist-mv2-browserify
       test-command: yarn test:e2e:firefox:dist
+      builds-from-run: ${{ inputs.builds-from-run }}
 
   test-e2e-firefox-report:
     needs:

--- a/test/e2e/dist/first-install.spec.ts
+++ b/test/e2e/dist/first-install.spec.ts
@@ -8,17 +8,13 @@ describe('First install', function () {
     await withFixtures(
       {
         disableServerMochaToBackground: true,
+        title: this.test?.fullTitle(),
       },
       async ({ driver }) => {
         // Wait for MetaMask to automatically open a new tab
-        await driver.waitUntilXWindowHandles(2);
-
-        const windowHandles = await driver.getAllWindowHandles();
-
-        // Switch to new tab and verify it's the start onboarding page
-        await driver.driver.switchTo().window(windowHandles[1]);
+        await driver.waitAndSwitchToWindowWithTitle(2, 'MetaMask');
         const startOnboardingPage = new StartOnboardingPage(driver);
-        await startOnboardingPage.check_loginPageIsLoaded();
+        await startOnboardingPage.checkBannerPageIsLoaded();
 
         await driver.executeScript('window.stateHooks.reloadExtension()');
 

--- a/test/e2e/dist/first-install.spec.ts
+++ b/test/e2e/dist/first-install.spec.ts
@@ -1,9 +1,7 @@
-import assert from 'assert/strict';
-import { Browser } from 'selenium-webdriver';
+import { hasProperty, isObject } from '@metamask/utils';
 import { withFixtures } from '../helpers';
 import { errorMessages } from '../webdriver/driver';
 import StartOnboardingPage from '../page-objects/pages/onboarding/start-onboarding-page';
-import { hasProperty, isObject } from '@metamask/utils';
 
 describe('First install', function () {
   it('opens new window upon install, but not on subsequent reloads', async function () {
@@ -15,12 +13,12 @@ describe('First install', function () {
         // Wait for MetaMask to automatically open a new tab
         await driver.waitUntilXWindowHandles(2);
 
-        let windowHandles = await driver.getAllWindowHandles();
+        const windowHandles = await driver.getAllWindowHandles();
 
         // Switch to new tab and verify it's the start onboarding page
         await driver.driver.switchTo().window(windowHandles[1]);
         const startOnboardingPage = new StartOnboardingPage(driver);
-        await startOnboardingPage.check_pageIsLoaded();
+        await startOnboardingPage.check_loginPageIsLoaded();
 
         await driver.executeScript('window.stateHooks.reloadExtension()');
 
@@ -42,9 +40,8 @@ describe('First install', function () {
             // Ignore timeout error, it's expected here in the success case
             console.log('Onboarding tab not opened');
             return;
-          } else {
-            throw error;
           }
+          throw error;
         }
         throw new Error('Onboarding tab opened unexpectedly');
       },

--- a/test/e2e/dist/first-install.spec.ts
+++ b/test/e2e/dist/first-install.spec.ts
@@ -1,0 +1,53 @@
+import assert from 'assert/strict';
+import { Browser } from 'selenium-webdriver';
+import { withFixtures } from '../helpers';
+import { errorMessages } from '../webdriver/driver';
+import StartOnboardingPage from '../page-objects/pages/onboarding/start-onboarding-page';
+import { hasProperty, isObject } from '@metamask/utils';
+
+describe('First install', function () {
+  it('opens new window upon install, but not on subsequent reloads', async function () {
+    await withFixtures(
+      {
+        disableServerMochaToBackground: true,
+      },
+      async ({ driver }) => {
+        // Wait for MetaMask to automatically open a new tab
+        await driver.waitUntilXWindowHandles(2);
+
+        let windowHandles = await driver.getAllWindowHandles();
+
+        // Switch to new tab and verify it's the start onboarding page
+        await driver.driver.switchTo().window(windowHandles[1]);
+        const startOnboardingPage = new StartOnboardingPage(driver);
+        await startOnboardingPage.check_pageIsLoaded();
+
+        await driver.executeScript('window.stateHooks.reloadExtension()');
+
+        // Wait for extension to reload, signified by the onboarding tab closing
+        await driver.waitUntilXWindowHandles(1);
+
+        // Test to see if it re-opens
+        try {
+          await driver.waitUntilXWindowHandles(2);
+        } catch (error) {
+          if (
+            isObject(error) &&
+            hasProperty(error, 'message') &&
+            typeof error.message === 'string' &&
+            error.message.startsWith(
+              errorMessages.waitUntilXWindowHandlesTimeout,
+            )
+          ) {
+            // Ignore timeout error, it's expected here in the success case
+            console.log('Onboarding tab not opened');
+            return;
+          } else {
+            throw error;
+          }
+        }
+        throw new Error('Onboarding tab opened unexpectedly');
+      },
+    );
+  });
+});

--- a/test/e2e/dist/first-install.spec.ts
+++ b/test/e2e/dist/first-install.spec.ts
@@ -14,7 +14,7 @@ describe('First install', function () {
         // Wait for MetaMask to automatically open a new tab
         await driver.waitAndSwitchToWindowWithTitle(2, 'MetaMask');
         const startOnboardingPage = new StartOnboardingPage(driver);
-        await startOnboardingPage.checkBannerPageIsLoaded();
+        await startOnboardingPage.checkLoginPageIsLoaded();
 
         await driver.executeScript('window.stateHooks.reloadExtension()');
 

--- a/test/e2e/dist/first-install.spec.ts
+++ b/test/e2e/dist/first-install.spec.ts
@@ -1,7 +1,9 @@
+import { Browser } from 'selenium-webdriver';
 import { hasProperty, isObject } from '@metamask/utils';
 import { withFixtures } from '../helpers';
 import { errorMessages } from '../webdriver/driver';
 import StartOnboardingPage from '../page-objects/pages/onboarding/start-onboarding-page';
+import OnboardingMetricsPage from '../page-objects/pages/onboarding/onboarding-metrics-page';
 
 describe('First install', function () {
   it('opens new window upon install, but not on subsequent reloads', async function () {
@@ -13,8 +15,13 @@ describe('First install', function () {
       async ({ driver }) => {
         // Wait for MetaMask to automatically open a new tab
         await driver.waitAndSwitchToWindowWithTitle(2, 'MetaMask');
-        const startOnboardingPage = new StartOnboardingPage(driver);
-        await startOnboardingPage.checkLoginPageIsLoaded();
+        if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
+          const onboardingMetricsPage = new OnboardingMetricsPage(driver);
+          await onboardingMetricsPage.checkPageIsLoaded();
+        } else {
+          const startOnboardingPage = new StartOnboardingPage(driver);
+          await startOnboardingPage.checkLoginPageIsLoaded();
+        }
 
         await driver.executeScript('window.stateHooks.reloadExtension()');
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -284,6 +284,11 @@ type StateHooks = {
    * This is initialized by the service worker in MV3. It is handled in `background.js`.
    */
   lazyListener?: ExtensionLazyListener<typeof globalThis.chrome>;
+  /**
+   * Reload the extension. This is used to trigger extension reload from a page context by E2E
+   * tests.
+   */
+  reloadExtension?: () => void;
 };
 
 export declare global {

--- a/ui/index.js
+++ b/ui/index.js
@@ -382,6 +382,15 @@ function setupStateHooks(store) {
     };
   }
 
+  /**
+   * Reload the extension.
+   *
+   * This is used for the `first-install` E2E test, which uses a production-like build. This
+   * function must be present even if `process.env.IN_TEST` is false.
+   */
+  window.stateHooks.reloadExtension = () => {
+    browser.runtime.reload();
+  };
   window.stateHooks.getCleanAppState = async function () {
     return getCleanAppState(store);
   };


### PR DESCRIPTION
## **Description**

Add E2E test to ensure a window opens upon first install.

This test needs to use a production-like build rather than a standard E2E build, so the existing "vault decryptor" job was repurposed to be more generically for E2E tests using a production-like build.

A global function `reloadExtension` is added to `stateHooks` for use by this test. This function had to be enabled for production builds because the test uses a production build.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31435?quickstart=1)

## **Related issues**

This is an E2E test for #31332

## **Manual testing steps**

* Create an MV3 production-like build (`yarn dist`)
* Run `yarn test:e2e:single ./test/e2e/first-install.spec.ts --browser chrome` to run the test on Chrome
* Create an MV2 production-like build (`yarn dist:mv2`)
* Run `yarn test:e2e:single ./test/e2e/first-install.spec.ts --browser firefox` to run the test on Firefox

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a production-like E2E to verify onboarding opens only on first install and not after reload.
> 
> - New `test/e2e/dist/first-install.spec.ts` uses `window.stateHooks.reloadExtension()` and handles Firefox/Chrome onboarding pages
> - Exposes `window.stateHooks.reloadExtension` in `ui/index.js` (always available) and declares it in `types/global.d.ts`
> - CI: Adds `test-e2e-firefox-dist` job in `.github/workflows/e2e-firefox.yml` and includes it in the aggregated report
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf75fc27e97919cf8bf07b3cfa2fd72c417f8df5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->