### PR TITLE
fix: cp-12.18.0 Removing validation to reject internal transactions not from selected account.

### DIFF
--- a/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch
+++ b/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch
@@ -1,0 +1,74 @@
+diff --git a/dist/helpers/IncomingTransactionHelper.cjs b/dist/helpers/IncomingTransactionHelper.cjs
+index cd4a8158be0960eaf9d74cc6328e0b3bbd06740d..21336f5b778c05f8cd0469ff9964c704c96f26b1 100644
+--- a/dist/helpers/IncomingTransactionHelper.cjs
++++ b/dist/helpers/IncomingTransactionHelper.cjs
+@@ -20,7 +20,7 @@ exports.IncomingTransactionHelper = void 0;
+ // eslint-disable-next-line import-x/no-nodejs-modules
+ const events_1 = __importDefault(require("events"));
+ const logger_1 = require("../logger.cjs");
+-const INTERVAL = 1000 * 30; // 30 Seconds
++const INTERVAL = 1000 * 60 * 4; // 4 Minutes
+ class IncomingTransactionHelper {
+     constructor({ getCache, getCurrentAccount, getLocalTransactions, includeTokenTransfers, isEnabled, queryEntireHistory, remoteTransactionSource, trimTransactions, updateCache, updateTransactions, }) {
+         _IncomingTransactionHelper_instances.add(this);
+diff --git a/dist/helpers/IncomingTransactionHelper.mjs b/dist/helpers/IncomingTransactionHelper.mjs
+index 45129a2bdc8f5bcb3955eb7c1a82a1164364a084..138efb1d178be8d2c5dc623ecd18b4997fb49b37 100644
+--- a/dist/helpers/IncomingTransactionHelper.mjs
++++ b/dist/helpers/IncomingTransactionHelper.mjs
+@@ -14,7 +14,7 @@ var _IncomingTransactionHelper_instances, _IncomingTransactionHelper_getCache, _
+ // eslint-disable-next-line import-x/no-nodejs-modules
+ import EventEmitter from "events";
+ import { incomingTransactionsLogger as log } from "../logger.mjs";
+-const INTERVAL = 1000 * 30; // 30 Seconds
++const INTERVAL = 1000 * 60 * 4; // 4 Minutes
+ export class IncomingTransactionHelper {
+     constructor({ getCache, getCurrentAccount, getLocalTransactions, includeTokenTransfers, isEnabled, queryEntireHistory, remoteTransactionSource, trimTransactions, updateCache, updateTransactions, }) {
+         _IncomingTransactionHelper_instances.add(this);
+diff --git a/dist/utils/validation.cjs b/dist/utils/validation.cjs
+index 71521677f3b61f3cc19c78707b09cb83a9a8505c..15997a10940bdfdae2f0250b0af511c40c1c6ff9 100644
+--- a/dist/utils/validation.cjs
++++ b/dist/utils/validation.cjs
+@@ -32,19 +32,8 @@ const TRANSACTION_ENVELOPE_TYPES_FEE_MARKET = [
+  * @throws Throws an error if the transaction is not permitted.
+  */
+ async function validateTransactionOrigin({ data, from, internalAccounts, origin, permittedAddresses, selectedAddress, txParams, type, }) {
+-    const isInternal = origin === controller_utils_1.ORIGIN_METAMASK;
+     const isExternal = origin && origin !== controller_utils_1.ORIGIN_METAMASK;
+     const { authorizationList, to, type: envelopeType } = txParams;
+-    if (isInternal && from !== selectedAddress) {
+-        throw rpc_errors_1.rpcErrors.internal({
+-            message: `Internally initiated transaction is using invalid account.`,
+-            data: {
+-                origin,
+-                fromAddress: from,
+-                selectedAddress,
+-            },
+-        });
+-    }
+     if (isExternal && permittedAddresses && !permittedAddresses.includes(from)) {
+         throw rpc_errors_1.providerErrors.unauthorized({ data: { origin } });
+     }
+diff --git a/dist/utils/validation.mjs b/dist/utils/validation.mjs
+index 5d4d4cba5f494ce276eda44e96bb88467a39b21e..2ead49fc4359aede7eba724a70151671677b2e49 100644
+--- a/dist/utils/validation.mjs
++++ b/dist/utils/validation.mjs
+@@ -29,19 +29,8 @@ const TRANSACTION_ENVELOPE_TYPES_FEE_MARKET = [
+  * @throws Throws an error if the transaction is not permitted.
+  */
+ export async function validateTransactionOrigin({ data, from, internalAccounts, origin, permittedAddresses, selectedAddress, txParams, type, }) {
+-    const isInternal = origin === ORIGIN_METAMASK;
+     const isExternal = origin && origin !== ORIGIN_METAMASK;
+     const { authorizationList, to, type: envelopeType } = txParams;
+-    if (isInternal && from !== selectedAddress) {
+-        throw rpcErrors.internal({
+-            message: `Internally initiated transaction is using invalid account.`,
+-            data: {
+-                origin,
+-                fromAddress: from,
+-                selectedAddress,
+-            },
+-        });
+-    }
+     if (isExternal && permittedAddresses && !permittedAddresses.includes(from)) {
+         throw providerErrors.unauthorized({ data: { origin } });
+     }

--- a/package.json
+++ b/package.json
@@ -334,7 +334,7 @@
     "@metamask/snaps-utils": "^9.2.1",
     "@metamask/solana-wallet-snap": "^1.28.0",
     "@metamask/solana-wallet-standard": "^0.4.1",
-    "@metamask/transaction-controller": "^54.3.0",
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A54.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch",
     "@metamask/user-operation-controller": "^31.0.0",
     "@metamask/utils": "^11.1.0",
     "@ngraveio/bc-ur": "^1.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6724,7 +6724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^54.3.0":
+"@metamask/transaction-controller@npm:54.3.0":
   version: 54.3.0
   resolution: "@metamask/transaction-controller@npm:54.3.0"
   dependencies:
@@ -6757,6 +6757,42 @@ __metadata:
     "@metamask/network-controller": ^23.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
   checksum: 10/a5dcf949cb8eddf5dfa64f5b3789f8011336f923a45cfde864974b5fb61425955273eb4bef321eb07cd4a78edd926f61bfb032b317f30cd5f4a7c679f017dd1e
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A54.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch":
+  version: 54.3.0
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A54.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch::version=54.3.0&hash=30675a"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/base-controller": "npm:^8.0.1"
+    "@metamask/controller-utils": "npm:^11.7.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.2.0"
+    async-mutex: "npm:^0.5.0"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/accounts-controller": ^27.0.0
+    "@metamask/approval-controller": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+    "@metamask/gas-fee-controller": ^23.0.0
+    "@metamask/network-controller": ^23.0.0
+    "@metamask/remote-feature-flag-controller": ^1.5.0
+  checksum: 10/4cd9746849e35f1d11b8484e3a567e019326ee9aa605ce8294be316a17295d5ba7fd5944eb1fe926a6ccd66e40caea8bcf1edd898a5f28876ae8243f7aea5124
   languageName: node
   linkType: hard
 
@@ -30121,7 +30157,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.3.0"
     "@metamask/test-dapp-multichain": "npm:^0.10.0"
     "@metamask/test-dapp-solana": "npm:^0.1.0"
-    "@metamask/transaction-controller": "npm:^54.3.0"
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A54.3.0#~/.yarn/patches/@metamask-transaction-controller-npm-54.3.0-2c90b81511.patch"
     "@metamask/user-operation-controller": "npm:^31.0.0"
     "@metamask/utils": "npm:^11.1.0"
     "@ngraveio/bc-ur": "npm:^1.1.13"


### PR DESCRIPTION
## **Description**

Remove validation that internal transaction can only be submitted from selected account.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32308

## **Manual testing steps**

1. Select account modal of an account different from selected account
2. Submit upgrade request
3. It should work as expected

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
