### PR TITLE
Ad/add solana accounts changed event emit onconnect

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/wallet-createSession/handler.test.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/wallet-createSession/handler.test.ts
@@ -7,10 +7,10 @@ import {
 } from '@metamask/chain-agnostic-permission';
 import * as Multichain from '@metamask/chain-agnostic-permission';
 import { Json, JsonRpcRequest, JsonRpcSuccess } from '@metamask/utils';
+import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
 import * as Util from '../../../util';
 import { walletCreateSession } from './handler';
 import { KnownSessionProperties } from './constants';
-import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
 
 jest.mock('../../../util', () => ({
   ...jest.requireActual('../../../util'),

--- a/app/scripts/lib/rpc-method-middleware/handlers/wallet-createSession/handler.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/wallet-createSession/handler.ts
@@ -12,7 +12,6 @@ import {
   getSupportedScopeObjects,
   Caip25CaveatValue,
   setPermittedAccounts,
-  KnownWalletRpcMethods,
 } from '@metamask/chain-agnostic-permission';
 import {
   invalidParams,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2870,6 +2870,16 @@ export default class MetamaskController extends EventEmitter {
               }
             });
 
+            // if changedAuthorizations contains solana account(s) and sessionProperties contains solanaAccountChangedNotifications
+            // we need to notify the solana account change
+            const solanaScope = sessionScopes[MultichainNetworks.SOLANA];
+
+            if (solanaScope) {
+              const {accounts} = solanaScope;
+
+              const solanaAccountChangedNotifications = solanaScope.notifications.includes(KnownSessionProperties.SolanaAccountChangedNotifications);
+            }
+
             this._notifyAuthorizationChange(origin, authorization);
           }
         },

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -147,6 +147,8 @@ import {
   hexToBigInt,
   toCaipChainId,
   parseCaipAccountId,
+  parseCaipChainId,
+  KnownCaipNamespace,
 } from '@metamask/utils';
 import { normalize } from '@metamask/eth-sig-util';
 
@@ -2836,21 +2838,35 @@ export default class MetamaskController extends EventEmitter {
               }
             });
 
-            const removedSolanaScope =
-              sessionScopes[MultichainNetworks.SOLANA] ||
-              sessionScopes[MultichainNetworks.SOLANA_DEVNET] ||
-              sessionScopes[MultichainNetworks.SOLANA_TESTNET];
+            // const removedSolanaScope =
+            //   sessionScopes[MultichainNetworks.SOLANA] ||
+            //   sessionScopes[MultichainNetworks.SOLANA_DEVNET] ||
+            //   sessionScopes[MultichainNetworks.SOLANA_TESTNET];
 
