### PR TITLE
build: git-diff-default-branch.ts should handle empty PR body

### DIFF
--- a/.circleci/scripts/git-diff-default-branch.ts
+++ b/.circleci/scripts/git-diff-default-branch.ts
@@ -1,6 +1,6 @@
 import { exec as execCallback } from 'child_process';
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import { promisify } from 'util';
 
 const exec = promisify(execCallback);
@@ -107,8 +107,10 @@ async function gitDiff(): Promise<string> {
 
 function writePrBodyAndInfoToFile(prInfo: PRInfo) {
   const prBodyPath = path.resolve(CHANGED_FILES_DIR, 'pr-body.txt');
-  const labels = prInfo.labels.map(label => label.name).join(', ');
-  const updatedPrBody = `PR labels: {${labels}}\nPR base: {${prInfo.base.ref}}\n${prInfo.body.trim()}`;
+  const labels = prInfo.labels.map((label) => label.name).join(', ');
+  const updatedPrBody = `PR labels: {${labels}}\nPR base: {${
+    prInfo.base.ref
+  }}\n${prInfo.body?.trim() ?? ''}`;
   fs.writeFileSync(prBodyPath, updatedPrBody);
   console.log(`PR body and info saved to ${prBodyPath}`);
 }
@@ -146,7 +148,7 @@ async function storeGitDiffOutputAndPrBody() {
 
     // Store the output of git diff
     const outputPath = path.resolve(CHANGED_FILES_DIR, 'changed-files.txt');
-    fs.writeFileSync(outputPath, diffOutput.trim());
+    fs.writeFileSync(outputPath, diffOutput?.trim() ?? '');
     console.log(`Git diff results saved to ${outputPath}`);
 
     writePrBodyAndInfoToFile(prInfo);


### PR DESCRIPTION
## **Description**
git-diff-default-branch.ts should handle empty PR bodies. 

[Example failure](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/135938/workflows/3d9877f6-10f1-40a3-8417-9d984de8ac0d/jobs/4723245) that is fixed by this PR.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31576?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
