### PR TITLE
fix: remove unnecessary method call cp-12.18.0

### DIFF
--- a/ui/components/multichain/account-list-menu/account-list-menu.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.tsx
@@ -76,11 +76,7 @@ import {
   getHDEntropyIndex,
   getAllChainsToPoll,
 } from '../../../selectors';
-import {
-  detectNfts,
-  setSelectedAccount,
-  getNetworksWithTransactionActivityByAccounts,
-} from '../../../store/actions';
+import { detectNfts, setSelectedAccount } from '../../../store/actions';
 import {
   MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
@@ -515,20 +511,6 @@ export const AccountListMenu = ({
     chainId: null,
   };
   ///: END:ONLY_INCLUDE_IF(multichain)
-
-  const fetchAccountsWithActivity = useCallback(async () => {
-    try {
-      await dispatch(getNetworksWithTransactionActivityByAccounts());
-    } catch (error) {
-      console.error('Failed to fetch accounts with activity:', error);
-    }
-  }, [dispatch]);
-
-  useEffect(() => {
-    if (filteredAccounts.length > 0) {
-      fetchAccountsWithActivity();
-    }
-  }, [fetchAccountsWithActivity, filteredAccounts]);
 
   return (
     <Modal isOpen onClose={onClose}>


### PR DESCRIPTION
## **Description**

Issue: This method call was added to prepare for this [PR](https://github.com/MetaMask/metamask-extension/pull/31223) but hasn't been merged yet and the underlying API has issues so we don't need it at all until its merged and the endpoint is fixed. Also, there is an issue where the `getNetworksWithTransactionActivityByAccounts` is being constantly called

Solution: Remove `getNetworksWithTransactionActivityByAccounts` for now until the PR is merged. This has no affect on the component/functionality 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32392?quickstart=1)

## **Related issues**

Fixes: [32283](https://github.com/MetaMask/metamask-extension/issues/32283)

## **Manual testing steps**

1. Open extension as usual 
2. Goto account selector 
3. Open console and check networks
4. Observe no calls are made

## **Screenshots/Recordings**

NA

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
