### PR TITLE
fix: change custom buttons to rounded rectangle shape

### DIFF
--- a/ui/components/ui/nickname-popover/index.scss
+++ b/ui/components/ui/nickname-popover/index.scss
@@ -70,7 +70,6 @@
     margin-top: 16px;
     width: 152px;
     height: 40px;
-    border-radius: 100px;
     background: var(--color-primary-default);
   }
 }

--- a/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
@@ -59,7 +59,6 @@ export default function SkipSRPBackup({ handleClose }) {
               handleClose();
             }}
             type="secondary"
-            rounded
           >
             {t('goBack')}
           </Button>
@@ -67,7 +66,6 @@ export default function SkipSRPBackup({ handleClose }) {
             data-testid="skip-srp-backup"
             disabled={!checked}
             type="primary"
-            rounded
             onClick={async () => {
               await dispatch(setSeedPhraseBackedUp(false));
               trackEvent({

--- a/ui/pages/swaps/swaps-footer/index.scss
+++ b/ui/pages/swaps/swaps-footer/index.scss
@@ -31,7 +31,6 @@
   }
 
   &__custom-page-container-footer-button-class {
-    border-radius: 100px;
     height: 39px;
     width: 140px;
 

--- a/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
+++ b/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
@@ -63,7 +63,7 @@ exports[`Unlock Page should match snapshot 1`] = `
         class="button btn-default"
         data-testid="unlock-submit"
         disabled=""
-        style="margin-top: 20px; height: 56px; font-weight: 500; box-shadow: none; border-radius: 100px;"
+        style="margin-top: 20px; height: 56px; font-weight: 500; box-shadow: none;"
         variant="contained"
       >
         Unlock

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -138,7 +138,6 @@ export default class UnlockPage extends Component {
       height: '56px',
       fontWeight: '500',
       boxShadow: 'none',
-      borderRadius: '100px',
     };
 
     return (


### PR DESCRIPTION
## **Description**

This PR updates custom button styles with pill shape overrides to align with the new rectangular button shape in our design system. 

Some components use custom overrides that won't automatically receive updates from the design system changes. This PR removes those custom border-radius overrides to ensure consistent button styling across the application, aligning with our brand evolution and home page redesign initiatives.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32809?quickstart=1)

## **Related issues**
Part of: https://github.com/MetaMask/metamask-extension/issues/31616

Related PRs:
- https://github.com/MetaMask/metamask-extension/pull/31818
- https://github.com/MetaMask/metamask-extension/pull/32802

## **Manual testing steps**

1. Check that buttons in the following areas now use the new rectangular shape:
   - Nickname popover
   - Swaps footer
   - Unlock page

## **Screenshots/Recordings**

### **Before**
<!-- Custom buttons with pill shape (border-radius: 100px) -->
<img width="200" alt="Screenshot 2025-05-11 at 12 23 21 PM" src="https://github.com/user-attachments/assets/3e6c7cd3-4b1a-4725-892b-e6244cbc2bf0" />
<img width="200" alt="Screenshot 2025-05-11 at 12 23 00 PM" src="https://github.com/user-attachments/assets/49ee1de4-8914-4e6a-b01f-d98f8d17953c" /><img width="200" alt="Screenshot 2025-05-17 at 10 11 29 AM" src="https://github.com/user-attachments/assets/eecdacce-4e92-4c1f-aa4a-7ff7b951854e" /><img width="200" alt="Screenshot 2025-05-17 at 10 10 12 AM" src="https://github.com/user-attachments/assets/2c28bfdc-bb07-443b-9e7f-b8ba1878ddec" />


### **After**
<!-- Custom buttons with rectangular shape matching design system -->

<img width="200" alt="Screenshot 2025-05-11 at 12 05 21 PM" src="https://github.com/user-attachments/assets/a2dfe06c-6c6c-4518-9f96-963bc841f6c8" /><img width="200" alt="Screenshot 2025-05-11 at 12 14 47 PM" src="https://github.com/user-attachments/assets/ee993410-3db5-42c3-ba74-46c298973126" /><img width="200" alt="Screenshot 2025-05-17 at 10 13 15 AM" src="https://github.com/user-attachments/assets/e7ce1c14-cc84-46d1-920e-4977bca2ed48" /><img width="200" alt="Screenshot 2025-05-17 at 10 08 44 AM" src="https://github.com/user-attachments/assets/06e0ab65-85fe-458a-94c9-24dca658cfd1" />

Also did a search for border-radius to check any other instances of button overrides for both scss and inline styles

https://github.com/user-attachments/assets/aa837ba3-f267-4839-83e1-7837fb890f83

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

