### PR TITLE
test: ensure `foundryup` works when bin path contains a space character

### DIFF
--- a/test/helpers/foundry/utils.ts
+++ b/test/helpers/foundry/utils.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { arch } from 'node:os';
 import {
   type Checksums,
@@ -64,7 +64,7 @@ export function say(message: string) {
  */
 export function getVersion(binPath: string): Buffer {
   try {
-    return execSync(`${binPath} --version`).subarray(0, -1); // ignore newline
+    return execFileSync(binPath, ['--version']).subarray(0, -1); // ignore newline
   } catch (error: unknown) {
     const msg = `Failed to get version for ${binPath}
 


### PR DESCRIPTION
## **Description**

Only effects the `yarn foundryup` command. Used by automated tests and run on repo install (`yarn` or `yarn install`). QA tests not required.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31577?quickstart=1)

## **Related issues**

Fixes: `yarn foundryup` on paths containing a space character

## **Manual testing steps**

1. clone the repo into a path with a space character
2. run `yarn`
3. it shouldn't fail now!

<!-- 
## **Screenshots/Recordings**

If applicable, add screenshots and/or recordings to visualize the before and after of your change.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
 -->