### PR TITLE
style: Remove shadow from toast

### DIFF
--- a/ui/components/multichain/toast/index.scss
+++ b/ui/components/multichain/toast/index.scss
@@ -11,7 +11,6 @@
 
   &__banner-base {
     border-radius: 8px;
-    box-shadow: var(--shadow-size-md);
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes the shadow from the toast component. This makes the component more visually consistent with our design system.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31618?quickstart=1)

## **Related issues**

None

## **Manual testing steps**

1. Open Settings
2. Disable NFT autodetection
3. Click on Enable in the NFT autodetection banner

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/4ddcdc0c-ec6f-48d9-a92d-7d884f4b0bac


### **After**

https://github.com/user-attachments/assets/27427f63-4a61-4537-a262-534fa9a93803


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
