### PR TITLE
chore: cp-12.18.0 modify multichain api `chain_id` event property logic

### DIFF
--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1138,16 +1138,16 @@ export default class MetaMetricsController extends BaseController<
     let chainId;
     if (
       properties &&
-      'chain_id' in properties &&
-      typeof properties.chain_id === 'string'
-    ) {
-      chainId = properties.chain_id;
-    } else if (
-      properties &&
       'chain_id_caip' in properties &&
       typeof properties.chain_id_caip === 'string'
     ) {
       chainId = null;
+    } else if (
+      properties &&
+      'chain_id' in properties &&
+      typeof properties.chain_id === 'string'
+    ) {
+      chainId = properties.chain_id;
     } else {
       chainId = this.chainId;
     }

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1135,6 +1135,23 @@ export default class MetaMetricsController extends BaseController<
     }
     ///: END:ONLY_INCLUDE_IF
 
+    let chainId;
+    if (
+      properties &&
+      'chain_id' in properties &&
+      typeof properties.chain_id === 'string'
+    ) {
+      chainId = properties.chain_id;
+    } else if (
+      properties &&
+      'chain_id_caip' in properties &&
+      typeof properties.chain_id_caip === 'string'
+    ) {
+      chainId = null;
+    } else {
+      chainId = this.chainId;
+    }
+
     return {
       event,
       messageId: buildUniqueMessageId(rawPayload),
@@ -1151,12 +1168,7 @@ export default class MetaMetricsController extends BaseController<
         currency,
         category,
         locale: this.locale,
-        chain_id:
-          properties &&
-          'chain_id' in properties &&
-          typeof properties.chain_id === 'string'
-            ? properties.chain_id
-            : this.chainId,
+        chain_id: chainId,
         environment_type: environmentType,
         ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
         ...mmiProps,

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -323,7 +323,7 @@ export default function createRPCMethodTrackingMiddleware({
     const eventType = EVENT_NAME_MAP[invokedMethod];
 
     const eventProperties = {
-      requested_through: requestedThrough,
+      api_source: requestedThrough,
     };
 
     if (multichainApiRequestScope) {

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -240,7 +240,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureRequested,
         properties: {
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
           signature_type: MESSAGE_TYPE.PERSONAL_SIGN,
           security_alert_response: BlockaidResultType.Malicious,
           security_alert_reason: BlockaidReason.maliciousDomain,
@@ -322,7 +322,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           security_alert_reason: BlockaidReason.maliciousDomain,
           ppom_eth_call_count: 5,
           ppom_eth_getCode_count: 3,
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
           ui_customizations: [
             MetaMetricsEventUiCustomization.RedesignedConfirmation,
           ],
@@ -353,7 +353,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
           signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
         },
         sensitiveProperties: {
           eip712_verifyingContract:
@@ -388,7 +388,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureRejected,
         properties: {
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
           signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
         },
         sensitiveProperties: {
@@ -423,7 +423,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureRejected,
         properties: {
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
           signature_type: MESSAGE_TYPE.PERSONAL_SIGN,
           location: 'some_location',
         },
@@ -449,7 +449,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         event: MetaMetricsEventName.PermissionsApproved,
         properties: {
           method: MESSAGE_TYPE.ETH_REQUEST_ACCOUNTS,
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
         },
         referrer: { url: 'some.dapp' },
       });
@@ -685,7 +685,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
           signature_type: MESSAGE_TYPE.PERSONAL_SIGN,
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
         },
         referrer: { url: 'some.dapp' },
       });
@@ -771,7 +771,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
           signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
           ui_customizations: [
             MetaMetricsEventUiCustomization.RedesignedConfirmation,
@@ -806,7 +806,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
           signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
           eip712_primary_type: 'Unknown',
           ui_customizations: [
@@ -838,7 +838,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           category: MetaMetricsEventCategory.InpageProvider,
           event: MetaMetricsEventName.SignatureRequested,
           properties: {
-            requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+            api_source: MetaMetricsRequestedThrough.EthereumProvider,
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
           },
           sensitiveProperties: {
@@ -973,7 +973,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         {
           batch_transaction_count: 2,
           method: MESSAGE_TYPE.WALLET_SEND_CALLS,
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
         },
       ],
       [
@@ -982,7 +982,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         ['0x123'],
         {
           method: MESSAGE_TYPE.WALLET_GET_CALLS_STATUS,
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
         },
       ],
       [
@@ -991,7 +991,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         ['0x123'],
         {
           method: MESSAGE_TYPE.WALLET_GET_CAPABILITIES,
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
         },
       ],
     ])(
@@ -1059,7 +1059,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           event: MetaMetricsEventName.PermissionsRequested,
           properties: {
             method: MESSAGE_TYPE.WALLET_CREATE_SESSION,
-            requested_through: MetaMetricsRequestedThrough.MultichainApi,
+            api_source: MetaMetricsRequestedThrough.MultichainApi,
             chain_id_list: expect.arrayContaining([
               'eip155:1',
               'eip155:137',
@@ -1076,14 +1076,14 @@ describe('createRPCMethodTrackingMiddleware', () => {
           event: MetaMetricsEventName.PermissionsApproved,
           properties: {
             method: MESSAGE_TYPE.WALLET_CREATE_SESSION,
-            requested_through: MetaMetricsRequestedThrough.MultichainApi,
+            api_source: MetaMetricsRequestedThrough.MultichainApi,
             chain_id_list: expect.arrayContaining(['eip155:1', 'eip155:137']),
           },
           referrer: { url: 'multichain.dapp' },
         });
       });
 
-      it('should track wallet_invokeMethod events with multichain_api category, requested_through, and chain_id_caip properties', async () => {
+      it('should track wallet_invokeMethod events with multichain_api category, api_source, and chain_id_caip properties', async () => {
         const req = {
           id: MOCK_ID,
           method: MESSAGE_TYPE.WALLET_INVOKE_METHOD,
@@ -1109,7 +1109,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           event: MetaMetricsEventName.SignatureRequested,
           properties: {
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
-            requested_through: MetaMetricsRequestedThrough.MultichainApi,
+            api_source: MetaMetricsRequestedThrough.MultichainApi,
             chain_id_caip: 'eip155:10',
           },
           referrer: { url: 'multichain.dapp' },
@@ -1120,14 +1120,14 @@ describe('createRPCMethodTrackingMiddleware', () => {
           event: MetaMetricsEventName.SignatureApproved,
           properties: {
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
-            requested_through: MetaMetricsRequestedThrough.MultichainApi,
+            api_source: MetaMetricsRequestedThrough.MultichainApi,
             chain_id_caip: 'eip155:10',
           },
           referrer: { url: 'multichain.dapp' },
         });
       });
 
-      it('should track wallet_invokeMethod rejections with multichain_api category, requested_through, and chain_id_caip properties', async () => {
+      it('should track wallet_invokeMethod rejections with multichain_api category, api_source, and chain_id_caip properties', async () => {
         const req = {
           id: MOCK_ID,
           method: MESSAGE_TYPE.WALLET_INVOKE_METHOD,
@@ -1158,7 +1158,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           event: MetaMetricsEventName.SignatureRequested,
           properties: {
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
-            requested_through: MetaMetricsRequestedThrough.MultichainApi,
+            api_source: MetaMetricsRequestedThrough.MultichainApi,
             chain_id_caip: 'eip155:137',
           },
           referrer: { url: 'multichain.dapp' },
@@ -1169,7 +1169,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           event: MetaMetricsEventName.SignatureRejected,
           properties: {
             signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
-            requested_through: MetaMetricsRequestedThrough.MultichainApi,
+            api_source: MetaMetricsRequestedThrough.MultichainApi,
             chain_id_caip: 'eip155:137',
           },
           referrer: { url: 'multichain.dapp' },

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -304,7 +304,7 @@ export type SegmentEventPayload = {
     params?: Record<string, string>;
     legacy_event?: boolean;
     locale: string;
-    chain_id: string;
+    chain_id: string | null;
     environment_type?: string;
     revenue?: number;
     value?: number;

--- a/test/e2e/tests/confirmations/signatures/signature-helpers.ts
+++ b/test/e2e/tests/confirmations/signatures/signature-helpers.ts
@@ -69,7 +69,7 @@ type SignatureEventProperty = {
   ui_customizations?: string[];
   location?: string;
   hd_entropy_index?: number;
-  requested_through?: string;
+  api_source?: string;
 };
 
 const signatureAnonProperties = {
@@ -124,7 +124,7 @@ function getSignatureEventProperty(
     security_alert_source: securityAlertSource,
     ui_customizations: uiCustomizations,
     hd_entropy_index: 0,
-    requested_through: requestedThrough,
+    api_source: requestedThrough,
   };
 
   if (primaryType !== '') {

--- a/test/e2e/tests/metrics/permissions-approved.spec.ts
+++ b/test/e2e/tests/metrics/permissions-approved.spec.ts
@@ -73,7 +73,7 @@ describe('Permissions Approved Event', function (this: Suite) {
           locale: 'en',
           chain_id: '0x539',
           environment_type: 'background',
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
         });
         assert.deepStrictEqual(events[1].properties, {
           method: 'eth_requestAccounts',
@@ -81,7 +81,7 @@ describe('Permissions Approved Event', function (this: Suite) {
           locale: 'en',
           chain_id: '0x539',
           environment_type: 'background',
-          requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+          api_source: MetaMetricsRequestedThrough.EthereumProvider,
         });
       },
     );

--- a/test/e2e/tests/metrics/signature-approved.spec.ts
+++ b/test/e2e/tests/metrics/signature-approved.spec.ts
@@ -50,7 +50,7 @@ const expectedEventPropertiesBase = {
   security_alert_reason: 'validation_in_progress',
   security_alert_response: 'loading',
   ui_customizations: ['redesigned_confirmation'],
-  requested_through: MetaMetricsRequestedThrough.EthereumProvider,
+  api_source: MetaMetricsRequestedThrough.EthereumProvider,
 } as const;
 
 describe('Signature Approved Event', function () {


### PR DESCRIPTION
## **Description**

Modifications to analytics event properties based on [request from data team](https://consensys.slack.com/archives/C03Q3TCUVRT/p1746566695754289?thread_ts=1745835152.754219&cid=C03Q3TCUVRT) also in [this doc](https://docs.google.com/document/d/1nCD273bmgDWQrHDe7rOvwkZk10eTJ04Utr4CaFZt0Ak/edit?pli=1&tab=t.0#heading=h.gr5wz74gfqy0)

### Changes
- `requested_through` -> `api_source` (renamed)
- `chain_id` should be `null` when `chain_id_caip` is truthy

Related recent PRs: 
- https://github.com/MetaMask/metamask-extension/pull/32013
- https://github.com/MetaMask/metamask-extension/pull/32380

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32586?quickstart=1)

