### PR TITLE
fix: notification details event

### DIFF
--- a/.madgerc
+++ b/.madgerc
@@ -24,7 +24,6 @@
   },
   "allowedCircularGlob": [
     "ui/pages/confirmations/**",
-    "ui/pages/notifications/**",
     "ui/ducks/**",
     "ui/selectors/**",
     "ui/hooks/**",

--- a/development/circular-deps.jsonc
+++ b/development/circular-deps.jsonc
@@ -61,34 +61,6 @@
     "ui/components/app/metamask-translation/metamask-translation.js"
   ],
   [
-    "ui/components/app/metamask-template-renderer/metamask-template-renderer.js",
-    "ui/components/app/metamask-template-renderer/safe-component-list.js",
-    "ui/components/app/snaps/snap-ui-renderer/index.js",
-    "ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js",
-    "ui/components/multichain/create-named-snap-account/create-named-snap-account.tsx",
-    "ui/components/multichain/create-named-snap-account/index.js",
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/index.ts",
-    "ui/pages/notifications/notification-components/snap/snap.tsx"
-  ],
-  [
-    "ui/components/app/metamask-template-renderer/metamask-template-renderer.js",
-    "ui/components/app/metamask-template-renderer/safe-component-list.js",
-    "ui/components/app/snaps/snap-ui-renderer/index.js",
-    "ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js",
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/index.ts",
-    "ui/pages/notifications/notification-components/snap/snap.tsx"
-  ],
-  [
     "ui/components/app/permission-page-container/index.js",
     "ui/components/app/permission-page-container/permission-page-container.component.js",
     "ui/components/app/permission-page-container/permission-page-container.container.js"
@@ -257,96 +229,6 @@
     "ui/components/multichain/edit-networks-modal/edit-networks-modal.js",
     "ui/components/multichain/edit-networks-modal/index.js",
     "ui/components/multichain/index.js"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/erc1155-sent-received/erc1155-sent-received.tsx",
-    "ui/pages/notifications/notification-components/index.ts"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/erc20-sent-received/erc20-sent-received.tsx",
-    "ui/pages/notifications/notification-components/index.ts"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/erc721-sent-received/erc721-sent-received.tsx",
-    "ui/pages/notifications/notification-components/index.ts"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx",
-    "ui/pages/notifications/notification-components/index.ts"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx",
-    "ui/pages/notifications/notification-components/index.ts"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/index.ts",
-    "ui/pages/notifications/notification-components/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/index.ts",
-    "ui/pages/notifications/notification-components/lido-withdrawal-requested/lido-withdrawal-requested.tsx"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/index.ts",
-    "ui/pages/notifications/notification-components/snap/snap.tsx"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/index.ts",
-    "ui/pages/notifications/notification-components/stake/stake.tsx"
-  ],
-  [
-    "ui/components/multichain/index.js",
-    "ui/components/multichain/notification-detail-block-explorer-button/index.ts",
-    "ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx",
-    "ui/components/multichain/notification-detail-button/index.ts",
-    "ui/components/multichain/notification-detail-button/notification-detail-button.tsx",
-    "ui/pages/notifications/notification-components/index.ts",
-    "ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx"
   ],
   ["ui/ducks/alerts/unconnected-account.js", "ui/store/actions.ts"],
   [

--- a/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.test.tsx
+++ b/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.test.tsx
@@ -64,7 +64,6 @@ describe('NotificationDetailBlockExplorerButton', () => {
           notification={mockNotification as Notification}
           chainId={1}
           txHash="0xf8d58eb524e9ac1ba924599adef1df3b75a3dfa1de68d20918979934db4eb379"
-          id="button1"
         />
       </Provider>,
     );

--- a/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx
+++ b/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx
@@ -17,10 +17,6 @@ import {
 type Notification = NotificationServicesController.Types.INotification;
 
 type NotificationDetailBlockExplorerButtonProps = {
-  /**
-   * @deprecated - this field is not used anymore
-   */
-  id?: string;
   notification: Notification;
   chainId: number;
   txHash: string;

--- a/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx
+++ b/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { NotificationServicesController } from '@metamask/notification-services-controller';
 import { toHex } from '@metamask/controller-utils';
@@ -8,23 +8,31 @@ import { ButtonVariant } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getNetworkDetailsByChainId } from '../../../helpers/utils/notification.util';
 import { NotificationDetailButton } from '../notification-detail-button';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 
 type Notification = NotificationServicesController.Types.INotification;
 
 type NotificationDetailBlockExplorerButtonProps = {
+  /**
+   * @deprecated - this field is not used anymore
+   */
+  id?: string;
   notification: Notification;
   chainId: number;
   txHash: string;
-  id: string;
 };
 
 export const NotificationDetailBlockExplorerButton = ({
   notification,
   chainId,
   txHash,
-  id,
 }: NotificationDetailBlockExplorerButtonProps) => {
   const t = useI18nContext();
+  const trackEvent = useContext(MetaMetricsContext);
 
   const chainIdHex = toHex(chainId);
   const { blockExplorerConfig } = getNetworkDetailsByChainId(
@@ -39,8 +47,7 @@ export const NotificationDetailBlockExplorerButton = ({
     ];
 
   const blockExplorerUrl = configuredBlockExplorer ?? blockExplorerConfig?.url;
-
-  const getBlockExplorerButtonText = () => {
+  const blockExplorerButtonText = useMemo(() => {
     if (configuredBlockExplorer) {
       return t('notificationItemCheckBlockExplorer');
     }
@@ -50,9 +57,20 @@ export const NotificationDetailBlockExplorerButton = ({
       ]);
     }
     return t('notificationItemCheckBlockExplorer');
-  };
+  }, [blockExplorerConfig?.name, configuredBlockExplorer, t]);
 
-  const blockExplorerButtonText = getBlockExplorerButtonText();
+  const analyticsEvent = useCallback(() => {
+    trackEvent({
+      category: MetaMetricsEventCategory.NotificationInteraction,
+      event: MetaMetricsEventName.NotificationDetailClicked,
+      properties: {
+        notification_id: notification.id,
+        notification_type: notification.type,
+        chain_id: chainId,
+        clicked_item: 'block_explorer',
+      },
+    });
+  }, [chainId, notification.id, notification.type, trackEvent]);
 
   if (!blockExplorerUrl) {
     return null;
@@ -60,12 +78,11 @@ export const NotificationDetailBlockExplorerButton = ({
 
   return (
     <NotificationDetailButton
-      notification={notification}
       variant={ButtonVariant.Secondary}
       text={blockExplorerButtonText}
       href={`${blockExplorerUrl}/tx/${txHash}`}
-      id={id}
       isExternal={true}
+      onClick={analyticsEvent}
     />
   );
 };

--- a/ui/components/multichain/notification-detail-button/notification-detail-button.test.tsx
+++ b/ui/components/multichain/notification-detail-button/notification-detail-button.test.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { NotificationServicesController } from '@metamask/notification-services-controller';
 import { ButtonVariant } from '../../component-library';
-import { NotificationDetailButton } from './notification-detail-button';
-
-const { TRIGGER_TYPES } = NotificationServicesController.Constants;
-
-type Notification = NotificationServicesController.Types.INotification;
+import {
+  NotificationDetailButton,
+  NotificationDetailButtonProps,
+} from './notification-detail-button';
 
 jest.mock('react-router-dom', () => {
   const original = jest.requireActual('react-router-dom');
@@ -19,45 +17,11 @@ jest.mock('react-router-dom', () => {
 });
 
 describe('NotificationDetailButton', () => {
-  const defaultProps = {
+  const defaultProps: NotificationDetailButtonProps = {
     variant: ButtonVariant.Primary,
     text: 'Click Me',
     href: 'http://example.com',
-    id: 'test-button',
     isExternal: true,
-    notification: {
-      createdAt: '2023-12-11T22:27:13.020176Z',
-      isRead: false,
-      block_number: 18765683,
-      block_timestamp: '1702330595',
-      chain_id: 1,
-      created_at: '2023-12-11T22:27:13.020176Z',
-      data: {
-        to: '0xeae7380dd4cef6fbd1144f49e4d1e6964258a4f4',
-        from: '0xdbf5e9c5206d0db70a90108bf936da60221dc080',
-        kind: 'erc20_received',
-        token: {
-          usd: '1.00',
-          name: 'Dai Stablecoin',
-          image:
-            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/dai.svg',
-          amount: '232708000000000000000000',
-          symbol: 'DAI',
-          address: '0x6b175474e89094c44da98b954eedeac495271d0f',
-          decimals: '18',
-        },
-        network_fee: {
-          gas_price: '40060432936',
-          native_token_price_in_usd: '2192.74',
-        },
-      },
-      id: '0441bf59-d211-5c55-91b5-c5d859a3d301',
-      trigger_id: 'e6a9210c-f367-4c9f-8767-12a6153e5c37',
-      tx_hash:
-        '0xf8d58eb524e9ac1ba924599adef1df3b75a3dfa1de68d20918979934db4eb379',
-      unread: true,
-      type: TRIGGER_TYPES.ERC20_RECEIVED,
-    } as Notification,
   };
 
   it('renders without crashing', () => {

--- a/ui/components/multichain/notification-detail-button/notification-detail-button.tsx
+++ b/ui/components/multichain/notification-detail-button/notification-detail-button.tsx
@@ -9,16 +9,6 @@ import { BlockSize } from '../../../helpers/constants/design-system';
 
 export type NotificationDetailButtonProps = {
   /**
-   * @deprecated - this is not needed anymore
-   */
-  id?: string;
-
-  /**
-   * @deprecated - this is not needed anymore
-   */
-  notification?: string;
-
-  /**
    * Button Variant (defaults to secondary)
    */
   variant: ButtonVariant;

--- a/ui/components/multichain/notification-detail-button/notification-detail-button.tsx
+++ b/ui/components/multichain/notification-detail-button/notification-detail-button.tsx
@@ -1,9 +1,4 @@
-import React, { useContext, useState } from 'react';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
-import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../../shared/constants/metametrics';
+import React from 'react';
 import {
   Button,
   ButtonVariant,
@@ -11,89 +6,57 @@ import {
   IconName,
 } from '../../component-library';
 import { BlockSize } from '../../../helpers/constants/design-system';
-import { TRIGGER_TYPES } from '../../../pages/notifications/notification-components';
-import useSnapNavigation from '../../../hooks/snaps/useSnapNavigation';
-import { type Notification } from '../../../pages/notifications/notification-components/types/notifications/notifications';
-import SnapLinkWarning from '../../app/snaps/snap-link-warning';
 
-type NotificationDetailButtonProps = {
-  notification: Notification;
+export type NotificationDetailButtonProps = {
+  /**
+   * @deprecated - this is not needed anymore
+   */
+  id?: string;
+
+  /**
+   * @deprecated - this is not needed anymore
+   */
+  notification?: string;
+
+  /**
+   * Button Variant (defaults to secondary)
+   */
   variant: ButtonVariant;
+  /**
+   * Button Text
+   */
   text: string;
-  href: string;
-  id: string;
+  /**
+   * Optional href if this navigates to a page
+   */
+  href?: string;
+  /**
+   * Opens Href in a seperate window
+   */
   isExternal?: boolean;
-  endIconName?: boolean;
+  /**
+   * Additional click functionality when button is pressed
+   * Can be used to call analytic events
+   */
+  onClick?: () => void;
 };
 
 export const NotificationDetailButton = ({
-  notification,
   variant = ButtonVariant.Secondary,
   text,
   href,
-  id,
   isExternal = false,
-  endIconName = true,
+  onClick,
 }: NotificationDetailButtonProps) => {
-  const trackEvent = useContext(MetaMetricsContext);
-  const { navigate } = useSnapNavigation();
-  const isMetaMaskUrl = href.startsWith('metamask:');
-  const [isOpen, setIsOpen] = useState(false);
-
-  const isSnapNotification = notification.type === TRIGGER_TYPES.SNAP;
-
-  const handleModalClose = () => {
-    setIsOpen(false);
-  };
-
-  // this logic can be expanded once this detail button is used outside of the current use cases
-  const getClickedItem = () => {
-    if (notification.type === TRIGGER_TYPES.FEATURES_ANNOUNCEMENT) {
-      return 'block_explorer';
-    }
-    return isExternal ? 'external_link' : 'internal_link';
-  };
-
-  const onClick = () => {
-    trackEvent({
-      category: MetaMetricsEventCategory.NotificationInteraction,
-      event: MetaMetricsEventName.NotificationDetailClicked,
-      properties: {
-        notification_id: notification.id,
-        notification_type: notification.type,
-        ...('chain_id' in notification && {
-          chain_id: notification.chain_id,
-        }),
-        clicked_item: getClickedItem(),
-      },
-    });
-
-    if (isSnapNotification) {
-      if (isMetaMaskUrl) {
-        navigate(href);
-      } else {
-        setIsOpen(true);
-      }
-    }
-  };
-
   return (
     <>
-      {isSnapNotification && (
-        <SnapLinkWarning
-          isOpen={isOpen}
-          onClose={handleModalClose}
-          url={href}
-        />
-      )}
       <Button
-        key={id}
-        href={!isSnapNotification && href ? href : undefined}
+        href={href}
+        externalLink={Boolean(href) && isExternal}
         variant={variant}
-        externalLink={isExternal || !isMetaMaskUrl}
         size={ButtonSize.Lg}
         width={BlockSize.Full}
-        endIconName={endIconName ? IconName.Arrow2UpRight : undefined}
+        endIconName={isExternal ? IconName.Arrow2UpRight : undefined}
         onClick={onClick}
       >
         {text}

--- a/ui/pages/notifications/notification-components/erc1155-sent-received/erc1155-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc1155-sent-received/erc1155-sent-received.tsx
@@ -199,7 +199,6 @@ export const components: NotificationComponent<ERC1155Notification> = {
           notification={notification}
           chainId={notification.chain_id}
           txHash={notification.tx_hash}
-          id={notification.id}
         />
       );
     },

--- a/ui/pages/notifications/notification-components/erc20-sent-received/erc20-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc20-sent-received/erc20-sent-received.tsx
@@ -204,7 +204,6 @@ export const components: NotificationComponent<ERC20Notification> = {
           notification={notification}
           chainId={notification.chain_id}
           txHash={notification.tx_hash}
-          id={notification.id}
         />
       );
     },

--- a/ui/pages/notifications/notification-components/erc721-sent-received/erc721-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc721-sent-received/erc721-sent-received.tsx
@@ -198,7 +198,6 @@ export const components: NotificationComponent<ERC721Notification> = {
           notification={notification}
           chainId={notification.chain_id}
           txHash={notification.tx_hash}
-          id={notification.id}
         />
       );
     },

--- a/ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx
@@ -213,7 +213,6 @@ export const components: NotificationComponent<ETHNotification> = {
           notification={notification}
           chainId={notification.chain_id}
           txHash={notification.tx_hash}
-          id={notification.id}
         />
       );
     },

--- a/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
@@ -1,12 +1,12 @@
-import { useCallback, useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
-import { FeatureAnnouncementNotification } from './types';
 import { NotificationDetailButton } from '../../../../components/multichain';
 import { ButtonVariant } from '../../../../components/component-library';
+import { FeatureAnnouncementNotification } from './types';
 
 const useAnalyticEventCallback = (props: {
   id: string;

--- a/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useContext } from 'react';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../../shared/constants/metametrics';
+import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import { FeatureAnnouncementNotification } from './types';
+import { NotificationDetailButton } from '../../../../components/multichain';
+import { ButtonVariant } from '../../../../components/component-library';
+
+const useAnalyticEventCallback = (props: {
+  id: string;
+  type: string;
+  clickType: 'external_link' | 'internal_link';
+}) => {
+  const trackEvent = useContext(MetaMetricsContext);
+
+  const analyticsEvent = useCallback(() => {
+    trackEvent({
+      category: MetaMetricsEventCategory.NotificationInteraction,
+      event: MetaMetricsEventName.NotificationDetailClicked,
+      properties: {
+        notification_id: props.id,
+        notification_type: props.type,
+        clicked_item: props.clickType,
+      },
+    });
+  }, [props.clickType, props.id, props.type, trackEvent]);
+
+  return analyticsEvent;
+};
+
+export const ExtensionLinkButton = (props: {
+  notification: FeatureAnnouncementNotification;
+}) => {
+  const { notification } = props;
+  const onClick = useAnalyticEventCallback({
+    id: notification.id,
+    type: notification.type,
+    clickType: 'internal_link',
+  });
+
+  if (!notification.data.extensionLink) {
+    return null;
+  }
+
+  return (
+    <NotificationDetailButton
+      variant={ButtonVariant.Primary}
+      text={notification.data.extensionLink.extensionLinkText}
+      href={`/${notification.data.extensionLink.extensionLinkRoute}`}
+      // Even if the link is not external, it will open in a new tab
+      // to avoid breaking the popup
+      isExternal={true}
+      onClick={onClick}
+    />
+  );
+};
+
+export const ExternalLinkButton = (props: {
+  notification: FeatureAnnouncementNotification;
+}) => {
+  const { notification } = props;
+  const onClick = useAnalyticEventCallback({
+    id: notification.id,
+    type: notification.type,
+    clickType: 'external_link',
+  });
+
+  if (!notification.data.externalLink) {
+    return null;
+  }
+
+  return (
+    <NotificationDetailButton
+      variant={ButtonVariant.Secondary}
+      text={notification.data.externalLink.externalLinkText}
+      href={`${notification.data.externalLink.externalLinkUrl}`}
+      isExternal={true}
+      onClick={onClick}
+    />
+  );
+};

--- a/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
@@ -1,26 +1,19 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
-import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
+import { isOfTypeNodeGuard } from '../node-guard';
 import {
   NotificationComponentType,
   type NotificationComponent,
 } from '../types/notifications/notifications';
 import { NotificationListItemIconType } from '../../../../components/multichain/notification-list-item-icon/notification-list-item-icon';
-
 import {
   createTextItems,
   formatIsoDateString,
 } from '../../../../helpers/utils/notification.util';
-
-import {
-  Box,
-  ButtonVariant,
-  Text,
-} from '../../../../components/component-library';
+import { Box, Text } from '../../../../components/component-library';
 import {
   NotificationListItem,
   NotificationDetailTitle,
-  NotificationDetailButton,
 } from '../../../../components/multichain';
 import {
   TextVariant,
@@ -29,11 +22,14 @@ import {
   BorderRadius,
   BlockSize,
 } from '../../../../helpers/constants/design-system';
+import { FeatureAnnouncementNotification } from './types';
+import {
+  ExtensionLinkButton,
+  ExternalLinkButton,
+} from './annonucement-footer-buttons';
 
 const { TRIGGER_TYPES } = NotificationServicesController.Constants;
 
-type FeatureAnnouncementNotification =
-  ExtractedNotification<NotificationServicesController.Constants.TRIGGER_TYPES.FEATURES_ANNOUNCEMENT>;
 const isFeatureAnnouncementNotification = isOfTypeNodeGuard([
   TRIGGER_TYPES.FEATURES_ANNOUNCEMENT,
 ]);
@@ -109,31 +105,7 @@ export const components: NotificationComponent<FeatureAnnouncementNotification> 
     },
     footer: {
       type: NotificationComponentType.AnnouncementFooter,
-      ExtensionLink: ({ notification }) =>
-        notification.data.extensionLink ? (
-          <NotificationDetailButton
-            notification={notification}
-            variant={ButtonVariant.Primary}
-            text={notification.data.extensionLink.extensionLinkText}
-            href={`/${notification.data.extensionLink.extensionLinkRoute}`}
-            id={notification.id}
-            endIconName={false}
-            // Even if the link is not external, it will open in a new tab
-            // to avoid breaking the popup
-            isExternal={true}
-          />
-        ) : null,
-      ExternalLink: ({ notification }) =>
-        notification.data.externalLink ? (
-          <NotificationDetailButton
-            notification={notification}
-            variant={ButtonVariant.Secondary}
-            text={notification.data.externalLink.externalLinkText}
-            href={`${notification.data.externalLink.externalLinkUrl}`}
-            id={notification.id}
-            endIconName={false}
-            isExternal={true}
-          />
-        ) : null,
+      ExtensionLink: ExtensionLinkButton,
+      ExternalLink: ExternalLinkButton,
     },
   };

--- a/ui/pages/notifications/notification-components/feature-announcement/types.ts
+++ b/ui/pages/notifications/notification-components/feature-announcement/types.ts
@@ -1,0 +1,5 @@
+import { TRIGGER_TYPES } from '@metamask/notification-services-controller/notification-services';
+import { ExtractedNotification } from '../node-guard';
+
+export type FeatureAnnouncementNotification =
+  ExtractedNotification<TRIGGER_TYPES.FEATURES_ANNOUNCEMENT>;

--- a/ui/pages/notifications/notification-components/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
+++ b/ui/pages/notifications/notification-components/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
@@ -175,7 +175,6 @@ export const components: NotificationComponent<LidoReadyWithDrawnNotification> =
             notification={notification}
             chainId={notification.chain_id}
             txHash={notification.tx_hash}
-            id={notification.id}
           />
         );
       },

--- a/ui/pages/notifications/notification-components/lido-withdrawal-requested/lido-withdrawal-requested.tsx
+++ b/ui/pages/notifications/notification-components/lido-withdrawal-requested/lido-withdrawal-requested.tsx
@@ -195,7 +195,6 @@ export const components: NotificationComponent<LidoWithdrawalRequestedNotificati
             notification={notification}
             chainId={notification.chain_id}
             txHash={notification.tx_hash}
-            id={notification.id}
           />
         );
       },

--- a/ui/pages/notifications/notification-components/snap/snap-footer-button.test.tsx
+++ b/ui/pages/notifications/notification-components/snap/snap-footer-button.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { processNotification } from '@metamask/notification-services-controller/notification-services';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { createMockSnapNotification } from '@metamask/notification-services-controller/notification-services/mocks';
+import * as SnapNavigation from '../../../../hooks/snaps/useSnapNavigation';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import { SnapFooterButton } from './snap-footer-button';
+import { DetailedViewData, SnapNotification } from './types';
+
+// Type Util for testing
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MockVar = any;
+
+describe('SnapFooterButton', () => {
+  const arrangeMocks = () => {
+    const mockNavigate = jest.fn();
+    const mockUseSnapNavigation = jest
+      .spyOn(SnapNavigation, 'default')
+      .mockReturnValue({ navigate: mockNavigate });
+    const notification = processNotification(
+      createMockSnapNotification(),
+    ) as SnapNotification;
+
+    return {
+      mockNavigate,
+      mockUseSnapNavigation,
+      notification,
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing if there is no footer', () => {
+    const { notification } = arrangeMocks();
+    delete (notification.data as MockVar).detailedView;
+
+    const { container } = renderWithProvider(
+      <SnapFooterButton notification={notification} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the NotificationDetailButton', () => {
+    const { notification } = arrangeMocks();
+    (notification.data as DetailedViewData).detailedView.footerLink = {
+      text: 'Go Home',
+      href: 'metamask://client/',
+    };
+
+    const { getByText } = renderWithProvider(
+      <SnapFooterButton notification={notification} />,
+    );
+    const button = getByText('Go Home');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('navigates when internal link is clicked', () => {
+    const { notification, mockNavigate } = arrangeMocks();
+    (notification.data as DetailedViewData).detailedView.footerLink = {
+      text: 'Go Home',
+      href: 'metamask://client/',
+    };
+
+    const { getByText } = renderWithProvider(
+      <SnapFooterButton notification={notification} />,
+    );
+    const button = getByText('Go Home');
+    fireEvent.click(button);
+    expect(mockNavigate).toHaveBeenCalledWith('metamask://client/');
+  });
+
+  it('opens SnapLinkWarning when external link is clicked', async () => {
+    const { notification } = arrangeMocks();
+    (notification.data as DetailedViewData).detailedView.footerLink = {
+      text: 'Go External',
+      href: 'https://www.foo.bar',
+    };
+
+    const { getByText } = renderWithProvider(
+      <SnapFooterButton notification={notification} />,
+    );
+
+    // Click Button
+    const button = getByText('Go External');
+    fireEvent.click(button);
+
+    // Confirm Leave
+    await waitFor(() => {
+      const leaveModalTitle = getByText('[leaveMetaMask]');
+      const leaveModalButton = getByText('[visitSite]');
+      expect(leaveModalTitle).toBeInTheDocument();
+      expect(leaveModalButton).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/pages/notifications/notification-components/snap/snap-footer-button.tsx
+++ b/ui/pages/notifications/notification-components/snap/snap-footer-button.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import useSnapNavigation from '../../../../hooks/snaps/useSnapNavigation';
-import { DetailedViewData, SnapNotification } from './types';
 import SnapLinkWarning from '../../../../components/app/snaps/snap-link-warning';
 import { NotificationDetailButton } from '../../../../components/multichain';
 import { ButtonVariant } from '../../../../components/component-library';
@@ -9,45 +8,49 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../../shared/constants/metametrics';
+import { DetailedViewData, SnapNotification } from './types';
 
 export const SnapFooterButton = (props: { notification: SnapNotification }) => {
   const trackEvent = useContext(MetaMetricsContext);
   const { navigate } = useSnapNavigation();
   const [isOpen, setIsOpen] = useState(false);
-  const detailedView = props.notification.data as DetailedViewData;
-  const footer = detailedView?.detailedView?.footerLink;
+  const data = props.notification.data as DetailedViewData;
+  const footer = data?.detailedView?.footerLink;
 
   const handleModalClose = useCallback(() => {
     setIsOpen(false);
   }, []);
 
+  const onClick = useCallback(
+    (href: string, isExternal: boolean) => {
+      // Analytics
+      trackEvent({
+        category: MetaMetricsEventCategory.NotificationInteraction,
+        event: MetaMetricsEventName.NotificationDetailClicked,
+        properties: {
+          notification_id: props.notification.id,
+          notification_type: props.notification.type,
+          clicked_item: isExternal ? 'external_link' : 'internal_link',
+        },
+      });
+
+      // Warning / Navigation
+      if (isExternal) {
+        setIsOpen(true);
+      } else {
+        navigate(href);
+      }
+    },
+    [navigate, props.notification.id, props.notification.type, trackEvent],
+  );
+
   if (!footer) {
     return null;
   }
 
-  const href = footer.href;
-  const text = footer.text;
+  const { href, text } = footer;
   const isMetaMaskUrl = href.startsWith('metamask:');
   const isExternal = !isMetaMaskUrl;
-  const onClick = useCallback(() => {
-    // Analytics
-    trackEvent({
-      category: MetaMetricsEventCategory.NotificationInteraction,
-      event: MetaMetricsEventName.NotificationDetailClicked,
-      properties: {
-        notification_id: props.notification.id,
-        notification_type: props.notification.type,
-        clicked_item: isExternal ? 'external_link' : 'internal_link',
-      },
-    });
-
-    // Warning / Navigation
-    if (isExternal) {
-      setIsOpen(true);
-    } else {
-      navigate(href);
-    }
-  }, []);
 
   return (
     <>
@@ -56,7 +59,7 @@ export const SnapFooterButton = (props: { notification: SnapNotification }) => {
         variant={ButtonVariant.Secondary}
         isExternal={isExternal}
         text={text}
-        onClick={onClick}
+        onClick={() => onClick(href, isExternal)}
       />
     </>
   );

--- a/ui/pages/notifications/notification-components/snap/snap-footer-button.tsx
+++ b/ui/pages/notifications/notification-components/snap/snap-footer-button.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useContext, useState } from 'react';
+import useSnapNavigation from '../../../../hooks/snaps/useSnapNavigation';
+import { DetailedViewData, SnapNotification } from './types';
+import SnapLinkWarning from '../../../../components/app/snaps/snap-link-warning';
+import { NotificationDetailButton } from '../../../../components/multichain';
+import { ButtonVariant } from '../../../../components/component-library';
+import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../../shared/constants/metametrics';
+
+export const SnapFooterButton = (props: { notification: SnapNotification }) => {
+  const trackEvent = useContext(MetaMetricsContext);
+  const { navigate } = useSnapNavigation();
+  const [isOpen, setIsOpen] = useState(false);
+  const detailedView = props.notification.data as DetailedViewData;
+  const footer = detailedView?.detailedView?.footerLink;
+
+  const handleModalClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  if (!footer) {
+    return null;
+  }
+
+  const href = footer.href;
+  const text = footer.text;
+  const isMetaMaskUrl = href.startsWith('metamask:');
+  const isExternal = !isMetaMaskUrl;
+  const onClick = useCallback(() => {
+    // Analytics
+    trackEvent({
+      category: MetaMetricsEventCategory.NotificationInteraction,
+      event: MetaMetricsEventName.NotificationDetailClicked,
+      properties: {
+        notification_id: props.notification.id,
+        notification_type: props.notification.type,
+        clicked_item: isExternal ? 'external_link' : 'internal_link',
+      },
+    });
+
+    // Warning / Navigation
+    if (isExternal) {
+      setIsOpen(true);
+    } else {
+      navigate(href);
+    }
+  }, []);
+
+  return (
+    <>
+      <SnapLinkWarning isOpen={isOpen} onClose={handleModalClose} url={href} />
+      <NotificationDetailButton
+        variant={ButtonVariant.Secondary}
+        isExternal={isExternal}
+        text={text}
+        onClick={onClick}
+      />
+    </>
+  );
+};

--- a/ui/pages/notifications/notification-components/snap/snap.tsx
+++ b/ui/pages/notifications/notification-components/snap/snap.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { TRIGGER_TYPES } from '@metamask/notification-services-controller/notification-services';
 import {
-  TRIGGER_TYPES,
-  type ExpandedView,
-} from '@metamask/notification-services-controller/notification-services';
-import {
-  NotificationDetailButton,
   NotificationDetailTitle,
   NotificationListItemSnap,
 } from '../../../../components/multichain';
@@ -25,23 +21,13 @@ import {
   FlexDirection,
   FontWeight,
 } from '../../../../helpers/constants/design-system';
-import {
-  Box,
-  ButtonVariant,
-  IconSize,
-  Text,
-} from '../../../../components/component-library';
-import { isOfTypeNodeGuard, type ExtractedNotification } from '../node-guard';
+import { Box, IconSize, Text } from '../../../../components/component-library';
+import { isOfTypeNodeGuard } from '../node-guard';
 import { SnapIcon } from '../../../../components/app/snaps/snap-icon';
 import { useMarkNotificationAsRead } from '../../../../hooks/metamask-notifications/useNotifications';
 import { SnapUIMarkdown } from '../../../../components/app/snaps/snap-ui-markdown';
-
-type SnapNotification = ExtractedNotification<TRIGGER_TYPES.SNAP>;
-
-type DetailedViewData = Extract<
-  SnapNotification['data'],
-  { origin: string; message: string; detailedView: ExpandedView }
->;
+import { DetailedViewData, SnapNotification } from './types';
+import { SnapFooterButton } from './snap-footer-button';
 
 export const components: NotificationComponent<SnapNotification> = {
   guardFn: isOfTypeNodeGuard([TRIGGER_TYPES.SNAP]),
@@ -140,21 +126,6 @@ export const components: NotificationComponent<SnapNotification> = {
   },
   footer: {
     type: NotificationComponentType.SnapFooter,
-    Link: ({ notification }) =>
-      (notification.data as DetailedViewData).detailedView.footerLink ? (
-        <NotificationDetailButton
-          notification={notification}
-          text={
-            (notification.data as DetailedViewData).detailedView.footerLink
-              ?.text as string
-          }
-          href={
-            (notification.data as DetailedViewData).detailedView.footerLink
-              ?.href as string
-          }
-          id={notification.id}
-          variant={ButtonVariant.Secondary}
-        />
-      ) : null,
+    Link: SnapFooterButton,
   },
 };

--- a/ui/pages/notifications/notification-components/snap/types.ts
+++ b/ui/pages/notifications/notification-components/snap/types.ts
@@ -1,0 +1,12 @@
+import {
+  TRIGGER_TYPES,
+  type ExpandedView,
+} from '@metamask/notification-services-controller/notification-services';
+import { ExtractedNotification } from '../node-guard';
+
+export type SnapNotification = ExtractedNotification<TRIGGER_TYPES.SNAP>;
+
+export type DetailedViewData = Extract<
+  SnapNotification['data'],
+  { origin: string; message: string; detailedView: ExpandedView }
+>;

--- a/ui/pages/notifications/notification-components/stake/stake.tsx
+++ b/ui/pages/notifications/notification-components/stake/stake.tsx
@@ -277,7 +277,6 @@ export const components: NotificationComponent<StakeNotification> = {
           notification={notification}
           chainId={notification.chain_id}
           txHash={notification.tx_hash}
-          id={notification.id}
         />
       );
     },

--- a/ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx
+++ b/ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx
@@ -234,7 +234,6 @@ export const components: NotificationComponent<SwapCompletedNotification> = {
           notification={notification}
           chainId={notification.chain_id}
           txHash={notification.tx_hash}
-          id={notification.id}
         />
       );
     },


### PR DESCRIPTION
## **Description**

The event click property was incorrect due to confusing branching logic when constructing the event.
Now we have split up the details button responsibilities to each unique notification instead of creating a god component that manages all notification clicks.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31526?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

N/A this was a fix/refactor

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
