### PR TITLE
chore: temporarily ignore `@solana/web3.js (deprecation)`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -141,6 +141,10 @@ npmAuditIgnoreAdvisories:
   # Check Trezor 9.5.X Changelog for more info: https://github.com/trezor/trezor-suite/blob/develop/packages/connect/CHANGELOG.md
   - '@trezor/connect-web (deprecation)'
 
+  # We temporarily ignore the deprecation notice to unblock ci
+  # Issue: @solana/web3.js version 2.0 is now @solana/kit! Remove @solana/web3.js@2 from your dependencies and replace it with @solana/kit.
+  # As needed, upgrade all of your @solana-program/* dependencies to the latest versions that use Kit.
+  - '@solana/web3.js (deprecation)'
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Temporarily ignore the audit failure for `@solana/web3.js (deprecation)`.

This issue is created to remove this entry from the ignore list: https://github.com/MetaMask/metamask-extension/issues/31468


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31467?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. The audit job should not fail


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot from 2025-04-01 09-25-38](https://github.com/user-attachments/assets/cbf9c201-4abb-4d77-aff5-652ca71042ad)


### **After**

![Screenshot from 2025-04-01 09-28-19](https://github.com/user-attachments/assets/ca9ce288-effe-43ac-9b34-ee0f70468ac7)


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
