### PR TITLE
feat: updating popup width of extension from 357px to 400px

### DIFF
--- a/app/popup-init.html
+++ b/app/popup-init.html
@@ -25,7 +25,7 @@
         * page may be a further UX improvement.
         */
       html {
-        width: 357px;
+        width: 400px;
         height: 600px;
         background: #f2f4f6;
       }

--- a/app/popup.html
+++ b/app/popup.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html style="width:357px; height:600px;" dir="ltr">
+<html style="width:400px; height:600px;" dir="ltr">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
@@ -7,7 +7,7 @@
     <link rel="preload" href="/_locales/en/messages.json" as="fetch" crossorigin="anonymous" />
     <link rel="stylesheet" href="../ui/css/index.scss" />
   </head>
-  <body style="width:357px; height:600px;">
+  <body style="width:400px; height:600px;">
     <div id="app-content">
       <img class="loading-logo" src="./images/logo/metamask-fox.svg" alt="" loading="lazy" />
       <img class="loading-spinner" src="./images/spinner.gif" alt="" loading="lazy" />

--- a/ui/components/app/modals/modal.js
+++ b/ui/components/app/modals/modal.js
@@ -86,7 +86,7 @@ const MODALS = {
     },
     laptopModalStyle: {
       width:
-        getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '357px' : '449px',
+        getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '400px' : '449px',
       top: 'calc(33% + 45px)',
       paddingLeft:
         getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '16px' : null,

--- a/ui/components/ui/mascot/mascot.stories.js
+++ b/ui/components/ui/mascot/mascot.stories.js
@@ -8,7 +8,7 @@ const animationEventEmitter = new EventEmitter();
 
 const containerStyle = {
   height: '600px',
-  width: '357px',
+  width: '400px',
   border: '1px solid black',
   display: 'flex',
   flexFlow: 'column',

--- a/ui/pages/unlock-page/index.scss
+++ b/ui/pages/unlock-page/index.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  width: 357px;
+  width: 400px;
   padding: 30px;
   font-weight: 400;
 


### PR DESCRIPTION
## **Description**

This PR increases the default popup width of the MetaMask extension from `357px` to `400px` in preparation for an upcoming change to increase the default font size from `14px` to `16px`.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/31444

## **Manual testing steps**

1. Install the extension with these changes
2. Open the MetaMask popup
3. Verify the popup width is 400px and content displays correctly
4. Test various screens and modals to ensure proper layout
5. Confirm no horizontal scrollbars appear in common workflows

## **Screenshots/Recordings**

### **Before**

Width: `357px `

<img width="851" alt="Screenshot 2025-03-31 at 10 19 26 AM" src="https://github.com/user-attachments/assets/060c7ad9-59eb-431d-bad3-4f93b4e77f13" />

### **After**

Width: `400px`

<img width="921" alt="Screenshot 2025-03-31 at 10 17 55 AM" src="https://github.com/user-attachments/assets/d8d56277-dd2f-406a-8023-993515a7f2cd" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots