### PR TITLE
feat: fix srp list padding

### DIFF
--- a/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
@@ -90,7 +90,6 @@ export const SrpList = ({
             flexDirection={FlexDirection.Row}
             alignItems={AlignItems.center}
             justifyContent={JustifyContent.spaceBetween}
-            paddingLeft={4}
           >
             <Box>
               <Text>{t('srpListName', [index + 1])}</Text>


### PR DESCRIPTION

## **Description**

Updates the srp-list padding.
## **Related issues**

Fixes:

## **Manual testing steps**

1. Open account menu
2. Make sure you have at least 2 SRPs (import new one if there is only one)
3. Click Ethereum account
4. Click selected SRP
5. SRP list should be displayed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="350" alt="Screenshot 2025-04-08 at 12 39 18" src="https://github.com/user-attachments/assets/50d59cd8-5ee4-4ff6-a6cb-59ea33ab0248" />
<img width="348" alt="Screenshot 2025-04-08 at 12 39 24" src="https://github.com/user-attachments/assets/0437e147-9785-4b96-ad8e-2efcbda3a5ee" />



### **After**
<img width="344" alt="Screenshot 2025-04-08 at 12 38 23" src="https://github.com/user-attachments/assets/e8ab825b-344d-48c2-9ac0-d884fff165ff" />
<img width="348" alt="Screenshot 2025-04-08 at 12 40 11" src="https://github.com/user-attachments/assets/46c31b83-9f34-4395-871f-7e30b41ed9ec" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
