### PR TITLE
fix(snaps): Change Snap UI Skeleton default width

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/skeleton.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/skeleton.ts
@@ -3,7 +3,7 @@ import { BorderRadius } from '../../../../../helpers/constants/design-system';
 import { mapSnapBorderRadiusToExtensionBorderRadius } from '../utils';
 import { UIComponentFactory } from './types';
 
-const DEFAULT_SKELETON_WIDTH = '100%';
+const DEFAULT_SKELETON_WIDTH = 96;
 const DEFAULT_SKELETON_HEIGHT = 22;
 const DEFAULT_SKELETON_BORDER_RADIUS = BorderRadius.MD;
 


### PR DESCRIPTION
## **Description**
Update default width of Snap UI Skeleton. This change has been introduced to mobile previously and is required because some of the parent components does not have full width, which makes Skeleton component invisible when `width` is set to `100%`. In this PR, default width is fixed to `96px`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32604?quickstart=1)

Related mobile PR: https://github.com/MetaMask/metamask-mobile/pull/15185

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Create Snap UI component with Skeleton without width specified and check the result.
2. Create Snap UI component with Skeleton with width specified and check the result.

Some Snap UI JSX that can be used for testing:
```xml
<Container backgroundColor="default">
    <Box>
        <Skeleton />
        <Section>
            <Box alignment="space-between" direction="horizontal">
                <Text fontWeight="medium" color="alternative">
                    Network Fee
                </Text>
                <Box direction="horizontal" alignment="center">
                    <Skeleton />
                    <Text>SOL</Text>
                </Box>
            </Box>
        </Section>
        <Box alignment="space-between" direction="horizontal">
            <Text fontWeight="medium" color="alternative">
                Network Fee
            </Text>
            <Box direction="horizontal" alignment="center">
                <Skeleton />
                <Text>SOL</Text>
            </Box>
        </Box>
    </Box>
</Container>
```

## **Screenshots/Recordings**
### **Before**
![Screenshot 2025-05-07 at 12 48 10](https://github.com/user-attachments/assets/e416b824-97a8-48fe-952b-996e7e0152f1)

### **After**
![Screenshot 2025-05-07 at 12 51 24](https://github.com/user-attachments/assets/a5190c43-6646-4610-a5b6-077e838e9af5)

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
