### PR TITLE
fix: Ensure only EVM networks are selected by default for `eth_requestAccounts` and `wallet_requestPermission` requests cp-12.18.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6827,6 +6827,11 @@ export default class MetamaskController extends EventEmitter {
           this.permissionController.requestPermissions(
             { origin },
             requestedPermissions,
+            {
+              metadata: {
+                isEip1193Request: true,
+              },
+            },
           ),
         revokePermissionsForOrigin: (permissionKeys) => {
           try {

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -84,6 +84,7 @@ export type ConnectPageRequest = {
   origin: string;
   permissions?: PermissionsRequest;
   metadata?: {
+    isEip1193Request?: boolean;
     promptToCreateSolanaAccount?: boolean;
   };
 };
@@ -124,8 +125,8 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
     requestedCaip25CaveatValue,
   );
 
-  const promptToCreateSolanaAccount =
-    request.metadata?.promptToCreateSolanaAccount;
+  const { promptToCreateSolanaAccount, isEip1193Request } =
+    request.metadata ?? {};
 
   const networkConfigurationsByCaipChainId = useSelector(
     getAllNetworkConfigurationsByCaipChainId,
@@ -177,11 +178,21 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
       network.caipChainId === currentlySelectedNetworkChainId,
   );
 
-  const defaultSelectedNetworkList = selectedTestNetwork
+  let defaultSelectedNetworkList = selectedTestNetwork
     ? [...nonTestNetworkConfigurations, selectedTestNetwork].map(
         ({ caipChainId }) => caipChainId,
       )
     : nonTestNetworkConfigurations.map(({ caipChainId }) => caipChainId);
+
+  // Only EVM networks should be selected if this request comes from the EIP-1193 API
+  if (isEip1193Request) {
+    defaultSelectedNetworkList = defaultSelectedNetworkList.filter(
+      (caipChainId) => {
+        const { namespace } = parseCaipChainId(caipChainId);
+        return namespace === KnownCaipNamespace.Eip155;
+      },
+    );
+  }
 
   const defaultSelectedChainIds =
     supportedRequestedCaipChainIds.length > 0


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

See title. Previously for `eth_requestAccounts` and `wallet_requestPermission` requests, all non EVM test networks were selected by default, incl all Solana networks. This was causing an issue with Portfolio due to how our wallet-standard implementation expects solana accounts to be authorized if any solana scope is authorized.

This PR makes it so that only EVM networks are selected by default for `eth_requestAccounts` and `wallet_requestPermission` requests.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32649?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ensure you have a solana account already (this enables solana networks)
1. Go to any webpage
2. `await window.ethereum.request({"method": "eth_requestAccounts"})`
3. See that the default selected networks do not incl Solana networks

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
