### PR TITLE
chore: Bump `@metamask/snaps-controllers` from `^12.1.0` to `^12.2.0`

### DIFF
--- a/app/scripts/controller-init/messengers/snaps/snap-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/snaps/snap-controller-messenger.ts
@@ -37,6 +37,8 @@ import {
   KeyringControllerGetKeyringsByTypeAction,
   KeyringControllerLockEvent,
 } from '@metamask/keyring-controller';
+import { SelectedNetworkControllerGetNetworkClientIdForDomainAction } from '@metamask/selected-network-controller';
+import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 import { PreferencesControllerGetStateAction } from '../../../controllers/preferences-controller';
 
 type Actions =
@@ -64,7 +66,9 @@ type Actions =
   | Update
   | ResolveVersion
   | CreateInterface
-  | GetInterface;
+  | GetInterface
+  | SelectedNetworkControllerGetNetworkClientIdForDomainAction
+  | NetworkControllerGetNetworkClientByIdAction;
 
 type Events =
   | ErrorMessageEvent
@@ -114,12 +118,14 @@ export function getSnapControllerMessenger(
       'ExecutionService:terminateSnap',
       'ExecutionService:terminateAllSnaps',
       'ExecutionService:handleRpcRequest',
+      'NetworkController:getNetworkClientById',
+      'SelectedNetworkController:getNetworkClientIdForDomain',
       'SnapsRegistry:get',
       'SnapsRegistry:getMetadata',
       'SnapsRegistry:update',
       'SnapsRegistry:resolveVersion',
-      `SnapInterfaceController:createInterface`,
-      `SnapInterfaceController:getInterface`,
+      'SnapInterfaceController:createInterface',
+      'SnapInterfaceController:getInterface',
     ],
   });
 }

--- a/app/scripts/controller-init/snaps/snap-controller-init.test.ts
+++ b/app/scripts/controller-init/snaps/snap-controller-init.test.ts
@@ -49,6 +49,7 @@ describe('SnapControllerInit', () => {
         allowLocalSnaps: false,
         rejectInvalidPlatformVersion: false,
         requireAllowlist: false,
+        useCaip25Permission: true,
       },
       getFeatureFlags: expect.any(Function),
       getMnemonicSeed: expect.any(Function),

--- a/app/scripts/controller-init/snaps/snap-controller-init.ts
+++ b/app/scripts/controller-init/snaps/snap-controller-init.ts
@@ -109,6 +109,7 @@ export const SnapControllerInit: ControllerInitFunction<
       allowLocalSnaps,
       requireAllowlist,
       rejectInvalidPlatformVersion,
+      useCaip25Permission: true,
     },
 
     // @ts-expect-error: `encryptorFactory` is not compatible with the expected

--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "@metamask/selected-network-controller": "^22.1.0",
     "@metamask/signature-controller": "^27.1.0",
     "@metamask/smart-transactions-controller": "^16.3.1",
-    "@metamask/snaps-controllers": "^12.1.0",
+    "@metamask/snaps-controllers": "^12.2.0",
     "@metamask/snaps-execution-environments": "^8.1.0",
     "@metamask/snaps-rpc-methods": "^12.3.0",
     "@metamask/snaps-sdk": "^6.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6446,9 +6446,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^12.1.0":
-  version: 12.1.0
-  resolution: "@metamask/snaps-controllers@npm:12.1.0"
+"@metamask/snaps-controllers@npm:^12.2.0":
+  version: 12.2.0
+  resolution: "@metamask/snaps-controllers@npm:12.2.0"
   dependencies:
     "@metamask/approval-controller": "npm:^7.1.3"
     "@metamask/base-controller": "npm:^8.0.1"
@@ -6483,7 +6483,7 @@ __metadata:
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: 10/de844bcc532ac967c0b9111aff8ca8ea61f106065454b0f571b93c637e9e2e7d8b6344a50c355d6ea9f8f933b6c29fccc28b2da29df47ff5b165138ed08f2232
+  checksum: 10/1213f43875bc2dc82bea558f1111d9ef4604b2608a21922fb823f6e85e55c5d924e2f17db31459d4e291e3df55e882815a180b3f5f90116febd21132686c11aa
   languageName: node
   linkType: hard
 
@@ -30071,7 +30071,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^22.1.0"
     "@metamask/signature-controller": "npm:^27.1.0"
     "@metamask/smart-transactions-controller": "npm:^16.3.1"
-    "@metamask/snaps-controllers": "npm:^12.1.0"
+    "@metamask/snaps-controllers": "npm:^12.2.0"
     "@metamask/snaps-execution-environments": "npm:^8.1.0"
     "@metamask/snaps-rpc-methods": "npm:^12.3.0"
     "@metamask/snaps-sdk": "npm:^6.24.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This bumps `@metamask/snaps-controllers` from `^12.1.0` to `^12.2.0`. The main changes are:

- A new `isMinimumPlatformVersion` action.
- `MultichainRouter` now provides the origin to `SnapKeyring`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33064?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
