### PR TITLE
fix: cp-12.18.0 fix metrics event capturing for advance setting dismissSmartAccountSuggestionEnabled

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1123,11 +1123,11 @@
   "confirmGasFeeTokenTooltip": {
     "message": "This is paid to the network to process your transaction. It includes a $1 MetaMask fee for non-ETH tokens."
   },
-  "confirmInfoAccountCurrentType": {
-    "message": "Current Type"
+  "confirmInfoAccountNow": {
+    "message": "Now"
   },
-  "confirmInfoAccountNewType": {
-    "message": "New Type"
+  "confirmInfoSwitchingTo": {
+    "message": "Switching To"
   },
   "confirmNestedTransactionTitle": {
     "message": "Transaction $1"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1129,9 +1129,6 @@
   "confirmInfoAccountNewType": {
     "message": "New Type"
   },
-  "confirmInfoAccountType": {
-    "message": "Account type"
-  },
   "confirmNestedTransactionTitle": {
     "message": "Transaction $1"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1123,11 +1123,11 @@
   "confirmGasFeeTokenTooltip": {
     "message": "This is paid to the network to process your transaction. It includes a $1 MetaMask fee for non-ETH tokens."
   },
-  "confirmInfoAccountCurrentType": {
-    "message": "Current Type"
+  "confirmInfoAccountNow": {
+    "message": "Now"
   },
-  "confirmInfoAccountNewType": {
-    "message": "New Type"
+  "confirmInfoSwitchingTo": {
+    "message": "Switching To"
   },
   "confirmNestedTransactionTitle": {
     "message": "Transaction $1"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1129,9 +1129,6 @@
   "confirmInfoAccountNewType": {
     "message": "New Type"
   },
-  "confirmInfoAccountType": {
-    "message": "Account type"
-  },
   "confirmNestedTransactionTitle": {
     "message": "Transaction $1"
   },

--- a/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.test.tsx
@@ -66,8 +66,8 @@ describe('TransactionAccountDetails', () => {
     });
 
     expect(getByText('Smart account')).toBeInTheDocument();
-    expect(getByText('Current Type')).toBeInTheDocument();
-    expect(queryByText('New type')).toBeNull();
+    expect(getByText('Now')).toBeInTheDocument();
+    expect(queryByText('Switching to')).toBeNull();
   });
 
   it('does not render if no authorization list', () => {
@@ -83,12 +83,12 @@ describe('TransactionAccountDetails', () => {
       nestedTransactions: [{ to: FROM_MOCK }],
     });
 
-    expect(getByText('Account type')).toBeInTheDocument();
+    expect(getByText('Now')).toBeInTheDocument();
   });
 
   it('renders required data for upgrade request with nested transactions', () => {
     const { getByText } = renderConfirmation(upgradeAccountConfirmation);
-    expect(getByText('Account type')).toBeInTheDocument();
+    expect(getByText('Now')).toBeInTheDocument();
     expect(getByText('Smart contract')).toBeInTheDocument();
   });
 

--- a/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
@@ -42,7 +42,7 @@ export function TransactionAccountDetails() {
         <>
           <ConfirmInfoAlertRow
             alertKey={RowAlertKey.AccountTypeUpgrade}
-            label={t('confirmInfoAccountCurrentType')}
+            label={t('confirmInfoAccountNow')}
             ownerId={id}
           >
             <ConfirmInfoRowText
@@ -50,17 +50,17 @@ export function TransactionAccountDetails() {
               data-testid="tx-type"
             />
           </ConfirmInfoAlertRow>
-          <ConfirmInfoRow label={t('confirmInfoAccountNewType')}>
+          <ConfirmInfoRow label={t('confirmInfoSwitchingTo')}>
             <ConfirmInfoRowText text={t('confirmAccountTypeSmartContract')} />
           </ConfirmInfoRow>
         </>
       )}
       {isDowngrade && (
         <>
-          <ConfirmInfoRow label={t('confirmInfoAccountCurrentType')}>
+          <ConfirmInfoRow label={t('confirmInfoAccountNow')}>
             <ConfirmInfoRowText text={t('confirmAccountTypeSmartContract')} />
           </ConfirmInfoRow>
-          <ConfirmInfoRow label={t('confirmInfoAccountNewType')}>
+          <ConfirmInfoRow label={t('confirmInfoSwitchingTo')}>
             <ConfirmInfoRowText text={t('confirmAccountTypeStandard')} />
           </ConfirmInfoRow>
         </>

--- a/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
@@ -42,11 +42,7 @@ export function TransactionAccountDetails() {
         <>
           <ConfirmInfoAlertRow
             alertKey={RowAlertKey.AccountTypeUpgrade}
-            label={
-              isBatch
-                ? t('confirmInfoAccountType')
-                : t('confirmInfoAccountCurrentType')
-            }
+            label={t('confirmInfoAccountCurrentType')}
             ownerId={id}
           >
             <ConfirmInfoRowText

--- a/ui/pages/confirmations/selectors/preferences.ts
+++ b/ui/pages/confirmations/selectors/preferences.ts
@@ -12,3 +12,7 @@ export const selectUseTransactionSimulations = (state: RootState) =>
 export function selectConfirmationAdvancedDetailsOpen(state: RootState) {
   return Boolean(getPreferences(state).showConfirmationAdvancedDetails);
 }
+
+export function getDismissSmartAccountSuggestionEnabled(state: RootState) {
+  return Boolean(getPreferences(state).dismissSmartAccountSuggestionEnabled);
+}

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -133,6 +133,7 @@ import { EndTraceRequest } from '../../shared/lib/trace';
 import { isInternalAccountInPermittedAccountIds } from '../../shared/lib/multichain/chain-agnostic-permission-utils/caip-accounts';
 import { SortCriteria } from '../components/app/assets/util/sort';
 import { NOTIFICATIONS_EXPIRATION_DELAY } from '../helpers/constants/notifications';
+import { getDismissSmartAccountSuggestionEnabled } from '../pages/confirmations/selectors/preferences';
 import * as actionConstants from './actionConstants';
 
 import {
@@ -3284,8 +3285,26 @@ export function setShowExtensionInFullSizeView(value: boolean) {
   return setPreference('showExtensionInFullSizeView', value);
 }
 
-export function setDismissSmartAccountSuggestionEnabled(value: boolean) {
-  return setPreference('dismissSmartAccountSuggestionEnabled', value);
+export function setDismissSmartAccountSuggestionEnabled(
+  value: boolean,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async (dispatch, getState) => {
+    const prevDismissSmartAccountSuggestionEnabled =
+      getDismissSmartAccountSuggestionEnabled(getState());
+    trackMetaMetricsEvent({
+      category: MetaMetricsEventCategory.Settings,
+      event: MetaMetricsEventName.SettingsUpdated,
+      properties: {
+        dismiss_smt_acc_suggestion_enabled: value,
+        prev_dismiss_smt_acc_suggestion_enabled:
+          prevDismissSmartAccountSuggestionEnabled,
+      },
+    });
+    await dispatch(
+      setPreference('dismissSmartAccountSuggestionEnabled', value),
+    );
+    await forceUpdateMetamaskState(dispatch);
+  };
 }
 
 export function setTokenSortConfig(value: SortCriteria) {


### PR DESCRIPTION
## **Description**

Fix metrics event capturing for advance setting dismissSmartAccountSuggestionEnabled

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32286

## **Manual testing steps**

1. Go to extension
2. Toggle advance setting - `Dismiss "Switch to Smart Account" suggestion`
3. Check that metrics event is recorded

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/7c724715-0353-47a6-a426-afb5c041de98

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
