### PR TITLE
fix: Remove validation to submit internal transaction from only selected account

### DIFF
--- a/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch
+++ b/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch
@@ -24,3 +24,51 @@ index 45129a2bdc8f5bcb3955eb7c1a82a1164364a084..138efb1d178be8d2c5dc623ecd18b499
  export class IncomingTransactionHelper {
      constructor({ getCache, getCurrentAccount, getLocalTransactions, includeTokenTransfers, isEnabled, queryEntireHistory, remoteTransactionSource, trimTransactions, updateCache, updateTransactions, }) {
          _IncomingTransactionHelper_instances.add(this);
+diff --git a/dist/utils/validation.cjs b/dist/utils/validation.cjs
+index 71521677f3b61f3cc19c78707b09cb83a9a8505c..15997a10940bdfdae2f0250b0af511c40c1c6ff9 100644
+--- a/dist/utils/validation.cjs
++++ b/dist/utils/validation.cjs
+@@ -32,19 +32,8 @@ const TRANSACTION_ENVELOPE_TYPES_FEE_MARKET = [
+  * @throws Throws an error if the transaction is not permitted.
+  */
+ async function validateTransactionOrigin({ data, from, internalAccounts, origin, permittedAddresses, selectedAddress, txParams, type, }) {
+-    const isInternal = origin === controller_utils_1.ORIGIN_METAMASK;
+     const isExternal = origin && origin !== controller_utils_1.ORIGIN_METAMASK;
+     const { authorizationList, to, type: envelopeType } = txParams;
+-    if (isInternal && from !== selectedAddress) {
+-        throw rpc_errors_1.rpcErrors.internal({
+-            message: `Internally initiated transaction is using invalid account.`,
+-            data: {
+-                origin,
+-                fromAddress: from,
+-                selectedAddress,
+-            },
+-        });
+-    }
+     if (isExternal && permittedAddresses && !permittedAddresses.includes(from)) {
+         throw rpc_errors_1.providerErrors.unauthorized({ data: { origin } });
+     }
+diff --git a/dist/utils/validation.mjs b/dist/utils/validation.mjs
+index 5d4d4cba5f494ce276eda44e96bb88467a39b21e..2ead49fc4359aede7eba724a70151671677b2e49 100644
+--- a/dist/utils/validation.mjs
++++ b/dist/utils/validation.mjs
+@@ -29,19 +29,8 @@ const TRANSACTION_ENVELOPE_TYPES_FEE_MARKET = [
+  * @throws Throws an error if the transaction is not permitted.
+  */
+ export async function validateTransactionOrigin({ data, from, internalAccounts, origin, permittedAddresses, selectedAddress, txParams, type, }) {
+-    const isInternal = origin === ORIGIN_METAMASK;
+     const isExternal = origin && origin !== ORIGIN_METAMASK;
+     const { authorizationList, to, type: envelopeType } = txParams;
+-    if (isInternal && from !== selectedAddress) {
+-        throw rpcErrors.internal({
+-            message: `Internally initiated transaction is using invalid account.`,
+-            data: {
+-                origin,
+-                fromAddress: from,
+-                selectedAddress,
+-            },
+-        });
+-    }
+     if (isExternal && permittedAddresses && !permittedAddresses.includes(from)) {
+         throw providerErrors.unauthorized({ data: { origin } });
+     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6781,7 +6781,7 @@ __metadata:
 
 "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A54.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch":
   version: 54.3.0
-  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A54.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch::version=54.3.0&hash=456359"
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A54.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch::version=54.3.0&hash=30675a"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -6811,7 +6811,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^23.0.0
     "@metamask/network-controller": ^23.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 10/3b7ed6a47706816e75b17188afd0b900698d19f4c647e949a6f1f21adc1da53e155de34ac710b279d408ee1498f11dea28c9974eb2e13f7a58d84aff49e375b5
+  checksum: 10/4cd9746849e35f1d11b8484e3a567e019326ee9aa605ce8294be316a17295d5ba7fd5944eb1fe926a6ccd66e40caea8bcf1edd898a5f28876ae8243f7aea5124
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Remove validation that internal transaction can only be submitted from selected account.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32308

## **Manual testing steps**

1. Select account modal of an account different from selected account
2. Submit upgrade request
3. It should work as expected

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
