### PR TITLE
chore: updating deprecated button shape to align with rounded rectangle

### DIFF
--- a/ui/components/app/modal/__snapshots__/modal.component.test.js.snap
+++ b/ui/components/app/modal/__snapshots__/modal.component.test.js.snap
@@ -12,12 +12,12 @@ exports[`Modal Component should render a modal with a cancel and a submit button
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-secondary modal-container__footer-button"
+        class="button btn-secondary modal-container__footer-button"
       >
         Cancel
       </button>
       <button
-        class="button btn--rounded btn-primary modal-container__footer-button"
+        class="button btn-primary modal-container__footer-button"
       >
         Submit
       </button>
@@ -51,12 +51,12 @@ exports[`Modal Component should render a modal with a header 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-secondary modal-container__footer-button"
+        class="button btn-secondary modal-container__footer-button"
       >
         Cancel
       </button>
       <button
-        class="button btn--rounded btn-primary modal-container__footer-button"
+        class="button btn-primary modal-container__footer-button"
       >
         Submit
       </button>
@@ -77,7 +77,7 @@ exports[`Modal Component should render a modal with a submit button 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-primary modal-container__footer-button"
+        class="button btn-primary modal-container__footer-button"
       />
     </div>
   </div>
@@ -100,12 +100,12 @@ exports[`Modal Component should render a modal with children 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-secondary modal-container__footer-button"
+        class="button btn-secondary modal-container__footer-button"
       >
         Cancel
       </button>
       <button
-        class="button btn--rounded btn-primary modal-container__footer-button"
+        class="button btn-primary modal-container__footer-button"
       >
         Submit
       </button>
@@ -126,12 +126,12 @@ exports[`Modal Component should render a modal with different button types 1`] =
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-default modal-container__footer-button"
+        class="button btn-default modal-container__footer-button"
       >
         Cancel
       </button>
       <button
-        class="button btn--rounded btn-default modal-container__footer-button"
+        class="button btn-default modal-container__footer-button"
       >
         Submit
       </button>

--- a/ui/components/app/modals/confirm-delete-network/__snapshots__/confirm-delete-network.test.js.snap
+++ b/ui/components/app/modals/confirm-delete-network/__snapshots__/confirm-delete-network.test.js.snap
@@ -28,12 +28,12 @@ exports[`Confirm Delete Network should match snapshot 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-secondary modal-container__footer-button"
+        class="button btn-secondary modal-container__footer-button"
       >
         Cancel
       </button>
       <button
-        class="button btn--rounded btn-danger-primary modal-container__footer-button"
+        class="button btn-danger-primary modal-container__footer-button"
       >
         Delete
       </button>

--- a/ui/components/app/modals/confirm-remove-account/__snapshots__/confirm-remove-account.test.js.snap
+++ b/ui/components/app/modals/confirm-remove-account/__snapshots__/confirm-remove-account.test.js.snap
@@ -136,12 +136,12 @@ exports[`Confirm Remove Account should match snapshot 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-secondary modal-container__footer-button"
+        class="button btn-secondary modal-container__footer-button"
       >
         Nevermind
       </button>
       <button
-        class="button btn--rounded btn-primary modal-container__footer-button"
+        class="button btn-primary modal-container__footer-button"
       >
         Remove
       </button>

--- a/ui/components/app/modals/confirm-reset-account/__snapshots__/confirm-reset-account.test.js.snap
+++ b/ui/components/app/modals/confirm-reset-account/__snapshots__/confirm-reset-account.test.js.snap
@@ -27,12 +27,12 @@ exports[`Confirm Reset Account should match snapshot 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-secondary modal-container__footer-button"
+        class="button btn-secondary modal-container__footer-button"
       >
         [nevermind]
       </button>
       <button
-        class="button btn--rounded btn-danger-primary modal-container__footer-button"
+        class="button btn-danger-primary modal-container__footer-button"
       >
         [clear]
       </button>

--- a/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
+++ b/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
@@ -98,12 +98,12 @@ exports[`Customize Nonce should match snapshot 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-secondary modal-container__footer-button"
+        class="button btn-secondary modal-container__footer-button"
       >
         Cancel
       </button>
       <button
-        class="button btn--rounded btn-primary modal-container__footer-button"
+        class="button btn-primary modal-container__footer-button"
       >
         Save
       </button>

--- a/ui/components/app/modals/hide-token-confirmation-modal/__snapshots__/hide-token-confirmation-modal.test.js.snap
+++ b/ui/components/app/modals/hide-token-confirmation-modal/__snapshots__/hide-token-confirmation-modal.test.js.snap
@@ -68,13 +68,13 @@ exports[`Hide Token Confirmation Modal should match snapshot 1`] = `
       class="hide-token-confirmation__buttons"
     >
       <button
-        class="button btn--rounded btn-secondary hide-token-confirmation__button"
+        class="button btn-secondary hide-token-confirmation__button"
         data-testid="hide-token-confirmation__cancel"
       >
         Cancel
       </button>
       <button
-        class="button btn--rounded btn-primary hide-token-confirmation__button"
+        class="button btn-primary hide-token-confirmation__button"
         data-testid="hide-token-confirmation__hide"
       >
         Hide

--- a/ui/components/app/modals/reject-transactions/__snapshots__/reject-transactions.test.js.snap
+++ b/ui/components/app/modals/reject-transactions/__snapshots__/reject-transactions.test.js.snap
@@ -33,12 +33,12 @@ exports[`Reject Transactions Model should match snapshot 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-secondary modal-container__footer-button"
+        class="button btn-secondary modal-container__footer-button"
       >
         [cancel]
       </button>
       <button
-        class="button btn--rounded btn-primary modal-container__footer-button"
+        class="button btn-primary modal-container__footer-button"
       >
         [rejectAll]
       </button>

--- a/ui/components/app/modals/transaction-confirmed/__snapshots__/transaction-confirmed.test.js.snap
+++ b/ui/components/app/modals/transaction-confirmed/__snapshots__/transaction-confirmed.test.js.snap
@@ -31,7 +31,7 @@ exports[`Transaction Confirmed should match snapshot 1`] = `
       class="modal-container__footer"
     >
       <button
-        class="button btn--rounded btn-primary modal-container__footer-button"
+        class="button btn-primary modal-container__footer-button"
       >
         [ok]
       </button>

--- a/ui/components/app/transaction-breakdown/transaction-breakdown-row/__snapshots__/transaction-breakdown-row.component.test.js.snap
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown-row/__snapshots__/transaction-breakdown-row.component.test.js.snap
@@ -17,7 +17,7 @@ exports[`TransactionBreakdownRow Component should match snapshot 1`] = `
       data-testid="transaction-breakdown-row-value"
     >
       <button
-        class="button btn--rounded btn-default"
+        class="button btn-default"
       >
         Button
       </button>

--- a/ui/components/ui/button/button.component.js
+++ b/ui/components/ui/button/button.component.js
@@ -39,7 +39,7 @@ const Button = ({
   children,
   icon,
   className,
-  rounded = true,
+  rounded = false,
   ...buttonProps
 }) => {
   const doRounding = rounded && type !== 'link' && type !== 'inline';

--- a/ui/components/ui/button/button.stories.js
+++ b/ui/components/ui/button/button.stories.js
@@ -48,13 +48,6 @@ export default {
     className: { control: 'text' },
     onClick: { action: 'clicked' },
   },
-  args: {
-    disabled: false,
-    large: false,
-    submit: false,
-    className: '',
-    rounded: true,
-  },
 };
 
 export const DefaultStory = (args) => (

--- a/ui/components/ui/button/buttons.scss
+++ b/ui/components/ui/button/buttons.scss
@@ -13,7 +13,7 @@
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
-  border-radius: 6px;
+  border-radius: 12px;
   width: 100%;
   transition: border-color 0.3s ease, background-color 0.3s ease;
 

--- a/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.js.snap
+++ b/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.js.snap
@@ -159,7 +159,7 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
           </label>
         </div>
         <button
-          class="button btn--rounded btn-primary btn--large create-password__form--submit-button"
+          class="button btn-primary btn--large create-password__form--submit-button"
           data-testid="create-password-wallet"
           disabled=""
         >

--- a/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.js.snap
+++ b/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.js.snap
@@ -279,7 +279,7 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
       class="recovery-phrase__footer"
     >
       <button
-        class="button btn--rounded btn-primary recovery-phrase__footer--button"
+        class="button btn-primary recovery-phrase__footer--button"
         data-testid="recovery-phrase-reveal"
       >
         Reveal Secret Recovery Phrase
@@ -592,7 +592,7 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
           </a>
         </div>
         <button
-          class="button btn--rounded btn-primary recovery-phrase__footer--button"
+          class="button btn-primary recovery-phrase__footer--button"
           data-testid="recovery-phrase-next"
         >
           Next

--- a/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
+++ b/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
@@ -28,7 +28,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
           class="settings-page__content-item-col"
         >
           <button
-            class="button btn--rounded btn-secondary btn--large"
+            class="button btn-secondary btn--large"
             data-testid="advanced-setting-state-logs-button"
           >
             Download state logs
@@ -59,7 +59,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
           class="settings-page__content-item-col"
         >
           <button
-            class="button btn--rounded btn-danger btn--large settings-tab__button--red"
+            class="button btn-danger btn--large settings-tab__button--red"
           >
             Clear activity tab data
           </button>
@@ -587,7 +587,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
             
           </div>
           <button
-            class="button btn--rounded btn-primary settings-tab__rpc-save-button"
+            class="button btn-primary settings-tab__rpc-save-button"
             data-testid="auto-lockout-button"
           >
             Save
@@ -618,7 +618,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
           class="settings-page__content-item-col"
         >
           <button
-            class="button btn--rounded btn-secondary btn--large"
+            class="button btn-secondary btn--large"
             data-testid="export-data-button"
           >
             Download

--- a/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
+++ b/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
@@ -60,7 +60,7 @@ exports[`Unlock Page should match snapshot 1`] = `
         </div>
       </form>
       <button
-        class="button btn--rounded btn-default"
+        class="button btn-default"
         data-testid="unlock-submit"
         disabled=""
         style="margin-top: 20px; height: 56px; font-weight: 500; box-shadow: none; border-radius: 100px;"


### PR DESCRIPTION
## **Description**

This PR updates old button styling across the application to align with our [brand evolution and home page](https://consensys.slack.com/archives/C0354T27M5M/p1747135800699529) redesign. This PR is a [one line file change](https://github.com/MetaMask/metamask-extension/pull/31818/files?file-filters%5B%5D=.tsx&show-viewed-files=true#diff-6a6f56e439ab2ab776db250936c8bb3f6ae127824f26022e5a9ca61590411c60R89) the rest are all snapshot updates that change the classname.

### Related
- [Slack thread](https://consensys.slack.com/archives/C0354T27M5M/p1747135800699529)
- Equivalent mobile PR https://github.com/MetaMask/metamask-mobile/pull/14540
- Component Library Button PR https://github.com/MetaMask/metamask-extension/pull/31818
- Custom border radius overrides PR https://github.com/MetaMask/metamask-extension/pull/32809

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32802?quickstart=1)

## **Related issues**

Part of: https://github.com/MetaMask/metamask-extension/issues/31616

## **Manual testing steps**

1. Start storybook `yarn storybook`
2. Navigate to the old button component
3. Verify buttons now display with rounded rectangle shape instead of fully rounded
4. Ensure button behavior remains unchanged and only appearance is affected

## **Screenshots/Recordings**

### **Before**
Buttons with fully rounded shape in storybook

https://github.com/user-attachments/assets/09b056a0-c98e-4a94-9833-0946c7bd779e

### **After**
Buttons with rounded rectangle shape in storybook

https://github.com/user-attachments/assets/d1294d33-089c-455f-8608-7e7b3ff509c3

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
