### PR TITLE
chore: cherry-pick #32062 – update privacy policy url for firefox on metametrics screen into v12.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [12.12.2]
-### Uncategorized
-- Version v12.12.1 ([#31125](https://github.com/MetaMask/metamask-extension/pull/31125))
-- chore: Disable CSP test ([#31122](https://github.com/MetaMask/metamask-extension/pull/31122))
-- chore: Support building backport prod build ([#31113](https://github.com/MetaMask/metamask-extension/pull/31113))
-- chore: Update changelog for v12.12.1 ([#31118](https://github.com/MetaMask/metamask-extension/pull/31118))
-- Update Attributions
-- chore: Fix CI failures affecting v12.12.x ([#31114](https://github.com/MetaMask/metamask-extension/pull/31114))
-- chore: Add missing mocked page object
-- fix: Temporarily disable "Test Snap update via snaps component" E2E test ([#30680](https://github.com/MetaMask/metamask-extension/pull/30680))
-- Skip snap UI link tests to get build passing
-- fix: add missing mock for portfolio site in e2e testing ([#31034](https://github.com/MetaMask/metamask-extension/pull/31034))
-- fix: cp-12.13.0 dependency version (#30375) ([#30375](https://github.com/MetaMask/metamask-extension/pull/30375))
-- chore: ignore babel audit failure temporarily ([#30946](https://github.com/MetaMask/metamask-extension/pull/30946))
-- chore: Temporarily ignore yarn audit failure for issue 1102472 ([#30910](https://github.com/MetaMask/metamask-extension/pull/30910))
-- chore: fix trezor audit ([#30850](https://github.com/MetaMask/metamask-extension/pull/30850))
-- chore: pin `github-tools` on specific commit
-- Version v12.12.1
-- Fix: Disable CSP override feature that is breaking sites
+### Changed
+- Update privacy policy url for Firefox builds on metametrics screen ([#32062](https://github.com/MetaMask/metamask-extension/pull/32062))
 
 ## [12.12.1]
 ### Fixed

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+// eslint-disable-next-line import/no-restricted-paths
+import { getPlatform } from '../../../../app/scripts/lib/util';
 import {
   Display,
   FlexDirection,
@@ -27,6 +29,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
+import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
@@ -212,7 +215,11 @@ export default function OnboardingMetametrics() {
       >
         {t('onboardingMetametricsInfuraTerms', [
           <a
-            href="https://metamask.io/privacy.html"
+            href={
+              getPlatform() === PLATFORM_FIREFOX
+                ? 'https://addons.mozilla.org/en-CA/firefox/addon/ether-metamask/privacy/'
+                : 'https://metamask.io/privacy.html'
+            }
             target="_blank"
             rel="noopener noreferrer"
             key="privacy-link"


### PR DESCRIPTION
* See #32062