### PR TITLE
fix: unlimited values in permit signature requests

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.test.tsx
@@ -15,6 +15,8 @@ jest.mock('../../../../../../../../store/actions', () => {
   };
 });
 
+const UNLIMITED_THRESHOLD = '1'.padEnd(15 + 4 + 1, '0');
+
 describe('PermitSimulationValueDisplay', () => {
   it('renders component correctly', async () => {
     const mockStore = configureMockStore([])(mockState);
@@ -52,5 +54,71 @@ describe('PermitSimulationValueDisplay', () => {
     });
 
     expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders unlimited if value at threshold', async () => {
+    const mockStore = configureMockStore([])(mockState);
+
+    const { getByText } = renderWithProvider(
+      <MetaMetricsContext.Provider value={jest.fn()}>
+        <PermitSimulationValueDisplay
+          tokenContract="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          value={UNLIMITED_THRESHOLD}
+          chainId="0x1"
+          canDisplayValueAsUnlimited
+        />
+      </MetaMetricsContext.Provider>,
+      mockStore,
+    );
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(getByText('Unlimited')).toBeInTheDocument();
+  });
+
+  it('renders unlimited if value over threshold', async () => {
+    const mockStore = configureMockStore([])(mockState);
+
+    const { getByText } = renderWithProvider(
+      <MetaMetricsContext.Provider value={jest.fn()}>
+        <PermitSimulationValueDisplay
+          tokenContract="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          value={`${UNLIMITED_THRESHOLD.slice(0, -1)}1`}
+          chainId="0x1"
+          canDisplayValueAsUnlimited
+        />
+      </MetaMetricsContext.Provider>,
+      mockStore,
+    );
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(getByText('Unlimited')).toBeInTheDocument();
+  });
+
+  it('renders unlimited if value under threshold', async () => {
+    const mockStore = configureMockStore([])(mockState);
+
+    const { queryByText } = renderWithProvider(
+      <MetaMetricsContext.Provider value={jest.fn()}>
+        <PermitSimulationValueDisplay
+          tokenContract="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          value={UNLIMITED_THRESHOLD.slice(0, -1)}
+          chainId="0x1"
+          canDisplayValueAsUnlimited
+        />
+      </MetaMetricsContext.Provider>,
+      mockStore,
+    );
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(queryByText('Unlimited')).toBeNull();
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.tsx
@@ -28,11 +28,9 @@ import {
   formatAmount,
   formatAmountMaxPrecision,
 } from '../../../../../simulation-details/formatAmount';
-import {
-  DAI_CONTRACT_ADDRESS,
-  TOKEN_VALUE_UNLIMITED_THRESHOLD,
-} from '../../../shared/constants';
+import { DAI_CONTRACT_ADDRESS } from '../../../shared/constants';
 import { getAmountColors } from '../../../utils';
+import { isSpendingCapUnlimited } from '../../../approve/hooks/use-approve-token-simulation';
 
 type PermitSimulationValueDisplayParams = {
   /** ID of the associated chain. */
@@ -118,8 +116,10 @@ const PermitSimulationValueDisplay: React.FC<
 
       const tokenAmount = calcTokenAmount(value, tokenDecimals);
 
-      const showUnlimitedDueToPermitValue =
-        Number(value) > TOKEN_VALUE_UNLIMITED_THRESHOLD;
+      const showUnlimitedDueToPermitValue = isSpendingCapUnlimited(
+        value,
+        tokenDecimals,
+      );
 
       return {
         tokenValue: formatAmount('en-US', tokenAmount),


### PR DESCRIPTION
## **Description**

When displaying permit signature values as `Unlimited`, verify against the threshold after applying token decimals.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33194?quickstart=1)

## **Related issues**

Fixes: #33174 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
