### PR TITLE
fix: flaky test `MetaMask onboarding User can add custom network during onboarding`

### DIFF
--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -9,6 +9,9 @@ export const LOCAL_NODE_PRIVATE_KEY =
 export const DEFAULT_FIXTURE_ACCOUNT =
   '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1';
 
+export const DEFAULT_FIXTURE_ACCOUNT_LOWERCASE =
+  DEFAULT_FIXTURE_ACCOUNT.toLowerCase();
+
 export const DEFAULT_FIXTURE_ACCOUNT_SHORTENED = '0x5CfE73b602...474086a7e1';
 
 /* Address of the 4337 entrypoint smart contract. */

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -10,7 +10,10 @@ const {
   TOKEN_API_BASE_URL,
 } = require('../../shared/constants/swaps');
 const { TX_SENTINEL_URL } = require('../../shared/constants/transaction');
-const { MOCK_META_METRICS_ID } = require('./constants');
+const {
+  DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+  MOCK_META_METRICS_ID,
+} = require('./constants');
 const { SECURITY_ALERTS_PROD_API_BASE_URL } = require('./tests/ppom/constants');
 
 const { ALLOWLISTED_HOSTS, ALLOWLISTED_URLS } = require('./mock-e2e-allowlist');
@@ -868,7 +871,7 @@ async function setupMocking(
   // Nft API: tokens
   await server
     .forGet(
-      'https://nft.api.cx.metamask.io/users/0x0cc5261ab8ce458dc977078a3623e2badd27afd3/tokens',
+      `https://nft.api.cx.metamask.io/users/${DEFAULT_FIXTURE_ACCOUNT_LOWERCASE}/tokens`,
     )
     .thenCallback(() => {
       return {

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -850,7 +850,7 @@ async function setupMocking(
       };
     });
 
-  // Client Side Detecition: Request Blocklist
+  // Client Side Detection: Request Blocklist
   const CLIENT_SIDE_DETECTION_BLOCKLIST = fs.readFileSync(
     CLIENT_SIDE_DETECTION_BLOCKLIST_PATH,
   );
@@ -862,6 +862,21 @@ async function setupMocking(
       return {
         statusCode: 200,
         json: JSON.parse(CLIENT_SIDE_DETECTION_BLOCKLIST),
+      };
+    });
+
+  // Nft API: tokens
+  await server
+    .forGet(
+      'https://nft.api.cx.metamask.io/users/0x0cc5261ab8ce458dc977078a3623e2badd27afd3/tokens',
+    )
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: {
+          tokens: [],
+          continuation: null,
+        },
       };
     });
 

--- a/test/e2e/tests/onboarding/onboarding.spec.ts
+++ b/test/e2e/tests/onboarding/onboarding.spec.ts
@@ -1,4 +1,5 @@
 import { Browser } from 'selenium-webdriver';
+import { Mockttp } from 'mockttp';
 import {
   convertToHexValue,
   TEST_SEED_PHRASE,
@@ -25,6 +26,24 @@ import {
   incompleteCreateNewWalletOnboardingFlow,
 } from '../../page-objects/flows/onboarding.flow';
 import { switchToNetworkFlow } from '../../page-objects/flows/network.flow';
+
+const IMPORTED_SRP_ACCOUNT_1 = '0x0Cc5261AB8cE458dc977078A3623E2BaDD27afD3';
+
+async function tokensMock(mockServer: Mockttp) {
+  return await mockServer
+    .forGet(
+      `https://nft.api.cx.metamask.io/users/${IMPORTED_SRP_ACCOUNT_1.toLowerCase()}/tokens`,
+    )
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: {
+          tokens: [],
+          continuation: null,
+        },
+      };
+    });
+}
 
 describe('MetaMask onboarding', function () {
   it("Creates a new wallet, sets up a secure password, and doesn't complete the onboarding process and refreshes the page", async function () {
@@ -225,11 +244,12 @@ describe('MetaMask onboarding', function () {
             },
           },
         ],
+        testSpecificMock: tokensMock,
         title: this.test?.fullTitle(),
       },
       async ({ driver, localNodes }) => {
         await localNodes[1].setAccountBalance(
-          '0x0Cc5261AB8cE458dc977078A3623E2BaDD27afD3',
+          IMPORTED_SRP_ACCOUNT_1,
           convertToHexValue(10000000000000000000),
         );
         await importSRPOnboardingFlow({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The problem is that a mock is missing. The request to `nft.api.cd.metamask.io` is redirected to the catch all mock, returning no data. Then, if the test is fast, there is no time for an error to appear in the console, but if you add a delay (or the test is slow enough) an error appears in the console, as it cannot parse the response (as the response is empty in the catch all mock). You can see this showcasted in the video below.
The fix is to add this as a mock, so this error does not happen anytime this request is triggered and there is enough time for the error to appear.

- Adding a global mock, with the default fixture account, which runs in most of our tests, to prevent this error to happen in other tests
- Adding a specific mock for the onboarding test, as we use an imported custom SRP, which derives another address, so the url needs that different address

![Screenshot from 2025-05-14 17-27-16](https://github.com/user-attachments/assets/3351fa3a-15ca-4bd4-be04-2d58a5b9c3e5)


Extra Note: the onboarding spec failed once in this branch due to another error (`The snaps execution environment failed to start`). This will be tackled in a separate PR, by mocking the execution environment for FF and webpack builds -- it's already in our radar and has been discussed with the snaps team.

![Screenshot from 2025-05-14 18-17-10](https://github.com/user-attachments/assets/4c202b59-a9c3-4a63-adec-c8633b48e824)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32932?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32931

## **Manual testing steps**

1. Check e2e are successful

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/75eb0f68-d3ba-4f86-a79a-e89802b5451b



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
