### PR TITLE
fix: optimize calls

### DIFF
--- a/ui/pages/asset/hooks/useHistoricalPrices.ts
+++ b/ui/pages/asset/hooks/useHistoricalPrices.ts
@@ -45,8 +45,37 @@ export const DEFAULT_USE_HISTORICAL_PRICES_METADATA: HistoricalPrices['metadata'
     yMax: -Infinity,
   };
 
+type UseHistoricalPricesParams = {
+  chainId: Hex | CaipChainId;
+  address: string;
+  currency: string;
+  timeRange: string;
+};
+
 /**
- * Fetches the historical prices for a given asset and over a given duration.
+ * Derives some metadata from the prices.
+ *
+ * @param prices - The prices to derive the metadata from.
+ * @returns The metadata derived from the prices.
+ */
+const deriveMetadata = (prices: Point[]) => {
+  const xMin = Math.min(...prices.map((p) => p.x));
+  const xMax = Math.max(...prices.map((p) => p.x));
+  const yMin = Math.min(...prices.map((p) => p.y));
+  const yMax = Math.max(...prices.map((p) => p.y));
+
+  const minPricePoint =
+    prices.find((p) => p.y === yMin) ??
+    DEFAULT_USE_HISTORICAL_PRICES_METADATA.minPricePoint;
+  const maxPricePoint =
+    prices.find((p) => p.y === yMax) ??
+    DEFAULT_USE_HISTORICAL_PRICES_METADATA.maxPricePoint;
+
+  return { minPricePoint, maxPricePoint, xMin, xMax, yMin, yMax };
+};
+
+/**
+ * Internal hook that fetches the historical prices for EVM chains. Returns default values otherwise.
  *
  * @param param0 - The parameters for the useHistoricalPrices hook.
  * @param param0.chainId - The chain ID of the asset.
@@ -55,20 +84,79 @@ export const DEFAULT_USE_HISTORICAL_PRICES_METADATA: HistoricalPrices['metadata'
  * @param param0.timeRange - The chart time range, as an ISO 8601 duration string ("P1D", "P1M", "P1Y", "P3YT45S", ...)
  * @returns The historical prices for the given asset and time range.
  */
