### PR TITLE
chore: quick cancel of workflow if dependant action fails

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -67,4 +67,4 @@ jobs:
 
       - if: failure()
         name: canceling workflow
-        uses: Metamask/cancel-action@main
+        uses: Metamask/cancel-action@2f9a9700f608f28936a88728937f5bef920f62c1 # v1

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -64,3 +64,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
           s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/builds-beta
           path: builds
+
+      - if: failure()
+        name: canceling workflow
+        uses: Metamask/cancel-action@main

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -111,3 +111,7 @@ jobs:
         with:
           name: test-e2e-chrome-report
           path: test/test-results/test-runs.json
+
+      - if: failure()
+        name: canceling workflow
+        uses: Metamask/cancel-action@main

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -114,4 +114,4 @@ jobs:
 
       - if: failure()
         name: canceling workflow
-        uses: Metamask/cancel-action@main
+        uses: Metamask/cancel-action@2f9a9700f608f28936a88728937f5bef920f62c1 # v1

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -71,4 +71,4 @@ jobs:
 
       - if: failure()
         name: canceling workflow
-        uses: Metamask/cancel-action@main
+        uses: Metamask/cancel-action@2f9a9700f608f28936a88728937f5bef920f62c1 # v1

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -68,3 +68,7 @@ jobs:
         with:
           name: test-e2e-firefox-report
           path: test/test-results/test-runs.json
+
+      - if: failure()
+        name: canceling workflow
+        uses: Metamask/cancel-action@main

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -50,3 +50,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
           s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/benchmarks/${{ env.OUTPUT_NAME }}
           path: test-artifacts/benchmarks/${{ env.OUTPUT_NAME }}
+
+      - if: failure()
+        name: canceling workflow
+        uses: Metamask/cancel-action@main

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -53,4 +53,4 @@ jobs:
 
       - if: failure()
         name: canceling workflow
-        uses: Metamask/cancel-action@main
+        uses: Metamask/cancel-action@2f9a9700f608f28936a88728937f5bef920f62c1 # v1

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -118,4 +118,4 @@ jobs:
 
       - if: failure()
         name: canceling workflow
-        uses: Metamask/cancel-action@main
+        uses: Metamask/cancel-action@2f9a9700f608f28936a88728937f5bef920f62c1 # v1

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -115,3 +115,7 @@ jobs:
           path: |
             ./test-artifacts
             ./test/test-results/e2e
+
+      - if: failure()
+        name: canceling workflow
+        uses: Metamask/cancel-action@main

--- a/.github/workflows/wait-for-circleci-workflow-status.yml
+++ b/.github/workflows/wait-for-circleci-workflow-status.yml
@@ -43,4 +43,4 @@ jobs:
           fi
       - if: failure()
         name: canceling workflow
-        uses: Metamask/cancel-action@main
+        uses: Metamask/cancel-action@2f9a9700f608f28936a88728937f5bef920f62c1 # v1

--- a/.github/workflows/wait-for-circleci-workflow-status.yml
+++ b/.github/workflows/wait-for-circleci-workflow-status.yml
@@ -41,3 +41,6 @@ jobs:
             echo "::error::Workflow status is '${workflow_status}'. Exiting with error."
             exit 1
           fi
+      - if: failure()
+        name: canceling workflow
+        uses: Metamask/cancel-action@main


### PR DESCRIPTION

## **Description**

Allows for quick cancel of workflow if a dependent/concurrent job fails. Reducing feedback loop, $$$ and improving job concurrency limits.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32289?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Long running jobs

## **Pre-merge author checklist**

- [x ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ x] I've completed the PR template to the best of my ability
- [ x] I’ve included tests if applicable
- [ x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
