### PR TITLE
fix: cp-12.18.0 duplicate accounts on srp select

### DIFF
--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -491,7 +491,9 @@
               "type": "HD Key Tree"
             }
           },
-          "options": {},
+          "options": {
+            "entropySource": "01JKAF3DSGM3AB87EM9N0K41AJ"
+          },
           "methods": [
             "personal_sign",
             "eth_signTransaction",
@@ -512,7 +514,9 @@
               "type": "HD Key Tree"
             }
           },
-          "options": {},
+          "options": {
+            "entropySource": "01JKAF3DSGM3AB87EM9N0K41AJ"
+          },
           "methods": [
             "personal_sign",
             "eth_signTransaction",
@@ -554,7 +558,9 @@
               "type": "HD Key Tree"
             }
           },
-          "options": {},
+          "options": {
+            "entropySource": "01JKAF3PJ247KAM6C03G5Q0NP8"
+          },
           "methods": [
             "personal_sign",
             "eth_signTransaction",

--- a/ui/components/multichain/multi-srp/srp-list/srp-list.test.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list.test.tsx
@@ -6,6 +6,7 @@ import { KeyringTypes } from '@metamask/keyring-controller';
 import { renderWithProvider } from '../../../../../test/jest/rendering';
 import mockState from '../../../../../test/data/mock-state.json';
 import { InternalAccountWithBalance } from '../../../../selectors';
+import { shortenAddress } from '../../../../helpers/utils/util';
 import { SrpList } from './srp-list';
 
 const mockTotalFiatBalance = '100';
@@ -67,5 +68,25 @@ describe('SrpList', () => {
     fireEvent.click(keyring);
 
     expect(mocks.onActionComplete).toHaveBeenCalledWith(firstKeyringId);
+  });
+
+  it('displays the correct accounts for a keyring and ensures no duplicates', () => {
+    const { getByText, getAllByText } = render();
+    const firstKeyringAccounts = mockState.metamask.keyrings[0].accounts;
+    const account1Address = firstKeyringAccounts[0];
+    const account2Address = firstKeyringAccounts[1];
+
+    const showAccountsButton = getByText('Show 2 accounts');
+    fireEvent.click(showAccountsButton);
+
+    const shortenedAccount1 = shortenAddress(account1Address);
+    const shortenedAccount2 = shortenAddress(account2Address);
+
+    expect(getByText(shortenedAccount1)).toBeInTheDocument();
+    expect(getByText(shortenedAccount2)).toBeInTheDocument();
+
+    // Ensure no duplicates by checking the count of each shortened address.
+    expect(getAllByText(shortenedAccount1).length).toBe(1);
+    expect(getAllByText(shortenedAccount2).length).toBe(1);
   });
 });

