### PR TITLE
fix: cp-12.18.0 solana bug on account list item

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -1,9 +1,6 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-///: BEGIN:ONLY_INCLUDE_IF(build-main)
-import { BigNumber } from 'bignumber.js';
-///: END:ONLY_INCLUDE_IF
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getSnapName, shortenAddress } from '../../../helpers/utils/util';
@@ -58,9 +55,6 @@ import {
   getSnapsMetadata,
   getMetaMaskKeyrings,
 } from '../../../selectors';
-///: BEGIN:ONLY_INCLUDE_IF(build-main)
-import { getIntlLocale } from '../../../ducks/locale/locale';
-///: END:ONLY_INCLUDE_IF
 import {
   getMultichainIsTestnet,
   getMultichainNativeCurrency,
@@ -78,12 +72,9 @@ import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { useGetFormattedTokensPerChain } from '../../../hooks/useGetFormattedTokensPerChain';
 import { useAccountTotalCrossChainFiatBalance } from '../../../hooks/useAccountTotalCrossChainFiatBalance';
 import { getAccountLabels } from '../../../helpers/utils/accounts';
-///: BEGIN:ONLY_INCLUDE_IF(multichain)
+
 import { getMultichainAggregatedBalance } from '../../../selectors/assets';
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(build-main)
-import { formatWithThreshold } from '../../app/assets/util/formatWithThreshold';
-///: END:ONLY_INCLUDE_IF
+
 import { AccountListItemMenuTypes } from './account-list-item.types';
 
 const MAXIMUM_CURRENCY_DECIMALS = 3;
@@ -108,9 +99,7 @@ const AccountListItem = ({
   privacyMode = false,
 }) => {
   const t = useI18nContext();
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main)
-  const locale = useSelector(getIntlLocale);
-  ///: END:ONLY_INCLUDE_IF
+
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
   const [accountOptionsMenuOpen, setAccountOptionsMenuOpen] = useState(false);
   const [accountListItemMenuElement, setAccountListItemMenuElement] =
@@ -149,11 +138,10 @@ const AccountListItem = ({
   const accountTotalFiatBalances =
     useMultichainAccountTotalFiatBalance(account);
 
-  ///: BEGIN:ONLY_INCLUDE_IF(multichain)
   const multichainAggregatedBalance = useSelector((state) =>
     getMultichainAggregatedBalance(state, account),
   );
-  ///: END:ONLY_INCLUDE_IF
+  console.log('multichainAggregatedBalance', multichainAggregatedBalance);
 
   // cross chain agg balance
   const shouldHideZeroBalanceTokens = useSelector(
@@ -188,23 +176,7 @@ const AccountListItem = ({
         ? account.balance
         : totalFiatBalance;
   } else {
-    ///: BEGIN:ONLY_INCLUDE_IF(multichain)
     balanceToTranslate = multichainAggregatedBalance;
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(build-main)
-    const balanceOrFallback = accountTotalFiatBalances?.totalBalance ?? 0;
-    const bnBalance = new BigNumber(balanceOrFallback);
-    const formattedBalanceToTranslate = formatWithThreshold(
-      bnBalance.toNumber(),
-      0.00001,
-      locale,
-      {
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 5,
-      },
-    );
-    balanceToTranslate = formattedBalanceToTranslate;
-    ///: END:ONLY_INCLUDE_IF
   }
 
   // If this is the selected item in the Account menu,
@@ -233,28 +205,15 @@ const AccountListItem = ({
   const isSingleAccount = accountsCount === 1;
 
   const getIsAggregatedFiatOverviewBalanceProp = () => {
-    let isAggregatedFiatOverviewBalance;
-    ///: BEGIN:ONLY_INCLUDE_IF(multichain)
-    isAggregatedFiatOverviewBalance =
+    const isAggregatedFiatOverviewBalance =
       (!isTestnet && process.env.PORTFOLIO_VIEW && shouldShowFiat) ||
       !isEvmNetwork;
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(build-main)
-    isAggregatedFiatOverviewBalance =
-      !isTestnet && process.env.PORTFOLIO_VIEW && shouldShowFiat;
-    ///: END:ONLY_INCLUDE_IF
+
     return isAggregatedFiatOverviewBalance;
   };
 
   const getPreferredCurrencyValue = () => {
-    let value;
-    ///: BEGIN:ONLY_INCLUDE_IF(multichain)
-    value = account.balance;
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(build-main)
-    value = isEvmNetwork ? account.balance : balanceToTranslate;
-    ///: END:ONLY_INCLUDE_IF
-    return value;
+    return account.balance;
   };
 
   return (

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -141,7 +141,6 @@ const AccountListItem = ({
   const multichainAggregatedBalance = useSelector((state) =>
     getMultichainAggregatedBalance(state, account),
   );
-  console.log('multichainAggregatedBalance', multichainAggregatedBalance);
 
   // cross chain agg balance
   const shouldHideZeroBalanceTokens = useSelector(

--- a/ui/components/multichain/account-list-item/account-list-item.test.js
+++ b/ui/components/multichain/account-list-item/account-list-item.test.js
@@ -12,6 +12,7 @@ import {
   CHAIN_IDS,
 } from '../../../../shared/constants/network';
 import { mockNetworkState } from '../../../../test/stub/networks';
+import { MultichainNativeAssets } from '../../../../shared/constants/multichain/assets';
 import { AccountListItem, AccountListItemMenuTypes } from '.';
 
 const mockAccount = {
@@ -22,7 +23,10 @@ const mockAccount = {
 };
 
 const mockNonEvmAccount = {
-  ...mockAccount,
+  ...mockState.metamask.internalAccounts.accounts[
+    'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3'
+  ],
+  balance: '1', // updating this  to 1 because the balance for native non evm networks comes from the multichainBalances controller in decimal format and not hex.
   id: 'b7893c59-e376-4cc0-93ad-05ddaab574a6',
   address: 'bc1qn3stuu6g37rpxk3jfxr4h4zmj68g0lwxx5eker',
   type: 'bip122:p2wpkh',
@@ -325,6 +329,9 @@ describe('AccountListItem', () => {
               preferences: {
                 showFiatInTestnets: false,
               },
+              accountsAssets: {
+                [mockNonEvmAccount.id]: [MultichainNativeAssets.BITCOIN],
+              },
             },
           },
         );
@@ -399,6 +406,9 @@ describe('AccountListItem', () => {
             metamask: {
               preferences: {
                 showFiatInTestnets: true,
+              },
+              accountsAssets: {
+                [mockNonEvmAccount.id]: [MultichainNativeAssets.BITCOIN],
               },
             },
           },

--- a/ui/components/multichain/account-list-item/account-list-item.test.js
+++ b/ui/components/multichain/account-list-item/account-list-item.test.js
@@ -138,7 +138,16 @@ describe('AccountListItem', () => {
   });
 
   it('renders AccountListItem component and shows account name, address, and balance for non-EVM account', () => {
-    const { container } = render({ account: mockNonEvmAccount });
+    const { container } = render(
+      { account: mockNonEvmAccount },
+      {
+        metamask: {
+          accountsAssets: {
+            [mockNonEvmAccount.id]: [MultichainNativeAssets.BITCOIN],
+          },
+        },
+      },
+    );
     expect(screen.getByText(mockAccount.metadata.name)).toBeInTheDocument();
     expect(
       screen.getByText(shortenAddress(mockNonEvmAccount.address)),


### PR DESCRIPTION
## **Description**

The SOL balance does not appear on a flask build but it appears on main build

(flask build)

https://github.com/user-attachments/assets/b3835f34-592b-4aec-b03e-999dee9265a6

(main build)

https://github.com/user-attachments/assets/f0295df1-ae34-4058-bce8-2a464183720a



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32684?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32683
Fixes : https://github.com/MetaMask/metamask-extension/issues/32628

## **Manual testing steps**

1. Click on Solana account
2. Open account picker; and you should see correct fiat value
3. Click on EVM account
4. And you should see correct EVM fiat balance on account picker


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->



### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
