### PR TITLE
fix: flaky test `Smart Transactions Swap`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -142,6 +143,7 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
+          <<: *mai_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,6 @@ workflows:
           requires:
             - prep-deps
       - test-e2e-chrome-webpack:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-webpack
             - get-changed-files-with-git-diff
@@ -143,7 +142,6 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
-          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ workflows:
             - prep-build-test
             - get-changed-files-with-git-diff
       - test-e2e-firefox:
-          <<: *mai_master_rc_only
+          <<: *main_master_rc_only
           requires:
             - prep-build-test-mv2
             - get-changed-files-with-git-diff

--- a/test/e2e/tests/swaps/shared.ts
+++ b/test/e2e/tests/swaps/shared.ts
@@ -74,8 +74,17 @@ export const reviewQuote = async (
     '[data-testid="exchange-rate-display-quote-rate"]',
   );
   const summaryText = await summary.getText();
-  assert.equal(summaryText.includes(options.swapFrom), true);
-  assert.equal(summaryText.includes(options.swapTo), true);
+
+  await driver.waitForSelector({
+    testId: 'prepare-swap-page-swap-from',
+    text: options.swapFrom,
+  });
+
+  await driver.waitForSelector({
+    testId: 'prepare-swap-page-swap-to',
+    text: options.swapTo,
+  });
+
   const quote = summaryText.split(`\n`);
 
   const elementSwapToAmount = await driver.findElement(

--- a/test/e2e/tests/swaps/shared.ts
+++ b/test/e2e/tests/swaps/shared.ts
@@ -147,22 +147,20 @@ export const checkActivityTransaction = async (
   await driver.clickElement('[data-testid="account-overview__activity-tab"]');
   await driver.waitForSelector('.activity-list-item');
 
-  const transactionList = await driver.findElements(
-    '[data-testid="activity-list-item-action"]',
-  );
-  const transactionText = await transactionList[options.index].getText();
-  assert.equal(
-    transactionText,
-    `Swap ${options.swapFrom} to ${options.swapTo}`,
-    'Transaction not found',
-  );
+  await driver.waitForSelector({
+    tag: 'p',
+    text: `Swap ${options.swapFrom} to ${options.swapTo}`,
+  });
 
   await driver.findElement({
     css: '[data-testid="transaction-list-item-primary-currency"]',
     text: `-${options.amount} ${options.swapFrom}`,
   });
 
-  await transactionList[options.index].click();
+  await driver.clickElement({
+    tag: 'p',
+    text: `Swap ${options.swapFrom} to ${options.swapTo}`,
+  });
   await driver.delay(regularDelayMs);
 
   await driver.findElement({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Flaky test due to anti-pattern usage of getText, instead of looking for the target text to be rendered.

https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/140221/workflows/d5037001-7fe3-4784-bf7c-4eecbdb58a97/jobs/4778615/tests#failed-test-0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32032?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32036
 
## **Manual testing steps**

1. Check FF run in ci here https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/140350/workflows/3024f7d1-5398-42a5-8274-af8c76709072/jobs/4781457/steps


## **Screenshots/Recordings**

![Screenshot from 2025-04-16 11-27-43](https://github.com/user-attachments/assets/1f1c006b-c8b1-430f-ad14-45f65453f549)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
