### PR TITLE
fix: asset picker scrolls up on quote fetch when network is solana

### DIFF
--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -299,7 +299,7 @@ export const getFromTokenConversionRate = createSelector(
       if (isSolanaChainId(fromChain.chainId)) {
         // For SOLANA tokens, we use the conversion rates provided by the multichain rates controller
         const tokenToNativeAssetRate = tokenPriceInNativeAsset(
-          assetsRates[fromToken.address]?.rate,
+          assetsRates[fromToken.assetId]?.rate,
           nonEvmNativeConversionRate?.sol?.conversionRate,
         );
         return exchangeRatesFromNativeAndCurrencyRates(

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -159,7 +159,7 @@ export const getTokenExchangeRate = async (request: {
 // This extracts a token's exchange rate from the marketData state object
 // These exchange rates are against the native asset of the chain
 export const exchangeRateFromMarketData = (
-  chainId: Hex | ChainId,
+  chainId: Hex | ChainId | CaipChainId,
   tokenAddress: string,
   marketData?: Record<string, ContractMarketData>,
 ) =>

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -12,6 +12,7 @@ import {
   type TxData,
   formatChainIdToHex,
   BridgeClientId,
+  formatChainIdToCaip,
 } from '@metamask/bridge-controller';
 import { decGWEIToHexWEI } from '../../../shared/modules/conversion.utils';
 import { Numeric } from '../../../shared/modules/Numeric';
@@ -144,8 +145,9 @@ export const getTokenExchangeRate = async (request: {
     currency,
     tokenAddress,
   );
-  if (isSolanaChainId(chainId)) {
-    return exchangeRates?.[tokenAddress];
+  const assetId = toAssetId(tokenAddress, formatChainIdToCaip(chainId));
+  if (isSolanaChainId(chainId) && assetId) {
+    return exchangeRates?.[assetId];
   }
   // The exchange rate can be checksummed or not, so we need to check both
   const exchangeRate =

--- a/ui/hooks/bridge/useBridgeExchangeRates.ts
+++ b/ui/hooks/bridge/useBridgeExchangeRates.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { isStrictHexString } from '@metamask/utils';
 import {
   getBridgeQuotes,
   getFromToken,
@@ -51,7 +50,7 @@ export const useBridgeExchangeRates = () => {
 
   // Fetch exchange rates for selected src token if not found in marketData
   useEffect(() => {
-    if (fromChainId && fromTokenAddress && isStrictHexString(fromChainId)) {
+    if (fromChainId && fromTokenAddress) {
       const exchangeRate = exchangeRateFromMarketData(
         fromChainId,
         fromTokenAddress,
@@ -68,7 +67,7 @@ export const useBridgeExchangeRates = () => {
         );
       }
     }
-  }, [fromChainId, fromTokenAddress]);
+  }, [currency, dispatch, fromChainId, fromTokenAddress, marketData]);
 
   // Fetch exchange rates for selected dest token if not found in marketData
   useEffect(() => {
@@ -99,5 +98,12 @@ export const useBridgeExchangeRates = () => {
         }
       }
     }
-  }, [toChainId, toTokenAddress]);
+  }, [
+    currency,
+    dispatch,
+    isMetaMetricsEnabled,
+    marketData,
+    toChainId,
+    toTokenAddress,
+  ]);
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31685?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/31340

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
