### PR TITLE
fix: filter NFTs on send flow

### DIFF
--- a/test/e2e/tests/tokens/nft/send-nft.spec.ts
+++ b/test/e2e/tests/tokens/nft/send-nft.spec.ts
@@ -1,0 +1,78 @@
+import {
+  clickNestedButton,
+  openActionMenuAndStartSendFlow,
+  withFixtures,
+} from '../../../helpers';
+import { SMART_CONTRACTS } from '../../../seeder/smart-contracts';
+import FixtureBuilder from '../../../fixture-builder';
+import Homepage from '../../../page-objects/pages/home/homepage';
+import NftListPage from '../../../page-objects/pages/home/nft-list';
+import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
+import { Driver } from '../../../webdriver/driver';
+import HeaderNavbar from '../../../page-objects/pages/header-navbar';
+import { switchToNetworkFlow } from '../../../page-objects/flows/network.flow';
+
+describe('Send NFTs', function () {
+  const smartContract = SMART_CONTRACTS.NFTS;
+
+  it('user should not be able to view ERC721 NFTs in send flow when on wrong network', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder().withNftControllerERC721().build(),
+        smartContract,
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithBalanceValidation(driver);
+        const nftListPage = new NftListPage(driver);
+
+        await new HeaderNavbar(driver).check_currentSelectedNetwork(
+          'Localhost 8545',
+        );
+
+        await new Homepage(driver).goToNftTab();
+
+        await switchToNetworkFlow(driver, 'Ethereum Mainnet');
+        await new HeaderNavbar(driver).check_currentSelectedNetwork(
+          'Ethereum Mainnet',
+        );
+
+        await openActionMenuAndStartSendFlow(driver);
+        await clickNestedButton(driver, 'Account 1');
+        await driver.clickElement('[data-testid="asset-picker-button"]');
+        await clickNestedButton(driver, 'NFTs');
+
+        await nftListPage.check_noNftInfoIsDisplayed();
+      },
+    );
+  });
+
+  it('user should only be able to view ERC721 NFTs on send flow that belong on selected network', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder().withNftControllerERC721().build(),
+        smartContract,
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithBalanceValidation(driver);
+        const nftListPage = new NftListPage(driver);
+
+        await new HeaderNavbar(driver).check_currentSelectedNetwork(
+          'Localhost 8545',
+        );
+
+        await new Homepage(driver).goToNftTab();
+
+        await openActionMenuAndStartSendFlow(driver);
+        await clickNestedButton(driver, 'Account 1');
+        await driver.clickElement('[data-testid="asset-picker-button"]');
+        await clickNestedButton(driver, 'NFTs');
+
+        await nftListPage.check_nftNameIsDisplayed('Test Dapp NFTs #1');
+      },
+    );
+  });
+});

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.test.tsx
@@ -66,7 +66,6 @@ const mockNfts = {
 const mockStore = configureStore([thunk]);
 
 describe('AssetPickerModalNftTab', () => {
-  // Add at the top of describe block
   beforeEach(() => {
     nock('https://mock.api')
       .get('/token/1')

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import nock from 'nock';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import mockState from '../../../../../test/data/mock-state.json';
+import { mockNetworkState } from '../../../../../test/stub/networks';
+import { AssetPickerModalNftTab } from './asset-picker-modal-nft-tab';
+
+jest.mock('../../../../hooks/useGetAssetImageUrl', () => ({
+  __esModule: true,
+  default: () => 'mock-image-url.png',
+}));
+
+const defaultProps = {
+  searchQuery: '',
+  onClose: jest.fn(),
+  renderSearch: jest.fn(),
+};
+
+const mockAccount = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+
+const mockNfts = {
+  [mockAccount]: {
+    [CHAIN_IDS.LINEA_MAINNET]: [
+      {
+        address: '0x123',
+        attributes: [{ key: 'test', value: 'test', kind: 'string' }],
+        image: 'mock-image.png',
+        name: 'Mock NFT #1',
+        standard: 'ERC721',
+        tokenId: '1',
+        isCurrentlyOwned: true,
+        tokenURI: 'https://mock.api/token/1',
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+      },
+      {
+        address: '0x123',
+        attributes: [{ key: 'test', value: 'test', kind: 'string' }],
+        image: 'mock-image.png',
+        name: 'Mock NFT #3',
+        standard: 'ERC721',
+        tokenId: '3',
+        isCurrentlyOwned: true,
+        tokenURI: 'https://mock.api/token/3',
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+      },
+    ],
+    [CHAIN_IDS.MAINNET]: [
+      {
+        address: '0x123',
+        attributes: [{ key: 'test', value: 'test', kind: 'string' }],
+        image: 'mock-image.png',
+        name: 'Mock NFT #2',
+        standard: 'ERC721',
+        tokenId: '2',
+        isCurrentlyOwned: true,
+        tokenURI: 'https://mock.api/token/2',
+        chainId: CHAIN_IDS.MAINNET,
+      },
+    ],
+  },
+};
+
+const mockStore = configureStore([thunk]);
+
+describe('AssetPickerModalNftTab', () => {
+  // Add at the top of describe block
+  beforeEach(() => {
+    nock('https://mock.api')
+      .get('/token/1')
+      .reply(200, { name: 'Mock NFT #1' })
+      .get('/token/2')
+      .reply(200, { name: 'Mock NFT #2' })
+      .get('/token/3')
+      .reply(200, { name: 'Mock NFT #3' });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.clearAllMocks();
+  });
+
+  it('renders modal with mainnet NFTs when mainnet is selected', () => {
+    const mainnetStore = mockStore({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+        allNfts: mockNfts,
+      },
+    });
+    const { getByText, getAllByTestId } = renderWithProvider(
+      <AssetPickerModalNftTab {...defaultProps} />,
+      mainnetStore,
+    );
+
+    const nftItems = getAllByTestId('nft-item');
+
+    const expectedNftItemTitle = getByText('Mock NFT #2');
+
+    expect(nftItems).toHaveLength(1);
+    expect(expectedNftItemTitle).toBeInTheDocument();
+  });
+
+  it('renders modal with Linea network NFTs when Linea is selected', () => {
+    const lineaStore = mockStore({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        ...mockNetworkState({ chainId: CHAIN_IDS.LINEA_MAINNET }),
+        allNfts: mockNfts,
+      },
+    });
+
+    const { getAllByTestId } = renderWithProvider(
+      <AssetPickerModalNftTab {...defaultProps} />,
+      lineaStore,
+    );
+
+    const nftItems = getAllByTestId('nft-item');
+    expect(nftItems).toHaveLength(2);
+  });
+});

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.tsx
@@ -66,7 +66,9 @@ export function AssetPickerModalNftTab({
     getNftIsStillFetchingIndication,
   );
 
-  const { currentlyOwnedNfts } = useNfts();
+  const { currentlyOwnedNfts } = useNfts({
+    overridePopularNetworkFilter: true,
+  });
   const trackEvent = useContext(MetaMetricsContext);
   const sendAnalytics = useSelector(getSendAnalyticProperties);
 

--- a/ui/hooks/useNfts.ts
+++ b/ui/hooks/useNfts.ts
@@ -12,7 +12,11 @@ import { NFT } from '../components/multichain/asset-picker-amount/asset-picker-m
 import { usePrevious } from './usePrevious';
 import { useI18nContext } from './useI18nContext';
 
-export function useNfts() {
+export function useNfts({
+  overridePopularNetworkFilter = false,
+}: {
+  overridePopularNetworkFilter?: boolean;
+} = {}) {
   const t = useI18nContext();
 
   const allUserNfts = useSelector(getAllNfts);
@@ -26,10 +30,16 @@ export function useNfts() {
   );
 
   const nfts = useMemo(() => {
-    return isTokenNetworkFilterEqualCurrentNetwork
+    return isTokenNetworkFilterEqualCurrentNetwork ||
+      overridePopularNetworkFilter
       ? allUserNfts?.[chainId] ?? []
       : allUserNfts;
-  }, [isTokenNetworkFilterEqualCurrentNetwork, allUserNfts, chainId]);
+  }, [
+    isTokenNetworkFilterEqualCurrentNetwork,
+    allUserNfts,
+    chainId,
+    overridePopularNetworkFilter,
+  ]);
 
   const nftContracts = useSelector(getNftContracts);
 


### PR DESCRIPTION
## **Description**

Fixes a bug introduced into 12.16.0 RC

Bug was that users could enter into a state where they could send NFTs on a different network than they belonged on. This is because we are now showing NFTs across all chains that a user has NFTs on, rather than the constrained to the GNS currentChain. 

Users could enter into NFT send flow in two ways:

1. Via the NFT detail screen. We proactively change the network on the users behalf if they enter the send flow this way (press Send from the detail screen of a NFT from a different chain)

2. Via the Send button on the main NFT Grid view. This is where the bug was caught. When entering into the send flow in this way, users could enter into a state where they could accidentally send an NFT on a different chain than intended.

View recording below to visualize this difference.

This fix filters out NFTs in the second flow so that they only ever show NFTs from the globally selected chain.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31850?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/31858

## **Manual testing steps**

1. Add account with NFTs on a network
2. Enter into Send flow as specified in flow 2
3. NFTs should only be listed on network that they are on.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/b35ec707-fe42-4212-8343-446a048758fc

### **After**

https://github.com/user-attachments/assets/eafe05fd-9950-4446-b79e-0d5773e724d1

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
