### PR TITLE
fix: Use DS buttons for `PageContainerFooter`

### DIFF
--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -40,6 +40,10 @@ describe('Test Snap manageState', function () {
           text: 'Connect',
           tag: 'button',
         });
+
+        // click and dismiss possible scroll element
+        await driver.clickElementSafe('[data-testid="snap-install-scroll"]');
+
         await driver.clickElement({
           text: 'Connect',
           tag: 'button',
@@ -184,6 +188,10 @@ describe('Test Snap manageState', function () {
           text: 'Connect',
           tag: 'button',
         });
+
+        // click and dismiss possible scroll element
+        await driver.clickElementSafe('[data-testid="snap-install-scroll"]');
+
         await driver.clickElement({
           text: 'Connect',
           tag: 'button',

--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -41,9 +41,6 @@ describe('Test Snap manageState', function () {
           tag: 'button',
         });
 
-        // click and dismiss possible scroll element
-        await driver.clickElementSafe('[data-testid="snap-install-scroll"]');
-
         await driver.clickElement({
           text: 'Connect',
           tag: 'button',
@@ -51,6 +48,10 @@ describe('Test Snap manageState', function () {
 
         // wait for and click confirm
         await driver.waitForSelector({ text: 'Confirm' });
+
+        // click and dismiss possible scroll element
+        await driver.clickElementSafe('[data-testid="snap-install-scroll"]');
+
         await driver.clickElement({
           text: 'Confirm',
           tag: 'button',
@@ -189,9 +190,6 @@ describe('Test Snap manageState', function () {
           tag: 'button',
         });
 
-        // click and dismiss possible scroll element
-        await driver.clickElementSafe('[data-testid="snap-install-scroll"]');
-
         await driver.clickElement({
           text: 'Connect',
           tag: 'button',
@@ -199,6 +197,10 @@ describe('Test Snap manageState', function () {
 
         // wait for and click confirm
         await driver.waitForSelector({ text: 'Confirm' });
+
+        // click and dismiss possible scroll element
+        await driver.clickElementSafe('[data-testid="snap-install-scroll"]');
+
         await driver.clickElement({
           text: 'Confirm',
           tag: 'button',

--- a/ui/components/app/permission-page-container/permission-page-container-footer.component.tsx
+++ b/ui/components/app/permission-page-container/permission-page-container-footer.component.tsx
@@ -26,7 +26,6 @@ export const PermissionPageContainerFooter = ({
       cancelText={cancelText}
       onSubmit={hasAlerts ? showAlertsModal : onSubmit}
       submitText={t('confirm')}
-      buttonSizeLarge={false}
       disabled={disabled}
       submitButtonIcon={
         hasAlerts ? <Icon name={IconName.Info} size={IconSize.Sm} /> : undefined

--- a/ui/components/app/permission-page-container/permission-page-container-footer.component.tsx
+++ b/ui/components/app/permission-page-container/permission-page-container-footer.component.tsx
@@ -28,7 +28,7 @@ export const PermissionPageContainerFooter = ({
       submitText={t('confirm')}
       disabled={disabled}
       submitButtonIcon={
-        hasAlerts ? <Icon name={IconName.Info} size={IconSize.Sm} /> : undefined
+        hasAlerts ? IconName.Info : undefined
       }
     />
   );

--- a/ui/components/app/permission-page-container/permission-page-container-footer.component.tsx
+++ b/ui/components/app/permission-page-container/permission-page-container-footer.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTemplateAlertContext } from '../../../pages/confirmations/confirmation/alerts/TemplateAlertContext';
-import { Icon, IconName, IconSize } from '../../component-library';
+import { IconName } from '../../component-library';
 import { PageContainerFooter } from '../../ui/page-container';
 
 export const PermissionPageContainerFooter = ({
@@ -27,9 +27,7 @@ export const PermissionPageContainerFooter = ({
       onSubmit={hasAlerts ? showAlertsModal : onSubmit}
       submitText={t('confirm')}
       disabled={disabled}
-      submitButtonIcon={
-        hasAlerts ? IconName.Info : undefined
-      }
+      submitButtonIcon={hasAlerts ? IconName.Info : undefined}
     />
   );
 };

--- a/ui/components/ui/page-container/page-container-footer/__snapshots__/page-container-footer.component.test.js.snap
+++ b/ui/components/ui/page-container/page-container-footer/__snapshots__/page-container-footer.component.test.js.snap
@@ -7,14 +7,15 @@ exports[`Page Footer should match snapshot 1`] = `
   >
     <footer>
       <button
-        class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
+        class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
         data-testid="page-container-footer-cancel"
       >
         Cancel
       </button>
       <button
-        class="button btn--rounded btn-default page-container__footer-button"
+        class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
         data-testid="page-container-footer-next"
+        data-theme="light"
       >
         Submit
       </button>
@@ -30,14 +31,15 @@ exports[`Page Footer should render a secondary footer inside page-container__foo
   >
     <footer>
       <button
-        class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
+        class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
         data-testid="page-container-footer-cancel"
       >
         [cancel]
       </button>
       <button
-        class="button btn--rounded btn-primary page-container__footer-button"
+        class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
         data-testid="page-container-footer-next"
+        data-theme="light"
       >
         [next]
       </button>

--- a/ui/components/ui/page-container/page-container-footer/page-container-footer.component.js
+++ b/ui/components/ui/page-container/page-container-footer/page-container-footer.component.js
@@ -43,6 +43,11 @@ export default class PageContainerFooter extends Component {
       submitButtonIcon,
     } = this.props;
 
+    const submitVariant =
+    submitButtonType === 'confirm'
+      ? ButtonVariant.Primary
+      : submitButtonType;
+
     const cancelVariant =
       cancelButtonType === 'default'
         ? ButtonVariant.Secondary
@@ -70,7 +75,7 @@ export default class PageContainerFooter extends Component {
 
           <Button
             size={ButtonSize.Lg}
-            variant={submitButtonType ?? ButtonVariant.Primary}
+            variant={submitVariant ?? ButtonVariant.Primary}
             className={classnames(
               'page-container__footer-button',
               footerButtonClassName,
@@ -78,7 +83,7 @@ export default class PageContainerFooter extends Component {
             disabled={disabled}
             onClick={(e) => onSubmit(e)}
             data-testid="page-container-footer-next"
-            icon={submitButtonIcon}
+            startIconName={submitButtonIcon}
             block
           >
             {submitText || this.context.t('next')}

--- a/ui/components/ui/page-container/page-container-footer/page-container-footer.component.js
+++ b/ui/components/ui/page-container/page-container-footer/page-container-footer.component.js
@@ -44,9 +44,7 @@ export default class PageContainerFooter extends Component {
     } = this.props;
 
     const submitVariant =
-    submitButtonType === 'confirm'
-      ? ButtonVariant.Primary
-      : submitButtonType;
+      submitButtonType === 'confirm' ? ButtonVariant.Primary : submitButtonType;
 
     const cancelVariant =
       cancelButtonType === 'default'

--- a/ui/components/ui/page-container/page-container-footer/page-container-footer.component.js
+++ b/ui/components/ui/page-container/page-container-footer/page-container-footer.component.js
@@ -1,7 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Button from '../../button';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../component-library/button';
 
 export default class PageContainerFooter extends Component {
   static propTypes = {
@@ -14,7 +18,6 @@ export default class PageContainerFooter extends Component {
     disabled: PropTypes.bool,
     submitButtonType: PropTypes.string,
     hideCancel: PropTypes.bool,
-    buttonSizeLarge: PropTypes.bool,
     footerClassName: PropTypes.string,
     footerButtonClassName: PropTypes.string,
     submitButtonIcon: PropTypes.string,
@@ -35,19 +38,23 @@ export default class PageContainerFooter extends Component {
       submitButtonType,
       hideCancel,
       cancelButtonType,
-      buttonSizeLarge = false,
       footerClassName,
       footerButtonClassName,
       submitButtonIcon,
     } = this.props;
+
+    const cancelVariant =
+      cancelButtonType === 'default'
+        ? ButtonVariant.Secondary
+        : cancelButtonType;
 
     return (
       <div className={classnames('page-container__footer', footerClassName)}>
         <footer>
           {!hideCancel && (
             <Button
-              type={cancelButtonType || 'secondary'}
-              large={buttonSizeLarge}
+              size={ButtonSize.Lg}
+              variant={cancelVariant ?? ButtonVariant.Secondary}
               className={classnames(
                 'page-container__footer-button',
                 'page-container__footer-button__cancel',
@@ -55,14 +62,15 @@ export default class PageContainerFooter extends Component {
               )}
               onClick={(e) => onCancel(e)}
               data-testid="page-container-footer-cancel"
+              block
             >
               {cancelText || this.context.t('cancel')}
             </Button>
           )}
 
           <Button
-            type={submitButtonType || 'primary'}
-            large={buttonSizeLarge}
+            size={ButtonSize.Lg}
+            variant={submitButtonType ?? ButtonVariant.Primary}
             className={classnames(
               'page-container__footer-button',
               footerButtonClassName,
@@ -71,6 +79,7 @@ export default class PageContainerFooter extends Component {
             onClick={(e) => onSubmit(e)}
             data-testid="page-container-footer-next"
             icon={submitButtonIcon}
+            block
           >
             {submitText || this.context.t('next')}
           </Button>

--- a/ui/components/ui/page-container/page-container-footer/page-container-footer.component.test.js
+++ b/ui/components/ui/page-container/page-container-footer/page-container-footer.component.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 
 import { renderWithProvider } from '../../../../../test/lib/render-helpers';
-import { Icon, IconName } from '../../../component-library';
+import { IconName } from '../../../component-library';
 import PageFooter from '.';
 
 describe('Page Footer', () => {
@@ -56,10 +56,7 @@ describe('Page Footer', () => {
 
     it('renders submitButtonIcon if passed', () => {
       const { container } = renderWithProvider(
-        <PageFooter
-          {...props}
-          submitButtonIcon={IconName.Add}
-        />,
+        <PageFooter {...props} submitButtonIcon={IconName.Add} />,
       );
 
       expect(container.querySelector('.mm-icon')).toBeInTheDocument();

--- a/ui/components/ui/page-container/page-container-footer/page-container-footer.component.test.js
+++ b/ui/components/ui/page-container/page-container-footer/page-container-footer.component.test.js
@@ -54,38 +54,15 @@ describe('Page Footer', () => {
       expect(props.onSubmit).toHaveBeenCalled();
     });
 
-    it('has danger class defined if type is danger', () => {
-      const { queryByTestId } = renderWithProvider(
-        <PageFooter {...props} submitButtonType="danger" />,
-      );
-
-      const submitButton = queryByTestId('page-container-footer-next');
-
-      expect(submitButton.className).toContain('danger');
-    });
-
-    it('has danger-primary class defined if type is danger-primary', () => {
-      const { queryByTestId } = renderWithProvider(
-        <PageFooter {...props} submitButtonType="danger-primary" />,
-      );
-
-      const submitButton = queryByTestId('page-container-footer-next');
-
-      console.log(submitButton.className);
-      expect(submitButton.className).toContain('danger-primary');
-    });
-
     it('renders submitButtonIcon if passed', () => {
-      const { getByTestId } = renderWithProvider(
+      const { container } = renderWithProvider(
         <PageFooter
           {...props}
-          submitButtonIcon={
-            <Icon name={IconName.Add} data-testid="icon-test-id" />
-          }
+          submitButtonIcon={IconName.Add}
         />,
       );
 
-      expect(getByTestId('icon-test-id')).toBeInTheDocument();
+      expect(container.querySelector('.mm-icon')).toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -206,14 +206,15 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
         >
           <footer>
             <button
-              class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
+              class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
               data-testid="page-container-footer-cancel"
             >
               Cancel
             </button>
             <button
-              class="button btn--rounded btn-primary page-container__footer-button"
+              class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
               data-testid="page-container-footer-next"
+              data-theme="light"
             >
               Add NFT
             </button>
@@ -421,14 +422,15 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
       >
         <footer>
           <button
-            class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
+            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
             data-testid="page-container-footer-cancel"
           >
             Cancel
           </button>
           <button
-            class="button btn--rounded btn-primary page-container__footer-button"
+            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
             data-testid="page-container-footer-next"
+            data-theme="light"
           >
             Add NFT
           </button>

--- a/ui/pages/confirm-decrypt-message/__snapshots__/confirm-decrypt-message.component.test.js.snap
+++ b/ui/pages/confirm-decrypt-message/__snapshots__/confirm-decrypt-message.component.test.js.snap
@@ -173,14 +173,15 @@ exports[`ConfirmDecryptMessage Component matches snapshot 1`] = `
     >
       <footer>
         <button
-          class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
           data-testid="page-container-footer-cancel"
         >
           Cancel
         </button>
         <button
-          class="button btn--rounded btn-primary page-container__footer-button"
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
           data-testid="page-container-footer-next"
+          data-theme="light"
         >
           Decrypt
         </button>
@@ -365,14 +366,15 @@ exports[`ConfirmDecryptMessage Component shows error on decrypt inline error 1`]
     >
       <footer>
         <button
-          class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
           data-testid="page-container-footer-cancel"
         >
           Cancel
         </button>
         <button
-          class="button btn--rounded btn-primary page-container__footer-button"
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
           data-testid="page-container-footer-next"
+          data-theme="light"
         >
           Decrypt
         </button>
@@ -581,14 +583,15 @@ exports[`ConfirmDecryptMessage Component shows the correct message data 1`] = `
     >
       <footer>
         <button
-          class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
           data-testid="page-container-footer-cancel"
         >
           Cancel
         </button>
         <button
-          class="button btn--rounded btn-primary page-container__footer-button"
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
           data-testid="page-container-footer-next"
+          data-theme="light"
         >
           Decrypt
         </button>

--- a/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
+++ b/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
@@ -229,14 +229,15 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
     >
       <footer>
         <button
-          class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
           data-testid="page-container-footer-cancel"
         >
           Cancel
         </button>
         <button
-          class="button btn--rounded btn-primary page-container__footer-button"
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
           data-testid="page-container-footer-next"
+          data-theme="light"
         >
           Provide
         </button>

--- a/ui/pages/permissions-connect/permissions-connect.stories.js
+++ b/ui/pages/permissions-connect/permissions-connect.stories.js
@@ -81,7 +81,6 @@ export const PermissionPageContainerComponent = () => {
           cancelButtonType="default"
           onSubmit={action('Account(s) Connected')}
           submitText="connect"
-          buttonSizeLarge={false}
         />
       </div>
     </div>

--- a/ui/pages/swaps/swaps-footer/__snapshots__/swaps-footer.test.js.snap
+++ b/ui/pages/swaps/swaps-footer/__snapshots__/swaps-footer.test.js.snap
@@ -13,14 +13,15 @@ exports[`SwapsFooter renders the component with initial props 1`] = `
       >
         <footer>
           <button
-            class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel swaps-footer__custom-page-container-footer-button-class"
+            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button page-container__footer-button__cancel swaps-footer__custom-page-container-footer-button-class mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
             data-testid="page-container-footer-cancel"
           >
             Back
           </button>
           <button
-            class="button btn--rounded btn-primary page-container__footer-button swaps-footer__custom-page-container-footer-button-class"
+            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block page-container__footer-button swaps-footer__custom-page-container-footer-button-class mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
             data-testid="page-container-footer-next"
+            data-theme="light"
           >
             submitText
           </button>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Use the DS Button component in `PageContainerFooter`. This impacts a couple of screens, including the Swaps footers. These changes are meant to be backwards compatible by mapping the previous types used to the DS variants and applying similar styling as the legacy buttons. The new DS button is slightly taller (48px instead of 45px), but some of the screens override this height anyway. Newer functionality such as `submitButtonIcon` is preserved, but some unused props are removed, e.g. `buttonSizeLarge`.

![image](https://github.com/user-attachments/assets/20f2d49f-0424-4035-843d-d1e812703fc7)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31870?quickstart=1)

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/f870e503-3047-4c3e-813a-e50dbd55ed9f)

![image](https://github.com/user-attachments/assets/04ffe5cf-85fa-4e1f-9a99-8a8b925c0f58)

![image](https://github.com/user-attachments/assets/f8c28959-c64e-42dc-ad1c-dcc45a6a3e7b)
