### PR TITLE
chore: bump profile-sync-controller to 13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
     "@metamask/post-message-stream": "^9.0.0",
     "@metamask/ppom-validator": "0.36.0",
     "@metamask/preinstalled-example-snap": "^0.3.0",
-    "@metamask/profile-sync-controller": "^12.0.0",
+    "@metamask/profile-sync-controller": "^13.0.0",
     "@metamask/providers": "^22.1.0",
     "@metamask/rate-limit-controller": "^6.0.3",
     "@metamask/remote-feature-flag-controller": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6278,27 +6278,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/profile-sync-controller@npm:^12.0.0":
-  version: 12.0.0
-  resolution: "@metamask/profile-sync-controller@npm:12.0.0"
+"@metamask/profile-sync-controller@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "@metamask/profile-sync-controller@npm:13.0.0"
   dependencies:
-    "@metamask/base-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^8.0.1"
     "@metamask/keyring-api": "npm:^17.4.0"
-    "@metamask/snaps-sdk": "npm:^6.17.1"
-    "@metamask/snaps-utils": "npm:^8.10.0"
+    "@metamask/snaps-sdk": "npm:^6.22.0"
+    "@metamask/snaps-utils": "npm:^9.2.0"
     "@noble/ciphers": "npm:^0.5.2"
     "@noble/hashes": "npm:^1.4.0"
     immer: "npm:^9.0.6"
     loglevel: "npm:^1.8.1"
     siwe: "npm:^2.3.2"
   peerDependencies:
-    "@metamask/accounts-controller": ^27.0.0
+    "@metamask/accounts-controller": ^28.0.0
     "@metamask/keyring-controller": ^21.0.0
     "@metamask/network-controller": ^23.0.0
-    "@metamask/providers": ^18.1.0
-    "@metamask/snaps-controllers": ^9.19.0
+    "@metamask/providers": ^21.0.0
+    "@metamask/snaps-controllers": ^11.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/8c59dddf5d105fcddeb5dd175613ced6fd83d673585a874c25ae7c43d0e8ca243cd53ebd56958998a5d3badb9a958ee4cb61899e04318b87434c059394676c4b
+  checksum: 10/792807369eb9286f8cb2080344f71a0172b73293ae9a41a496111915078a9e8611f5c7cb43becc3cd22ebc02baadb08d7a9d43a4f1167b9b96b9dde4a6fe2d5e
   languageName: node
   linkType: hard
 
@@ -30077,7 +30077,7 @@ __metadata:
     "@metamask/ppom-validator": "npm:0.36.0"
     "@metamask/preferences-controller": "npm:^17.0.0"
     "@metamask/preinstalled-example-snap": "npm:^0.3.0"
-    "@metamask/profile-sync-controller": "npm:^12.0.0"
+    "@metamask/profile-sync-controller": "npm:^13.0.0"
     "@metamask/providers": "npm:^22.1.0"
     "@metamask/rate-limit-controller": "npm:^6.0.3"
     "@metamask/remote-feature-flag-controller": "npm:^1.6.0"


### PR DESCRIPTION
## **Description**

This PR bumps `@metamak/profile-sync-controller` to `^13.0.0`
There are no required changes client side.

`@metamask/accounts-controller` peer dependency is not aligned yet, and was marked as breaking BUT the breaking changes are the same as we have ([profile-sync-controller CHANGELOG](https://github.com/MetaMask/core/blob/f0742fae34560969852787b6b9ad772ac2b7c4d8/packages/profile-sync-controller/CHANGELOG.md), [accounts-controller CHANGELOG](https://github.com/MetaMask/core/blob/f0742fae34560969852787b6b9ad772ac2b7c4d8/packages/accounts-controller/CHANGELOG.md)) so they can be bumped independently.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32601?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
