### PR TITLE
chore:  cp-12.18.0 - Remove `MULTICHAIN_API` feature flag and expose Multichain API on all build types (#32351) Cherry-pick

### DIFF
--- a/app/manifest/v2/brave.json
+++ b/app/manifest/v2/brave.json
@@ -1,7 +1,7 @@
 {
   "content_security_policy": "frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; font-src 'self';",
   "externally_connectable": {
-    "matches": ["https://metamask.io/*"],
+    "matches": ["http://*/*", "https://*/*"],
     "ids": ["*"]
   }
 }

--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -1,7 +1,7 @@
 {
   "content_security_policy": "frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; font-src 'self';",
   "externally_connectable": {
-    "matches": ["https://metamask.io/*"],
+    "matches": ["http://*/*", "https://*/*"],
     "ids": ["*"]
   },
   "minimum_chrome_version": "89"

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -4,7 +4,7 @@
     "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval'; object-src 'none'; default-src 'none'; connect-src *; font-src 'self';"
   },
   "externally_connectable": {
-    "matches": ["https://metamask.io/*"],
+    "matches": ["http://*/*", "https://*/*"],
     "ids": ["*"]
   },
   "minimum_chrome_version": "89"

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1045,7 +1045,7 @@ export function setupController(
 
       connectEip1193(portStream, remotePort.sender);
 
-      if (process.env.MULTICHAIN_API && isFirefox) {
+      if (isFirefox) {
         const mux = setupMultiplex(portStream);
         mux.ignoreStream(METAMASK_EIP_1193_PROVIDER);
 
@@ -1062,7 +1062,7 @@ export function setupController(
       overrides?.getPortStream?.(remotePort) || new PortStream(remotePort);
 
     const isDappConnecting = remotePort.sender.tab?.id;
-    if (isDappConnecting && process.env.MULTICHAIN_API) {
+    if (isDappConnecting) {
       if (metamaskBlockedPorts.includes(remotePort.name)) {
         return;
       }
@@ -1084,10 +1084,6 @@ export function setupController(
   };
 
   connectCaipMultichain = (connectionStream, sender) => {
-    if (!process.env.MULTICHAIN_API) {
-      return;
-    }
-
     controller.setupUntrustedCommunicationCaip({
       connectionStream,
       sender,

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -38,15 +38,11 @@ import { initializeProvider } from '@metamask/providers/initializeInpageProvider
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { pipeline } from 'readable-stream';
 
-// this is currently equivalent to process.env.MULTICHAIN_API
-// which can't be used for conditional imports
-///: BEGIN:ONLY_INCLUDE_IF(build-beta,build-flask)
 import {
   getMultichainClient,
   getDefaultTransport,
 } from '@metamask/multichain-api-client';
 import { registerSolanaWalletStandard } from '@metamask/solana-wallet-standard';
-///: END:ONLY_INCLUDE_IF
 
 import shouldInjectProvider from '../../shared/modules/provider-injection';
 import { METAMASK_EIP_1193_PROVIDER } from './constants/stream';
@@ -91,12 +87,9 @@ if (shouldInjectProvider()) {
     },
   });
 
-  // this is currently equivalent to process.env.MULTICHAIN_API
-  ///: BEGIN:ONLY_INCLUDE_IF(build-beta,build-flask)
   getMultichainClient({
     transport: getDefaultTransport(),
   }).then((client) => {
     registerSolanaWalletStandard({ client });
   });
-  ///: END:ONLY_INCLUDE_IF
 }

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -2685,7 +2685,6 @@ describe('MetaMaskController', () => {
     describe('#setupUntrustedCommunicationCaip', () => {
       let localMetamaskController;
       beforeEach(() => {
-        process.env.MULTICHAIN_API = true;
         localMetamaskController = new MetaMaskController({
           showUserConfirmation: noop,
           encryptor: mockEncryptor,
@@ -2711,7 +2710,6 @@ describe('MetaMaskController', () => {
       });
 
       afterAll(() => {
-        process.env.MULTICHAIN_API = false;
         tearDownMockMiddlewareLog();
       });
 

--- a/builds.yml
+++ b/builds.yml
@@ -57,7 +57,6 @@ buildTypes:
       - REJECT_INVALID_SNAPS_PLATFORM_VERSION: true
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/7.2.1/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
-      - MULTICHAIN_API: true
     # Modifies how the version is displayed.
     # eg. instead of 10.25.0 -> 10.25.0-beta.2
     isPrerelease: true
@@ -90,7 +89,6 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_FLASK_WRITE_KEY
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://metamask.github.io/snaps-directory-staging/main/account-management
       - EIP_4337_ENTRYPOINT: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
-      - MULTICHAIN_API: true
     isPrerelease: true
     manifestOverrides: ./app/build-types/flask/manifest/
     buildNameOverride: MetaMask Flask
@@ -306,14 +304,6 @@ env:
   - NODE_DEBUG: ''
   # Used by react-devtools-core
   - EDITOR_URL: ''
-  # Determines if Multichain API features should be used
-  # NOTE: The manifest.json for the build that sets this feature flag
-  # must also include an "externally_connectable" entry as follows:
-  # "externally_connectable": {
-  #   "matches": ["http://*/*", "https://*/*"],
-  #   "ids": ["*"]
-  # }
-  - MULTICHAIN_API: false
   # Determines if feature flagged Chain permissions
   - CHAIN_PERMISSIONS: ''
   # Determines if Portfolio View UI should be shown

--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "@metamask/ppom-validator": "0.36.0",
     "@metamask/preinstalled-example-snap": "^0.3.0",
     "@metamask/profile-sync-controller": "^12.0.0",
-    "@metamask/providers": "^22.0.1",
+    "@metamask/providers": "^22.1.0",
     "@metamask/rate-limit-controller": "^6.0.3",
     "@metamask/remote-feature-flag-controller": "^1.6.0",
     "@metamask/rpc-errors": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6190,9 +6190,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/providers@npm:^22.0.1":
-  version: 22.0.1
-  resolution: "@metamask/providers@npm:22.0.1"
+"@metamask/providers@npm:^22.1.0":
+  version: 22.1.0
+  resolution: "@metamask/providers@npm:22.1.0"
   dependencies:
     "@metamask/json-rpc-engine": "npm:^10.0.2"
     "@metamask/json-rpc-middleware-stream": "npm:^8.0.6"
@@ -6207,7 +6207,7 @@ __metadata:
     readable-stream: "npm:^3.6.2"
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/c4966023b69ba603ff1e62e57adf9968ebfd548f8e018b4e4181810131a554d71168fbd0056127a425b204e76ebb426620db0e192895bd4379a970b41ab1b9d0
+  checksum: 10/d6dc969296e3d478a904228f27adae3b6dcbfdbf49eb6d571c9d73d7506df3c6e3bf3c3464f1e69e4c0acb6f6072d12d1c8182348e626ca1572f4f22f9c585e6
   languageName: node
   linkType: hard
 
@@ -27735,7 +27735,7 @@ __metadata:
     "@metamask/preferences-controller": "npm:^17.0.0"
     "@metamask/preinstalled-example-snap": "npm:^0.3.0"
     "@metamask/profile-sync-controller": "npm:^12.0.0"
-    "@metamask/providers": "npm:^22.0.1"
+    "@metamask/providers": "npm:^22.1.0"
     "@metamask/rate-limit-controller": "npm:^6.0.3"
     "@metamask/remote-feature-flag-controller": "npm:^1.6.0"
     "@metamask/rpc-errors": "npm:^7.0.0"


### PR DESCRIPTION
Previously the Multichain API was only available on Flask and Beta builds. Starting in 12.18.0 we are releasing the Multichain API to all build types including `stable`

[![Open in GitHub
Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32351?quickstart=1)
Cherry-pick: https://github.com/MetaMask/metamask-extension/pull/32351/files
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4779

1. Build this branch in a normal stable build (`yarn start`)
2. Go to https://metamask.github.io/test-dapp-multichain/latest/
3. Enter your extensionId (watch video below to see where) -> Detection on `stable` blocked by https://github.com/MetaMask/providers/pull/420
4. See that you're able to connect and interact with the multichain api

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

https://github.com/user-attachments/assets/282cfd24-428f-4eff-ab27-1a9424c27ad0

https://github.com/user-attachments/assets/7af12e3c-05a8-4277-a439-5c54fefdd13d

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---------

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32409?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
