### PR TITLE
feat: Adds Remote Mode hardware wallet gating

### DIFF
--- a/ui/helpers/utils/remote-mode.test.ts
+++ b/ui/helpers/utils/remote-mode.test.ts
@@ -1,0 +1,63 @@
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { isRemoteModeSupported } from './remote-mode';
+
+describe('Remote Mode Utils', () => {
+  describe('isRemoteModeSupported', () => {
+    it('returns true for supported hardware wallet types', () => {
+      const ledgerAccount: InternalAccount = {
+        address: '0x12C7e...q135f',
+        type: 'eip155:eoa',
+        id: '1',
+        options: {},
+        metadata: {
+          name: 'Ledger Hardware',
+          importTime: 1717334400,
+          keyring: {
+            type: 'Ledger Hardware',
+          },
+        },
+        scopes: [],
+        methods: [],
+      };
+
+      const latticeAccount: InternalAccount = {
+        address: '0x12C7e...q135f',
+        type: 'eip155:eoa',
+        id: '2',
+        options: {},
+        metadata: {
+          name: 'Lattice Hardware',
+          importTime: 1717334400,
+          keyring: {
+            type: 'Lattice Hardware',
+          },
+        },
+        scopes: [],
+        methods: [],
+      };
+
+      expect(isRemoteModeSupported(ledgerAccount)).toBe(true);
+      expect(isRemoteModeSupported(latticeAccount)).toBe(true);
+    });
+
+    it('returns false for unsupported hardware wallet types', () => {
+      const unsupportedAccount: InternalAccount = {
+        address: '0x12C7e...q135f',
+        type: 'eip155:eoa',
+        id: '3',
+        options: {},
+        metadata: {
+          name: 'Some Other Wallet',
+          importTime: 1717334400,
+          keyring: {
+            type: 'eip155',
+          },
+        },
+        scopes: [],
+        methods: [],
+      };
+
+      expect(isRemoteModeSupported(unsupportedAccount)).toBe(false);
+    });
+  });
+});

--- a/ui/helpers/utils/remote-mode.ts
+++ b/ui/helpers/utils/remote-mode.ts
@@ -1,11 +1,10 @@
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
-const SUPPORTED_HARDWARE_WALLET_TYPES = [
-  'Ledger Hardware',
-  'Lattice Hardware',
-];
+const SUPPORTED_HARDWARE_WALLET_TYPES = ['Ledger Hardware', 'Lattice Hardware'];
 
 export function isRemoteModeSupported(account: InternalAccount) {
   // todo: add check that account also implements signEip7702Authorization()
-  return SUPPORTED_HARDWARE_WALLET_TYPES.includes(account.metadata.keyring.type);
+  return SUPPORTED_HARDWARE_WALLET_TYPES.includes(
+    account.metadata.keyring.type,
+  );
 }

--- a/ui/helpers/utils/remote-mode.ts
+++ b/ui/helpers/utils/remote-mode.ts
@@ -1,0 +1,11 @@
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+
+const SUPPORTED_HARDWARE_WALLET_TYPES = [
+  'Ledger Hardware',
+  'Lattice Hardware',
+];
+
+export function isRemoteModeSupported(account: InternalAccount) {
+  // todo: add check that account also implements signEip7702Authorization()
+  return SUPPORTED_HARDWARE_WALLET_TYPES.includes(account.metadata.keyring.type);
+}

--- a/ui/pages/pages.scss
+++ b/ui/pages/pages.scss
@@ -21,6 +21,7 @@
 @import 'snaps/snaps-list/index';
 @import 'snaps/snap-view/index';
 @import 'create-snap-account/index';
+@import 'remote-mode/setup/setup-swaps/index';
 @import 'remove-snap-account/index';
 @import 'swaps/index';
 @import 'bridge/index';

