### PR TITLE
fix: use confirmation chain ID to get native currency from network config

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -8,6 +8,7 @@ import { createMockInternalAccount } from '../../../../../../test/jest/mocks';
 import { getMockConfirmState } from '../../../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import mockState from '../../../../../../test/data/mock-state.json';
 import { useInsufficientBalanceAlerts } from './useInsufficientBalanceAlerts';
 
 const TRANSACTION_ID_MOCK = '123-456';
@@ -84,12 +85,15 @@ function buildState({
             : {},
       },
       transactions: transaction ? [transaction] : [],
+      networkConfigurationsByChainId:
+        mockState.metamask.networkConfigurationsByChainId,
     },
   });
 }
 
 function runHook(stateOptions?: Parameters<typeof buildState>[0]) {
   const state = buildState(stateOptions);
+
   const response = renderHookWithConfirmContextProvider(
     useInsufficientBalanceAlerts,
     state,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -5,11 +5,11 @@ import { useSelector } from 'react-redux';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import {
+  selectNetworkConfigurationByChainId,
   selectTransactionAvailableBalance,
   selectTransactionFeeById,
   selectTransactionValue,
 } from '../../../../../selectors';
-import { getMultichainNativeCurrency } from '../../../../../selectors/multichain';
 import { isBalanceSufficient } from '../../../send/send.utils';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -48,7 +48,9 @@ export function useInsufficientBalanceAlerts(): Alert[] {
     selectTransactionFeeById(state, transactionId),
   );
 
-  const nativeCurrency = useSelector(getMultichainNativeCurrency);
+  const networkConfiguration = useSelector((state) =>
+    selectNetworkConfigurationByChainId(state, chainId),
+  );
 
   const insufficientBalance = !isBalanceSufficient({
     amount: totalValue,
@@ -62,7 +64,7 @@ export function useInsufficientBalanceAlerts(): Alert[] {
     if (!showAlert) {
       return [];
     }
-
+    const { nativeCurrency } = networkConfiguration;
     return [
       {
         actions: [
@@ -81,5 +83,5 @@ export function useInsufficientBalanceAlerts(): Alert[] {
         severity: Severity.Danger,
       },
     ];
-  }, [nativeCurrency, showAlert, t]);
+  }, [networkConfiguration, showAlert, t]);
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR aims to remove the global select and use network configuration by confirmation chainId to get the native currency.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32665?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32650

## **Manual testing steps**

1. Have the global network selector set to BNB
2. Go to Accounts details for a non-upgraded account
3. Click on Switch to Smart Account on Ethereum
4. Notice the weird gas info

## **Screenshots/Recordings**

- Wrong ticker being shown in the insufficient funds modal

[1-alert-insufficient.webm](https://github.com/user-attachments/assets/e6c59cbe-56d4-47a5-a827-904c02058e24)

- Gas station feature displays USDC image as a jazzicon instead of the token image
- Wrong fiat conversion for USDC

[1-fiat_convertion.webm](https://github.com/user-attachments/assets/3b224a58-e9b8-406c-acc3-9c0dc7897639)

![Screenshot from 2025-05-08 09-36-04](https://github.com/user-attachments/assets/9b63bb0d-0556-4aeb-81a2-f1f336642746)

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
