### PR TITLE
test: refactor `waitUntil` for more precise timing

### DIFF
--- a/test/e2e/page-objects/pages/defi-tab.ts
+++ b/test/e2e/page-objects/pages/defi-tab.ts
@@ -67,7 +67,7 @@ class DeFiTab {
     await this.driver.clickElement(this.networksToggle);
     await this.driver.waitUntil(
       async () => {
-        return await this.driver.findElement(this.allNetworksOption);
+        return Boolean(await this.driver.findElement(this.allNetworksOption));
       },
       {
         timeout: 5000,

--- a/test/e2e/page-objects/pages/dialog/snap-install.ts
+++ b/test/e2e/page-objects/pages/dialog/snap-install.ts
@@ -114,10 +114,10 @@ class SnapInstall {
     await this.driver.waitUntil(
       async () => {
         await this.driver.clickElementSafe(this.snapUpdateScrollArea);
-        const isEnabled = await this.driver.findClickableElement(
+        const element = await this.driver.findClickableElement(
           this.nextPageButton,
         );
-        return isEnabled;
+        return Boolean(element);
       },
       { timeout: veryLargeDelayMs, interval: 100 },
     );

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -281,7 +281,7 @@ class AssetListPage {
     await this.driver.clickElement(this.networksToggle);
     await this.driver.waitUntil(
       async () => {
-        return await this.driver.findElement(this.allNetworksOption);
+        return Boolean(await this.driver.findElement(this.allNetworksOption));
       },
       {
         timeout: 5000,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1,3 +1,4 @@
+const { setTimeout: asyncSetTimeout } = require('node:timers/promises');
 const { promises: fs } = require('fs');
 const { strict: assert } = require('assert');
 const {
@@ -856,24 +857,38 @@ class Driver {
   /**
    * Waits for a condition to be met within a given timeout period.
    *
-   * @param {Function} condition - The condition to wait for. This function should return a boolean indicating whether the condition is met.
+   * @param {() => Promise<boolean>} condition - The condition to wait for. This function must return a boolean indicating whether the condition is met.
    * @param {object} options - Options for the wait.
    * @param {number} options.timeout - The maximum amount of time (in milliseconds) to wait for the condition to be met.
    * @param {number} options.interval - The interval (in milliseconds) between checks for the condition.
    * @returns {Promise<void>} A promise that resolves when the condition is met or the timeout is reached.
    * @throws {Error} Throws an error if the condition is not met within the timeout period.
    */
-  async waitUntil(condition, options) {
-    const { timeout, interval } = options;
-    const endTime = Date.now() + timeout;
+  async waitUntil(condition, { interval, timeout }) {
+    const startTime = Date.now();
+    const endTime = startTime + timeout;
 
-    while (Date.now() < endTime) {
-      if (await condition()) {
-        return true;
+    // Loop indefinitely until condition met or timeout
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = await condition();
+      if (result === true) {
+        return; // Condition met
       }
-      await new Promise((resolve) => setTimeout(resolve, interval));
+
+      const currentTime = Date.now();
+      if (currentTime >= endTime) {
+        throw new Error(`Condition not met within ${timeout}ms.`);
+      }
+
+      // Calculate remaining time to ensure we don't overshoot the timeout
+      const remainingTime = endTime - currentTime;
+      const waitTime = Math.min(interval, remainingTime);
+
+      // always yield to the event loop, even for an interval of `0`, to avoid a
+      // macro-task deadlock
+      await asyncSetTimeout(waitTime, null, { ref: false });
     }
-    throw new Error('Condition not met within timeout');
   }
 
   /**


### PR DESCRIPTION
## **Description**

This refactor enhances `waitUntil`'s robustness with two key improvements:

1. **Precise Timeout Adherence:**
`waitUntil` now ensures it doesn't overshoot the specified `timeout`. It intelligently adjusts the final polling `interval` to attempt one last condition check just before or at the `timeout` deadline, rather than potentially missing a check or extending beyond the `timeout`.

2. **Improved Node.js Event Loop Behavior in Timed-Out Tests:**
Addresses an issue where `waitUntil`'s internal timer could unnecessarily keep the Node.js process alive after our test runner has already timed out and aborted the test. Now, the internal timer is automatically "unreffed" so that it won't prevent the Node.js process from exiting more promptly.

**Example of the potential issue:**

Consider a test with a 5-second timeout using a `waitUntil` call with an interval that would exceed the test's own allow duration:

```javascript
it("my async test", async function() {
  this.timeout(5000); // test's timeout for this test is 5 seconds
  await driver.waitUntil(someConditionFn, { interval: 10000, timeout: 30000 });
  // ^ `waitUntil`'s internal `interval` is 5 seconds longer than the test's own timeout
});
```

**Previously**: Even if the test runner aborted this test after 5 seconds, Node would remain active for _up to_ an additional 10 seconds (due to `waitUntil`'s scheduled `setTimeout`).
**Now**: After the test runner terminates the test at 5 seconds, `waitUntil`'s internal timer will not keep the Node.js process alive unnecessarily, allowing for a quicker exit.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33126?quickstart=1)
<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
