### PR TITLE
fix: Gas timing component should not be visible if an alternate token is used to pay for gas.

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
@@ -103,4 +103,21 @@ describe('<GasFeesDetails />', () => {
 
     expect(queryByTestId('gas-fee-details-max-fee')).toBeNull();
   });
+
+  it('does not render gas timing if selected gas fee token', async () => {
+    const { queryByText } = renderWithConfirmContextProvider(
+      <GasFeesDetails
+        setShowCustomizeGasPopover={() => {
+          // Intentionally empty
+        }}
+      />,
+      getStore({ isAdvanced: true, selectedGasFeeToken: '0x123' }),
+    );
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(queryByText('Speed')).not.toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
@@ -88,7 +88,7 @@ export const GasFeesDetails = ({
           />
         </>
       )}
-      {supportsEIP1559 && (
+      {supportsEIP1559 && !transactionMeta.selectedGasFeeToken && (
         <ConfirmInfoAlertRow
           alertKey={RowAlertKey.Speed}
           data-testid="gas-fee-details-speed"


### PR DESCRIPTION
## **Description**

Gas timing component should not be visible if an alternate token is used to pay for gas.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4668

## **Manual testing steps**

1. Go to test dapp
2. Submit a confirmation
3. Select to pay using a non-native token
4. Check that gas timing row disappears

## **Screenshots/Recordings**
<img width="404" alt="Screenshot 2025-04-22 at 4 26 26 PM" src="https://github.com/user-attachments/assets/c503f6fd-20b1-497e-b541-1ba59c53581c" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
