### PR TITLE
fix: Add `displayAvatar` prop to Snap `AddressInput` component

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/address-input.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/address-input.test.ts.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SnapUIAddressInput will not render avatar when displayAvatar is false 1`] = `
+<div>
+  <div
+    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    style="overflow-y: auto; margin-bottom: 0px;"
+  >
+    <div
+      class="box snap-ui-renderer__container box--display-flex box--flex-direction-column"
+    >
+      <div
+        class="box snap-ui-renderer__panel box--display-flex box--flex-direction-column box--justify-content-flex-start box--color-text-default"
+      >
+        <div
+          class="mm-box mm-form-text-field snap-ui-renderer__address-input mm-box--display-flex mm-box--flex-direction-column"
+        >
+          <div
+            class="mm-box mm-text-field mm-text-field--size-lg mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-4 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          >
+            <input
+              autocomplete="off"
+              class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+              focused="false"
+              id="input"
+              type="text"
+              value="0xabcd5d886577d5081b0c52e242ef29e70be3e7bc"
+            />
+            <span
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-info-default"
+              style="mask-image: url('./images/icons/close.svg'); cursor: pointer;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <span
+      data-renders="1"
+      data-testid="performance"
+    />
+  </div>
+</div>
+`;
+
 exports[`SnapUIAddressInput will render 1`] = `
 <div>
   <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts
@@ -142,4 +142,25 @@ describe('SnapUIAddressInput', () => {
     expect(avatar).toBeDefined();
     expect(container).toMatchSnapshot();
   });
+
+  it('will not render avatar when displayAvatar is false', () => {
+    const testAddress = '0xabcd5d886577d5081b0c52e242ef29e70be3e7bc';
+
+    const { container, getByDisplayValue } = renderInterface(
+      Box({
+        children: AddressInput({
+          name: 'input',
+          chainId: 'eip155:0',
+          displayAvatar: false,
+        }),
+      }),
+      { state: { input: `eip155:0:${testAddress}` } },
+    );
+
+    const matchedAddress = getByDisplayValue(testAddress);
+    expect(matchedAddress).toBeDefined();
+    const avatar = container.querySelector('svg');
+    expect(avatar).toBeNull();
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/ui/components/app/snaps/snap-ui-renderer/components/address-input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/address-input.ts
@@ -13,6 +13,7 @@ export const addressInput: UIComponentFactory<AddressInputElement> = ({
       disabled: element.props.disabled,
       chainId: element.props.chainId,
       form,
+      displayAvatar: element.props.displayAvatar,
     },
   };
 };


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? The `AddressInput` component isn't being passed the `displayAvatar` prop.
2. What is the improvement/solution? Add the prop into the mapper.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
