### PR TITLE
fix: flaky test `Smart Transactions Swap` due to incorrect quote taken

### DIFF
--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -81,6 +81,7 @@ describe('Smart Transactions', function () {
         await buildQuote(driver, {
           amount: 2,
           swapTo: 'DAI',
+          mainnet: true,
         });
 
         await reviewQuote(driver, {

--- a/test/e2e/tests/swaps/shared.ts
+++ b/test/e2e/tests/swaps/shared.ts
@@ -21,6 +21,7 @@ type SwapOptions = {
   amount: number;
   swapTo?: string;
   swapToContractAddress?: string;
+  mainnet?: boolean;
 };
 
 export const buildQuote = async (driver: Driver, options: SwapOptions) => {
@@ -30,7 +31,7 @@ export const buildQuote = async (driver: Driver, options: SwapOptions) => {
     options.amount.toString(),
   );
 
-  if (options.swapTo) {
+  if (options.swapTo && options.mainnet) {
     await driver.waitForSelector({
       tag: 'h6',
       text: 'Estimated gas fee',

--- a/test/e2e/tests/swaps/shared.ts
+++ b/test/e2e/tests/swaps/shared.ts
@@ -51,7 +51,7 @@ export const buildQuote = async (driver: Driver, options: SwapOptions) => {
       '[data-testid="searchable-item-list-import-button"]',
     );
   }
-  await driver.clickElement(
+  await driver.clickElementAndWaitToDisappear(
     '[data-testid="searchable-item-list-primary-label"]',
   );
   await driver.fill(

--- a/test/e2e/tests/swaps/shared.ts
+++ b/test/e2e/tests/swaps/shared.ts
@@ -25,6 +25,18 @@ type SwapOptions = {
 
 export const buildQuote = async (driver: Driver, options: SwapOptions) => {
   await driver.clickElement('[data-testid="token-overview-button-swap"]');
+  await driver.fill(
+    'input[data-testid="prepare-swap-page-from-token-amount"]',
+    options.amount.toString(),
+  );
+
+  if (options.swapTo) {
+    await driver.waitForSelector({
+      tag: 'h6',
+      text: 'Estimated gas fee',
+    });
+  };
+
   await driver.clickElement('[data-testid="prepare-swap-page-swap-to"]');
   await driver.waitForSelector('[id="list-with-search__text-search"]');
 
@@ -51,12 +63,8 @@ export const buildQuote = async (driver: Driver, options: SwapOptions) => {
       '[data-testid="searchable-item-list-import-button"]',
     );
   }
-  await driver.clickElementAndWaitToDisappear(
+  await driver.clickElement(
     '[data-testid="searchable-item-list-primary-label"]',
-  );
-  await driver.fill(
-    'input[data-testid="prepare-swap-page-from-token-amount"]',
-    options.amount.toString(),
   );
 };
 

--- a/test/e2e/tests/swaps/shared.ts
+++ b/test/e2e/tests/swaps/shared.ts
@@ -58,7 +58,6 @@ export const buildQuote = async (driver: Driver, options: SwapOptions) => {
     'input[data-testid="prepare-swap-page-from-token-amount"]',
     options.amount.toString(),
   );
-  await driver.delay(veryLargeDelayMs); // Need an extra delay after typing an amount.
 };
 
 export const reviewQuote = async (

--- a/test/e2e/tests/swaps/shared.ts
+++ b/test/e2e/tests/swaps/shared.ts
@@ -25,11 +25,6 @@ type SwapOptions = {
 
 export const buildQuote = async (driver: Driver, options: SwapOptions) => {
   await driver.clickElement('[data-testid="token-overview-button-swap"]');
-  await driver.fill(
-    'input[data-testid="prepare-swap-page-from-token-amount"]',
-    options.amount.toString(),
-  );
-  await driver.delay(veryLargeDelayMs); // Need an extra delay after typing an amount.
   await driver.clickElement('[data-testid="prepare-swap-page-swap-to"]');
   await driver.waitForSelector('[id="list-with-search__text-search"]');
 
@@ -59,6 +54,11 @@ export const buildQuote = async (driver: Driver, options: SwapOptions) => {
   await driver.clickElement(
     '[data-testid="searchable-item-list-primary-label"]',
   );
+  await driver.fill(
+    'input[data-testid="prepare-swap-page-from-token-amount"]',
+    options.amount.toString(),
+  );
+  await driver.delay(veryLargeDelayMs); // Need an extra delay after typing an amount.
 };
 
 export const reviewQuote = async (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The problem is that the assert is looking for the swap ETH-DAI but in the tx activity the swap appears ETH-USDC.
This happens because there is a race condition within the test actions that whenever we start the swap, the default token value is ETH-USDC whenever we are on mainnet. Then, whenever we add an amount, this starts a query for getting the quotes for that swap. but in our test, after adding the amount, we then switch the token to DAI.
Then, sometimtes the order is correct ETH-USDC loaded, then we switch to DAI and then ETH-DAI quote is loaded, but sometimes we switch to DAI and then the ETH-USDC quote is loaded making the tx with the incorrect token. 

To avoid this problem there was a delay, for waiting until the first quotes are done and then switch tokens, but this is not sufficient and not deterministic. To fix it, we can wait for a deterministic condition and then proceed with the next action

![Screenshot from 2025-04-24 12-10-59](https://github.com/user-attachments/assets/70d70620-8765-4e43-b762-203b8b2272d3)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32233?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

![image](https://github.com/user-attachments/assets/46880f57-a169-4d50-8df1-afdedf307d63)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
