### PR TITLE
feat: Add MMSans and MMPoly font family support to Text component

### DIFF
--- a/ui/components/component-library/text/README.mdx
+++ b/ui/components/component-library/text/README.mdx
@@ -166,6 +166,33 @@ import { FontStyle } from '../../../helpers/constants/design-system';
 </Text>
 ```
 
+### Font Family
+
+Use the `fontFamily` prop and the `FontFamily` enum from `./text.types` to change the font family of the `Text` component. There are 3 font families:
+
+- `FontFamily.Default` (CentraNo1)
+- `FontFamily.Accent` (MMSans)
+- `FontFamily.Hero` (MMPoly)
+
+<Canvas>
+  <Story id="components-componentlibrary-text--font-family-story" />
+</Canvas>
+
+```jsx
+import { Text } from '../../component-library';
+import { FontFamily } from '../../../helpers/constants/design-system';
+
+<Text fontFamily={FontFamily.Default}>
+  Default Font (CentraNo1)
+</Text>
+<Text fontFamily={FontFamily.Accent}>
+  Accent Font (MMSans)
+</Text>
+<Text fontFamily={FontFamily.Hero}>
+  Hero Font (MMPoly)
+</Text>
+```
+
 ### Text Transform
 
 Use the `textTransform` prop and the `TextTransform` enum from `./ui/helpers/constants/design-system.ts` to change the text alignment of the `Text` component

--- a/ui/components/component-library/text/text.scss
+++ b/ui/components/component-library/text/text.scss
@@ -100,6 +100,19 @@ $text-variants: (
   &--text-transform-capitalize {
     text-transform: capitalize;
   }
+
+  // Font Family Variants
+  &--font-family-default {
+    font-family: var(--font-family-default);
+  }
+
+  &--font-family-accent {
+    font-family: var(--font-family-accent);
+  }
+
+  &--font-family-hero {
+    font-family: var(--font-family-hero);
+  }
 }
 
 

--- a/ui/components/component-library/text/text.stories.tsx
+++ b/ui/components/component-library/text/text.stories.tsx
@@ -6,6 +6,7 @@ import {
   BorderColor,
   FontWeight,
   FontStyle,
+  FontFamily,
   TextColor,
   TextAlign,
   OverflowWrap,
@@ -142,6 +143,26 @@ export const FontStyleStory: StoryFn<typeof Text> = (args) => (
 );
 
 FontStyleStory.storyName = 'Font Style';
+
+export const FontFamilyStory: StoryFn<typeof Text> = (args) => (
+  <Box
+    display={Display.Flex}
+    flexDirection={FlexDirection.Column}
+    gap={4}
+  >
+    <Text {...args} fontFamily={FontFamily.Default}>
+      Default Font (CentraNo1) - The quick brown fox jumps over the lazy dog
+    </Text>
+    <Text {...args} fontFamily={FontFamily.Accent}>
+      Accent Font (MMSans) - The quick brown fox jumps over the lazy dog
+    </Text>
+    <Text {...args} fontFamily={FontFamily.Hero}>
+      Hero Font (MMPoly) - The quick brown fox jumps over the lazy dog
+    </Text>
+  </Box>
+);
+
+FontFamilyStory.storyName = 'Font Family';
 
 export const TextTransformStory: StoryFn<typeof Text> = (args) => (
   <>

--- a/ui/components/component-library/text/text.test.tsx
+++ b/ui/components/component-library/text/text.test.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import {
-  FontStyle,
   FontWeight,
-  OverflowWrap,
-  TextAlign,
+  FontStyle,
+  FontFamily,
   TextColor,
+  TextAlign,
+  OverflowWrap,
   TextTransform,
   TextVariant,
 } from '../../../helpers/constants/design-system';
@@ -111,6 +112,19 @@ describe('Text', () => {
     expect(getByText('bold')).toHaveClass('mm-text--font-weight-bold');
     expect(getByText('medium')).toHaveClass('mm-text--font-weight-medium');
     expect(getByText('normal')).toHaveClass('mm-text--font-weight-normal');
+  });
+
+  it('should render the Text with proper font family class name', () => {
+    const { getByText } = render(
+      <>
+        <Text fontFamily={FontFamily.Default}>default</Text>
+        <Text fontFamily={FontFamily.Accent}>accent</Text>
+        <Text fontFamily={FontFamily.Hero}>hero</Text>
+      </>,
+    );
+    expect(getByText('default')).toHaveClass('mm-text--font-family-default');
+    expect(getByText('accent')).toHaveClass('mm-text--font-family-accent');
+    expect(getByText('hero')).toHaveClass('mm-text--font-family-hero');
   });
 
   it('should render the Text with proper text color class name', () => {

--- a/ui/components/component-library/text/text.tsx
+++ b/ui/components/component-library/text/text.tsx
@@ -35,6 +35,7 @@ export const Text: TextComponent = React.forwardRef(
       variant = TextVariant.bodyMd,
       fontWeight,
       fontStyle,
+      fontFamily,
       textTransform,
       textAlign,
       textDirection,
@@ -56,6 +57,7 @@ export const Text: TextComponent = React.forwardRef(
       {
         [`mm-text--font-weight-${fontWeight}`]: Boolean(fontWeight),
         [`mm-text--font-style-${fontStyle}`]: Boolean(fontStyle),
+        [`mm-text--font-family-${fontFamily}`]: Boolean(fontFamily),
         [`mm-text--ellipsis`]: Boolean(ellipsis),
         [`mm-text--text-transform-${textTransform}`]: Boolean(textTransform),
         [`mm-text--text-align-${textAlign}`]: Boolean(textAlign),

--- a/ui/components/component-library/text/text.types.ts
+++ b/ui/components/component-library/text/text.types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  FontFamily,
   FontWeight,
   FontStyle,
   TextVariant,
@@ -115,6 +116,10 @@ export interface TextStyleUtilityProps extends StyleUtilityProps {
    * ./ui/helpers/constants/design-system.js
    */
   fontStyle?: FontStyle;
+  /**
+   * The font family of the Text component. Should use the FontFamily enum
+   */
+  fontFamily?: FontFamily;
   /**
    * The textTransform of the Text component. Should use the TextTransform enum from
    * ./ui/helpers/constants/design-system.js

--- a/ui/css/utilities/fonts.scss
+++ b/ui/css/utilities/fonts.scss
@@ -66,16 +66,16 @@ $font-path: './fonts';
 }
 
 @font-face {
-  font-family: 'MM Sans';
+  font-family: 'MMSans';
   src: url('#{$font-path}/MMSans/MM_Sans-Variable.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
 }
 
-// MM Sans Vairable Font - supports: 400, 500, 600, 700, 800, 900
+// MMSans Vairable Font - supports: 400, 500, 600, 700, 800, 900
 
 @font-face {
-  font-family: 'MM Sans';
+  font-family: 'MMSans';
   src: url('#{$font-path}/MMSans/MM_Sans-Variable.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;

--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -476,6 +476,12 @@ export enum FontWeight {
   Normal = 'normal',
 }
 
+export enum FontFamily {
+  Default = 'default', // CentraNo1
+  Accent = 'accent', // MMSans
+  Hero = 'hero', // MMPoly
+}
+
 /**
  * @deprecated `FONT_WEIGHT` const has been deprecated in favor of the `FontWeight` enum which can still be imported from `ui/helpers/constants/design-system.ts`
  *


### PR DESCRIPTION
## **Description**

This PR adds support for three font families to the `Text` component: Default (CentraNo1), Accent (MMSans), and Hero (MMPoly). The changes include:

1. Adding a new `fontFamily` prop to the `Text` component with an enum for the three supported font families
2. Updating the SCSS to support the new font family variants
3. Adding documentation and examples in the Text component's README
6. Adding tests for the new font family functionality

The changes are focused solely on font family support and do not include other unrelated changes from other PRs.

## **Related issues**

Fixes: #31365

## **Manual testing steps**

1. Go to the Text component storybook page
2. Navigate to the "Font Family" story
3. Verify that all three font families (Default, Accent, Hero) are displayed correctly
4. Check that the fonts are applied properly in different text variants and sizes

## **Screenshots/Recordings**

### **Before**

No font family support in Text component

### **After**

https://github.com/user-attachments/assets/f9a61731-ed4c-4774-a82b-3403a9a7d4f0

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests for the new font family functionality
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.