### PR TITLE
chore: remove unused `CONNECTION_READY` event

### DIFF
--- a/app/scripts/lib/stream-utils.js
+++ b/app/scripts/lib/stream-utils.js
@@ -11,12 +11,6 @@ import { EXTENSION_MESSAGES } from '../../../shared/constants/app';
  */
 export function setupMultiplex(connectionStream) {
   const mux = new ObjectMultiplex();
-  /**
-   * We are using this streams to send keep alive message between backend/ui without setting up a multiplexer
-   * We need to tell the multiplexer to ignore them, else we get the " orphaned data for stream " warnings
-   * https://github.com/MetaMask/object-multiplex/blob/280385401de84f57ef57054d92cfeb8361ef2680/src/ObjectMultiplex.ts#L63
-   */
-  mux.ignoreStream(EXTENSION_MESSAGES.CONNECTION_READY);
   pipeline(connectionStream, mux, connectionStream, (err) => {
     // For context and todos related to the error message match, see https://github.com/MetaMask/metamask-extension/issues/26337
     if (err && !err.message?.match('Premature close')) {

--- a/app/scripts/lib/stream-utils.js
+++ b/app/scripts/lib/stream-utils.js
@@ -1,8 +1,6 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { pipeline } from 'readable-stream';
 
-import { EXTENSION_MESSAGES } from '../../../shared/constants/app';
-
 /**
  * Sets up stream multiplexing for the given stream
  *

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -94,7 +94,7 @@ async function start() {
 
   /*
    * In case of MV3 the issue of blank screen was very frequent, it is caused by UI initialising before background is ready to send state.
-   * Code below ensures that UI is rendered only after "CONNECTION_READY" or "startUISync"
+   * Code below ensures that UI is rendered only after "startUISync"
    * messages are received thus the background is ready, and ensures that streams and
    * phishing warning page load only after the "startUISync" message is received.
    * In case the UI is already rendered, only update the streams.

--- a/shared/constants/app.ts
+++ b/shared/constants/app.ts
@@ -82,7 +82,6 @@ export const SMART_TRANSACTION_CONFIRMATION_TYPES = {
  * Custom messages to send and be received by the extension
  */
 export const EXTENSION_MESSAGES = {
-  CONNECTION_READY: 'CONNECTION_READY',
   READY: 'METAMASK_EXTENSION_READY',
 } as const;
 


### PR DESCRIPTION
## **Description**

Removes unused `CONNECTION_READY` event from our code.


Here are all the places in the code, including in `node_modules` that `CONNECTION_READY` appears. It is only ignored, never listened to or otherwise used.

![image](https://github.com/user-attachments/assets/abafcb71-2047-4481-8dfa-17eb721108fb)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33163?quickstart=1)

<!--

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

-->