### PR TITLE
fix(ledger-mv3-bridge): cp-12.18.0 return `response.success` when payload is undefined

### DIFF
--- a/app/scripts/lib/offscreen-bridge/ledger-offscreen-bridge.ts
+++ b/app/scripts/lib/offscreen-bridge/ledger-offscreen-bridge.ts
@@ -145,7 +145,7 @@ export class LedgerOffscreenBridge
         (response) => {
           clearTimeout(responseTimeout);
           if (response?.success) {
-            resolve(response.payload);
+            resolve(response.payload || response.success);
           } else {
             reject(
               new Error(response?.payload?.error || 'Unknown Ledger error'),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Ledger MV3 bridge consumers are expecting `attemptMakeApp` and `updateLedgerTransport` to return `true` when the operation is successful, even if no error was thrown. This PR changes the `#sendMessage` method to return the `response.success` value if `response.payload` is `undefined`. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32411?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32319

## **Manual testing steps**

1. Pair a Ledger account
2. Go to https://metamask.github.io/test-dapp/
3. Connect the wallet
4. Sign a typed message with the Ledger account
5. The "connect" button should be enabled

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
![20250430_14h06m06s_grim](https://github.com/user-attachments/assets/564a7368-6f68-49ad-8435-22a77665534f)

### **After**

<!-- [screenshots/recordings] -->
![20250430_14h05m42s_grim](https://github.com/user-attachments/assets/9968ba17-4cc8-4127-a00d-a55159d61b8e)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
