### PR TITLE
fix: "createSlice.extraReducers" warning

### DIFF
--- a/ui/ducks/alerts/unconnected-account.js
+++ b/ui/ducks/alerts/unconnected-account.js
@@ -64,13 +64,13 @@ const slice = createSlice({
       state.state = ALERT_STATE.OPEN;
     },
   },
-  extraReducers: {
-    [actionConstants.SELECTED_ADDRESS_CHANGED]: (state) => {
+  extraReducers: (builder) => {
+    builder.addCase(actionConstants.SELECTED_ADDRESS_CHANGED, (state) => {
       // close the alert if the account is switched while it's open
       if (state.state === ALERT_STATE.OPEN) {
         state.state = ALERT_STATE.CLOSED;
       }
-    },
+    });
   },
 });
 


### PR DESCRIPTION
## **Description**

Fixes this warning that happens in almost every unit test

```
console.warn
      The object notation for `createSlice.extraReducers` is deprecated, and will be removed in RTK 2.0. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createSlice

      15 | import confirmAlertsReducer from './confirm-alerts/confirm-alerts';
      16 |
    > 17 | export default combineReducers({
         |                               ^
      18 |   [AlertTypes.invalidCustomNetwork]: invalidCustomNetwork,
      19 |   [AlertTypes.unconnectedAccount]: unconnectedAccount,
      20 |   activeTab: (s) => (s === undefined ? null : s),

      at buildReducer (node_modules/@reduxjs/toolkit/src/createSlice.ts:356:21)
      at reducer (node_modules/@reduxjs/toolkit/src/createSlice.ts:379:23)
      at node_modules/redux/lib/redux.js:476:24
          at Array.forEach (<anonymous>)
      at assertReducerShape (node_modules/redux/lib/redux.js:474:25)
      at combineReducers (node_modules/redux/lib/redux.js:539:5)
      at Object.<anonymous> (ui/ducks/index.js:17:31)
      at Object.require (ui/store/store.ts:4:1)
      at Object.require (ui/components/multichain/account-list-item/account-list-item.test.js:6:1)
```
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33030?quickstart=1)

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->