### PR TITLE
fix: cp-12.17.0 - Center buttons in wider popup

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -56,6 +56,7 @@ import { AssetType } from '../../../../shared/constants/transaction';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { startNewDraftTransaction } from '../../../ducks/send';
 import {
+  BlockSize,
   Display,
   IconColor,
   JustifyContent,
@@ -359,7 +360,11 @@ const CoinButtons = ({
   ]);
 
   return (
-    <Box display={Display.Flex} justifyContent={JustifyContent.spaceEvenly}>
+    <Box
+      display={Display.Flex}
+      justifyContent={JustifyContent.spaceEvenly}
+      width={BlockSize.Full}
+    >
       {
         ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
         <IconButton

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -36,6 +36,11 @@
     height: 100%;
     margin-bottom: 16px;
     padding: 0 16px;
+    width: 100%;
+
+    .wallet-overview-fullscreen > & {
+      width: auto;
+    }
   }
 
   &__currency-wrapper {

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`AssetPage should render a native asset 1`] = `
       class="mm-box mm-box--margin-top-4"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--justify-content-space-evenly"
+        class="mm-box mm-box--display-flex mm-box--justify-content-space-evenly mm-box--width-full"
       >
         <button
           class="icon-button coin-overview__button"


### PR DESCRIPTION
## **Description**

Ensures buttons are centered in full screen and the new, wider popup

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31897?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check positioning of buttons in full screen
2. Check positioning of buttons in popup

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


<img width="424" alt="SCR-20250411-kjmt" src="https://github.com/user-attachments/assets/ab03c2a6-4095-42bb-aec5-b55e29232362" />


### **After**

<img width="1082" alt="SCR-20250411-kopr" src="https://github.com/user-attachments/assets/5d0fad3b-4c3b-4cec-b6ae-b3cbd13ce3d8" />

<img width="402" alt="SCR-20250411-kooc" src="https://github.com/user-attachments/assets/fcbd26d1-e9a8-468e-9922-143665b3b937" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
