### PR TITLE
feat: add runway api

### DIFF
--- a/.github/workflows/get-release-timelines.yml
+++ b/.github/workflows/get-release-timelines.yml
@@ -15,4 +15,4 @@ jobs:
       version: ${{ inputs.version }}
     secrets:
       RUNWAY_APP_ID: ${{ secrets.RUNWAY_APP_ID }}
-      RUNWAY_API_KEY: ${{ secrets.RUNWAY_API_KEY}}
+      RUNWAY_API_KEY: ${{ secrets.RUNWAY_API_KEY }}

--- a/.github/workflows/get-release-timelines.yml
+++ b/.github/workflows/get-release-timelines.yml
@@ -6,13 +6,13 @@ on:
       version:
         required: true
         type: string
-        description: 'The version of the release'
+        description: The version of the release
 
 jobs:
   get-release-timelines:
     uses: metamask/github-tools/.github/workflows/get-release-timelines.yml@3e0b0204e41b576263b9060945de3b3b9b8c5448
     with:
-      version: ${{ github.event.inputs.version }}
+      version: ${{ inputs.version }}
     secrets:
-      RUNWAY_APP_ID: ''
-      RUNWAY_API_KEY: ''
+      RUNWAY_APP_ID: ${{ secrets.RUNWAY_APP_ID }}
+      RUNWAY_API_KEY: ${{ secrets.RUNWAY_API_KEY}}

--- a/.github/workflows/get-release-timelines.yml
+++ b/.github/workflows/get-release-timelines.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   get-release-timelines:
-    uses: metamask/github-tools/.github/workflows/get-release-timelines.yml@3e0b0204e41b576263b9060945de3b3b9b8c5448
+    uses: metamask/github-tools/.github/workflows/get-release-timelines.yml@13b73c8c7dd15f38bacc1bb95401fe11914c6629
     with:
       version: ${{ inputs.version }}
     secrets:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31524?quickstart=1)

This PR updates the `get-release-timelines.yml` workflow to use the runway api key secret. We did not use it before as it did not exist.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4206

## **Manual testing steps**

1. The workflow should still work. It should return data from Runway. We can only run it on Main.

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
