### PR TITLE
style: Update Sepolia background color

### DIFF
--- a/ui/css/utilities/colors.scss
+++ b/ui/css/utilities/colors.scss
@@ -12,7 +12,7 @@ Before adding a color here make sure that there isn't a design token available.
   // DEPRECATED
   // These third party network colors have been deprecated and should be removed once they are no longer in use. We should be using images to represent these networks instead.
   --color-network-goerli-default: #1098fc;
-  --color-network-sepolia-default: #cfb5f0;
+  --color-network-sepolia-default: #c65cf2;
   --color-network-goerli-inverse: #fcfcfc;
   --color-network-sepolia-inverse: #fcfcfc;
   --color-network-localhost-default: #bbc0c5;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This updates the background color of Sepolia so that it looks more cohesive with other network logos in the network menu.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31680?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open MetaMask
2. Click on network selector

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="398" alt="Screenshot 2025-04-08 at 4 40 18 AM" src="https://github.com/user-attachments/assets/ba0cc14d-315d-4397-a329-104414a6d1ef" />


### **After**
<img width="396" alt="Screenshot 2025-04-08 at 4 43 13 AM" src="https://github.com/user-attachments/assets/93e80188-acf5-4466-a382-07ba525956ab" />



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
