### PR TITLE
fix: Fixing z-index of splash screen

### DIFF
--- a/ui/pages/confirmations/components/confirm/splash/smart-account-update/smart-account-update.scss
+++ b/ui/pages/confirmations/components/confirm/splash/smart-account-update/smart-account-update.scss
@@ -6,7 +6,7 @@
     position: fixed;
     height: 100%;
     width: 100%;
-    z-index: 10;
+    z-index: design-system.$modal-z-index;
 
     @media screen and (min-width: design-system.$break-small) {
       max-width: 360px;


### PR DESCRIPTION
## **Description**

Fix z-index of splash screen.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32618

## **Manual testing steps**

1. In test-dapp, submit 5792 request
2. Ensure that gas token banner is not above splash page

## **Screenshots/Recordings**
<img width="403" alt="Screenshot 2025-05-07 at 8 38 19 PM" src="https://github.com/user-attachments/assets/eb7835d4-8e00-4d12-911d-d991354b38c2" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
