### PR TITLE
fix: cp-12.17.3 Adding metrics to check rejection of smart account update by user

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -4,7 +4,6 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { errorCodes } from '@metamask/rpc-errors';
 import { toHex } from '@metamask/controller-utils';
 import {
   createTestProviderTools,
@@ -16,6 +15,7 @@ import {
 } from '../../../../shared/constants/app';
 import {
   AssetType,
+  EIP5792ErrorCode,
   TokenStandard,
   TransactionMetaMetricsEvent,
 } from '../../../../shared/constants/transaction';
@@ -1194,7 +1194,7 @@ describe('Transaction metrics', () => {
             authorizationList: [{}],
           },
           error: {
-            code: errorCodes.rpc.methodNotSupported,
+            code: EIP5792ErrorCode.RejectedUpgrade,
           },
           status: TransactionStatus.rejected,
         } as unknown as TransactionMeta,

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -8,7 +8,6 @@ import {
 } from '@metamask/transaction-controller';
 import { Json, add0x } from '@metamask/utils';
 import { Hex } from 'viem';
-import { errorCodes } from '@metamask/rpc-errors';
 import {
   MESSAGE_TYPE,
   ORIGIN_METAMASK,
@@ -24,6 +23,7 @@ import {
   MetaMetricsEventTransactionEstimateType,
 } from '../../../../shared/constants/metametrics';
 import {
+  EIP5792ErrorCode,
   TokenStandard,
   TransactionApprovalAmountType,
   TransactionMetaMetricsEvent,
@@ -1252,7 +1252,7 @@ async function addBatchProperties(
 
     properties.eip7702_upgrade_rejection =
       // @ts-expect-error Code has string type in controller
-      isUpgrade && error.code === errorCodes.rpc.methodNotSupported;
+      isUpgrade && error.code === EIP5792ErrorCode.RejectedUpgrade;
   }
 
   properties.eip7702_upgrade_transaction = isUpgrade;

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -1,5 +1,4 @@
 import { Hex } from '@metamask/utils';
-import { NetworkConfiguration } from '@metamask/network-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -49,7 +48,7 @@ export function useInsufficientBalanceAlerts(): Alert[] {
     selectTransactionFeeById(state, transactionId),
   );
 
-  const networkConfiguration: Record<Hex, NetworkConfiguration> = useSelector((state) =>
+  const networkConfiguration = useSelector((state) =>
     selectNetworkConfigurationByChainId(state, chainId),
   );
   const nativeCurrency = networkConfiguration?.nativeCurrency;

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -1,12 +1,12 @@
-import { Hex } from '@metamask/utils';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import { CaipChainId, Hex } from '@metamask/utils';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { TransactionMeta } from '@metamask/transaction-controller';
 
 import { sumHexes } from '../../../../../../shared/modules/conversion.utils';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import {
-  selectNetworkConfigurationByChainId,
+  getMultichainNetworkConfigurationsByChainId,
   selectTransactionAvailableBalance,
   selectTransactionFeeById,
   selectTransactionValue,
@@ -48,10 +48,12 @@ export function useInsufficientBalanceAlerts(): Alert[] {
     selectTransactionFeeById(state, transactionId),
   );
 
-  const networkConfiguration = useSelector((state) =>
-    selectNetworkConfigurationByChainId(state, chainId),
+  const [multichainNetworks, evmNetworks] = useSelector(
+    getMultichainNetworkConfigurationsByChainId,
   );
-  const nativeCurrency = networkConfiguration?.nativeCurrency;
+  const nativeCurrency = (
+    multichainNetworks[chainId as CaipChainId] ?? evmNetworks[chainId]
+  )?.nativeCurrency;
 
   const insufficientBalance = !isBalanceSufficient({
     amount: totalValue,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -1,12 +1,13 @@
-import { CaipChainId, Hex } from '@metamask/utils';
+import { Hex } from '@metamask/utils';
+import { NetworkConfiguration } from '@metamask/network-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { TransactionMeta } from '@metamask/transaction-controller';
 
 import { sumHexes } from '../../../../../../shared/modules/conversion.utils';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import {
-  getMultichainNetworkConfigurationsByChainId,
+  selectNetworkConfigurationByChainId,
   selectTransactionAvailableBalance,
   selectTransactionFeeById,
   selectTransactionValue,
@@ -48,12 +49,10 @@ export function useInsufficientBalanceAlerts(): Alert[] {
     selectTransactionFeeById(state, transactionId),
   );
 
-  const [multichainNetworks, evmNetworks] = useSelector(
-    getMultichainNetworkConfigurationsByChainId,
+  const networkConfiguration: Record<Hex, NetworkConfiguration> = useSelector((state) =>
+    selectNetworkConfigurationByChainId(state, chainId),
   );
-  const nativeCurrency = (
-    multichainNetworks[chainId as CaipChainId] ?? evmNetworks[chainId]
-  )?.nativeCurrency;
+  const nativeCurrency = networkConfiguration?.nativeCurrency;
 
   const insufficientBalance = !isBalanceSufficient({
     amount: totalValue,


### PR DESCRIPTION
## **Description**

Adding metrics to check rejection of smart account update by user

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4845

## **Manual testing steps**

1. Go to test dapp and submit request 5792
2. Reject the request on splash page
3. Ensure that metrics event is recorded for the rejection

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
