### PR TITLE
fix: cp-12.18.0 Fix test of alert displayed of selected currency is different from currency of confirmation

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -200,7 +200,7 @@ describe('useInsufficientBalanceAlerts', () => {
       balance: 7,
       currentConfirmation: TRANSACTION_MOCK,
       transaction: TRANSACTION_MOCK,
-      selectedNetworkClientId: 'testNetworkConfigurationId'
+      selectedNetworkClientId: 'testNetworkConfigurationId',
     });
 
     expect(alerts).toEqual(ALERT);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -48,10 +48,12 @@ function buildState({
   balance,
   currentConfirmation,
   transaction,
+  selectedNetworkClientId,
 }: {
   balance?: number;
   currentConfirmation?: Partial<TransactionMeta>;
   transaction?: Partial<TransactionMeta>;
+  selectedNetworkClientId?: string;
 } = {}) {
   const accountAddress = transaction?.txParams?.from as string;
   const mockAccount = createMockInternalAccount({
@@ -71,6 +73,7 @@ function buildState({
 
   return getMockConfirmState({
     metamask: {
+      selectedNetworkClientId: selectedNetworkClientId ?? 'goerli',
       pendingApprovals,
       internalAccounts: {
         accounts:
@@ -187,6 +190,17 @@ describe('useInsufficientBalanceAlerts', () => {
       balance: 7,
       currentConfirmation: TRANSACTION_MOCK,
       transaction: TRANSACTION_MOCK,
+    });
+
+    expect(alerts).toEqual(ALERT);
+  });
+
+  it('returns correct alert test if selected chain is different from chain in confirmation', () => {
+    const alerts = runHook({
+      balance: 7,
+      currentConfirmation: TRANSACTION_MOCK,
+      transaction: TRANSACTION_MOCK,
+      selectedNetworkClientId: 'testNetworkConfigurationId'
     });
 
     expect(alerts).toEqual(ALERT);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -1,24 +1,25 @@
-import { Hex } from '@metamask/utils';
+import { CaipChainId, Hex } from '@metamask/utils';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-
 import { TransactionMeta } from '@metamask/transaction-controller';
+
+import { sumHexes } from '../../../../../../shared/modules/conversion.utils';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import {
+  getMultichainNetworkConfigurationsByChainId,
   selectTransactionAvailableBalance,
   selectTransactionFeeById,
   selectTransactionValue,
 } from '../../../../../selectors';
-import { getMultichainNativeCurrency } from '../../../../../selectors/multichain';
-import { isBalanceSufficient } from '../../../send/send.utils';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import {
   AlertActionKey,
   RowAlertKey,
 } from '../../../../../components/app/confirm/info/row/constants';
+import { isBalanceSufficient } from '../../../send/send.utils';
 import { useConfirmContext } from '../../../context/confirm';
-import { sumHexes } from '../../../../../../shared/modules/conversion.utils';
+import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
 
 export function useInsufficientBalanceAlerts(): Alert[] {
   const t = useI18nContext();
@@ -48,7 +49,12 @@ export function useInsufficientBalanceAlerts(): Alert[] {
     selectTransactionFeeById(state, transactionId),
   );
 
-  const nativeCurrency = useSelector(getMultichainNativeCurrency);
+  const [multichainNetworks, evmNetworks] = useSelector(
+    getMultichainNetworkConfigurationsByChainId,
+  );
+  const nativeCurrency = (
+    multichainNetworks[chainId as CaipChainId] ?? evmNetworks[chainId]
+  )?.nativeCurrency;
 
   const insufficientBalance = !isBalanceSufficient({
     amount: totalValue,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -19,7 +19,6 @@ import {
 } from '../../../../../components/app/confirm/info/row/constants';
 import { isBalanceSufficient } from '../../../send/send.utils';
 import { useConfirmContext } from '../../../context/confirm';
-import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
 
 export function useInsufficientBalanceAlerts(): Alert[] {
   const t = useI18nContext();


### PR DESCRIPTION
## **Description**

Fix test of alert displayed of selected currency is different from currency of confirmation

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32322
Fixes: https://github.com/MetaMask/metamask-extension/issues/32650

## **Manual testing steps**

1. Select solana in extension
2. Go to test dapp and connect with a network where you have less balance
3. Check test of alert and ensure that it is correct

## **Screenshots/Recordings**
<img width="397" alt="Screenshot 2025-05-08 at 5 27 20 PM" src="https://github.com/user-attachments/assets/cb2d720f-79ba-416c-a114-958fcf0788a8" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
