### PR TITLE
fix(multi-srp): cp-12.18.0 use password input for import srp

### DIFF
--- a/ui/components/multichain/multi-srp/import-srp/import-srp.tsx
+++ b/ui/components/multichain/multi-srp/import-srp/import-srp.tsx
@@ -28,6 +28,7 @@ import { parseSecretRecoveryPhrase } from '../../../app/srp-input/parse-secret-r
 import { clearClipboard } from '../../../../helpers/utils/util';
 import { useTheme } from '../../../../hooks/useTheme';
 import { ThemeType } from '../../../../../shared/constants/preferences';
+import ShowHideToggle from '../../../ui/show-hide-toggle';
 
 const hasUpperCase = (draftSrp: string) => {
   return draftSrp !== draftSrp.toLowerCase();
@@ -51,6 +52,9 @@ export const ImportSrp = ({
   const [numberOfWords, setNumberOfWords] = useState(defaultNumberOfWords);
   const [invalidSrpWords, setInvalidSrpWords] = useState(
     Array(defaultNumberOfWords).fill(false),
+  );
+  const [showSrp, setShowSrp] = useState(
+    new Array(defaultNumberOfWords).fill(false),
   );
 
   const [loading, setLoading] = useState(false);
@@ -181,6 +185,19 @@ export const ImportSrp = ({
     [t, setSrpError, setSecretRecoveryPhrase, numberOfWords],
   );
 
+  const toggleShowSrp = useCallback((index) => {
+    setShowSrp((currentShowSrp) => {
+      const newShowSrp = currentShowSrp.slice();
+      if (newShowSrp[index]) {
+        newShowSrp[index] = false;
+      } else {
+        newShowSrp.fill(false);
+        newShowSrp[index] = true;
+      }
+      return newShowSrp;
+    });
+  }, []);
+
   const onSrpPaste = useCallback(
     (rawSrp) => {
       const parsedSrp = parseSecretRecoveryPhrase(rawSrp);
@@ -211,6 +228,7 @@ export const ImportSrp = ({
           new Array(newNumberOfWords - newDraftSrp.length).fill(''),
         );
       }
+      setShowSrp(new Array(newNumberOfWords).fill(false));
       onSrpChange(newDraftSrp);
       clearClipboard();
     },
@@ -270,7 +288,11 @@ export const ImportSrp = ({
                     data-testid={id}
                     borderRadius={BorderRadius.LG}
                     error={invalidSrpWords[index]}
-                    type={TextFieldType.Text}
+                    type={
+                      showSrp[index]
+                        ? TextFieldType.Text
+                        : TextFieldType.Password
+                    }
                     onChange={(e) => {
                       e.preventDefault();
                       onSrpWordChange(index, e.target.value);
@@ -285,6 +307,15 @@ export const ImportSrp = ({
                         onSrpPaste(newSrp);
                       }
                     }}
+                  />
+                  <ShowHideToggle
+                    id={`${id}-checkbox`}
+                    ariaLabelHidden={t('srpWordHidden')}
+                    ariaLabelShown={t('srpWordShown')}
+                    shown={showSrp[index]}
+                    data-testid={`${id}-checkbox`}
+                    onChange={() => toggleShowSrp(index)}
+                    title={t('srpToggleShow')}
                   />
                 </Box>
               </Box>
@@ -314,6 +345,9 @@ export const ImportSrp = ({
                 setSrpError('');
                 setInvalidSrpWords(
                   Array(numberOfWords === 12 ? 24 : 12).fill(false),
+                );
+                setShowSrp(
+                  new Array(numberOfWords === 12 ? 24 : 12).fill(false),
                 );
               }}
               data-testid="import-srp__multi-srp__switch-word-count-button"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Currently Import SRP component used for importing secondary SRP is using text type input fields, which is inconsistent and potentially less secure than using password input fields. This PR changes the input types and adds and option to show/hide words on the list.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to account manu
2. Click add account
3. Click Secret Recovery Phrase
4. Words you type or paste should be hidden

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="340" alt="Screenshot 2025-05-13 at 16 17 40" src="https://github.com/user-attachments/assets/2ef3f4ab-aacb-456f-9aa3-dac433e01178" />

### **After**
<img width="343" alt="Screenshot 2025-05-13 at 16 13 52" src="https://github.com/user-attachments/assets/5779e2c4-ebb4-4789-9e81-f259ae0303ac" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