-export const useHistoricalPrices = ({
+const useHistoricalPricesEvm = ({
   chainId,
   address,
   currency,
   timeRange,
-}: {
-  chainId: Hex | CaipChainId;
-  address: string;
-  currency: string;
-  timeRange: string;
-}) => {
+}: UseHistoricalPricesParams) => {
   const isEvm = useSelector(getMultichainIsEvm);
   const showFiat: boolean = useSelector(getShouldShowFiat);
 
+  const [loading, setLoading] = useState<boolean>(false);
+  const [prices, setPrices] = useState<Point[]>([]);
+  const [metadata, setMetadata] = useState<HistoricalPrices['metadata']>(
+    DEFAULT_USE_HISTORICAL_PRICES_METADATA,
+  );
+
+  // Fetch the prices, and set them locally as a result of the fetch
+  useEffect(() => {
+    if (!isEvm) {
+      return;
+    }
+
+    const chainSupported = showFiat && chainSupportsPricing(chainId as Hex);
+    if (!chainSupported) {
+      return;
+    }
+    setLoading(true);
+    const timePeriod = fromIso8601DurationToPriceApiTimePeriod(timeRange);
+    fetchWithCache({
+      url: `https://price.api.cx.metamask.io/v1/chains/${chainId}/historical-prices/${address}?vsCurrency=${currency}&timePeriod=${timePeriod}`,
+      cacheOptions: { cacheRefreshTime: 5 * MINUTE },
+      functionName: 'GetAssetHistoricalPrices',
+      fetchOptions: { headers: { 'X-Client-Id': 'extension' } },
+    })
+      .catch(() => ({}))
+      .then((resp?: { prices?: number[][] }) => {
+        const pricesToSet =
+          resp?.prices?.map((p) => ({ x: p?.[0], y: p?.[1] })) ?? [];
+        setPrices(pricesToSet);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [isEvm, chainId, address, currency, timeRange, showFiat]);
+
+  // Compute the metadata
+  useEffect(() => {
+    if (!isEvm) {
+      return;
+    }
+    const metadataToSet = deriveMetadata(prices);
+    setMetadata(metadataToSet);
+  }, [isEvm, prices]);
+
+  return { loading, data: { prices, metadata } };
+};
+
+/**
+ * Internal hook that fetches the historical prices for non-EVM chains. Returns default values otherwise.
+ *
+ * @param param0 - The parameters for the useHistoricalPrices hook.
+ * @param param0.chainId - The chain ID of the asset.
+ * @param param0.address - The address of the asset.
+ * @param param0.currency - The currency of the asset.
+ * @param param0.timeRange - The chart time range, as an ISO 8601 duration string ("P1D", "P1M", "P1Y", "P3YT45S", ...)
+ * @returns The historical prices for the given asset and time range.
+ */
+const useHistoricalPricesNonEvm = ({
+  chainId,
+  address,
+  currency,
+  timeRange,
+}: UseHistoricalPricesParams) => {
+  const isEvm = useSelector(getMultichainIsEvm);
   const [loading, setLoading] = useState<boolean>(false);
   const [prices, setPrices] = useState<Point[]>([]);
   const [metadata, setMetadata] = useState<HistoricalPrices['metadata']>(
@@ -80,40 +168,13 @@ export const useHistoricalPrices = ({
   const dispatch = useDispatch();
 
   /**
-   * Trigger a fetch of prices
-   *
-   * On EVM, we set setPrices directly as a result of the fetch.
-   *
-   * On non-EVM, we dispatch an action to fetch the prices and update the redux state.
+   * Fetch the prices by dispatching an action and then updating the redux state.
    * So we follow up with an other effect that will respond on the redux state update and set the prices locally in this hook.
    */
   useEffect(() => {
     if (isEvm) {
-      const chainSupported = showFiat && chainSupportsPricing(chainId as Hex);
-      if (!chainSupported) {
-        return () => {
-          // No cleanup needed
-        };
-      }
-      setLoading(true);
-      const timePeriod = fromIso8601DurationToPriceApiTimePeriod(timeRange);
-      fetchWithCache({
-        url: `https://price.api.cx.metamask.io/v1/chains/${chainId}/historical-prices/${address}?vsCurrency=${currency}&timePeriod=${timePeriod}`,
-        cacheOptions: { cacheRefreshTime: 5 * MINUTE },
-        functionName: 'GetAssetHistoricalPrices',
-        fetchOptions: { headers: { 'X-Client-Id': 'extension' } },
-      })
-        .catch(() => ({}))
-        .then((resp?: { prices?: number[][] }) => {
-          const pricesToSet =
-            resp?.prices?.map((p) => ({ x: p?.[0], y: p?.[1] })) ?? [];
-          setPrices(pricesToSet);
-        })
-        .finally(() => {
-          setLoading(false);
-        });
       return () => {
-        // No cleanup needed
+        // No clean up needed
       };
     }
 
@@ -139,18 +200,9 @@ export const useHistoricalPrices = ({
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     const intervalId = setInterval(fetchPrices, 60000); // Refresh every minute
     return () => clearInterval(intervalId); // Cleanup on unmount
-  }, [
-    chainId,
-    address,
-    currency,
-    timeRange,
-    isEvm,
-    historicalPricesNonEvm,
-    showFiat,
-    dispatch,
-  ]);
+  }, [isEvm, chainId, address, dispatch]);
 
-  // On non-EVM, retrieve the prices from the state
+  // Retrieve the prices from the state
   useEffect(() => {
     if (isEvm) {
       return;
@@ -168,20 +220,53 @@ export const useHistoricalPrices = ({
 
   // Compute the metadata
   useEffect(() => {
-    const xMin = Math.min(...prices.map((p) => p.x));
-    const xMax = Math.max(...prices.map((p) => p.x));
-    const yMin = Math.min(...prices.map((p) => p.y));
-    const yMax = Math.max(...prices.map((p) => p.y));
+    if (isEvm) {
+      return;
+    }
 
-    const minPricePoint =
-      prices.find((p) => p.y === yMin) ??
-      DEFAULT_USE_HISTORICAL_PRICES_METADATA.minPricePoint;
-    const maxPricePoint =
-      prices.find((p) => p.y === yMax) ??
-      DEFAULT_USE_HISTORICAL_PRICES_METADATA.maxPricePoint;
-
-    setMetadata({ minPricePoint, maxPricePoint, xMin, xMax, yMin, yMax });
-  }, [prices]);
+    const metadataToSet = deriveMetadata(prices);
+    setMetadata(metadataToSet);
+  }, [isEvm, prices]);
 
   return { loading, data: { prices, metadata } };
+};
+
+/**
+ * Exposed hook that fetches the historical prices for a given asset and over a given duration.
+ * Uses the correct internal hook based on the chain type.
+ *
+ * @param param0 - The parameters for the useHistoricalPrices hook.
+ * @param param0.chainId - The chain ID of the asset.
+ * @param param0.address - The address of the asset.
+ * @param param0.currency - The currency of the asset.
+ * @param param0.timeRange - The chart time range, as an ISO 8601 duration string ("P1D", "P1M", "P1Y", "P3YT45S", ...)
+ * @returns The historical prices for the given asset and time range.
+ */
+export const useHistoricalPrices = ({
+  chainId,
+  address,
+  currency,
+  timeRange,
+}: UseHistoricalPricesParams) => {
+  const isEvm = useSelector(getMultichainIsEvm);
+
+  const historicalPricesEvm = useHistoricalPricesEvm({
+    chainId,
+    address,
+    currency,
+    timeRange,
+  });
+
+  const historicalPricesNonEvm = useHistoricalPricesNonEvm({
+    chainId,
+    address,
+    currency,
+    timeRange,
+  });
+
+  if (isEvm) {
+    return historicalPricesEvm;
+  }
+
+  return historicalPricesNonEvm;
 };


### PR DESCRIPTION
This PR optimizes how we fetch historical prices for non-EVM chains.

Unlike EVM chains, the snap returns the entire historical price range in a single call for non-EVM chains. However, our previous implementation still triggered a fetch on every time range change, unnecessarily repeating the same request.

This PR addresses that by splitting the `useHistoricalPrices` hook into two separate hooks, ensuring non-EVM chains only fetch prices once, regardless of the selected time range.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32865?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
