### PR TITLE
style: Update font weights for balance, price and other headers

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
@@ -96,7 +96,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
             class="mm-box mm-box--display-flex mm-box--align-items-center"
           >
             <h3
-              class="mm-box mm-text mm-text--heading-md mm-text--font-weight-bold mm-text--font-style-normal mm-box--color-text-default"
+              class="mm-box mm-text mm-text--heading-md mm-text--font-weight-medium mm-text--font-style-normal mm-box--color-text-default"
               data-testid="nft-details__name"
               style="font-size: 24px;"
             >

--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -404,7 +404,7 @@ export function NftDetailsComponent({
             <Box display={Display.Flex} alignItems={AlignItems.center}>
               <Text
                 variant={TextVariant.headingMd}
-                fontWeight={FontWeight.Bold}
+                fontWeight={FontWeight.Medium}
                 color={TextColor.textDefault}
                 fontStyle={FontStyle.Normal}
                 style={{ fontSize: '24px' }}

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -86,7 +86,7 @@
     @include design-system.H2;
 
     color: var(--color-text-default);
-    font-weight: 700;
+    font-weight: 500;
   }
 
   &__cached-star {

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -750,7 +750,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
         class="mm-box mm-box--margin-right-4 mm-box--margin-left-4"
       >
         <h1
-          class="mm-box mm-text mm-text--display-md mm-box--margin-bottom-1 mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"
+          class="mm-box mm-text mm-text--display-md mm-text--font-weight-medium mm-box--margin-bottom-1 mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"
           data-testid="asset-hovered-price"
           style="width: 100px;"
         >

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -749,13 +749,13 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
       <div
         class="mm-box mm-box--margin-right-4 mm-box--margin-left-4"
       >
-        <h2
-          class="mm-box mm-text mm-text--heading-lg mm-box--margin-bottom-1 mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"
+        <h1
+          class="mm-box mm-text mm-text--display-md mm-box--margin-bottom-1 mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"
           data-testid="asset-hovered-price"
           style="width: 100px;"
         >
           $15,129.00
-        </h2>
+        </h1>
         <div
           class="mm-box"
         >

--- a/ui/pages/asset/components/asset-price.tsx
+++ b/ui/pages/asset/components/asset-price.tsx
@@ -87,7 +87,7 @@ const AssetPrice = forwardRef(
         <Text
           data-testid="asset-hovered-price"
           style={{ width: '100px' }}
-          variant={TextVariant.headingLg}
+          variant={TextVariant.displayMd}
           borderRadius={BorderRadius.LG}
           marginBottom={1}
           backgroundColor={

--- a/ui/pages/asset/components/asset-price.tsx
+++ b/ui/pages/asset/components/asset-price.tsx
@@ -3,6 +3,7 @@ import {
   BackgroundColor,
   BorderRadius,
   Display,
+  FontWeight,
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
@@ -88,6 +89,7 @@ const AssetPrice = forwardRef(
           data-testid="asset-hovered-price"
           style={{ width: '100px' }}
           variant={TextVariant.displayMd}
+          fontWeight={FontWeight.Medium}
           borderRadius={BorderRadius.LG}
           marginBottom={1}
           backgroundColor={


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This updates the font weight for the headers on these pages: home, token details and NFT details. It refines the visual language of the product.

[Link to relevant designs](https://www.figma.com/design/9e6RSJCvezaLqDQ3mtE5wB/MaWaSB?node-id=3071-13203&t=ZihUyfVzJqXqS4Uh-4)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31624?quickstart=1)

## **Related issues**

Fixes: None

## **Manual testing steps**

1. Open MetaMask
2. Go to token details
3. Go to NFT details

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1095" alt="Screenshot 2025-04-05 at 4 32 30 AM" src="https://github.com/user-attachments/assets/82556076-3fcd-414e-99e2-a93faa95424f" />


### **After**

<img width="893" alt="Screenshot 2025-04-05 at 4 31 16 AM" src="https://github.com/user-attachments/assets/3e8bc108-7608-4ee6-934e-b7f274b4e042" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
