### PR TITLE
feat: add is_suggested_name segment property

### DIFF
--- a/app/scripts/lib/snap-keyring/snap-keyring.test.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.test.ts
@@ -311,6 +311,7 @@ describe('Snap Keyring Methods', () => {
           account_type: 'snap',
           snap_id: mockSnapId,
           snap_name: mockSnapName,
+          is_suggested_name: false,
         },
       });
       expect(mockShowSuccess).toHaveBeenCalledTimes(1);
@@ -353,6 +354,7 @@ describe('Snap Keyring Methods', () => {
           account_type: 'snap',
           snap_id: mockSnapId,
           snap_name: mockSnapName,
+          is_suggested_name: false,
         },
       });
       expect(mockSetAccountName).not.toHaveBeenCalled();
@@ -425,6 +427,7 @@ describe('Snap Keyring Methods', () => {
           account_type: 'snap',
           snap_id: mockSnapId,
           snap_name: mockSnapName,
+          is_suggested_name: true,
         },
       });
       expect(mockSetAccountName).toHaveBeenCalledWith([
@@ -474,6 +477,7 @@ describe('Snap Keyring Methods', () => {
           account_type: 'snap',
           snap_id: mockSnapId,
           snap_name: mockSnapName,
+          is_suggested_name: true,
         },
       });
       expect(mockSetAccountName).toHaveBeenCalledTimes(1);
@@ -550,6 +554,7 @@ describe('Snap Keyring Methods', () => {
           account_type: 'snap',
           snap_id: mockSnapId,
           snap_name: mockSnapName,
+          is_suggested_name: true,
         },
       });
       expect(mockSetAccountName).toHaveBeenCalledTimes(1);

--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -282,6 +282,7 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
     skipSetSelectedAccountStep,
     accountName,
     onceSaved,
+    defaultAccountNameChosen,
   }: {
     address: string;
     snapId: SnapId;
@@ -289,6 +290,7 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
     skipSetSelectedAccountStep: boolean;
     onceSaved: Promise<string>;
     accountName?: string;
+    defaultAccountNameChosen: boolean;
   }) {
     const learnMoreLink =
       'https://support.metamask.io/managing-my-wallet/accounts-and-addresses/how-to-add-accounts-in-your-wallet/';
@@ -303,6 +305,9 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
           account_type: MetaMetricsEventAccountType.Snap,
           snap_id: snapId,
           snap_name: snapName,
+          ...(event === MetaMetricsEventName.AccountAdded && {
+            is_suggested_name: defaultAccountNameChosen,
+          }),
         },
       });
     };
@@ -434,6 +439,8 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
       skipSetSelectedAccountStep,
       accountName,
       onceSaved,
+      defaultAccountNameChosen:
+        Boolean(accountNameSuggestion) && accountName === accountNameSuggestion,
     });
   }
 

--- a/ui/components/multichain/create-account/create-account.tsx
+++ b/ui/components/multichain/create-account/create-account.tsx
@@ -149,6 +149,9 @@ export const CreateAccount: CreateAccountComponent = React.memo(
                 account_type: MetaMetricsEventAccountType.Default,
                 location: 'Home',
                 hd_entropy_index: hdEntropyIndex,
+                is_suggested_name:
+                  !trimmedAccountName ||
+                  trimmedAccountName === defaultAccountName,
               },
             });
             history.push(mostRecentOverviewPage);

--- a/ui/components/multichain/import-account/import-account.js
+++ b/ui/components/multichain/import-account/import-account.js
@@ -79,6 +79,7 @@ export const ImportAccount = ({ onActionComplete }) => {
         account_type: MetaMetricsEventAccountType.Imported,
         account_import_type: accountImportType,
         hd_entropy_index: hdEntropyIndex,
+        is_suggested_name: true,
       },
     });
   }

--- a/ui/pages/create-account/connect-hardware/index.js
+++ b/ui/pages/create-account/connect-hardware/index.js
@@ -313,6 +313,7 @@ class ConnectHardwareForm extends Component {
             // For now we keep using the device name to avoid any discrepancies with our current metrics.
             // TODO: This will be addressed later, see: https://github.com/MetaMask/metamask-extension/issues/29777
             account_hardware_type: deviceName,
+            is_suggested_name: true,
           },
         });
         history.push(mostRecentOverviewPage);


### PR DESCRIPTION
## **Description**

This is to add property to Account Added event, to understand how many users are using default account names.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
