### PR TITLE
fix(useMultichainWalletSnapClient): stop calling `listAccountTransactions` twice on account creation

### DIFF
--- a/ui/hooks/accounts/useMultichainWalletSnapClient.test.ts
+++ b/ui/hooks/accounts/useMultichainWalletSnapClient.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { SnapKeyringInternalOptions } from '@metamask/eth-snap-keyring';
 import {
   BtcAccountType,
   BtcMethod,
@@ -7,14 +7,11 @@ import {
   SolMethod,
   SolScope,
 } from '@metamask/keyring-api';
-import { SnapKeyringInternalOptions } from '@metamask/eth-snap-keyring';
+import { renderHook } from '@testing-library/react-hooks';
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
 import { BITCOIN_WALLET_SNAP_ID } from '../../../shared/lib/accounts/bitcoin-wallet-snap';
 import { SOLANA_WALLET_SNAP_ID } from '../../../shared/lib/accounts/solana-wallet-snap';
-import {
-  createSnapAccount,
-  multichainUpdateTransactions,
-} from '../../store/actions';
+import { createSnapAccount } from '../../store/actions';
 import {
   MultichainWalletSnapOptions,
   useMultichainWalletSnapClient,
@@ -23,12 +20,9 @@ import {
 
 jest.mock('../../store/actions', () => ({
   createSnapAccount: jest.fn(),
-  multichainUpdateTransactions: jest.fn(),
 }));
 
 const mockCreateSnapAccount = createSnapAccount as jest.Mock;
-const mockMultichainUpdateTransactions =
-  multichainUpdateTransactions as jest.Mock;
 
 describe('useMultichainWalletSnapClient', () => {
   beforeEach(() => {
@@ -107,20 +101,6 @@ describe('useMultichainWalletSnapClient', () => {
         snapId,
         options,
         internalOptions,
-      );
-    });
-
-    it(`force fetches the transactions after creating a ${clientType} account`, async () => {
-      const { result } = renderHook(() =>
-        useMultichainWalletSnapClient(clientType),
-      );
-      const multichainWalletSnapClient = result.current;
-
-      mockCreateSnapAccount.mockResolvedValue(mockAccount);
-
-      await multichainWalletSnapClient.createAccount({ scope: network });
-      expect(mockMultichainUpdateTransactions).toHaveBeenCalledWith(
-        mockAccount.id,
       );
     });
   });

--- a/ui/hooks/accounts/useMultichainWalletSnapClient.ts
+++ b/ui/hooks/accounts/useMultichainWalletSnapClient.ts
@@ -1,31 +1,30 @@
-import { Sender } from '@metamask/keyring-snap-client';
-import { HandlerType } from '@metamask/snaps-utils';
-import { Json, JsonRpcRequest } from '@metamask/utils';
-import { SnapId } from '@metamask/snaps-sdk';
-import { useMemo } from 'react';
 import { SnapKeyringInternalOptions } from '@metamask/eth-snap-keyring';
 import { KeyringAccount } from '@metamask/keyring-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
-import {
-  createSnapAccount,
-  getNextAvailableAccountName,
-  handleSnapRequest,
-  multichainUpdateTransactions,
-} from '../../store/actions';
-import {
-  BITCOIN_WALLET_SNAP_ID,
-  BITCOIN_WALLET_NAME,
-} from '../../../shared/lib/accounts/bitcoin-wallet-snap';
-import {
-  SOLANA_WALLET_SNAP_ID,
-  SOLANA_WALLET_NAME,
-} from '../../../shared/lib/accounts/solana-wallet-snap';
+import { Sender } from '@metamask/keyring-snap-client';
+import { SnapId } from '@metamask/snaps-sdk';
+import { HandlerType } from '@metamask/snaps-utils';
+import { Json, JsonRpcRequest } from '@metamask/utils';
+import { useMemo } from 'react';
 import {
   getNextAvailableSnapAccountName,
   SnapAccountNameOptions,
   WalletSnapClient,
   WalletSnapOptions,
 } from '../../../shared/lib/accounts';
+import {
+  BITCOIN_WALLET_NAME,
+  BITCOIN_WALLET_SNAP_ID,
+} from '../../../shared/lib/accounts/bitcoin-wallet-snap';
+import {
+  SOLANA_WALLET_NAME,
+  SOLANA_WALLET_SNAP_ID,
+} from '../../../shared/lib/accounts/solana-wallet-snap';
+import {
+  createSnapAccount,
+  getNextAvailableAccountName,
+  handleSnapRequest,
+} from '../../store/actions';
 
 export enum WalletClientType {
   Bitcoin = 'bitcoin-wallet-snap',
@@ -111,9 +110,6 @@ export class MultichainWalletSnapClient implements WalletSnapClient {
       snapOptions,
       internalOptions,
     );
-
-    // TODO: Remove this once Snap account creation flow is async
-    await multichainUpdateTransactions(account.id);
 
     return account;
   }


### PR DESCRIPTION
## **Description**

We used to need to force the initial transactions sync from the extension's side. Now that the flow is fully async and already embedded this first force fetch is not needed.

## **Related issues**

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
