### PR TITLE
fix: Default paying with erc20 when there's insufficient ETH

### DIFF
--- a/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.test.ts
+++ b/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.test.ts
@@ -114,4 +114,34 @@ describe('useAutomaticGasFeeTokenSelect', () => {
 
     expect(updateSelectedGasFeeTokenMock).toHaveBeenCalledTimes(0);
   });
+
+  it('does not select first gas fee token after firstCheck is set to false', () => {
+    const { rerender, state } = runHook();
+    // Simulate a rerender with new state that would otherwise trigger selection
+    act(() => {
+      (
+        state.metamask.transactions[0] as unknown as TransactionMeta
+      ).selectedGasFeeToken = undefined;
+    });
+    rerender();
+    expect(updateSelectedGasFeeTokenMock).toHaveBeenCalledTimes(1); // Only first run
+  });
+
+  it('does not select if transactionId is falsy', () => {
+    const state = getMockConfirmStateForTransaction(
+      genUnapprovedContractInteractionConfirmation({
+        gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+        selectedGasFeeToken: undefined,
+      }),
+    );
+    // Remove transactionId
+    state.metamask.transactions = [];
+    renderHookWithConfirmContextProvider(useAutomaticGasFeeTokenSelect, state);
+    expect(updateSelectedGasFeeTokenMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not select if gasFeeTokens is falsy', () => {
+    runHook({ noGasFeeTokens: true });
+    expect(updateSelectedGasFeeTokenMock).toHaveBeenCalledTimes(0);
+  });
 });

--- a/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
+++ b/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
@@ -1,16 +1,17 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useConfirmContext } from '../context/confirm';
 import { useAsyncResult } from '../../../hooks/useAsync';
-import { updateSelectedGasFeeToken } from '../../../store/controller-actions/transaction-controller';
 import { forceUpdateMetamaskState } from '../../../store/actions';
+import { updateSelectedGasFeeToken } from '../../../store/controller-actions/transaction-controller';
+import { useConfirmContext } from '../context/confirm';
 import { useInsufficientBalanceAlerts } from './alerts/transactions/useInsufficientBalanceAlerts';
 import { useIsGaslessSupported } from './gas/useIsGaslessSupported';
 
 export function useAutomaticGasFeeTokenSelect() {
   const dispatch = useDispatch();
   const isGaslessSupported = useIsGaslessSupported();
+  const [firstCheck, setFirstCheck] = useState(true);
 
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
@@ -39,10 +40,14 @@ export function useAutomaticGasFeeTokenSelect() {
     Boolean(firstGasFeeTokenAddress);
 
   useAsyncResult(async () => {
-    if (!shouldSelect) {
+    if (!gasFeeTokens || !transactionId || !firstCheck) {
       return;
     }
 
-    await selectFirstToken();
-  }, []);
+    setFirstCheck(false);
+
+    if (shouldSelect) {
+      await selectFirstToken();
+    }
+  }, [shouldSelect, selectFirstToken, firstCheck, gasFeeTokens, transactionId]);
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Introduce an additional check that runs the selected gas fee token update only the first time the component renders, and after gasFeeTokens have loaded.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33092?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4934

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
