### PR TITLE
fix: Rejecting account upgrade

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../../../../shared/constants/app';
 import {
   AssetType,
-  EIP5792ErrorCode,
   TokenStandard,
   TransactionMetaMetricsEvent,
 } from '../../../../shared/constants/transaction';
@@ -1194,7 +1193,7 @@ describe('Transaction metrics', () => {
             authorizationList: [{}],
           },
           error: {
-            code: EIP5792ErrorCode.RejectedUpgrade,
+            code: 4001,
           },
           status: TransactionStatus.rejected,
         } as unknown as TransactionMeta,

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -23,7 +23,6 @@ import {
   MetaMetricsEventTransactionEstimateType,
 } from '../../../../shared/constants/metametrics';
 import {
-  EIP5792ErrorCode,
   TokenStandard,
   TransactionApprovalAmountType,
   TransactionMetaMetricsEvent,
@@ -1252,7 +1251,7 @@ async function addBatchProperties(
 
     properties.eip7702_upgrade_rejection =
       // @ts-expect-error Code has string type in controller
-      isUpgrade && error.code === EIP5792ErrorCode.RejectedUpgrade;
+      isUpgrade && error.code === 4001; // user rejected request
   }
 
   properties.eip7702_upgrade_transaction = isUpgrade;

--- a/ui/pages/confirmations/hooks/useSmartAccountActions.ts
+++ b/ui/pages/confirmations/hooks/useSmartAccountActions.ts
@@ -1,11 +1,9 @@
+import { providerErrors, serializeError } from '@metamask/rpc-errors';
 import { TransactionMeta } from '@metamask/transaction-controller';
-import { JsonRpcError, serializeError } from '@metamask/rpc-errors';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-
 import { rejectPendingApproval } from '../../../store/actions';
 import { useConfirmContext } from '../context/confirm';
-import { EIP5792ErrorCode } from '../../../../shared/constants/transaction';
 
 export function useSmartAccountActions() {
   const dispatch = useDispatch();
@@ -18,10 +16,7 @@ export function useSmartAccountActions() {
       return;
     }
 
-    const error = new JsonRpcError(
-      EIP5792ErrorCode.RejectedUpgrade,
-      'User rejected account upgrade',
-    );
+    const error = providerErrors.userRejectedRequest();
 
     const serializedError = serializeError(error);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Previously, when clicking "Don't use smart account" on the upgrade modal, the error that was set `EIP5792ErrorCode.RejectedUpgrade` didn't correctly reject the transaction. Instead, it was marked as finalised. Using the `userRejectedRequest` error code (4001), the transaction is now correctly rejected.

When canceling the confirmation, the transaction was already correctly rejected, but now it also includes the `eip7702_upgrade_rejection: true` property.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32960?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4878

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1200" alt="Screenshot 2025-05-15 at 12 06 38" src="https://github.com/user-attachments/assets/5deeb17f-24d5-44f3-bf37-30b3fa05e9ff" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
