### PR TITLE
ci: add a soft gate for our page load benchmarks

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -64,5 +64,6 @@ jobs:
           MERGE_BASE_COMMIT_HASH: ${{ steps.get-merge-base.outputs.MERGE_BASE }}
           CIRCLE_BUILD_NUM: ${{ steps.get-circleci-job-details.outputs.CIRCLE_BUILD_NUM }}
           CIRCLE_WORKFLOW_JOB_ID: ${{ steps.get-circleci-job-details.outputs.CIRCLE_WORKFLOW_JOB_ID }}
-          HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ github.run_id }}
+          HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: yarn tsx ./development/metamaskbot-build-announce.ts

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -64,6 +64,6 @@ jobs:
           MERGE_BASE_COMMIT_HASH: ${{ steps.get-merge-base.outputs.MERGE_BASE }}
           CIRCLE_BUILD_NUM: ${{ steps.get-circleci-job-details.outputs.CIRCLE_BUILD_NUM }}
           CIRCLE_WORKFLOW_JOB_ID: ${{ steps.get-circleci-job-details.outputs.CIRCLE_WORKFLOW_JOB_ID }}
-          HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
+          AWS_CLOUDFRONT_URL_WITH_REPO: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
+          HOST_URL: ${{ env.AWS_CLOUDFRONT_URL_WITH_REPO }}/${{ env.GITHUB_RUN_ID }}
         run: yarn tsx ./development/metamaskbot-build-announce.ts

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -65,5 +65,5 @@ jobs:
           CIRCLE_BUILD_NUM: ${{ steps.get-circleci-job-details.outputs.CIRCLE_BUILD_NUM }}
           CIRCLE_WORKFLOW_JOB_ID: ${{ steps.get-circleci-job-details.outputs.CIRCLE_WORKFLOW_JOB_ID }}
           CLOUDFRONT_REPO_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
-          HOST_URL: ${{ env.CLOUDFRONT_REPO_URL }}/${{ env.GITHUB_RUN_ID }}
+          HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ github.run_id }}
         run: yarn tsx ./development/metamaskbot-build-announce.ts

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -64,6 +64,6 @@ jobs:
           MERGE_BASE_COMMIT_HASH: ${{ steps.get-merge-base.outputs.MERGE_BASE }}
           CIRCLE_BUILD_NUM: ${{ steps.get-circleci-job-details.outputs.CIRCLE_BUILD_NUM }}
           CIRCLE_WORKFLOW_JOB_ID: ${{ steps.get-circleci-job-details.outputs.CIRCLE_WORKFLOW_JOB_ID }}
-          AWS_CLOUDFRONT_URL_WITH_REPO: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
-          HOST_URL: ${{ env.AWS_CLOUDFRONT_URL_WITH_REPO }}/${{ env.GITHUB_RUN_ID }}
+          CLOUDFRONT_REPO_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
+          HOST_URL: ${{ env.CLOUDFRONT_REPO_URL }}/${{ env.GITHUB_RUN_ID }}
         run: yarn tsx ./development/metamaskbot-build-announce.ts

