### PR TITLE
fix: cp-12.18.0 Update reject data on `rejectAllApprovals` utility

### DIFF
--- a/app/scripts/lib/approval/utils.test.ts
+++ b/app/scripts/lib/approval/utils.test.ts
@@ -12,6 +12,11 @@ import { rejectAllApprovals, rejectOriginApprovals } from './utils';
 const ID_MOCK = '123';
 const ID_MOCK_2 = '456';
 const INTERFACE_ID_MOCK = '789';
+const REJECT_ALL_APPROVALS_DATA = {
+  data: {
+    cause: 'rejectAllApprovals',
+  },
+};
 
 function createApprovalControllerMock(
   pendingApprovals: Partial<ApprovalRequest<Record<string, Json>>>[],
@@ -40,15 +45,14 @@ describe('Approval Utils', () => {
       expect(approvalController.reject).toHaveBeenCalledTimes(2);
       expect(approvalController.reject).toHaveBeenCalledWith(
         ID_MOCK,
-        providerErrors.userRejectedRequest(),
+        providerErrors.userRejectedRequest(REJECT_ALL_APPROVALS_DATA),
       );
       expect(approvalController.reject).toHaveBeenCalledWith(
         ID_MOCK_2,
-        providerErrors.userRejectedRequest(),
+        providerErrors.userRejectedRequest(REJECT_ALL_APPROVALS_DATA),
       );
     });
 
-    // @ts-expect-error This function is missing from the Mocha type definitions
     it.each([
       ApprovalType.SnapDialogAlert,
       ApprovalType.SnapDialogPrompt,
@@ -64,7 +68,6 @@ describe('Approval Utils', () => {
       expect(approvalController.accept).toHaveBeenCalledWith(ID_MOCK, null);
     });
 
-    // @ts-expect-error This function is missing from the Mocha type definitions
     it.each([
       ApprovalType.SnapDialogConfirmation,
       SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountCreation,
@@ -81,7 +84,6 @@ describe('Approval Utils', () => {
       expect(approvalController.accept).toHaveBeenCalledWith(ID_MOCK, false);
     });
 
-    // @ts-expect-error This function is missing from the Mocha type definitions
     it.each([
       ApprovalType.SnapDialogAlert,
       ApprovalType.SnapDialogPrompt,
@@ -122,7 +124,7 @@ describe('Approval Utils', () => {
       expect(approvalController.reject).toHaveBeenCalledTimes(1);
       expect(approvalController.reject).toHaveBeenCalledWith(
         ID_MOCK,
-        providerErrors.userRejectedRequest(),
+        providerErrors.userRejectedRequest(REJECT_ALL_APPROVALS_DATA),
       );
     });
   });

--- a/app/scripts/lib/approval/utils.test.ts
+++ b/app/scripts/lib/approval/utils.test.ts
@@ -53,6 +53,7 @@ describe('Approval Utils', () => {
       );
     });
 
+    // @ts-expect-error This function is missing from the Mocha type definitions
     it.each([
       ApprovalType.SnapDialogAlert,
       ApprovalType.SnapDialogPrompt,
@@ -68,6 +69,7 @@ describe('Approval Utils', () => {
       expect(approvalController.accept).toHaveBeenCalledWith(ID_MOCK, null);
     });
 
+    // @ts-expect-error This function is missing from the Mocha type definitions
     it.each([
       ApprovalType.SnapDialogConfirmation,
       SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountCreation,
@@ -84,6 +86,7 @@ describe('Approval Utils', () => {
       expect(approvalController.accept).toHaveBeenCalledWith(ID_MOCK, false);
     });
 
+    // @ts-expect-error This function is missing from the Mocha type definitions
     it.each([
       ApprovalType.SnapDialogAlert,
       ApprovalType.SnapDialogPrompt,

--- a/app/scripts/lib/approval/utils.ts
+++ b/app/scripts/lib/approval/utils.ts
@@ -94,7 +94,14 @@ function rejectApproval({
 
     default:
       log('Rejecting pending approval', { id, origin, type });
-      approvalController.reject(id, providerErrors.userRejectedRequest());
+      approvalController.reject(
+        id,
+        providerErrors.userRejectedRequest({
+          data: {
+            cause: 'rejectAllApprovals',
+          },
+        }),
+      );
       break;
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the unintentionally removed rejection data `cause` property back into `rejectAllApprovals` utility. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32466?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32162

## **Manual testing steps**

1. Go to test-dapp
2. Trigger 3 transaction request back to back
3. Use reject all in the last one
4. Be able to trigger another transaction after "rejecting all"

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
