### PR TITLE
feat: updated portfolio button to discover

### DIFF
--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -297,7 +297,7 @@ export const CoinOverview = ({
           data-testid="portfolio-link"
           textProps={{ variant: TextVariant.bodyMdMedium }}
         >
-          {t('portfolio')}
+          {process.env.REMOVE_GNS ? t('discover') : t('portfolio')}
         </ButtonLink>
       );
       ///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
This PR is to change the portfolio button text to Discover

## **Related issues**

Fixes: [https://github.com/MetaMask/MetaMask-planning/issues/4850](https://github.com/MetaMask/MetaMask-planning/issues/4850
)
## **Manual testing steps**

1. Run extension with `process.env.REMOVE_GNS yarn start`
2. Go to homepage, check the portfolio button is called discover now


## **Screenshots/Recordings**


### **Before**
![Screenshot 2025-05-15 at 10 02 59 PM](https://github.com/user-attachments/assets/c8862d2d-4fa1-47f4-9a36-c3f55bff3404)


### **After**
![Screenshot 2025-05-15 at 10 02 38 PM](https://github.com/user-attachments/assets/759e2887-c38d-4f5b-8fa0-16f4412aaf00)


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.



## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