-            const currentValueHasNoSolanaScope =
-              !currentValue.get(origin)?.sessionScopes?.[
-                MultichainNetworks.SOLANA
-              ] &&
-              !currentValue.get(origin)?.sessionScopes?.[
-                MultichainNetworks.SOLANA_DEVNET
-              ] &&
-              !currentValue.get(origin)?.sessionScopes?.[
-                MultichainNetworks.SOLANA_TESTNET
-              ];
+            const removedSolanaScope = Object.keys(
+              previousValue.get(origin)?.sessionScopes ?? {},
+            ).some((scope) => {
+              const { namespace } = parseCaipChainId(scope);
+              return namespace === KnownCaipNamespace.Solana;
+            });
+
+            // const currentValueHasNoSolanaScope =
+            //   !currentValue.get(origin)?.sessionScopes?.[
+            //     MultichainNetworks.SOLANA
+            //   ] &&
+            //   !currentValue.get(origin)?.sessionScopes?.[
+            //     MultichainNetworks.SOLANA_DEVNET
+            //   ] &&
+            //   !currentValue.get(origin)?.sessionScopes?.[
+            //     MultichainNetworks.SOLANA_TESTNET
+            //   ];
+
+            const currentValueHasSolanaScope = Object.keys(
+              currentValue.get(origin)?.sessionScopes ?? {},
+            ).some((scope) => {
+              const { namespace } = parseCaipChainId(scope);
+              return namespace === KnownCaipNamespace.Solana;
+            });
 
             const solanaAccountChangedNotifications =
               previousValue.get(origin)?.sessionProperties?.[
@@ -2859,7 +2875,7 @@ export default class MetamaskController extends EventEmitter {
 
             if (
               removedSolanaScope &&
-              currentValueHasNoSolanaScope &&
+              !currentValueHasSolanaScope &&
               solanaAccountChangedNotifications
             ) {
               this._notifySolanaAccountChange(origin, []);
@@ -2899,10 +2915,17 @@ export default class MetamaskController extends EventEmitter {
               }
             });
 
-            const addedSolanaScope =
-              sessionScopes[MultichainNetworks.SOLANA] ||
-              sessionScopes[MultichainNetworks.SOLANA_DEVNET] ||
-              sessionScopes[MultichainNetworks.SOLANA_TESTNET];
+            // const addedSolanaScope =
+            //   sessionScopes[MultichainNetworks.SOLANA] ||
+            //   sessionScopes[MultichainNetworks.SOLANA_DEVNET] ||
+            //   sessionScopes[MultichainNetworks.SOLANA_TESTNET];
+
+            const addedSolanaScope = Object.keys(
+              currentValue.get(origin)?.sessionScopes ?? {},
+            ).some((scope) => {
+              const { namespace } = parseCaipChainId(scope);
+              return namespace === KnownCaipNamespace.Solana;
+            });
 
             if (addedSolanaScope) {
               const solanaAccountChangedNotifications =

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2881,7 +2881,10 @@ export default class MetamaskController extends EventEmitter {
             this._notifyAuthorizationChange(origin, authorization);
           }
 
-          const origins = uniq([...previousValue.keys(), currentValue.keys()]);
+          const origins = uniq([
+            ...previousValue.keys(),
+            ...currentValue.keys(),
+          ]);
           origins.forEach((origin) => {
             const previousCaveatValue = previousValue.get(origin);
             const currentCaveatValue = currentValue.get(origin);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6393,54 +6393,54 @@ export default class MetamaskController extends EventEmitter {
           }, 500);
         }
       }
-
-      if (sender.id && sender.id !== this.extension.runtime.id) {
-        this.subjectMetadataController.addSubjectMetadata({
-          origin,
-          extensionId: sender.id,
-          subjectType: SubjectType.Extension,
-        });
-      }
-
-      let tabId;
-      if (sender.tab && sender.tab.id) {
-        tabId = sender.tab.id;
-      }
-
-      const engine = this.setupProviderEngineCaip({
-        origin,
-        sender,
-        subjectType,
-        tabId,
-      });
-
-      const dupeReqFilterStream = createDupeReqFilterStream();
-
-      // setup connection
-      const providerStream = createEngineStream({ engine });
-
-      const connectionId = this.addConnection(origin, {
-        tabId,
-        apiType: API_TYPE.CAIP_MULTICHAIN,
-        engine,
-      });
-
-      pipeline(
-        outStream,
-        dupeReqFilterStream,
-        providerStream,
-        outStream,
-        (err) => {
-          // handle any middleware cleanup
-          engine.destroy();
-          connectionId && this.removeConnection(origin, connectionId);
-          // For context and todos related to the error message match, see https://github.com/MetaMask/metamask-extension/issues/26337
-          if (err && !err.message?.match('Premature close')) {
-            log.error(err);
-          }
-        },
-      );
     }
+
+    if (sender.id && sender.id !== this.extension.runtime.id) {
+      this.subjectMetadataController.addSubjectMetadata({
+        origin,
+        extensionId: sender.id,
+        subjectType: SubjectType.Extension,
+      });
+    }
+
+    let tabId;
+    if (sender.tab && sender.tab.id) {
+      tabId = sender.tab.id;
+    }
+
+    const engine = this.setupProviderEngineCaip({
+      origin,
+      sender,
+      subjectType,
+      tabId,
+    });
+
+    const dupeReqFilterStream = createDupeReqFilterStream();
+
+    // setup connection
+    const providerStream = createEngineStream({ engine });
+
+    const connectionId = this.addConnection(origin, {
+      tabId,
+      apiType: API_TYPE.CAIP_MULTICHAIN,
+      engine,
+    });
+
+    pipeline(
+      outStream,
+      dupeReqFilterStream,
+      providerStream,
+      outStream,
+      (err) => {
+        // handle any middleware cleanup
+        engine.destroy();
+        connectionId && this.removeConnection(origin, connectionId);
+        // For context and todos related to the error message match, see https://github.com/MetaMask/metamask-extension/issues/26337
+        if (err && !err.message?.match('Premature close')) {
+          log.error(err);
+        }
+      },
+    );
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -155,8 +155,6 @@ import {
   hexToBigInt,
   toCaipChainId,
   parseCaipAccountId,
-  parseCaipChainId,
-  KnownCaipNamespace,
 } from '@metamask/utils';
 import { normalize } from '@metamask/eth-sig-util';
 
