### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/confirmation-refactoring/README.md
+++ b/docs/confirmation-refactoring/README.md
@@ -6,7 +6,7 @@ The following pages document the ongoing refactoring efforts of confirmation pag
 
 2. [Confirmation Pages Routing](./confirmation-pages-routing/README.md)
 
-3. [Confirmation Page Structure](./confirmation-page=structure/README.md)
+3. [Confirmation Page Structure](./confirmation-page-structure/README.md)
 
 4. [Confirmation State Management](./confirmation-state-management/README.md)
 


### PR DESCRIPTION


## **Description**

I've fixed the broken link by changing confirmation-page=structure to confirmation-page-structure in the README file. The link should now work correctly since it matches the actual directory name in the filesystem.



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
