### PR TITLE
fix: prevents unintended second redirection to activity tab

### DIFF
--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -241,10 +241,15 @@ export default function useSubmitBridgeTransaction() {
     }
     // Route user to activity tab on Home page
     await dispatch(setDefaultHomeActiveTabName('activity'));
-    history.push({
-      pathname: DEFAULT_ROUTE,
-      state: { stayOnHomePage: true },
-    });
+    // Only redirect to activity tab if not on Solana
+    // This avoids an unintended side effect where the user is redirected to the activity tab
+    // after already being redirected from a different flow.
+    if (!isSolana) {
+      history.push({
+        pathname: DEFAULT_ROUTE,
+        state: { stayOnHomePage: true },
+      });
+    }
   };
 
   return {


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Users reported that 'every time when tx is confirmed (probably any tx status update) the extension automatically switches to the Activity tab'. The bridge experience + snap flow is redirecting users to the activity tab twice, so we avoid navigation at the end of the bridge hook if it is within the Solana experience, to avoid this behavior. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31822?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/31341

## **Manual testing steps**

1. Swap on Solana
2. Get redirected to the activity tab
3. Before the transaction shows up, navigate away
4. Observe that you are not pulled back to the Activity tab.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e61c07c8-22d1-43b5-b0ed-ac5c8fd642d6

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/709ee0e0-515a-45d6-aa03-c42927325b41

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