@@ -180,6 +178,7 @@ import {
   getSessionScopes,
   setPermittedEthChainIds,
   setEthAccounts,
+  getPermittedAccountsForScopes,
 } from '@metamask/chain-agnostic-permission';
 
 import {
@@ -2882,82 +2881,81 @@ export default class MetamaskController extends EventEmitter {
             this._notifyAuthorizationChange(origin, authorization);
           }
 
-          // start solana
+          const origins = uniq([...previousValue.keys(), currentValue.keys()]);
+          origins.forEach((origin) => {
+            const previousCaveatValue = previousValue.get(origin);
+            const currentCaveatValue = currentValue.get(origin);
 
-          const previousCaveatValue = previousValue.get(origin);
-          const currentCaveatValue = currentValue.get(origin);
-
-          const previousSolanaAccountChangedNotificationsEnabled = Boolean(
-            previousCaveatValue?.sessionProperties?.[
-              KnownSessionProperties.SolanaAccountChangedNotifications
-            ],
-          );
-          const currentSolanaAccountChangedNotificationsEnabled = Boolean(
-            currentCaveatValue?.sessionProperties?.[
-              KnownSessionProperties.SolanaAccountChangedNotifications
-            ],
-          );
-
-          if (
-            !previousSolanaAccountChangedNotificationsEnabled &&
-            !currentSolanaAccountChangedNotificationsEnabled
-          ) {
-            return;
-          }
-
-          const previousSolanaCaipAccountIds = previousCaveatValue
-            ? getPermittedAccountsForScopes(previousCaveatValue, [
-                MultichainNetworks.SOLANA,
-                MultichainNetworks.SOLANA_DEVNET,
-                MultichainNetworks.SOLANA_TESTNET,
-              ])
-            : [];
-          const _previousSolanaHexAccountAddresses =
-            previousSolanaCaipAccountIds.map((caipAccountId) => {
-              const { address } = parseCaipAccountId(caipAccountId);
-              return address;
-            });
-          const previousSolanaHexAccountAddresses = uniq(
-            _previousSolanaHexAccountAddresses,
-          );
-          const previousSelectedSolanaAccountAddress =
-            this.sortAccountsByLastSelected(
-              previousSolanaHexAccountAddresses,
-            )[0];
-
-          const currentSolanaCaipAccountIds = currentCaveatValue
-            ? getPermittedAccountsForScopes(currentCaveatValue, [
-                MultichainNetworks.SOLANA,
-                MultichainNetworks.SOLANA_DEVNET,
-                MultichainNetworks.SOLANA_TESTNET,
-              ])
-            : [];
-          const _currentSolanaHexAccountAddresses =
-            currentSolanaCaipAccountIds.map((caipAccountId) => {
-              const { address } = parseCaipAccountId(caipAccountId);
-              return address;
-            });
-          const currentSolanaHexAccountAddresses = uniq(
-            _currentSolanaHexAccountAddresses,
-          );
-          const currentSelectedSolanaAccountAddress =
-            this.sortAccountsByLastSelected(
-              currentSolanaHexAccountAddresses,
-            )[0];
-
-          if (
-            previousSelectedSolanaAccountAddress !==
-            currentSelectedSolanaAccountAddress
-          ) {
-            this._notifySolanaAccountChange(
-              origin,
-              currentSelectedSolanaAccountAddress
-                ? [currentSelectedSolanaAccountAddress]
-                : [],
+            const previousSolanaAccountChangedNotificationsEnabled = Boolean(
+              previousCaveatValue?.sessionProperties?.[
+                KnownSessionProperties.SolanaAccountChangedNotifications
+              ],
             );
-          }
+            const currentSolanaAccountChangedNotificationsEnabled = Boolean(
+              currentCaveatValue?.sessionProperties?.[
+                KnownSessionProperties.SolanaAccountChangedNotifications
+              ],
+            );
 
-          /// end solana
+            if (
+              !previousSolanaAccountChangedNotificationsEnabled &&
+              !currentSolanaAccountChangedNotificationsEnabled
+            ) {
+              return;
+            }
+
+            const previousSolanaCaipAccountIds = previousCaveatValue
+              ? getPermittedAccountsForScopes(previousCaveatValue, [
+                  MultichainNetworks.SOLANA,
+                  MultichainNetworks.SOLANA_DEVNET,
+                  MultichainNetworks.SOLANA_TESTNET,
+                ])
+              : [];
+            const _previousSolanaHexAccountAddresses =
+              previousSolanaCaipAccountIds.map((caipAccountId) => {
+                const { address } = parseCaipAccountId(caipAccountId);
+                return address;
+              });
+            const previousSolanaHexAccountAddresses = uniq(
+              _previousSolanaHexAccountAddresses,
+            );
+            const previousSelectedSolanaAccountAddress =
+              this.sortAccountsByLastSelected(
+                previousSolanaHexAccountAddresses,
+              )[0];
+
+            const currentSolanaCaipAccountIds = currentCaveatValue
+              ? getPermittedAccountsForScopes(currentCaveatValue, [
+                  MultichainNetworks.SOLANA,
+                  MultichainNetworks.SOLANA_DEVNET,
+                  MultichainNetworks.SOLANA_TESTNET,
+                ])
+              : [];
+            const _currentSolanaHexAccountAddresses =
+              currentSolanaCaipAccountIds.map((caipAccountId) => {
+                const { address } = parseCaipAccountId(caipAccountId);
+                return address;
+              });
+            const currentSolanaHexAccountAddresses = uniq(
+              _currentSolanaHexAccountAddresses,
+            );
+            const currentSelectedSolanaAccountAddress =
+              this.sortAccountsByLastSelected(
+                currentSolanaHexAccountAddresses,
+              )[0];
+
+            if (
+              previousSelectedSolanaAccountAddress !==
+              currentSelectedSolanaAccountAddress
+            ) {
+              this._notifySolanaAccountChange(
+                origin,
+                currentSelectedSolanaAccountAddress
+                  ? [currentSelectedSolanaAccountAddress]
+                  : [],
+              );
+            }
+          });
         },
         getAuthorizedScopesByOrigin,
       );

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6293,15 +6293,21 @@ export default class MetamaskController extends EventEmitter {
     }
 
     // solana account changed notifications
