### PR TITLE
refactor: unlock page to reduce css and align design

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2168,9 +2168,6 @@
   "enterOptionalPassword": {
     "message": "Enter optional password"
   },
-  "enterPassword": {
-    "message": "Enter password"
-  },
   "enterPasswordContinue": {
     "message": "Enter password to continue"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2168,9 +2168,6 @@
   "enterOptionalPassword": {
     "message": "Enter optional password"
   },
-  "enterPassword": {
-    "message": "Enter password"
-  },
   "enterPasswordContinue": {
     "message": "Enter password to continue"
   },

--- a/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
+++ b/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
@@ -3,17 +3,17 @@
 exports[`Unlock Page should match snapshot 1`] = `
 <div>
   <div
-    class="mm-box unlock-page__container mm-box--margin-top-0 mm-box--margin-bottom-auto mm-box--margin-inline-0 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
+    class="mm-box mm-box--padding-bottom-12 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--background-color-background-default"
   >
     <form
-      class="mm-box unlock-page mm-box--margin-auto mm-box--padding-6 mm-box--display-flex mm-box--gap-6 mm-box--flex-direction-column mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--rounded-lg"
+      class="mm-box unlock-page mm-box--padding-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full"
       data-testid="unlock-page"
     >
       <div
         class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
       >
         <div
-          class="mm-box unlock-page__mascot-container mm-box--margin-top-6 mm-box--margin-bottom-0"
+          class="mm-box unlock-page__mascot-container mm-box--margin-bottom-0"
         >
           <div
             style="z-index: 0;"
@@ -22,73 +22,52 @@ exports[`Unlock Page should match snapshot 1`] = `
           </div>
         </div>
         <h1
-          class="mm-box mm-text mm-text--heading-lg mm-box--margin-top-1 mm-box--margin-bottom-2 mm-box--color-text-default"
+          class="mm-box mm-text mm-text--display-md mm-text--font-weight-medium mm-text--text-align-center mm-box--margin-bottom-12 mm-box--color-text-default"
           data-testid="unlock-page-title"
         >
           Welcome back
         </h1>
         <div
-          class="mm-box mm-form-text-field mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+          class="mm-box mm-form-text-field mm-box--margin-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
         >
-          <label
-            class="mm-box mm-text mm-label mm-label--html-for mm-form-text-field__label mm-text--body-md mm-text--font-weight-medium mm-box--margin-bottom-1 mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
-            for="password"
-          >
-            <div
-              class="mm-box mm-box--display-flex mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full"
-            >
-              <p
-                class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
-              >
-                Password
-              </p>
-            </div>
-          </label>
           <div
             class="mm-box mm-text-field mm-text-field--size-lg mm-text-field--focused mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
           >
             <input
+              aria-label="Password"
               autocomplete="on"
               class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
               data-testid="unlock-password"
               focused="true"
               id="password"
-              placeholder="Enter password"
+              placeholder="Enter your password"
               type="password"
               value=""
             />
           </div>
         </div>
-      </div>
-      <div
-        class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
-      >
-        <div
-          class="mm-box unlock-page__buttons mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--width-full"
+        <button
+          class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--disabled mm-button-base--block mm-button-primary mm-button-primary--disabled mm-text--body-md-medium mm-box--margin-bottom-6 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
+          data-testid="unlock-submit"
+          disabled=""
+          type="submit"
         >
-          <button
-            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--disabled mm-button-base--block mm-button-primary mm-button-primary--disabled mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
-            data-testid="unlock-submit"
-            disabled=""
-            type="submit"
-          >
-            Unlock
-          </button>
-          <button
-            class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
-            data-testid="unlock-forgot-password-button"
-            type="button"
-          >
-            Forgot password?
-          </button>
-        </div>
-        <div
-          class="mm-box unlock-page__support mm-box--margin-top-6"
+          Unlock
+        </button>
+        <button
+          class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--margin-bottom-6 mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+          data-testid="unlock-forgot-password-button"
+        >
+          Forgot password?
+        </button>
+        <p
+          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
         >
           <span>
              
             Need help? Contact 
             <a
+              class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
               href="https://support.metamask.io"
               rel="noopener noreferrer"
               target="_blank"
@@ -98,7 +77,7 @@ exports[`Unlock Page should match snapshot 1`] = `
             
              
           </span>
-        </div>
+        </p>
       </div>
     </form>
   </div>

--- a/ui/pages/unlock-page/index.scss
+++ b/ui/pages/unlock-page/index.scss
@@ -1,43 +1,15 @@
 @use "design-system";
 
 .unlock-page {
-  max-width: 446px;
-
-  @include design-system.screen-sm-min {
-    margin: 12px auto auto;
-    padding: 24px;
-    border: 1px solid var(--color-border-muted);
-    min-height: 627px;
-    height: unset;
-  }
-
-  &__container {
-    align-self: stretch;
-    flex: 1 0 auto;
-  }
+  max-width: 400px;
 
   &__mascot-container {
     position: relative;
 
     &__beta {
-      background: var(--color-primary-default);
-      color: var(--color-primary-inverse);
-      padding: 3px 6px;
-      font-size: 16px;
       position: absolute;
       bottom: 10px;
       right: 0;
-      border-radius: 10px;
-      text-transform: uppercase;
-    }
-  }
-
-  &__support {
-    font-size: 0.75rem;
-    color: var(--color-text-alternative);
-
-    a {
-      color: var(--color-primary-default);
     }
   }
 

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -5,11 +5,10 @@ import {
   Text,
   FormTextField,
   Box,
-  ButtonLink,
   Button,
   ButtonSize,
   ButtonVariant,
-  InputType,
+  TextFieldType,
   FormTextFieldSize,
 } from '../../components/component-library';
 import {
@@ -23,6 +22,8 @@ import {
   FlexDirection,
   TextAlign,
   BackgroundColor,
+  TextTransform,
+  FontWeight,
 } from '../../helpers/constants/design-system';
 import Mascot from '../../components/ui/mascot';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
@@ -227,14 +228,11 @@ export default class UnlockPage extends Component {
       <Box
         display={Display.Flex}
         flexDirection={FlexDirection.Column}
+        alignItems={AlignItems.center}
         justifyContent={JustifyContent.center}
         backgroundColor={BackgroundColor.backgroundDefault}
         width={BlockSize.Full}
-        height={BlockSize.Full}
-        marginTop={0}
-        marginBottom="auto"
-        marginInline={0}
-        className="unlock-page__container"
+        paddingBottom={12} // offset header to center content
       >
         {showResetPasswordModal && (
           <ResetPasswordModal
@@ -246,14 +244,10 @@ export default class UnlockPage extends Component {
           as="form"
           display={Display.Flex}
           flexDirection={FlexDirection.Column}
-          justifyContent={JustifyContent.spaceBetween}
+          justifyContent={JustifyContent.center}
           alignItems={AlignItems.center}
-          margin="auto"
-          padding={6}
+          padding={4}
           width={BlockSize.Full}
-          height={BlockSize.Full}
-          borderRadius={BorderRadius.LG}
-          gap={6}
           className="unlock-page"
           data-testid="unlock-page"
           onSubmit={this.handleSubmit}
@@ -265,94 +259,80 @@ export default class UnlockPage extends Component {
             alignItems={AlignItems.center}
           >
             <Box
-              marginTop={6}
-              marginBottom={isBeta() || isFlask() ? 6 : 0}
               className="unlock-page__mascot-container"
+              marginBottom={isBeta() || isFlask() ? 6 : 0}
             >
               {this.renderMascot()}
               {isBeta() ? (
-                <Box className="unlock-page__mascot-container__beta">
+                <Text
+                  className="unlock-page__mascot-container__beta"
+                  backgroundColor={BackgroundColor.primaryDefault}
+                  color={TextColor.primaryInverse}
+                  padding={1}
+                  borderRadius={BorderRadius.LG}
+                  textTransform={TextTransform.Uppercase}
+                  fontWeight={FontWeight.Medium}
+                >
                   {t('beta')}
-                </Box>
+                </Text>
               ) : null}
             </Box>
             <Text
               data-testid="unlock-page-title"
               as="h1"
-              variant={TextVariant.headingLg}
-              marginTop={1}
-              marginBottom={2}
+              variant={TextVariant.displayMd}
+              marginBottom={12}
+              fontWeight={FontWeight.Medium}
               color={TextColor.textDefault}
+              textAlign={TextAlign.Center}
             >
               {t('welcomeBack')}
             </Text>
             <FormTextField
               id="password"
-              label={
-                <Box
-                  display={Display.Flex}
-                  width={BlockSize.Full}
-                  justifyContent={JustifyContent.spaceBetween}
-                  alignItems={AlignItems.center}
-                >
-                  <Text variant={TextVariant.bodyMdMedium}>
-                    {t('password')}
-                  </Text>
-                </Box>
-              }
-              placeholder={t('enterPassword')}
+              placeholder={t('enterYourPassword')}
               size={FormTextFieldSize.Lg}
               inputProps={{
                 'data-testid': 'unlock-password',
-                type: InputType.Password,
+                'aria-label': t('password'),
               }}
               onChange={(event) => this.handleInputChange(event)}
+              type={TextFieldType.Password}
+              value={password}
               error={Boolean(error)}
               helpText={this.renderHelpText()}
               autoComplete
               autoFocus
               disabled={isLocked}
               width={BlockSize.Full}
-              textFieldProps={{
-                borderRadius: BorderRadius.LG,
-              }}
+              marginBottom={4}
             />
-          </Box>
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Column}
-            width={BlockSize.Full}
-            alignItems={AlignItems.center}
-          >
-            <Box
-              className="unlock-page__buttons"
-              display={Display.Flex}
-              flexDirection={FlexDirection.Column}
-              width={BlockSize.Full}
-              gap={4}
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              block
+              type="submit"
+              data-testid="unlock-submit"
+              disabled={!password || isLocked}
+              marginBottom={6}
             >
-              <Button
-                variant={ButtonVariant.Primary}
-                size={ButtonSize.Lg}
-                block
-                type="submit"
-                data-testid="unlock-submit"
-                disabled={!password || isLocked}
-              >
-                {this.context.t('unlock')}
-              </Button>
-              <ButtonLink
-                data-testid="unlock-forgot-password-button"
-                key="import-account"
-                type="button"
-                onClick={() => this.onForgotPassword()}
-              >
-                {t('forgotPassword')}
-              </ButtonLink>
-            </Box>
-            <Box marginTop={6} className="unlock-page__support">
+              {this.context.t('unlock')}
+            </Button>
+
+            <Button
+              variant={ButtonVariant.Link}
+              data-testid="unlock-forgot-password-button"
+              key="import-account"
+              onClick={() => this.onForgotPassword()}
+              marginBottom={6}
+            >
+              {t('forgotPassword')}
+            </Button>
+
+            <Text>
               {t('needHelp', [
-                <a
+                <Button
+                  variant={ButtonVariant.Link}
                   href={SUPPORT_LINK}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -375,9 +355,9 @@ export default class UnlockPage extends Component {
                   }}
                 >
                   {needHelpText}
-                </a>,
+                </Button>,
               ])}
-            </Box>
+            </Text>
           </Box>
         </Box>
       </Box>


### PR DESCRIPTION
## **Description**

This PR builds off of the changes in [social-flow-header-and-unlock](https://github.com/MetaMask/metamask-extension/pull/33360/) to improve the design and remove unused CSS of the unlock page. The changes focus on visual improvements and code cleanup without affecting any core functionality.

Key changes:
1. Simplified and modernized the unlock page layout
2. Removed unused CSS classes and styles
3. Updated component spacing and alignment
4. Improved button and text field styling
5. Enhanced accessibility with proper ARIA labels
6. Streamlined the beta version indicator styling

The changes are purely cosmetic and do not affect any of the existing unlock page logic or functionality.

## **Related issues**

Fixes: N/A (Design improvements)

## **Manual testing steps**

1. Start the extension in development mode
2. Verify the unlock page appears correctly
3. Test the unlock page in both regular and beta modes:
   **Main:**

   ```bash
   yarn webpack --watch
   ```

   **Beta:**

   ```bash
   yarn webpack --type beta --watch
   ```

   **Flask:**

   ```bash
   yarn start:flask
   ```
4. Verify all buttons (Unlock, Forgot password) work as expected
5. Check that the support link opens correctly
6. Verify the page is responsive and looks good at different screen sizes

## **Screenshots/Recordings**

### **Before**

**Main**

https://github.com/user-attachments/assets/26b6421f-0b65-471f-81c1-3e0f4a134d22

**Beta**

https://github.com/user-attachments/assets/4bb5d0df-f85a-4393-a390-36a37b03808c

**Flask** 



https://github.com/user-attachments/assets/5d099302-e6c8-4a2f-955d-9df784910934



### **After**
**Main**

https://github.com/user-attachments/assets/5a181549-7492-4126-9615-4e7d0211782c

**Beta**

https://github.com/user-attachments/assets/9b324880-994f-4073-b2bf-a5ea9c29dc8d

**Flask** 

https://github.com/user-attachments/assets/5b2c89e9-b598-409d-8b25-b806d942d55c

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests (existing tests updated to match new UI)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format where applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.