### PR TITLE
fix: Cherry pick 6d86472 into cp-12.18.0

### DIFF
--- a/.yarn/patches/@metamask-bridge-controller-npm-18.0.0-d2f6e87282.patch
+++ b/.yarn/patches/@metamask-bridge-controller-npm-18.0.0-d2f6e87282.patch
@@ -1,0 +1,42 @@
+diff --git a/dist/constants/tokens.cjs b/dist/constants/tokens.cjs
+index db43ed22aead16bea7736dbd1917cecd29b38860..1e78ff1a2dee8e12563f73f2b65fea0d83952f94 100644
+--- a/dist/constants/tokens.cjs
++++ b/dist/constants/tokens.cjs
+@@ -4,7 +4,6 @@ exports.SYMBOL_TO_SLIP44_MAP = exports.SWAPS_CHAINID_DEFAULT_TOKEN_MAP = void 0;
+ const keyring_api_1 = require("@metamask/keyring-api");
+ const chains_1 = require("./chains.cjs");
+ const DEFAULT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
+-const DEFAULT_SOLANA_TOKEN_ADDRESS = `${keyring_api_1.SolScope.Mainnet}/slip44:501`;
+ const CURRENCY_SYMBOLS = {
+     ARBITRUM: 'ETH',
+     AVALANCHE: 'AVAX',
+@@ -97,7 +96,7 @@ const BASE_SWAPS_TOKEN_OBJECT = {
+ const SOLANA_SWAPS_TOKEN_OBJECT = {
+     symbol: CURRENCY_SYMBOLS.SOL,
+     name: 'Solana',
+-    address: DEFAULT_SOLANA_TOKEN_ADDRESS,
++    address: DEFAULT_TOKEN_ADDRESS,
+     decimals: 9,
+     iconUrl: '',
+ };
+diff --git a/dist/constants/tokens.mjs b/dist/constants/tokens.mjs
+index 27280664758ee3052790aa5c6d54296a010fbbd3..ee0d8e7cbc27d72726111971158921e930504d6b 100644
+--- a/dist/constants/tokens.mjs
++++ b/dist/constants/tokens.mjs
+@@ -1,7 +1,6 @@
+ import { SolScope } from "@metamask/keyring-api";
+ import { CHAIN_IDS } from "./chains.mjs";
+ const DEFAULT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
+-const DEFAULT_SOLANA_TOKEN_ADDRESS = `${SolScope.Mainnet}/slip44:501`;
+ const CURRENCY_SYMBOLS = {
+     ARBITRUM: 'ETH',
+     AVALANCHE: 'AVAX',
+@@ -94,7 +93,7 @@ const BASE_SWAPS_TOKEN_OBJECT = {
+ const SOLANA_SWAPS_TOKEN_OBJECT = {
+     symbol: CURRENCY_SYMBOLS.SOL,
+     name: 'Solana',
+-    address: DEFAULT_SOLANA_TOKEN_ADDRESS,
++    address: DEFAULT_TOKEN_ADDRESS,
+     decimals: 9,
+     iconUrl: '',
+ };

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A58.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-58.0.0-e574d55300.patch",
     "@metamask/base-controller": "^8.0.0",
     "@metamask/bitcoin-wallet-snap": "^0.9.0",
-    "@metamask/bridge-controller": "^18.0.0",
+    "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A18.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-18.0.0-d2f6e87282.patch",
     "@metamask/bridge-status-controller": "^20.0.0",
     "@metamask/browser-passworder": "^4.3.0",
     "@metamask/chain-agnostic-permission": "^0.3.0",

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -3,8 +3,8 @@ import { useSelector } from 'react-redux';
 import {
   formatChainIdToCaip,
   isNativeAddress,
+  type BridgeToken,
 } from '@metamask/bridge-controller';
-import type { BridgeToken } from '@metamask/bridge-controller';
 import { getAccountLink } from '@metamask/etherscan-link';
 import {
   Text,
@@ -43,6 +43,7 @@ import {
   MultichainNetworks,
 } from '../../../../shared/constants/multichain/networks';
 import { formatBlockExplorerAddressUrl } from '../../../../shared/lib/multichain/networks';
+import { getMultichainCurrentChainId } from '../../../selectors/multichain';
 import { BridgeAssetPickerButton } from './components/bridge-asset-picker-button';
 
 const sanitizeAmountInput = (textToSanitize: string) => {
@@ -98,7 +99,8 @@ export const BridgeInputGroup = ({
   const currency = useSelector(getCurrentCurrency);
   const locale = useSelector(getIntlLocale);
 
-  const selectedChainId = networkProps?.network?.chainId;
+  const currentChainId = useSelector(getMultichainCurrentChainId);
+  const selectedChainId = networkProps?.network?.chainId ?? currentChainId;
   const balanceAmount = useLatestBalance(token);
 
   const [, handleCopy] = useCopyToClipboard(MINUTE) as [

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -83,7 +83,10 @@ import {
   setSelectedAccount,
 } from '../../../store/actions';
 import { calcTokenValue } from '../../../../shared/lib/swaps-utils';
-import { formatTokenAmount } from '../utils/quote';
+import {
+  formatTokenAmount,
+  isQuoteExpiredOrInvalid as isQuoteExpiredOrInvalidUtil,
+} from '../utils/quote';
 import {
   CrossChainSwapsEventProperties,
   useCrossChainSwapsEventTracker,
@@ -178,15 +181,19 @@ const PrepareBridgePage = () => {
   );
 
   const wasTxDeclined = useSelector(getWasTxDeclined);
-  // If latest quote is expired and user has sufficient balance
-  // set activeQuote to undefined to hide stale quotes but keep inputs filled
-  const activeQuote =
-    isQuoteExpired &&
-    (!quoteRequest.insufficientBal ||
-      // insufficientBal is always true for solana
-      (fromChain && isSolanaChainId(fromChain.chainId)))
-      ? undefined
-      : activeQuote_;
+
+  // Determine if the current quote is expired or does not match the currently
+  // selected destination asset/chain.
+  const isQuoteExpiredOrInvalid = isQuoteExpiredOrInvalidUtil({
+    activeQuote: activeQuote_,
+    toToken,
+    toChain,
+    fromChain,
+    isQuoteExpired,
+    insufficientBal: quoteRequest.insufficientBal,
+  });
+
+  const activeQuote = isQuoteExpiredOrInvalid ? undefined : activeQuote_;
 
   const isEvm = useMultichainSelector(getMultichainIsEvm);
   const selectedEvmAccount = useSelector(getSelectedEvmInternalAccount);

--- a/ui/pages/bridge/utils/quote.test.ts
+++ b/ui/pages/bridge/utils/quote.test.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'bignumber.js';
+import { ChainId, getNativeAssetForChainId } from '@metamask/bridge-controller';
 import {
   formatTokenAmount,
   formatCurrencyAmount,
@@ -6,6 +7,21 @@ import {
 } from './quote';
 
 describe('Bridge quote utils', () => {
+  describe('getNativeAssetForChainId', () => {
+    it('should return the native asset for a given chainId', () => {
+      const result = getNativeAssetForChainId(ChainId.SOLANA);
+      expect(result).toStrictEqual({
+        address: '0x0000000000000000000000000000000000000000',
+        assetId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        chainId: 1151111081099710,
+        decimals: 9,
+        iconUrl: '',
+        name: 'Solana',
+        symbol: 'SOL',
+      });
+    });
+  });
+
   describe('formatTokenAmount', () => {
     it('should format token amount with symbol', () => {
       const locale = 'en-US';

--- a/ui/pages/bridge/utils/quote.ts
+++ b/ui/pages/bridge/utils/quote.ts
@@ -1,8 +1,18 @@
 import { BigNumber } from 'bignumber.js';
-import { type QuoteResponse } from '@metamask/bridge-controller';
+import {
+  type QuoteResponse,
+  isSolanaChainId,
+  formatChainIdToCaip,
+  isNativeAddress,
+} from '@metamask/bridge-controller';
+import type {
+  NetworkConfiguration,
+  AddNetworkFields,
+} from '@metamask/network-controller';
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
 import { DEFAULT_PRECISION } from '../../../hooks/useCurrencyDisplay';
 import { formatAmount } from '../../confirmations/components/simulation-details/formatAmount';
+import type { BridgeToken } from '../../../ducks/bridge/types';
 
 export const formatTokenAmount = (
   locale: string,
@@ -39,3 +49,54 @@ export const formatProviderLabel = (args?: {
   bridgeId: QuoteResponse['quote']['bridgeId'];
   bridges: QuoteResponse['quote']['bridges'];
 }): `${string}_${string}` => `${args?.bridgeId}_${args?.bridges[0]}`;
+
+export const isQuoteExpiredOrInvalid = ({
+  activeQuote,
+  toToken,
+  toChain,
+  fromChain,
+  isQuoteExpired,
+  insufficientBal,
+}: {
+  activeQuote: QuoteResponse | null;
+  toToken: BridgeToken | null;
+  toChain?: NetworkConfiguration | AddNetworkFields;
+  fromChain?: NetworkConfiguration;
+  isQuoteExpired: boolean;
+  insufficientBal?: boolean;
+}): boolean => {
+  // 1. Ignore quotes that are expired (unless the only reason is an `insufficientBal` override for non-Solana chains)
+  if (
+    isQuoteExpired &&
+    (!insufficientBal ||
+      // `insufficientBal` is always true for Solana
+      (fromChain && isSolanaChainId(fromChain.chainId)))
+  ) {
+    return true;
+  }
+
+  // 2. Ensure the quote still matches the currently selected destination asset / chain
+  if (activeQuote && toToken) {
+    const quoteDestAddress =
+      activeQuote.quote?.destAsset?.address?.toLowerCase() || '';
+    const selectedDestAddress = toToken.address?.toLowerCase() || '';
+
+    const quoteDestChainIdCaip = activeQuote.quote?.destChainId
+      ? formatChainIdToCaip(activeQuote.quote.destChainId)
+      : '';
+    const selectedDestChainIdCaip = toChain?.chainId
+      ? formatChainIdToCaip(toChain.chainId)
+      : '';
+
+    return !(
+      (quoteDestAddress === selectedDestAddress ||
+        // Extension's native asset address may be different from bridge-api's native
+        // asset address so if both assets are native, we should still return true
+        (isNativeAddress(quoteDestAddress) &&
+          isNativeAddress(selectedDestAddress))) &&
+      quoteDestChainIdCaip === selectedDestChainIdCaip
+    );
+  }
+
+  return false;
+};

--- a/ui/pages/bridge/utils/quote.ts
+++ b/ui/pages/bridge/utils/quote.ts
@@ -4,6 +4,7 @@ import {
   isSolanaChainId,
   formatChainIdToCaip,
   isNativeAddress,
+  type BridgeToken,
 } from '@metamask/bridge-controller';
 import type {
   NetworkConfiguration,
@@ -12,7 +13,6 @@ import type {
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
 import { DEFAULT_PRECISION } from '../../../hooks/useCurrencyDisplay';
 import { formatAmount } from '../../confirmations/components/simulation-details/formatAmount';
-import type { BridgeToken } from '../../../ducks/bridge/types';
 
 export const formatTokenAmount = (
   locale: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,7 +5125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^18.0.0":
+"@metamask/bridge-controller@npm:18.0.0":
   version: 18.0.0
   resolution: "@metamask/bridge-controller@npm:18.0.0"
   dependencies:
@@ -5151,6 +5151,35 @@ __metadata:
     "@metamask/snaps-controllers": ^11.0.0
     "@metamask/transaction-controller": ^54.0.0
   checksum: 10/8178599c0f712bc4ed47c9fe870f5ce1b927efeb939e3ac64719394c8bd3f2a12ec64dc1c404f4f5efe74d6fe58a13469e16e90290d311251c8a073e0d0aa08c
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A18.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-18.0.0-d2f6e87282.patch":
+  version: 18.0.0
+  resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A18.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-18.0.0-d2f6e87282.patch::version=18.0.0&hash=9d9a85"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/base-controller": "npm:^8.0.0"
+    "@metamask/controller-utils": "npm:^11.7.0"
+    "@metamask/gas-fee-controller": "npm:^23.0.0"
+    "@metamask/keyring-api": "npm:^17.4.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^0.5.1"
+    "@metamask/polling-controller": "npm:^13.0.0"
+    "@metamask/utils": "npm:^11.2.0"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+  peerDependencies:
+    "@metamask/accounts-controller": ^27.0.0
+    "@metamask/assets-controllers": ^59.0.0
+    "@metamask/network-controller": ^23.0.0
+    "@metamask/snaps-controllers": ^11.0.0
+    "@metamask/transaction-controller": ^54.0.0
+  checksum: 10/fa3c3f0c63a7f07a9af94824d7f5e556a9ce6dd213a446955e871e9bf1409194d47c50ff8c8a2e38468449782627dcd98bf461589984217a4214f855c4ddf877
   languageName: node
   linkType: hard
 
@@ -30077,7 +30106,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^2.1.0"
     "@metamask/base-controller": "npm:^8.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^0.9.0"
-    "@metamask/bridge-controller": "npm:^18.0.0"
+    "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A18.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-18.0.0-d2f6e87282.patch"
     "@metamask/bridge-status-controller": "npm:^20.0.0"
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^3.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Cherry pick https://github.com/MetaMask/metamask-extension/pull/32878
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32944?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
