### PR TITLE
 fix: cp-12.18.0 smart account splash 3rd title copy

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5214,6 +5214,9 @@
   "smartAccountRequestFor": {
     "message": "Request for"
   },
+  "smartAccountSameAccount": {
+    "message": "Same account, smarter features."
+  },
   "smartAccountSplashTitle": {
     "message": "Use smart account?"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5214,6 +5214,9 @@
   "smartAccountRequestFor": {
     "message": "Request for"
   },
+  "smartAccountSameAccount": {
+    "message": "Same account, smarter features."
+  },
   "smartAccountSplashTitle": {
     "message": "Use smart account?"
   },

--- a/ui/pages/confirmations/components/confirm/splash/smart-account-update/smart-account-update.tsx
+++ b/ui/pages/confirmations/components/confirm/splash/smart-account-update/smart-account-update.tsx
@@ -129,7 +129,7 @@ export function SmartAccountUpdate() {
         />
         <ListItem
           imgSrc="./images/sparkle.svg"
-          title={t('smartAccountPayToken')}
+          title={t('smartAccountSameAccount')}
           description={
             <>
               <Text


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The originally copy was accidentally removed in https://github.com/MetaMask/metamask-extension/pull/31774/files. This restores the copy and replaces the duplicated title 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32528?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32523

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="404" alt="Image" src="https://github.com/user-attachments/assets/87e75bfb-e349-4254-a4c8-2fa96086c5cd" />

### **After**

![CleanShot 2025-05-05 at 13 55 01](https://github.com/user-attachments/assets/6a50f186-34ac-41dd-bdb8-a8e5dacbbb82)


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