--- a/ui/pages/remote-mode/introducing/remote-mode-introducing.component.tsx
+++ b/ui/pages/remote-mode/introducing/remote-mode-introducing.component.tsx
@@ -27,11 +27,15 @@ export default function RemoteModeIntroducing() {
         color={IconColor.infoDefault}
         size={AvatarIconSize.Xl}
       />
-      <Text variant={TextVariant.headingSm} fontWeight={FontWeight.Bold}>
-        Introducing Remote Mode
+      <Text
+        variant={TextVariant.headingSm}
+        fontWeight={FontWeight.Bold}
+        paddingBottom={2}
+      >
+        Cold storage. Fast access.
       </Text>
       <Text variant={TextVariant.bodyMd} color={TextColor.textAlternativeSoft}>
-        Safely access your hardware wallet funds without plugging it in.
+        Remote Mode lets you use your hardware wallet without plugging it in.
       </Text>
       <Box marginTop={4} marginBottom={6}>
         <Box
@@ -42,10 +46,13 @@ export default function RemoteModeIntroducing() {
           paddingBottom={2}
         >
           <Icon name={IconName.SwapHorizontal} color={IconColor.infoDefault} />
-          <Text>
-            Easier yet safe to trade with cold funds. Never miss a market
-            opportunity.
-          </Text>
+          <Text
+            fontWeight={FontWeight.Bold}
+            style={{ display: 'inline-block' }}
+          >
+            Stay secure.
+          </Text>{' '}
+          Your keys stay offline, and your funds stay in cold storage.
         </Box>
         <Box
           display={Display.Flex}
@@ -55,10 +62,13 @@ export default function RemoteModeIntroducing() {
           paddingBottom={2}
         >
           <Icon name={IconName.WalletCard} color={IconColor.infoDefault} />
-          <Text>
-            Use allowances for transactions, limiting exposure of cold funds &
-            keys.
-          </Text>
+          <Text
+            fontWeight={FontWeight.Bold}
+            style={{ display: 'inline-block' }}
+          >
+            Move faster.
+          </Text>{' '}
+          Allow limited actions like swaps or approvals ahead of time.
         </Box>
         <Box
           display={Display.Flex}
@@ -68,10 +78,13 @@ export default function RemoteModeIntroducing() {
           paddingBottom={2}
         >
           <Icon name={IconName.SecurityTick} color={IconColor.infoDefault} />
-          <Text>
-            Set your terms with spending caps & other smart contract enforced
-            rules.
-          </Text>
+          <Text
+            fontWeight={FontWeight.Bold}
+            style={{ display: 'inline-block' }}
+          >
+            Stay in control.
+          </Text>{' '}
+          Set your own rules, like spending caps and allowed actions.
         </Box>
         <Box
           display={Display.Flex}
@@ -81,9 +94,13 @@ export default function RemoteModeIntroducing() {
           paddingBottom={2}
         >
           <Icon name={IconName.Star} color={IconColor.infoDefault} />
-          <Text>
-            Get all the benefits of a smart account, and switch back anytime.
-          </Text>
+          <Text
+            fontWeight={FontWeight.Bold}
+            style={{ display: 'inline-block' }}
+          >
+            Get smart.
+          </Text>{' '}
+          All the benefits of a smart account, and your keys stay safe.
         </Box>
       </Box>
     </Box>

--- a/ui/pages/remote-mode/overview/remote-mode-overview.container.tsx
+++ b/ui/pages/remote-mode/overview/remote-mode-overview.container.tsx
@@ -3,7 +3,16 @@ import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
 import { getIsRemoteModeEnabled } from '../../../selectors/remote-mode';
-import { Button, Box, ButtonSize } from '../../../components/component-library';
+import { Button, ButtonIcon, ButtonSize, ButtonIconSize, IconName } from '../../../components/component-library';
+import {
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import {
+  Content,
+  Footer,
+  Header,
+  Page,
+} from '../../../components/multichain/pages/page';
 
 import {
   DEFAULT_ROUTE,
@@ -39,21 +48,21 @@ export default function RemoteModeIntroducing() {
     switch (currentScreen) {
       case RemoteScreen.OVERVIEW:
         return (
-          <Box padding={6}>
+          <Content padding={6}>
             <RemoteModeOverview />
             <Button
               style={{ width: '100%' }}
               onClick={() => setCurrentScreen(RemoteScreen.PERMISSIONS)}
               size={ButtonSize.Lg}
             >
-              Continue
+              Get Remote Mode
             </Button>
-          </Box>
+          </Content>
         );
 
       case RemoteScreen.PERMISSIONS:
         return (
-          <Box padding={6}>
+          <Content padding={6}>
             <RemoteModePermissions
               setStartEnableRemoteSwap={() => {
                 history.push(REMOTE_ROUTE_SETUP_SWAPS);
@@ -62,14 +71,14 @@ export default function RemoteModeIntroducing() {
                 history.push(REMOTE_ROUTE_SETUP_DAILY_ALLOWANCE);
               }}
             />
-          </Box>
+          </Content>
         );
 
       case RemoteScreen.SETUP_REMOTE_SWAPS:
         return (
-          <Box padding={2}>
+          <Content padding={2}>
             <RemoteModeSetup />
-          </Box>
+          </Content>
         );
 
       default:
@@ -77,9 +86,28 @@ export default function RemoteModeIntroducing() {
     }
   };
 
+  const onCancel = () => {
+    history.push(DEFAULT_ROUTE);
+  };
+
   return (
-    <div className="main-container" data-testid="remote-mode">
+    <Page className="main-container" data-testid="remote-mode">
+      <Header
+        textProps={{
+          variant: TextVariant.headingSm,
+        }}
+        startAccessory={
+          <ButtonIcon
+            size={ButtonIconSize.Sm}
+            ariaLabel={'back'}
+            iconName={IconName.ArrowLeft}
+            onClick={onCancel}
+          />
+        }
+      >
+        Remote mode
+      </Header>
       {renderScreen()}
-    </div>
+    </Page>
   );
 }

--- a/ui/pages/remote-mode/overview/remote-mode-overview.container.tsx
+++ b/ui/pages/remote-mode/overview/remote-mode-overview.container.tsx
@@ -2,14 +2,26 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
+import { getSelectedInternalAccount } from '../../../selectors';
+
 import { getIsRemoteModeEnabled } from '../../../selectors/remote-mode';
-import { Button, ButtonIcon, ButtonSize, ButtonIconSize, IconName } from '../../../components/component-library';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+  Box,
+  Button,
+  ButtonIcon,
+  ButtonSize,
+  ButtonIconSize,
+  IconName,
+  Text,
+} from '../../../components/component-library';
 import {
   TextVariant,
+  FontWeight,
 } from '../../../helpers/constants/design-system';
 import {
   Content,
-  Footer,
   Header,
   Page,
 } from '../../../components/multichain/pages/page';
@@ -35,8 +47,18 @@ export default function RemoteModeIntroducing() {
   const [currentScreen, setCurrentScreen] = useState<RemoteScreen>(
     RemoteScreen.OVERVIEW,
   );
+  const [isHardwareAccount, setIsHardwareAccount] = useState<boolean>(false);
+
+  const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const history = useHistory();
   const isRemoteModeEnabled = useSelector(getIsRemoteModeEnabled);
+
+  useEffect(() => {
+    setIsHardwareAccount(
+      selectedHardwareAccount.metadata.keyring.type === 'Ledger Hardware' ||
+        selectedHardwareAccount.metadata.keyring.type === 'Lattice Hardware',
+    );
+  }, [selectedHardwareAccount]);
 
   useEffect(() => {
     if (!isRemoteModeEnabled) {
@@ -54,6 +76,7 @@ export default function RemoteModeIntroducing() {
               style={{ width: '100%' }}
               onClick={() => setCurrentScreen(RemoteScreen.PERMISSIONS)}
               size={ButtonSize.Lg}
+              disabled={!isHardwareAccount}
             >
               Get Remote Mode
             </Button>
@@ -107,6 +130,18 @@ export default function RemoteModeIntroducing() {
       >
         Remote mode
       </Header>
+      {!isHardwareAccount && (
+        <Box padding={4}>
+          <BannerAlert severity={BannerAlertSeverity.Warning} marginBottom={2}>
+            <Text variant={TextVariant.headingSm} fontWeight={FontWeight.Bold}>
+              Select a hardware wallet
+            </Text>
+            <Text variant={TextVariant.bodyMd}>
+              To continue, select your hardware wallet from the account menu.
+            </Text>
+          </BannerAlert>
+        </Box>
+      )}
       {renderScreen()}
     </Page>
   );

--- a/ui/pages/remote-mode/overview/remote-mode-overview.container.tsx
+++ b/ui/pages/remote-mode/overview/remote-mode-overview.container.tsx
@@ -35,6 +35,7 @@ import {
 import RemoteModeOverview from '../introducing/remote-mode-introducing.component';
 import RemoteModeSetup from '../setup/setup-swaps/remote-mode-setup-swaps.component';
 import RemoteModePermissions from './remote-mode-permissions.component';
+import { isRemoteModeSupported } from '../../../helpers/utils/remote-mode';
 
 enum RemoteScreen {
   OVERVIEW = 'OVERVIEW',
@@ -54,10 +55,7 @@ export default function RemoteModeIntroducing() {
   const isRemoteModeEnabled = useSelector(getIsRemoteModeEnabled);
 
   useEffect(() => {
-    setIsHardwareAccount(
-      selectedHardwareAccount.metadata.keyring.type === 'Ledger Hardware' ||
-        selectedHardwareAccount.metadata.keyring.type === 'Lattice Hardware',
-    );
+    setIsHardwareAccount(isRemoteModeSupported(selectedHardwareAccount));
   }, [selectedHardwareAccount]);
 
   useEffect(() => {

--- a/ui/pages/remote-mode/overview/remote-mode-overview.container.tsx
+++ b/ui/pages/remote-mode/overview/remote-mode-overview.container.tsx
@@ -3,8 +3,9 @@ import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
 import { getSelectedInternalAccount } from '../../../selectors';
-
 import { getIsRemoteModeEnabled } from '../../../selectors/remote-mode';
+import { isRemoteModeSupported } from '../../../helpers/utils/remote-mode';
+
 import {
   BannerAlert,
   BannerAlertSeverity,
@@ -35,7 +36,6 @@ import {
 import RemoteModeOverview from '../introducing/remote-mode-introducing.component';
 import RemoteModeSetup from '../setup/setup-swaps/remote-mode-setup-swaps.component';
 import RemoteModePermissions from './remote-mode-permissions.component';
-import { isRemoteModeSupported } from '../../../helpers/utils/remote-mode';
 
 enum RemoteScreen {
   OVERVIEW = 'OVERVIEW',

--- a/ui/pages/remote-mode/overview/remote-mode-permissions.component.tsx
+++ b/ui/pages/remote-mode/overview/remote-mode-permissions.component.tsx
@@ -32,9 +32,6 @@ export default function RemoteModePermissions({
 
   return (
     <Box>
-      <Text variant={TextVariant.headingSm} fontWeight={FontWeight.Bold}>
-        Permissions
-      </Text>
       <Text variant={TextVariant.bodyMd} color={TextColor.textAlternativeSoft}>
         Safely access your hardware wallet funds without plugging it in. Revoke
         permissions anytime.
@@ -48,13 +45,13 @@ export default function RemoteModePermissions({
             paddingTop={2}
             paddingBottom={2}
           >
-            <Text>Swap</Text>
+            <Text>Remote Swaps</Text>
             <Text
               color={TextColor.infoDefault}
               style={{ cursor: 'pointer' }}
               onClick={handleEnableRemoteSwap}
             >
-              Enable
+              Turn on
             </Text>
           </Box>
           <Text color={TextColor.textAlternativeSoft}>
@@ -72,12 +69,13 @@ export default function RemoteModePermissions({
             paddingTop={2}
             paddingBottom={2}
           >
-            <Text>Daily allowances</Text>
+            <Text>Withdrawal limit</Text>
             <Text
               color={TextColor.infoDefault}
+              style={{ cursor: 'pointer' }}
               onClick={handleEnableDailyAllowance}
             >
-              Enable
+              Turn on
             </Text>
           </Box>
           <Text color={TextColor.textAlternativeSoft}>

--- a/ui/pages/remote-mode/overview/remote-mode-permissions.component.tsx
+++ b/ui/pages/remote-mode/overview/remote-mode-permissions.component.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Box, Text } from '../../../components/component-library';
 import Card from '../../../components/ui/card';
 import {
-  FontWeight,
   TextVariant,
   Display,
   JustifyContent,

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
@@ -58,6 +58,7 @@ import {
 import RemoteModeHardwareWalletConfirm from '../hardware-wallet-confirm-modal';
 import RemoteModeDailyAllowanceCard from '../daily-allowance-card';
 import StepIndicator from '../step-indicator/step-indicator.component';
+import { isRemoteModeSupported } from '../../../../helpers/utils/remote-mode';
 
 const TOTAL_STEPS = 3;
 
@@ -94,10 +95,7 @@ export default function RemoteModeSetupDailyAllowance() {
   const isRemoteModeEnabled = useSelector(getIsRemoteModeEnabled);
 
   useEffect(() => {
-    setIsHardwareAccount(
-      selectedHardwareAccount.metadata.keyring.type === 'Ledger Hardware' ||
-        selectedHardwareAccount.metadata.keyring.type === 'Lattice Hardware',
-    );
+    setIsHardwareAccount(isRemoteModeSupported(selectedHardwareAccount));
   }, [selectedHardwareAccount]);
 
   useEffect(() => {

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
@@ -4,8 +4,16 @@ import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import {
+  Content,
+  Footer,
+  Header,
+  Page,
+} from '../../../../components/multichain/pages/page';
+import {
   Box,
   Button,
+  ButtonIcon,
+  ButtonIconSize,
   ButtonVariant,
   ButtonSize,
   Text,
@@ -144,6 +152,10 @@ export default function RemoteModeSetupDailyAllowance() {
 
   const handleConfigureRemoteSwaps = () => {
     history.replace(REMOTE_ROUTE);
+  };
+
+  const onCancel = () => {
+    history.goBack();
   };
 
   const renderStepContent = () => {
@@ -471,12 +483,28 @@ export default function RemoteModeSetupDailyAllowance() {
   };
 
   return (
-    <div className="main-container" data-testid="remote-mode-setup-swaps">
-      <Box
+    <Page className="main-container" data-testid="remote-mode-setup-swaps">
+      <Header
+        textProps={{
+          variant: TextVariant.headingSm,
+        }}
+        startAccessory={
+          <ButtonIcon
+            size={ButtonIconSize.Sm}
+            ariaLabel={'back'}
+            iconName={IconName.ArrowLeft}
+            onClick={onCancel}
+          />
+        }
+      >
+        Remote mode
+      </Header>
+      <Content
         display={Display.Flex}
         flexDirection={FlexDirection.Column}
         gap={2}
-        padding={2}
+        paddingLeft={4}
+        paddingRight={4}
         width={BlockSize.Full}
       >
         <StepIndicator currentStep={currentStep} totalSteps={TOTAL_STEPS} />
@@ -493,28 +521,6 @@ export default function RemoteModeSetupDailyAllowance() {
 
         {renderStepContent()}
 
-        <Box
-          paddingTop={2}
-          display={Display.Flex}
-          gap={6}
-          justifyContent={JustifyContent.center}
-        >
-          <Button
-            onClick={handleBack}
-            variant={ButtonVariant.Secondary}
-            width={BlockSize.Half}
-            size={ButtonSize.Lg}
-          >
-            {currentStep === 1 ? 'Cancel' : 'Back'}
-          </Button>
-          <Button
-            onClick={currentStep === 3 ? handleShowConfirmation : handleNext}
-            width={BlockSize.Half}
-            size={ButtonSize.Lg}
-          >
-            {currentStep === TOTAL_STEPS ? 'Confirm' : 'Next'}
-          </Button>
-        </Box>
         <RemoteModeHardwareWalletConfirm
           visible={isConfirmModalOpen}
           onConfirm={handleConfigureRemoteSwaps}
@@ -522,7 +528,25 @@ export default function RemoteModeSetupDailyAllowance() {
             setIsConfirmModalOpen(false);
           }}
         />
-      </Box>
-    </div>
+      </Content>
+
+      <Footer>
+        <Button
+          onClick={handleBack}
+          variant={ButtonVariant.Secondary}
+          width={BlockSize.Half}
+          size={ButtonSize.Lg}
+        >
+          {currentStep === 1 ? 'Cancel' : 'Back'}
+        </Button>
+        <Button
+          onClick={currentStep === 3 ? handleShowConfirmation : handleNext}
+          width={BlockSize.Half}
+          size={ButtonSize.Lg}
+        >
+          {currentStep === TOTAL_STEPS ? 'Confirm' : 'Next'}
+        </Button>
+      </Footer>
+    </Page>
   );
 }

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
@@ -518,10 +518,7 @@ export default function RemoteModeSetupDailyAllowance() {
         width={BlockSize.Full}
       >
         {!isHardwareAccount && (
-          <BannerAlert
-            severity={BannerAlertSeverity.Warning}
-            marginBottom={2}
-          >
+          <BannerAlert severity={BannerAlertSeverity.Warning} marginBottom={2}>
             <Text variant={TextVariant.headingSm} fontWeight={FontWeight.Bold}>
               Select a hardware wallet
             </Text>

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
@@ -40,9 +40,7 @@ import {
   REMOTE_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { getIsRemoteModeEnabled } from '../../../../selectors/remote-mode';
-import {
-  InternalAccountWithBalance,
-} from '../../../../selectors/selectors.types';
+import { InternalAccountWithBalance } from '../../../../selectors/selectors.types';
 import {
   getSelectedInternalAccount,
   getMetaMaskAccountsOrdered,
@@ -72,7 +70,8 @@ export default function RemoteModeSetupDailyAllowance() {
   const [dailyLimit, setDailyLimit] = useState<string>('');
   const [isAllowancesExpanded, setIsAllowancesExpanded] =
     useState<boolean>(false);
-  const [selectedAccount, setSelectedAccount] = useState<InternalAccount | null>(null);
+  const [selectedAccount, setSelectedAccount] =
+    useState<InternalAccount | null>(null);
 
   const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
@@ -160,7 +159,7 @@ export default function RemoteModeSetupDailyAllowance() {
                   onClick: (account: InternalAccount) => {
                     setSelectedAccount(account);
                     setIsModalOpen(false);
-                  }
+                  },
                 }}
               />
             )}

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
@@ -40,7 +40,9 @@ import {
   REMOTE_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { getIsRemoteModeEnabled } from '../../../../selectors/remote-mode';
-import { InternalAccountWithBalance } from '../../../../selectors/selectors.types';
+import {
+  InternalAccountWithBalance,
+} from '../../../../selectors/selectors.types';
 import {
   getSelectedInternalAccount,
   getMetaMaskAccountsOrdered,
@@ -70,8 +72,7 @@ export default function RemoteModeSetupDailyAllowance() {
   const [dailyLimit, setDailyLimit] = useState<string>('');
   const [isAllowancesExpanded, setIsAllowancesExpanded] =
     useState<boolean>(false);
-  const [selectedAccount, setSelectedAccount] =
-    useState<InternalAccount | null>(null);
+  const [selectedAccount, setSelectedAccount] = useState<InternalAccount | null>(null);
 
   const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
@@ -159,7 +160,7 @@ export default function RemoteModeSetupDailyAllowance() {
                   onClick: (account: InternalAccount) => {
                     setSelectedAccount(account);
                     setIsModalOpen(false);
-                  },
+                  }
                 }}
               />
             )}

--- a/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-daily-allowance/remote-mode-setup-daily-allowance.component.tsx
@@ -10,6 +10,8 @@ import {
   Page,
 } from '../../../../components/multichain/pages/page';
 import {
+  BannerAlert,
+  BannerAlertSeverity,
   Box,
   Button,
   ButtonIcon,
@@ -80,6 +82,7 @@ export default function RemoteModeSetupDailyAllowance() {
     useState<boolean>(false);
   const [selectedAccount, setSelectedAccount] =
     useState<InternalAccount | null>(null);
+  const [isHardwareAccount, setIsHardwareAccount] = useState<boolean>(false);
 
   const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
@@ -89,6 +92,13 @@ export default function RemoteModeSetupDailyAllowance() {
   const history = useHistory();
 
   const isRemoteModeEnabled = useSelector(getIsRemoteModeEnabled);
+
+  useEffect(() => {
+    setIsHardwareAccount(
+      selectedHardwareAccount.metadata.keyring.type === 'Ledger Hardware' ||
+        selectedHardwareAccount.metadata.keyring.type === 'Lattice Hardware',
+    );
+  }, [selectedHardwareAccount]);
 
   useEffect(() => {
     if (authorizedAccounts.length > 0) {
@@ -507,8 +517,20 @@ export default function RemoteModeSetupDailyAllowance() {
         paddingRight={4}
         width={BlockSize.Full}
       >
+        {!isHardwareAccount && (
+          <BannerAlert
+            severity={BannerAlertSeverity.Warning}
+            marginBottom={2}
+          >
+            <Text variant={TextVariant.headingSm} fontWeight={FontWeight.Bold}>
+              Select a hardware wallet
+            </Text>
+            <Text variant={TextVariant.bodyMd}>
+              To continue, select your hardware wallet from the account menu.
+            </Text>
+          </BannerAlert>
+        )}
         <StepIndicator currentStep={currentStep} totalSteps={TOTAL_STEPS} />
-
         <Text
           textAlign={TextAlign.Center}
           variant={TextVariant.headingMd}
@@ -543,6 +565,7 @@ export default function RemoteModeSetupDailyAllowance() {
           onClick={currentStep === 3 ? handleShowConfirmation : handleNext}
           width={BlockSize.Half}
           size={ButtonSize.Lg}
+          disabled={!isHardwareAccount}
         >
           {currentStep === TOTAL_STEPS ? 'Confirm' : 'Next'}
         </Button>

--- a/ui/pages/remote-mode/setup/setup-swaps/index.scss
+++ b/ui/pages/remote-mode/setup/setup-swaps/index.scss
@@ -1,0 +1,13 @@
+@use "design-system";
+
+.unit-input {
+  width: 100%;
+  border-radius: 0.5rem;
+  min-height: 45px;
+  margin-top: 8px;
+}
+
+// override the default width of the unit input as the placeholder text is being truncated
+.unit-input .unit-input__input {
+  width: 100% !important;
+}

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -7,6 +7,8 @@ import {
   AvatarAccount,
   AvatarAccountSize,
   AvatarAccountVariant,
+  BannerAlert,
+  BannerAlertSeverity,
   Box,
   Button,
   ButtonIcon,
@@ -88,6 +90,7 @@ export default function RemoteModeSetupSwaps() {
     useState<boolean>(false);
   const [selectedAccount, setSelectedAccount] =
     useState<InternalAccount | null>(null);
+  const [isHardwareAccount, setIsHardwareAccount] = useState<boolean>(false);
 
   const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
@@ -97,6 +100,13 @@ export default function RemoteModeSetupSwaps() {
   const history = useHistory();
 
   const isRemoteModeEnabled = useSelector(getIsRemoteModeEnabled);
+
+  useEffect(() => {
+    setIsHardwareAccount(
+      selectedHardwareAccount.metadata.keyring.type === 'Ledger Hardware' ||
+        selectedHardwareAccount.metadata.keyring.type === 'Lattice Hardware',
+    );
+  }, [selectedHardwareAccount]);
 
   useEffect(() => {
     if (authorizedAccounts.length > 0) {
@@ -630,7 +640,19 @@ export default function RemoteModeSetupSwaps() {
         paddingRight={4}
         width={BlockSize.Full}
       >
-
+        {!isHardwareAccount && (
+          <BannerAlert
+            severity={BannerAlertSeverity.Warning}
+            marginBottom={2}
+          >
+            <Text variant={TextVariant.headingSm} fontWeight={FontWeight.Bold}>
+              Select a hardware wallet
+            </Text>
+            <Text variant={TextVariant.bodyMd}>
+              To continue, select your hardware wallet from the account menu.
+            </Text>
+          </BannerAlert>
+        )}
         <StepIndicator currentStep={currentStep} totalSteps={TOTAL_STEPS} />
         <Text
           textAlign={TextAlign.Center}
@@ -665,6 +687,7 @@ export default function RemoteModeSetupSwaps() {
           onClick={currentStep === 3 ? handleShowConfirmation : handleNext}
           width={BlockSize.Half}
           size={ButtonSize.Lg}
+          disabled={!isHardwareAccount}
         >
           {currentStep === TOTAL_STEPS ? 'Confirm' : 'Next'}
         </Button>

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -4,15 +4,19 @@ import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import {
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarAccountVariant,
   Box,
   Button,
+  ButtonIcon,
+  ButtonIconSize,
   ButtonVariant,
   ButtonSize,
   Text,
   Icon,
   IconName,
   IconSize,
-  Tag,
 } from '../../../../components/component-library';
 import Tooltip from '../../../../components/ui/tooltip';
 import UnitInput from '../../../../components/ui/unit-input';
@@ -34,6 +38,13 @@ import {
 import Card from '../../../../components/ui/card';
 import { AccountPicker } from '../../../../components/multichain/account-picker';
 import { AccountListMenu } from '../../../../components/multichain/account-list-menu';
+import {
+  Content,
+  Footer,
+  Header,
+  Page,
+} from '../../../../components/multichain/pages/page';
+
 import { SwapAllowance, TokenSymbol, ToTokenOption } from '../../remote.types';
 import {
   DEFAULT_ROUTE,
@@ -150,6 +161,10 @@ export default function RemoteModeSetupSwaps() {
     history.replace(REMOTE_ROUTE);
   };
 
+  const onCancel = () => {
+    history.goBack();
+  };
+
   const renderStepContent = () => {
     switch (currentStep) {
       case 1:
@@ -217,7 +232,15 @@ export default function RemoteModeSetupSwaps() {
                       <Icon name={IconName.Info} size={IconSize.Sm} />
                     </Tooltip>
                   </Box>
-                  <Text>{selectedHardwareAccount.metadata.name}</Text>
+                  <Box display={Display.Flex} gap={2}>
+                    <AvatarAccount
+                      variant={AvatarAccountVariant.Jazzicon}
+                      address={selectedHardwareAccount.address}
+                      size={AvatarAccountSize.Xs}
+                      marginTop={1}
+                    />
+                    <Text>{selectedHardwareAccount.metadata.name}</Text>
+                  </Box>
                 </Box>
               </Box>
             </Card>
@@ -226,7 +249,7 @@ export default function RemoteModeSetupSwaps() {
               marginBottom={2}
             >
               <Box marginBottom={2}>
-                <Text variant={TextVariant.headingMd}>Allowances</Text>
+                <Text variant={TextVariant.headingSm}>Swap limit</Text>
               </Box>
               <Box marginTop={4} marginBottom={2}>
                 <Box
@@ -269,7 +292,12 @@ export default function RemoteModeSetupSwaps() {
                         setDailyLimit(newDecimalValue)
                       }
                       placeholder="Enter amount"
-                      style={{ width: '100%' }}
+                      style={{
+                        width: '100%',
+                        borderRadius: BorderRadius.MD,
+                        minHeight: '45px',
+                        marginTop: '8px',
+                      }}
                     />
                   </Box>
                 </Box>
@@ -300,9 +328,13 @@ export default function RemoteModeSetupSwaps() {
                     style={{ width: '100%' }}
                   />
                 </Box>
-                <Text marginTop={2} marginBottom={2}>
-                  Allow trading for any token. Higher risk option, in case the
-                  authorized account gets compromised.
+                <Text
+                  variant={TextVariant.bodySm}
+                  marginTop={1}
+                  marginBottom={2}
+                >
+                  Tip: This is a higher risk option if your authorized account
+                  is compromised.
                 </Text>
                 <Button
                   width={BlockSize.Full}
@@ -349,56 +381,98 @@ export default function RemoteModeSetupSwaps() {
               alignItems={AlignItems.center}
               gap={2}
             >
-              <Tag
-                label="Includes 2 transactions"
-                style={{ padding: '0 1rem' }}
-              />
+              <Text variant={TextVariant.bodyMd} color={TextColor.textMuted}>
+                Unlock enhanced capabilities while keeping the same address.
+              </Text>
             </Box>
 
-            <Card backgroundColor={BackgroundColor.backgroundMuted}>
+            <Card
+              backgroundColor={BackgroundColor.backgroundMuted}
+              marginBottom={4}
+            >
               <Box
                 display={Display.Flex}
                 gap={2}
+                paddingBottom={2}
+                justifyContent={JustifyContent.spaceBetween}
+              >
+                <Text>Account</Text>
+
+                <Box
+                  display={Display.Flex}
+                  alignItems={AlignItems.center}
+                  gap={2}
+                >
+                  <Text
+                    textAlign={TextAlign.Center}
+                    variant={TextVariant.bodySm}
+                    fontWeight={FontWeight.Medium}
+                    color={TextColor.infoDefault}
+                    backgroundColor={BackgroundColor.primaryMuted}
+                    style={{
+                      padding: '4px 8px',
+                      borderRadius: '16px',
+                      display: 'inline-block',
+                    }}
+                  >
+                    {/* <Box
+                      display={Display.Flex}
+                      alignItems={AlignItems.center}
+                      gap={2}
+                    > */}
+                      {/* <AvatarAccount
+                        variant={AvatarAccountVariant.Jazzicon}
+                        address={selectedHardwareAccount.address}
+                        size={AvatarAccountSize.Xs}
+                        marginTop={1}
+                        paddingRight={2}
+                      /> */}
+                      {selectedHardwareAccount.metadata.name}
+                    {/* </Box> */}
+                  </Text>
+                </Box>
+              </Box>
+              <Box
+                display={Display.Flex}
+                gap={2}
+                paddingBottom={2}
+                justifyContent={JustifyContent.spaceBetween}
+              >
+                <Text>Now</Text>
+                <Text>Standard account (EOA)</Text>
+              </Box>
+              <Box
+                display={Display.Flex}
+                gap={2}
+                paddingBottom={2}
                 justifyContent={JustifyContent.spaceBetween}
               >
                 <Text>
-                  Account type <Icon name={IconName.Info} size={IconSize.Sm} />
+                  Updating to <Icon name={IconName.Info} size={IconSize.Sm} />
                 </Text>
                 <Text>Smart account</Text>
               </Box>
+              <Box
+                display={Display.Flex}
+                gap={2}
+                justifyContent={JustifyContent.spaceBetween}
+              >
+                <Text>Interacting with</Text>
+                <Text>Smart contract</Text>
+              </Box>
             </Card>
 
             <Card backgroundColor={BackgroundColor.backgroundMuted}>
-              <Box>
-                <Text>Estimated changes</Text>
+              <Box
+                display={Display.Flex}
+                gap={2}
+                paddingBottom={2}
+                justifyContent={JustifyContent.spaceBetween}
+              >
                 <Text>
-                  Authorize {selectedAccount?.metadata.name} to swap from your{' '}
-                  {selectedHardwareAccount.metadata.name} balance.
-                </Text>
-              </Box>
-            </Card>
-
-            <Card backgroundColor={BackgroundColor.backgroundMuted}>
-              <Box
-                display={Display.Flex}
-                gap={2}
-                justifyContent={JustifyContent.spaceBetween}
-              >
-                <Text>Request from</Text>
-                <Text>MetaMask</Text>
-              </Box>
-            </Card>
-
-            <Card backgroundColor={BackgroundColor.backgroundMuted}>
-              <Box
-                display={Display.Flex}
-                gap={2}
-                justifyContent={JustifyContent.spaceBetween}
-              >
-                <Text paddingBottom={2}>
                   Network fee <Icon name={IconName.Info} size={IconSize.Sm} />
                 </Text>
-                <Text paddingBottom={2}>0.0013 ETH</Text>
+                <Text>0.0013 ETH</Text>
               </Box>
               <Box
                 paddingTop={2}
@@ -406,8 +480,8 @@ export default function RemoteModeSetupSwaps() {
                 gap={2}
                 justifyContent={JustifyContent.spaceBetween}
               >
-                <Text paddingBottom={2}>Speed</Text>
-                <Text paddingBottom={2}>🦊 Market &lt; 30 sec</Text>
+                <Text>Speed</Text>
+                <Text>🦊 Market &lt; 30 sec</Text>
               </Box>
             </Card>
           </>
@@ -415,7 +489,7 @@ export default function RemoteModeSetupSwaps() {
       case 3:
         return (
           <>
-            <Card backgroundColor={BackgroundColor.backgroundMuted}>
+            <Card backgroundColor={BackgroundColor.backgroundMuted} marginBottom={4}>
               <Box
                 display={Display.Flex}
                 gap={2}
@@ -532,50 +606,44 @@ export default function RemoteModeSetupSwaps() {
   };
 
   return (
-    <div className="main-container" data-testid="remote-mode-setup-swaps">
-      <Box
+    <Page className="main-container" data-testid="remote-mode-setup-swaps">
+      <Header
+        textProps={{
+          variant: TextVariant.headingSm,
+        }}
+        startAccessory={
+          <ButtonIcon
+            size={ButtonIconSize.Sm}
+            ariaLabel={'back'}
+            iconName={IconName.ArrowLeft}
+            onClick={onCancel}
+          />
+        }
+      >
+        Remote mode
+      </Header>
+      <Content
         display={Display.Flex}
         flexDirection={FlexDirection.Column}
         gap={2}
-        padding={2}
+        paddingLeft={4}
+        paddingRight={4}
         width={BlockSize.Full}
       >
-        <StepIndicator currentStep={currentStep} totalSteps={TOTAL_STEPS} />
 
+        <StepIndicator currentStep={currentStep} totalSteps={TOTAL_STEPS} />
         <Text
           textAlign={TextAlign.Center}
           variant={TextVariant.headingMd}
           fontWeight={FontWeight.Bold}
         >
-          {currentStep === 1 && 'Enable Remote Swaps'}
-          {currentStep === 2 && 'Transaction Request'}
-          {currentStep === 3 && 'Confirm changes'}
+          {currentStep === 1 && 'Set up Remote Swaps'}
+          {currentStep === 2 && 'Update to a smart account'}
+          {currentStep === 3 && 'Review changes'}
         </Text>
 
         {renderStepContent()}
 
-        <Box
-          paddingTop={2}
-          display={Display.Flex}
-          gap={6}
-          justifyContent={JustifyContent.center}
-        >
-          <Button
-            onClick={handleBack}
-            variant={ButtonVariant.Secondary}
-            width={BlockSize.Half}
-            size={ButtonSize.Lg}
-          >
-            {currentStep === 1 ? 'Cancel' : 'Back'}
-          </Button>
-          <Button
-            onClick={currentStep === 3 ? handleShowConfirmation : handleNext}
-            width={BlockSize.Half}
-            size={ButtonSize.Lg}
-          >
-            {currentStep === TOTAL_STEPS ? 'Confirm' : 'Next'}
-          </Button>
-        </Box>
         <RemoteModeHardwareWalletConfirm
           visible={isConfirmModalOpen}
           onConfirm={handleConfigureRemoteSwaps}
@@ -583,7 +651,24 @@ export default function RemoteModeSetupSwaps() {
             setIsConfirmModalOpen(false);
           }}
         />
-      </Box>
-    </div>
+      </Content>
+      <Footer>
+        <Button
+          onClick={handleBack}
+          variant={ButtonVariant.Secondary}
+          width={BlockSize.Half}
+          size={ButtonSize.Lg}
+        >
+          {currentStep === 1 ? 'Cancel' : 'Back'}
+        </Button>
+        <Button
+          onClick={currentStep === 3 ? handleShowConfirmation : handleNext}
+          width={BlockSize.Half}
+          size={ButtonSize.Lg}
+        >
+          {currentStep === TOTAL_STEPS ? 'Confirm' : 'Next'}
+        </Button>
+      </Footer>
+    </Page>
   );
 }

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -430,14 +430,14 @@ export default function RemoteModeSetupSwaps() {
                       alignItems={AlignItems.center}
                       gap={2}
                     > */}
-                      {/* <AvatarAccount
+                    {/* <AvatarAccount
                         variant={AvatarAccountVariant.Jazzicon}
                         address={selectedHardwareAccount.address}
                         size={AvatarAccountSize.Xs}
                         marginTop={1}
                         paddingRight={2}
                       /> */}
-                      {selectedHardwareAccount.metadata.name}
+                    {selectedHardwareAccount.metadata.name}
                     {/* </Box> */}
                   </Text>
                 </Box>
@@ -499,7 +499,10 @@ export default function RemoteModeSetupSwaps() {
       case 3:
         return (
           <>
-            <Card backgroundColor={BackgroundColor.backgroundMuted} marginBottom={4}>
+            <Card
+              backgroundColor={BackgroundColor.backgroundMuted}
+              marginBottom={4}
+            >
               <Box
                 display={Display.Flex}
                 gap={2}
@@ -641,10 +644,7 @@ export default function RemoteModeSetupSwaps() {
         width={BlockSize.Full}
       >
         {!isHardwareAccount && (
-          <BannerAlert
-            severity={BannerAlertSeverity.Warning}
-            marginBottom={2}
-          >
+          <BannerAlert severity={BannerAlertSeverity.Warning} marginBottom={2}>
             <Text variant={TextVariant.headingSm} fontWeight={FontWeight.Bold}>
               Select a hardware wallet
             </Text>

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -56,6 +56,7 @@ import { getIsRemoteModeEnabled } from '../../../../selectors/remote-mode';
 import RemoteModeHardwareWalletConfirm from '../hardware-wallet-confirm-modal';
 import RemoteModeSwapAllowanceCard from '../swap-allowance-card';
 import StepIndicator from '../step-indicator/step-indicator.component';
+import { isRemoteModeSupported } from '../../../../helpers/utils/remote-mode';
 
 import { InternalAccountWithBalance } from '../../../../selectors/selectors.types';
 import {
@@ -102,10 +103,7 @@ export default function RemoteModeSetupSwaps() {
   const isRemoteModeEnabled = useSelector(getIsRemoteModeEnabled);
 
   useEffect(() => {
-    setIsHardwareAccount(
-      selectedHardwareAccount.metadata.keyring.type === 'Ledger Hardware' ||
-        selectedHardwareAccount.metadata.keyring.type === 'Lattice Hardware',
-    );
+    setIsHardwareAccount(isRemoteModeSupported(selectedHardwareAccount));
   }, [selectedHardwareAccount]);
 
   useEffect(() => {

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -44,9 +44,7 @@ import RemoteModeHardwareWalletConfirm from '../hardware-wallet-confirm-modal';
 import RemoteModeSwapAllowanceCard from '../swap-allowance-card';
 import StepIndicator from '../step-indicator/step-indicator.component';
 
-import {
-  InternalAccountWithBalance,
-} from '../../../../selectors/selectors.types';
+import { InternalAccountWithBalance } from '../../../../selectors/selectors.types';
 import {
   getSelectedInternalAccount,
   getMetaMaskAccountsOrdered,
@@ -77,7 +75,8 @@ export default function RemoteModeSetupSwaps() {
   const [dailyLimit, setDailyLimit] = useState<string>('');
   const [isAllowancesExpanded, setIsAllowancesExpanded] =
     useState<boolean>(false);
-  const [selectedAccount, setSelectedAccount] = useState<InternalAccount | null>(null);
+  const [selectedAccount, setSelectedAccount] =
+    useState<InternalAccount | null>(null);
 
   const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
@@ -164,7 +163,7 @@ export default function RemoteModeSetupSwaps() {
                   onClick: (account: InternalAccount) => {
                     setSelectedAccount(account);
                     setIsModalOpen(false);
-                  }
+                  },
                 }}
               />
             )}
@@ -193,15 +192,15 @@ export default function RemoteModeSetupSwaps() {
                   borderRadius={BorderRadius.LG}
                   borderColor={BorderColor.borderDefault}
                 >
-                {selectedAccount && (
-                  <AccountPicker
-                    address={selectedAccount?.address}
-                    name={selectedAccount?.metadata.name}
-                    onClick={() => {
-                      setIsModalOpen(true);
-                    }}
-                  />
-                )}
+                  {selectedAccount && (
+                    <AccountPicker
+                      address={selectedAccount?.address}
+                      name={selectedAccount?.metadata.name}
+                      onClick={() => {
+                        setIsModalOpen(true);
+                      }}
+                    />
+                  )}
                 </Box>
                 <Box
                   display={Display.Flex}

--- a/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
+++ b/ui/pages/remote-mode/setup/setup-swaps/remote-mode-setup-swaps.component.tsx
@@ -44,7 +44,9 @@ import RemoteModeHardwareWalletConfirm from '../hardware-wallet-confirm-modal';
 import RemoteModeSwapAllowanceCard from '../swap-allowance-card';
 import StepIndicator from '../step-indicator/step-indicator.component';
 
-import { InternalAccountWithBalance } from '../../../../selectors/selectors.types';
+import {
+  InternalAccountWithBalance,
+} from '../../../../selectors/selectors.types';
 import {
   getSelectedInternalAccount,
   getMetaMaskAccountsOrdered,
@@ -75,8 +77,7 @@ export default function RemoteModeSetupSwaps() {
   const [dailyLimit, setDailyLimit] = useState<string>('');
   const [isAllowancesExpanded, setIsAllowancesExpanded] =
     useState<boolean>(false);
-  const [selectedAccount, setSelectedAccount] =
-    useState<InternalAccount | null>(null);
+  const [selectedAccount, setSelectedAccount] = useState<InternalAccount | null>(null);
 
   const selectedHardwareAccount = useSelector(getSelectedInternalAccount);
   const authorizedAccounts: InternalAccountWithBalance[] = useSelector(
@@ -163,7 +164,7 @@ export default function RemoteModeSetupSwaps() {
                   onClick: (account: InternalAccount) => {
                     setSelectedAccount(account);
                     setIsModalOpen(false);
-                  },
+                  }
                 }}
               />
             )}
@@ -192,15 +193,15 @@ export default function RemoteModeSetupSwaps() {
                   borderRadius={BorderRadius.LG}
                   borderColor={BorderColor.borderDefault}
                 >
-                  {selectedAccount && (
-                    <AccountPicker
-                      address={selectedAccount?.address}
-                      name={selectedAccount?.metadata.name}
-                      onClick={() => {
-                        setIsModalOpen(true);
-                      }}
-                    />
-                  )}
+                {selectedAccount && (
+                  <AccountPicker
+                    address={selectedAccount?.address}
+                    name={selectedAccount?.metadata.name}
+                    onClick={() => {
+                      setIsModalOpen(true);
+                    }}
+                  />
+                )}
                 </Box>
                 <Box
                   display={Display.Flex}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Adds enforcement that only hardware-based accounts can setup remote mode.
- Note that the check is also triggered if the user changes the active account during the setup process
- Also includes a number of (still work-in-progress) [design](https://www.figma.com/design/yNlc4iZHrF6Hao8F85AjIE/Remote-Mode?node-id=3040-2998&p=f&t=qy92MFMF3rkNuKdh-0) parity tweaks
  - Using appropriate `Page`, `Header`, `Footer`, etc components
  - Various copy updates
  - Other minor design / stylistic updates

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32012?quickstart=1)

## **Related issues**

Fixes: [#31677](https://github.com/MetaMask/metamask-extension/issues/31677)

## **Manual testing steps**

1. Create the build (yarn webpack)
2. Go to `remote/setup-swaps` and `remote/setup-daily-allowance` and switch between a hardware and non-hardware wallet based accounts. This can be done during both the overview screen and at any time during the setup flow(s)
3. [Designs for reference](https://www.figma.com/design/yNlc4iZHrF6Hao8F85AjIE/Remote-Mode?node-id=3040-2998&p=f&t=qy92MFMF3rkNuKdh-0) when reviewing the design parity related updates, although note these are still work-in-process
- Note to override the vaultRemoteMode feature flag (which will implicitly default to disabled), the configuration steps are available [here](https://github.com/MetaMask/contributor-docs/blob/main/docs/remote-feature-flags.md#a-local-build). Example.manifest-overrides.json:
```json
{
  "_flags": {
    "remoteFeatureFlags": {
      "vaultRemoteMode": true
    }
  }
}
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

![image](https://github.com/user-attachments/assets/3898e809-d76c-47fa-baa0-0bcb73d472a0)
![image](https://github.com/user-attachments/assets/c183c5e3-45a0-4384-aebe-e5f12ad26d34)
![image](https://github.com/user-attachments/assets/a7264c34-982f-4cbe-8bcc-0627e8597e62)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
