### PR TITLE
feat: restore OneKey under QR connection list

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3894,6 +3894,9 @@
   "onboardingPinExtensionTitle": {
     "message": "Your MetaMask install is complete!"
   },
+  "onekey": {
+    "message": "OneKey"
+  },
   "onlyConnectTrust": {
     "message": "Only connect with sites you trust. $1",
     "description": "Text displayed above the buttons for connection confirmation. $1 is the link to the learn more web page."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3894,6 +3894,9 @@
   "onboardingPinExtensionTitle": {
     "message": "Your MetaMask install is complete!"
   },
+  "onekey": {
+    "message": "OneKey"
+  },
   "onlyConnectTrust": {
     "message": "Only connect with sites you trust. $1",
     "description": "Text displayed above the buttons for connection confirmation. $1 is the link to the learn more web page."

--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -777,6 +777,41 @@ export default class SelectHardware extends Component {
         message: (
           <>
             <p className="hw-connect__QR-subtitle">
+              {this.context.t('onekey')}
+            </p>
+            <Button
+              className="hw-connect__external-btn-first"
+              variant={BUTTON_VARIANT.SECONDARY}
+              onClick={() => {
+                this.context.trackEvent({
+                  category: MetaMetricsEventCategory.Navigation,
+                  event: 'Clicked OneKey Learn More',
+                });
+                openWindow(HardwareAffiliateLinks.onekey);
+              }}
+            >
+              {this.context.t('buyNow')}
+            </Button>
+            <Button
+              className="hw-connect__external-btn"
+              variant={BUTTON_VARIANT.SECONDARY}
+              onClick={() => {
+                this.context.trackEvent({
+                  category: MetaMetricsEventCategory.Navigation,
+                  event: 'Clicked OneKey Tutorial',
+                });
+                openWindow(HardwareAffiliateTutorialLinks.onekey);
+              }}
+            >
+              {this.context.t('tutorial')}
+            </Button>
+          </>
+        ),
+      },
+      {
+        message: (
+          <>
+            <p className="hw-connect__QR-subtitle">
               {this.context.t('QRHardwareWalletSteps2Description')}
             </p>
             <Button


### PR DESCRIPTION
## **Description**

While removing Onekey from devices list on select hardware screen, it has also been mistakenly been removed from QR tutorial. This PR now restores it.
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32596?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32594

## **Manual testing steps**

1. Go to this hardware selection screen
2. Select QR based hardware
3. See that OneKey is now listed back

## **Screenshots/Recordings**



### **Before**

<img width="689" alt="Capture d’écran 2025-05-07 à 10 13 03" src="https://github.com/user-attachments/assets/78894097-17a2-44d6-a650-a2481808e351" />

### **After**

<img width="662" alt="Capture d’écran 2025-05-07 à 10 13 32" src="https://github.com/user-attachments/assets/1dde396a-00a6-4367-ad7c-97a7c5292411" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
