### PR TITLE
feat: INFRA-2406: Automated RCA questionaire workflow

### DIFF
--- a/.github/workflows/automated-rca.yml
+++ b/.github/workflows/automated-rca.yml
@@ -1,0 +1,19 @@
+name: Automated RCA
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  automated-rca:
+    uses: MetaMask/github-tools/.github/workflows/post-gh-rca.yml@115cc6dce7aa32c85cbd77a19e9c04db85fb7920
+    with:
+      google-form-base-url: 'https://docs.google.com/forms/d/e/1FAIpQLSfnfEWH7JCFFtvjCHixgyqJdTU3LW3BmTwdF1dDezTNf7m4ig/viewform?usp=pp_url&entry.340898780='
+      repo-owner: ${{ github.repository_owner }}
+      repo-name: ${{ github.event.repository.name }}
+      issue-number: ${{ github.event.issue.number }}
+      issue-labels: '["Sev0-urgent", "Sev1-high"]'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-2406
1. What is the reason for the change? Add a gh action workflow for automated rca. Will post questionnaire in 
2. What is the improvement/solution? A new 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31665?quickstart=1)

## **Related issues**
https://github.com/MetaMask/metamask-extension/issues/30834

Testing: https://github.com/MetaMask/metamask-extension/issues/31620

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
