### PR TITLE
fix: Update preferences asyncronously

### DIFF
--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3181,7 +3181,7 @@ export function setPreference(
   return (dispatch: MetaMaskReduxDispatch) => {
     showLoading && dispatch(showLoadingIndication());
     return new Promise<TemporaryPreferenceFlagDef>((resolve, reject) => {
-      callBackgroundMethod<TemporaryPreferenceFlagDef>(
+      submitRequestToBackground<TemporaryPreferenceFlagDef>(
         'setPreference',
         [preference, value],
         (err, updatedPreferences) => {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3223,8 +3223,8 @@ export function setShowFiatConversionOnTestnetsPreference(value: boolean) {
  * Sets shouldShowAggregatedBalancePopover to false once the user toggles
  * the setting to show native token as main balance.
  */
-export function setAggregatedBalancePopoverShown() {
-  return setPreference('shouldShowAggregatedBalancePopover', false);
+export async function setAggregatedBalancePopoverShown() {
+  return await setPreference('shouldShowAggregatedBalancePopover', false);
 }
 
 export function setShowTestNetworks(value: boolean) {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3207,16 +3207,20 @@ export function setDefaultHomeActiveTabName(
   };
 }
 
-export function setShowNativeTokenAsMainBalancePreference(value: boolean) {
-  return setPreference('showNativeTokenAsMainBalance', value);
+export async function setShowNativeTokenAsMainBalancePreference(
+  value: boolean,
+) {
+  return await setPreference('showNativeTokenAsMainBalance', value);
 }
 
-export function setHideZeroBalanceTokens(value: boolean) {
-  return setPreference('hideZeroBalanceTokens', value);
+export async function setHideZeroBalanceTokens(value: boolean) {
+  return await setPreference('hideZeroBalanceTokens', value);
 }
 
-export function setShowFiatConversionOnTestnetsPreference(value: boolean) {
-  return setPreference('showFiatInTestnets', value);
+export async function setShowFiatConversionOnTestnetsPreference(
+  value: boolean,
+) {
+  return await setPreference('showFiatInTestnets', value);
 }
 
 /**
@@ -3227,31 +3231,31 @@ export async function setAggregatedBalancePopoverShown() {
   return await setPreference('shouldShowAggregatedBalancePopover', false);
 }
 
-export function setShowTestNetworks(value: boolean) {
-  return setPreference('showTestNetworks', value);
+export async function setShowTestNetworks(value: boolean) {
+  return await setPreference('showTestNetworks', value);
 }
 
-export function setPrivacyMode(value: boolean) {
-  return setPreference('privacyMode', value, false);
+export async function setPrivacyMode(value: boolean) {
+  return await setPreference('privacyMode', value, false);
 }
 
-export function setFeatureNotificationsEnabled(value: boolean) {
-  return setPreference('featureNotificationsEnabled', value);
+export async function setFeatureNotificationsEnabled(value: boolean) {
+  return await setPreference('featureNotificationsEnabled', value);
 }
 
-export function setShowExtensionInFullSizeView(value: boolean) {
-  return setPreference('showExtensionInFullSizeView', value);
+export async function setShowExtensionInFullSizeView(value: boolean) {
+  return await setPreference('showExtensionInFullSizeView', value);
 }
 
-export function setTokenSortConfig(value: SortCriteria) {
-  return setPreference('tokenSortConfig', value, false);
+export async function setTokenSortConfig(value: SortCriteria) {
+  return await setPreference('tokenSortConfig', value, false);
 }
 
-export function setTokenNetworkFilter(value: Record<string, boolean>) {
-  return setPreference('tokenNetworkFilter', value, false);
+export async function setTokenNetworkFilter(value: Record<string, boolean>) {
+  return await setPreference('tokenNetworkFilter', value, false);
 }
 
-export function setSmartTransactionsPreferenceEnabled(
+export async function setSmartTransactionsPreferenceEnabled(
   value: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch, getState) => {
@@ -3270,12 +3274,12 @@ export function setSmartTransactionsPreferenceEnabled(
   };
 }
 
-export function setShowMultiRpcModal(value: boolean) {
-  return setPreference('showMultiRpcModal', value);
+export async function setShowMultiRpcModal(value: boolean) {
+  return await setPreference('showMultiRpcModal', value);
 }
 
-export function setAutoLockTimeLimit(value: number | null) {
-  return setPreference('autoLockTimeLimit', value);
+export async function setAutoLockTimeLimit(value: number | null) {
+  return await setPreference('autoLockTimeLimit', value);
 }
 
 export function setIncomingTransactionsPreferences(
@@ -5960,8 +5964,8 @@ export function disableMetamaskNotifications(): ThunkAction<
   };
 }
 
-export function setConfirmationAdvancedDetailsOpen(value: boolean) {
-  return setPreference('showConfirmationAdvancedDetails', value);
+export async function setConfirmationAdvancedDetailsOpen(value: boolean) {
+  return await setPreference('showConfirmationAdvancedDetails', value);
 }
 
 export async function getNextAvailableAccountName(


### PR DESCRIPTION
## **Description**

setPreferences was calling a deprecated, synchronous method to update state in the application's appState. This PR changes this to use the asyncronous version `submitRequestToBackground`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32357?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
