### PR TITLE
chore: Add send flow to Confirmations ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,7 @@ app/scripts/lib/transaction/decode                                @MetaMask/conf
 app/scripts/lib/transaction/metrics.*                             @MetaMask/confirmations
 app/scripts/lib/transaction/util.*                                @MetaMask/confirmations
 ui/pages/confirmations                                            @MetaMask/confirmations
+ui/components/multichain/pages/send                               @MetaMask/confirmations
 
 # Design System to own code for the component-library folder
 # Slack handle: @metamask-design-system-team | Slack channel: #metamask-design-system

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,16 +60,6 @@ development/circular-deps.jsonc      @MetaMask/extension-security-team @HowardBr
 # who were involved with the Codespaces project.
 .devcontainer/                       @MetaMask/extension-security-team @HowardBraham
 
-# Confirmations team to own code for confirmations on UI.
-app/scripts/controller-init/confirmations                         @MetaMask/confirmations
-app/scripts/lib/ppom                                              @MetaMask/confirmations
-app/scripts/lib/signature                                         @MetaMask/confirmations
-app/scripts/lib/transaction/decode                                @MetaMask/confirmations
-app/scripts/lib/transaction/metrics.*                             @MetaMask/confirmations
-app/scripts/lib/transaction/util.*                                @MetaMask/confirmations
-ui/pages/confirmations                                            @MetaMask/confirmations
-ui/components/multichain/pages/send                               @MetaMask/confirmations
-
 # Design System to own code for the component-library folder
 # Slack handle: @metamask-design-system-team | Slack channel: #metamask-design-system
 ui/components/component-library      @MetaMask/design-system-engineers
@@ -89,7 +79,6 @@ ui/components/component-library      @MetaMask/design-system-engineers
 # Identity team is responsible for authentication and backup and sync inside the Extension.
 # Slack handle: @identity_team | Slack channel: #metamask-identity
 **/identity/**                                          @MetaMask/identity
-
 
 # Accounts team is responsible for code related with snap management accounts
 # Slack handle: @accounts-team-devs | Slack channel: #metamask-accounts-team
@@ -122,6 +111,16 @@ ui/components/app/whats-new-popup     @MetaMask/wallet-ux
 ui/css                                @MetaMask/wallet-ux
 ui/pages/home                         @MetaMask/wallet-ux
 ui/pages/onboarding-flow              @MetaMask/wallet-ux
+
+# Confirmations team to own code for confirmations on UI.
+app/scripts/controller-init/confirmations                         @MetaMask/confirmations
+app/scripts/lib/ppom                                              @MetaMask/confirmations
+app/scripts/lib/signature                                         @MetaMask/confirmations
+app/scripts/lib/transaction/decode                                @MetaMask/confirmations
+app/scripts/lib/transaction/metrics.*                             @MetaMask/confirmations
+app/scripts/lib/transaction/util.*                                @MetaMask/confirmations
+ui/pages/confirmations                                            @MetaMask/confirmations
+ui/components/multichain/pages/send                               @MetaMask/confirmations
 
 # Assets
 ui/components/app/add-network                         @MetaMask/metamask-assets


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Since we want to override a specific folder inside of multichain that already belongs to the Wallet UX team, I moved the Confirmations rules to after the Wallet UX ones.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33023?quickstart=1)

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
