### PR TITLE
fix: cp-12.18.0 revert mv2 manifest files externally_connectable values

### DIFF
--- a/app/manifest/v2/brave.json
+++ b/app/manifest/v2/brave.json
@@ -1,7 +1,7 @@
 {
   "content_security_policy": "frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; font-src 'self';",
   "externally_connectable": {
-    "matches": ["http://*/*", "https://*/*"],
+    "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   }
 }

--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -1,7 +1,7 @@
 {
   "content_security_policy": "frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; font-src 'self';",
   "externally_connectable": {
-    "matches": ["http://*/*", "https://*/*"],
+    "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
   "minimum_chrome_version": "89"

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1045,7 +1045,7 @@ export function setupController(
 
       connectEip1193(portStream, remotePort.sender);
 
-      if (!isManifestV3) {
+      if (isFirefox) {
         const mux = setupMultiplex(portStream);
         mux.ignoreStream(METAMASK_EIP_1193_PROVIDER);
 

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1045,7 +1045,7 @@ export function setupController(
 
       connectEip1193(portStream, remotePort.sender);
 
-      if (isFirefox) {
+      if (!isManifestV3) {
         const mux = setupMultiplex(portStream);
         mux.ignoreStream(METAMASK_EIP_1193_PROVIDER);
 


### PR DESCRIPTION
## **Description**

Reverts changes to the MV2 manifest files recently made in https://github.com/MetaMask/metamask-extension/pull/32351

These changes appear to be causing issues with webpack builds. [Slack thread here](https://consensys.slack.com/archives/CTQAGKY5V/p1745996121036399?thread_ts=1745922026.773709&cid=CTQAGKY5V)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32419?quickstart=1)

