### PR TITLE
fix: add scroll to srp list

### DIFF
--- a/ui/components/multichain/multi-srp/srp-list/index.scss
+++ b/ui/components/multichain/multi-srp/srp-list/index.scss
@@ -2,7 +2,8 @@
 
 .srp-list {
   &__container {
-    overflow-y: hidden;
+    max-height: 500px;
+    overflow-y: auto;
   }
 
   &__divider {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds scroll top SRP List, allowing user to see more accounts if the list is very long.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32988

## **Manual testing steps**

1. Add at least one SRP (to have 2 or more)
2. Add multiple Ethereum accounts
3. Click Secret Recovery Phrase on add account form
4. Click Show Accounts for SRP with multiple accounts
5. Scroll should appear if there is enough accounts rendered

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="362" alt="Screenshot 2025-05-20 at 12 06 59" src="https://github.com/user-attachments/assets/44d54c35-c6ca-4e11-9610-6ba6d6ee45bf" />

### **After**

<img width="357" alt="Screenshot 2025-05-20 at 12 06 38" src="https://github.com/user-attachments/assets/0a308b04-ec8f-4acf-8393-fdba57ccb4c3" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
