### PR TITLE
Jl/chain agnostic permission connection UI from top/add caip account id to merged internal account

### DIFF
--- a/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.stories.tsx
+++ b/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.stories.tsx
@@ -26,31 +26,29 @@ export default {
     ],
     accounts: [
       {
-        internalAccount: {
-          id: '689821df-0e8f-4093-bbbb-b95cf0fa79cb',
-          address: '0x860092756917d3e069926ba130099375eeeb9440',
-          options: {},
-          methods: [
-            'personal_sign',
-            'eth_sign',
-            'eth_signTransaction',
-            'eth_signTypedData_v1',
-            'eth_signTypedData_v3',
-            'eth_signTypedData_v4',
-          ],
-          type: 'eip155:eoa',
-          metadata: {
-            name: 'Account 1',
-            importTime: 1726046726882,
-            keyring: {
-              type: 'HD Key Tree',
-            },
-            lastSelected: 1726046726882,
+        id: '689821df-0e8f-4093-bbbb-b95cf0fa79cb',
+        address: '0x860092756917d3e069926ba130099375eeeb9440',
+        options: {},
+        methods: [
+          'personal_sign',
+          'eth_sign',
+          'eth_signTransaction',
+          'eth_signTypedData_v1',
+          'eth_signTypedData_v3',
+          'eth_signTypedData_v4',
+        ],
+        type: 'eip155:eoa',
+        metadata: {
+          name: 'Account 1',
+          importTime: 1726046726882,
+          keyring: {
+            type: 'HD Key Tree',
           },
-          balance: '0x00',
+          lastSelected: 1726046726882,
         },
+        balance: '0x00',
         caipAccountId: 'eip155:0:0x860092756917d3e069926ba130099375eeeb9440'
-      }
+      },
     ],
   },
 };

