### PR TITLE
chore: Modify Multichain API analytics property cp-12.18.0

### DIFF
--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -327,7 +327,7 @@ export default function createRPCMethodTrackingMiddleware({
     };
 
     if (multichainApiRequestScope) {
-      eventProperties.multichain_api_request_scope = multichainApiRequestScope;
+      eventProperties.chain_id_caip = multichainApiRequestScope;
     }
 
     let sensitiveEventProperties;

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -1083,7 +1083,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         });
       });
 
-      it('should track wallet_invokeMethod events with multichain_api category, requested_through, and multichain_api_request_scope properties', async () => {
+      it('should track wallet_invokeMethod events with multichain_api category, requested_through, and chain_id_caip properties', async () => {
         const req = {
           id: MOCK_ID,
           method: MESSAGE_TYPE.WALLET_INVOKE_METHOD,
@@ -1110,7 +1110,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           properties: {
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
             requested_through: MetaMetricsRequestedThrough.MultichainApi,
-            multichain_api_request_scope: 'eip155:10',
+            chain_id_caip: 'eip155:10',
           },
           referrer: { url: 'multichain.dapp' },
         });
@@ -1121,13 +1121,13 @@ describe('createRPCMethodTrackingMiddleware', () => {
           properties: {
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
             requested_through: MetaMetricsRequestedThrough.MultichainApi,
-            multichain_api_request_scope: 'eip155:10',
+            chain_id_caip: 'eip155:10',
           },
           referrer: { url: 'multichain.dapp' },
         });
       });
 
-      it('should track wallet_invokeMethod rejections with multichain_api category, requested_through, and multichain_api_request_scope properties', async () => {
+      it('should track wallet_invokeMethod rejections with multichain_api category, requested_through, and chain_id_caip properties', async () => {
         const req = {
           id: MOCK_ID,
           method: MESSAGE_TYPE.WALLET_INVOKE_METHOD,
@@ -1159,7 +1159,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           properties: {
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
             requested_through: MetaMetricsRequestedThrough.MultichainApi,
-            multichain_api_request_scope: 'eip155:137',
+            chain_id_caip: 'eip155:137',
           },
           referrer: { url: 'multichain.dapp' },
         });
@@ -1170,7 +1170,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           properties: {
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
             requested_through: MetaMetricsRequestedThrough.MultichainApi,
-            multichain_api_request_scope: 'eip155:137',
+            chain_id_caip: 'eip155:137',
           },
           referrer: { url: 'multichain.dapp' },
         });


### PR DESCRIPTION
## **Description**

Simply renames a event property for requests made via the Multichain API from `multichain_api_request_scope` to `chain_id_caip` per the request of the data team.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32380?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32306


- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
