### PR TITLE
fix: (cp-12.18.0) re-initialise dom purify after startup

### DIFF
--- a/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
@@ -30,6 +30,8 @@ import {
   ExternalLinkButton,
 } from './annonucement-footer-buttons';
 
+const purify = DOMPurify(window);
+
 const { TRIGGER_TYPES } = NotificationServicesController.Constants;
 
 const isFeatureAnnouncementNotification = isOfTypeNodeGuard([
@@ -99,7 +101,7 @@ export const components: NotificationComponent<FeatureAnnouncementNotification> 
               as="div"
               // TODO - we can replace the raw HTML string injection with react components
               dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(notification.data.longDescription),
+                __html: purify.sanitize(notification.data.longDescription),
               }}
             />
           </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This was a weird bug. The DomPurify module worked with:
- `yarn webpack --watch`
- `yarn start`

But failed when using `yarn dist`.

Looking into the library, it seemed that on dist builds DomPurify was not setup on initialisation.
So we now re-initialise DomPurify when the `feature-announcement.ts` module/file is loaded.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32714?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32672 https://github.com/MetaMask/metamask-extension/issues/32681

## **Manual testing steps**

Create a production build

1. Onboard
2. Enable Notifications
3. Click on a feature announcement
4. Expected: it should not crash

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See issues linked above

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/a73dc610cd3249c7b8c12b688fb2a6df?sid=c59ff05e-012d-4df5-9fe0-35f3432b618b

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
