### PR TITLE
fix: missing padding in retry popover

### DIFF
--- a/ui/components/app/transaction-list-item-details/index.scss
+++ b/ui/components/app/transaction-list-item-details/index.scss
@@ -62,7 +62,7 @@
   }
 
   &__operations {
-    margin: 0 0 16px 16px;
+    margin: 0 16px 16px 16px;
     display: flex;
     justify-content: flex-end;
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds missing padding in Retry (Cancel/Speed up) popover

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31904?quickstart=1)

## **Related issues**

Fixes:  https://github.com/MetaMask/metamask-extension/issues/31903

## **Manual testing steps**

1. Create failed transaction
2. Go to MM
3. Go to Activity
4. Click Failed transaction
5. Observe buttons

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![CleanShot 2025-04-11 at 09 40 59](https://github.com/user-attachments/assets/8eed32a8-65bb-4b6d-b078-a7e9f7c091ed)

### **After**

![CleanShot 2025-04-11 at 09 40 46](https://github.com/user-attachments/assets/86e5d239-e8bd-4031-b23c-4b1d13a62aeb)

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
