### PR TITLE
feat: integrate dynamic banners through contentful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unify confirmation page styles and responsive behavior ([#31454](https://github.com/MetaMask/metamask-extension/pull/31454))
 - Integrate @metamask/bridge-status-controller@^14.0.0 and replace existing BridgeStatusController instance ([#31907](https://github.com/MetaMask/metamask-extension/pull/31907))
 - Add RPC (sub)domain tracking to transaction event metrics for RPC endpoints usage ([#32076](https://github.com/MetaMask/metamask-extension/pull/32076))
+- Integrate dynamic content banners ([#32101](https://github.com/MetaMask/metamask-extension/pull/32101))
 
 ### Changed
 - Update multichain network controller to implement `getNetworksWithActivityByAccounts` method and add state management for networks with activity ([#31414](https://github.com/MetaMask/metamask-extension/pull/31414))

--- a/shared/constants/app-state.ts
+++ b/shared/constants/app-state.ts
@@ -30,4 +30,6 @@ export type CarouselSlide = {
   dismissed?: boolean;
   href?: string;
   undismissable?: boolean;
+  startDate?: string;
+  endDate?: string;
 };

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -934,6 +934,22 @@ async function setupMocking(
       };
     });
 
+  // Dynamic Banner Content
+  await server
+    .forGet(/^https:\/\/(cdn|preview)\.contentful\.com\/.*$/u)
+    .withQuery({
+      content_type: 'promotionalBanner',
+    })
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: {
+          items: [],
+          includes: { Asset: [] },
+        },
+      };
+    });
+
   /**
    * Returns an array of alphanumerically sorted hostnames that were requested
    * during the current test suite.

--- a/test/e2e/tests/carousel/carousel.spec.ts
+++ b/test/e2e/tests/carousel/carousel.spec.ts
@@ -2,9 +2,10 @@ import { strict as assert } from 'assert';
 import { tinyDelayMs, withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+import { MAX_SLIDES } from '../../../../ui/components/multichain/carousel/constants';
 
 describe('Carousel component e2e tests', function () {
-  const MAX_VISIBLE_SLIDES = 5;
+  const MAX_VISIBLE_SLIDES = MAX_SLIDES;
   const SLIDE_IDS = [
     'solana',
     'smartAccountUpgrade',

--- a/ui/components/multichain/carousel/carousel.stories.tsx
+++ b/ui/components/multichain/carousel/carousel.stories.tsx
@@ -53,7 +53,8 @@ export const WithCloseButton: Story = {
   ...Template,
   args: {
     ...DefaultStory.args,
-    onClose: (id: string) => console.log(`Closing slide with id: ${id}`),
+    onClose: (isLastSlide: boolean, id: string) =>
+      console.log(`Closing slide with id: ${id}`),
   },
 };
 

--- a/ui/components/multichain/carousel/carousel.test.tsx
+++ b/ui/components/multichain/carousel/carousel.test.tsx
@@ -3,8 +3,9 @@ import { render, fireEvent } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { SolAccountType } from '@metamask/keyring-api';
 import { SOLANA_SLIDE } from '../../../hooks/useCarouselManagement';
+import { fetchCarouselSlidesFromContentful } from '../../../hooks/useCarouselManagement/fetchCarouselSlidesFromContentful';
 import { Carousel } from './carousel';
-import { MARGIN_VALUES, WIDTH_VALUES } from './constants';
+import { MARGIN_VALUES, MAX_SLIDES, WIDTH_VALUES } from './constants';
 
 jest.mock('react-responsive-carousel', () => ({
   Carousel: ({
@@ -23,6 +24,11 @@ jest.mock('react-responsive-carousel', () => ({
     </div>
   ),
 }));
+
+jest.mock(
+  '../../../hooks/useCarouselManagement/fetchCarouselSlidesFromContentful',
+);
+jest.mocked(fetchCarouselSlidesFromContentful).mockResolvedValue([]);
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -229,38 +235,21 @@ describe('Carousel', () => {
   });
 
   it('should limit the number of slides to MAX_SLIDES', () => {
-    const manySlides = [
-      ...mockSlides,
-      {
-        id: '3',
-        title: 'Slide 3',
-        description: 'Description 3',
-        image: 'image3.jpg',
-      },
-      {
-        id: '4',
-        title: 'Slide 4',
-        description: 'Description 4',
-        image: 'image4.jpg',
-      },
-      {
-        id: '5',
-        title: 'Slide 5',
-        description: 'Description 5',
-        image: 'image5.jpg',
-      },
-      {
-        id: '6',
-        title: 'Slide 6',
-        description: 'Description 6',
-        image: 'image6.jpg',
-      },
-    ];
+    const createSlide = (id: string) => ({
+      id,
+      title: `Slide ${id}`,
+      description: `Description ${id}`,
+      image: `imagejpg`,
+    });
+    const slides = [...Array(MAX_SLIDES)].map((_, i) => createSlide(`${i}`));
+    slides.push(createSlide('1 more than max!'));
+    slides.push(createSlide('2 more than max!'));
+    slides.push(createSlide('3 more than max!'));
 
-    const { container } = render(<Carousel slides={manySlides} />);
+    const { container } = render(<Carousel slides={slides} />);
 
     const visibleSlides = container.querySelectorAll('.mm-carousel-slide');
-    expect(visibleSlides).toHaveLength(5);
+    expect(visibleSlides).toHaveLength(MAX_SLIDES);
   });
 
   describe('Solana slide filtering', () => {

--- a/ui/components/multichain/carousel/carousel.tsx
+++ b/ui/components/multichain/carousel/carousel.tsx
@@ -83,7 +83,6 @@ export const Carousel = React.forwardRef(
         const isSweepstakesActive = getSweepstakesCampaignActive(
           new Date(new Date().toISOString()),
         );
-
         if (isSweepstakesActive) {
           if (a.id === 'sweepStake') {
             return -1;
@@ -229,62 +228,68 @@ export const Carousel = React.forwardRef(
           emulateTouch
           centerMode
         >
-          {visibleSlides.map((slide, index) => (
-            <BannerBase
-              data-testid={`slide-${slide.id}`}
-              onClick={() => {
-                if (index !== selectedIndex) {
-                  return;
+          {visibleSlides.map((slide, index) => {
+            const isContentfulContent = slide.id.startsWith('contentful-');
+            return (
+              <BannerBase
+                data-testid={`slide-${slide.id}`}
+                onClick={() => {
+                  if (index !== selectedIndex) {
+                    return;
+                  }
+                  if (slide.href) {
+                    global.platform.openTab({ url: slide.href });
+                  }
+                  onClick?.(slide.id);
+                }}
+                key={slide.id}
+                className="mm-carousel-slide"
+                startAccessory={
+                  <img
+                    className="mm-carousel-slide__accessory"
+                    src={slide.image}
+                    alt={slide.title}
+                  />
                 }
-                if (slide.href) {
-                  global.platform.openTab({ url: slide.href });
+                textAlign={TextAlign.Left}
+                alignItems={AlignItems.center}
+                title={isContentfulContent ? slide.title : t(slide.title)}
+                description={
+                  isContentfulContent ? slide.description : t(slide.description)
                 }
-                onClick?.(slide.id);
-              }}
-              key={slide.id}
-              className="mm-carousel-slide"
-              startAccessory={
-                <img
-                  className="mm-carousel-slide__accessory"
-                  src={slide.image}
-                />
-              }
-              textAlign={TextAlign.Left}
-              alignItems={AlignItems.center}
-              title={t(slide.title)}
-              description={t(slide.description)}
-              titleProps={{
-                variant: TextVariant.bodySmMedium,
-                fontWeight: FontWeight.Medium,
-                marginLeft: 1,
-              }}
-              descriptionProps={{
-                variant: TextVariant.bodyXs,
-                fontWeight: FontWeight.Normal,
-                color: TextColor.textAlternative,
-                marginLeft: 1,
-              }}
-              onClose={
-                Boolean(handleClose) && !slide.undismissable
-                  ? (e: React.MouseEvent<HTMLElement>) =>
-                      handleClose(e, slide.id)
-                  : undefined
-              }
-              closeButtonProps={{
-                className: 'mm-carousel-slide__close-button',
-              }}
-              style={{
-                height: BANNER_STYLES.HEIGHT,
-                margin: getSlideMargin(index, visibleSlides.length),
-                width: getSlideWidth(index, visibleSlides.length),
-                position: 'relative',
-              }}
-              padding={0}
-              paddingLeft={3}
-              paddingRight={3}
-              borderRadius={BorderRadius.XL}
-            />
-          ))}
+                titleProps={{
+                  variant: TextVariant.bodySmMedium,
+                  fontWeight: FontWeight.Medium,
+                  marginLeft: 1,
+                }}
+                descriptionProps={{
+                  variant: TextVariant.bodyXs,
+                  fontWeight: FontWeight.Normal,
+                  color: TextColor.textAlternative,
+                  marginLeft: 1,
+                }}
+                onClose={
+                  Boolean(handleClose) && !slide.undismissable
+                    ? (e: React.MouseEvent<HTMLElement>) =>
+                        handleClose(e, slide.id)
+                    : undefined
+                }
+                closeButtonProps={{
+                  className: 'mm-carousel-slide__close-button',
+                }}
+                style={{
+                  height: BANNER_STYLES.HEIGHT,
+                  margin: getSlideMargin(index, visibleSlides.length),
+                  width: getSlideWidth(index, visibleSlides.length),
+                  position: 'relative',
+                }}
+                padding={0}
+                paddingLeft={3}
+                paddingRight={3}
+                borderRadius={BorderRadius.XL}
+              />
+            );
+          })}
         </ResponsiveCarousel>
       </Box>
     );

--- a/ui/components/multichain/carousel/constants.ts
+++ b/ui/components/multichain/carousel/constants.ts
@@ -15,4 +15,4 @@ export const BANNER_STYLES = {
   HEIGHT: '64px',
 };
 
-export const MAX_SLIDES = 5;
+export const MAX_SLIDES = 7;

--- a/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts
+++ b/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts
@@ -1,0 +1,63 @@
+import { CarouselSlide } from '../../../shared/constants/app-state';
+import { isProduction } from '../../../shared/modules/environment';
+
+const isProductionEnv = process.env.IN_TEST || isProduction();
+
+const SPACE_ID = process.env.CONTENTFUL_ACCESS_SPACE_ID ?? '';
+const ACCESS_TOKEN = process.env.CONTENTFUL_ACCESS_TOKEN ?? '';
+const ENVIRONMENT = isProductionEnv ? 'master' : 'dev';
+const CONTENT_TYPE = 'promotionalBanner';
+const DEFAULT_DOMAIN = isProductionEnv
+  ? 'cdn.contentful.com'
+  : 'preview.contentful.com';
+const CONTENTFUL_API = `https://${DEFAULT_DOMAIN}/spaces/${SPACE_ID}/environments/${ENVIRONMENT}/entries`;
+// Ideally we could construct the type through contentful package, but this is not installed
+type ContentfulSysField = { sys: { id: string } };
+type ContentfulBanner = ContentfulSysField & {
+  fields: {
+    headline: string;
+    teaser: string;
+    image: ContentfulSysField;
+    linkUrl: string;
+    undismissable: boolean;
+    startDate?: string;
+    endDate?: string;
+  };
+};
+
+type ContentfulBannerResponse = {
+  items: ContentfulBanner[];
+  includes?: {
+    Asset?: (ContentfulSysField & {
+      fields?: { file?: { url?: string } };
+    })[];
+  };
+};
+
+export async function fetchCarouselSlidesFromContentful() {
+  const url = new URL(CONTENTFUL_API);
+  url.searchParams.set('access_token', ACCESS_TOKEN);
+  url.searchParams.set('content_type', CONTENT_TYPE);
+  const res: ContentfulBannerResponse = await fetch(url).then((r) => r.json());
+
+  const assets = res.includes?.Asset || [];
+  const resolveImage = (imageRef: ContentfulSysField) => {
+    const asset = assets.find((a) => a.sys.id === imageRef?.sys?.id);
+    const rawUrl = asset?.fields?.file?.url || '';
+    return rawUrl.startsWith('//') ? `https:${rawUrl}` : rawUrl;
+  };
+
+  const slides: CarouselSlide[] = res.items.map((entry) => ({
+    id: `contentful-${entry.sys.id}`,
+    title: entry.fields.headline,
+    description: entry.fields.teaser,
+    image: resolveImage(entry.fields.image),
+    href: entry.fields.linkUrl,
+    undismissable: entry.fields.undismissable,
+    dismissed: false,
+    startDate: entry.fields.startDate,
+    endDate: entry.fields.endDate,
+  }));
+
+  return slides;
+}

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.test.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateSlides } from '../../store/actions';
 import {
@@ -28,6 +29,10 @@ import {
   SOLANA_SLIDE,
   SMART_ACCOUNT_UPGRADE_SLIDE,
 } from './constants';
+import { fetchCarouselSlidesFromContentful } from './fetchCarouselSlidesFromContentful';
+
+jest.mock('./fetchCarouselSlidesFromContentful');
+jest.mocked(fetchCarouselSlidesFromContentful).mockResolvedValue([]);
 
 const SLIDES_ZERO_FUNDS_REMOTE_OFF_SWEEPSTAKES_OFF = [
   { ...FUND_SLIDE, undismissable: true },
@@ -272,9 +277,10 @@ describe('useCarouselManagement', () => {
   });
 
   describe('zero funds, remote off, sweepstakes off', () => {
-    it('should have correct slide order', () => {
+    it('should have correct slide order', async () => {
       renderHook(() => useCarouselManagement({ testDate: invalidTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -282,9 +288,10 @@ describe('useCarouselManagement', () => {
       );
     });
 
-    it('should mark fund slide as undismissable', () => {
+    it('should mark fund slide as undismissable', async () => {
       renderHook(() => useCarouselManagement({ testDate: invalidTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides[0].undismissable).toBe(true);
@@ -296,9 +303,10 @@ describe('useCarouselManagement', () => {
       mockGetIsRemoteModeEnabled.mockReturnValue(true);
     });
 
-    it('should have correct slide order', () => {
+    it('should have correct slide order', async () => {
       renderHook(() => useCarouselManagement({ testDate: invalidTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -308,9 +316,10 @@ describe('useCarouselManagement', () => {
   });
 
   describe('zero funds, remote off, sweepstakes on', () => {
-    it('should have correct slide order', () => {
+    it('should have correct slide order', async () => {
       renderHook(() => useCarouselManagement({ testDate: validTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -324,9 +333,10 @@ describe('useCarouselManagement', () => {
       mockGetIsRemoteModeEnabled.mockReturnValue(true);
     });
 
-    it('should have correct slide order', () => {
+    it('should have correct slide order', async () => {
       renderHook(() => useCarouselManagement({ testDate: validTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -340,9 +350,10 @@ describe('useCarouselManagement', () => {
       mockGetSelectedAccountCachedBalance.mockReturnValue('0x1');
     });
 
-    it('should have correct slide order', () => {
+    it('should have correct slide order', async () => {
       renderHook(() => useCarouselManagement({ testDate: invalidTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -357,9 +368,10 @@ describe('useCarouselManagement', () => {
       mockGetIsRemoteModeEnabled.mockReturnValue(true);
     });
 
-    it('should have correct slide order', () => {
+    it('should have correct slide order', async () => {
       renderHook(() => useCarouselManagement({ testDate: invalidTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -373,9 +385,10 @@ describe('useCarouselManagement', () => {
       mockGetSelectedAccountCachedBalance.mockReturnValue('0x1');
     });
 
-    it('should have correct slide order', () => {
+    it('should have correct slide order', async () => {
       renderHook(() => useCarouselManagement({ testDate: validTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -390,9 +403,10 @@ describe('useCarouselManagement', () => {
       mockGetIsRemoteModeEnabled.mockReturnValue(true);
     });
 
-    it('should have correct slide order', () => {
+    it('should have correct slide order', async () => {
       renderHook(() => useCarouselManagement({ testDate: validTestDate }));
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -402,14 +416,14 @@ describe('useCarouselManagement', () => {
   });
 
   describe('state changes', () => {
-    it('should update slides when balance changes', () => {
+    it('should update slides when balance changes', async () => {
       mockGetSelectedAccountCachedBalance.mockReturnValue('0x1');
 
       const { rerender } = renderHook((props) => useCarouselManagement(props), {
         initialProps: { testDate: invalidTestDate },
       });
 
-      expect(mockUpdateSlides).toHaveBeenCalled();
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       let updatedSlides = mockUpdateSlides.mock.calls[0][0];
       expect(updatedSlides).toStrictEqual(
         SLIDES_POSITIVE_FUNDS_REMOTE_OFF_SWEEPSTAKES_OFF,
@@ -420,7 +434,7 @@ describe('useCarouselManagement', () => {
 
       rerender({ testDate: invalidTestDate });
 
-      expect(mockUpdateSlides).toHaveBeenCalled();
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
 
       updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
@@ -429,12 +443,12 @@ describe('useCarouselManagement', () => {
       );
     });
 
-    it('should update slides when testDate changes', () => {
+    it('should update slides when testDate changes', async () => {
       const { rerender } = renderHook((props) => useCarouselManagement(props), {
         initialProps: { hasZeroBalance: false, testDate: invalidTestDate },
       });
 
-      expect(mockUpdateSlides).toHaveBeenCalled();
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       let updatedSlides = mockUpdateSlides.mock.calls[0][0];
 
       expect(updatedSlides).toStrictEqual(
@@ -445,7 +459,7 @@ describe('useCarouselManagement', () => {
 
       rerender({ hasZeroBalance: false, testDate: validTestDate });
 
-      expect(mockUpdateSlides).toHaveBeenCalled();
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       updatedSlides = mockUpdateSlides.mock.calls[0][0];
       expect(updatedSlides).toStrictEqual(
         SLIDES_ZERO_FUNDS_REMOTE_OFF_SWEEPSTAKES_ON,
@@ -454,7 +468,7 @@ describe('useCarouselManagement', () => {
   });
 
   describe('edge cases', () => {
-    it('should handle exactly at SWEEPSTAKES_START time', () => {
+    it('should handle exactly at SWEEPSTAKES_START time', async () => {
       const testDate = SWEEPSTAKES_START.toISOString();
 
       renderHook(() =>
@@ -463,12 +477,13 @@ describe('useCarouselManagement', () => {
         }),
       );
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock
         .calls[0][0] as CarouselSlide[];
       expect(updatedSlides[0].id).toBe(SWEEPSTAKES_SLIDE.id);
     });
 
-    it('should handle exactly at SWEEPSTAKES_END time', () => {
+    it('should handle exactly at SWEEPSTAKES_END time', async () => {
       const testDate = SWEEPSTAKES_END.toISOString();
 
       renderHook(() =>
@@ -477,12 +492,13 @@ describe('useCarouselManagement', () => {
         }),
       );
 
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
       const updatedSlides = mockUpdateSlides.mock
         .calls[0][0] as CarouselSlide[];
       expect(updatedSlides[0].id).toBe(SWEEPSTAKES_SLIDE.id);
     });
 
-    it('should handle invalid testDate gracefully', () => {
+    it('should handle invalid testDate for sweepstakes gracefully', async () => {
       const testDate = 'invalid-date';
 
       expect(() =>
@@ -493,7 +509,7 @@ describe('useCarouselManagement', () => {
         ),
       ).not.toThrow();
 
-      expect(mockUpdateSlides).toHaveBeenCalled();
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
     });
   });
 

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.ts
@@ -2,10 +2,12 @@ import { isEqual } from 'lodash';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import log from 'loglevel';
 import { isSolanaAddress } from '../../../shared/lib/multichain/accounts';
 import type { CarouselSlide } from '../../../shared/constants/app-state';
 import { updateSlides } from '../../store/actions';
 import {
+  getRemoteFeatureFlags,
   getSelectedAccountCachedBalance,
   getSelectedInternalAccount,
   getSlides,
@@ -30,6 +32,7 @@ import {
   SOLANA_SLIDE,
   ///: END:ONLY_INCLUDE_IF
 } from './constants';
+import { fetchCarouselSlidesFromContentful } from './fetchCarouselSlidesFromContentful';
 
 type UseSlideManagementProps = {
   testDate?: string; // Only used in unit/e2e tests to simulate dates for sweepstakes campaign
@@ -39,12 +42,29 @@ export function getSweepstakesCampaignActive(currentDate: Date) {
   return currentDate >= SWEEPSTAKES_START && currentDate <= SWEEPSTAKES_END;
 }
 
+export function isActive(
+  slide: { startDate?: string; endDate?: string },
+  now = new Date(),
+): boolean {
+  const start = slide.startDate ? new Date(slide.startDate) : null;
+  const end = slide.endDate ? new Date(slide.endDate) : null;
+
+  if (start && now < start) {
+    return false;
+  }
+  if (end && now > end) {
+    return false;
+  }
+  return true;
+}
+
 export const useCarouselManagement = ({
   testDate,
 }: UseSlideManagementProps = {}) => {
   const inTest = Boolean(process.env.IN_TEST);
   const dispatch = useDispatch();
-  const slides = useSelector(getSlides);
+  const slides: CarouselSlide[] = useSelector(getSlides);
+  const remoteFeatureFlags = useSelector(getRemoteFeatureFlags);
   const totalBalance = useSelector(getSelectedAccountCachedBalance);
   const isRemoteModeEnabled = useSelector(getIsRemoteModeEnabled);
   const selectedAccount = useSelector(getSelectedInternalAccount);
@@ -110,11 +130,53 @@ export const useCarouselManagement = ({
 
       defaultSlides.push(dismissedSweepstakesSlide);
     }
+    // Handle Contentful Data
+    const maybeFetchContentful = async () => {
+      const contentfulEnabled =
+        remoteFeatureFlags?.contentfulCarouselEnabled ?? false;
 
-    if (!isEqual(slides, defaultSlides)) {
-      dispatch(updateSlides(defaultSlides));
-    }
-  }, [dispatch, hasZeroBalance, isRemoteModeEnabled, slides, testDate, inTest]);
+      if (contentfulEnabled) {
+        try {
+          const contentfulSlides = await fetchCarouselSlidesFromContentful();
+          const checkedContentfulSlides = contentfulSlides
+            .map((slide) => {
+              const existing = slides.find(
+                (s: CarouselSlide) => s.id === slide.id,
+              );
+              return {
+                ...slide,
+                dismissed: existing?.dismissed ?? false,
+              };
+            })
+            .filter((slide) =>
+              isActive(slide, testDate ? new Date(testDate) : new Date()),
+            );
+          const mergedSlides = [...defaultSlides, ...checkedContentfulSlides];
+          if (!isEqual(slides, mergedSlides)) {
+            dispatch(updateSlides(mergedSlides));
+          }
+        } catch (err) {
+          log.warn('Failed to fetch Contentful slides:', err);
+          if (!isEqual(slides, defaultSlides)) {
+            dispatch(updateSlides(defaultSlides));
+          }
+        }
+      } else if (!isEqual(slides, defaultSlides)) {
+        dispatch(updateSlides(defaultSlides));
+      }
+    };
+
+    maybeFetchContentful();
+  }, [
+    dispatch,
+    hasZeroBalance,
+    isRemoteModeEnabled,
+    remoteFeatureFlags,
+    testDate,
+    inTest,
+    slides,
+    selectedAccount.address,
+  ]);
 
   return { slides };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR focuses on integrating the Contentful API with metamask-extension to manage promotional banners in a more dynamic way. Promotional banners are like advertising banners, helping Growth team initiatives (Rewards, Loyalty Program, etc) to communicate with all MetaMask users within their favorite wallet.

**Please Note: **
* New contentful banners are appended to the end to ensure the current sorting is not touched. 
* The max number of slides has been modified from 5 to 7 to give a couple of slots to Contentful content. 
* Current hard-coded promotional banners have not been touched/modified. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32101?quickstart=1)

## **Related issues**

Fixes: PMs no longer have to ask devs to hard code the promotional content into the repository. They can now manage promotional banners within Contentful. 

## **Manual testing steps**

1. Go to Contentful.com
2. Go to the `dev` environment 
3. Create a new Entry of `Promotional Banner` type
4. Make sure you have  `const DEFAULT_DOMAIN = 'preview.contentful.com';` and `const ENVIRONMENT = 'dev'; ` in the file  `/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts`
5. Run locally and test the new Promotional banner!

## **Screenshots/Recordings**

![Screenshot 2025-04-16 at 11 05 15 PM](https://github.com/user-attachments/assets/a90fac3a-354d-49e4-b727-3293a44abba1)
![Screenshot 2025-04-16 at 11 05 30 PM](https://github.com/user-attachments/assets/becd3244-d4f6-4798-b043-aa3621f30be8)

https://github.com/user-attachments/assets/8b00e3c1-a98f-4212-af26-da50811ed925




### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
