### PR TITLE
feat: Use chainId / networkClientId from a transaction for STX cp-12.17.0

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -10,7 +10,7 @@ import SmartTransactionsController from '@metamask/smart-transactions-controller
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller/dist/types';
 import { Hex } from '@metamask/utils';
 import {
-  getCurrentChainSupportsSmartTransactions,
+  getChainSupportsSmartTransactions,
   getFeatureFlagsByChainId,
   getIsSmartTransaction,
   getSmartTransactionsPreferenceEnabled,
@@ -114,7 +114,7 @@ export const TransactionControllerInit: ControllerInitFunction<
         const uiState = getUIState(getFlatState());
         return !(
           getSmartTransactionsPreferenceEnabled(uiState) &&
-          getCurrentChainSupportsSmartTransactions(uiState)
+          getChainSupportsSmartTransactions(uiState)
         );
       },
     },

--- a/app/scripts/lib/transaction/smart-transactions.ts
+++ b/app/scripts/lib/transaction/smart-transactions.ts
@@ -170,6 +170,7 @@ class SmartTransactionHook {
       getFeesResponse = await this.#smartTransactionsController.getFees(
         { ...this.#txParams, chainId: this.#chainId },
         undefined,
+        { networkClientId: this.#transactionMeta.networkClientId },
       );
     } catch (error) {
       log.error(

--- a/shared/modules/selectors/feature-flags.test.ts
+++ b/shared/modules/selectors/feature-flags.test.ts
@@ -2,10 +2,12 @@ import { RpcEndpointType } from '@metamask/network-controller';
 import { CHAIN_IDS } from '../../constants/network';
 // Import the module to spy on
 import * as featureFlags from '../feature-flags';
-import { getFeatureFlagsByChainId } from './feature-flags';
+import {
+  getFeatureFlagsByChainId,
+  type SwapsFeatureFlags,
+} from './feature-flags';
 import { ProviderConfigState } from './networks';
 
-// Type definition for state matching ProviderConfigState & FeatureFlagsMetaMaskState
 type MockState = ProviderConfigState & {
   metamask: {
     networkConfigurationsByChainId: Record<
@@ -29,17 +31,7 @@ type MockState = ProviderConfigState & {
       [clientId: string]: { status: string };
     };
     swapsState: {
-      swapsFeatureFlags: {
-        [network: string]: {
-          extensionActive: boolean;
-          mobileActive: boolean;
-          smartTransactions: {
-            expectedDeadline?: number;
-            maxDeadline?: number;
-            extensionReturnTxHashAsap?: boolean;
-          };
-        };
-      };
+      swapsFeatureFlags: SwapsFeatureFlags;
     };
   };
 };
@@ -93,15 +85,11 @@ describe('Feature Flags Selectors', () => {
               },
             },
             smartTransactions: {
+              mobileActive: true,
               extensionActive: true,
-              mobileActive: false,
-              smartTransactions: {
-                expectedDeadline: 0,
-                maxDeadline: 0,
-                extensionReturnTxHashAsap: false,
-              },
+              extensionReturnTxHashAsap: false,
             },
-          },
+          } as SwapsFeatureFlags,
         },
       },
     };
