### PR TITLE
fix: small amounts on activity tab

### DIFF
--- a/ui/components/app/transaction-list/transaction-list.test.js
+++ b/ui/components/app/transaction-list/transaction-list.test.js
@@ -111,7 +111,7 @@ const solanaSwapState = {
                 address: MOCK_ACCOUNT_SOLANA_MAINNET.address,
                 asset: {
                   fungible: true,
-                  type: '',
+                  type: 'solCaip19',
                   unit: 'SOL',
                   amount: '0.01',
                 },
@@ -122,9 +122,9 @@ const solanaSwapState = {
                 address: MOCK_ACCOUNT_SOLANA_MAINNET.address,
                 asset: {
                   fungible: true,
-                  type: '',
+                  type: 'bonkCaip19',
                   unit: 'BONK',
-                  amount: '2583.72',
+                  amount: '0.00000001', // Test extremely small amounts
                 },
               },
             ],
@@ -335,7 +335,7 @@ describe('TransactionList', () => {
 
     expect(getByTestId('activity-list-item')).toBeInTheDocument();
 
-    expect(getByText('2,583.72 BONK')).toBeInTheDocument();
+    expect(getByText('<0.00001 BONK')).toBeInTheDocument();
 
     const viewOnExplorerBtn = getByRole('button', {
       name: 'View on block explorer',

--- a/ui/hooks/useMultichainTransactionDisplay.ts
+++ b/ui/hooks/useMultichainTransactionDisplay.ts
@@ -111,9 +111,10 @@ function parseAsset(
   isNegative: boolean,
   decimals?: number,
 ) {
+  const threshold = 1 / 10 ** (decimals || 8); // Smallest unit to display given the decimals.
   const displayAmount = formatWithThreshold(
     movement.amount,
-    0.00000001,
+    threshold,
     locale,
     {
       minimumFractionDigits: 0,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

 We are currently wrongly displaying very small amounts for Solana in the activity tab (< 1e-8).
 
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31563?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/877

## **Manual testing steps**

1. Create Solana account
2. Receive very small amount of any token (<1e8)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2025-04-03 at 15 35 57](https://github.com/user-attachments/assets/8181e58e-cd0f-4010-a2e9-90c97894ed67)

### **After**

![Screenshot 2025-04-03 at 15 36 50](https://github.com/user-attachments/assets/25b5de71-d9ff-402c-b35a-64c3fa39a8d9)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
