### PR TITLE
fix: add accounts to caip25 permissions when adding chain permissions to ethereum-provider enabled snaps

### DIFF
--- a/app/scripts/migrations/160.test.ts
+++ b/app/scripts/migrations/160.test.ts
@@ -28,7 +28,7 @@ describe(`migration #${version}`, () => {
     expect(newStorage.meta).toStrictEqual({ version });
   });
 
-  it('adds the `endowment:caip25` permission with the current globally selected chainId (and no accounts) permissioned to Snaps with the `endowment:ethereum-provider` permission which do not have the `endowment:caip25` permission', async () => {
+  it('adds the `endowment:caip25` permission with the current globally selected chainId (and no accounts) permissioned to Snaps with the `endowment:ethereum-provider` permission and which do not already a `endowment:caip25` permission', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {

--- a/app/scripts/migrations/160.test.ts
+++ b/app/scripts/migrations/160.test.ts
@@ -28,7 +28,7 @@ describe(`migration #${version}`, () => {
     expect(newStorage.meta).toStrictEqual({ version });
   });
 
-  it('adds the network endowment to Snaps with the `endowment:ethereum-provider` permission', async () => {
+  it('adds the `endowment:caip25` permission with the current globally selected chainId (and no accounts) permissioned to Snaps with the `endowment:ethereum-provider` permission which do not have the `endowment:caip25` permission', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {
@@ -122,7 +122,7 @@ describe(`migration #${version}`, () => {
     });
   });
 
-  it('merges with an existing permission if the Snap already has `endowment:caip25`', async () => {
+  it('merges with an existing permission and adds existing account permissions along with the current globally selected chainId if the Snap already has `endowment:caip25`', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {
@@ -166,7 +166,7 @@ describe(`migration #${version}`, () => {
                         optionalScopes: {
                           'wallet:eip155': {
                             accounts: [
-                              '0x1234567890123456789012345678901234567890',
+                              'wallet:eip155:0x1234567890123456789012345678901234567890',
                             ],
                           },
                         },
@@ -214,11 +214,13 @@ describe(`migration #${version}`, () => {
                     optionalScopes: {
                       'wallet:eip155': {
                         accounts: [
-                          '0x1234567890123456789012345678901234567890',
+                          'wallet:eip155:0x1234567890123456789012345678901234567890',
                         ],
                       },
                       'eip155:1': {
-                        accounts: [],
+                        accounts: [
+                          'eip155:1:0x1234567890123456789012345678901234567890',
+                        ],
                       },
                     },
                     requiredScopes: {},

--- a/app/scripts/migrations/160.test.ts
+++ b/app/scripts/migrations/160.test.ts
@@ -28,7 +28,7 @@ describe(`migration #${version}`, () => {
     expect(newStorage.meta).toStrictEqual({ version });
   });
 
-  it('adds the `endowment:caip25` permission with the current globally selected chainId (and no accounts) permissioned to Snaps with the `endowment:ethereum-provider` permission and which do not already have a `endowment:caip25` permission', async () => {
+  it('adds the `endowment:caip25` permission with the current globally selected chainId (and no accounts) permissioned to Snaps which have a `endowment:ethereum-provider` permission but which do not already have a `endowment:caip25` permission', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {
@@ -122,7 +122,7 @@ describe(`migration #${version}`, () => {
     });
   });
 
-  it('merges with an existing permission and adds existing account permissions along with the current globally selected chainId if the Snap already has `endowment:caip25`', async () => {
+  it('adds the current globally selected chainId as a new scope with the existing permitted eth accounts to an existing snap `endowment:caip25` permission', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {

--- a/app/scripts/migrations/160.test.ts
+++ b/app/scripts/migrations/160.test.ts
@@ -28,7 +28,7 @@ describe(`migration #${version}`, () => {
     expect(newStorage.meta).toStrictEqual({ version });
   });
 
-  it('adds the `endowment:caip25` permission with the current globally selected chainId (and no accounts) permissioned to Snaps with the `endowment:ethereum-provider` permission and which do not already a `endowment:caip25` permission', async () => {
+  it('adds the `endowment:caip25` permission with the current globally selected chainId (and no accounts) permissioned to Snaps with the `endowment:ethereum-provider` permission and which do not already have a `endowment:caip25` permission', async () => {
     const oldStorage = {
       meta: { version: oldVersion },
       data: {

--- a/app/scripts/migrations/160.ts
+++ b/app/scripts/migrations/160.ts
@@ -213,11 +213,13 @@ function transformState(state: Record<string, unknown>) {
       caip25PermissionCaveatWithCurrentChainIdSet;
 
     if (existingCaip25Caveat) {
-      const alreadyPermissionedAccounts = getEthAccounts(existingCaip25Caveat);
-      if (alreadyPermissionedAccounts) {
+      const existingPermittedAccounts = getEthAccounts(existingCaip25Caveat);
+      // if there are existing permitted accounts in the `wallet:eip155` scope
+      // we add them to the newly added (currentChainId) scope
+      if (existingPermittedAccounts.length > 0) {
         caip25PermissionCaveatWithCurrentChainIdAndAccountsSet = setEthAccounts(
           caip25PermissionCaveatWithCurrentChainIdSet,
-          alreadyPermissionedAccounts,
+          existingPermittedAccounts,
         );
       }
     }

--- a/app/scripts/migrations/160.ts
+++ b/app/scripts/migrations/160.ts
@@ -11,6 +11,8 @@ import {
   Caip25EndowmentPermissionName,
   addPermittedEthChainId,
   Caip25CaveatValue,
+  setEthAccounts,
+  getEthAccounts,
 } from '@metamask/chain-agnostic-permission';
 
 type GenericPermissionControllerSubject =
@@ -206,6 +208,24 @@ function transformState(state: Record<string, unknown>) {
       currentChainId,
     );
 
+    let caip25PermissionCaveatWithCurrentChainIdAndAccountsSet =
+      caip25PermissionCaveatWithCurrentChainIdSet;
+
+    if (subject.permissions[Caip25EndowmentPermissionName]) {
+      const existingCaveat = subject.permissions[
+        Caip25EndowmentPermissionName
+      ]?.caveats?.find((caveat) => caveat.type === Caip25CaveatType);
+      if (existingCaveat && existingCaveat.value) {
+        const alreadyPermissionedAccounts = getEthAccounts(
+          existingCaveat.value as Caip25CaveatValue,
+        );
+        caip25PermissionCaveatWithCurrentChainIdAndAccountsSet = setEthAccounts(
+          caip25PermissionCaveatWithCurrentChainIdSet,
+          alreadyPermissionedAccounts,
+        );
+      }
+    }
+
     const {
       date = Date.now(),
       id = nanoid(),
@@ -221,7 +241,7 @@ function transformState(state: Record<string, unknown>) {
           caveats: [
             {
               type: Caip25CaveatType,
-              value: caip25PermissionCaveatWithCurrentChainIdSet,
+              value: caip25PermissionCaveatWithCurrentChainIdAndAccountsSet,
             },
           ],
           date,

--- a/app/scripts/migrations/160.ts
+++ b/app/scripts/migrations/160.ts
@@ -203,22 +203,18 @@ function transformState(state: Record<string, unknown>) {
 
     updatedSubjects.push(key);
 
+    const existingCaip25Caveat = getExistingCaip25PermissionCaveat(subject);
     const caip25PermissionCaveatWithCurrentChainIdSet = addPermittedEthChainId(
-      getExistingCaip25PermissionCaveat(subject),
+      existingCaip25Caveat,
       currentChainId,
     );
 
     let caip25PermissionCaveatWithCurrentChainIdAndAccountsSet =
       caip25PermissionCaveatWithCurrentChainIdSet;
 
-    if (subject.permissions[Caip25EndowmentPermissionName]) {
-      const existingCaveat = subject.permissions[
-        Caip25EndowmentPermissionName
-      ]?.caveats?.find((caveat) => caveat.type === Caip25CaveatType);
-      if (existingCaveat && existingCaveat.value) {
-        const alreadyPermissionedAccounts = getEthAccounts(
-          existingCaveat.value as Caip25CaveatValue,
-        );
+    if (existingCaip25Caveat) {
+      const alreadyPermissionedAccounts = getEthAccounts(existingCaip25Caveat);
+      if (alreadyPermissionedAccounts) {
         caip25PermissionCaveatWithCurrentChainIdAndAccountsSet = setEthAccounts(
           caip25PermissionCaveatWithCurrentChainIdSet,
           alreadyPermissionedAccounts,


### PR DESCRIPTION
## **Description**


This PR updates migration 160 - recently added in https://github.com/MetaMask/metamask-extension/pull/33018 - to add missing account permissions for Snaps with the `endowment:caip25` permission.

Previously, when migrating Snaps with an existing `endowment:caip25` permission, the accounts associated with that permission were not explicitly carried over to the newly added chainId scope. This change ensures that:

If a Snap already has the `endowment:caip25` permission, any accounts previously permissioned under `wallet:eip155`  are applied to the new scopes added to the permission. This means these accounts will be permissioned for the `currentChainId` that is being added by the migration.

The corresponding tests in `160.test.ts` have been updated to verify this new behavior, ensuring that existing accounts are correctly merged and applied to the relevant chainId scope in the `endowment:caip25` permission caveat. 

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