--- a/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.test.tsx
+++ b/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.test.tsx
@@ -44,7 +44,7 @@ const render = (
   const accountsWithCaipAccountId = accounts.map((account) => {
     const { namespace, reference } = parseCaipChainId(account.scopes[0]);
     return {
-      internalAccount: account,
+      ...account,
       caipAccountId:
         `${namespace}:${reference}:${account.address}` as CaipAccountId,
     };

--- a/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
+++ b/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
@@ -30,7 +30,7 @@ import {
   AlignItems,
   BlockSize,
 } from '../../../helpers/constants/design-system';
-import { MergedInternalAccount } from '../../../selectors/selectors.types';
+import { MergedInternalAccountWithCaipAccountId } from '../../../selectors/selectors.types';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -39,10 +39,7 @@ import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 
 type EditAccountsModalProps = {
-  accounts: {
-    internalAccount: MergedInternalAccount;
-    caipAccountId: CaipAccountId;
-  }[];
+  accounts: MergedInternalAccountWithCaipAccountId[];
   defaultSelectedAccountAddresses: CaipAccountId[];
   onClose: () => void;
   onSubmit: (addresses: CaipAccountId[]) => void;
@@ -148,9 +145,9 @@ export const EditAccountsModal: React.FC<EditAccountsModalProps> = ({
               {accounts.map((account) => (
                 <AccountListItem
                   onClick={() => handleAccountClick(account.caipAccountId)}
-                  account={account.internalAccount}
+                  account={account}
                   key={account.caipAccountId}
-                  isPinned={Boolean(account.internalAccount.pinned)}
+                  isPinned={Boolean(account.pinned)}
                   startAccessory={
                     <Checkbox
                       isChecked={selectedAccountAddresses.some(

--- a/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
+++ b/ui/components/multichain/edit-accounts-modal/edit-accounts-modal.tsx
@@ -78,17 +78,18 @@ export const EditAccountsModal: React.FC<EditAccountsModalProps> = ({
   };
 
   const handleAccountClick = (caipAccountId: CaipAccountId) => {
-    console.log('caipAccountId', caipAccountId);
-    if (selectedAccountAddresses.includes(caipAccountId)) {
-      console.log('removing caipAccountId', caipAccountId);
-      setSelectedAccountAddresses(
-        selectedAccountAddresses.filter(
-          (_caipAccountId) => _caipAccountId !== caipAccountId,
-        ),
-      );
-    } else {
-      console.log('adding caipAccountId', caipAccountId);
+    const updatedSelectedAccountAddresses = selectedAccountAddresses.filter(
+      (selectedAccountId) => {
+        return !isEqualCaseInsensitive(selectedAccountId, caipAccountId);
+      },
+    );
+
+    if (
+      updatedSelectedAccountAddresses.length === selectedAccountAddresses.length
+    ) {
       setSelectedAccountAddresses([...selectedAccountAddresses, caipAccountId]);
+    } else {
+      setSelectedAccountAddresses(updatedSelectedAccountAddresses);
     }
   };
 

--- a/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
@@ -58,9 +58,9 @@ import {
 } from '../../disconnect-all-modal/disconnect-all-modal';
 import { PermissionsHeader } from '../../permissions-header/permissions-header';
 import { MergedInternalAccountWithCaipAccountId } from '../../../../selectors/selectors.types';
-import { caipFormattedTestChains } from '../../../../pages/permissions-connect/connect-page/connect-page';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
 import { SiteCell } from './site-cell/site-cell';
+import { CAIP_FORMATTED_EVM_TEST_CHAINS } from '../../../../../shared/constants/network';
 
 export const ReviewPermissions = () => {
   const t = useI18nContext();
@@ -127,7 +127,7 @@ export const ReviewPermissions = () => {
       Object.entries(networkConfigurationsByCaipChainId).reduce(
         ([nonTestNetworksList, testNetworksList], [chainId, network]) => {
           const caipChainId = chainId as CaipChainId;
-          const isTestNetwork = caipFormattedTestChains.includes(caipChainId);
+          const isTestNetwork = CAIP_FORMATTED_EVM_TEST_CHAINS.includes(caipChainId);
           (isTestNetwork ? testNetworksList : nonTestNetworksList).push({
             ...network,
             caipChainId,

--- a/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
@@ -25,7 +25,7 @@ import {
   getConnectedSitesList,
   getPermissionSubjects,
   getShowPermittedNetworkToastOpen,
-  getUpdatedAndSortedAccounts,
+  getUpdatedAndSortedAccountsWithCaipAccountId,
 } from '../../../../selectors';
 import {
   addPermittedAccounts,
@@ -57,7 +57,7 @@ import {
   DisconnectType,
 } from '../../disconnect-all-modal/disconnect-all-modal';
 import { PermissionsHeader } from '../../permissions-header/permissions-header';
-import { MergedInternalAccount } from '../../../../selectors/selectors.types';
+import { MergedInternalAccountWithCaipAccountId } from '../../../../selectors/selectors.types';
 import { caipFormattedTestChains } from '../../../../pages/permissions-connect/connect-page/connect-page';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
 import { SiteCell } from './site-cell/site-cell';
@@ -171,18 +171,8 @@ export const ReviewPermissions = () => {
   };
 
   const allAccounts = useSelector(
-    getUpdatedAndSortedAccounts,
-  ) as MergedInternalAccount[];
-
-  const allAccountsWithCaipAccountId = allAccounts.map((account) => {
-    // I hope we can reliably use the first scope to determine the namespace
-    const { namespace, reference } = parseCaipChainId(account.scopes[0]);
-    return {
-      internalAccount: account,
-      caipAccountId:
-        `${namespace}:${reference}:${account.address}` as CaipAccountId,
-    };
-  });
+    getUpdatedAndSortedAccountsWithCaipAccountId,
+  ) as MergedInternalAccountWithCaipAccountId[];
 
   const _connectedAccountAddresses = useSelector((state) =>
     getAllPermittedAccountsForSelectedTab(state, activeTabOrigin),
@@ -281,7 +271,7 @@ export const ReviewPermissions = () => {
             <SiteCell
               nonTestNetworks={nonTestNetworks}
               testNetworks={testNetworks}
-              accounts={allAccountsWithCaipAccountId}
+              accounts={allAccounts}
               onSelectAccountAddresses={handleSelectAccountAddresses}
               onSelectChainIds={handleSelectChainIds}
               selectedAccountAddresses={connectedAccountAddresses}

--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell-tooltip.js
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell-tooltip.js
@@ -37,7 +37,7 @@ export const SiteCellTooltip = ({ accounts, networks }) => {
     : AvatarAccountVariant.Jazzicon;
 
   const avatarAccountsData = accounts?.map((account) => ({
-    avatarValue: account.internalAccount.address,
+    avatarValue: account.address,
   }));
 
   const avatarNetworksData = networks?.map((network) => ({
@@ -55,37 +55,35 @@ export const SiteCellTooltip = ({ accounts, networks }) => {
           data-test-id="site-cell-tooltip"
         >
           <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
-            {accounts
-              ?.slice(0, TOOLTIP_LIMIT)
-              .map(({ internalAccount: acc }) => {
-                return (
-                  <Box
-                    display={Display.Flex}
-                    flexDirection={FlexDirection.Row}
-                    alignItems={AlignItems.center}
-                    textAlign={TextAlign.Left}
-                    key={acc.address}
-                    padding={1}
-                    paddingInline={2}
-                    gap={2}
+            {accounts?.slice(0, TOOLTIP_LIMIT).map((acc) => {
+              return (
+                <Box
+                  display={Display.Flex}
+                  flexDirection={FlexDirection.Row}
+                  alignItems={AlignItems.center}
+                  textAlign={TextAlign.Left}
+                  key={acc.address}
+                  padding={1}
+                  paddingInline={2}
+                  gap={2}
+                >
+                  <AvatarAccount
+                    size={AvatarAccountSize.Xs}
+                    address={acc.address}
+                    variant={avatarAccountVariant}
+                    borderStyle={BorderStyle.none}
+                  />
+                  <Text
+                    color={TextColor.overlayInverse}
+                    variant={TextVariant.bodyMdMedium}
+                    data-testid="accounts-list-item-connected-account-name"
+                    ellipsis
                   >
-                    <AvatarAccount
-                      size={AvatarAccountSize.Xs}
-                      address={acc.address}
-                      variant={avatarAccountVariant}
-                      borderStyle={BorderStyle.none}
-                    />
-                    <Text
-                      color={TextColor.overlayInverse}
-                      variant={TextVariant.bodyMdMedium}
-                      data-testid="accounts-list-item-connected-account-name"
-                      ellipsis
-                    >
-                      {acc.metadata.name || acc.label}
-                    </Text>
-                  </Box>
-                );
-              })}
+                    {acc.metadata.name || acc.label}
+                  </Text>
+                </Box>
+              );
+            })}
             {networks?.slice(0, TOOLTIP_LIMIT).map((network) => {
               return (
                 <Box

--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell.tsx
@@ -13,7 +13,7 @@ import {
   IconName,
 } from '../../../../component-library';
 import { EditAccountsModal, EditNetworksModal } from '../../..';
-import { MergedInternalAccount } from '../../../../../selectors/selectors.types';
+import { MergedInternalAccountWithCaipAccountId } from '../../../../../selectors/selectors.types';
 import { MetaMetricsContext } from '../../../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
@@ -33,10 +33,7 @@ type Network = {
 type SiteCellProps = {
   nonTestNetworks: Network[];
   testNetworks: Network[];
-  accounts: {
-    internalAccount: MergedInternalAccount;
-    caipAccountId: CaipAccountId;
-  }[];
+  accounts: MergedInternalAccountWithCaipAccountId[];
   onSelectAccountAddresses: (addresses: CaipAccountId[]) => void;
   onSelectChainIds: (chainIds: CaipChainId[]) => void;
   selectedAccountAddresses: CaipAccountId[];
@@ -80,15 +77,13 @@ export const SiteCell: React.FC<SiteCellProps> = ({
   const accountMessageConnectedState =
     selectedAccounts.length === 1
       ? t('connectedWithAccountName', [
-          selectedAccounts[0].internalAccount.metadata.name ||
-            selectedAccounts[0].internalAccount.label,
+          selectedAccounts[0].metadata.name || selectedAccounts[0].label,
         ])
       : t('connectedWithAccount', [selectedAccounts.length]);
   const accountMessageNotConnectedState =
     selectedAccounts.length === 1
       ? t('requestingForAccount', [
-          selectedAccounts[0].internalAccount.metadata.name ||
-            selectedAccounts[0].internalAccount.label,
+          selectedAccounts[0].metadata.name || selectedAccounts[0].label,
         ])
       : t('requestingFor');
 
@@ -148,7 +143,7 @@ export const SiteCell: React.FC<SiteCellProps> = ({
             // Why this difference?
             selectedAccounts.length === 1 ? (
               <AvatarAccount
-                address={selectedAccounts[0].internalAccount.address}
+                address={selectedAccounts[0].address}
                 size={AvatarAccountSize.Xs}
                 borderColor={BorderColor.transparent}
               />

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -247,10 +247,11 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
   const [selectedCaip10AccountAddresses, setSelectedCaip10AccountAddresses] =
     useState(defaultCaip10AccountAddresses);
 
-  const selectedAccounts = allAccounts.filter(({ caipAccountId }) =>
-    // Does this need to be a case insensitive compare?
-    selectedCaip10AccountAddresses.includes(caipAccountId),
-  );
+  const selectedAccounts = allAccounts.filter(({ caipAccountId }) => {
+    return selectedCaip10AccountAddresses.some((selectedCaipAccountId) => {
+      return isEqualCaseInsensitive(selectedCaipAccountId, caipAccountId);
+    });
+  });
 
   const onConfirm = () => {
     const _request = {

--- a/ui/pages/permissions-connect/connect-page/utils.ts
+++ b/ui/pages/permissions-connect/connect-page/utils.ts
@@ -1,9 +1,4 @@
-import {
-  CaipNamespace,
-  Hex,
-  CaipAccountId,
-  parseCaipAccountId,
-} from '@metamask/utils';
+import { CaipNamespace, Hex, parseCaipAccountId } from '@metamask/utils';
 import {
   Caip25CaveatType,
   Caip25CaveatValue,
@@ -12,7 +7,7 @@ import {
   setPermittedEthChainIds,
 } from '@metamask/chain-agnostic-permission';
 import { NetworkConfiguration } from '@metamask/network-controller';
-import { MergedInternalAccount } from '../../../selectors/selectors.types';
+import { MergedInternalAccountWithCaipAccountId } from '../../../selectors/selectors.types';
 
 export type PermissionsRequest = Record<
   string,
@@ -178,22 +173,10 @@ export function getFilteredNetworks(
  */
 export function getDefaultAccounts(
   requestedNamespaces: CaipNamespace[],
-  supportedRequestedAccounts: {
-    internalAccount: MergedInternalAccount;
-    caipAccountId: CaipAccountId;
-  }[],
-  allAccounts: {
-    internalAccount: MergedInternalAccount;
-    caipAccountId: CaipAccountId;
-  }[],
-): {
-  internalAccount: MergedInternalAccount;
-  caipAccountId: CaipAccountId;
-}[] {
-  const defaultAccounts: {
-    internalAccount: MergedInternalAccount;
-    caipAccountId: CaipAccountId;
-  }[] = [];
+  supportedRequestedAccounts: MergedInternalAccountWithCaipAccountId[],
+  allAccounts: MergedInternalAccountWithCaipAccountId[],
+): MergedInternalAccountWithCaipAccountId[] {
+  const defaultAccounts: MergedInternalAccountWithCaipAccountId[] = [];
 
   supportedRequestedAccounts.forEach((account) => {
     const {
@@ -206,8 +189,8 @@ export function getDefaultAccounts(
 
   // sort accounts by lastSelected descending
   const allAccountsSortedByLastSelected = allAccounts.sort((a, b) => {
-    const lastSelectedA = a.internalAccount.metadata.lastSelected;
-    const lastSelectedB = b.internalAccount.metadata.lastSelected;
+    const lastSelectedA = a.metadata.lastSelected;
+    const lastSelectedB = b.metadata.lastSelected;
     if (!lastSelectedA && !lastSelectedB) {
       return 0;
     }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -134,6 +134,7 @@ import {
 } from './multichain';
 import { getRemoteFeatureFlags } from './remote-feature-flags';
 import { getApprovalRequestsByType } from './approvals';
+import { parseCaipChainId } from '@metamask/utils';
 
 /** `appState` slice selectors */
 
@@ -3033,6 +3034,17 @@ export const getUpdatedAndSortedAccounts = createDeepEqualSelector(
     return sortedSearchResults;
   },
 );
+
+export const getUpdatedAndSortedAccountsWithCaipAccountId =
+  createDeepEqualSelector(getUpdatedAndSortedAccounts, (accounts) => {
+    return accounts.map((account) => {
+      const { namespace, reference } = parseCaipChainId(account.scopes[0]);
+      return {
+        ...account,
+        caipAccountId: `${namespace}:${reference}:${account.address}`,
+      };
+    });
+  });
 
 export const useSafeChainsListValidationSelector = (state) => {
   return state.metamask.useSafeChainsListValidation;

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -26,6 +26,7 @@ import {
 } from '@metamask/chain-agnostic-permission';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { BridgeFeatureFlagsKey } from '@metamask/bridge-controller';
+import { parseCaipChainId } from '@metamask/utils';
 import {
   getCurrentChainId,
   getProviderConfig,
@@ -134,7 +135,6 @@ import {
 } from './multichain';
 import { getRemoteFeatureFlags } from './remote-feature-flags';
 import { getApprovalRequestsByType } from './approvals';
-import { parseCaipChainId } from '@metamask/utils';
 
 /** `appState` slice selectors */
 

--- a/ui/selectors/selectors.types.ts
+++ b/ui/selectors/selectors.types.ts
@@ -1,5 +1,6 @@
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { SubjectMetadata } from '@metamask/permission-controller';
+import { CaipAccountId } from '@metamask/utils';
 
 type KeyringType = {
   type: string;
@@ -22,6 +23,10 @@ export type MergedInternalAccount =
     keyring: KeyringType;
     label: string | null;
   };
+
+export type MergedInternalAccountWithCaipAccountId = MergedInternalAccount & {
+  caipAccountId: CaipAccountId;
+};
 
 export type AccountConnections = {
   [address: string]: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31523?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
