### PR TITLE
chore: change the ordering for test networks

### DIFF
--- a/shared/modules/network.utils.test.ts
+++ b/shared/modules/network.utils.test.ts
@@ -1,10 +1,14 @@
 import { SolScope, BtcScope, EthScope } from '@metamask/keyring-api';
-import type { MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
+import {
+  toEvmCaipChainId,
+  type MultichainNetworkConfiguration,
+} from '@metamask/multichain-network-controller';
 import {
   type NetworkConfiguration,
   RpcEndpointType,
 } from '@metamask/network-controller';
 import { CaipChainId } from '@metamask/utils';
+import { ChainId } from '@metamask/controller-utils';
 import { MAX_SAFE_CHAIN_ID } from '../constants/network';
 import {
   isSafeChainId,
@@ -14,6 +18,7 @@ import {
   convertCaipToHexChainId,
   sortNetworks,
   getRpcDataByChainId,
+  sortNetworksByPrioity,
 } from './network.utils';
 
 describe('network utils', () => {
@@ -319,6 +324,48 @@ describe('network utils', () => {
       expect(() => getRpcDataByChainId('eip155:2', evmNetworks)).toThrow(
         'Network configuration not found for chain ID: eip155:2 (0x2)',
       );
+    });
+  });
+
+  describe('sortNetworksByPrioity', () => {
+    it('sorts a list of networks based on the predefined priority and following with alphabetical order', () => {
+      const networkB = {
+        chainId: 'eip155:0x123456',
+        name: 'Some Testnet',
+      };
+      const networkA = {
+        chainId: 'eip155:0x12345',
+        name: 'Another Testnet',
+      };
+      const sepolia = {
+        chainId: toEvmCaipChainId(ChainId.sepolia),
+        name: 'Sepolia',
+      };
+      const lineaSepolia = {
+        chainId: toEvmCaipChainId(ChainId['linea-sepolia']),
+        name: 'Linea Sepolia',
+      };
+
+      const networks = [
+        networkB,
+        networkA,
+        sepolia,
+        lineaSepolia,
+      ] as unknown as MultichainNetworkConfiguration[];
+
+      const expectedResult = [
+        sepolia,
+        lineaSepolia,
+        networkA,
+        networkB,
+      ] as unknown as MultichainNetworkConfiguration[];
+
+      const result = sortNetworksByPrioity(networks, [
+        sepolia.chainId,
+        lineaSepolia.chainId,
+      ]);
+
+      expect(result).toStrictEqual(expectedResult);
     });
   });
 });

--- a/shared/modules/network.utils.ts
+++ b/shared/modules/network.utils.ts
@@ -193,3 +193,34 @@ export const getRpcDataByChainId = (
     defaultRpcEndpoint,
   };
 };
+
+/**
+ * Sorts a list of test networks based on the predefined priority.
+ * And then sorts the rest of the networks in alphabetical order.
+ *
+ * @param networks - The networks to sort.
+ * @param priorityList - The list of CAIP Chain IDs to prioritize.
+ * @returns The sorted list of networks.
+ */
+export const sortNetworksByPrioity = (
+  networks: MultichainNetworkConfiguration[],
+  priorityList: CaipChainId[],
+) => {
+  return networks.sort((networkA, networkB) => {
+    const indexA = priorityList.indexOf(networkA.chainId);
+    const indexB = priorityList.indexOf(networkB.chainId);
+
+    if (indexA !== -1 && indexB !== -1) {
+      // if both are in the priority list, networkA will go first then networkB
+      return indexA - indexB;
+    } else if (indexA !== -1) {
+      // if networkA in the priority list and the networkB not in the list, networkA will go first
+      return -1;
+    } else if (indexB !== -1) {
+      // if networkB in the priority list and the networkA not in the list, networkB will go first
+      return 1;
+    }
+    // if both are not in the priority list, sort by name
+    return networkA.name.localeCompare(networkB.name);
+  });
+};

--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -19,13 +19,17 @@ import {
   RpcEndpointType,
   type UpdateNetworkFields,
 } from '@metamask/network-controller';
-import { type MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
+import {
+  toEvmCaipChainId,
+  type MultichainNetworkConfiguration,
+} from '@metamask/multichain-network-controller';
 import {
   type CaipChainId,
   type Hex,
   parseCaipChainId,
   KnownCaipNamespace,
 } from '@metamask/utils';
+import { ChainId } from '@metamask/controller-utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useAccountCreationOnNetworkChange } from '../../../hooks/accounts/useAccountCreationOnNetworkChange';
 import { NetworkListItem } from '../network-list-item';
@@ -104,6 +108,7 @@ import {
   sortNetworks,
   getNetworkIcon,
   getRpcDataByChainId,
+  sortNetworksByPrioity,
 } from '../../../../shared/modules/network.utils';
 import {
   getCompletedOnboarding,
@@ -294,6 +299,14 @@ export const NetworkListMenu = ({ onClose }: { onClose: () => void }) => {
     Object.values(testNetworks),
     searchQuery,
   );
+  // A sorted list of test networks that put Sepolia first then Linea Sepolia at the top
+  // and the rest of the test networks in alphabetical order.
+  const sortedTestNetworks = useMemo(() => {
+    return sortNetworksByPrioity(searchedTestNetworks, [
+      toEvmCaipChainId(ChainId.sepolia),
+      toEvmCaipChainId(ChainId['linea-sepolia']),
+    ]);
+  }, [searchedTestNetworks]);
 
   const handleEvmNetworkChange = (chainId: CaipChainId) => {
     const hexChainId = convertCaipToHexChainId(chainId);
@@ -651,7 +664,7 @@ export const NetworkListMenu = ({ onClose }: { onClose: () => void }) => {
 
               {showTestnets || currentlyOnTestnet ? (
                 <Box className="multichain-network-list-menu">
-                  {searchedTestNetworks.map((network) =>
+                  {sortedTestNetworks.map((network) =>
                     generateMultichainNetworkListItem(network),
                   )}
                 </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Currently there is no specific order for test network
This PR is to adding a custom order with the follow rules
- Sepolia go first,
- then Linea Sepolia 
- then sort the rest of the test networks in alphabetical order


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31827?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open MetaMask Wallet
2. Go to network list
3. Switch on 'Show Test network'
4. The list of the network should display in above order

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="416" alt="image" src="https://github.com/user-attachments/assets/d695d021-c9e1-4f95-b2fe-3e2697ec7f14" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="403" alt="image" src="https://github.com/user-attachments/assets/3160a19c-51a7-4f73-b104-d4612130348f" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
