### PR TITLE
fix: non-evm aggregated balance when evm network is selected

### DIFF
--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -296,31 +296,21 @@ const zeroBalanceAssetFallback = { amount: 0, unit: '' };
 
 export const getMultichainAggregatedBalance = createDeepEqualSelector(
   (_state, selectedAccount) => selectedAccount,
-  getSelectedMultichainNetworkConfiguration,
   getMultichainBalances,
   getAccountAssets,
   getAssetsRates,
-  (
-    selectedAccountAddress,
-    currentNetwork,
-    multichainBalances,
-    accountAssets,
-    assetRates,
-  ) => {
+  (selectedAccountAddress, multichainBalances, accountAssets, assetRates) => {
     const assetIds = accountAssets?.[selectedAccountAddress.id] || [];
     const balances = multichainBalances?.[selectedAccountAddress.id];
 
     let aggregatedBalance = new BigNumber(0);
 
     assetIds.forEach((assetId: CaipAssetId) => {
-      const { chainId } = parseCaipAssetType(assetId);
-      if (chainId === currentNetwork.chainId) {
-        const balance = balances?.[assetId] || zeroBalanceAssetFallback;
-        const rate = assetRates?.[assetId]?.rate || '0';
-        const balanceInFiat = new BigNumber(balance.amount).times(rate);
+      const balance = balances?.[assetId] || zeroBalanceAssetFallback;
+      const rate = assetRates?.[assetId]?.rate || '0';
+      const balanceInFiat = new BigNumber(balance.amount).times(rate);
 
-        aggregatedBalance = aggregatedBalance.plus(balanceInFiat);
-      }
+      aggregatedBalance = aggregatedBalance.plus(balanceInFiat);
     });
 
     return aggregatedBalance.toNumber();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Non-evm aggreagted balance was showing 0 when an evm network was selected

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32145?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create two accounts 1 evm and another non-evm
2. Change to the EVM, non-evm
3. Aggregated balance in account selector should show for all accounts
4. Change to the non-EVM
5. Aggregated balance in account selector should show for all accounts

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="1037" alt="Screenshot 2025-04-21 at 11 43 22" src="https://github.com/user-attachments/assets/d3dd957d-a497-4f17-8ee7-50dfb9253c3c" />


### **After**

<!-- [screenshots/recordings] -->

<img width="1035" alt="Screenshot 2025-04-21 at 12 09 20" src="https://github.com/user-attachments/assets/a32489da-0036-414e-8fb4-e3206aab77d2" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
