### PR TITLE
fix: reverts evm transaction ordering to preserve nonce ordering

### DIFF
--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -200,6 +200,7 @@ const getFilteredTransactionGroupsAllChains = (
 const groupTransactionsByDate = (
   transactionGroups,
   getTransactionTimestamp,
+  shouldSort = true,
 ) => {
   const groupedTransactions = [];
 
@@ -217,12 +218,14 @@ const groupTransactionsByDate = (
 
     if (existingGroup) {
       existingGroup.transactionGroups.push(transactionGroup);
-      // Sort transactions within the group by timestamp (newest first)
-      existingGroup.transactionGroups.sort((a, b) => {
-        const aTime = getTransactionTimestamp(a);
-        const bTime = getTransactionTimestamp(b);
-        return bTime - aTime; // Descending order (newest first)
-      });
+      if (shouldSort) {
+        // Sort transactions within the group by timestamp (newest first)
+        existingGroup.transactionGroups.sort((a, b) => {
+          const aTime = getTransactionTimestamp(a);
+          const bTime = getTransactionTimestamp(b);
+          return bTime - aTime; // Descending order (newest first)
+        });
+      }
     } else {
       groupedTransactions.push({
         date,
@@ -230,8 +233,10 @@ const groupTransactionsByDate = (
         transactionGroups: [transactionGroup],
       });
     }
-    // Sort date groups by timestamp (newest first)
-    groupedTransactions.sort((a, b) => b.dateMillis - a.dateMillis);
+    if (shouldSort) {
+      // Sort date groups by timestamp (newest first)
+      groupedTransactions.sort((a, b) => b.dateMillis - a.dateMillis);
+    }
   });
 
   return groupedTransactions;
@@ -241,6 +246,7 @@ const groupEvmTransactionsByDate = (transactionGroups) =>
   groupTransactionsByDate(
     transactionGroups,
     (transactionGroup) => transactionGroup.primaryTransaction.time,
+    false, // maintains nonce ordering for EVM
   );
 
 ///: BEGIN:ONLY_INCLUDE_IF(multichain)
@@ -248,6 +254,7 @@ const groupNonEvmTransactionsByDate = (nonEvmTransactions) =>
   groupTransactionsByDate(
     nonEvmTransactions?.transactions,
     (transaction) => transaction.timestamp * 1000,
+    true, // timestamp sorting for non-EVM
   );
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
When adding multichain transactions and sorting, we incorrectly sorted EVM transactions by Timestamp after they are sorted by Nonce - this can cause an incorrect sorting of nonces which are expected to be in order for some components to display correctly.

This change reverts the sorting of EVM back to the pre-bug state and keeps Multichain transactions where they are by using props on the sorting function.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32576?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32261

## **Manual testing steps**

1. Follow repro steps in https://github.com/MetaMask/metamask-extension/issues/32261
2. Observe the fix

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
