### PR TITLE
fix: Solana aggregated fiat balance in AccountPicker

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -1,9 +1,7 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-///: BEGIN:ONLY_INCLUDE_IF(build-main)
 import { BigNumber } from 'bignumber.js';
-///: END:ONLY_INCLUDE_IF
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getSnapName, shortenAddress } from '../../../helpers/utils/util';
@@ -249,7 +247,9 @@ const AccountListItem = ({
   const getPreferredCurrencyValue = () => {
     let value;
     ///: BEGIN:ONLY_INCLUDE_IF(multichain)
-    value = account.balance;
+    value = isEvmNetwork
+      ? new BigNumber(account.balance).toNumber()
+      : account.balance;
     ///: END:ONLY_INCLUDE_IF
     ///: BEGIN:ONLY_INCLUDE_IF(build-main)
     value = isEvmNetwork ? account.balance : balanceToTranslate;

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -190,10 +190,9 @@ const AccountListItem = ({
     balanceToTranslate = multichainAggregatedBalance;
     ///: END:ONLY_INCLUDE_IF
     ///: BEGIN:ONLY_INCLUDE_IF(build-main)
-    const balanceOrFallback = accountTotalFiatBalances?.totalBalance ?? 0;
-    const bnBalance = new BigNumber(balanceOrFallback);
+    const balanceOrFallback = multichainAggregatedBalance ?? 0;
     const formattedBalanceToTranslate = formatWithThreshold(
-      bnBalance.toNumber(),
+      balanceOrFallback,
       0.00001,
       locale,
       {


### PR DESCRIPTION
## **Description**

Aggregated balance for Solana were broken on `main` builds. This fixes the issue for Solana aggregated balance.

Note that there is also an issue where for some accounts, EVM token balances are also broken. We decided to keep these fixes separate, but imo they are both important enough to warrant release blockers.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32651?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32628

## **Manual testing steps**

1. Run this branch as a main build `yarn start` or `yarn webpack --watch`
2. Add a Solana SRP with account with Solana tokens
3. AccountPicker aggregated fiat balance should match what you see on the main wallet screen

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="350" alt="Screenshot 2025-05-07 at 10 24 44 AM" src="https://github.com/user-attachments/assets/3f6a897d-6a0f-4f96-ae02-faa5814ab84d" />
<img width="350" alt="Screenshot 2025-05-07 at 10 24 21 AM" src="https://github.com/user-attachments/assets/f125ee46-b411-4221-ac6b-9248c9ae3a3e" />

### **After**

![Screenshot 2025-05-07 at 4 06 07 PM](https://github.com/user-attachments/assets/a588c6d0-8832-47af-906e-779f9066c663)
![Screenshot 2025-05-07 at 4 06 30 PM](https://github.com/user-attachments/assets/a2be9285-0014-4797-a343-ef5a5f00dfa7)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
