### PR TITLE
fix: cp-12.18.0 Clear unencrypted Snap state properly

### DIFF
--- a/.yarn/patches/@metamask-snaps-controllers-npm-11.2.3-06777e0090.patch
+++ b/.yarn/patches/@metamask-snaps-controllers-npm-11.2.3-06777e0090.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/snaps/SnapController.cjs b/dist/snaps/SnapController.cjs
+index 1699ba7939a87cfd2776490be8e8a26b1413279d..d5ed95d9d786b3807575a7c75c308417cfe4c52a 100644
+--- a/dist/snaps/SnapController.cjs
++++ b/dist/snaps/SnapController.cjs
+@@ -523,6 +523,7 @@ class SnapController extends base_controller_1.BaseController {
+         this.update((state) => {
+             state.snaps = {};
+             state.snapStates = {};
++            state.unencryptedSnapStates = {};
+         });
+         __classPrivateFieldGet(this, _SnapController_snapsRuntimeData, "f").clear();
+         // We want to remove all snaps & permissions, except for preinstalled snaps
+diff --git a/dist/snaps/SnapController.mjs b/dist/snaps/SnapController.mjs
+index b52ee05c9c4d83bc7b27e76e6229efc032b0146c..d1dfc88a95ebce026d292223bae866b361b5630c 100644
+--- a/dist/snaps/SnapController.mjs
++++ b/dist/snaps/SnapController.mjs
+@@ -520,6 +520,7 @@ export class SnapController extends BaseController {
+         this.update((state) => {
+             state.snaps = {};
+             state.snapStates = {};
++            state.unencryptedSnapStates = {};
+         });
+         __classPrivateFieldGet(this, _SnapController_snapsRuntimeData, "f").clear();
+         // We want to remove all snaps & permissions, except for preinstalled snaps

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4834,7 +4834,7 @@ export default class MetamaskController extends EventEmitter {
       this.permissionController.clearState();
 
       // Clear snap state
-      this.snapController.clearState();
+      await this.snapController.clearState();
 
       // Currently, the account-order-controller is not in sync with
       // the accounts-controller. To properly persist the hidden state

--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "@metamask/selected-network-controller": "^19.0.0",
     "@metamask/signature-controller": "^27.1.0",
     "@metamask/smart-transactions-controller": "^16.3.1",
-    "@metamask/snaps-controllers": "^11.2.3",
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A11.2.3#~/.yarn/patches/@metamask-snaps-controllers-npm-11.2.3-06777e0090.patch",
     "@metamask/snaps-execution-environments": "^7.2.2",
     "@metamask/snaps-rpc-methods": "^12.1.0",
     "@metamask/snaps-sdk": "^6.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6445,7 +6445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^11.2.3":
+"@metamask/snaps-controllers@npm:11.2.3":
   version: 11.2.3
   resolution: "@metamask/snaps-controllers@npm:11.2.3"
   dependencies:
@@ -6483,6 +6483,47 @@ __metadata:
     "@metamask/snaps-execution-environments":
       optional: true
   checksum: 10/f201e2ebac4e478d702ae92b10237a5a774e6830136ce23b8f109668bd6d5d9dc5042ca0c3b3c1123ea08041089c0f4a1f7a0363700a1c50956e5914aceca12f
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A11.2.3#~/.yarn/patches/@metamask-snaps-controllers-npm-11.2.3-06777e0090.patch":
+  version: 11.2.3
+  resolution: "@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A11.2.3#~/.yarn/patches/@metamask-snaps-controllers-npm-11.2.3-06777e0090.patch::version=11.2.3&hash=dc81de"
+  dependencies:
+    "@metamask/approval-controller": "npm:^7.1.3"
+    "@metamask/base-controller": "npm:^8.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.0.2"
+    "@metamask/json-rpc-middleware-stream": "npm:^8.0.7"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/object-multiplex": "npm:^2.1.0"
+    "@metamask/permission-controller": "npm:^11.0.6"
+    "@metamask/phishing-controller": "npm:^12.5.0"
+    "@metamask/post-message-stream": "npm:^9.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-registry": "npm:^3.2.3"
+    "@metamask/snaps-rpc-methods": "npm:^12.1.0"
+    "@metamask/snaps-sdk": "npm:^6.22.1"
+    "@metamask/snaps-utils": "npm:^9.2.1"
+    "@metamask/utils": "npm:^11.4.0"
+    "@xstate/fsm": "npm:^2.0.0"
+    async-mutex: "npm:^0.5.0"
+    browserify-zlib: "npm:^0.2.0"
+    concat-stream: "npm:^2.0.0"
+    fast-deep-equal: "npm:^3.1.3"
+    get-npm-tarball-url: "npm:^2.0.3"
+    immer: "npm:^9.0.6"
+    luxon: "npm:^3.5.0"
+    nanoid: "npm:^3.3.10"
+    readable-stream: "npm:^3.6.2"
+    readable-web-to-node-stream: "npm:^3.0.2"
+    semver: "npm:^7.5.4"
+    tar-stream: "npm:^3.1.7"
+  peerDependencies:
+    "@metamask/snaps-execution-environments": ^7.2.2
+  peerDependenciesMeta:
+    "@metamask/snaps-execution-environments":
+      optional: true
+  checksum: 10/68dfde20bbc148a3e691dd85b68c307604d48fe1760f55e6ec90c895b1c03e9d5e6fdef7bf864e8b9d2cea60eee364ed8ec8e3d95160da00cdfa242dd633d9e3
   languageName: node
   linkType: hard
 
@@ -30088,7 +30129,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^19.0.0"
     "@metamask/signature-controller": "npm:^27.1.0"
     "@metamask/smart-transactions-controller": "npm:^16.3.1"
-    "@metamask/snaps-controllers": "npm:^11.2.3"
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A11.2.3#~/.yarn/patches/@metamask-snaps-controllers-npm-11.2.3-06777e0090.patch"
     "@metamask/snaps-execution-environments": "npm:^7.2.2"
     "@metamask/snaps-rpc-methods": "npm:^12.1.0"
     "@metamask/snaps-sdk": "npm:^6.22.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a patch to properly clear unencrypted Snap state when `clearState` is called. This change has [already landed upstream](https://github.com/MetaMask/snaps/pull/3382), but bringing it in as a patch to hotfix main and the RC.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32642?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32612
