### PR TITLE
fix: chromedriver crash on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -630,7 +630,7 @@
     "sass-embedded": "^1.71.0",
     "sass-loader": "^14.1.1",
     "schema-utils": "^4.2.0",
-    "selenium-webdriver": "^4.28.1",
+    "selenium-webdriver": "^4.31.0",
     "semver": "^7.5.4",
     "serve-handler": "^6.1.2",
     "sinon": "^9.0.0",

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -492,9 +492,28 @@ class Driver {
   /**
    * Quits the browser session, closing all windows and tabs.
    *
+   * This was previously implemented as just `await this.driver.quit()`, but on Windows,
+   * that was causing Google Chrome for Testing to not close, and sit open indefinitely
+   * taking CPU load. It is also possible that this was causing some cascading errors on CI.
+   *
    * @returns {Promise} promise resolving after quitting
    */
   async quit() {
+    if (this.browser === 'chrome') {
+      try {
+        const handles = await this.driver.getAllWindowHandles();
+
+        for (const handle of handles) {
+          await this.driver.switchTo().window(handle);
+          await this.driver.close();
+        }
+      } catch (e) {
+        console.info(
+          'Problem encountered closing Chrome windows/tabs, but continuing anyway',
+        );
+      }
+    }
+
     await this.driver.quit();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27691,7 +27691,7 @@ __metadata:
     sass-embedded: "npm:^1.71.0"
     sass-loader: "npm:^14.1.1"
     schema-utils: "npm:^4.2.0"
-    selenium-webdriver: "npm:^4.28.1"
+    selenium-webdriver: "npm:^4.31.0"
     semver: "npm:^7.5.4"
     serve-handler: "npm:^6.1.2"
     ses: "npm:^1.1.0"
@@ -34034,15 +34034,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selenium-webdriver@npm:^4.28.1":
-  version: 4.28.1
-  resolution: "selenium-webdriver@npm:4.28.1"
+"selenium-webdriver@npm:^4.31.0":
+  version: 4.31.0
+  resolution: "selenium-webdriver@npm:4.31.0"
   dependencies:
     "@bazel/runfiles": "npm:^6.3.1"
     jszip: "npm:^3.10.1"
     tmp: "npm:^0.2.3"
     ws: "npm:^8.18.0"
-  checksum: 10/a8917b532d16904d6a76a69be1f3a5db23e1dc520821b3bc276845eb835856691594c2c142eff91519d72bafacd285cf50e9b0db51025ab493b1263bab9caa19
+  checksum: 10/90d2552fb99ba9c43789b74b3b601b54f72c0122140aa4c806261d695218af306e1147d08fd8cd862957612c9b1f987ea95a0823343eecfc9786f214e14f8a5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

On Windows, after you run any E2E test, Google Chrome for Testing does not close, and sits open indefinitely taking CPU load (see screenshot below).

I found that if you loop through the windows/tabs and `close()` them before you `quit()` it stops this problem.

It's also possible that this is the cause of some of our cascading crash errors on CI.

For good measure, I updated `selenium-webdriver`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/31962?quickstart=1)

## **Screenshots/Recordings**
### **Before**

![image](https://github.com/user-attachments/assets/af5d6541-c798-4270-9c1e-9421912d8aed)

<!--## **Related issues**
## **Manual testing steps**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->