### PR TITLE
fix: bump `@metamask/providers` version to v22.0.1 which contains fix to catch errors thrown when window.ethereum provider is set before we get to it

### DIFF
--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "@metamask/ppom-validator": "0.36.0",
     "@metamask/preinstalled-example-snap": "^0.3.0",
     "@metamask/profile-sync-controller": "^12.0.0",
-    "@metamask/providers": "^22.0.0",
+    "@metamask/providers": "^22.0.1",
     "@metamask/rate-limit-controller": "^6.0.3",
     "@metamask/remote-feature-flag-controller": "^1.6.0",
     "@metamask/rpc-errors": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6175,9 +6175,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/providers@npm:^22.0.0":
-  version: 22.0.0
-  resolution: "@metamask/providers@npm:22.0.0"
+"@metamask/providers@npm:^22.0.1":
+  version: 22.0.1
+  resolution: "@metamask/providers@npm:22.0.1"
   dependencies:
     "@metamask/json-rpc-engine": "npm:^10.0.2"
     "@metamask/json-rpc-middleware-stream": "npm:^8.0.6"
@@ -6192,7 +6192,7 @@ __metadata:
     readable-stream: "npm:^3.6.2"
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/b9bd381e5669e07ecee0a98f8748993fed4e02bc855e2ad342db9b9bb8b2d453a01c0e4c9f1e2c7b80929c5ce15d7aafa88c0a6a78651737efdb16f707a84017
+  checksum: 10/c4966023b69ba603ff1e62e57adf9968ebfd548f8e018b4e4181810131a554d71168fbd0056127a425b204e76ebb426620db0e192895bd4379a970b41ab1b9d0
   languageName: node
   linkType: hard
 
@@ -27670,7 +27670,7 @@ __metadata:
     "@metamask/preferences-controller": "npm:^17.0.0"
     "@metamask/preinstalled-example-snap": "npm:^0.3.0"
     "@metamask/profile-sync-controller": "npm:^12.0.0"
-    "@metamask/providers": "npm:^22.0.0"
+    "@metamask/providers": "npm:^22.0.1"
     "@metamask/rate-limit-controller": "npm:^6.0.3"
     "@metamask/remote-feature-flag-controller": "npm:^1.6.0"
     "@metamask/rpc-errors": "npm:^7.0.0"


### PR DESCRIPTION
## **Description**

Currently when another wallet (currently only seeing this with Rabby) is installed and gets to the ethereum global before us (and [pulls up the ladder behind them](https://github.com/RabbyHub/page-provider/blob/9ea723257defaaa8f00c323715ba388f504b6c2a/src/index.ts#L508)) our provider errors out. This is now downstream causing our Solana Wallet Standard Provider to also fail to register.

Though we cannot overcome this issue we can atleast prevent the subsequent provider registration from failing.

## Video Demo of Bug
https://github.com/user-attachments/assets/4d26cc8a-dd39-4fe2-a85d-552f69f6fa44


## After
https://github.com/user-attachments/assets/b236b3c7-e9f3-4185-9821-f3239c3d12cd


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32175?quickstart=1)

## **Related issues**

Related: https://github.com/MetaMask/metamask-extension/issues/30685

## **Manual testing steps**

1. Build this in Flask
2. Install Rabby
3. Go to jup.ag
4. Check that MetaMask is detected
5. Connect to MetaMask with Solana Accounts

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
