### PR TITLE
fix: cp-12.18.0 Skip metrics on RPC calls made by preinstalled Snaps

### DIFF
--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -29,8 +29,8 @@ import {
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { shouldUseRedesignForSignatures } from '../../../shared/lib/confirmation.utils';
-import { getSnapAndHardwareInfoForMetrics } from './snap-keyring/metrics';
 import { isSnapPreinstalled } from '../../../shared/lib/snaps/snaps';
+import { getSnapAndHardwareInfoForMetrics } from './snap-keyring/metrics';
 
 /**
  * These types determine how the method tracking middleware handles incoming

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -30,6 +30,7 @@ import {
 // eslint-disable-next-line import/no-restricted-paths
 import { shouldUseRedesignForSignatures } from '../../../shared/lib/confirmation.utils';
 import { getSnapAndHardwareInfoForMetrics } from './snap-keyring/metrics';
+import { isSnapPreinstalled } from '../../../shared/lib/snaps/snaps';
 
 /**
  * These types determine how the method tracking middleware handles incoming
@@ -332,10 +333,14 @@ export default function createRPCMethodTrackingMiddleware({
 
     let sensitiveEventProperties;
 
+    const isPreinstalledSnap = isSnapPreinstalled(origin);
+
     // Boolean variable that reduces code duplication and increases legibility
     const shouldTrackEvent =
       // Don't track if the request came from our own UI or background
       origin !== ORIGIN_METAMASK &&
+      // Don't track requests coming from preinstalled Snaps
+      !isPreinstalledSnap &&
       // Don't track if the rate limit has been hit
       !isRateLimited &&
       // Don't track if the global rate limit has been hit


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Skip collecting metrics on RPC calls made by preinstalled Snaps as they may be a bit excessive.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/32977?quickstart=1)
