### PR TITLE
fix: price chart loading styles

### DIFF
--- a/ui/pages/asset/asset.scss
+++ b/ui/pages/asset/asset.scss
@@ -60,7 +60,7 @@
 }
 
 .asset-chart__empty-state-container {
-  aspect-ratio: 2.9;
+  aspect-ratio: 2.6;
   margin-top: 22px;
   margin-bottom: 22px;
 }
@@ -87,13 +87,14 @@
 }
 
 .asset-chart__skeleton-container {
-  aspect-ratio: 2.9;
-  margin-top: 22px;
-  margin-bottom: 22px;
+  aspect-ratio: 2.6;
+  margin-top: 28px;
+  margin-bottom: 28px;
+  padding-right: 1rem;
+  padding-left: 1rem;
 }
 
 .asset-chart__skeleton {
-  aspect-ratio: 2.9;
-  margin-right: 1rem;
-  margin-left: 1rem;
+  width: 100%;
+  height: 100%;
 }

--- a/ui/pages/asset/asset.scss
+++ b/ui/pages/asset/asset.scss
@@ -59,10 +59,12 @@
   }
 }
 
-.asset-chart__empty-state-container {
+.asset-chart__empty-or-loading-state-container {
   aspect-ratio: 2.6;
-  margin-top: 22px;
-  margin-bottom: 22px;
+  margin-top: 28px;
+  margin-bottom: 28px;
+  padding-right: 1rem;
+  padding-left: 1rem;
 }
 
 .asset-chart__empty-state-content {
@@ -74,8 +76,6 @@
   line-height: 20px;
   border-radius: 1rem;
   background: linear-gradient(101.63deg, #e7f2f8 39.39%, #e9f2f9 44.98%, #ebf2fa 50.57%, #edf2fb 56.16%, #eff2fc 61.75%, #f0f2fd 67.35%, #f1f2fd 72.94%, #f2f2fe 78.53%, #f2f2fe 84.12%, #f3f2fe 89.71%, #f3f2ff 95.3%, #f4f2ff 100.89%, #f4f2ff 106.49%, #f4f2ff 112.08%, #f4f2ff 117.67%, #f4f2ff 123.26%, #f4f2ff 128.85%), linear-gradient(0deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.2));
-  margin-right: 1rem;
-  margin-left: 1rem;
   height: 100%;
 }
 
@@ -86,15 +86,8 @@
   height: 47%;
 }
 
-.asset-chart__skeleton-container {
-  aspect-ratio: 2.6;
-  margin-top: 28px;
-  margin-bottom: 28px;
-  padding-right: 1rem;
-  padding-left: 1rem;
-}
-
 .asset-chart__skeleton {
   width: 100%;
   height: 100%;
+  border-radius: 1rem;
 }

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`AssetPage should render a native asset 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--rounded-lg"
+      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--rounded-lg"
     >
       <div
         class="mm-box mm-box--margin-right-4 mm-box--margin-left-4"
@@ -61,7 +61,7 @@ exports[`AssetPage should render a native asset 1`] = `
         data-testid="asset-price-chart"
       >
         <div
-          class="mm-box asset-chart__skeleton-container"
+          class="mm-box asset-chart__empty-or-loading-state-container"
           data-testid="asset-chart-loading"
         >
           <div
@@ -479,7 +479,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--rounded-lg"
+      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--rounded-lg"
     >
       <div
         class="mm-box mm-box--margin-right-4 mm-box--margin-left-4"
@@ -510,7 +510,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
         data-testid="asset-price-chart"
       >
         <div
-          class="mm-box asset-chart__skeleton-container"
+          class="mm-box asset-chart__empty-or-loading-state-container"
           data-testid="asset-chart-loading"
         >
           <div
@@ -952,7 +952,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--rounded-lg"
+      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--rounded-lg"
     >
       <div
         class="mm-box mm-box--margin-right-4 mm-box--margin-left-4"
@@ -980,7 +980,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
         data-testid="asset-price-chart"
       >
         <div
-          class="mm-box asset-chart__skeleton-container"
+          class="mm-box asset-chart__empty-or-loading-state-container"
           data-testid="asset-chart-loading"
         >
           <div

--- a/ui/pages/asset/components/chart/asset-chart-empty-state.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-empty-state.tsx
@@ -12,7 +12,7 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 export const AssetChartEmptyState = () => {
   const t = useI18nContext();
   return (
-    <Box className="asset-chart__empty-state-container">
+    <Box className="asset-chart__empty-or-loading-state-container">
       <Box className="asset-chart__empty-state-content">
         <img
           src="./images/asset-chart-empty-state-illustration.png"

--- a/ui/pages/asset/components/chart/asset-chart-loading.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-loading.tsx
@@ -7,7 +7,7 @@ import { BorderRadius } from '../../../../helpers/constants/design-system';
 export const AssetChartLoading = () => {
   return (
     <Box
-      className="asset-chart__skeleton-container"
+      className="asset-chart__empty-or-loading-state-container"
       data-testid="asset-chart-loading"
     >
       <Skeleton

--- a/ui/pages/asset/components/chart/asset-chart.tsx
+++ b/ui/pages/asset/components/chart/asset-chart.tsx
@@ -190,7 +190,11 @@ const AssetChart = ({
   }, [currentPrice]);
 
   return (
-    <Box borderRadius={BorderRadius.LG}>
+    <Box
+      borderRadius={BorderRadius.LG}
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+    >
       <AssetChartPrice
         ref={priceRef}
         loading={loading}


### PR DESCRIPTION
## **Description**

Adapt the styles of the price chart loading and empty states, to follow the aspect ratio change introduced in [this PR](https://github.com/MetaMask/metamask-extension/pull/32478) (from 2.9 to 2.6).

This fix makes it so the layout doesn't shift vertically when the price chart switches across states "empty", "loading" and "with data".

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33139?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

Notice how elements now stay properly aligned.
| Loading | Empty | With data |
|----------|----------|----------|
| ![image](https://github.com/user-attachments/assets/703023fe-c02a-4e1a-ae3a-b84832ca93c3) | ![image](https://github.com/user-attachments/assets/886e413a-5eb5-4b24-b022-ad6087d09b79)| ![image](https://github.com/user-attachments/assets/7ffbf287-7499-4f4e-8f8b-fdbc3b42f29e) |


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
