### PR TITLE
fix: flaky test `App Installed Events are sent immediately when user installs app and chooses to opt in metrics`

### DIFF
--- a/test/e2e/tests/metrics/app-installed.spec.ts
+++ b/test/e2e/tests/metrics/app-installed.spec.ts
@@ -22,7 +22,15 @@ async function mockSegment(mockServer: Mockttp) {
     await mockServer
       .forPost('https://api.segment.io/v1/batch')
       .withJsonBodyIncluding({
-        batch: [{ type: 'track', event: 'App Installed' }],
+        batch: [
+          {
+            type: 'track',
+            event: 'App Installed',
+            properties: {
+              category: 'App',
+            },
+          },
+        ],
       })
       .thenCallback(() => {
         return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The problem is that in the mockSegment method, we are matching 2 different events. Those 2 have the same name `App Installed` but they have different properties. Then, when we assert the segment properties, sometimes they don't match with our expected result, as depending on which event was first, it will compare one or the other.
The video below, which showcasts this.


Error logs:

```js
AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

  {
+   category: 'Onboarding',
-   category: 'App',
    chain_id: '0x539',
+   environment_type: 'fullscreen',
-   environment_type: 'background',
    locale: 'en'
  }

    at <anonymous> (test/e2e/tests/metrics/app-installed.spec.ts:70:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async withFixtures (test/e2e/helpers.js:306:5)
    at async Context.<anonymous> (test/e2e/tests/metrics/app-installed.spec.ts:37:5)

      + expected - actual

       {
      -  "category": "Onboarding"
      +  "category": "App"
         "chain_id": "0x539"
      -  "environment_type": "fullscreen"
      +  "environment_type": "background"
         "locale": "en"
       }
      
```

Solution: in this test we want to check that a segment event is sent whenever we onboard with metametrics, so we'll make the mock more specific, to make sure we always match 1 event, and then we can assert safely, as the event will always be the same.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32923?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32922

## **Manual testing steps**

1. e2e should pass with the x5 extra runs

## **Screenshots/Recordings**

Notice how there are 2 requests matching the App Installed event, with different properties. The 2 are matched by our mock, and then depending which one was first, the assert properties will pass or fail

https://github.com/user-attachments/assets/0f50126d-628c-4fc1-ad80-03c007fca778



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
