### PR TITLE
feat: for batch transaction simulation section approve rows should be displayed at the top

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
@@ -179,7 +179,8 @@ describe('SimulationDetails', () => {
 
     renderSimulationDetails({}, false, staticRows);
 
-    expect(BalanceChangeList).toHaveBeenLastCalledWith(
+    expect(BalanceChangeList).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         heading: 'Test Label',
         balanceChanges: staticRows[0].balanceChanges,

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -350,6 +350,13 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
       transactionId={transactionId}
     >
       <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={3}>
+        {staticRows.map((staticRow, index) => (
+          <BalanceChangeList
+            key={index}
+            heading={staticRow.label}
+            balanceChanges={staticRow.balanceChanges}
+          />
+        ))}
         <BalanceChangeList
           heading={t('simulationDetailsOutgoingHeading')}
           balanceChanges={outgoing}
@@ -360,13 +367,6 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
           balanceChanges={incoming}
           testId="simulation-rows-incoming"
         />
-        {staticRows.map((staticRow, index) => (
-          <BalanceChangeList
-            key={index}
-            heading={staticRow.label}
-            balanceChanges={staticRow.balanceChanges}
-          />
-        ))}
       </Box>
     </SimulationDetailsLayout>
   );


### PR DESCRIPTION
## **Description**

for batch transaction simulation section approve rows should be displayed at the top

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4489

## **Manual testing steps**

1. Go to test dapp
2. Submit a batch with an approval in it
3. Ensure that in simulation section approve rows are towards the top

## **Screenshots/Recordings**
<img width="358" alt="Screenshot 2025-04-02 at 4 08 20 PM" src="https://github.com/user-attachments/assets/5491cc90-e44a-4fcb-987e-993f20a58262" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
