### PR TITLE
test: Add E2E coverage for protocol Snaps

### DIFF
--- a/test/e2e/flask/snaps/test-snap-protocol.spec.ts
+++ b/test/e2e/flask/snaps/test-snap-protocol.spec.ts
@@ -1,9 +1,9 @@
 import { strict as assert } from 'assert';
-import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
-import { largeDelayMs } from '../helpers';
-import TestDappMultichain from '../page-objects/pages/test-dapp-multichain';
-import { DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS } from '../flask/multichain-api/testHelpers';
-import { withSolanaAccountSnap } from '../tests/solana/common-solana';
+import { openTestSnapClickButtonAndInstall } from '../../page-objects/flows/install-test-snap.flow';
+import { largeDelayMs } from '../../helpers';
+import TestDappMultichain from '../../page-objects/pages/test-dapp-multichain';
+import { DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS } from '../multichain-api/testHelpers';
+import { withSolanaAccountSnap } from '../../tests/solana/common-solana';
 
 describe('Test Protocol Snaps', function () {
   it('can call getBlockHeight exposed by Snap', async function () {

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -1,8 +1,8 @@
-import { Browser, By } from 'selenium-webdriver';
+import { Browser } from 'selenium-webdriver';
 import { NormalizedScopeObject } from '@metamask/chain-agnostic-permission';
+import { Json } from '@metamask/utils';
 import { largeDelayMs, WINDOW_TITLES } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
-import { Json } from '@metamask/utils';
 
 const DAPP_HOST_ADDRESS = '127.0.0.1:8080';
 const DAPP_URL = `http://${DAPP_HOST_ADDRESS}`;
@@ -168,6 +168,9 @@ class TestDappMultichain {
   /**
    * Invokes a method and retrieves the result.
    *
+   * @param scope
+   * @param method
+   * @param params
    * @returns The result as JSON.
    */
   async invokeMethod(

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -166,11 +166,11 @@ class TestDappMultichain {
   }
 
   /**
-   * Invokes a method and retrieves the result.
+   * Invokes a JSON-RPC method for a given scope and retrieves the result.
    *
-   * @param scope
-   * @param method
-   * @param params
+   * @param scope - The CAIP-2 scope.
+   * @param method - The JSON-RPC method to invoke.
+   * @param params - The parameters for the JSON-RPC method.
    * @returns The result as JSON.
    */
   async invokeMethod(

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -182,9 +182,9 @@ class TestDappMultichain {
   }> {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
 
-    await this.driver.findScrollToAndClickElement(`[data-testid="${scope}-select"]`);
+    await this.driver.clickElement(`[data-testid="${scope}-select"]`);
 
-    await this.driver.findScrollToAndClickElement(`[data-testid="${scope}-${method}-option"]`);
+    await this.driver.clickElement(`[data-testid="${scope}-${method}-option"]`);
 
     const card = await this.driver.findElement(
       `[data-testid="scope-card-${scope}`,
@@ -209,7 +209,7 @@ class TestDappMultichain {
       JSON.stringify(request),
     );
 
-    await this.driver.findScrollToAndClickElement(
+    await this.driver.clickElement(
       `[data-testid="invoke-method-${scope}-btn"]`,
     );
 

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -177,9 +177,7 @@ class TestDappMultichain {
     scope: string,
     method: string,
     params: Json,
-  ): Promise<{
-    sessionScopes: Record<string, NormalizedScopeObject>;
-  }> {
+  ): Promise<Json> {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
 
     await this.driver.clickElement(`[data-testid="${scope}-select"]`);

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -182,9 +182,9 @@ class TestDappMultichain {
   }> {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
 
-    await this.driver.clickElement(`[data-testid="${scope}-select"]`);
+    await this.driver.findScrollToAndClickElement(`[data-testid="${scope}-select"]`);
 
-    await this.driver.clickElement(`[data-testid="${scope}-${method}-option"]`);
+    await this.driver.findScrollToAndClickElement(`[data-testid="${scope}-${method}-option"]`);
 
     const card = await this.driver.findElement(
       `[data-testid="scope-card-${scope}`,
@@ -209,7 +209,7 @@ class TestDappMultichain {
       JSON.stringify(request),
     );
 
-    await this.driver.clickElement(
+    await this.driver.findScrollToAndClickElement(
       `[data-testid="invoke-method-${scope}-btn"]`,
     );
 

--- a/test/e2e/page-objects/pages/test-snaps.ts
+++ b/test/e2e/page-objects/pages/test-snaps.ts
@@ -37,6 +37,7 @@ export const buttonLocator = {
   connectManageStateButton: '#connectmanage-state',
   connectstateButton: '#connectstate',
   connectPreinstalledButton: '#connectpreinstalled-snap',
+  connectProtocolButton: '#connectprotocol',
   connectTransactionInsightButton: '#connecttransaction-insights',
   connectUpdateButton: '#connectUpdate',
   connectUpdateNewButton: '#connectUpdateNew',

--- a/test/e2e/snaps/test-snap-protocol.spec.ts
+++ b/test/e2e/snaps/test-snap-protocol.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
-import { WINDOW_TITLES } from '../helpers';
+import { largeDelayMs, WINDOW_TITLES } from '../helpers';
 import TestDappMultichain from '../page-objects/pages/test-dapp-multichain';
 import { DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS } from '../flask/multichain-api/testHelpers';
 import { withSolanaAccountSnap } from '../tests/solana/common-solana';
@@ -38,7 +38,8 @@ describe('Test Protocol Snaps', function () {
           tag: 'button',
         });
 
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
+        await driver.delay(largeDelayMs);
+
         const blockHeight = await testDapp.invokeMethod(
           devnetScope,
           'getBlockHeight',

--- a/test/e2e/snaps/test-snap-protocol.spec.ts
+++ b/test/e2e/snaps/test-snap-protocol.spec.ts
@@ -1,0 +1,51 @@
+import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
+import { WINDOW_TITLES } from '../helpers';
+import TestDappMultichain from '../page-objects/pages/test-dapp-multichain';
+import { DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS } from '../flask/multichain-api/testHelpers';
+import { withSolanaAccountSnap } from '../tests/solana/common-solana';
+import { strict as assert } from 'assert';
+
+describe('Test Protocol Snaps', function () {
+  it('can call getBlockHeight exposed by Snap', async function () {
+    await withSolanaAccountSnap(
+      {
+        title: this.test?.fullTitle(),
+        ...DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS,
+      },
+      async (driver, mockServer, extensionId) => {
+        const mockBlockHeight = 368556246;
+        await mockServer
+          .forPost('https://api.devnet.solana.com/')
+          .thenJson(200, {
+            id: 1,
+            jsonrpc: '2.0',
+            result: mockBlockHeight,
+          });
+
+        const devnetScope = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+        await openTestSnapClickButtonAndInstall(
+          driver,
+          'connectProtocolButton',
+        );
+
+        const testDapp = new TestDappMultichain(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.connectExternallyConnectable(extensionId);
+        await testDapp.initCreateSessionScopes([devnetScope]);
+
+        await driver.clickElementAndWaitForWindowToClose({
+          text: 'Connect',
+          tag: 'button',
+        });
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
+        const blockHeight = await testDapp.invokeMethod(
+          devnetScope,
+          'getBlockHeight',
+          [],
+        );
+        assert.strictEqual(blockHeight, mockBlockHeight);
+      },
+    );
+  });
+});

--- a/test/e2e/snaps/test-snap-protocol.spec.ts
+++ b/test/e2e/snaps/test-snap-protocol.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
-import { largeDelayMs, WINDOW_TITLES } from '../helpers';
+import { largeDelayMs } from '../helpers';
 import TestDappMultichain from '../page-objects/pages/test-dapp-multichain';
 import { DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS } from '../flask/multichain-api/testHelpers';
 import { withSolanaAccountSnap } from '../tests/solana/common-solana';

--- a/test/e2e/snaps/test-snap-protocol.spec.ts
+++ b/test/e2e/snaps/test-snap-protocol.spec.ts
@@ -1,9 +1,9 @@
+import { strict as assert } from 'assert';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
 import { WINDOW_TITLES } from '../helpers';
 import TestDappMultichain from '../page-objects/pages/test-dapp-multichain';
 import { DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS } from '../flask/multichain-api/testHelpers';
 import { withSolanaAccountSnap } from '../tests/solana/common-solana';
-import { strict as assert } from 'assert';
 
 describe('Test Protocol Snaps', function () {
   it('can call getBlockHeight exposed by Snap', async function () {

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -2336,7 +2336,11 @@ export async function withSolanaAccountSnap(
     sendFailedTransaction?: boolean;
     dappPaths?: string[];
   },
-  test: (driver: Driver, mockServer: Mockttp, extensionId: string) => Promise<void>,
+  test: (
+    driver: Driver,
+    mockServer: Mockttp,
+    extensionId: string,
+  ) => Promise<void>,
 ) {
   console.log('Starting withSolanaAccountSnap');
   let fixtures = new FixtureBuilder();
@@ -2446,7 +2450,15 @@ export async function withSolanaAccountSnap(
         'No Infura network client was found with the ID "linea-mainnet"',
       ],
     },
-    async ({ driver, mockServer, extensionId }: { driver: Driver; mockServer: Mockttp; extensionId: string; }) => {
+    async ({
+      driver,
+      mockServer,
+      extensionId,
+    }: {
+      driver: Driver;
+      mockServer: Mockttp;
+      extensionId: string;
+    }) => {
       await loginWithoutBalanceValidation(driver);
       const headerComponent = new HeaderNavbar(driver);
       const accountListPage = new AccountListPage(driver);

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -2336,7 +2336,7 @@ export async function withSolanaAccountSnap(
     sendFailedTransaction?: boolean;
     dappPaths?: string[];
   },
-  test: (driver: Driver, mockServer: Mockttp) => Promise<void>,
+  test: (driver: Driver, mockServer: Mockttp, extensionId: string) => Promise<void>,
 ) {
   console.log('Starting withSolanaAccountSnap');
   let fixtures = new FixtureBuilder();
@@ -2446,7 +2446,7 @@ export async function withSolanaAccountSnap(
         'No Infura network client was found with the ID "linea-mainnet"',
       ],
     },
-    async ({ driver, mockServer }: { driver: Driver; mockServer: Mockttp }) => {
+    async ({ driver, mockServer, extensionId }: { driver: Driver; mockServer: Mockttp; extensionId: string; }) => {
       await loginWithoutBalanceValidation(driver);
       const headerComponent = new HeaderNavbar(driver);
       const accountListPage = new AccountListPage(driver);
@@ -2465,7 +2465,7 @@ export async function withSolanaAccountSnap(
       }
 
       await driver.delay(regularDelayMs); // workaround to avoid flakiness
-      await test(driver, mockServer);
+      await test(driver, mockServer, extensionId);
     },
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a test for the example protocol Snap to ensure E2E coverage of that functionality. The example Snap just returns the block height of the Solana devnet and has been mocked.

This is a Flask only test for now since Solana devnet was turned off and that causes issues with the E2E.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32853?quickstart=1)

## **Related issues**

Closes: https://github.com/MetaMask/metamask-extension/issues/31006