### PR TITLE
fix: Fix `useTransactionGasFeeEstimate` to calculate gas estimate properly

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.test.ts
@@ -1,3 +1,4 @@
+import { GasFeeEstimates } from '@metamask/gas-fee-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import {
   CONTRACT_INTERACTION_SENDER_ADDRESS,
@@ -5,21 +6,46 @@ import {
 } from '../../../../../../../test/data/confirmations/contract-interaction';
 import mockState from '../../../../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../../../../test/lib/render-helpers';
+import { useGasFeeEstimates } from '../../../../../../hooks/useGasFeeEstimates';
 import { useTransactionGasFeeEstimate } from './useTransactionGasFeeEstimate';
 
-describe('getGasFeeEstimate', () => {
-  it('returns the correct estimate when EIP1559 is supported', () => {
-    const transactionMeta = genUnapprovedContractInteractionConfirmation({
-      address: CONTRACT_INTERACTION_SENDER_ADDRESS,
-    }) as TransactionMeta;
-    const supportsEIP1559 = true;
+jest.mock('../../../../../../hooks/useGasFeeEstimates', () => ({
+  useGasFeeEstimates: jest.fn(),
+}));
+
+describe('useTransactionGasFeeEstimate', () => {
+  let mockUseGasFeeEstimates = jest.mocked(useGasFeeEstimates);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseGasFeeEstimates.mockReturnValue({
+      gasFeeEstimates: {
+        estimatedBaseFee: '0.5', // 0.5 GWEI
+      },
+    } as unknown as ReturnType<typeof useGasFeeEstimates>);
+  });
+
+  it('correctly calculates gas estimate using estimatedBaseFee for EIP1559', () => {
+    const transactionMeta = {
+      ...genUnapprovedContractInteractionConfirmation({
+        address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+      }),
+      txParams: {
+        gas: '0x5208', // 21000 in hex
+        maxPriorityFeePerGas: '0x3b9aca00', // 1 GWEI in hex
+        maxFeePerGas: '0x77359400', // 2 GWEI in hex
+      },
+    } as TransactionMeta;
 
     const { result } = renderHookWithProvider(
-      () => useTransactionGasFeeEstimate(transactionMeta, supportsEIP1559),
+      () => useTransactionGasFeeEstimate(transactionMeta, true),
       mockState,
     );
 
-    expect(result.current).toMatchInlineSnapshot(`"3be226d2d900"`);
+    // 21000 * (0.5 + 1) = 21000 * 1.5 = 31500
+    // 31500 in hex is 1ca62a4f7800
+    expect(result.current).toBe('1ca62a4f7800');
   });
 
   it('returns the correct estimate when EIP1559 is not supported', () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.test.ts
@@ -1,4 +1,3 @@
-import { GasFeeEstimates } from '@metamask/gas-fee-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import {
   CONTRACT_INTERACTION_SENDER_ADDRESS,
@@ -14,7 +13,7 @@ jest.mock('../../../../../../hooks/useGasFeeEstimates', () => ({
 }));
 
 describe('useTransactionGasFeeEstimate', () => {
-  let mockUseGasFeeEstimates = jest.mocked(useGasFeeEstimates);
+  const mockUseGasFeeEstimates = jest.mocked(useGasFeeEstimates);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
@@ -3,6 +3,7 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import {
   addHexes,
+  decGWEIToHexWEI,
   multiplyHexes,
 } from '../../../../../../../shared/modules/conversion.utils';
 import { Numeric } from '../../../../../../../shared/modules/Numeric';
@@ -30,9 +31,11 @@ export function useTransactionGasFeeEstimate(
 
   let gasEstimate: Hex;
   if (supportsEIP1559) {
+    const estimatedBaseFeeWeiHex = decGWEIToHexWEI(estimatedBaseFee);
+
     // Minimum Total Fee = (estimatedBaseFee + maxPriorityFeePerGas) * gasLimit
     let minimumFeePerGas = addHexes(
-      estimatedBaseFee || HEX_ZERO,
+      estimatedBaseFeeWeiHex || HEX_ZERO,
       maxPriorityFeePerGas,
     );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a bug where `useTransactionGasFeeEstimate` treats `estimatedBaseFee` as WEI hex. However this value is GWEI decimal. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31469?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4563

## **Manual testing steps**

No user flow changes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
