### PR TITLE
feat: Adding TotalBalance component

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3742,6 +3742,10 @@
   "numberOfTokens": {
     "message": "Number of tokens"
   },
+  "ofNetworksLoaded": {
+    "message": "of $1 networks loaded",
+    "description": "$1 is replaced with the total number of networks"
+  },
   "ofTextNofM": {
     "message": "of"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3742,6 +3742,10 @@
   "numberOfTokens": {
     "message": "Number of tokens"
   },
+  "ofNetworksLoaded": {
+    "message": "of $1 networks loaded",
+    "description": "$1 is replaced with the total number of networks"
+  },
   "ofTextNofM": {
     "message": "of"
   },

--- a/ui/components/multichain/network-manager/components/total-balance/index.ts
+++ b/ui/components/multichain/network-manager/components/total-balance/index.ts
@@ -1,0 +1,1 @@
+export * from './total-balance';

--- a/ui/components/multichain/network-manager/components/total-balance/total-balance.stories.tsx
+++ b/ui/components/multichain/network-manager/components/total-balance/total-balance.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { StoryFn, Meta } from '@storybook/react';
+import { TotalBalance } from './total-balance';
+
+export default {
+  title: 'Components/Multichain/NetworkManager/TotalBalance',
+  component: TotalBalance,
+  argTypes: {
+    totalAmount: {
+      control: 'text',
+      description: 'The total balance amount to display',
+    },
+    networksLoaded: {
+      control: 'number',
+      description: 'Number of networks loaded out of total networks',
+    },
+    totalNetworks: {
+      control: 'number',
+      description: 'Total number of networks',
+    },
+  },
+} as Meta<typeof TotalBalance>;
+
+const Template: StoryFn<typeof TotalBalance> = (args) => <TotalBalance {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  totalAmount: '$12.00',
+  networksLoaded: 1,
+  totalNetworks: 8,
+};

--- a/ui/components/multichain/network-manager/components/total-balance/total-balance.test.tsx
+++ b/ui/components/multichain/network-manager/components/total-balance/total-balance.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../../test/jest';
+import configureStore from '../../../../../store/store';
+import { TotalBalance } from './total-balance';
+
+describe('TotalBalance Component', () => {
+  const renderComponent = (props = {}) => {
+    const store = configureStore({});
+    return renderWithProvider(<TotalBalance {...props} />, store);
+  };
+
+  it('renders with default props', () => {
+    renderComponent();
+
+    expect(screen.getByText('Total $12.00')).toBeInTheDocument();
+    // We don't test the popover content directly as it's only visible on hover
+  });
+
+  it('renders with custom props', () => {
+    renderComponent({
+      totalAmount: '$25.50',
+      networksLoaded: 5,
+      totalNetworks: 10,
+    });
+
+    expect(screen.getByText('Total $25.50')).toBeInTheDocument();
+    // We don't test the popover content directly as it's only visible on hover
+  });
+});

--- a/ui/components/multichain/network-manager/components/total-balance/total-balance.tsx
+++ b/ui/components/multichain/network-manager/components/total-balance/total-balance.tsx
@@ -50,7 +50,8 @@ export const TotalBalance = memo(
   }: TotalBalanceProps) => {
     const t = useI18nContext();
     const [isOpen, setIsOpen] = useState(false);
-    const [referenceElement, setReferenceElement] = useState();
+    const [referenceElement, setReferenceElement] =
+      useState<HTMLDivElement | null>(null);
 
     const handleMouseEnter = useCallback(() => {
       setIsOpen(true);
@@ -60,7 +61,7 @@ export const TotalBalance = memo(
       setIsOpen(false);
     }, []);
 
-    const setBoxRef = useCallback((ref: any) => {
+    const setBoxRef = useCallback((ref: HTMLDivElement | null) => {
       setReferenceElement(ref);
     }, []);
 
@@ -88,11 +89,11 @@ export const TotalBalance = memo(
           hasArrow
           isOpen={isOpen}
           position={PopoverPosition.BottomEnd}
+          // zIndex fix for Skeleton component
           style={{ zIndex: 100, width: '200px' }}
           arrowProps={{
             style: {
               right: -10,
-              // position: 'absolute',
             },
           }}
           referenceElement={referenceElement}

--- a/ui/components/multichain/network-manager/components/total-balance/total-balance.tsx
+++ b/ui/components/multichain/network-manager/components/total-balance/total-balance.tsx
@@ -1,0 +1,105 @@
+import React, { useState, useCallback, memo } from 'react';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+  TextColor,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import {
+  Icon,
+  IconName,
+  IconSize,
+  Popover,
+  PopoverPosition,
+} from '../../../../component-library';
+import { Box } from '../../../../component-library/box';
+import { Text } from '../../../../component-library/text';
+
+type TotalBalanceProps = {
+  /**
+   * The total balance amount to display
+   */
+  totalAmount?: string;
+  /**
+   * Number of networks loaded out of total networks
+   */
+  networksLoaded?: number;
+  /**
+   * Total number of networks
+   */
+  totalNetworks?: number;
+};
+
+/**
+ * TotalBalance component
+ *
+ * Displays the total balance amount across networks with a loading indicator.
+ * Shows how many networks have been loaded out of the total networks.
+ * Includes a hover tooltip with network loading information.
+ *
+ * @param props - Component props
+ * @returns TotalBalance component
+ */
+export const TotalBalance = memo(
+  ({
+    totalAmount = '$12.00',
+    networksLoaded = 1,
+    totalNetworks = 8,
+  }: TotalBalanceProps) => {
+    const t = useI18nContext();
+    const [isOpen, setIsOpen] = useState(false);
+    const [referenceElement, setReferenceElement] = useState();
+
+    const handleMouseEnter = useCallback(() => {
+      setIsOpen(true);
+    }, []);
+
+    const handleMouseLeave = useCallback(() => {
+      setIsOpen(false);
+    }, []);
+
+    const setBoxRef = useCallback((ref: any) => {
+      setReferenceElement(ref);
+    }, []);
+
+    return (
+      <Box
+        display={Display.Flex}
+        alignItems={AlignItems.center}
+        flexDirection={FlexDirection.Row}
+        gap={3}
+        onMouseLeave={handleMouseLeave}
+        style={{
+          position: 'relative',
+        }}
+      >
+        <Text
+          variant={TextVariant.bodyMdMedium}
+          color={TextColor.textAlternative}
+        >
+          {t('total')} {totalAmount}
+        </Text>
+        <Box onMouseEnter={handleMouseEnter} ref={setBoxRef}>
+          <Icon name={IconName.Refresh} size={IconSize.Sm} />
+        </Box>
+        <Popover
+          hasArrow
+          isOpen={isOpen}
+          position={PopoverPosition.BottomEnd}
+          style={{ zIndex: 100, width: '200px' }}
+          arrowProps={{
+            style: {
+              right: -10,
+              // position: 'absolute',
+            },
+          }}
+          referenceElement={referenceElement}
+        >
+          {networksLoaded} {t('ofNetworksLoaded', [totalNetworks])}
+        </Popover>
+      </Box>
+    );
+  },
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->
Adding TotalBalance component

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33149?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**
`-`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

`-`

### **After**

<img width="785" alt="Screenshot 2025-05-23 at 12 07 19 PM" src="https://github.com/user-attachments/assets/223212e2-bae6-455a-950e-494b82f19076" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
