### PR TITLE
chore: adding stories for various connect pages and components

### DIFF
--- a/ui/components/multichain/pages/connections/connections.stories.tsx
+++ b/ui/components/multichain/pages/connections/connections.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { Meta, StoryObj } from '@storybook/react';
+import { Connections } from './connections';
+import configureStore from '../../../../store/store';
+import state from '../../../../../.storybook/test-data';
+
+const store = configureStore(state);
+
+const meta = {
+  title: 'Components/Multichain/Pages/Connections',
+  component: Connections,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/connections/metamask.github.io']}>
+          <Route path="/connections/:origin">
+            <Story />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    ),
+  ],
+} satisfies Meta<typeof Connections>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/ui/components/multichain/permissions-header/permissions-header.stories.tsx
+++ b/ui/components/multichain/permissions-header/permissions-header.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { PermissionsHeader } from './permissions-header';
+
+const meta = {
+  title: 'Components/Multichain/Pages/PermissionsHeader',
+  component: PermissionsHeader,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof PermissionsHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    securedOrigin: 'https://github.io',
+    connectedSubjectsMetadata: {
+      name: 'GitHub Pages',
+      iconUrl: 'https://github.githubassets.com/favicons/favicon.svg',
+    },
+  },
+};
+
+export const WithoutIcon: Story = {
+  args: {
+    securedOrigin: 'https://example.com',
+  },
+};
+
+export const LongDomainName: Story = {
+  args: {
+    securedOrigin: 'https://very-very-very-very-very-very-very-very-very-very-long-domain-name-that-should-be-truncated.com',
+    connectedSubjectsMetadata: {
+      name: 'Very Very Very Very Very Very Very Long Domain Name',
+      iconUrl: 'https://example.com/favicon.ico',
+    },
+  },
+};


### PR DESCRIPTION
## **Description**

This PR adds Storybook stories to document and test the UI components before implementing the accessibility and responsive design improvements proposed in #31963. The key changes include:

1. Adding a basic `Default` story for the `Connections` page component using the test data store
2. Adding comprehensive stories for the `PermissionsHeader` component to showcase different states:
   - Default state with icon and domain name
   - State without an icon
   - State with a long domain name to test truncation behavior

These stories will serve as a baseline for the upcoming accessibility and responsive design improvements, allowing us to visually document the changes and ensure proper testing coverage.

## **Related issues**

Related to: #31963 (Parent accessibility improvements PR)

## **Manual testing steps**

1. Start Storybook locally: `yarn storybook`
2. Navigate to "Pages/Connections" story
   - Verify the connections page renders correctly with test data
   - Check that routing and store integration works as expected
3. Navigate to "Components/Multichain/Pages/PermissionsHeader" stories
   - Verify all three states render correctly (Default, WithoutIcon, LongDomainName)
   - Check that long domain names truncate appropriately
   - Verify icon display and spacing in different states

## **Screenshots/Recordings**

### **Before**
No existing stories for these components.

### **After**
<!-- Please add screenshots of the new stories in Storybook -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests (Storybook stories serve as visual regression tests)
- [x] I've documented my code using proper component stories and prop descriptions
- [x] I've applied the right labels on the PR (team-design-system)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run Storybook, test stories)
- [ ] I confirm that this PR addresses all acceptance criteria by providing proper story coverage for the components being modified in #31963