### PR TITLE
fix: Fix Sentry reporting in the offscreen document

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -45,18 +45,23 @@ export default function setupSentry() {
 
   log('Initializing');
 
-  // Normally this would be awaited, but getSelf should be available by the time the report is finalized.
-  // If it's not, we still get the extensionId, but the installType will default to "unknown"
-  browser.management
-    .getSelf()
-    .then((extensionInfo) => {
-      if (extensionInfo.installType) {
-        installType = extensionInfo.installType;
-      }
-    })
-    .catch((error) => {
-      log('Error getting extension installType', error);
-    });
+  // The browser management API may not be available in all contexts of the app
+  // For example, it is not available in the offscreen document.
+  if (browser.management && browser.management.getSelf) {
+    // Normally this would be awaited, but getSelf should be available by the time the report is finalized.
+    // If it's not, we still get the extensionId, but the installType will default to "unknown"
+    browser.management
+      .getSelf()
+      .then((extensionInfo) => {
+        if (extensionInfo.installType) {
+          installType = extensionInfo.installType;
+        }
+      })
+      .catch((error) => {
+        log('Error getting extension installType', error);
+      });
+  }
+
   integrateLogging();
   setSentryClient();
 

--- a/shared/modules/mv3.utils.js
+++ b/shared/modules/mv3.utils.js
@@ -1,7 +1,10 @@
 /* eslint-disable import/unambiguous -- Not an external module and not of concern */
 
 const runtimeManifest =
-  global.chrome?.runtime.getManifest() || global.browser?.runtime.getManifest();
+  (global.chrome?.runtime.getManifest &&
+    global.chrome?.runtime.getManifest()) ??
+  (global.browser?.runtime.getManifest &&
+    global.browser?.runtime.getManifest());
 
 /**
  * A boolean indicating whether the manifest of the current extension is set to manifest version 3.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Sentry reporting in the offscreen document was broken due to usage of `browser.management` which seems to not be available in the offscreen document. This prevents us from receiving Sentry traces that originate from the offscreen document. This PR fixes the issue by only using the API if it is available.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32901?quickstart=1)
