### PR TITLE
chore: cp-12.16.0 Add default platform for suggested key

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -20,6 +20,7 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
+        "default": "Alt+Shift+M",
         "windows": "Alt+Shift+M",
         "mac": "Alt+Shift+M",
         "chromeos": "Alt+Shift+M",

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -19,6 +19,7 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
+        "default": "Alt+Shift+M",
         "windows": "Alt+Shift+M",
         "mac": "Alt+Shift+M",
         "chromeos": "Alt+Shift+M",


### PR DESCRIPTION
## **Description**

The `suggested_key` manifest property supports a default, but we haven't set it. This PR adds a default so that the property is compatible with a wider set of platforms.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31812?quickstart=1)

## **Related issues**

N/A

## **Manual testing steps**

* Test that keyboard shortcut still works correctly on on supported browsers (Chrome, Firefox, Edge, and Opera).
* Test that it works on macOS and non-macOS platforms.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