-    const caip25Caveat = this.permissionController.getCaveat(
-      origin,
-      Caip25EndowmentPermissionName,
-      Caip25CaveatType,
-    );
-    const solanaAccountsChangedNotifications =
-      caip25Caveat.value.sessionProperties[
-        KnownSessionProperties.SolanaAccountChangedNotifications
-      ];
+    let caip25Caveat;
+    try {
+      caip25Caveat = this.permissionController.getCaveat(
+        origin,
+        Caip25EndowmentPermissionName,
+        Caip25CaveatType,
+      );
+    } catch {
+      // noop
+    }
+    if (caip25Caveat) {
+      const solanaAccountsChangedNotifications =
+        caip25Caveat.value.sessionProperties[
+          KnownSessionProperties.SolanaAccountChangedNotifications
+        ];
 
     const sessionScopes = getSessionScopes(caip25Caveat.value, {
       getNonEvmSupportedMethods: this.getNonEvmSupportedMethods.bind(this),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2899,19 +2899,19 @@ export default class MetamaskController extends EventEmitter {
               }
             });
 
-            const solanaScope =
+            const addedSolanaScope =
               sessionScopes[MultichainNetworks.SOLANA] ||
               sessionScopes[MultichainNetworks.SOLANA_DEVNET] ||
               sessionScopes[MultichainNetworks.SOLANA_TESTNET];
 
-            if (solanaScope) {
+            if (addedSolanaScope) {
               const solanaAccountChangedNotifications =
                 currentValue.get(origin)?.sessionProperties?.[
                   KnownSessionProperties.SolanaAccountChangedNotifications
                 ];
 
               if (solanaAccountChangedNotifications) {
-                const { accounts } = solanaScope;
+                const { accounts } = addedSolanaScope;
                 const solanaFormattedAccounts = accounts.map(
                   (caipAccountId) => {
                     const { address } = parseCaipAccountId(caipAccountId);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -12,7 +12,7 @@ import { ThunkAction } from 'redux-thunk';
 import { Action, AnyAction } from 'redux';
 import { providerErrors, serializeError } from '@metamask/rpc-errors';
 import type { DataWithOptionalCause } from '@metamask/rpc-errors';
-import type { CaipChainId, Hex, Json } from '@metamask/utils';
+import { parseCaipChainId, parseCaipAccountId, type CaipChainId, type Hex, type Json } from '@metamask/utils';
 import {
   AssetsContractController,
   BalanceMap,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -12,7 +12,13 @@ import { ThunkAction } from 'redux-thunk';
 import { Action, AnyAction } from 'redux';
 import { providerErrors, serializeError } from '@metamask/rpc-errors';
 import type { DataWithOptionalCause } from '@metamask/rpc-errors';
-import { parseCaipChainId, parseCaipAccountId, type CaipChainId, type Hex, type Json } from '@metamask/utils';
+import {
+  parseCaipChainId,
+  parseCaipAccountId,
+  type CaipChainId,
+  type Hex,
+  type Json,
+} from '@metamask/utils';
 import {
   AssetsContractController,
   BalanceMap,


### PR DESCRIPTION
Covers extra cases not handled by the [initial PR to add an accountsChanged event for Solana](https://github.com/MetaMask/metamask-extension/pull/30949)

This adds handling for emitting the event upon initial connection and emitting the event with an empty array when the Solana scope is revoked