--- a/ui/hooks/multi-srp/useHdKeyringsWithSnapAccounts.test.ts
+++ b/ui/hooks/multi-srp/useHdKeyringsWithSnapAccounts.test.ts
@@ -22,12 +22,14 @@ const mockFirstPartySnapAccount = createMockInternalAccount({
   options: {
     entropySource: 'keyring1',
   },
+  keyringType: KeyringTypes.snap,
 });
 
 const mockSnapAccount2 = createMockInternalAccount({
   address: '',
   name: 'Second Party Snap Account',
   options: {},
+  keyringType: KeyringTypes.snap,
 });
 
 const mockHdKeyring = {

--- a/ui/hooks/multi-srp/useHdKeyringsWithSnapAccounts.test.ts
+++ b/ui/hooks/multi-srp/useHdKeyringsWithSnapAccounts.test.ts
@@ -4,6 +4,7 @@ import { getMetaMaskHdKeyrings } from '../../selectors';
 import { getInternalAccounts } from '../../selectors/accounts';
 import { createMockInternalAccount } from '../../../test/jest/mocks';
 import mockState from '../../../test/data/mock-state.json';
+import { isSnapPreinstalled } from '../../../shared/lib/snaps/snaps';
 import { useHdKeyringsWithSnapAccounts } from './useHdKeyringsWithSnapAccounts';
 
 const mockHdAccount = createMockInternalAccount({
@@ -58,8 +59,15 @@ jest.mock('../../selectors/accounts', () => ({
   getInternalAccounts: jest.fn(),
 }));
 
+jest.mock('../../../shared/lib/snaps/snaps', () => ({
+  ...jest.requireActual('../../../shared/lib/snaps/snaps'),
+  isSnapPreinstalled: jest.fn(),
+}));
+
 const mockGetMetaMaskHdKeyrings = getMetaMaskHdKeyrings as unknown as jest.Mock;
 const mockGetInternalAccounts = getInternalAccounts as unknown as jest.Mock;
+const mockIsSnapPreinstalled = isSnapPreinstalled as unknown as jest.Mock;
+
 describe('useHdKeyringsWithSnapAccounts', () => {
   beforeEach(() => {
     mockGetMetaMaskHdKeyrings.mockReturnValue([mockHdKeyring, mockHdKeyring2]);
@@ -69,6 +77,7 @@ describe('useHdKeyringsWithSnapAccounts', () => {
       mockFirstPartySnapAccount,
       mockSnapAccount2,
     ]);
+    mockIsSnapPreinstalled.mockReturnValue(true);
   });
 
   it('includes snap accounts that have a matching entropy source', () => {

--- a/ui/hooks/multi-srp/useHdKeyringsWithSnapAccounts.ts
+++ b/ui/hooks/multi-srp/useHdKeyringsWithSnapAccounts.ts
@@ -2,8 +2,10 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { KeyringMetadata, KeyringObject } from '@metamask/keyring-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
+import { SnapId } from '@metamask/snaps-sdk';
 import { getInternalAccounts } from '../../selectors/accounts';
 import { getMetaMaskHdKeyrings } from '../../selectors';
+import { isSnapPreinstalled } from '../../../shared/lib/snaps/snaps';
 
 // TODO: Move this data type to the @metamask/keyring-controller module
 type KeyringObjectWithMetadata = KeyringObject & { metadata: KeyringMetadata };
@@ -24,7 +26,8 @@ export const useHdKeyringsWithSnapAccounts = () => {
       const firstPartySnapAccounts = internalAccounts
         .filter(
           (account: InternalAccount) =>
-            account.metadata.snap?.id &&
+            account.metadata.snap &&
+            isSnapPreinstalled(account.metadata.snap.id as SnapId) &&
             account.options?.entropySource === keyring.metadata.id,
         )
         .map((account: InternalAccount) => account.address);

--- a/ui/hooks/multi-srp/useHdKeyringsWithSnapAccounts.ts
+++ b/ui/hooks/multi-srp/useHdKeyringsWithSnapAccounts.ts
@@ -18,11 +18,13 @@ export const useHdKeyringsWithSnapAccounts = () => {
     getMetaMaskHdKeyrings,
   );
   const internalAccounts = useSelector(getInternalAccounts);
+
   return useMemo(() => {
     return hdKeyrings.map((keyring) => {
       const firstPartySnapAccounts = internalAccounts
         .filter(
           (account: InternalAccount) =>
+            account.metadata.snap?.id &&
             account.options?.entropySource === keyring.metadata.id,
         )
         .map((account: InternalAccount) => account.address);

--- a/ui/selectors/accounts.test.ts
+++ b/ui/selectors/accounts.test.ts
@@ -56,7 +56,9 @@ describe('Accounts Selectors', () => {
             type: 'HD Key Tree',
           },
         },
-        options: {},
+        options: {
+          entropySource: '01JKAF3DSGM3AB87EM9N0K41AJ',
+        },
         methods: [
           'personal_sign',
           'eth_signTransaction',

--- a/ui/selectors/multi-srp/multi-srp.ts
+++ b/ui/selectors/multi-srp/multi-srp.ts
@@ -109,6 +109,7 @@ export const getSnapAccountsByKeyringId = createDeepEqualSelector(
   (accounts, keyringId) => {
     return accounts.filter(
       (account: InternalAccount) =>
+        account.metadata.snap?.id &&
         account.options?.entropySource === keyringId,
     );
   },

--- a/ui/selectors/multi-srp/multi-srp.ts
+++ b/ui/selectors/multi-srp/multi-srp.ts
@@ -11,6 +11,7 @@ import { createDeepEqualSelector } from '../../../shared/modules/selectors/util'
 import { getMultichainAggregatedBalance } from '../assets';
 import { isMultichainWalletSnap } from '../../../shared/lib/accounts/snaps';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
+import { isSnapPreinstalled } from '../../../shared/lib/snaps/snaps';
 
 type AccountsByChainId = {
   [chainId: string]: {
@@ -109,7 +110,8 @@ export const getSnapAccountsByKeyringId = createDeepEqualSelector(
   (accounts, keyringId) => {
     return accounts.filter(
       (account: InternalAccount) =>
-        account.metadata.snap?.id &&
+        account.metadata.snap &&
+        isSnapPreinstalled(account.metadata.snap.id as SnapId) &&
         account.options?.entropySource === keyringId,
     );
   },

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -1427,7 +1427,9 @@ describe('Selectors', () => {
             type: 'HD Key Tree',
           },
         },
-        options: {},
+        options: {
+          entropySource: '01JKAF3DSGM3AB87EM9N0K41AJ',
+        },
         methods: [
           'personal_sign',
           'eth_signTransaction',
@@ -1453,7 +1455,9 @@ describe('Selectors', () => {
             type: 'HD Key Tree',
           },
         },
-        options: {},
+        options: {
+          entropySource: '01JKAF3PJ247KAM6C03G5Q0NP8',
+        },
         methods: [
           'personal_sign',
           'eth_signTransaction',
@@ -1478,7 +1482,9 @@ describe('Selectors', () => {
             type: 'HD Key Tree',
           },
         },
-        options: {},
+        options: {
+          entropySource: '01JKAF3DSGM3AB87EM9N0K41AJ',
+        },
         methods: [
           'personal_sign',
           'eth_signTransaction',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes duplicate account returned by some selectors. `entropySource` has been added to hd keyring accounts, but several selectors and tests have not beed updated.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32984

## **Manual testing steps**

1. Open fresh MM
2. Import second SRP
3. Notice that ETH Accounts are doubled

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="353" alt="Screenshot 2025-05-16 at 11 40 13" src="https://github.com/user-attachments/assets/2ab96a28-b736-4eb1-b377-55a3cb1ba486" />

<!-- [screenshots/recordings] -->

### **After**
<img width="351" alt="Screenshot 2025-05-16 at 11 42 06" src="https://github.com/user-attachments/assets/8abfc2de-2110-4099-9c29-34acf56e9604" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
