### PR TITLE
fix: asset chart styles

### DIFF
--- a/ui/pages/asset/asset.scss
+++ b/ui/pages/asset/asset.scss
@@ -80,6 +80,13 @@
   height: 100%;
 }
 
+.asset-chart__empty-state-illustration {
+  max-width: 134px;
+  max-height: 106px;
+  width: 21%;
+  height: 47%;
+}
+
 .asset-chart__skeleton-container {
   aspect-ratio: 2.9;
   margin-top: 22px;
@@ -88,4 +95,6 @@
 
 .asset-chart__skeleton {
   aspect-ratio: 2.9;
+  margin-right: 1rem;
+  margin-left: 1rem;
 }

--- a/ui/pages/asset/components/chart/asset-chart-empty-state.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-empty-state.tsx
@@ -16,8 +16,7 @@ export const AssetChartEmptyState = () => {
       <Box className="asset-chart__empty-state-content">
         <img
           src="./images/asset-chart-empty-state-illustration.png"
-          width="134"
-          height="106"
+          className="asset-chart__empty-state-illustration"
         />
         <Text
           textAlign={TextAlign.Center}


### PR DESCRIPTION
Slight improvements on styles of loading+empty states of the price chart:
- adds margins on both sides of the chart loading skeleton.
- fixes size of the illustration. It was not scaling down on smaller screen sizes, breaking the intended 2.9 aspect ratio, causing the layout to shift vertically.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32505?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
![image](https://github.com/user-attachments/assets/cd7fbe52-657f-4c86-8f8f-a869d50a3405)
![image](https://github.com/user-attachments/assets/dfc3c633-0423-4a6a-a202-18fd93a62d7c)


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
