### PR TITLE
chore: never emit `Dapp Viewed` events on Firefox cp-12.17.3

### DIFF
--- a/app/scripts/lib/util.test.js
+++ b/app/scripts/lib/util.test.js
@@ -280,6 +280,17 @@ describe('app utils', () => {
         shouldEmitDappViewedEvent('fake-metrics-id-invalid'),
       ).toStrictEqual(false);
     });
+
+    it('should return false for Firefox', () => {
+      jest
+        .spyOn(window.navigator, 'userAgent', 'get')
+        .mockReturnValue(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:95.0) Gecko/20100101 Firefox/95.0',
+        );
+      expect(shouldEmitDappViewedEvent('fake-metrics-id-fd20')).toStrictEqual(
+        false,
+      );
+    });
   });
 
   describe('formatTxMetaForRpcResult', () => {

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -291,7 +291,9 @@ export function isWebUrl(urlString: string): boolean {
  * @returns Whether to emit the event or not.
  */
 export function shouldEmitDappViewedEvent(metaMetricsId: string): boolean {
-  if (metaMetricsId === null) {
+  const isFireFox = getPlatform() === PLATFORM_FIREFOX;
+
+  if (metaMetricsId === null || isFireFox) {
     return false;
   }
 

--- a/test/e2e/tests/metrics/dapp-viewed.spec.ts
+++ b/test/e2e/tests/metrics/dapp-viewed.spec.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import { Mockttp } from 'mockttp';
+import { Browser } from 'selenium-webdriver';
 import { getEventPayloads, withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
@@ -65,6 +66,9 @@ async function mockPermissionApprovedEndpoint(mockServer: Mockttp) {
 describe('Dapp viewed Event', function () {
   const validFakeMetricsId = 'fake-metrics-fd20';
   it('is not sent when metametrics ID is not valid', async function () {
+    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
+      this.skip();
+    }
     async function mockSegment(mockServer: Mockttp) {
       return [await mockedDappViewedEndpointFirstVisit(mockServer)];
     }
@@ -97,6 +101,9 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when navigating to dapp with no account connected', async function () {
+    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
+      this.skip();
+    }
     async function mockSegment(mockServer: Mockttp) {
       return [await mockedDappViewedEndpointFirstVisit(mockServer)];
     }
@@ -132,6 +139,9 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when opening the dapp in a new tab with one account connected', async function () {
+    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
+      this.skip();
+    }
     async function mockSegment(mockServer: Mockttp) {
       return [
         await mockedDappViewedEndpointFirstVisit(mockServer),
@@ -174,6 +184,9 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when refreshing dapp with one account connected', async function () {
+    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
+      this.skip();
+    }
     async function mockSegment(mockServer: Mockttp) {
       return [
         await mockedDappViewedEndpointFirstVisit(mockServer),
@@ -217,6 +230,9 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when navigating to a connected dapp', async function () {
+    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
+      this.skip();
+    }
     async function mockSegment(mockServer: Mockttp) {
       return [
         await mockedDappViewedEndpointFirstVisit(mockServer),
@@ -262,6 +278,9 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when reconnect to a dapp that has been connected before', async function () {
+    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
+      this.skip();
+    }
     async function mockSegment(mockServer: Mockttp) {
       return [
         await mockedDappViewedEndpointFirstVisit(mockServer),

--- a/test/e2e/tests/metrics/dapp-viewed.spec.ts
+++ b/test/e2e/tests/metrics/dapp-viewed.spec.ts
@@ -64,11 +64,14 @@ async function mockPermissionApprovedEndpoint(mockServer: Mockttp) {
 }
 
 describe('Dapp viewed Event', function () {
-  const validFakeMetricsId = 'fake-metrics-fd20';
-  it('is not sent when metametrics ID is not valid', async function () {
+  before(function () {
+    // currently we are not emitting dapp viewed events on Firefox
     if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
       this.skip();
     }
+  });
+  const validFakeMetricsId = 'fake-metrics-fd20';
+  it('is not sent when metametrics ID is not valid', async function () {
     async function mockSegment(mockServer: Mockttp) {
       return [await mockedDappViewedEndpointFirstVisit(mockServer)];
     }
@@ -101,9 +104,6 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when navigating to dapp with no account connected', async function () {
-    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
-      this.skip();
-    }
     async function mockSegment(mockServer: Mockttp) {
       return [await mockedDappViewedEndpointFirstVisit(mockServer)];
     }
@@ -139,9 +139,6 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when opening the dapp in a new tab with one account connected', async function () {
-    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
-      this.skip();
-    }
     async function mockSegment(mockServer: Mockttp) {
       return [
         await mockedDappViewedEndpointFirstVisit(mockServer),
@@ -184,9 +181,6 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when refreshing dapp with one account connected', async function () {
-    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
-      this.skip();
-    }
     async function mockSegment(mockServer: Mockttp) {
       return [
         await mockedDappViewedEndpointFirstVisit(mockServer),
@@ -230,9 +224,6 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when navigating to a connected dapp', async function () {
-    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
-      this.skip();
-    }
     async function mockSegment(mockServer: Mockttp) {
       return [
         await mockedDappViewedEndpointFirstVisit(mockServer),
@@ -278,9 +269,6 @@ describe('Dapp viewed Event', function () {
   });
 
   it('is sent when reconnect to a dapp that has been connected before', async function () {
-    if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
-      this.skip();
-    }
     async function mockSegment(mockServer: Mockttp) {
       return [
         await mockedDappViewedEndpointFirstVisit(mockServer),


### PR DESCRIPTION

## **Description**

In a recent  PR we [made the `Dapp Viewed` event anonymous](https://github.com/MetaMask/metamask-extension/pull/32207). More recently we've learned that this was not sufficient to unblock release on Firefox: see [here](https://consensys.slack.com/archives/CTQAGKY5V/p1746542727192369?thread_ts=1745413333.736539&cid=CTQAGKY5V).

So here we're completely excluding emission of the `Dapp Viewed` event in Firefox builds
