### PR TITLE
ci: rename browserify test suites

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  test-e2e-chrome:
+  test-e2e-chrome-browserify:
     uses: ./.github/workflows/run-e2e.yml
     strategy:
       fail-fast: false
@@ -12,7 +12,7 @@ jobs:
         index:
           [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     with:
-      test-suite-name: test-e2e-chrome
+      test-suite-name: test-e2e-chrome-browserify
       build-artifact: prep-build-test-browserify-chrome
       build-command: yarn build:test
       test-command: yarn test:e2e:chrome
@@ -72,7 +72,7 @@ jobs:
 
   test-e2e-chrome-report:
     needs:
-      - test-e2e-chrome
+      - test-e2e-chrome-browserify
       - test-e2e-chrome-webpack
       - test-e2e-chrome-multiple-providers
       - test-e2e-chrome-rpc

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  test-e2e-firefox:
+  test-e2e-firefox-browserify:
     uses: ./.github/workflows/run-e2e.yml
     strategy:
       fail-fast: false
@@ -12,7 +12,7 @@ jobs:
         index:
           [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     with:
-      test-suite-name: test-e2e-firefox
+      test-suite-name: test-e2e-firefox-browserify
       build-command: yarn build:test:mv2
       test-command: yarn test:e2e:firefox
       matrix-index: ${{ matrix.index }}
@@ -33,7 +33,7 @@ jobs:
 
   test-e2e-firefox-report:
     needs:
-      - test-e2e-firefox
+      - test-e2e-firefox-browserify
       - test-e2e-firefox-flask
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}


### PR DESCRIPTION
## **Description**

Rename the test suites of
`test-e2e-chrome` to `test-e2e-chrome-browserify`
`test-e2e-firefox` to `test-e2e-firefox-browserify`

The main reason to do this is so you can do an artifact search for
`pattern: test-e2e-chrome*` or
`pattern: test-e2e-chrome-browserify*`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32127?quickstart=1)

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->