### PR TITLE
test: Add E2E coverage for `SnapExportUsed` metric

### DIFF
--- a/test/e2e/snaps/test-snap-metrics.spec.js
+++ b/test/e2e/snaps/test-snap-metrics.spec.js
@@ -137,6 +137,19 @@ async function mockedSnapUpdateFailed(mockServer) {
     });
 }
 
+async function mockedSnapExportUsed(mockServer) {
+  return await mockServer
+    .forPost('https://api.segment.io/v1/batch')
+    .withJsonBodyIncluding({
+      batch: [{ type: 'track', event: 'Snap Export Used' }],
+    })
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+      };
+    });
+}
+
 async function mockedNpmInstall(mockServer) {
   return await mockServer
     .forGet(/https:\/\/registry\.npmjs\.org/u)
@@ -165,6 +178,7 @@ describe('Test Snap Metrics', function () {
       return [
         await mockedSnapInstallStarted(mockServer),
         await mockedSnapInstall(mockServer),
+        await mockedSnapExportUsed(mockServer),
       ];
     }
 
@@ -231,6 +245,11 @@ describe('Test Snap Metrics', function () {
           tag: 'button',
         });
 
+        // switch to test Snaps
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
+
+        await driver.clickElement('#sendInAppNotification');
+
         // check that snap installed event metrics have been sent
         const events = await getEventPayloads(driver, mockedEndpoints);
         assert.deepStrictEqual(events[0].event, 'Snap Install Started');
@@ -247,6 +266,17 @@ describe('Test Snap Metrics', function () {
           snap_id: 'npm:@metamask/notification-example-snap',
           origin: 'https://metamask.github.io',
           version: '2.3.0',
+          category: 'Snaps',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+        assert.deepStrictEqual(events[2].event, 'Snap Export Used');
+        assert.deepStrictEqual(events[2].properties, {
+          snap_id: 'npm:@metamask/notification-example-snap',
+          origin: 'https://metamask.github.io',
+          export: 'onRpcRequest',
+          success: true,
           category: 'Snaps',
           locale: 'en',
           chain_id: '0x539',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add E2E coverage for the `SnapExportUsed` metric before refactoring it.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32844?quickstart=1)
