### PR TITLE
fix: Show Connection Toast when at least one account is connected to Dapp

### DIFF
--- a/ui/components/app/toast-master/selectors.ts
+++ b/ui/components/app/toast-master/selectors.ts
@@ -103,6 +103,7 @@ export function selectShowConnectAccountToast(
     account &&
     state.activeTab?.origin &&
     isConnectableAccount &&
+    connectedAccounts.length > 0 &&
     !isInternalAccountInPermittedAccountIds(account, connectedAccounts);
 
   return showConnectAccountToast;

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`AssetPickerModalNetwork renders modal with no network list by default 1
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex"
+            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
           >
             <div
               class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
@@ -132,7 +132,7 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex"
+            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
           >
             <div
               class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
@@ -302,7 +302,7 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex"
+            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
           >
             <div
               class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`AssetPickerModalNetwork renders modal with no network list by default 1
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
+            class="mm-box multichain-asset-picker__network-list mm-box--display-flex"
           >
             <div
               class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
@@ -132,7 +132,7 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
+            class="mm-box multichain-asset-picker__network-list mm-box--display-flex"
           >
             <div
               class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
@@ -302,7 +302,7 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
+            class="mm-box multichain-asset-picker__network-list mm-box--display-flex"
           >
             <div
               class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"


### PR DESCRIPTION
This PR ensures that the connection toast is shown when at least one account is connected to the Dapp. If no account is connected, then the Toast to connect accounts should not be displayed

## **Related issues**


Fixes: #32045 

## **Manual testing steps**

1. Run extension
2. Open the Dapp, and MM in popup view. No toast should show
3. Connect MM to Dapp
4. Switch to the second account
5. Toast should appear

## **Screenshots/Recordings**


### **Before**
![Screenshot 2025-04-23 at 3 49 29 PM](https://github.com/user-attachments/assets/479deafb-1374-4cf8-9904-02654e926347)


### **After**
#### When Dapp is not connected
https://github.com/user-attachments/assets/77cbac36-10cf-44ea-a49e-d50c5003bb4f


#### When Dapp is connected
https://github.com/user-attachments/assets/188b0179-6848-4e8e-98d7-8a4234c4a318

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
