### PR TITLE
fix: Stop injecting the MMI Snap into the bundle

### DIFF
--- a/shared/lib/accounts/institutional-wallet-snap.ts
+++ b/shared/lib/accounts/institutional-wallet-snap.ts
@@ -1,8 +1,6 @@
 import { SnapId } from '@metamask/snaps-sdk';
-import InstitutionalWalletSnap from '@metamask/institutional-wallet-snap/dist/preinstalled-snap.json';
 
 export const INSTITUTIONAL_WALLET_SNAP_ID: SnapId =
-  InstitutionalWalletSnap.snapId as SnapId;
+  'npm:@metamask/institutional-wallet-snap' as SnapId;
 
-export const INSTITUTIONAL_WALLET_NAME: string =
-  InstitutionalWalletSnap.manifest.proposedName;
+export const INSTITUTIONAL_WALLET_NAME: string = 'Institutional Wallet';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Stop injecting the institutional Snap into the bundle since it isn't required for loading the Snap anymore following https://github.com/MetaMask/metamask-extension/pull/31320. This reduces the bundle size significantly.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33052?quickstart=1)
