### PR TITLE
ci: fix changed-files error

### DIFF
--- a/.github/scripts/git-diff-default-branch.ts
+++ b/.github/scripts/git-diff-default-branch.ts
@@ -72,6 +72,13 @@ function writePrBodyAndInfoToFile(prInfo: PRInfo) {
   core.info(`PR body and info saved to ${prBodyPath}`);
 }
 
+function writeEmptyGitDiff() {
+  core.info('Not a PR, skipping git diff');
+  const outputPath = path.resolve(CHANGED_FILES_DIR, 'changed-files.json');
+  fs.writeFileSync(outputPath, '[]');
+  core.info(`Empty git diff results saved to ${outputPath}`);
+}
+
 /**
  * Main run function, stores the output of git diff and the body of the matching PR to a file.
  *
@@ -84,7 +91,7 @@ async function storeGitDiffOutputAndPrBody() {
 
     core.info(`Determining whether to run git diff...`);
     if (!PR_NUMBER) {
-      core.info('Not a PR, skipping git diff');
+      writeEmptyGitDiff();
       return;
     }
 
@@ -92,7 +99,7 @@ async function storeGitDiffOutputAndPrBody() {
 
     const baseRef = prInfo?.base.ref;
     if (!baseRef) {
-      core.info('Not a PR, skipping git diff');
+      writeEmptyGitDiff();
       return;
     }
     // We perform git diff even if the PR base is not main or skip-e2e-quality-gate label is applied


### PR DESCRIPTION
## **Description**

If something is on the Merge Queue, or it's a release branch, or it fits one of `main, master, Version-v*, trigger-ci*`, it will be considered "not a PR."

In these cases, you will see almost a hundred of these errors in the GitHub Actions log.

![image](https://github.com/user-attachments/assets/b409935e-3fd4-45fb-b3fa-8f814d9c091a)

It's not actually a real error though, it's expected behavior.  So I've changed the flow to make an artifact of an empty `changed-files.json` list.

A separate problem is actually do we **WANT** a non-empty `changed-files.json` in some of these cases, but I'm not going to tackle that one right now.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32633?quickstart=1)

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->