### PR TITLE
fix: removes incorrect fallback label in bridge cta button

### DIFF
--- a/ui/pages/bridge/prepare/__snapshots__/bridge-cta-button.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-cta-button.test.tsx.snap
@@ -46,9 +46,7 @@ exports[`BridgeCTAButton should render the component's initial state 1`] = `
   >
     <p
       class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative-soft"
-    >
-      Select token
-    </p>
+    />
   </div>
 </div>
 `;

--- a/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
@@ -23,14 +23,12 @@ describe('BridgeCTAButton', () => {
       },
       bridgeSliceOverrides: { fromTokenInputValue: 1 },
     });
-    const { container, getByText } = renderWithProvider(
+    const { container } = renderWithProvider(
       <BridgeCTAButton onFetchNewQuotes={jest.fn()} />,
       configureStore(mockStore),
     );
 
     expect(container).toMatchSnapshot();
-
-    expect(getByText('Select token')).toBeInTheDocument();
   });
 
   it('should render the component when amount is missing', () => {

--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -135,7 +135,7 @@ export const BridgeCTAButton = ({
       return 'submit';
     }
 
-    return 'swapSelectToken';
+    return '';
   }, [
     isLoading,
     fromAmount,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We have 'select token' as a fallback label in the bridge CTA button, when it should be empty if all states are satisfied (both tokens are selected, an amount is inputted, etc). This PR resolves this by changing the default label returned to an empty string.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32216?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
