### PR TITLE
feat: bump multichain-api-client to v0.6.0 to speed-up Wallet Standard registration

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -87,12 +87,11 @@ if (shouldInjectProvider()) {
     },
   });
 
-  getMultichainClient({
+  const multichainClient = getMultichainClient({
     transport: getDefaultTransport(),
-  }).then((client) => {
-    registerSolanaWalletStandard({
-      client,
-      walletName: process.env.METAMASK_BUILD_NAME,
-    });
+  });
+  registerSolanaWalletStandard({
+    client: multichainClient,
+    walletName: process.env.METAMASK_BUILD_NAME,
   });
 }

--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "@metamask/message-manager": "^12.0.1",
     "@metamask/message-signing-snap": "1.1.2",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/multichain-api-client": "^0.5.0",
+    "@metamask/multichain-api-client": "^0.6.0",
     "@metamask/multichain-api-middleware": "^0.1.1",
     "@metamask/multichain-network-controller": "^0.5.1",
     "@metamask/multichain-transactions-controller": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5919,10 +5919,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-api-client@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@metamask/multichain-api-client@npm:0.5.0"
-  checksum: 10/3703a71f9643633084198c2d4abc3c1c03bc231a3d377f510a0088fb586d70231664aa77908934ec90b8cdc7a277747f11ee4a443680685f2f38ffca756e5499
+"@metamask/multichain-api-client@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@metamask/multichain-api-client@npm:0.6.0"
+  checksum: 10/f51a99f0f38596b4c60ce389f7f2ab8cee336524fc661667f1255ce9513b0928444587065c4c7b0d3b36de75a956f17daecd7406a3a21c015619843e5a7b649c
   languageName: node
   linkType: hard
 
@@ -30041,7 +30041,7 @@ __metadata:
     "@metamask/message-manager": "npm:^12.0.1"
     "@metamask/message-signing-snap": "npm:1.1.2"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-api-client": "npm:^0.5.0"
+    "@metamask/multichain-api-client": "npm:^0.6.0"
     "@metamask/multichain-api-middleware": "npm:^0.1.1"
     "@metamask/multichain-network-controller": "npm:^0.5.1"
     "@metamask/multichain-transactions-controller": "npm:^0.9.0"


### PR DESCRIPTION
## **Description**

This PR bumps `multichain-api-client` to [v0.6.0](https://github.com/MetaMask/multichain-api-client/pull/56).
This new version makes `getMultichainClient` method synchronous, in order to have the Wallet Standard registration event sent as soon as possible. This makes MetaMask displayed higher

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32939?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="392" alt="Screenshot" src="https://github.com/user-attachments/assets/afabd579-f5e0-4559-9794-79078a9db0fe" />

### **After**

![Screenshot](https://github.com/user-attachments/assets/64ac5ece-8f14-41f1-abb2-f8eca2283890)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
