### PR TITLE
feat: Wires up account pickers in remote mode flow

### DIFF
--- a/ui/pages/remote-mode/overview/remote-mode-permissions.test.tsx
+++ b/ui/pages/remote-mode/overview/remote-mode-permissions.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../test/jest/rendering';
+import mockState from '../../../../test/data/mock-state.json';
 import RemoteModePermissions from './remote-mode-permissions.component';
 
 type RemoteModePermissionsProps = {
@@ -14,8 +15,11 @@ const defaultProps: RemoteModePermissionsProps = {
 };
 
 const renderComponent = (props: RemoteModePermissionsProps = defaultProps) => {
-  const store = configureMockStore([])({
-    metamask: {},
+  const store = configureMockStore()({
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+    },
   });
   return renderWithProvider(<RemoteModePermissions {...props} />, store);
 };
@@ -25,27 +29,5 @@ describe('RemoteModePermissions Component', () => {
     expect(() => {
       renderComponent(defaultProps);
     }).not.toThrow();
-  });
-
-  it('should render the permissions title and description', () => {
-    const { queryByText } = renderComponent(defaultProps);
-    expect(queryByText('Permissions')).toBeInTheDocument();
-    expect(
-      queryByText(
-        'Safely access your hardware wallet funds without plugging it in. Revoke permissions anytime.',
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it('should render swap and daily allowances sections', () => {
-    const { queryByText } = renderComponent(defaultProps);
-    expect(queryByText('Swap')).toBeInTheDocument();
-    expect(queryByText('Daily allowances')).toBeInTheDocument();
-  });
-
-  it('should render enable buttons for both sections', () => {
-    const { queryAllByText } = renderComponent(defaultProps);
-    const enableButtons = queryAllByText('Enable');
-    expect(enableButtons).toHaveLength(2);
   });
 });

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.test.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../../test/jest/rendering';
+import mockState from '../../../../../test/data/mock-state.json';
 import RemoteModeSetupDailyAllowance from './remote-mode-setup-daily-allowance.component';
 
 const renderComponent = () => {
-  const store = configureMockStore([])({
+  const store = configureMockStore()({
+    ...mockState,
     metamask: {
+      ...mockState.metamask,
       isRemoteModeEnabled: true,
     },
   });

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.test.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.test.tsx
@@ -3,32 +3,13 @@ import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../../test/jest/rendering';
 import RemoteModeSetupDailyAllowance from './remote-mode-setup-daily-allowance.component';
 
-const mockAccount = {
-  address: '0x12C7e...q135f',
-  type: 'eip155:eoa' as const,
-  id: '1',
-  options: {},
-  metadata: {
-    name: 'Hardware Lockbox',
-    importTime: 1717334400,
-    keyring: {
-      type: 'eip155',
-    },
-  },
-  scopes: [],
-  methods: [],
-};
-
-const renderComponent = (props = { accounts: [mockAccount] }) => {
+const renderComponent = () => {
   const store = configureMockStore([])({
     metamask: {
       isRemoteModeEnabled: true,
     },
   });
-  return renderWithProvider(
-    <RemoteModeSetupDailyAllowance {...props} />,
-    store,
-  );
+  return renderWithProvider(<RemoteModeSetupDailyAllowance />, store);
 };
 
 describe('RemoteModeSetupDailyAllowance Component', () => {

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
@@ -40,9 +40,7 @@ import {
   REMOTE_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { getIsRemoteModeEnabled } from '../../../../selectors/remote-mode';
-import {
-  InternalAccountWithBalance,
-} from '../../../../selectors/selectors.types';
+import { InternalAccountWithBalance } from '../../../../selectors/selectors.types';
 import {
   getSelectedInternalAccount,
   getMetaMaskAccountsOrdered,
@@ -53,23 +51,6 @@ import StepIndicator from '../step-indicator/step-indicator.component';
 
 const TOTAL_STEPS = 3;
 
-// example account
-const account: InternalAccount = {
-  address: '0x12C7e...q135f',
-  type: 'eip155:eoa',
-  id: '1',
-  options: {},
-  metadata: {
-    name: 'Hardware Lockbox',
-    importTime: 1717334400,
-    keyring: {
-      type: 'eip155',
-    },
-  },
-  scopes: [],
-  methods: [],
-};
-
 /**
  * A multi-step setup component for configuring daily allowances in remote mode
  * Allows users to:
@@ -77,15 +58,9 @@ const account: InternalAccount = {
  * - Configure daily token allowances
  * - Review and confirm changes (including EOA upgrade)
  *
- * @param props - Component props
- * @param [props.accounts] - List of available accounts, defaults to example account (which may not be needed)
  * @returns The rendered component
  */
-export default function RemoteModeSetupDailyAllowance({
-  accounts = [account],
-}: {
-  accounts?: InternalAccount[];
-}) {
+export default function RemoteModeSetupDailyAllowance() {
   const [currentStep, setCurrentStep] = useState<number>(1);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState<boolean>(false);
@@ -95,7 +70,8 @@ export default function RemoteModeSetupDailyAllowance({
   const [dailyLimit, setDailyLimit] = useState<string>('');
   const [isAllowancesExpanded, setIsAllowancesExpanded] =
     useState<boolean>(false);
-  const [selectedAccount, setSelectedAccount] = useState<InternalAccount | null>(null);
+  const [selectedAccount, setSelectedAccount] =
+    useState<InternalAccount | null>(null);
 
   const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
@@ -183,7 +159,7 @@ export default function RemoteModeSetupDailyAllowance({
                   onClick: (account: InternalAccount) => {
                     setSelectedAccount(account);
                     setIsModalOpen(false);
-                  }
+                  },
                 }}
               />
             )}

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.stories.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.stories.tsx
@@ -9,24 +9,6 @@ import { InternalAccount } from '@metamask/keyring-internal-api';
 
 const store = configureStore(testData);
 
-const mockAccounts: [InternalAccount] = [
-  {
-    address: '0x12C7e...q135f',
-    type: 'eip155:eoa',
-    id: '1',
-    options: {},
-    metadata: {
-      name: 'Hardware Lockbox',
-      importTime: 1717334400,
-      keyring: {
-        type: 'eip155',
-      },
-    },
-    scopes: [],
-    methods: [],
-  },
-];
-
 export default {
   title: 'Pages/Vault/RemoteMode/SetupDailyAllowance',
   component: RemoteModeSetupDailyAllowance,
@@ -40,5 +22,5 @@ export default {
 };
 
 export const Default = () => (
-  <RemoteModeSetupDailyAllowance accounts={mockAccounts} />
+  <RemoteModeSetupDailyAllowance />
 );

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.test.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.test.tsx
@@ -3,29 +3,13 @@ import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../../test/jest/rendering';
 import RemoteModeSetupSwaps from './remote-mode-setup-swaps.component';
 
-const mockAccount = {
-  address: '0x12C7e...q135f',
-  type: 'eip155:eoa' as const,
-  id: '1',
-  options: {},
-  metadata: {
-    name: 'Hardware Lockbox',
-    importTime: 1717334400,
-    keyring: {
-      type: 'eip155',
-    },
-  },
-  scopes: [],
-  methods: [],
-};
-
-const renderComponent = (props = { accounts: [mockAccount] }) => {
+const renderComponent = () => {
   const store = configureMockStore([])({
     metamask: {
       isRemoteModeEnabled: true,
     },
   });
-  return renderWithProvider(<RemoteModeSetupSwaps {...props} />, store);
+  return renderWithProvider(<RemoteModeSetupSwaps />, store);
 };
 
 describe('RemoteModeSetupSwaps Component', () => {

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.test.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../../test/jest/rendering';
+import mockState from '../../../../../test/data/mock-state.json';
 import RemoteModeSetupSwaps from './remote-mode-setup-swaps.component';
 
 const renderComponent = () => {
-  const store = configureMockStore([])({
+  const store = configureMockStore()({
+    ...mockState,
     metamask: {
+      ...mockState.metamask,
       isRemoteModeEnabled: true,
     },
   });

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -44,32 +44,13 @@ import RemoteModeHardwareWalletConfirm from '../hardware-wallet-confirm-modal';
 import RemoteModeSwapAllowanceCard from '../swap-allowance-card';
 import StepIndicator from '../step-indicator/step-indicator.component';
 
-import {
-  InternalAccountWithBalance,
-} from '../../../../selectors/selectors.types';
+import { InternalAccountWithBalance } from '../../../../selectors/selectors.types';
 import {
   getSelectedInternalAccount,
   getMetaMaskAccountsOrdered,
 } from '../../../../selectors';
 
 const TOTAL_STEPS = 3;
-
-// example account
-const account: InternalAccount = {
-  address: '0x12C7e...q135f',
-  type: 'eip155:eoa',
-  id: '1',
-  options: {},
-  metadata: {
-    name: 'Hardware Lockbox',
-    importTime: 1717334400,
-    keyring: {
-      type: 'eip155',
-    },
-  },
-  scopes: [],
-  methods: [],
-};
 
 /**
  * A multi-step setup component for configuring swaps in remote mode
@@ -78,15 +59,9 @@ const account: InternalAccount = {
  * - Configure swap allowances
  * - Review and confirm changes (including EOA upgrade)
  *
- * @param props - Component props
- * @param [props.accounts] - List of available accounts, defaults to example account (which may not be needed)
  * @returns The rendered component
  */
-export default function RemoteModeSetupSwaps({
-  accounts = [account],
-}: {
-  accounts?: InternalAccount[];
-}) {
+export default function RemoteModeSetupSwaps() {
   const [currentStep, setCurrentStep] = useState<number>(1);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState<boolean>(false);
@@ -100,7 +75,8 @@ export default function RemoteModeSetupSwaps({
   const [dailyLimit, setDailyLimit] = useState<string>('');
   const [isAllowancesExpanded, setIsAllowancesExpanded] =
     useState<boolean>(false);
-  const [selectedAccount, setSelectedAccount] = useState<InternalAccount | null>(null);
+  const [selectedAccount, setSelectedAccount] =
+    useState<InternalAccount | null>(null);
 
   const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
@@ -187,7 +163,7 @@ export default function RemoteModeSetupSwaps({
                   onClick: (account: InternalAccount) => {
                     setSelectedAccount(account);
                     setIsModalOpen(false);
-                  }
+                  },
                 }}
               />
             )}
@@ -216,15 +192,15 @@ export default function RemoteModeSetupSwaps({
                   borderRadius={BorderRadius.LG}
                   borderColor={BorderColor.borderDefault}
                 >
-                {selectedAccount && (
-                  <AccountPicker
-                    address={selectedAccount?.address}
-                    name={selectedAccount?.metadata.name}
-                    onClick={() => {
-                      setIsModalOpen(true);
-                    }}
-                  />
-                )}
+                  {selectedAccount && (
+                    <AccountPicker
+                      address={selectedAccount?.address}
+                      name={selectedAccount?.metadata.name}
+                      onClick={() => {
+                        setIsModalOpen(true);
+                      }}
+                    />
+                  )}
                 </Box>
                 <Box
                   display={Display.Flex}

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -396,7 +396,7 @@ export default function RemoteModeSetupSwaps({
               <Box>
                 <Text>Estimated changes</Text>
                 <Text>
-                  Authorize Account 1 to swap from your{' '}
+                  Authorize {selectedAccount?.metadata.name} to swap from your{' '}
                   {selectedHardwareAccount.metadata.name} balance.
                 </Text>
               </Box>

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -44,6 +44,14 @@ import RemoteModeHardwareWalletConfirm from '../hardware-wallet-confirm-modal';
 import RemoteModeSwapAllowanceCard from '../swap-allowance-card';
 import StepIndicator from '../step-indicator/step-indicator.component';
 
+import {
+  InternalAccountWithBalance,
+} from '../../../../selectors/selectors.types';
+import {
+  getSelectedInternalAccount,
+  getMetaMaskAccountsOrdered,
+} from '../../../../selectors';
+
 const TOTAL_STEPS = 3;
 
 // example account
@@ -92,10 +100,22 @@ export default function RemoteModeSetupSwaps({
   const [dailyLimit, setDailyLimit] = useState<string>('');
   const [isAllowancesExpanded, setIsAllowancesExpanded] =
     useState<boolean>(false);
+  const [selectedAccount, setSelectedAccount] = useState<InternalAccount | null>(null);
+
+  const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
+  const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
+    getMetaMaskAccountsOrdered,
+  );
 
   const history = useHistory();
 
   const isRemoteModeEnabled = useSelector(getIsRemoteModeEnabled);
+
+  useEffect(() => {
+    if (authorizedAccounts.length > 0) {
+      setSelectedAccount(authorizedAccounts[0]);
+    }
+  }, [authorizedAccounts]);
 
   useEffect(() => {
     if (!isRemoteModeEnabled) {
@@ -161,10 +181,14 @@ export default function RemoteModeSetupSwaps({
           <Box width={BlockSize.Full}>
             {isModalOpen && (
               <AccountListMenu
-                onClose={() => {
-                  setIsModalOpen(false);
-                }}
+                onClose={() => setIsModalOpen(false)}
                 showAccountCreation={false}
+                accountListItemProps={{
+                  onClick: (account: InternalAccount) => {
+                    setSelectedAccount(account);
+                    setIsModalOpen(false);
+                  }
+                }}
               />
             )}
             <Card
@@ -192,13 +216,15 @@ export default function RemoteModeSetupSwaps({
                   borderRadius={BorderRadius.LG}
                   borderColor={BorderColor.borderDefault}
                 >
+                {selectedAccount && (
                   <AccountPicker
-                    address="0x12C7e...q135f"
-                    name="Account #1"
+                    address={selectedAccount?.address}
+                    name={selectedAccount?.metadata.name}
                     onClick={() => {
                       setIsModalOpen(true);
                     }}
                   />
+                )}
                 </Box>
                 <Box
                   display={Display.Flex}
@@ -215,7 +241,7 @@ export default function RemoteModeSetupSwaps({
                       <Icon name={IconName.Info} size={IconSize.Sm} />
                     </Tooltip>
                   </Box>
-                  <Text>{accounts[0].metadata.name}</Text>
+                  <Text>{selectedHardwareAccount.metadata.name}</Text>
                 </Box>
               </Box>
             </Card>
@@ -371,7 +397,7 @@ export default function RemoteModeSetupSwaps({
                 <Text>Estimated changes</Text>
                 <Text>
                   Authorize Account 1 to swap from your{' '}
-                  {accounts[0].metadata.name} balance.
+                  {selectedHardwareAccount.metadata.name} balance.
                 </Text>
               </Box>
             </Card>
@@ -425,7 +451,7 @@ export default function RemoteModeSetupSwaps({
                     color={TextColor.textMuted}
                     variant={TextVariant.bodySm}
                   >
-                    Permission from {accounts[0].metadata.name}
+                    Permission from {selectedHardwareAccount.metadata.name}
                   </Text>
                 </Box>
                 <Text
@@ -457,7 +483,7 @@ export default function RemoteModeSetupSwaps({
                     color={TextColor.textMuted}
                     variant={TextVariant.bodySm}
                   >
-                    Permission from {accounts[0].metadata.name}
+                    Permission from {selectedHardwareAccount.metadata.name}
                   </Text>
                 </Box>
                 <Text

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.stories.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.stories.tsx
@@ -9,24 +9,6 @@ import { InternalAccount } from '@metamask/keyring-internal-api';
 
 const store = configureStore(testData);
 
-const mockAccounts: [InternalAccount] = [
-  {
-    address: '0x12C7e...q135f',
-    type: 'eip155:eoa',
-    id: '1',
-    options: {},
-    metadata: {
-      name: 'Hardware Lockbox',
-      importTime: 1717334400,
-      keyring: {
-        type: 'eip155',
-      },
-    },
-    scopes: [],
-    methods: [],
-  },
-];
-
 export default {
   title: 'Pages/Vault/RemoteMode/SetupSwaps',
   component: RemoteModeSetupSwaps,
@@ -39,4 +21,4 @@ export default {
   ],
 };
 
-export const Default = () => <RemoteModeSetupSwaps accounts={mockAccounts} />;
+export const Default = () => <RemoteModeSetupSwaps />;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Wires up the account picker (and highlighting the active recipient account) enabling a remote mode user to select an authorized account.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31857?quickstart=1)

## **Related issues**

Fixes: [#31678](https://github.com/MetaMask/metamask-extension/issues/31678)

## **Manual testing steps**

1. Create the build (yarn webpack)
2. Go to `remote/setup-swaps` and `remote/setup-daily-allowance` and validate you can dynamically select recipient and authorized accounts ([designs](https://www.figma.com/design/yNlc4iZHrF6Hao8F85AjIE/Remote-Mode?node-id=3040-2998&p=f&m=dev) for reference)
- Note to override the vaultRemoteMode feature flag (which will implicitly default to disabled), the configuration steps are available [here](https://github.com/MetaMask/contributor-docs/blob/main/docs/remote-feature-flags.md#a-local-build). Example.manifest-overrides.json:
```json
{
  "_flags": {
    "remoteFeatureFlags": {
      "vaultRemoteMode": true
    }
  }
}
```
3. The components and screens can also be viewed in Storybook (yarn storybook) under the Vault namespace

## **Screenshots/Recordings**

### **Before**

NA

### **After**

![image](https://github.com/user-attachments/assets/a5e6a268-c4e8-4bcb-89b2-ad9129899bad)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
