### PR TITLE
fix: account sorting for snap accounts that derive entropySource cp-12.18.0

### DIFF
--- a/ui/components/multichain/account-list-menu/account-list-menu.test.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.test.tsx
@@ -653,6 +653,7 @@ describe('AccountListMenu', () => {
     const mockBtcAccount = createMockInternalAccount({
       name: 'Bitcoin Account',
       type: BtcAccountType.P2wpkh,
+      keyringType: KeyringTypes.snap,
       address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
     });
     const defaultMockState = {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the account sorting order where discovered accounts are not sorted with their srp. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32690?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32653
Resolves: https://consensyssoftware.atlassian.net/browse/MMMULTISRP-207?atlOrigin=eyJpIjoiYTlhZGQ0NjMyNjQxNGRmZGEyNjAyYzI4ZGRjYjQzZDAiLCJwIjoiaiJ9

## **Manual testing steps**

1. Open fresh srp
2. Import a srp where it won't discover accounts 
3. Import a srp where it won't discover accounts 
4. See that the accounts are still sorted

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="375" alt="Screenshot 2025-05-08 at 23 17 19" src="https://github.com/user-attachments/assets/34dea535-28c9-4b98-893c-14bccce4ff8d" />

<!-- [screenshots/recordings] -->

### **After**
<img width="369" alt="Screenshot 2025-05-08 at 23 17 01" src="https://github.com/user-attachments/assets/ac8f6f78-596b-4b6b-985e-26c69914203e" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
