### PR TITLE
fix: include gas properties in PPOM request cp-12.18.2

### DIFF
--- a/app/scripts/lib/ppom/ppom-util.test.ts
+++ b/app/scripts/lib/ppom/ppom-util.test.ts
@@ -1,15 +1,21 @@
 import { PPOMController } from '@metamask/ppom-validator';
-import { PPOM } from '@blockaid/ppom_release';
 import {
   TransactionController,
+  TransactionControllerUnapprovedTransactionAddedEvent,
+  TransactionEnvelopeType,
+  TransactionMeta,
   TransactionParams,
   normalizeTransactionParams,
 } from '@metamask/transaction-controller';
 import {
   SignatureController,
+  SignatureControllerState,
   SignatureRequest,
+  SignatureStateChange,
 } from '@metamask/signature-controller';
 import { Hex, JsonRpcRequest } from '@metamask/utils';
+import { PPOM } from '@blockaid/ppom_release';
+import { Messenger } from '@metamask/base-controller';
 import {
   BlockaidReason,
   BlockaidResultType,
@@ -17,10 +23,10 @@ import {
   SecurityAlertSource,
 } from '../../../../shared/constants/security-provider';
 import { AppStateController } from '../../controllers/app-state-controller';
+import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import {
   generateSecurityAlertId,
-  METHOD_SIGN_TYPED_DATA_V3,
-  METHOD_SIGN_TYPED_DATA_V4,
+  PPOMMessenger,
   updateSecurityAlertResponse,
   validateRequestWithPPOM,
 } from './ppom-util';
@@ -35,6 +41,8 @@ jest.mock('@metamask/transaction-controller', () => ({
 const SECURITY_ALERT_ID_MOCK = '1234-5678';
 const TRANSACTION_ID_MOCK = '123';
 const CHAIN_ID_MOCK = '0x1' as Hex;
+const GAS_MOCK = '0x1234';
+const GAS_PRICE_MOCK = '0x5678';
 
 const REQUEST_MOCK = {
   method: 'eth_signTypedData_v4',
@@ -65,6 +73,10 @@ const TRANSACTION_PARAMS_MOCK_2: TransactionParams = {
   to: '0x456',
 };
 
+const MESSENGER_MOCK = {
+  subscribe: jest.fn(),
+} as unknown as PPOMMessenger;
+
 function createPPOMMock() {
   return {
     validateJsonRpc: jest.fn(),
@@ -91,10 +103,12 @@ function createAppStateControllerMock() {
 }
 
 function createSignatureControllerMock(
-  messages: SignatureController['messages'],
+  signatureRequests: SignatureControllerState['signatureRequests'],
 ) {
   return {
-    messages,
+    state: {
+      signatureRequests,
+    },
   } as unknown as jest.Mocked<SignatureController>;
 }
 
@@ -107,13 +121,22 @@ function createTransactionControllerMock(
   } as unknown as jest.Mocked<TransactionController>;
 }
 
+function createMessengerMock() {
+  return new Messenger<
+    never,
+    SignatureStateChange | TransactionControllerUnapprovedTransactionAddedEvent
+  >();
+}
+
 describe('PPOM Utils', () => {
+  const updateSecurityAlertResponseMock = jest.fn();
+  let isSecurityAlertsEnabledMock: jest.SpyInstance;
+  let ppomController: jest.Mocked<PPOMController>;
+  let ppom: jest.Mocked<PPOM>;
+
   const normalizeTransactionParamsMock = jest.mocked(
     normalizeTransactionParams,
   );
-  let isSecurityAlertsEnabledMock: jest.SpyInstance;
-
-  const updateSecurityAlertResponseMock = jest.fn();
 
   const validateRequestWithPPOMOptionsBase = {
     request: REQUEST_MOCK,
@@ -125,23 +148,25 @@ describe('PPOM Utils', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
     isSecurityAlertsEnabledMock = jest
       .spyOn(securityAlertAPI, 'isSecurityAlertsAPIEnabled')
       .mockReturnValue(false);
+
+    ppomController = createPPOMControllerMock();
+    ppom = createPPOMMock();
+
+    // @ts-expect-error PPOM from package does not match controller type
+    ppomController.usePPOM.mockImplementation((callback) => callback(ppom));
+
+    normalizeTransactionParamsMock.mockImplementation(
+      (params: TransactionParams) => params,
+    );
   });
 
   describe('validateRequestWithPPOM', () => {
     it('updates response from validation with PPOM instance via controller', async () => {
-      const ppom = createPPOMMock();
-      const ppomController = createPPOMControllerMock();
-
       ppom.validateJsonRpc.mockResolvedValue(SECURITY_ALERT_RESPONSE_MOCK);
-
-      ppomController.usePPOM.mockImplementation(
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (callback) => callback(ppom as any) as any,
-      );
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
@@ -161,8 +186,6 @@ describe('PPOM Utils', () => {
     });
 
     it('updates securityAlertResponse with loading state', async () => {
-      const ppomController = createPPOMControllerMock();
-
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
         ppomController,
@@ -176,17 +199,7 @@ describe('PPOM Utils', () => {
     });
 
     it('updates error response if validation with PPOM instance throws', async () => {
-      const ppom = createPPOMMock();
-      const ppomController = createPPOMControllerMock();
-
       ppom.validateJsonRpc.mockRejectedValue(createErrorMock());
-
-      ppomController.usePPOM.mockImplementation(
-        (callback) =>
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          callback(ppom as any) as any,
-      );
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
@@ -206,8 +219,6 @@ describe('PPOM Utils', () => {
     });
 
     it('updates error response if controller throws', async () => {
-      const ppomController = createPPOMControllerMock();
-
       ppomController.usePPOM.mockRejectedValue(createErrorMock());
 
       await validateRequestWithPPOM({
@@ -227,71 +238,21 @@ describe('PPOM Utils', () => {
       );
     });
 
-    it('normalizes request if method is eth_sendTransaction', async () => {
-      const ppom = createPPOMMock();
-      const ppomController = createPPOMControllerMock();
-
-      ppomController.usePPOM.mockImplementation(
-        (callback) =>
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          callback(ppom as any) as any,
-      );
-
-      normalizeTransactionParamsMock.mockReturnValue(TRANSACTION_PARAMS_MOCK_2);
-
-      const request = {
-        ...REQUEST_MOCK,
-        method: 'eth_sendTransaction',
-        params: [TRANSACTION_PARAMS_MOCK_1],
-      };
-
-      await validateRequestWithPPOM({
-        ...validateRequestWithPPOMOptionsBase,
-        ppomController,
-        request,
-      });
-
-      expect(ppom.validateJsonRpc).toHaveBeenCalledTimes(1);
-      expect(ppom.validateJsonRpc).toHaveBeenCalledWith({
-        ...request,
-        params: [TRANSACTION_PARAMS_MOCK_2],
-      });
-
-      expect(normalizeTransactionParamsMock).toHaveBeenCalledTimes(1);
-      expect(normalizeTransactionParamsMock).toHaveBeenCalledWith(
-        TRANSACTION_PARAMS_MOCK_1,
-      );
-    });
-
-    // @ts-expect-error This is missing from the Mocha type definitions
-    it.each([METHOD_SIGN_TYPED_DATA_V3, METHOD_SIGN_TYPED_DATA_V4])(
-      'sanitizes request params if method is %s',
-      async (method: string) => {
-        const ppom = createPPOMMock();
-        const ppomController = createPPOMControllerMock();
-
-        ppomController.usePPOM.mockImplementation(
-          (callback) =>
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            callback(ppom as any) as any,
+    describe('if method is eth_sendTransaction', () => {
+      it('normalizes transaction params', async () => {
+        normalizeTransactionParamsMock.mockReturnValue(
+          TRANSACTION_PARAMS_MOCK_2,
         );
 
-        const firstTwoParams = [
-          SIGN_TYPED_DATA_PARAMS_MOCK_1,
-          SIGN_TYPED_DATA_PARAMS_MOCK_2,
-        ];
-
-        const unwantedParams = [{}, undefined, 1, null];
-
-        const params = [...firstTwoParams, ...unwantedParams];
+        updateSecurityAlertResponseMock.mockResolvedValue({
+          txParams: TRANSACTION_PARAMS_MOCK_1,
+        });
 
         const request = {
           ...REQUEST_MOCK,
-          method,
-          params,
-        } as unknown as JsonRpcRequest;
+          method: 'eth_sendTransaction',
+          params: [TRANSACTION_PARAMS_MOCK_1],
+        };
 
         await validateRequestWithPPOM({
           ...validateRequestWithPPOMOptionsBase,
@@ -302,10 +263,187 @@ describe('PPOM Utils', () => {
         expect(ppom.validateJsonRpc).toHaveBeenCalledTimes(1);
         expect(ppom.validateJsonRpc).toHaveBeenCalledWith({
           ...request,
-          params: firstTwoParams,
+          params: [TRANSACTION_PARAMS_MOCK_2],
         });
-      },
-    );
+
+        expect(normalizeTransactionParamsMock).toHaveBeenCalledTimes(1);
+        expect(normalizeTransactionParamsMock).toHaveBeenCalledWith(
+          TRANSACTION_PARAMS_MOCK_1,
+        );
+      });
+
+      it('includes gas properties', async () => {
+        updateSecurityAlertResponseMock.mockResolvedValue({
+          txParams: {
+            ...TRANSACTION_PARAMS_MOCK_1,
+            gas: GAS_MOCK,
+            maxFeePerGas: GAS_PRICE_MOCK,
+          },
+        });
+
+        const request = {
+          ...REQUEST_MOCK,
+          method: MESSAGE_TYPE.ETH_SEND_TRANSACTION,
+          params: [TRANSACTION_PARAMS_MOCK_1],
+        };
+
+        await validateRequestWithPPOM({
+          ...validateRequestWithPPOMOptionsBase,
+          ppomController,
+          request,
+        });
+
+        expect(ppom.validateJsonRpc).toHaveBeenCalledTimes(1);
+        expect(ppom.validateJsonRpc).toHaveBeenCalledWith({
+          ...request,
+          params: [
+            {
+              ...TRANSACTION_PARAMS_MOCK_1,
+              gas: GAS_MOCK,
+              gasPrice: GAS_PRICE_MOCK,
+            },
+          ],
+        });
+      });
+
+      it('includes gas properties using gas price', async () => {
+        updateSecurityAlertResponseMock.mockResolvedValue({
+          txParams: {
+            ...TRANSACTION_PARAMS_MOCK_1,
+            gas: GAS_MOCK,
+            gasPrice: GAS_PRICE_MOCK,
+          },
+        });
+
+        const request = {
+          ...REQUEST_MOCK,
+          method: MESSAGE_TYPE.ETH_SEND_TRANSACTION,
+          params: [TRANSACTION_PARAMS_MOCK_1],
+        };
+
+        await validateRequestWithPPOM({
+          ...validateRequestWithPPOMOptionsBase,
+          ppomController,
+          request,
+        });
+
+        expect(ppom.validateJsonRpc).toHaveBeenCalledTimes(1);
+        expect(ppom.validateJsonRpc).toHaveBeenCalledWith({
+          ...request,
+          params: [
+            {
+              ...TRANSACTION_PARAMS_MOCK_1,
+              gas: GAS_MOCK,
+              gasPrice: GAS_PRICE_MOCK,
+            },
+          ],
+        });
+      });
+
+      it('removes unnecessary params', async () => {
+        updateSecurityAlertResponseMock.mockResolvedValue({
+          txParams: {
+            ...TRANSACTION_PARAMS_MOCK_1,
+            gas: GAS_MOCK,
+            maxFeePerGas: GAS_PRICE_MOCK,
+          },
+        });
+
+        const request = {
+          ...REQUEST_MOCK,
+          method: MESSAGE_TYPE.ETH_SEND_TRANSACTION,
+          params: [
+            {
+              ...TRANSACTION_PARAMS_MOCK_1,
+              gasLimit: GAS_MOCK,
+              maxFeePerGas: GAS_PRICE_MOCK,
+              maxPriorityFeePerGas: GAS_PRICE_MOCK,
+              type: TransactionEnvelopeType.feeMarket,
+            },
+          ],
+        };
+
+        await validateRequestWithPPOM({
+          ...validateRequestWithPPOMOptionsBase,
+          ppomController,
+          request,
+        });
+
+        expect(ppom.validateJsonRpc).toHaveBeenCalledTimes(1);
+        expect(ppom.validateJsonRpc).toHaveBeenCalledWith({
+          ...request,
+          params: [
+            {
+              ...TRANSACTION_PARAMS_MOCK_1,
+              gas: GAS_MOCK,
+              gasPrice: GAS_PRICE_MOCK,
+            },
+          ],
+        });
+      });
+    });
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V3,
+      MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
+    ])('sanitizes request params if method is %s', async (method: string) => {
+      const firstTwoParams = [
+        SIGN_TYPED_DATA_PARAMS_MOCK_1,
+        SIGN_TYPED_DATA_PARAMS_MOCK_2,
+      ];
+
+      const unwantedParams = [{}, undefined, 1, null];
+
+      const params = [...firstTwoParams, ...unwantedParams];
+
+      const request = {
+        ...REQUEST_MOCK,
+        method,
+        params,
+      } as unknown as JsonRpcRequest;
+
+      await validateRequestWithPPOM({
+        ...validateRequestWithPPOMOptionsBase,
+        ppomController,
+        request,
+      });
+
+      expect(ppom.validateJsonRpc).toHaveBeenCalledTimes(1);
+      expect(ppom.validateJsonRpc).toHaveBeenCalledWith({
+        ...request,
+        params: firstTwoParams,
+      });
+    });
+
+    it('removes unnecessary properties from request', async () => {
+      updateSecurityAlertResponseMock.mockResolvedValue({
+        txParams: TRANSACTION_PARAMS_MOCK_1,
+      });
+
+      const request = {
+        ...REQUEST_MOCK,
+        delegationMock: '0x123',
+        method: 'eth_sendTransaction',
+        origin: 'test.com',
+        params: [TRANSACTION_PARAMS_MOCK_1],
+        test1: 'test1',
+        test2: 'test2',
+      };
+
+      await validateRequestWithPPOM({
+        ...validateRequestWithPPOMOptionsBase,
+        ppomController,
+        request: request as never,
+      });
+
+      expect(ppom.validateJsonRpc).toHaveBeenCalledTimes(1);
+      expect(ppom.validateJsonRpc).toHaveBeenCalledWith({
+        ...request,
+        test1: undefined,
+        test2: undefined,
+      });
+    });
   });
 
   describe('generateSecurityAlertId', () => {
@@ -319,7 +457,7 @@ describe('PPOM Utils', () => {
   });
 
   describe('updateSecurityAlertResponse', () => {
-    it('adds response to app state controller if matching message found', async () => {
+    it('adds response to app state controller if signature request already exisists', async () => {
       const appStateController = createAppStateControllerMock();
 
       const signatureController = createSignatureControllerMock({
@@ -333,7 +471,8 @@ describe('PPOM Utils', () => {
 
       await updateSecurityAlertResponse({
         appStateController,
-        method: 'eth_signTypedData_v4',
+        method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
+        messenger: MESSENGER_MOCK,
         securityAlertId: SECURITY_ALERT_ID_MOCK,
         securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
         signatureController,
@@ -349,7 +488,45 @@ describe('PPOM Utils', () => {
       ).toHaveBeenCalledWith(SECURITY_ALERT_RESPONSE_MOCK);
     });
 
-    it('adds response to transaction controller if matching transaction found', async () => {
+    it('adds response to app state controller after signature controller state change event', async () => {
+      const appStateController = createAppStateControllerMock();
+      const signatureController = createSignatureControllerMock({});
+      const messenger = createMessengerMock();
+
+      const updatePromise = updateSecurityAlertResponse({
+        appStateController,
+        method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
+        messenger,
+        securityAlertId: SECURITY_ALERT_ID_MOCK,
+        securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
+        signatureController,
+        transactionController: {} as unknown as TransactionController,
+      });
+
+      messenger.publish(
+        'SignatureController:stateChange',
+        {
+          signatureRequests: {
+            '123': {
+              securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
+            } as unknown as SignatureRequest,
+          },
+        } as unknown as SignatureControllerState,
+        [],
+      );
+
+      await updatePromise;
+
+      expect(
+        appStateController.addSignatureSecurityAlertResponse,
+      ).toHaveBeenCalledTimes(1);
+
+      expect(
+        appStateController.addSignatureSecurityAlertResponse,
+      ).toHaveBeenCalledWith(SECURITY_ALERT_RESPONSE_MOCK);
+    });
+
+    it('adds response to transaction controller if transaction already exists', async () => {
       const transactionController = createTransactionControllerMock({
         transactions: [
           {
@@ -366,6 +543,7 @@ describe('PPOM Utils', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         appStateController: {} as any,
         method: 'eth_sendTransaction',
+        messenger: MESSENGER_MOCK,
         securityAlertId: SECURITY_ALERT_ID_MOCK,
         securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
@@ -373,6 +551,44 @@ describe('PPOM Utils', () => {
         signatureController: {} as any,
         transactionController,
       });
+
+      expect(
+        transactionController.updateSecurityAlertResponse,
+      ).toHaveBeenCalledTimes(1);
+
+      expect(
+        transactionController.updateSecurityAlertResponse,
+      ).toHaveBeenCalledWith(TRANSACTION_ID_MOCK, SECURITY_ALERT_RESPONSE_MOCK);
+    });
+
+    it('adds response to transaction controller after transaction added event', async () => {
+      const transactionController = createTransactionControllerMock({
+        transactions: [],
+      } as unknown as TransactionController['state']);
+
+      const messenger = createMessengerMock();
+
+      const updatePromise = updateSecurityAlertResponse({
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        appStateController: {} as any,
+        method: 'eth_sendTransaction',
+        messenger,
+        securityAlertId: SECURITY_ALERT_ID_MOCK,
+        securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        signatureController: {} as any,
+        transactionController,
+      });
+
+      messenger.publish('TransactionController:unapprovedTransactionAdded', {
+        id: TRANSACTION_ID_MOCK,
+        securityAlertResponse: SECURITY_ALERT_RESPONSE_MOCK,
+        txParams: TRANSACTION_PARAMS_MOCK_1,
+      } as TransactionMeta);
+
+      await updatePromise;
 
       expect(
         transactionController.updateSecurityAlertResponse,
@@ -393,13 +609,14 @@ describe('PPOM Utils', () => {
 
     it('uses security alerts API if enabled', async () => {
       isSecurityAlertsEnabledMock.mockReturnValue(true);
-      normalizeTransactionParamsMock.mockReturnValue(TRANSACTION_PARAMS_MOCK_1);
+
       const validateWithSecurityAlertsAPIMock = jest
         .spyOn(securityAlertAPI, 'validateWithSecurityAlertsAPI')
         .mockResolvedValue(SECURITY_ALERT_RESPONSE_MOCK);
 
-      const ppom = createPPOMMock();
-      const ppomController = createPPOMControllerMock();
+      updateSecurityAlertResponseMock.mockResolvedValue({
+        txParams: TRANSACTION_PARAMS_MOCK_1,
+      });
 
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
@@ -419,9 +636,10 @@ describe('PPOM Utils', () => {
 
     it('uses controller if security alerts API throws', async () => {
       isSecurityAlertsEnabledMock.mockReturnValue(true);
-      normalizeTransactionParamsMock.mockReturnValue(TRANSACTION_PARAMS_MOCK_1);
 
-      const ppomController = createPPOMControllerMock();
+      updateSecurityAlertResponseMock.mockResolvedValue({
+        txParams: TRANSACTION_PARAMS_MOCK_1,
+      });
 
       const validateWithSecurityAlertsAPIMock = jest
         .spyOn(securityAlertAPI, 'validateWithSecurityAlertsAPI')

--- a/app/scripts/lib/ppom/ppom-util.test.ts
+++ b/app/scripts/lib/ppom/ppom-util.test.ts
@@ -457,7 +457,7 @@ describe('PPOM Utils', () => {
   });
 
   describe('updateSecurityAlertResponse', () => {
-    it('adds response to app state controller if signature request already exisists', async () => {
+    it('adds response to app state controller if signature request already exists', async () => {
       const appStateController = createAppStateControllerMock();
 
       const signatureController = createSignatureControllerMock({

--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -27,6 +27,7 @@ import { SIGNING_METHODS } from '../../../../shared/constants/transaction';
 import { AppStateController } from '../../controllers/app-state-controller';
 import { sanitizeMessageRecursively } from '../../../../shared/modules/typed-signature';
 import { parseTypedDataMessage } from '../../../../shared/modules/transaction.utils';
+import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { SecurityAlertResponse, UpdateSecurityAlertResponse } from './types';
 import {
   isSecurityAlertsAPIEnabled,
@@ -37,10 +38,6 @@ import {
 const log = createProjectLogger('ppom-util');
 
 const { sentry } = global;
-
-const METHOD_SEND_TRANSACTION = 'eth_sendTransaction';
-export const METHOD_SIGN_TYPED_DATA_V3 = 'eth_signTypedData_v3';
-export const METHOD_SIGN_TYPED_DATA_V4 = 'eth_signTypedData_v4';
 
 const SECURITY_ALERT_RESPONSE_ERROR = {
   result_type: BlockaidResultType.Errored,
@@ -91,6 +88,8 @@ export async function validateRequestWithPPOM({
 
     await updateSecurityResponse(request.method, securityAlertId, ppomResponse);
   } catch (error: unknown) {
+    log('Error', error);
+
     await updateSecurityResponse(
       request.method,
       securityAlertId,
@@ -201,7 +200,7 @@ function normalizeTransactionRequest(
   request: PPOMRequest,
   transactionMeta: TransactionMeta,
 ): PPOMRequest {
-  if (request.method !== METHOD_SEND_TRANSACTION) {
+  if (request.method !== MESSAGE_TYPE.ETH_SEND_TRANSACTION) {
     return request;
   }
 
@@ -233,8 +232,8 @@ function normalizeTransactionRequest(
 function normalizeSignatureRequest(request: PPOMRequest): PPOMRequest {
   // This is a temporary fix to prevent a PPOM bypass
   if (
-    request.method !== METHOD_SIGN_TYPED_DATA_V4 &&
-    request.method !== METHOD_SIGN_TYPED_DATA_V3
+    request.method !== MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V3 &&
+    request.method !== MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4
   ) {
     return request;
   }

--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -1,13 +1,22 @@
 import { PPOMController } from '@metamask/ppom-validator';
 import {
   TransactionController,
+  TransactionControllerUnapprovedTransactionAddedEvent,
+  TransactionMeta,
   TransactionParams,
   normalizeTransactionParams,
 } from '@metamask/transaction-controller';
-import { Hex, JsonRpcRequest } from '@metamask/utils';
+import { Hex, JsonRpcRequest, createProjectLogger } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 import { PPOM } from '@blockaid/ppom_release';
-import { SignatureController } from '@metamask/signature-controller';
+import {
+  SignatureController,
+  SignatureControllerState,
+  SignatureRequest,
+  SignatureStateChange,
+} from '@metamask/signature-controller';
+import { Messenger } from '@metamask/base-controller';
+import { cloneDeep } from 'lodash';
 import {
   BlockaidReason,
   BlockaidResultType,
@@ -25,6 +34,8 @@ import {
   validateWithSecurityAlertsAPI,
 } from './security-alerts-api';
 
+const log = createProjectLogger('ppom-util');
+
 const { sentry } = global;
 
 const METHOD_SEND_TRANSACTION = 'eth_sendTransaction';
@@ -36,10 +47,15 @@ const SECURITY_ALERT_RESPONSE_ERROR = {
   reason: BlockaidReason.errored,
 };
 
-type PPOMRequest = Omit<JsonRpcRequest, 'method' | 'params'> & {
-  method: typeof METHOD_SEND_TRANSACTION;
-  params: [TransactionParams];
+type PPOMRequest = JsonRpcRequest & {
+  delegationMock?: Hex;
+  origin?: string;
 };
+
+export type PPOMMessenger = Messenger<
+  never,
+  SignatureStateChange | TransactionControllerUnapprovedTransactionAddedEvent
+>;
 
 export async function validateRequestWithPPOM({
   ppomController,
@@ -49,19 +65,21 @@ export async function validateRequestWithPPOM({
   updateSecurityAlertResponse: updateSecurityResponse,
 }: {
   ppomController: PPOMController;
-  request: JsonRpcRequest;
+  request: PPOMRequest;
   securityAlertId: string;
   chainId: Hex;
   updateSecurityAlertResponse: UpdateSecurityAlertResponse;
 }) {
   try {
-    await updateSecurityResponse(
+    const controllerObject = await updateSecurityResponse(
       request.method,
       securityAlertId,
       LOADING_SECURITY_ALERT_RESPONSE,
     );
 
-    const normalizedRequest = normalizePPOMRequest(request);
+    const normalizedRequest = normalizePPOMRequest(request, controllerObject);
+
+    log('Normalized request', normalizedRequest);
 
     const ppomResponse = isSecurityAlertsAPIEnabled()
       ? await validateWithAPI(ppomController, chainId, normalizedRequest)
@@ -70,6 +88,7 @@ export async function validateRequestWithPPOM({
           normalizedRequest,
           chainId,
         );
+
     await updateSecurityResponse(request.method, securityAlertId, ppomResponse);
   } catch (error: unknown) {
     await updateSecurityResponse(
@@ -86,6 +105,7 @@ export function generateSecurityAlertId(): string {
 
 export async function updateSecurityAlertResponse({
   appStateController,
+  messenger,
   method,
   securityAlertId,
   securityAlertResponse,
@@ -93,32 +113,42 @@ export async function updateSecurityAlertResponse({
   transactionController,
 }: {
   appStateController: AppStateController;
+  messenger: PPOMMessenger;
   method: string;
   securityAlertId: string;
   securityAlertResponse: SecurityAlertResponse;
   signatureController: SignatureController;
   transactionController: TransactionController;
-}) {
+}): Promise<TransactionMeta | SignatureRequest> {
   const isSignatureRequest = SIGNING_METHODS.includes(method);
 
-  const confirmation = await findConfirmationBySecurityAlertId(
-    securityAlertId,
-    method,
-    signatureController,
-    transactionController,
-  );
-
   if (isSignatureRequest) {
+    const signatureRequest = await waitForSignatureRequest(
+      signatureController,
+      securityAlertId,
+      messenger,
+    );
+
     appStateController.addSignatureSecurityAlertResponse({
       ...securityAlertResponse,
       securityAlertId,
     });
-  } else {
-    transactionController.updateSecurityAlertResponse(confirmation.id, {
-      ...securityAlertResponse,
-      securityAlertId,
-    } as SecurityAlertResponse);
+
+    return signatureRequest;
   }
+
+  const transactionMeta = await waitForTransactionMetadata(
+    transactionController,
+    securityAlertId,
+    messenger,
+  );
+
+  transactionController.updateSecurityAlertResponse(transactionMeta.id, {
+    ...securityAlertResponse,
+    securityAlertId,
+  } as SecurityAlertResponse);
+
+  return transactionMeta;
 }
 
 export function handlePPOMError(
@@ -142,18 +172,57 @@ export function handlePPOMError(
 }
 
 function normalizePPOMRequest(
-  request: PPOMRequest | JsonRpcRequest,
-): PPOMRequest | JsonRpcRequest {
-  if (
-    !((req): req is PPOMRequest => req.method === METHOD_SEND_TRANSACTION)(
-      request,
-    )
-  ) {
-    return sanitizeRequest(request);
+  request: PPOMRequest,
+  controllerObject: TransactionMeta | SignatureRequest,
+): PPOMRequest {
+  let normalizedRequest = cloneDeep(request);
+
+  normalizedRequest = normalizeSignatureRequest(normalizedRequest);
+
+  normalizedRequest = normalizeTransactionRequest(
+    normalizedRequest,
+    controllerObject as TransactionMeta,
+  );
+
+  const { delegationMock, id, jsonrpc, method, origin, params } =
+    normalizedRequest;
+
+  return {
+    delegationMock,
+    id,
+    jsonrpc,
+    method,
+    origin,
+    params,
+  };
+}
+
+function normalizeTransactionRequest(
+  request: PPOMRequest,
+  transactionMeta: TransactionMeta,
+): PPOMRequest {
+  if (request.method !== METHOD_SEND_TRANSACTION) {
+    return request;
   }
 
-  const transactionParams = request.params[0];
-  const normalizedParams = normalizeTransactionParams(transactionParams);
+  if (!Array.isArray(request.params) || !request.params[0]) {
+    return request;
+  }
+
+  const txParams = request.params[0] as TransactionParams;
+
+  txParams.gas = transactionMeta.txParams.gas;
+  txParams.gasPrice =
+    transactionMeta.txParams.maxFeePerGas ?? transactionMeta.txParams.gasPrice;
+
+  delete txParams.gasLimit;
+  delete txParams.maxFeePerGas;
+  delete txParams.maxPriorityFeePerGas;
+  delete txParams.type;
+
+  const normalizedParams = normalizeTransactionParams(txParams);
+
+  log('Normalized transaction params', normalizedParams);
 
   return {
     ...request,
@@ -161,36 +230,37 @@ function normalizePPOMRequest(
   };
 }
 
-function sanitizeRequest(request: JsonRpcRequest): JsonRpcRequest {
+function normalizeSignatureRequest(request: PPOMRequest): PPOMRequest {
   // This is a temporary fix to prevent a PPOM bypass
   if (
-    request.method === METHOD_SIGN_TYPED_DATA_V4 ||
-    request.method === METHOD_SIGN_TYPED_DATA_V3
+    request.method !== METHOD_SIGN_TYPED_DATA_V4 &&
+    request.method !== METHOD_SIGN_TYPED_DATA_V3
   ) {
-    if (Array.isArray(request.params) && request.params[1]) {
-      const typedDataMessage = parseTypedDataMessage(
-        request.params[1].toString(),
-      );
-
-      const sanitizedMessageRecursively = sanitizeMessageRecursively(
-        typedDataMessage.message,
-        typedDataMessage.types,
-        typedDataMessage.primaryType,
-      );
-
-      return {
-        ...request,
-        params: [
-          request.params[0],
-          JSON.stringify({
-            ...typedDataMessage,
-            message: sanitizedMessageRecursively,
-          }),
-        ],
-      };
-    }
+    return request;
   }
-  return request;
+
+  if (!Array.isArray(request.params) || !request.params[1]) {
+    return request;
+  }
+
+  const typedDataMessage = parseTypedDataMessage(request.params[1].toString());
+
+  const sanitizedMessageRecursively = sanitizeMessageRecursively(
+    typedDataMessage.message,
+    typedDataMessage.types,
+    typedDataMessage.primaryType,
+  );
+
+  return {
+    ...request,
+    params: [
+      request.params[0],
+      JSON.stringify({
+        ...typedDataMessage,
+        message: sanitizedMessageRecursively,
+      }),
+    ],
+  };
 }
 
 function getErrorMessage(error: unknown) {
@@ -209,44 +279,9 @@ function getErrorData(error: unknown) {
   return JSON.stringify(error);
 }
 
-async function findConfirmationBySecurityAlertId(
-  securityAlertId: string,
-  method: string,
-  signatureController: SignatureController,
-  transactionController: TransactionController,
-) {
-  const isSignatureRequest = SIGNING_METHODS.includes(method);
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    let confirmation;
-
-    if (isSignatureRequest) {
-      confirmation = Object.values(signatureController.messages).find(
-        (message) =>
-          message.securityAlertResponse?.securityAlertId === securityAlertId,
-      );
-    } else {
-      confirmation = transactionController.state.transactions.find(
-        (meta) =>
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (meta.securityAlertResponse as any)?.securityAlertId ===
-          securityAlertId,
-      );
-    }
-
-    if (confirmation) {
-      return confirmation;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-}
-
 async function validateWithController(
   ppomController: PPOMController,
-  request: SecurityAlertsAPIRequest | JsonRpcRequest,
+  request: SecurityAlertsAPIRequest | PPOMRequest,
   chainId: string,
 ): Promise<SecurityAlertResponse> {
   try {
@@ -271,7 +306,7 @@ async function validateWithController(
 async function validateWithAPI(
   ppomController: PPOMController,
   chainId: string,
-  request: SecurityAlertsAPIRequest | JsonRpcRequest,
+  request: SecurityAlertsAPIRequest | PPOMRequest,
 ): Promise<SecurityAlertResponse> {
   try {
     const response = await validateWithSecurityAlertsAPI(chainId, request);
@@ -284,4 +319,84 @@ async function validateWithAPI(
     handlePPOMError(error, `Error validating request with security alerts API`);
     return await validateWithController(ppomController, request, chainId);
   }
+}
+
+async function waitForTransactionMetadata(
+  transactionController: TransactionController,
+  securityAlertId: string,
+  messenger: PPOMMessenger,
+): Promise<TransactionMeta> {
+  const transactionFilter = (meta: TransactionMeta) =>
+    meta.securityAlertResponse?.securityAlertId === securityAlertId;
+
+  return new Promise((resolve) => {
+    const transactionMeta =
+      transactionController.state.transactions.find(transactionFilter);
+
+    if (transactionMeta) {
+      resolve(transactionMeta);
+      return;
+    }
+
+    const callback = (event: TransactionMeta) => {
+      if (!transactionFilter(event)) {
+        return;
+      }
+
+      log('Found transaction metadata', event);
+
+      messenger.unsubscribe(
+        'TransactionController:unapprovedTransactionAdded',
+        callback,
+      );
+
+      resolve(event);
+    };
+
+    log('Waiting for transaction metadata', securityAlertId);
+
+    messenger.subscribe(
+      'TransactionController:unapprovedTransactionAdded',
+      callback,
+    );
+  });
+}
+
+async function waitForSignatureRequest(
+  signatureController: SignatureController,
+  securityAlertId: string,
+  messenger: PPOMMessenger,
+): Promise<SignatureRequest> {
+  const signatureFilter = (state: SignatureControllerState) =>
+    Object.values(state.signatureRequests).find(
+      (request) =>
+        request.securityAlertResponse?.securityAlertId === securityAlertId,
+    );
+
+  return new Promise((resolve) => {
+    const signatureRequest = signatureFilter(signatureController.state);
+
+    if (signatureRequest) {
+      resolve(signatureRequest);
+      return;
+    }
+
+    const callback = (state: SignatureControllerState) => {
+      const request = signatureFilter(state);
+
+      if (!request) {
+        return;
+      }
+
+      log('Found signature request', request);
+
+      messenger.unsubscribe('SignatureController:stateChange', callback);
+
+      resolve(request);
+    };
+
+    log('Waiting for signature request', securityAlertId);
+
+    messenger.subscribe('SignatureController:stateChange', callback);
+  });
 }

--- a/app/scripts/lib/ppom/types.ts
+++ b/app/scripts/lib/ppom/types.ts
@@ -1,3 +1,5 @@
+import { SignatureRequest } from '@metamask/signature-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import { SecurityAlertSource } from '../../../../shared/constants/security-provider';
 
 export type SecurityAlertResponse = {
@@ -15,4 +17,4 @@ export type UpdateSecurityAlertResponse = (
   method: string,
   securityAlertId: string,
   securityAlertResponse: SecurityAlertResponse,
-) => Promise<void>;
+) => Promise<TransactionMeta | SignatureRequest>;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5967,8 +5967,9 @@ export default class MetamaskController extends EventEmitter {
     securityAlertId,
     securityAlertResponse,
   ) {
-    await updateSecurityAlertResponse({
+    return await updateSecurityAlertResponse({
       appStateController: this.appStateController,
+      messenger: this.controllerMessenger,
       method,
       securityAlertId,
       securityAlertResponse,


### PR DESCRIPTION
## **Description**

Populate `gas` and `gasPrice` in requests to security alerts API and `PPOMController`.

Specifically:

- Extract gas properties from `TransactionMeta`.
- Remove excess properties from PPOM request such as `networkClientId` and `tabId`.
- Wait for controller objects using events instead of `setTimeout` loop.
- Remove duplication in unit tests.
- Use `MESSAGE_TYPE` constant for RPC method names.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33180?quickstart=1)

## **Related issues**

Fixes: [#4968](https://github.com/MetaMask/MetaMask-planning/issues/4968)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
