### PR TITLE
fix: do not wait for snapclient response on account create

### DIFF
--- a/ui/components/multichain/create-snap-account/create-snap-account.test.tsx
+++ b/ui/components/multichain/create-snap-account/create-snap-account.test.tsx
@@ -113,27 +113,6 @@ describe('CreateSnapAccount', () => {
     });
   });
 
-  it('calls onActionComplete with false when account creation fails', async () => {
-    const error = new Error('Failed to create account');
-    jest.spyOn(console, 'error').mockImplementation(() => {
-      /* Suppress error log */
-    });
-    mockCreateAccount.mockRejectedValueOnce(error);
-
-    const onActionComplete = jest.fn();
-    const { getByTestId } = render({
-      ...defaultProps,
-      onActionComplete,
-    });
-
-    const createButton = getByTestId('submit-add-account-with-name');
-    fireEvent.click(createButton);
-
-    await waitFor(() => {
-      expect(onActionComplete).toHaveBeenCalledWith(false);
-    });
-  });
-
   it('passes the correct chainId and keyringId to createAccount', async () => {
     const { getByTestId } = render();
 

--- a/ui/components/multichain/create-snap-account/create-snap-account.tsx
+++ b/ui/components/multichain/create-snap-account/create-snap-account.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback } from 'react';
 import { CaipChainId } from '@metamask/utils';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { getNextAvailableAccountName } from '../../../store/actions';
@@ -40,27 +40,15 @@ export const CreateSnapAccount = ({
   chainId,
 }: CreateSnapAccountProps) => {
   const snapClient = useMultichainWalletSnapClient(clientType);
-  const isCreatingAccount = useRef(false);
 
   const onCreateAccount = useCallback(
     async (_accountNameSuggestion?: string) => {
-      if (isCreatingAccount.current) {
-        return;
-      }
-
-      try {
-        isCreatingAccount.current = true;
-        await snapClient.createAccount({
-          scope: chainId,
-          entropySource: selectedKeyringId,
-          accountNameSuggestion: _accountNameSuggestion,
-        });
-        onActionComplete(true);
-      } catch (error) {
-        onActionComplete(false);
-      } finally {
-        isCreatingAccount.current = false;
-      }
+      snapClient.createAccount({
+        scope: chainId,
+        entropySource: selectedKeyringId,
+        accountNameSuggestion: _accountNameSuggestion,
+      });
+      onActionComplete(true);
     },
     [snapClient, chainId, selectedKeyringId, onActionComplete],
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR prevents the UI from waiting for the snapClient response during account creation. Both account creation and error handling should be handled at the Snap level, rather than being managed by the CreateAccount component.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMMULTISRP-162

## **Manual testing steps**

1. Open account menu
2. Click "Add account or hardware wallet"
3. Click "Solana account"
4. Click "Add account"
5. Modal should close without waiting for the snap response

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
