### PR TITLE
fix: patch increase incoming trx polling  cp-12.17.2

### DIFF
--- a/.yarn/patches/@metamask-transaction-controller-patch-47fbbc917e.patch
+++ b/.yarn/patches/@metamask-transaction-controller-patch-47fbbc917e.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/helpers/IncomingTransactionHelper.cjs b/dist/helpers/IncomingTransactionHelper.cjs
+index cd4a8158be0960eaf9d74cc6328e0b3bbd06740d..21336f5b778c05f8cd0469ff9964c704c96f26b1 100644
+--- a/dist/helpers/IncomingTransactionHelper.cjs
++++ b/dist/helpers/IncomingTransactionHelper.cjs
+@@ -20,7 +20,7 @@ exports.IncomingTransactionHelper = void 0;
+ // eslint-disable-next-line import-x/no-nodejs-modules
+ const events_1 = __importDefault(require("events"));
+ const logger_1 = require("../logger.cjs");
+-const INTERVAL = 1000 * 30; // 30 Seconds
++const INTERVAL = 1000 * 60 * 4; // 4 Minutes
+ class IncomingTransactionHelper {
+     constructor({ getCache, getCurrentAccount, getLocalTransactions, includeTokenTransfers, isEnabled, queryEntireHistory, remoteTransactionSource, trimTransactions, updateCache, updateTransactions, }) {
+         _IncomingTransactionHelper_instances.add(this);
+diff --git a/dist/helpers/IncomingTransactionHelper.mjs b/dist/helpers/IncomingTransactionHelper.mjs
+index 45129a2bdc8f5bcb3955eb7c1a82a1164364a084..138efb1d178be8d2c5dc623ecd18b4997fb49b37 100644
+--- a/dist/helpers/IncomingTransactionHelper.mjs
++++ b/dist/helpers/IncomingTransactionHelper.mjs
+@@ -14,7 +14,7 @@ var _IncomingTransactionHelper_instances, _IncomingTransactionHelper_getCache, _
+ // eslint-disable-next-line import-x/no-nodejs-modules
+ import EventEmitter from "events";
+ import { incomingTransactionsLogger as log } from "../logger.mjs";
+-const INTERVAL = 1000 * 30; // 30 Seconds
++const INTERVAL = 1000 * 60 * 4; // 4 Minutes
+ export class IncomingTransactionHelper {
+     constructor({ getCache, getCurrentAccount, getLocalTransactions, includeTokenTransfers, isEnabled, queryEntireHistory, remoteTransactionSource, trimTransactions, updateCache, updateTransactions, }) {
+         _IncomingTransactionHelper_instances.add(this);

--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "@metamask/snaps-utils": "^9.2.0",
     "@metamask/solana-wallet-snap": "^1.24.0",
     "@metamask/solana-wallet-standard": "^0.1.1",
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A54.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch",
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@patch%3A@metamask/transaction-controller@npm%253A54.0.0%23~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch%3A%3Aversion=54.0.0&hash=38d6b9#~/.yarn/patches/@metamask-transaction-controller-patch-47fbbc917e.patch",
     "@metamask/user-operation-controller": "^31.0.0",
     "@metamask/utils": "^11.1.0",
     "@ngraveio/bc-ur": "^1.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6677,7 +6677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A54.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch":
+"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A54.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch::version=54.0.0&hash=38d6b9":
   version: 54.0.0
   resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A54.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch::version=54.0.0&hash=38d6b9"
   dependencies:
@@ -6710,6 +6710,42 @@ __metadata:
     "@metamask/network-controller": ^23.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
   checksum: 10/47f007e13f6ec3a651cd2af3f998fbdd234eed02cbfac00fc7ef005c55aa53ae4be69d9c46e4abf2965f10fe41e05d500b00499e3a651624e19f10b7d086a0a9
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-controller@patch:@metamask/transaction-controller@patch%3A@metamask/transaction-controller@npm%253A54.0.0%23~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch%3A%3Aversion=54.0.0&hash=38d6b9#~/.yarn/patches/@metamask-transaction-controller-patch-47fbbc917e.patch":
+  version: 54.0.0
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@patch%3A@metamask/transaction-controller@npm%253A54.0.0%23~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch%3A%3Aversion=54.0.0&hash=38d6b9#~/.yarn/patches/@metamask-transaction-controller-patch-47fbbc917e.patch::version=54.0.0&hash=456359"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/base-controller": "npm:^8.0.0"
+    "@metamask/controller-utils": "npm:^11.7.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.2.0"
+    async-mutex: "npm:^0.5.0"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/accounts-controller": ^27.0.0
+    "@metamask/approval-controller": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+    "@metamask/gas-fee-controller": ^23.0.0
+    "@metamask/network-controller": ^23.0.0
+    "@metamask/remote-feature-flag-controller": ^1.5.0
+  checksum: 10/4ffb5982fdb21a89abb8efe3a7aa2ad3900526815a11e9a9a96eddd3de3b21e36eb440879586997666e243c46cbff71cd93d09d76aa00c08218445d9c008e0b8
   languageName: node
   linkType: hard
 
@@ -27518,7 +27554,7 @@ __metadata:
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:9.3.0"
     "@metamask/test-dapp-multichain": "npm:^0.6.0"
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A54.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch"
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@patch%3A@metamask/transaction-controller@npm%253A54.0.0%23~/.yarn/patches/@metamask-transaction-controller-npm-54.0.0-ccc4668363.patch%3A%3Aversion=54.0.0&hash=38d6b9#~/.yarn/patches/@metamask-transaction-controller-patch-47fbbc917e.patch"
     "@metamask/user-operation-controller": "npm:^31.0.0"
     "@metamask/utils": "npm:^11.1.0"
     "@ngraveio/bc-ur": "npm:^1.1.13"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Increase polling interval to 4min to balance increased load to our backend servers due to updating the incoming trx polling behaviour. Now all users will poll, for all networks, as long as they have basic functionality toggled on.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32547?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4832

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
