### PR TITLE
fix: flaky test `Multichain API Calling wallet_invokeMethod on the same dapp across three different connected chains Write operations: calling eth_sendTransaction` on each connected scope should match chosen addresses in each chain to the selected address`

### DIFF
--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -90,7 +90,10 @@ export const addAccountInWalletAndAuthorize = async (
   await checkboxes[0].click(); // select all checkbox
   await driver.delay(regularDelayMs);
 
-  await driver.clickElement({ text: 'Update', tag: 'button' });
+  await driver.clickElementAndWaitToDisappear({
+    text: 'Update',
+    tag: 'button',
+  });
 };
 
 /**

--- a/test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts
@@ -73,17 +73,10 @@ describe('Multichain API', function () {
                 `[data-testid="invoke-method-${scope}-btn"]`,
               );
 
-              const resultElement = await driver.findElement(
-                `#invoke-method-${escapeColon(scope)}-${invokeMethod}-result-0`,
-              );
-
-              const result = await resultElement.getText();
-
-              assert.strictEqual(
-                result,
-                `"${EXPECTED_RESULTS[scope]}"`,
-                `${scope} method ${invokeMethod} expected "${EXPECTED_RESULTS[scope]}", got ${result} instead`,
-              );
+              await driver.waitForSelector({
+                css: `[id="invoke-method-${scope}-${invokeMethod}-result-0"]`,
+                text: `"${EXPECTED_RESULTS[scope]}"`,
+              });
             }
           },
         );
@@ -201,7 +194,7 @@ describe('Multichain API', function () {
             for (let i = 0; i < totalNumberOfScopes; i++) {
               await driver.delay(largeDelayMs);
               await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-              await driver.clickElementAndWaitForWindowToClose({
+              await driver.clickElement({
                 text: 'Confirm',
                 tag: 'button',
               });

--- a/test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts
@@ -200,6 +200,7 @@ describe('Multichain API', function () {
               });
             }
 
+            await driver.delay(largeDelayMs);
             await driver.switchToWindowWithTitle(
               WINDOW_TITLES.MultichainTestDApp,
             );

--- a/test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts
@@ -108,9 +108,11 @@ describe('Multichain API', function () {
             await testDapp.connectExternallyConnectable(extensionId);
             await testDapp.initCreateSessionScopes(GANACHE_SCOPES, ACCOUNTS);
             await addAccountInWalletAndAuthorize(driver);
-            await driver.clickElement({ text: 'Connect', tag: 'button' });
+            await driver.clickElementAndWaitForWindowToClose({
+              text: 'Connect',
+              tag: 'button',
+            });
 
-            await driver.delay(largeDelayMs);
             await driver.switchToWindowWithTitle(
               WINDOW_TITLES.MultichainTestDApp,
             );
@@ -135,18 +137,13 @@ describe('Multichain API', function () {
               await driver.delay(largeDelayMs);
               await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-              const accountWebElement = await driver.findElement(
-                '[data-testid="sender-address"]',
-              );
-              const accountText = await accountWebElement.getText();
               const expectedAccount =
                 i === INDEX_FOR_ALTERNATE_ACCOUNT ? 'Account 2' : 'Account 1';
 
-              assert.strictEqual(
-                accountText,
-                expectedAccount,
-                `Should have ${expectedAccount} selected, got ${accountText}`,
-              );
+              await driver.waitForSelector({
+                tesId: 'sender-address',
+                text: expectedAccount,
+              });
 
               await driver.clickElement({
                 text: 'Confirm',

--- a/test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts
@@ -44,8 +44,10 @@ describe('Multichain API', function () {
             await testDapp.connectExternallyConnectable(extensionId);
             await testDapp.initCreateSessionScopes(GANACHE_SCOPES, ACCOUNTS);
             await addAccountInWalletAndAuthorize(driver);
-            await driver.clickElement({ text: 'Connect', tag: 'button' });
-            await driver.delay(largeDelayMs);
+            await driver.clickElementAndWaitForWindowToClose({
+              text: 'Connect',
+              tag: 'button',
+            });
             await driver.switchToWindowWithTitle(
               WINDOW_TITLES.MultichainTestDApp,
             );
@@ -171,9 +173,10 @@ describe('Multichain API', function () {
             await testDapp.connectExternallyConnectable(extensionId);
             await testDapp.initCreateSessionScopes(GANACHE_SCOPES, ACCOUNTS);
             await addAccountInWalletAndAuthorize(driver);
-            await driver.clickElement({ text: 'Connect', tag: 'button' });
-
-            await driver.delay(largeDelayMs);
+            await driver.clickElementAndWaitForWindowToClose({
+              text: 'Connect',
+              tag: 'button',
+            });
             await driver.switchToWindowWithTitle(
               WINDOW_TITLES.MultichainTestDApp,
             );
@@ -198,13 +201,12 @@ describe('Multichain API', function () {
             for (let i = 0; i < totalNumberOfScopes; i++) {
               await driver.delay(largeDelayMs);
               await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-              await driver.clickElement({
+              await driver.clickElementAndWaitForWindowToClose({
                 text: 'Confirm',
                 tag: 'button',
               });
             }
 
-            await driver.delay(largeDelayMs);
             await driver.switchToWindowWithTitle(
               WINDOW_TITLES.MultichainTestDApp,
             );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes flakiness due to using the anti-pattern `await element.getText();` and then asserting for our expected value.

This causes that sometimes, when we assert, the value for that element is not yet loaded, and the previous one is asserted, which makes the test fail:

```js
AssertionError [ERR_ASSERTION]: Should have Account 2 selected, got Account 1
+ actual - expected

+ 'Account 1'
- 'Account 2'
           ^

    at <anonymous> (test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts:145:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async withFixtures (test/e2e/helpers.js:306:5)
    at async Context.<anonymous> (test/e2e/flask/multichain-api/wallet_invokeMethod.spec.ts:95:9)

      + expected - actual

      -Account 1
      +Account 2
```


It also adds a couple of more tweaks to make the test more robust in relation to windows.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32962?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32961

## **Manual testing steps**

1. e2e should pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
