### PR TITLE
fix: add hd_entropy_index also for snap accounts

### DIFF
--- a/ui/components/multichain/account-list-menu/account-list-menu.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.tsx
@@ -351,6 +351,7 @@ export const AccountListMenu = ({
         snap_name: client.getSnapName(),
         location: 'Main Menu',
         hd_entropy_index: hdEntropyIndex,
+        chain_id_caip: _options.scope,
       },
     });
 
@@ -630,17 +631,6 @@ export const AccountListMenu = ({
                         },
                         ACTION_MODES.ADD_SOLANA,
                       );
-
-                      trackEvent({
-                        category: MetaMetricsEventCategory.Navigation,
-                        event: MetaMetricsEventName.AccountAddSelected,
-                        properties: {
-                          account_type: MetaMetricsEventAccountType.Default,
-                          location: 'Main Menu',
-                          hd_entropy_index: hdEntropyIndex,
-                          chain_id_caip: MultichainNetworks.SOLANA,
-                        },
-                      });
                     }}
                     data-testid="multichain-account-menu-popover-add-solana-account"
                   >

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -577,9 +577,20 @@ export function getHDEntropyIndex(state) {
   const hdKeyrings = keyrings.filter(
     (keyring) => keyring.type === KeyringType.hdKeyTree,
   );
-  const hdEntropyIndex = hdKeyrings.findIndex((keyring) =>
+  let hdEntropyIndex = hdKeyrings.findIndex((keyring) =>
     keyring.accounts.includes(selectedAddress),
   );
+  // if the account is not found in the hd keyring, we should try to get entropySource from the accounts options
+  if (hdEntropyIndex === -1) {
+    const account = getSelectedInternalAccount(state);
+    if (account) {
+      const { entropySource } = account.options;
+      const keyringsMetadata = getMetaMaskKeyringsMetadata(state);
+      hdEntropyIndex = keyringsMetadata.findIndex(
+        (metadata) => metadata.id === entropySource,
+      );
+    }
+  }
   return hdEntropyIndex === -1 ? undefined : hdEntropyIndex;
 }
 

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -2395,6 +2395,237 @@ describe('#getConnectedSitesList', () => {
       expect(selectors.getManageInstitutionalWallets(state)).toBe(true);
     });
   });
