### PR TITLE
fix: Update PR max lines limit to ignore test snapshots

### DIFF
--- a/.github/workflows/check-pr-max-lines.yml
+++ b/.github/workflows/check-pr-max-lines.yml
@@ -9,4 +9,4 @@ jobs:
     uses: metamask/github-tools/.github/workflows/pr-line-check.yml@main
     with:
       max_lines: 1000
-      ignore_patterns: '(\.lock$)'
+      ignore_patterns: '(\.lock$|\.snap$)'

--- a/.github/workflows/check-pr-max-lines.yml
+++ b/.github/workflows/check-pr-max-lines.yml
@@ -9,4 +9,4 @@ jobs:
     uses: metamask/github-tools/.github/workflows/pr-line-check.yml@main
     with:
       max_lines: 1000
-      ignore_patterns: '(\.lock$|\.snap$)'
+      ignore_patterns: '(\.lock|\.snap)$'


### PR DESCRIPTION
## **Description**
Having PR max lines limit set too low is causing issues when introducing UI changes which have significant impact on test snapshot files. 
This PR is proposal to update PR max lines check ignore pattern to ignore `*.snap` files used for test snapshots.

Proof of issues encountered:
![Screenshot 2025-05-26 at 12 54 43](https://github.com/user-attachments/assets/bd47c11d-6b7a-4e06-ba97-09e2519571d4)
https://github.com/MetaMask/metamask-extension/actions/runs/15251982269/job/42890801855?pr=33158
https://github.com/MetaMask/metamask-extension/pull/33158/files

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33173?quickstart=1)

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Check `check-pr-max-lines.yml` file configuration.

## **Screenshots/Recordings**
### **Before**
n/a

### **After**
n/a

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.