### PR TITLE
fix: should not show NonContractAddressAlert for auth request

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.test.ts
@@ -1,3 +1,4 @@
+import { Hex } from '@metamask/utils';
 import {
   TransactionMeta,
   TransactionStatus,
@@ -9,6 +10,7 @@ import { useSelector } from 'react-redux';
 import { readAddressAsContract } from '../../../../../../shared/modules/contract-utils';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
 import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { I18nContext } from '../../../../../contexts/i18n';
@@ -214,6 +216,46 @@ describe('useNonContractAddressAlerts', () => {
         currentConfirmation: transactionWithData,
       }),
     ).toEqual([]);
+  });
+
+  it('returns no alert for authorization request', async () => {
+    const authorizationList = [{ address: '0x123' as Hex }];
+    const transaction = genUnapprovedContractInteractionConfirmation({
+      authorizationList,
+    });
+
+    useContextMock.mockImplementation((context) => {
+      if (context === ConfirmContext) {
+        return { currentConfirmation: transaction };
+      } else if (context === I18nContext) {
+        return (translationKey: string) => translationKey;
+      }
+      return undefined;
+    });
+
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getNetworkConfigurationsByChainId) {
+        return {
+          '0x5': {
+            chainId: '0x5',
+            name: 'Mainnet',
+          },
+        };
+      } else if (selector === selectPendingApprovalsForNavigation) {
+        return [transaction];
+      }
+
+      return undefined;
+    });
+
+    const { result } = renderHookWithConfirmContextProvider(
+      useNonContractAddressAlerts,
+      {
+        currentConfirmation: transaction,
+      },
+    );
+
+    expect(result.current).toEqual([]);
   });
 
   it('returns alert if the transaction has data and the recipient is not a contract', async () => {

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
@@ -62,5 +62,8 @@ export function useNonContractAddressAlerts(): Alert[] {
         severity: Severity.Warning,
       },
     ];
-  }, [isSendingHexDataWhileInteractingWithNonContractAddress]);
+  }, [
+    isSendingHexDataWhileInteractingWithNonContractAddress,
+    isUpgradeTransaction,
+  ]);
 }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts
@@ -13,12 +13,14 @@ import { Severity } from '../../../../../helpers/constants/design-system';
 import { useAsyncResult } from '../../../../../hooks/useAsync';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
+import { useIsUpgradeTransaction } from '../../../components/confirm/info/hooks/useIsUpgradeTransaction';
 import { NonContractAddressAlertMessage } from './NonContractAddressAlertMessage';
 
 export function useNonContractAddressAlerts(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
+  const isUpgradeTransaction = useIsUpgradeTransaction();
 
   const isSendingHexData =
     currentConfirmation?.txParams?.data !== undefined &&
@@ -43,7 +45,10 @@ export function useNonContractAddressAlerts(): Alert[] {
     !isContractDeploymentTx;
 
   return useMemo(() => {
-    if (!isSendingHexDataWhileInteractingWithNonContractAddress) {
+    if (
+      !isSendingHexDataWhileInteractingWithNonContractAddress ||
+      isUpgradeTransaction
+    ) {
       return [];
     }
 


### PR DESCRIPTION
## **Description**

Fix the issue that currently we're showing the "Potential mistake" warning of sending call data for the batch transaction since the user is sending call data to themselves to enable.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4522

## **Manual testing steps**

1. Go to test dapp
2. Submit EIP-5792 Send Call for first time
3. Ensure that "Potential mistake" alert is not visible

## **Screenshots/Recordings**
<img width="358" alt="Screenshot 2025-04-02 at 11 37 57 AM" src="https://github.com/user-attachments/assets/bdb2c7f9-7ec2-4d5a-b5b1-fd112d77792e" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
