### PR TITLE
test: Wait for login to finish

### DIFF
--- a/test/e2e/page-objects/flows/login.flow.ts
+++ b/test/e2e/page-objects/flows/login.flow.ts
@@ -19,6 +19,10 @@ export const loginWithoutBalanceValidation = async (
   const loginPage = new LoginPage(driver);
   await loginPage.check_pageIsLoaded();
   await loginPage.loginToHomepage(password);
+
+  // user should land on homepage after successfully logging in with password
+  const homePage = new HomePage(driver);
+  await homePage.check_pageIsLoaded();
 };
 
 /**
@@ -34,10 +38,8 @@ export const loginWithBalanceValidation = async (
   password?: string,
 ) => {
   await loginWithoutBalanceValidation(driver, password);
-  // user should land on homepage after successfully logging in with password
-  const homePage = new HomePage(driver);
-  await homePage.check_pageIsLoaded();
 
+  const homePage = new HomePage(driver);
   // Verify the expected balance on the homepage
   if (localNode) {
     await homePage.check_localNodeBalanceIsDisplayed(localNode);

--- a/test/e2e/page-objects/flows/login.flow.ts
+++ b/test/e2e/page-objects/flows/login.flow.ts
@@ -19,10 +19,6 @@ export const loginWithoutBalanceValidation = async (
   const loginPage = new LoginPage(driver);
   await loginPage.check_pageIsLoaded();
   await loginPage.loginToHomepage(password);
-
-  // user should land on homepage after successfully logging in with password
-  const homePage = new HomePage(driver);
-  await homePage.check_pageIsLoaded();
 };
 
 /**
@@ -38,8 +34,10 @@ export const loginWithBalanceValidation = async (
   password?: string,
 ) => {
   await loginWithoutBalanceValidation(driver, password);
-
+  // user should land on homepage after successfully logging in with password
   const homePage = new HomePage(driver);
+  await homePage.check_pageIsLoaded();
+
   // Verify the expected balance on the homepage
   if (localNode) {
     await homePage.check_localNodeBalanceIsDisplayed(localNode);

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -1,6 +1,6 @@
 import { TestSnaps } from '../page-objects/pages/test-snaps';
 import { Driver } from '../webdriver/driver';
-import { loginWithoutBalanceValidation } from '../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
 import { withFixtures } from '../helpers';
 import { switchAndApproveDialogSwitchToTestSnap } from '../page-objects/flows/snap-permission.flow';
@@ -29,7 +29,8 @@ describe('Test Snap bip-32', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        // We explicitly choose to await balances to prevent flakiness due to long login times.
+        await loginWithBalanceValidation(driver);
 
         const testSnaps = new TestSnaps(driver);
 

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -1,6 +1,6 @@
 import { TestSnaps } from '../page-objects/pages/test-snaps';
 import { Driver } from '../webdriver/driver';
-import { loginWithoutBalanceValidation } from '../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
 import { withFixtures } from '../helpers';
 import { switchAndApproveDialogSwitchToTestSnap } from '../page-objects/flows/snap-permission.flow';
@@ -23,7 +23,8 @@ describe('Test Snap bip-44', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        // We explicitly choose to await balances to prevent flakiness due to long login times.
+        await loginWithBalanceValidation(driver);
 
         const testSnaps = new TestSnaps(driver);
 

--- a/test/e2e/snaps/test-snap-get-entropy.spec.ts
+++ b/test/e2e/snaps/test-snap-get-entropy.spec.ts
@@ -2,7 +2,7 @@ import { Suite } from 'mocha';
 import { Driver } from '../webdriver/driver';
 import { withFixtures } from '../helpers';
 import FixtureBuilder from '../fixture-builder';
-import { loginWithoutBalanceValidation } from '../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import { TestSnaps } from '../page-objects/pages/test-snaps';
 import { switchAndApproveDialogSwitchToTestSnap } from '../page-objects/flows/snap-permission.flow';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
@@ -22,7 +22,8 @@ describe('Test Snap getEntropy', function (this: Suite) {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        // We explicitly choose to await balances to prevent flakiness due to long login times.
+        await loginWithBalanceValidation(driver);
 
         const testSnaps = new TestSnaps(driver);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Attempt to prevent flakiness in tests that use `withKeyringControllerMultiSRP` which seems to add more login time. Swapping out `loginWithoutBalanceValidation` for `loginWithBalanceValidation`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32974?quickstart=1)
