### PR TITLE
test: Add E2E coverage for initialConnections

### DIFF
--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -7,9 +7,8 @@ import { withFixtures, WINDOW_TITLES } from '../../helpers';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PreinstalledExampleSettings from '../../page-objects/pages/settings/preinstalled-example-settings';
 import { TestSnaps } from '../../page-objects/pages/test-snaps';
-import SnapInstall from '../../page-objects/pages/dialog/snap-install';
 
-describe('Pre-install example', function () {
+describe('Preinstalled example Snap', function () {
   it('can display the Snap settings page', async function () {
     await withFixtures(
       {
@@ -31,13 +30,10 @@ describe('Pre-install example', function () {
         );
         await preInstalledExample.check_selectedDropdownOption('Option 2');
 
-        // Navigate to `test-snaps` page, click connect Preinstalled button, connect and approve
+        // Navigate to `test-snaps` page, we don't need to connect because the Snap uses
+        // initialConnections to pre-approve the dapp.
         const testSnaps = new TestSnaps(driver);
-        const snapInstall = new SnapInstall(driver);
         await testSnaps.openPage();
-        await testSnaps.scrollAndClickButton('connectPreinstalledButton');
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await snapInstall.clickConnectButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
         await testSnaps.clickButton('getSettingsStateButton');
         const jsonTextValidation = '"setting1": true';
@@ -45,6 +41,31 @@ describe('Pre-install example', function () {
           'rpcResultSpan',
           jsonTextValidation,
         );
+      },
+    );
+  });
+
+  it('can use initialConnections to allow JSON-RPC', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+
+        const testSnaps = new TestSnaps(driver);
+        await testSnaps.openPage();
+
+        // This test clicks this button without connecting and functions as E2E
+        // for the initialConnections functionality.
+        await testSnaps.scrollAndClickButton('showPreinstalledDialogButton');
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        await driver.waitForSelector({
+          css: '.snap-ui-renderer__text',
+          text: 'This is a custom dialog. It has a custom footer and can be resolved to any value.'
+        })
       },
     );
   });

--- a/test/e2e/page-objects/pages/test-snaps.ts
+++ b/test/e2e/page-objects/pages/test-snaps.ts
@@ -80,6 +80,7 @@ export const buttonLocator = {
   sendUnencryptedStateButton: '#sendUnencryptedState',
   sendGetUnencryptedStateButton: '#sendGetUnencryptedState',
   clearStateUnencryptedButton: '#clearStateUnencrypted',
+  showPreinstalledDialogButton: '#showPreinstalledDialog',
 } satisfies Record<string, string>;
 
 const spanLocator = {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds E2E coverage for `initialConnections` by using the preinstalled example Snap which has had `initialConnections` functionality added and fixes some older E2Es.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32954?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24718