@@ -135,8 +123,8 @@ describe('Feature Flags Selectors', () => {
 
       expect(result).toStrictEqual({
         smartTransactions: {
+          mobileActive: true,
           extensionActive: true,
-          mobileActive: false,
           expectedDeadline: 45,
           maxDeadline: 150,
           extensionReturnTxHashAsap: false,
@@ -166,7 +154,7 @@ describe('Feature Flags Selectors', () => {
       expect(result).toStrictEqual({
         smartTransactions: {
           extensionActive: true,
-          mobileActive: false,
+          mobileActive: true,
           expectedDeadline: 60,
           maxDeadline: 180,
           extensionReturnTxHashAsap: true,
@@ -181,7 +169,7 @@ describe('Feature Flags Selectors', () => {
       expect(result).toStrictEqual({
         smartTransactions: {
           extensionActive: true,
-          mobileActive: false,
+          mobileActive: true,
           expectedDeadline: 45,
           maxDeadline: 150,
           extensionReturnTxHashAsap: false,

--- a/shared/modules/selectors/feature-flags.test.ts
+++ b/shared/modules/selectors/feature-flags.test.ts
@@ -1,0 +1,130 @@
+import { CHAIN_IDS } from '../../constants/network';
+import { getFeatureFlagsByChainId } from './feature-flags';
+
+// Mock the feature flags module
+jest.mock('../feature-flags', () => ({
+  getNetworkNameByChainId: (chainId: string) => {
+    switch (chainId) {
+      case CHAIN_IDS.MAINNET:
+        return 'ethereum';
+      case CHAIN_IDS.BSC:
+        return 'bsc';
+      case CHAIN_IDS.POLYGON:
+        return 'polygon';
+      default:
+        return '';
+    }
+  },
+}));
+
+describe('Feature Flags Selectors', () => {
+  const createMockState = (chainId = CHAIN_IDS.MAINNET) => {
+    // Use a simpler approach - explicit type cast for test purposes
+    return {
+      metamask: {
+        // Network state for provider config
+        networkConfigurationsByChainId: {
+          [chainId]: {
+            chainId,
+            rpcEndpoints: [{ networkClientId: 'test-client-id' }],
+          },
+        },
+        selectedNetworkClientId: 'test-client-id',
+        networksMetadata: {
+          'test-client-id': { status: 'available' },
+        },
+        // Swaps feature flags
+        swapsState: {
+          swapsFeatureFlags: {
+            ethereum: {
+              extensionActive: true,
+              mobileActive: false,
+              smartTransactions: {
+                expectedDeadline: 45,
+                maxDeadline: 150,
+                extensionReturnTxHashAsap: false,
+              },
+            },
+            bsc: {
+              extensionActive: true,
+              mobileActive: false,
+              smartTransactions: {
+                expectedDeadline: 60,
+                maxDeadline: 180,
+                extensionReturnTxHashAsap: true,
+              },
+            },
+            smartTransactions: {
+              extensionActive: true,
+              mobileActive: false,
+            },
+          },
+        },
+      },
+    } as any; // Cast to any for test purposes
+  };
+
+  describe('getFeatureFlagsByChainId', () => {
+    it('returns correct feature flags for current chain ID in state', () => {
+      const state = createMockState(CHAIN_IDS.MAINNET);
+      const result = getFeatureFlagsByChainId(state);
+
+      expect(result).toEqual({
+        smartTransactions: {
+          extensionActive: true,
+          mobileActive: false,
+          expectedDeadline: 45,
+          maxDeadline: 150,
+          extensionReturnTxHashAsap: false,
+        },
+      });
+    });
+
+    it('returns null if chainId is not supported', () => {
+      // Instead of using SEPOLIA, create a state with a custom network
+      // and mock getNetworkNameByChainId to return empty string
+      const state = createMockState(CHAIN_IDS.MAINNET);
+
+      const mockModule = jest.requireMock('../feature-flags');
+      const originalFn = mockModule.getNetworkNameByChainId;
+      mockModule.getNetworkNameByChainId = jest.fn().mockReturnValue('');
+
+      const result = getFeatureFlagsByChainId(state);
+      expect(result).toBeNull();
+
+      // Restore original mock
+      mockModule.getNetworkNameByChainId = originalFn;
+    });
+
+    it('prioritizes provided chainId parameter over state chainId', () => {
+      // State has Ethereum network, but we're providing BSC chainId
+      const state = createMockState(CHAIN_IDS.MAINNET);
+      const result = getFeatureFlagsByChainId(state, CHAIN_IDS.BSC);
+
+      expect(result).toEqual({
+        smartTransactions: {
+          extensionActive: true,
+          mobileActive: false,
+          expectedDeadline: 60,
+          maxDeadline: 180,
+          extensionReturnTxHashAsap: true,
+        },
+      });
+    });
+
+    it('falls back to state chainId if provided chainId is falsy', () => {
+      const state = createMockState(CHAIN_IDS.MAINNET);
+      const result = getFeatureFlagsByChainId(state, '');
+
+      expect(result).toEqual({
+        smartTransactions: {
+          extensionActive: true,
+          mobileActive: false,
+          expectedDeadline: 45,
+          maxDeadline: 150,
+          extensionReturnTxHashAsap: false,
+        },
+      });
+    });
+  });
+});

--- a/shared/modules/selectors/feature-flags.test.ts
+++ b/shared/modules/selectors/feature-flags.test.ts
@@ -1,24 +1,51 @@
+import { RpcEndpointType } from '@metamask/network-controller';
 import { CHAIN_IDS } from '../../constants/network';
+// Import the module to spy on
+import * as featureFlags from '../feature-flags';
 import { getFeatureFlagsByChainId } from './feature-flags';
+import { ProviderConfigState } from './networks';
 
-// Mock the feature flags module
-jest.mock('../feature-flags', () => ({
-  getNetworkNameByChainId: (chainId: string) => {
-    switch (chainId) {
-      case CHAIN_IDS.MAINNET:
-        return 'ethereum';
-      case CHAIN_IDS.BSC:
-        return 'bsc';
-      case CHAIN_IDS.POLYGON:
-        return 'polygon';
-      default:
-        return '';
-    }
-  },
-}));
+// Type definition for state matching ProviderConfigState & FeatureFlagsMetaMaskState
+type MockState = ProviderConfigState & {
+  metamask: {
+    networkConfigurationsByChainId: Record<
+      string,
+      {
+        chainId: string;
+        rpcEndpoints: {
+          networkClientId: string;
+          type: RpcEndpointType;
+          url: string;
+        }[];
+        blockExplorerUrls: string[];
+        defaultBlockExplorerUrlIndex: number;
+        name: string;
+        nativeCurrency: string;
+        defaultRpcEndpointIndex: number;
+      }
+    >;
+    selectedNetworkClientId: string;
+    networksMetadata: {
+      [clientId: string]: { status: string };
+    };
+    swapsState: {
+      swapsFeatureFlags: {
+        [network: string]: {
+          extensionActive: boolean;
+          mobileActive: boolean;
+          smartTransactions: {
+            expectedDeadline?: number;
+            maxDeadline?: number;
+            extensionReturnTxHashAsap?: boolean;
+          };
+        };
+      };
+    };
+  };
+};
 
 describe('Feature Flags Selectors', () => {
-  const createMockState = (chainId = CHAIN_IDS.MAINNET) => {
+  const createMockState = (chainId = CHAIN_IDS.MAINNET): MockState => {
     // Use a simpler approach - explicit type cast for test purposes
     return {
       metamask: {
@@ -26,7 +53,18 @@ describe('Feature Flags Selectors', () => {
         networkConfigurationsByChainId: {
           [chainId]: {
             chainId,
-            rpcEndpoints: [{ networkClientId: 'test-client-id' }],
+            rpcEndpoints: [
+              {
+                networkClientId: 'test-client-id',
+                type: RpcEndpointType.Custom,
+                url: 'https://example.com',
+              },
+            ],
+            blockExplorerUrls: ['https://example.com'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Test Network',
+            nativeCurrency: 'ETH',
+            defaultRpcEndpointIndex: 0,
           },
         },
         selectedNetworkClientId: 'test-client-id',
@@ -57,19 +95,45 @@ describe('Feature Flags Selectors', () => {
             smartTransactions: {
               extensionActive: true,
               mobileActive: false,
+              smartTransactions: {
+                expectedDeadline: 0,
+                maxDeadline: 0,
+                extensionReturnTxHashAsap: false,
+              },
             },
           },
         },
       },
-    } as any; // Cast to any for test purposes
+    };
   };
 
   describe('getFeatureFlagsByChainId', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(featureFlags, 'getNetworkNameByChainId')
+        .mockImplementation((chainId: string) => {
+          switch (chainId) {
+            case CHAIN_IDS.MAINNET:
+              return 'ethereum';
+            case CHAIN_IDS.BSC:
+              return 'bsc';
+            case CHAIN_IDS.POLYGON:
+              return 'polygon';
+            default:
+              return '';
+          }
+        });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('returns correct feature flags for current chain ID in state', () => {
       const state = createMockState(CHAIN_IDS.MAINNET);
       const result = getFeatureFlagsByChainId(state);
 
-      expect(result).toEqual({
+      expect(result).toStrictEqual({
         smartTransactions: {
           extensionActive: true,
           mobileActive: false,
@@ -85,15 +149,13 @@ describe('Feature Flags Selectors', () => {
       // and mock getNetworkNameByChainId to return empty string
       const state = createMockState(CHAIN_IDS.MAINNET);
 
-      const mockModule = jest.requireMock('../feature-flags');
-      const originalFn = mockModule.getNetworkNameByChainId;
-      mockModule.getNetworkNameByChainId = jest.fn().mockReturnValue('');
+      // Mock the implementation for this specific test
+      jest
+        .spyOn(featureFlags, 'getNetworkNameByChainId')
+        .mockReturnValueOnce('');
 
       const result = getFeatureFlagsByChainId(state);
       expect(result).toBeNull();
-
-      // Restore original mock
-      mockModule.getNetworkNameByChainId = originalFn;
     });
 
     it('prioritizes provided chainId parameter over state chainId', () => {
@@ -101,7 +163,7 @@ describe('Feature Flags Selectors', () => {
       const state = createMockState(CHAIN_IDS.MAINNET);
       const result = getFeatureFlagsByChainId(state, CHAIN_IDS.BSC);
 
-      expect(result).toEqual({
+      expect(result).toStrictEqual({
         smartTransactions: {
           extensionActive: true,
           mobileActive: false,
@@ -116,7 +178,7 @@ describe('Feature Flags Selectors', () => {
       const state = createMockState(CHAIN_IDS.MAINNET);
       const result = getFeatureFlagsByChainId(state, '');
 
-      expect(result).toEqual({
+      expect(result).toStrictEqual({
         smartTransactions: {
           extensionActive: true,
           mobileActive: false,

--- a/shared/modules/selectors/feature-flags.ts
+++ b/shared/modules/selectors/feature-flags.ts
@@ -21,9 +21,10 @@ type FeatureFlagsMetaMaskState = {
 
 export function getFeatureFlagsByChainId(
   state: ProviderConfigState & FeatureFlagsMetaMaskState,
+  chainId?: string,
 ) {
-  const chainId = getCurrentChainId(state);
-  const networkName = getNetworkNameByChainId(chainId);
+  const effectiveChainId = chainId || getCurrentChainId(state);
+  const networkName = getNetworkNameByChainId(effectiveChainId);
   const featureFlags = state.metamask.swapsState?.swapsFeatureFlags;
   if (!featureFlags?.[networkName]) {
     return null;

--- a/shared/modules/selectors/feature-flags.ts
+++ b/shared/modules/selectors/feature-flags.ts
@@ -1,20 +1,33 @@
 import { getNetworkNameByChainId } from '../feature-flags';
 import { ProviderConfigState, getCurrentChainId } from './networks';
 
+type NetworkFeatureFlag = {
+  extensionActive: boolean;
+  mobileActive: boolean;
+  smartTransactions?: {
+    mobileActive?: boolean;
+    extensionActive?: boolean;
+    expectedDeadline?: number;
+    maxDeadline?: number;
+    extensionReturnTxHashAsap?: boolean;
+  };
+};
+
+type SmartTransactionsFeatureFlag = {
+  mobileActive: boolean;
+  extensionActive: boolean;
+  extensionReturnTxHashAsap: boolean;
+};
+
+export type SwapsFeatureFlags = {
+  [networkName: string]: NetworkFeatureFlag;
+  smartTransactions: SmartTransactionsFeatureFlag;
+};
+
 type FeatureFlagsMetaMaskState = {
   metamask: {
     swapsState: {
-      swapsFeatureFlags: {
-        [key: string]: {
-          extensionActive: boolean;
-          mobileActive: boolean;
-          smartTransactions: {
-            expectedDeadline?: number;
-            maxDeadline?: number;
-            extensionReturnTxHashAsap?: boolean;
-          };
-        };
-      };
+      swapsFeatureFlags: SwapsFeatureFlags;
     };
   };
 };

--- a/shared/modules/selectors/index.test.ts
+++ b/shared/modules/selectors/index.test.ts
@@ -4,6 +4,7 @@ import { it as jestIt } from '@jest/globals';
 import { createSwapsMockStore } from '../../../test/jest';
 import { CHAIN_IDS } from '../../constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
+import * as envModule from '../environment';
 import {
   getSmartTransactionsOptInStatusForMetrics,
   getCurrentChainSupportsSmartTransactions,
@@ -145,6 +146,32 @@ describe('Selectors', () => {
         };
         const result = getCurrentChainSupportsSmartTransactions(newState);
         expect(result).toBe(false);
+      },
+    );
+
+    jestIt(
+      'should prioritize provided chainId parameter over state chainId',
+      () => {
+        const state = createMockState(); // Has allowed chain ID
+        // Should be false for non-allowed chain ID regardless of state
+        expect(
+          getCurrentChainSupportsSmartTransactions(state, CHAIN_IDS.POLYGON),
+        ).toBe(false);
+
+        const nonSupportedState = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
+          },
+        };
+        // Should be true for allowed chain ID regardless of state
+        expect(
+          getCurrentChainSupportsSmartTransactions(
+            nonSupportedState,
+            CHAIN_IDS.MAINNET,
+          ),
+        ).toBe(true);
       },
     );
   });
@@ -303,6 +330,124 @@ describe('Selectors', () => {
         '36eb02e0-7925-47f0-859f-076608f09b69';
       expect(getSmartTransactionsEnabled(state)).toBe(false);
     });
+
+    jestIt('prioritizes provided chainId parameter over state chainId', () => {
+      const state = createSwapsMockStore(); // Ethereum network (supported)
+
+      // Should be false for Polygon chainId regardless of state
+      expect(getSmartTransactionsEnabled(state, CHAIN_IDS.POLYGON)).toBe(false);
+
+      // Should be true for BSC chainId (supported) regardless of state
+      const polygonState = {
+        ...state,
+        metamask: {
+          ...state.metamask,
+          ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
+        },
+      };
+      expect(getSmartTransactionsEnabled(polygonState, CHAIN_IDS.BSC)).toBe(
+        true,
+      );
+    });
+
+    // RPC URL checking tests
+    jestIt('permits Infura URLs in production for RPC URL checks', () => {
+      jest.spyOn(envModule, 'isProduction').mockReturnValue(true);
+
+      const state = createSwapsMockStore();
+      const newState = {
+        ...state,
+        metamask: {
+          ...state.metamask,
+          ...mockNetworkState({
+            chainId: CHAIN_IDS.MAINNET,
+            rpcUrl: 'https://mainnet.infura.io/v3/some-project-id',
+          }),
+        },
+      };
+
+      expect(getSmartTransactionsEnabled(newState)).toBe(true);
+    });
+
+    jestIt('permits Binance URLs in production for RPC URL checks', () => {
+      jest.spyOn(envModule, 'isProduction').mockReturnValue(true);
+
+      const state = createSwapsMockStore();
+      const newState = {
+        ...state,
+        metamask: {
+          ...state.metamask,
+          ...mockNetworkState({
+            chainId: CHAIN_IDS.BSC,
+            rpcUrl: 'https://bsc-dataseed.binance.org/',
+          }),
+        },
+      };
+
+      expect(getSmartTransactionsEnabled(newState)).toBe(true);
+    });
+
+    jestIt('rejects other URLs in production for RPC URL checks', () => {
+      jest.spyOn(envModule, 'isProduction').mockReturnValue(true);
+
+      const state = createSwapsMockStore();
+      const newState = {
+        ...state,
+        metamask: {
+          ...state.metamask,
+          ...mockNetworkState({
+            chainId: CHAIN_IDS.BSC,
+            rpcUrl: 'https://bsc-dataseed1.defibit.io/',
+          }),
+        },
+      };
+
+      expect(getSmartTransactionsEnabled(newState)).toBe(false);
+    });
+
+    jestIt('allows any URL in non-production for RPC URL checks', () => {
+      jest.spyOn(envModule, 'isProduction').mockReturnValue(false);
+
+      const state = createSwapsMockStore();
+      const newState = {
+        ...state,
+        metamask: {
+          ...state.metamask,
+          ...mockNetworkState({
+            chainId: CHAIN_IDS.BSC,
+            rpcUrl: 'https://some-random-rpc.example.com',
+          }),
+        },
+      };
+
+      expect(getSmartTransactionsEnabled(newState)).toBe(true);
+    });
+
+    jestIt(
+      'prioritizes provided chainId parameter over state chainId for RPC URL checks',
+      () => {
+        jest.spyOn(envModule, 'isProduction').mockReturnValue(false);
+
+        // Set up a state with a chain ID that should be skipped, but a non-acceptable RPC URL
+        const state = createSwapsMockStore();
+        const stateWithCustomRpc = {
+          ...state,
+          metamask: {
+            ...state.metamask,
+            ...mockNetworkState({
+              chainId: CHAIN_IDS.MAINNET,
+              rpcUrl: 'https://some-random-rpc.example.com',
+            }),
+          },
+        };
+
+        // When we pass CHAIN_IDS.BSC which is in the skip list, it should work
+        // regardless of the RPC URL in the state
+        expect(
+          getSmartTransactionsEnabled(stateWithCustomRpc, CHAIN_IDS.BSC),
+        ).toBe(true);
+      },
+    );
   });
 
   describe('getIsSmartTransaction', () => {
@@ -359,6 +504,27 @@ describe('Selectors', () => {
       };
       const result = getIsSmartTransaction(newState);
       expect(result).toBe(false);
+    });
+
+    jestIt('prioritizes provided chainId parameter over state chainId', () => {
+      const state = createMockState(); // Has enabled smart transactions
+
+      // Should be false for non-supported chain ID despite state supporting it
+      expect(getIsSmartTransaction(state, CHAIN_IDS.POLYGON)).toBe(false);
+
+      // Create a state with Polygon (non-supported) chain ID
+      const nonSupportedState = {
+        ...state,
+        metamask: {
+          ...state.metamask,
+          ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
+        },
+      };
+
+      // Should be true for supported chain ID despite state not supporting it
+      expect(getIsSmartTransaction(nonSupportedState, CHAIN_IDS.MAINNET)).toBe(
+        true,
+      );
     });
   });
 });

--- a/shared/modules/selectors/index.test.ts
+++ b/shared/modules/selectors/index.test.ts
@@ -7,7 +7,7 @@ import { mockNetworkState } from '../../../test/stub/networks';
 import * as envModule from '../environment';
 import {
   getSmartTransactionsOptInStatusForMetrics,
-  getCurrentChainSupportsSmartTransactions,
+  getChainSupportsSmartTransactions,
   getSmartTransactionsEnabled,
   getIsSmartTransaction,
   getSmartTransactionsPreferenceEnabled,
@@ -123,12 +123,12 @@ describe('Selectors', () => {
     });
   });
 
-  describe('getCurrentChainSupportsSmartTransactions', () => {
+  describe('getChainSupportsSmartTransactions', () => {
     jestIt(
       'should return true if the chain ID is allowed for smart transactions',
       () => {
         const state = createMockState();
-        const result = getCurrentChainSupportsSmartTransactions(state);
+        const result = getChainSupportsSmartTransactions(state);
         expect(result).toBe(true);
       },
     );
@@ -144,7 +144,7 @@ describe('Selectors', () => {
             ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
           },
         };
-        const result = getCurrentChainSupportsSmartTransactions(newState);
+        const result = getChainSupportsSmartTransactions(newState);
         expect(result).toBe(false);
       },
     );
@@ -155,7 +155,7 @@ describe('Selectors', () => {
         const state = createMockState(); // Has allowed chain ID
         // Should be false for non-allowed chain ID regardless of state
         expect(
-          getCurrentChainSupportsSmartTransactions(state, CHAIN_IDS.POLYGON),
+          getChainSupportsSmartTransactions(state, CHAIN_IDS.POLYGON),
         ).toBe(false);
 
         const nonSupportedState = {
@@ -167,7 +167,7 @@ describe('Selectors', () => {
         };
         // Should be true for allowed chain ID regardless of state
         expect(
-          getCurrentChainSupportsSmartTransactions(
+          getChainSupportsSmartTransactions(
             nonSupportedState,
             CHAIN_IDS.MAINNET,
           ),

--- a/shared/modules/selectors/index.test.ts
+++ b/shared/modules/selectors/index.test.ts
@@ -342,7 +342,13 @@ describe('Selectors', () => {
         ...state,
         metamask: {
           ...state.metamask,
-          ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
+          ...mockNetworkState(
+            { chainId: CHAIN_IDS.POLYGON },
+            {
+              chainId: CHAIN_IDS.BSC,
+              rpcUrl: 'https://bsc-dataseed.binance.org/',
+            },
+          ),
         },
       };
       expect(getSmartTransactionsEnabled(polygonState, CHAIN_IDS.BSC)).toBe(
@@ -517,7 +523,13 @@ describe('Selectors', () => {
         ...state,
         metamask: {
           ...state.metamask,
-          ...mockNetworkState({ chainId: CHAIN_IDS.POLYGON }),
+          ...mockNetworkState(
+            { chainId: CHAIN_IDS.POLYGON },
+            {
+              chainId: CHAIN_IDS.MAINNET,
+              rpcUrl: 'https://mainnet.infura.io/v3/',
+            },
+          ),
         },
       };
 

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -4,9 +4,9 @@ import {
   SKIP_STX_RPC_URL_CHECK_CHAIN_IDS,
 } from '../../constants/smartTransactions';
 import {
-  getCurrentNetwork,
   accountSupportsSmartTx,
   getPreferences,
+  selectDefaultRpcEndpointByChainId,
   // TODO: Remove restricted import
   // eslint-disable-next-line import/no-restricted-paths
 } from '../../../ui/selectors/selectors'; // TODO: Migrate shared selectors to this file.
@@ -149,15 +149,20 @@ const getIsAllowedRpcUrlForSmartTransactions = (
   ) {
     return true;
   }
-  const rpcUrl = getCurrentNetwork(state)?.rpcUrl;
-  if (!rpcUrl) {
-    return false;
-  }
-  const { hostname } = new URL(rpcUrl);
-  if (!hostname) {
-    return false;
-  }
-  return hostname.endsWith('.infura.io') || hostname.endsWith('.binance.org');
+
+  // Get the default RPC endpoint directly for this chain ID
+  const defaultRpcEndpoint = selectDefaultRpcEndpointByChainId(
+    state,
+    effectiveChainId,
+  );
+  const rpcUrl = defaultRpcEndpoint?.url;
+  const hostname = rpcUrl && new URL(rpcUrl).hostname;
+
+  return (
+    hostname?.endsWith('.infura.io') ||
+    hostname?.endsWith('.binance.org') ||
+    false
+  );
 };
 
 export const getSmartTransactionsEnabled = (

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -129,7 +129,7 @@ export const getSmartTransactionsPreferenceEnabled = createSelector(
   },
 );
 
-export const getCurrentChainSupportsSmartTransactions = (
+export const getChainSupportsSmartTransactions = (
   state: NetworkState,
   chainId?: string,
 ): boolean => {
@@ -173,7 +173,7 @@ export const getSmartTransactionsEnabled = (
   const smartTransactionsLiveness =
     state.metamask.smartTransactionsState?.liveness;
   return Boolean(
-    getCurrentChainSupportsSmartTransactions(state, chainId) &&
+    getChainSupportsSmartTransactions(state, chainId) &&
       getIsAllowedRpcUrlForSmartTransactions(state, chainId) &&
       supportedAccount &&
       smartTransactionsFeatureFlagEnabled &&

--- a/ui/pages/confirmations/components/smart-transactions-banner-alert/smart-transactions-banner-alert.tsx
+++ b/ui/pages/confirmations/components/smart-transactions-banner-alert/smart-transactions-banner-alert.tsx
@@ -20,7 +20,7 @@ import {
   getSmartTransactionsMigrationAppliedInternal,
 } from '../../../../../shared/modules/selectors/smart-transactions';
 import {
-  getCurrentChainSupportsSmartTransactions,
+  getChainSupportsSmartTransactions,
   getSmartTransactionsPreferenceEnabled,
 } from '../../../../../shared/modules/selectors';
 
@@ -60,7 +60,7 @@ export const SmartTransactionsBannerAlert: React.FC<SmartTransactionsBannerAlert
     );
 
     const chainSupportsSmartTransactions = useSelector(
-      getCurrentChainSupportsSmartTransactions,
+      getChainSupportsSmartTransactions,
     );
 
     const smartTransactionsPreferenceEnabled = useSelector(

--- a/ui/pages/confirmations/hooks/useSmartTransactionFeatureFlags.ts
+++ b/ui/pages/confirmations/hooks/useSmartTransactionFeatureFlags.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import log from 'loglevel';
 import {
-  getCurrentChainSupportsSmartTransactions,
+  getChainSupportsSmartTransactions,
   getSmartTransactionsPreferenceEnabled,
 } from '../../../../shared/modules/selectors';
 import { fetchSwapsFeatureFlags } from '../../swaps/swaps.util';
@@ -25,7 +25,7 @@ export function useSmartTransactionFeatureFlags() {
   );
 
   const currentChainSupportsSmartTransactions = useSelector(
-    getCurrentChainSupportsSmartTransactions,
+    getChainSupportsSmartTransactions,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## **Description**
When a chainId / networkClientId is available in a transaction, we should prioritise that over the chainId that is selected in a wallet.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31776?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
