### PR TITLE
chore: update minimum browser versions to Chrome 109 and Firefox 102 cp-12.18.0

### DIFF
--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -4,5 +4,5 @@
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "89"
+  "minimum_chrome_version": "109"
 }

--- a/app/manifest/v2/firefox.json
+++ b/app/manifest/v2/firefox.json
@@ -2,7 +2,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "89.0"
+      "strict_min_version": "102.0"
     }
   },
   "browser_action": {

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -7,5 +7,5 @@
     "matches": ["http://*/*", "https://*/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "89"
+  "minimum_chrome_version": "109"
 }

--- a/app/manifest/v3/firefox.json
+++ b/app/manifest/v3/firefox.json
@@ -2,7 +2,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "89.0"
+      "strict_min_version": "102.0"
     }
   },
   "background": {

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -16,17 +16,18 @@ export const PASSWORD_MIN_LENGTH = 8;
 export const OUTDATED_BROWSER_VERSIONS = {
   // Chrome and Edge should match the latest Chrome version released ~2 years ago,
   // or the earliest version that supports our MV3 functionality, whichever is higher
-  chrome: '<109',
-  edge: '<109',
+  chrome: '<113',
+  edge: '<113',
   // Firefox should match the previous extended support release
-  // Current ESR: 115
-  // Previous ESR: 102
-  firefox: '<102',
+  // Current ESR: 128 - first available to ESR 2024/07/09
+  // Previous ESR: 115 - first released to ESR 2023/07/04
+  // per https://whattrainisitnow.com/calendar/firefox ("Click to toggle past releases table data")
+  firefox: '<115',
   // Opera versions correspond to differently numbered Chromium versions.
   // Opera should be set to the equivalent of the Chromium version set
-  // Opera 95 is based on Chromium 109
+  // Opera 99 is based on Chromium 113
   // See https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser
-  opera: '<95',
+  opera: '<99',
 };
 
 /**

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -209,56 +209,56 @@ describe('util', () => {
     });
     it('should return false when given a modern chrome browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.2623.112 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.52',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(false);
     });
     it('should return true when given an outdated chrome browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.2623.112 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(true);
     });
     it('should return false when given a modern firefox browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:78.0) Gecko/20100101 Firefox/102.0',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:115.0) Gecko/20100101 Firefox/115.0',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(false);
     });
     it('should return true when given an outdated firefox browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:75.0) Gecko/20100101 Firefox/91.0',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(true);
     });
     it('should return false when given a modern opera browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_16_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.3578.98 Safari/537.36 OPR/95.0.3135.47',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_16_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 OPR/101.0.0.0',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(false);
     });
     it('should return true when given an outdated opera browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_16_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.3578.98 Safari/537.36 OPR/58.0.3135.47',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_16_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.165 Safari/537.36 OPR/98.0.4759.39',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(true);
     });
     it('should return false when given a modern edge browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.3578.98 Safari/537.36 Edg/109.0.416.68',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.5672.126 Safari/537.36 Edg/113.0.1774.50',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(false);
     });
     it('should return true when given an outdated edge browser', () => {
       const browser = Bowser.getParser(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.3578.98 Safari/537.36 Edge/89.0.416.68',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.3578.98 Safari/537.36 Edge/109.0.416.68',
       );
       const result = util.getIsBrowserDeprecated(browser);
       expect(result).toStrictEqual(true);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

[Documented extension browser support is](https://github.com/MetaMask/metamask-extension/blob/dc7325148c1ac03f050422e07156087b53af92d2/docs/browser-support.md):

* The last two years of Chrome stable releases
* The current and previous Firefox Extended Support Release

This PR updates our minimum supported Chrome version to Chrome 109, and our minimum supported Firefox version to Firefox 102.

* Chrome 109
  * released January 2023
  * Over two years? ✅ 
 * Firefox 102
   * released June 28, 2022.
   * Current and Previous ESR? ✅ 
     * there are actually _two_ more up to date Firefox releases: 115 ESR and 128 ESR. So we will be supporting 3 versions.

The _actual_ minimum browsers we _can_ update to, per policy, are:

 * Chrome 113 (released Apr 26, 2023)
 * Firefox 115 ESR (because 128 ESR is available)
  
The reason this PR does NOT update directly to those versions is because we must `update the OUTDATED_BROWSER_VERSIONS` constant in the release prior to the minimum version bump. This PR does that. After one release we can further bump our minimum supported versions to Chrome 113 and Firefox 115.
 
Notes:

 * Firefox 140 ESR will be released June 24 2025, meaning we can then drop Firefox 115 ESR support and update our minimum supported version to Firefox 128 at that time.
 * This PR does *not* update our compilation targets, because our browser tools don't support all of the new JavaScript syntax available in these newer browsers.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32520?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ensure that the extension still works on versions equal to or above the new minimum versions.


## **Screenshots/Recordings**
If you install on an "old" version, like Firefox 102.0 as I did here, you'll see a warning like this:

![image](https://github.com/user-attachments/assets/e9c2627e-558f-450c-8085-c237f00a04ff)


<!--
### **Before**



### **After**

-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
