### PR TITLE
fix: make phishing warning events anonymous cp-12.17.3

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -342,19 +342,24 @@ function maybeDetectPhishing(theController) {
         blockedUrl = details.initiator;
       }
 
-      theController.metaMetricsController.trackEvent({
-        // should we differentiate between background redirection and content script redirection?
-        event: MetaMetricsEventName.PhishingPageDisplayed,
-        category: MetaMetricsEventCategory.Phishing,
-        properties: {
-          url: blockedUrl,
-          referrer: {
+      theController.metaMetricsController.trackEvent(
+        {
+          // should we differentiate between background redirection and content script redirection?
+          event: MetaMetricsEventName.PhishingPageDisplayed,
+          category: MetaMetricsEventCategory.Phishing,
+          properties: {
             url: blockedUrl,
+            referrer: {
+              url: blockedUrl,
+            },
+            reason: blockReason,
+            requestDomain: blockedRequestResponse.result ? hostname : undefined,
           },
-          reason: blockReason,
-          requestDomain: blockedRequestResponse.result ? hostname : undefined,
         },
-      });
+        {
+          excludeMetaMetricsId: true,
+        },
+      );
       const querystring = new URLSearchParams({ hostname, href });
       const redirectUrl = new URL(phishingPageHref);
       redirectUrl.hash = querystring.toString();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -342,24 +342,28 @@ function maybeDetectPhishing(theController) {
         blockedUrl = details.initiator;
       }
 
-      theController.metaMetricsController.trackEvent(
-        {
-          // should we differentiate between background redirection and content script redirection?
-          event: MetaMetricsEventName.PhishingPageDisplayed,
-          category: MetaMetricsEventCategory.Phishing,
-          properties: {
-            url: blockedUrl,
-            referrer: {
+      if (!isFirefox) {
+        theController.metaMetricsController.trackEvent(
+          {
+            // should we differentiate between background redirection and content script redirection?
+            event: MetaMetricsEventName.PhishingPageDisplayed,
+            category: MetaMetricsEventCategory.Phishing,
+            properties: {
               url: blockedUrl,
+              referrer: {
+                url: blockedUrl,
+              },
+              reason: blockReason,
+              requestDomain: blockedRequestResponse.result
+                ? hostname
+                : undefined,
             },
-            reason: blockReason,
-            requestDomain: blockedRequestResponse.result ? hostname : undefined,
           },
-        },
-        {
-          excludeMetaMetricsId: true,
-        },
-      );
+          {
+            excludeMetaMetricsId: true,
+          },
+        );
+      }
       const querystring = new URLSearchParams({ hostname, href });
       const redirectUrl = new URL(phishingPageHref);
       redirectUrl.hash = querystring.toString();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -216,6 +216,7 @@ import {
   POLLING_TOKEN_ENVIRONMENT_TYPES,
   MESSAGE_TYPE,
   SMART_TRANSACTION_CONFIRMATION_TYPES,
+  PLATFORM_FIREFOX,
 } from '../../shared/constants/app';
 import {
   MetaMetricsEventCategory,
@@ -313,6 +314,7 @@ import {
   getMethodDataName,
   previousValueComparator,
   initializeRpcProviderDomains,
+  getPlatform,
 } from './lib/util';
 import createMetamaskMiddleware from './lib/createMetamaskMiddleware';
 import { hardwareKeyringBuilderFactory } from './lib/hardware-keyring-builder-factory';
@@ -7981,16 +7983,24 @@ export default class MetamaskController extends EventEmitter {
    * @param {string} origin - the domain to safelist
    */
   safelistPhishingDomain(origin) {
-    this.metaMetricsController.trackEvent({
-      category: MetaMetricsEventCategory.Phishing,
-      event: MetaMetricsEventName.ProceedAnywayClicked,
-      properties: {
-        url: origin,
-        referrer: {
-          url: origin,
+    const isFirefox = getPlatform() === PLATFORM_FIREFOX;
+    if (!isFirefox) {
+      this.metaMetricsController.trackEvent(
+        {
+          category: MetaMetricsEventCategory.Phishing,
+          event: MetaMetricsEventName.ProceedAnywayClicked,
+          properties: {
+            url: origin,
+            referrer: {
+              url: origin,
+            },
+          },
         },
-      },
-    });
+        {
+          excludeMetaMetricsId: true,
+        },
+      );
+    }
 
     return this.phishingController.bypass(origin);
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
- Excludes the MetaMetrics ID when the `PhishingPageDisplayed` event is emitted and also won't emit `PhishingPageDisplayed` when on Firefox.
- Excludes the MetaMetrics ID when the `ProceedAnywayClicked` event is emitted and also won't emit `ProceedAnywayClicked` when on Firefox.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32635?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4842

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
