### PR TITLE
ci: skip webpack tests on the Merge Queue

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -24,6 +24,7 @@ jobs:
 
   test-e2e-chrome-webpack:
     uses: ./.github/workflows/run-e2e.yml
+    if: ${{ github.event_name != 'merge_group' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## **Description**

On the Merge Queue, do not run the `test-e2e-chrome-webpack` test suite

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32880?quickstart=1)

## **Related issues**

Fixes: #32877 

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->