### PR TITLE
fix: add dom-purify to sanitize announcement notifications

### DIFF
--- a/.yarn/patches/dompurify-npm-3.2.5-d9af707abe.patch
+++ b/.yarn/patches/dompurify-npm-3.2.5-d9af707abe.patch
@@ -1,0 +1,72 @@
+diff --git a/dist/purify.cjs.js b/dist/purify.cjs.js
+index ec64aceb16ff80431581f1001093ddfac4bbc95c..c143a7f2e2bfa04b4c7c8e9a90393e41327b9278 100644
+--- a/dist/purify.cjs.js
++++ b/dist/purify.cjs.js
+@@ -1178,7 +1178,8 @@ function createDOMPurify() {
+       the user has requested a DOM object rather than a string */
+     IS_EMPTY_INPUT = !dirty;
+     if (IS_EMPTY_INPUT) {
+-      dirty = '<!-->';
++      // Modifying to avoid lavamoat SES_HTML_COMMENT_REJECTED
++      dirty = '<!' + '--' + '>';
+     }
+     /* Stringify, in case dirty is an object */
+     if (typeof dirty !== 'string' && !_isNode(dirty)) {
+@@ -1216,7 +1217,8 @@ function createDOMPurify() {
+     } else if (dirty instanceof Node) {
+       /* If dirty is a DOM element, append to an empty document to avoid
+          elements being stripped by the parser */
+-      body = _initDocument('<!---->');
++      // Modifying to avoid lavamoat SES_HTML_COMMENT_REJECTED
++      body = _initDocument('<!' + '--' + '--' + '>');
+       importedNode = body.ownerDocument.importNode(dirty, true);
+       if (importedNode.nodeType === NODE_TYPE.element && importedNode.nodeName === 'BODY') {
+         /* Node is already a body, use as is */
+diff --git a/dist/purify.es.mjs b/dist/purify.es.mjs
+index cee9b2115bda905594048e69f8125ca05a47716a..d9390133393c2553f0a9754dc813645353df4564 100644
+--- a/dist/purify.es.mjs
++++ b/dist/purify.es.mjs
+@@ -1176,7 +1176,8 @@ function createDOMPurify() {
+       the user has requested a DOM object rather than a string */
+     IS_EMPTY_INPUT = !dirty;
+     if (IS_EMPTY_INPUT) {
+-      dirty = '<!-->';
++      // Modifying to avoid lavamoat SES_HTML_COMMENT_REJECTED
++      dirty = '<!' + '--' + '>';
+     }
+     /* Stringify, in case dirty is an object */
+     if (typeof dirty !== 'string' && !_isNode(dirty)) {
+@@ -1214,7 +1215,8 @@ function createDOMPurify() {
+     } else if (dirty instanceof Node) {
+       /* If dirty is a DOM element, append to an empty document to avoid
+          elements being stripped by the parser */
+-      body = _initDocument('<!---->');
++      // Modifying to avoid lavamoat SES_HTML_COMMENT_REJECTED
++      body = _initDocument('<!' + '--' + '--' + '>');
+       importedNode = body.ownerDocument.importNode(dirty, true);
+       if (importedNode.nodeType === NODE_TYPE.element && importedNode.nodeName === 'BODY') {
+         /* Node is already a body, use as is */
+diff --git a/dist/purify.js b/dist/purify.js
+index 7a33b2b046ab3c3f850d651f9f77099eeb84a3a0..10b5fb6841cfed1f9f520d3a0e860de977623978 100644
+--- a/dist/purify.js
++++ b/dist/purify.js
+@@ -1182,7 +1182,8 @@
+         the user has requested a DOM object rather than a string */
+       IS_EMPTY_INPUT = !dirty;
+       if (IS_EMPTY_INPUT) {
+-        dirty = '<!-->';
++        // Modifying to avoid lavamoat SES_HTML_COMMENT_REJECTED
++        dirty = '<!' + '--' + '>';
+       }
+       /* Stringify, in case dirty is an object */
+       if (typeof dirty !== 'string' && !_isNode(dirty)) {
+@@ -1220,7 +1221,8 @@
+       } else if (dirty instanceof Node) {
+         /* If dirty is a DOM element, append to an empty document to avoid
+            elements being stripped by the parser */
+-        body = _initDocument('<!---->');
++        // Modifying to avoid lavamoat SES_HTML_COMMENT_REJECTED
++        body = _initDocument('<!' + '--' + '--' + '>');
+         importedNode = body.ownerDocument.importNode(dirty, true);
+         if (importedNode.nodeType === NODE_TYPE.element && importedNode.nodeName === 'BODY') {
+           /* Node is already a body, use as is */

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -3728,6 +3728,12 @@
         "@babel/runtime": true
       }
     },
+    "dompurify": {
+      "globals": {
+        "console.warn": true,
+        "define": true
+      }
+    },
     "string.prototype.matchall>get-intrinsic>get-proto>dunder-proto": {
       "packages": {
         "string.prototype.matchall>get-intrinsic>call-bind-apply-helpers": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -3728,6 +3728,12 @@
         "@babel/runtime": true
       }
     },
+    "dompurify": {
+      "globals": {
+        "console.warn": true,
+        "define": true
+      }
+    },
     "string.prototype.matchall>get-intrinsic>get-proto>dunder-proto": {
       "packages": {
         "string.prototype.matchall>get-intrinsic>call-bind-apply-helpers": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -3728,6 +3728,12 @@
         "@babel/runtime": true
       }
     },
+    "dompurify": {
+      "globals": {
+        "console.warn": true,
+        "define": true
+      }
+    },
     "string.prototype.matchall>get-intrinsic>get-proto>dunder-proto": {
       "packages": {
         "string.prototype.matchall>get-intrinsic>call-bind-apply-helpers": true,

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -3859,6 +3859,12 @@
         "@babel/runtime": true
       }
     },
+    "dompurify": {
+      "globals": {
+        "console.warn": true,
+        "define": true
+      }
+    },
     "string.prototype.matchall>get-intrinsic>get-proto>dunder-proto": {
       "packages": {
         "string.prototype.matchall>get-intrinsic>call-bind-apply-helpers": true,

--- a/package.json
+++ b/package.json
@@ -358,6 +358,7 @@
     "currency-formatter": "^1.4.2",
     "debounce-stream": "^2.0.0",
     "deep-freeze-strict": "1.1.1",
+    "dompurify": "^3.2.5",
     "eth-chainlist": "~0.0.498",
     "eth-ens-namehash": "^2.0.8",
     "eth-lattice-keyring": "patch:eth-lattice-keyring@npm%3A0.12.4#~/.yarn/patches/eth-lattice-keyring-npm-0.12.4-c5fb3fcf54.patch",

--- a/package.json
+++ b/package.json
@@ -358,7 +358,7 @@
     "currency-formatter": "^1.4.2",
     "debounce-stream": "^2.0.0",
     "deep-freeze-strict": "1.1.1",
-    "dompurify": "^3.2.5",
+    "dompurify": "patch:dompurify@npm%3A3.2.5#~/.yarn/patches/dompurify-npm-3.2.5-d9af707abe.patch",
     "eth-chainlist": "~0.0.498",
     "eth-ens-namehash": "^2.0.8",
     "eth-lattice-keyring": "patch:eth-lattice-keyring@npm%3A0.12.4#~/.yarn/patches/eth-lattice-keyring-npm-0.12.4-c5fb3fcf54.patch",

--- a/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
+import { sanitize } from 'dompurify';
 import { isOfTypeNodeGuard } from '../node-guard';
 import {
   NotificationComponentType,
@@ -95,8 +96,9 @@ export const components: NotificationComponent<FeatureAnnouncementNotification> 
             <Text
               variant={TextVariant.bodyMd}
               as="div"
+              // TODO - we can replace the raw HTML string injection with react components
               dangerouslySetInnerHTML={{
-                __html: notification.data.longDescription,
+                __html: sanitize(notification.data.longDescription),
               }}
             />
           </Box>

--- a/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
-import { sanitize } from 'dompurify';
+// eslint-disable-next-line import/no-named-as-default
+import DOMPurify from 'dompurify';
 import { isOfTypeNodeGuard } from '../node-guard';
 import {
   NotificationComponentType,
@@ -98,7 +99,7 @@ export const components: NotificationComponent<FeatureAnnouncementNotification> 
               as="div"
               // TODO - we can replace the raw HTML string injection with react components
               dangerouslySetInnerHTML={{
-                __html: sanitize(notification.data.longDescription),
+                __html: DOMPurify.sanitize(notification.data.longDescription),
               }}
             />
           </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -18138,7 +18138,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.5":
+"dompurify@npm:3.2.5":
   version: 3.2.5
   resolution: "dompurify@npm:3.2.5"
   dependencies:
@@ -18147,6 +18147,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: 10/03974f18851fb4e447d26adc0ebf7a64b6c5b4a11caebebec3e04de8fcaa19cdb67bf3575a2335727123d0fc1c2febc1bc992a84f327a8ce65a0bfd11e3afc50
+  languageName: node
+  linkType: hard
+
+"dompurify@patch:dompurify@npm%3A3.2.5#~/.yarn/patches/dompurify-npm-3.2.5-d9af707abe.patch":
+  version: 3.2.5
+  resolution: "dompurify@patch:dompurify@npm%3A3.2.5#~/.yarn/patches/dompurify-npm-3.2.5-d9af707abe.patch::version=3.2.5&hash=ea78bd"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10/40dafddc09171ee92af898c6d7df81f3486f2ab15275592427fe105f7afa230b92973891ee41935fb5565cca6b50b67d86b85e4a3dd0486e1738736efaf3d77c
   languageName: node
   linkType: hard
 
@@ -27588,7 +27600,7 @@ __metadata:
     del: "npm:^6.1.1"
     depcheck: "npm:^1.4.3"
     detect-port: "npm:^1.5.1"
-    dompurify: "npm:^3.2.5"
+    dompurify: "patch:dompurify@npm%3A3.2.5#~/.yarn/patches/dompurify-npm-3.2.5-d9af707abe.patch"
     dotenv: "npm:^16.4.5"
     duplexify: "npm:^4.1.1"
     eslint: "patch:eslint@npm%3A8.57.0#~/.yarn/patches/eslint-npm-8.57.0-4286e12a3a.patch"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11992,10 +11992,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/trusted-types@npm:^2.0.2":
-  version: 2.0.5
-  resolution: "@types/trusted-types@npm:2.0.5"
-  checksum: 10/e138a70a702e31b49ac73cc33852d892367224be6e096c445194d76327cb46f54f971ae311e34371f649a2d5ac9204afee345bb22f32cfc515eb21c3f12f66b7
+"@types/trusted-types@npm:^2.0.2, @types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10/8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
   languageName: node
   linkType: hard
 
@@ -18135,6 +18135,18 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10/809b805a50a9c6884a29f38aec0a4e1b4537f40e1c861950ed47d10b049febe6b79ab72adaeeebb3cc8fc1cd33f34e97048a72a9265103426d93efafa78d3e96
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "dompurify@npm:3.2.5"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10/03974f18851fb4e447d26adc0ebf7a64b6c5b4a11caebebec3e04de8fcaa19cdb67bf3575a2335727123d0fc1c2febc1bc992a84f327a8ce65a0bfd11e3afc50
   languageName: node
   linkType: hard
 
@@ -27576,6 +27588,7 @@ __metadata:
     del: "npm:^6.1.1"
     depcheck: "npm:^1.4.3"
     detect-port: "npm:^1.5.1"
+    dompurify: "npm:^3.2.5"
     dotenv: "npm:^16.4.5"
     duplexify: "npm:^4.1.1"
     eslint: "patch:eslint@npm%3A8.57.0#~/.yarn/patches/eslint-npm-8.57.0-4286e12a3a.patch"


### PR DESCRIPTION
## **Description**

Adds `dompurify` to sanitize announcement notifications. This is a safety precaution.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32001?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/pm-security/issues/405

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
