### PR TITLE
test: migrate benchmark tests to anvil and remove more ganache old references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,7 @@ jobs:
   run-benchmarks:
     uses: ./.github/workflows/run-benchmarks.yml
     needs:
+      - needs-e2e
       - prep-build-test-browserify
       - prep-build-test-webpack
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,6 @@ jobs:
   run-benchmarks:
     uses: ./.github/workflows/run-benchmarks.yml
     needs:
-      - needs-e2e
       - prep-build-test-browserify
       - prep-build-test-webpack
     permissions:

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -30,6 +30,10 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
+      # not installed by checkout-and-setup when cache is restored
+      - name: Install anvil
+        run: yarn foundryup
+
       - name: Download artifact ${{ env.ARTIFACT_NAME }}
         uses: actions/download-artifact@v4
         with:

--- a/test/e2e/benchmark.mjs
+++ b/test/e2e/benchmark.mjs
@@ -34,7 +34,6 @@ async function measurePage(pageName, pageLoads) {
     {
       fixtures: new FixtureBuilder().build(),
       disableServerMochaToBackground: true,
-      localNodeOptions: 'ganache',
       title: 'benchmark-pageload',
     },
     async ({ driver }) => {

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -5,15 +5,8 @@ import {
   KnownNotifications,
 } from '@metamask/chain-agnostic-permission';
 import { JsonRpcRequest } from '@metamask/utils';
-import {
-  convertETHToHexGwei,
-  multipleGanacheOptions,
-  PRIVATE_KEY,
-  regularDelayMs,
-  WINDOW_TITLES,
-} from '../../helpers';
+import { regularDelayMs, WINDOW_TITLES } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
-import { DEFAULT_LOCAL_NODE_ETH_BALANCE_DEC } from '../../constants';
 import {
   CONTENT_SCRIPT,
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
@@ -39,27 +32,20 @@ export const DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS = {
   ],
   localNodeOptions: [
     {
-      type: 'ganache',
-      options: {
-        secretKey: PRIVATE_KEY,
-        balance: convertETHToHexGwei(DEFAULT_LOCAL_NODE_ETH_BALANCE_DEC),
-        accounts: multipleGanacheOptions.accounts,
-      },
+      type: 'anvil',
     },
     {
-      type: 'ganache',
+      type: 'anvil',
       options: {
         port: 8546,
         chainId: 1338,
-        accounts: multipleGanacheOptions.accounts,
       },
     },
     {
-      type: 'ganache',
+      type: 'anvil',
       options: {
         port: 7777,
         chainId: 1000,
-        accounts: multipleGanacheOptions.accounts,
       },
     },
   ],

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -544,7 +544,7 @@ const PRIVATE_KEY_TWO =
 const ACCOUNT_1 = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
 const ACCOUNT_2 = '0x09781764c08de8ca82e156bbf156a3ca217c7950';
 
-const defaultGanacheOptionsForType2Transactions = {
+const defaultOptionsForType2Transactions = {
   // EVM version that supports type 2 transactions (EIP1559)
   hardfork: 'london',
 };
@@ -941,7 +941,7 @@ module.exports = {
   switchToOrOpenDapp,
   connectToDapp,
   multipleGanacheOptions,
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   sendTransaction,
   sendScreenToConfirmScreen,
   unlockWallet,

--- a/test/e2e/json-rpc/eth_newBlockFilter.spec.ts
+++ b/test/e2e/json-rpc/eth_newBlockFilter.spec.ts
@@ -5,7 +5,7 @@ import FixtureBuilder from '../fixture-builder';
 import { Driver } from '../webdriver/driver';
 
 describe('eth_newBlockFilter', function () {
-  const ganacheOptions: { blockTime: number } = {
+  const localNodeOptions: { blockTime: number } = {
     blockTime: 0.1,
   };
   it('executes a new block filter call', async function () {
@@ -15,7 +15,7 @@ describe('eth_newBlockFilter', function () {
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
-        localNodeOptions: ganacheOptions,
+        localNodeOptions,
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {

--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -1,7 +1,7 @@
 import { TransactionEnvelopeType } from '@metamask/transaction-controller';
 import FixtureBuilder from '../../fixture-builder';
 import {
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   withFixtures,
 } from '../../helpers';
 import { MockedEndpoint, Mockttp } from '../../mock-e2e';
@@ -44,7 +44,7 @@ export function withTransactionEnvelopeTypeFixtures(
       localNodeOptions:
         transactionEnvelopeType === TransactionEnvelopeType.legacy
           ? {}
-          : defaultGanacheOptionsForType2Transactions,
+          : defaultOptionsForType2Transactions,
       ...(smartContract && { smartContract }),
       ...(mocks && { testSpecificMock: mocks }),
       title,

--- a/test/e2e/tests/confirmations/transactions/contract-deployment-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-deployment-redesign.spec.ts
@@ -9,7 +9,7 @@ import {
 } from './shared';
 
 const {
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   withFixtures,
 } = require('../../../helpers');
 const FixtureBuilder = require('../../../fixture-builder');
@@ -49,7 +49,7 @@ describe('Confirmation Redesign Contract Deployment Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           title: this.test?.fullTitle(),
         },
         async ({ driver }: TestSuiteArguments) => {

--- a/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
@@ -18,7 +18,7 @@ import {
 
 const { hexToNumber } = require('@metamask/utils');
 const {
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   WINDOW_TITLES,
   withFixtures,
 } = require('../../../helpers');
@@ -59,7 +59,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           smartContract,
           title: this.test?.fullTitle(),
         },
@@ -128,7 +128,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
             .withNetworkControllerOnOptimism()
             .build(),
           localNodeOptions: {
-            ...defaultGanacheOptionsForType2Transactions,
+            ...defaultOptionsForType2Transactions,
             chainId: hexToNumber(CHAIN_IDS.OPTIMISM),
           },
           smartContract,
@@ -163,7 +163,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           smartContract,
           title: this.test?.fullTitle(),
         },
@@ -184,7 +184,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           smartContract,
           title: this.test?.fullTitle(),
         },
@@ -213,7 +213,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           smartContract,
           title: this.test?.fullTitle(),
         },
@@ -238,7 +238,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           smartContract,
           title: this.test?.fullTitle(),
         },

--- a/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
@@ -11,7 +11,7 @@ import {
 } from './shared';
 
 const {
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   withFixtures,
 } = require('../../../helpers');
 const FixtureBuilder = require('../../../fixture-builder');
@@ -53,7 +53,7 @@ describe('Confirmation Redesign ERC20 Approve Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           smartContract,
           testSpecificMock: mocks,
           title: this.test?.fullTitle(),

--- a/test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts
@@ -10,7 +10,7 @@ import {
 } from './shared';
 
 const {
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   withFixtures,
 } = require('../../../helpers');
 const FixtureBuilder = require('../../../fixture-builder');
@@ -52,7 +52,7 @@ describe('Confirmation Redesign ERC721 Approve Component', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           smartContract,
           testSpecificMock: mocks,
           title: this.test?.fullTitle(),

--- a/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
@@ -1,6 +1,6 @@
 import FixtureBuilder from '../../../fixture-builder';
 import {
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   WINDOW_TITLES,
   withFixtures,
 } from '../../../helpers';
@@ -91,7 +91,7 @@ function generateFixtureOptionsForEIP1559Tx(mochaContext: Mocha.Context) {
     fixtures: new FixtureBuilder()
       .withPermissionControllerConnectedToTestDapp()
       .build(),
-    localNodeOptions: defaultGanacheOptionsForType2Transactions,
+    localNodeOptions: defaultOptionsForType2Transactions,
     smartContract: SMART_CONTRACTS.HST,
     testSpecificMock: mocks,
     title: mochaContext.test?.fullTitle(),

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -15,7 +15,7 @@ import {
 } from './shared';
 
 const {
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   openDapp,
   unlockWallet,
   WINDOW_TITLES,
@@ -36,7 +36,7 @@ describe('Metrics', function () {
             participateInMetaMetrics: true,
           })
           .build(),
-        localNodeOptions: defaultGanacheOptionsForType2Transactions,
+        localNodeOptions: defaultOptionsForType2Transactions,
         title: this.test?.fullTitle(),
         testSpecificMock: mocks,
       },

--- a/test/e2e/tests/confirmations/transactions/revoke-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/revoke-allowance-redesign.spec.ts
@@ -12,7 +12,7 @@ import {
 } from './shared';
 
 const {
-  defaultGanacheOptionsForType2Transactions,
+  defaultOptionsForType2Transactions,
   withFixtures,
 } = require('../../../helpers');
 const FixtureBuilder = require('../../../fixture-builder');
@@ -60,7 +60,7 @@ describe('Confirmation Redesign ERC20 Revoke Allowance', function () {
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
-          localNodeOptions: defaultGanacheOptionsForType2Transactions,
+          localNodeOptions: defaultOptionsForType2Transactions,
           smartContract,
           testSpecificMock: mocks,
           title: this.test?.fullTitle(),

--- a/test/e2e/tests/network/chain-interactions.spec.js
+++ b/test/e2e/tests/network/chain-interactions.spec.js
@@ -10,7 +10,7 @@ describe('Chain Interactions', function () {
   const port = 8546;
   const chainId = 1338;
 
-  it('should add the Ganache chain and switch the network', async function () {
+  it('should add the Local chain and switch the network', async function () {
     await withFixtures(
       {
         dapp: true,

--- a/test/e2e/tests/network/custom-rpc-history.spec.js
+++ b/test/e2e/tests/network/custom-rpc-history.spec.js
@@ -36,7 +36,7 @@ describe('Custom RPC history', function () {
         await unlockWallet(driver);
 
         const rpcUrl = `http://127.0.0.1:${port}`;
-        const networkName = 'Secondary Ganache Testnet';
+        const networkName = 'Secondary Local Testnet';
 
         await driver.clickElement('[data-testid="network-display"]');
         await driver.clickElement({
@@ -87,12 +87,12 @@ describe('Custom RPC history', function () {
 
         // Validate the network was added
         const networkAdded = await driver.isElementPresent({
-          text: '“Secondary Ganache Testnet” was successfully added!',
+          text: '“Secondary Local Testnet” was successfully added!',
         });
         assert.equal(
           networkAdded,
           true,
-          '“Secondary Ganache Testnet” was successfully added!',
+          '“Secondary Local Testnet” was successfully added!',
         );
       },
     );

--- a/test/e2e/tests/onboarding/onboarding.spec.ts
+++ b/test/e2e/tests/onboarding/onboarding.spec.ts
@@ -27,16 +27,6 @@ import {
 import { switchToNetworkFlow } from '../../page-objects/flows/network.flow';
 
 describe('MetaMask onboarding', function () {
-  const ganacheOptions2 = {
-    accounts: [
-      {
-        secretKey:
-          '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9',
-        balance: convertToHexValue(10000000000000000000),
-      },
-    ],
-  };
-
   it("Creates a new wallet, sets up a secure password, and doesn't complete the onboarding process and refreshes the page", async function () {
     await withFixtures(
       {
@@ -225,20 +215,23 @@ describe('MetaMask onboarding', function () {
         fixtures: new FixtureBuilder({ onboarding: true }).build(),
         localNodeOptions: [
           {
-            type: 'ganache',
+            type: 'anvil',
           },
           {
-            type: 'ganache',
+            type: 'anvil',
             options: {
               port,
               chainId,
-              ...ganacheOptions2,
             },
           },
         ],
         title: this.test?.fullTitle(),
       },
       async ({ driver, localNodes }) => {
+        await localNodes[1].setAccountBalance(
+          '0x0Cc5261AB8cE458dc977078A3623E2BaDD27afD3',
+          convertToHexValue(10000000000000000000),
+        );
         await importSRPOnboardingFlow({
           driver,
           seedPhrase: TEST_SEED_PHRASE,
@@ -270,9 +263,9 @@ describe('MetaMask onboarding', function () {
 
         // Check the correct balance for the custom network is displayed
         if (localNodes[1] && Array.isArray(localNodes)) {
-          await homePage.check_localNodeBalanceIsDisplayed(localNodes[1]);
+          await homePage.check_expectedBalanceIsDisplayed('10');
         } else {
-          throw new Error('Custom network Ganache server not available');
+          throw new Error('Custom network server not available');
         }
       },
     );

--- a/test/e2e/tests/request-queuing/ui.spec.js
+++ b/test/e2e/tests/request-queuing/ui.spec.js
@@ -696,7 +696,7 @@ describe('Request-queue UI changes', function () {
             },
           },
         ],
-        // This test intentionally quits Ganache while the extension is using it, causing
+        // This test intentionally quits the local node server while the extension is using it, causing
         // PollingBlockTracker errors and others. These are expected.
         ignoredConsoleErrors: ['ignore-all'],
         dappOptions: { numberOfDapps: 2 },
@@ -720,7 +720,7 @@ describe('Request-queue UI changes', function () {
           text: 'Ethereum Mainnet',
         });
 
-        // Kill ganache servers
+        // Kill local node servers
         await localNodes[0].quit();
         await localNodes[1].quit();
 

--- a/test/e2e/tests/swap-send/swap-send-erc20.spec.ts
+++ b/test/e2e/tests/swap-send/swap-send-erc20.spec.ts
@@ -22,7 +22,7 @@ describe('Swap-Send ERC20', function () {
         getSwapSendFixtures(
           this.test?.fullTitle(),
           SWAP_SEND_QUOTES_RESPONSE_TST_ETH,
-          '?sourceAmount=100000&sourceToken=0x581c3C1A2A4EBDE2A0Df29B5cf4c116E42945947&destinationToken=0x0000000000000000000000000000000000000000&sender=0x5cfe73b6021e818b776b421b1c4db2474086a7e1&recipient=0xc427D562164062a23a5cFf596A4a3208e72Acd28&slippage=2',
+          '?sourceAmount=100000&sourceToken=0x581c3c1a2a4ebde2a0df29b5cf4c116e42945947&destinationToken=0x0000000000000000000000000000000000000000&sender=0x5cfe73b6021e818b776b421b1c4db2474086a7e1&recipient=0xc427D562164062a23a5cFf596A4a3208e72Acd28&slippage=2',
         ),
         async ({ driver }) => {
           const swapSendPage = new SwapSendPage(driver);

--- a/test/e2e/tests/swap-send/swap-send-test-utils.ts
+++ b/test/e2e/tests/swap-send/swap-send-test-utils.ts
@@ -323,14 +323,9 @@ export const getSwapSendFixtures = (
     smartContract: SMART_CONTRACTS.HST,
     ethConversionInUsd: ETH_CONVERSION_RATE_USD,
     testSpecificMock: mockSwapsApi(swapsQuotes, swapsQuery),
-    localNodeOptions: [
-      {
-        type: 'ganache',
-        options: {
-          hardfork: 'london',
-        },
-      },
-    ],
+    localNodeOptions: {
+      hardfork: 'london',
+    },
     title,
   };
 };

--- a/test/e2e/user-actions-benchmark.ts
+++ b/test/e2e/user-actions-benchmark.ts
@@ -24,8 +24,10 @@ async function loadNewAccount(): Promise<number> {
   await withFixtures(
     {
       fixtures: new FixtureBuilder().build(),
-      localNodeOptions: 'ganache',
       disableServerMochaToBackground: true,
+      localNodeOptions: {
+        accounts: 1,
+      },
       title: 'benchmark-userActions-loadNewAccount',
     },
     async ({ driver }: { driver: Driver }) => {
@@ -58,7 +60,6 @@ async function confirmTx(): Promise<number> {
   await withFixtures(
     {
       fixtures: new FixtureBuilder().build(),
-      localNodeOptions: 'ganache',
       disableServerMochaToBackground: true,
       title: 'benchmark-userActions-confirmTx',
     },
@@ -116,7 +117,6 @@ async function bridgeUserActions(): Promise<{
     {
       fixtures: fixtureBuilder.build(),
       disableServerMochaToBackground: true,
-      localNodeOptions: 'ganache',
       title: 'benchmark-userActions-bridgeUserActions',
       testSpecificMock: async (mockServer: Mockttp) => [
         await mockFeatureFlag(mockServer, {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Migrate benchmark specs to use anvil instead of ganache, and remove more ganache old references.

Skipping e2e quality gate as touching several spec files, but mostly they are variable renames.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32493?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/31761

## **Manual testing steps**

1. Test should continue to pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
