### PR TITLE
fix: fix rerender for suggested nfts

### DIFF
--- a/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.js
+++ b/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.js
@@ -180,7 +180,7 @@ const ConfirmAddSuggestedNFT = () => {
     };
 
     addImageUrlToSuggestedNFTs();
-  }, []); // Empty dependency array to run only on mount
+  }, [suggestedNfts]); // rerender when suggestedNfts changes
 
   return (
     <Box
@@ -269,7 +269,6 @@ const ConfirmAddSuggestedNFT = () => {
                 const nftImageURL = found
                   ? found.requestData.asset.assetImageUrl
                   : '';
-
                 const blockExplorerLink = getTokenTrackerLink(
                   address,
                   chainId,


### PR DESCRIPTION

## **Description**

PR fixes re-render of images when a user tries to watch multiple nfts

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32031?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/27619

## **Manual testing steps**
(steps are described in issue)
1. Go to test-dapp
2. Deploy multiple nfts
3. Watch NFTs
4. You should see all images


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/d3f24d04-035c-44f3-b718-2e5bc3c4bf13




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
