### PR TITLE
fix: flaky tests around snaps due to race condition with windows

### DIFF
--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -37,7 +37,7 @@ describe('Pre-install example', function () {
         await testSnaps.openPage();
         await testSnaps.scrollAndClickButton('connectPreinstalledButton');
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await snapInstall.clickConfirmButton();
+        await snapInstall.clickConnectButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
         await testSnaps.clickButton('getSettingsStateButton');
         const jsonTextValidation = '"setting1": true';

--- a/test/e2e/page-objects/flows/install-test-snap.flow.ts
+++ b/test/e2e/page-objects/flows/install-test-snap.flow.ts
@@ -11,13 +11,19 @@ import { WINDOW_TITLES } from '../../helpers';
  *
  * @param driver - WebDriver instance used to interact with the browser.
  * @param buttonName - The name of the button to click.
- * @param withWarning - Whether the installation will have a warning dialog, default is false.
+ * @param options - Optional parameters.
+ * @param options.withWarning - Whether the installation will have a warning dialog, default is false.
+ * @param options.withExtraScreen - Whether there is an extra screen after the Ok, defaults to false.
  */
 export async function openTestSnapClickButtonAndInstall(
   driver: Driver,
   buttonName: keyof typeof buttonLocator,
-  withWarning = false,
+  options: {
+    withWarning?: boolean;
+    withExtraScreen?: boolean;
+  } = {},
 ) {
+  const { withWarning = false, withExtraScreen = false } = options;
   const snapInstall = new SnapInstall(driver);
   const snapInstallWarning = new SnapInstallWarning(driver);
   const testSnaps = new TestSnaps(driver);
@@ -25,13 +31,17 @@ export async function openTestSnapClickButtonAndInstall(
   await testSnaps.scrollAndClickButton(buttonName);
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
   await snapInstall.check_pageIsLoaded();
-  await snapInstall.clickNextButton();
+  await snapInstall.clickConnectButton();
   await snapInstall.clickConfirmButton();
   if (withWarning) {
     await snapInstallWarning.check_pageIsLoaded();
     await snapInstallWarning.clickCheckboxPermission();
     await snapInstallWarning.clickConfirmButton();
   }
-  await snapInstall.clickNextButton();
+  if (withExtraScreen) {
+    await snapInstall.clickOkButtonAndContinueOnDialog();
+  } else {
+    await snapInstall.clickOkButton();
+  }
   await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
 }

--- a/test/e2e/page-objects/flows/snap-permission.flow.ts
+++ b/test/e2e/page-objects/flows/snap-permission.flow.ts
@@ -18,14 +18,14 @@ export async function confirmPermissionSwitchToTestSnap(
   const snapInstallWarning = new SnapInstallWarning(driver);
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
   await snapInstall.check_pageIsLoaded();
-  await snapInstall.clickNextButton();
+  await snapInstall.clickConnectButton();
   await snapInstall.clickConfirmButton();
   if (withWarning) {
     await snapInstallWarning.check_pageIsLoaded();
     await snapInstallWarning.clickCheckboxPermission();
     await snapInstallWarning.clickConfirmButton();
   }
-  await snapInstall.clickNextButton();
+  await snapInstall.clickOkButton();
   await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
 }
 
@@ -51,8 +51,8 @@ export async function switchAndApproveDialogSwitchToTestSnap(driver: Driver) {
 export async function completeSnapInstallSwitchToTestSnap(driver: Driver) {
   const snapInstall = new SnapInstall(driver);
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-  await snapInstall.clickNextButton();
-  await snapInstall.clickNextButton();
-  await snapInstall.clickNextButton();
+  await snapInstall.clickConnectButton();
+  await snapInstall.clickConfirmButton();
+  await snapInstall.clickOkButton();
   await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
 }

--- a/test/e2e/page-objects/pages/dialog/snap-install-warning.ts
+++ b/test/e2e/page-objects/pages/dialog/snap-install-warning.ts
@@ -37,7 +37,7 @@ class SnapInstallWarning {
 
   async clickConfirmButton() {
     console.log('Click confirm button');
-    await this.driver.clickElementAndWaitForWindowToClose(this.buttonConfirm);
+    await this.driver.clickElementAndWaitToDisappear(this.buttonConfirm);
   }
 }
 

--- a/test/e2e/page-objects/pages/dialog/snap-install-warning.ts
+++ b/test/e2e/page-objects/pages/dialog/snap-install-warning.ts
@@ -37,7 +37,7 @@ class SnapInstallWarning {
 
   async clickConfirmButton() {
     console.log('Click confirm button');
-    await this.driver.clickElement(this.buttonConfirm);
+    await this.driver.clickElementAndWaitForWindowToClose(this.buttonConfirm);
   }
 }
 

--- a/test/e2e/page-objects/pages/dialog/snap-install.ts
+++ b/test/e2e/page-objects/pages/dialog/snap-install.ts
@@ -57,11 +57,6 @@ class SnapInstall {
     await this.driver.clickElement(this.nextPageButton);
   }
 
-  async waitForNextButton() {
-    console.log('Waiting for Confirm/Ok button to load');
-    await this.driver.waitForSelector(this.nextPageButton);
-  }
-
   async clickConfirmButton() {
     console.log(
       'Clicking on the scroll button and then clicking the confirm button',

--- a/test/e2e/page-objects/pages/dialog/snap-install.ts
+++ b/test/e2e/page-objects/pages/dialog/snap-install.ts
@@ -4,8 +4,23 @@ import { veryLargeDelayMs } from '../../../helpers';
 class SnapInstall {
   private driver: Driver;
 
+  private readonly confirmButton = {
+    tag: 'button',
+    text: 'Confirm',
+  };
+
+  private readonly connectButton = {
+    tag: 'button',
+    text: 'Connect',
+  };
+
   private readonly nextPageButton =
     '[data-testid="page-container-footer-next"]';
+
+  private readonly okButton = {
+    tag: 'button',
+    text: 'OK',
+  };
 
   private readonly pageFooter = '.page-container__footer';
 
@@ -18,17 +33,21 @@ class SnapInstall {
 
   private readonly approveButton = '[data-testid="confirmation-submit-button"]';
 
-  private readonly connectButton = '[data-testid="confirm-btn"]';
-
   public readonly lifeCycleHookMessageElement = '.snap-ui-renderer__panel';
-
-  private readonly insightTitle = {
-    text: 'Insights Example Snap',
-    tag: 'span',
-  };
 
   constructor(driver: Driver) {
     this.driver = driver;
+  }
+
+  async check_messageResultSpan(
+    spanSelectorId: string,
+    expectedMessage: string,
+  ) {
+    console.log('Checking message result');
+    await this.driver.waitForSelector({
+      css: spanSelectorId,
+      text: expectedMessage,
+    });
   }
 
   async check_pageIsLoaded(): Promise<void> {
@@ -47,14 +66,14 @@ class SnapInstall {
     console.log('Snap install dialog is loaded');
   }
 
+  async clickApproveButton() {
+    console.log('Clicking the approve button');
+    await this.driver.clickElement(this.approveButton);
+  }
+
   async clickCheckboxPermission() {
     console.log('Clicking permission checkbox');
     await this.driver.clickElement(this.permissionConnect);
-  }
-
-  async clickNextButton() {
-    console.log('Clicking Confirm/Ok button');
-    await this.driver.clickElement(this.nextPageButton);
   }
 
   async clickConfirmButton() {
@@ -71,12 +90,29 @@ class SnapInstall {
       },
       { timeout: veryLargeDelayMs, interval: 100 },
     );
-    await this.driver.clickElement(this.nextPageButton);
+    await this.driver.clickElement(this.confirmButton);
+  }
+
+  async clickConnectButton() {
+    console.log('Clicking the connect button');
+    await this.driver.clickElement(this.connectButton);
+  }
+
+  async clickOkButton() {
+    console.log('Clicking Confirm/Ok button and wait for dialog to close');
+    await this.driver.clickElementAndWaitForWindowToClose(this.okButton);
+  }
+
+  async clickOkButtonAndContinueOnDialog() {
+    console.log(
+      'Clicking Confirm/Ok button without waiting for the dialog to close',
+    );
+    await this.driver.clickElement(this.okButton);
   }
 
   async updateScrollAndClickConfirmButton() {
     console.log(
-      'Clicking on the scroll button and then  clicking the confirm button',
+      'Clicking on the scroll button and then clicking the confirm button',
     );
     await this.driver.waitUntil(
       async () => {
@@ -89,27 +125,6 @@ class SnapInstall {
       { timeout: veryLargeDelayMs, interval: 100 },
     );
     await this.driver.clickElement(this.nextPageButton);
-  }
-
-  async clickApproveButton() {
-    console.log('Clicking the approve button');
-    await this.driver.clickElement(this.approveButton);
-  }
-
-  async clickConnectButton() {
-    console.log('Clicking the connect button');
-    await this.driver.clickElement(this.connectButton);
-  }
-
-  async check_messageResultSpan(
-    spanSelectorId: string,
-    expectedMessage: string,
-  ) {
-    console.log('Checking message result');
-    await this.driver.waitForSelector({
-      css: spanSelectorId,
-      text: expectedMessage,
-    });
   }
 }
 

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -34,7 +34,7 @@ describe('Test Snap bip-32', function () {
         const testSnaps = new TestSnaps(driver);
 
         // Navigate to `test-snaps` page, click bip32, connect and approve
-        await openTestSnapClickButtonAndInstall(driver, 'connectBip44Button', {
+        await openTestSnapClickButtonAndInstall(driver, 'connectBip32Button', {
           withWarning: true,
         });
 

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -34,11 +34,9 @@ describe('Test Snap bip-32', function () {
         const testSnaps = new TestSnaps(driver);
 
         // Navigate to `test-snaps` page, click bip32, connect and approve
-        await openTestSnapClickButtonAndInstall(
-          driver,
-          'connectBip32Button',
-          true,
-        );
+        await openTestSnapClickButtonAndInstall(driver, 'connectBip44Button', {
+          withWarning: true,
+        });
 
         // check the installation status
         await testSnaps.check_installationComplete(

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -28,11 +28,9 @@ describe('Test Snap bip-44', function () {
         const testSnaps = new TestSnaps(driver);
 
         // Navigate to `test-snaps` page, and install the Snap.
-        await openTestSnapClickButtonAndInstall(
-          driver,
-          'connectBip44Button',
-          true,
-        );
+        await openTestSnapClickButtonAndInstall(driver, 'connectBip44Button', {
+          withWarning: true,
+        });
 
         // check the installation status
         await testSnaps.check_installationComplete(

--- a/test/e2e/snaps/test-snap-clientstatus.spec.ts
+++ b/test/e2e/snaps/test-snap-clientstatus.spec.ts
@@ -23,7 +23,6 @@ describe('Test Snap Client Status', function () {
         await openTestSnapClickButtonAndInstall(
           driver,
           'connectClientStatusButton',
-          false,
         );
         await testSnaps.scrollAndClickButton('submitClientStatusButton');
 

--- a/test/e2e/snaps/test-snap-get-entropy.spec.ts
+++ b/test/e2e/snaps/test-snap-get-entropy.spec.ts
@@ -30,7 +30,7 @@ describe('Test Snap getEntropy', function (this: Suite) {
         await openTestSnapClickButtonAndInstall(
           driver,
           'connectGetEntropyButton',
-          false,
+          { withWarning: true },
         );
         await testSnaps.fillMessage('entropyMessageInput', '1234');
         await testSnaps.clickButton('signEntropyMessageButton');

--- a/test/e2e/snaps/test-snap-get-entropy.spec.ts
+++ b/test/e2e/snaps/test-snap-get-entropy.spec.ts
@@ -30,7 +30,6 @@ describe('Test Snap getEntropy', function (this: Suite) {
         await openTestSnapClickButtonAndInstall(
           driver,
           'connectGetEntropyButton',
-          { withWarning: true },
         );
         await testSnaps.fillMessage('entropyMessageInput', '1234');
         await testSnaps.clickButton('signEntropyMessageButton');

--- a/test/e2e/snaps/test-snap-homepage.spec.ts
+++ b/test/e2e/snaps/test-snap-homepage.spec.ts
@@ -23,7 +23,6 @@ describe('Test Snap Homepage', function (this: Suite) {
         await openTestSnapClickButtonAndInstall(
           driver,
           'connectHomePageButton',
-          false,
         );
 
         // switch to metamask page and open the three dots menu

--- a/test/e2e/snaps/test-snap-installed.spec.ts
+++ b/test/e2e/snaps/test-snap-installed.spec.ts
@@ -64,11 +64,7 @@ describe('Test Snap installed', function () {
 
         // Open a new tab and navigate to test snaps page and click dialog snap
         const testSnaps = new TestSnaps(driver);
-        await openTestSnapClickButtonAndInstall(
-          driver,
-          'connectDialogsButton',
-          false,
-        );
+        await openTestSnapClickButtonAndInstall(driver, 'connectDialogsButton');
 
         // Check installation success
         await testSnaps.check_installationComplete(

--- a/test/e2e/snaps/test-snap-lifecycle.spec.ts
+++ b/test/e2e/snaps/test-snap-lifecycle.spec.ts
@@ -23,6 +23,7 @@ describe('Test Snap Lifecycle Hooks', function () {
         await openTestSnapClickButtonAndInstall(
           driver,
           'connectLifeCycleButton',
+          { withExtraScreen: true },
         );
         // Check installation success
         await testSnaps.check_installationComplete(

--- a/test/e2e/snaps/test-snap-update.spec.ts
+++ b/test/e2e/snaps/test-snap-update.spec.ts
@@ -32,7 +32,6 @@ describe('Test Snap update', function () {
         await driver.waitForSelector({ text: 'Update request' });
         await snapInstall.check_pageIsLoaded();
         await snapInstall.updateScrollAndClickConfirmButton();
-        await snapInstall.waitForNextButton();
         await snapInstall.clickNextButton();
 
         // Switch to test snap page and validate the version text

--- a/test/e2e/snaps/test-snap-update.spec.ts
+++ b/test/e2e/snaps/test-snap-update.spec.ts
@@ -32,7 +32,7 @@ describe('Test Snap update', function () {
         await driver.waitForSelector({ text: 'Update request' });
         await snapInstall.check_pageIsLoaded();
         await snapInstall.updateScrollAndClickConfirmButton();
-        await snapInstall.clickNextButton();
+        await snapInstall.clickOkButton();
 
         // Switch to test snap page and validate the version text
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR includes these 2 changes which fix flakiness, on snaps tests that perform the Install Snap flow, due to race conditions with windows and modals (not waiting for window/modal to close, before performing the next action):

- https://github.com/MetaMask/metamask-extension/pull/32320#discussion_r2062669099
- https://github.com/MetaMask/metamask-extension/pull/32320#discussion_r2062669296

And a small refactor on the selectors, to improve readability (see comments)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32320?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Tests pass in ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