+
+  describe('#getHDEntropyIndex', () => {
+    const selectedAddress = '0xSelectedAddress';
+    const otherAddress = '0xOtherAddress';
+    const hdKeyringType = KeyringType.hdKeyTree;
+    const nonHdKeyringType = 'some-other-keyring-type';
+    const entropySourceId1 = 'entropy-id-1';
+    const entropySourceId2 = 'entropy-id-2';
+
+    const baseMockState = {
+      metamask: {
+        internalAccounts: {
+          accounts: {
+            acc1: {
+              address: selectedAddress,
+              metadata: { keyring: { type: 'some-type' } },
+              options: {},
+            },
+            acc2: {
+              address: otherAddress,
+              metadata: { keyring: { type: 'some-type' } },
+              options: {},
+            },
+          },
+          selectedAccount: 'acc1',
+        },
+        keyrings: [],
+        keyringsMetadata: [],
+      },
+    };
+
+    it('should return the index of the HD keyring containing the selected address', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          keyrings: [
+            { type: nonHdKeyringType, accounts: [otherAddress] },
+            { type: hdKeyringType, accounts: [otherAddress, selectedAddress] }, // Index 1 (0 for hdKeyrings filter)
+            { type: hdKeyringType, accounts: [otherAddress] }, // Index 2 (1 for hdKeyrings filter)
+          ],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBe(0);
+    });
+
+    it('should return the index from keyringsMetadata if account not in HD keyring but entropySource matches', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          internalAccounts: {
+            ...baseMockState.metamask.internalAccounts,
+            accounts: {
+              ...baseMockState.metamask.internalAccounts.accounts,
+              acc1: {
+                ...baseMockState.metamask.internalAccounts.accounts.acc1,
+                options: { entropySource: entropySourceId2 },
+              },
+            },
+          },
+          keyrings: [
+            { type: hdKeyringType, accounts: [otherAddress] }, // No selectedAddress here
+            { type: nonHdKeyringType, accounts: [selectedAddress] },
+          ],
+          keyringsMetadata: [
+            { id: 'some-other-id' },
+            { id: entropySourceId1 },
+            { id: entropySourceId2 }, // Index 2
+          ],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBe(2);
+    });
+
+    it('should return undefined if account not in HD keyring and entropySource does not match any metadata id', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          internalAccounts: {
+            ...baseMockState.metamask.internalAccounts,
+            accounts: {
+              ...baseMockState.metamask.internalAccounts.accounts,
+              acc1: {
+                ...baseMockState.metamask.internalAccounts.accounts.acc1,
+                options: { entropySource: 'non-matching-entropy-id' },
+              },
+            },
+          },
+          keyrings: [{ type: hdKeyringType, accounts: [otherAddress] }],
+          keyringsMetadata: [
+            { id: entropySourceId1 },
+            { id: entropySourceId2 },
+          ],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBeUndefined();
+    });
+
+    it('should return undefined if account not in HD keyring and no entropySource in account options', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          // selected account acc1 has no options.entropySource by default in baseMockState
+          keyrings: [{ type: hdKeyringType, accounts: [otherAddress] }],
+          keyringsMetadata: [{ id: entropySourceId1 }],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBeUndefined();
+    });
+
+    it('should return undefined if account not in HD keyring and no selected internal account found', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          internalAccounts: {
+            ...baseMockState.metamask.internalAccounts,
+            selectedAccount: 'non-existent-acc-id',
+          },
+          keyrings: [{ type: hdKeyringType, accounts: [otherAddress] }],
+          keyringsMetadata: [{ id: entropySourceId1 }],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBeUndefined();
+    });
+
+    it('should return undefined if no HD keyrings and no matching entropySource', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          internalAccounts: {
+            ...baseMockState.metamask.internalAccounts,
+            accounts: {
+              ...baseMockState.metamask.internalAccounts.accounts,
+              acc1: {
+                ...baseMockState.metamask.internalAccounts.accounts.acc1,
+                options: { entropySource: 'non-matching-entropy-id' },
+              },
+            },
+          },
+          keyrings: [
+            { type: nonHdKeyringType, accounts: [selectedAddress] },
+            { type: nonHdKeyringType, accounts: [otherAddress] },
+          ],
+          keyringsMetadata: [{ id: entropySourceId1 }],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBeUndefined();
+    });
+
+    it('should return correct index from metadata if no HD keyrings but matching entropySource', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          internalAccounts: {
+            ...baseMockState.metamask.internalAccounts,
+            accounts: {
+              ...baseMockState.metamask.internalAccounts.accounts,
+              acc1: {
+                ...baseMockState.metamask.internalAccounts.accounts.acc1,
+                options: { entropySource: entropySourceId1 },
+              },
+            },
+          },
+          keyrings: [{ type: nonHdKeyringType, accounts: [selectedAddress] }],
+          keyringsMetadata: [
+            { id: 'another-id' },
+            { id: entropySourceId1 }, // Index 1
+          ],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBe(1);
+    });
+
+    it('should return undefined if keyringsMetadata is empty and account not in HD keyring', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          internalAccounts: {
+            ...baseMockState.metamask.internalAccounts,
+            accounts: {
+              ...baseMockState.metamask.internalAccounts.accounts,
+              acc1: {
+                ...baseMockState.metamask.internalAccounts.accounts.acc1,
+                options: { entropySource: entropySourceId1 },
+              },
+            },
+          },
+          keyrings: [{ type: hdKeyringType, accounts: [otherAddress] }], // Not selectedAddress
+          keyringsMetadata: [],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBeUndefined();
+    });
+
+    it('should correctly identify the first HD keyring if multiple HD keyrings exist and selected address is in the first one', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          keyrings: [
+            { type: hdKeyringType, accounts: [selectedAddress, otherAddress] }, // Index 0 (0 for hdKeyrings filter)
+            { type: hdKeyringType, accounts: [otherAddress] }, // Index 1 (1 for hdKeyrings filter)
+            { type: nonHdKeyringType, accounts: [otherAddress] },
+          ],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBe(0);
+    });
+
+    it('should correctly identify a later HD keyring if selected address is not in earlier ones', () => {
+      const state = {
+        ...baseMockState,
+        metamask: {
+          ...baseMockState.metamask,
+          keyrings: [
+            { type: hdKeyringType, accounts: [otherAddress] }, // Index 0 (0 for hdKeyrings filter)
+            { type: nonHdKeyringType, accounts: [otherAddress] },
+            { type: hdKeyringType, accounts: [selectedAddress, otherAddress] }, // Index 2 (1 for hdKeyrings filter)
+          ],
+        },
+      };
+      expect(selectors.getHDEntropyIndex(state)).toBe(1); // 1st HD keyring (index 1 of filtered hdKeyrings)
+    });
+  });
 });
 
 describe('getNativeTokenInfo', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR fixes two bugs with multi-srp segment events for adding Solana account.

## **Related issues**

Fixes:
- Account Added is firing twice when adding a Solana account
- When clicking addAccount for Solana, it is not adding the hd_entropy_index property

## **Manual testing steps**

1. Open MM and Segment Debugger
2. Click Add Solana Account
3. Notice on Segment debugger that hd_entropy_index is added as a property and is fired only once

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
