### PR TITLE
fix: validate keyring type in EIP-5792 requests cp-12.18.1

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2180,6 +2180,7 @@ export default class MetamaskController extends EventEmitter {
           getDismissSmartAccountSuggestionEnabled: () =>
             this.preferencesController.state.preferences
               .dismissSmartAccountSuggestionEnabled,
+          getKeyringType: this.#getKeyringType.bind(this),
           isAtomicBatchSupported: this.txController.isAtomicBatchSupported.bind(
             this.txController,
           ),
@@ -2200,6 +2201,7 @@ export default class MetamaskController extends EventEmitter {
         getDismissSmartAccountSuggestionEnabled: () =>
           this.preferencesController.state.preferences
             .dismissSmartAccountSuggestionEnabled,
+        getKeyringType: this.#getKeyringType.bind(this),
         isAtomicBatchSupported: this.txController.isAtomicBatchSupported.bind(
           this.txController,
         ),
@@ -8727,6 +8729,16 @@ export default class MetamaskController extends EventEmitter {
    */
   #getGlobalNetworkClientId() {
     return this.networkController.state.selectedNetworkClientId;
+  }
+
+  #getKeyringType(accountAddress) {
+    const { accounts } = this.accountsController.state.internalAccounts;
+
+    const account = Object.values(accounts).find(
+      (acc) => acc.address === accountAddress.toLowerCase(),
+    );
+
+    return account?.metadata?.keyring?.type;
   }
 
   #initControllers({ existingControllers, initFunctions, initState }) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2180,7 +2180,6 @@ export default class MetamaskController extends EventEmitter {
           getDismissSmartAccountSuggestionEnabled: () =>
             this.preferencesController.state.preferences
               .dismissSmartAccountSuggestionEnabled,
-          getKeyringType: this.#getKeyringType.bind(this),
           isAtomicBatchSupported: this.txController.isAtomicBatchSupported.bind(
             this.txController,
           ),
@@ -2197,15 +2196,18 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
       ),
       getCallsStatus: getCallsStatus.bind(null, this.controllerMessenger),
-      getCapabilities: getCapabilities.bind(null, {
-        getDismissSmartAccountSuggestionEnabled: () =>
-          this.preferencesController.state.preferences
-            .dismissSmartAccountSuggestionEnabled,
-        getKeyringType: this.#getKeyringType.bind(this),
-        isAtomicBatchSupported: this.txController.isAtomicBatchSupported.bind(
-          this.txController,
-        ),
-      }),
+      getCapabilities: getCapabilities.bind(
+        null,
+        {
+          getDismissSmartAccountSuggestionEnabled: () =>
+            this.preferencesController.state.preferences
+              .dismissSmartAccountSuggestionEnabled,
+          isAtomicBatchSupported: this.txController.isAtomicBatchSupported.bind(
+            this.txController,
+          ),
+        },
+        this.controllerMessenger,
+      ),
     });
 
     // ensure isClientOpenAndUnlocked is updated when memState updates
@@ -8729,16 +8731,6 @@ export default class MetamaskController extends EventEmitter {
    */
   #getGlobalNetworkClientId() {
     return this.networkController.state.selectedNetworkClientId;
-  }
-
-  #getKeyringType(accountAddress) {
-    const { accounts } = this.accountsController.state.internalAccounts;
-
-    const account = Object.values(accounts).find(
-      (acc) => acc.address === accountAddress.toLowerCase(),
-    );
-
-    return account?.metadata?.keyring?.type;
   }
 
   #initControllers({ existingControllers, initFunctions, initState }) {


### PR DESCRIPTION
## **Description**

Validate if the account keyring is supported in `wallet_sendCalls` and `wallet_getCapabilities`.

Currently only supports `HD Key Tree` keyring type.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33034?quickstart=1)

## **Related issues**

Fixes [#4952](https://github.com/MetaMask/MetaMask-planning/issues/4952)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
