### PR TITLE
fix: Prevent overflow in from Snaps UI header in confirmations

### DIFF
--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -210,7 +210,7 @@ function Header({ confirmation, isSnapCustomUIDialog, onCancel }) {
   }
 
   return (
-    <Box style={{ width: '100%', position: 'relative' }}>
+    <Box style={{ width: '100%', position: 'relative', overflow: 'hidden' }}>
       <Nav confirmationId={confirmation?.id} />
       {requiresSnapHeader && (
         <SnapAuthorshipHeader snapId={origin} onCancel={onCancel} />

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-named-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-named-snap-account.test.js.snap
@@ -7,7 +7,7 @@ exports[`create-named-snap-account confirmation matches snapshot 1`] = `
   >
     <div
       class="mm-box"
-      style="width: 100%; position: relative;"
+      style="width: 100%; position: relative; overflow: hidden;"
     >
       <div
         class="mm-box mm-box--padding-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-background-default"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an issue where Snap with long titles could overflow and stretch the UI beyond the viewport. This is reproducible in production and was probably introduced as part of #28761.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31595?quickstart=1)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/b6d57386-2355-482d-b167-b46c764ce3e9)

### **After**

![image](https://github.com/user-attachments/assets/0a480ef6-4e64-4c35-8f97-23b0ecb5ee6d)

(The changes to fonts etc are from differences between main and prod)
