### PR TITLE
feat: toggle Solana test networks with feature flags

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4944,9 +4944,14 @@ export default class MetamaskController extends EventEmitter {
     const keyring = await this.getSnapKeyring();
     const messenger = this.controllerMessenger;
 
+    const scopes = this.remoteFeatureFlagController.state.remoteFeatureFlags
+      .solanaTestnetsEnabled
+      ? [SolScope.Mainnet, SolScope.Devnet, SolScope.Testnet]
+      : [SolScope.Mainnet];
+
     return new MultichainWalletSnapClient(
       SOLANA_WALLET_SNAP_ID,
-      [SolScope.Mainnet, SolScope.Devnet, SolScope.Testnet],
+      scopes,
       keyring,
       messenger,
     );

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -4046,9 +4046,7 @@ describe('MetaMaskController', () => {
 
         // All calls should include the solana scopes
         expect(mockDiscoverAccounts.mock.calls[0][0]).toStrictEqual(
-          expect.arrayContaining([
-            SolScope.Mainnet,
-          ]),
+          expect.arrayContaining([SolScope.Mainnet]),
         );
 
         // First call should be for index 0

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -4048,8 +4048,6 @@ describe('MetaMaskController', () => {
         expect(mockDiscoverAccounts.mock.calls[0][0]).toStrictEqual(
           expect.arrayContaining([
             SolScope.Mainnet,
-            SolScope.Testnet,
-            SolScope.Devnet,
           ]),
         );
 


### PR DESCRIPTION
## **Description**

We had hardcoded Solana test networks but that shouldn't be the case, they should be toggled using feature flags

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33120?quickstart=1)

## **Related issues**

n/a

## **Manual testing steps**

n/a

## **Screenshots/Recordings**

### **Before**

n/a

### **After**

n/a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