--- a/development/metamaskbot-build-announce.ts
+++ b/development/metamaskbot-build-announce.ts
@@ -296,10 +296,10 @@ async function start(): Promise<void> {
         .join('')}</tr></thead>`;
       const benchmarkTableBody = `<tbody>${tableRows.join('')}</tbody>`;
       const benchmarkTable = `<table>${benchmarkTableHeader}${benchmarkTableBody}</table>`;
-      const benchmarkBody = `<details><summary>${benchmarkSummary}</summary>${benchmarkTable}</details>\n\n`;
-      commentBody += `${benchmarkBody}`;
+      const benchmarkWarnings = await runBenchmarkGate(benchmarkResults);
+      const benchmarkBody = `<details><summary>${benchmarkSummary}</summary>${benchmarkTable}${benchmarkWarnings}</details>\n\n`;
 
-      commentBody += await runBenchmarkGate(benchmarkResults);
+      commentBody += `${benchmarkBody}`;
     } catch (error) {
       console.error(`Error constructing benchmark results: '${error}'`);
     }
@@ -438,7 +438,7 @@ async function runBenchmarkGate(
                   exceededSums.p95 += ceiledValue - gateValue;
                 }
 
-                benchmarkGateBody += `Benchmark value ${ceiledValue} exceeds gate value ${gateValue} for ${platform} ${buildType} ${page} ${measure} ${metric}\n`;
+                benchmarkGateBody += `Benchmark value ${ceiledValue} exceeds gate value ${gateValue} for ${platform} ${buildType} ${page} ${measure} ${metric}<br>\n`;
               }
             }
           }
@@ -447,13 +447,13 @@ async function runBenchmarkGate(
     }
 
     if (benchmarkGateBody) {
-      benchmarkGateBody += `**Sum of mean exceeds: ${
+      benchmarkGateBody += `<b>Sum of mean exceeds: ${
         exceededSums.mean
       }ms | Sum of p95 exceeds: ${
         exceededSums.p95
-      }ms\nSum of all benchmark exceeds: ${
+      }ms<br>\nSum of all benchmark exceeds: ${
         exceededSums.mean + exceededSums.p95
-      }ms**\n`;
+      }ms</b><br>\n`;
 
       if (
         exceededSums.mean > pingThresholds.mean ||
@@ -462,7 +462,7 @@ async function runBenchmarkGate(
           pingThresholds.mean + pingThresholds.p95
       ) {
         // Soft gate, just pings @HowardBraham
-        benchmarkGateBody = `cc: @HowardBraham\n${benchmarkGateBody}`;
+        benchmarkGateBody = `cc: @HowardBraham<br>\n${benchmarkGateBody}`;
       }
     }
   } catch (error) {

--- a/development/metamaskbot-build-announce.ts
+++ b/development/metamaskbot-build-announce.ts
@@ -398,7 +398,7 @@ async function start(): Promise<void> {
 async function runBenchmarkGate(
   benchmarkResults: BenchmarkResults,
 ): Promise<string> {
-  const benchmarkGateUrl = `${process.env.AWS_CLOUDFRONT_URL_WITH_REPO}/benchmark-gate/benchmark-gate.json`;
+  const benchmarkGateUrl = `${process.env.CLOUDFRONT_REPO_URL}/benchmark-gate/benchmark-gate.json`;
   const exceededSums = { mean: 0, p95: 0 };
   let benchmarkGateBody = '';
 

--- a/development/metamaskbot-build-announce.ts
+++ b/development/metamaskbot-build-announce.ts
@@ -59,7 +59,6 @@ async function start(): Promise<void> {
     CIRCLE_BUILD_NUM,
     CIRCLE_WORKFLOW_JOB_ID,
     HOST_URL,
-    GITHUB_RUN_ID,
   } = process.env as Record<string, string>;
 
   if (!PR_NUMBER) {
@@ -67,7 +66,6 @@ async function start(): Promise<void> {
     return;
   }
 
-  const HOST_RUN_URL = `${HOST_URL}/${GITHUB_RUN_ID}`;
   const SHORT_SHA1 = HEAD_COMMIT_HASH.slice(0, 7);
   const BUILD_LINK_BASE = `https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0`;
 
@@ -140,7 +138,7 @@ async function start(): Promise<void> {
   const bundleSizeDataUrl =
     'https://raw.githubusercontent.com/MetaMask/extension_bundlesize_stats/main/stats/bundle_size_data.json';
 
-  const storybookUrl = `${HOST_RUN_URL}/storybook-build/index.html`;
+  const storybookUrl = `${HOST_URL}/storybook-build/index.html`;
   const storybookLink = `<a href="${storybookUrl}">Storybook</a>`;
 
   const tsMigrationDashboardUrl = `${BUILD_LINK_BASE}/ts-migration-dashboard/index.html`;
@@ -150,10 +148,10 @@ async function start(): Promise<void> {
   const depVizUrl = `${BUILD_LINK_BASE}/build-artifacts/build-viz/index.html`;
   const depVizLink = `<a href="${depVizUrl}">Build System</a>`;
 
-  const bundleSizeStatsUrl = `${HOST_RUN_URL}/bundle-size/bundle_size.json`;
+  const bundleSizeStatsUrl = `${HOST_URL}/bundle-size/bundle_size.json`;
   const bundleSizeStatsLink = `<a href="${bundleSizeStatsUrl}">Bundle Size Stats</a>`;
 
-  const userActionsStatsUrl = `${HOST_RUN_URL}/benchmarks/benchmark-chrome-browserify-userActions.json`;
+  const userActionsStatsUrl = `${HOST_URL}/benchmarks/benchmark-chrome-browserify-userActions.json`;
   const userActionsStatsLink = `<a href="${userActionsStatsUrl}">User Actions Stats</a>`;
 
   // link to artifacts
@@ -182,7 +180,7 @@ async function start(): Promise<void> {
   for (const platform of benchmarkPlatforms) {
     benchmarkResults[platform] = {};
     for (const buildType of buildTypes) {
-      const benchmarkUrl = `${HOST_RUN_URL}/benchmarks/benchmark-${platform}-${buildType}-pageload.json`;
+      const benchmarkUrl = `${HOST_URL}/benchmarks/benchmark-${platform}-${buildType}-pageload.json`;
       try {
         const benchmarkResponse = await fetch(benchmarkUrl);
         if (!benchmarkResponse.ok) {
@@ -400,7 +398,7 @@ async function start(): Promise<void> {
 async function runBenchmarkGate(
   benchmarkResults: BenchmarkResults,
 ): Promise<string> {
-  const benchmarkGateUrl = `${process.env.HOST_URL}/benchmark-gate/benchmark-gate.json`;
+  const benchmarkGateUrl = `${process.env.AWS_CLOUDFRONT_URL_WITH_REPO}/benchmark-gate/benchmark-gate.json`;
   const exceededSums = { mean: 0, p95: 0 };
   let benchmarkGateBody = '';
 


### PR DESCRIPTION
## **Description**

Adds a gate of do-not-exceed values on every single one of our pageload benchmarks across all configurations (chrome, firefox, browserify, webpack) for mean and p95, across all metrics.  **(That's 84 gates in total)**

As suggested by Mark Stacey, it's a soft gate for now, that does not block the PR, but just pings HowardBraham.  Once we merge to main and do more testing on this, we should make it a hard gate.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31912?quickstart=1)

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->