### PR TITLE
fix: cp-12.18.2 bump solana to v1.31.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
     "@metamask/snaps-rpc-methods": "^12.3.0",
     "@metamask/snaps-sdk": "^6.24.0",
     "@metamask/snaps-utils": "^9.3.0",
-    "@metamask/solana-wallet-snap": "^1.30.4",
+    "@metamask/solana-wallet-snap": "^1.31.0",
     "@metamask/solana-wallet-standard": "^0.4.1",
     "@metamask/transaction-controller": "^56.2.0",
     "@metamask/user-operation-controller": "^31.0.0",

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
     "@metamask/snaps-rpc-methods": "^12.3.0",
     "@metamask/snaps-sdk": "^6.24.0",
     "@metamask/snaps-utils": "^9.3.0",
-    "@metamask/solana-wallet-snap": "^1.31.0",
+    "@metamask/solana-wallet-snap": "^1.31.1",
     "@metamask/solana-wallet-standard": "^0.4.1",
     "@metamask/transaction-controller": "^56.2.0",
     "@metamask/user-operation-controller": "^31.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6463,10 +6463,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/solana-wallet-snap@npm:^1.30.4":
-  version: 1.30.4
-  resolution: "@metamask/solana-wallet-snap@npm:1.30.4"
-  checksum: 10/72ca2257ff8037ce7a95d12c50da3896f14f5a4d1b78f88784944427efb3d21281963aae1a063e10b07c0f340dbdb1d7f0dbb282238cae1e5465fa3606ae1b8f
+"@metamask/solana-wallet-snap@npm:^1.31.0":
+  version: 1.31.0
+  resolution: "@metamask/solana-wallet-snap@npm:1.31.0"
+  checksum: 10/7cedb9344dfb0f1d6c6dd03a43cf4390623886cf45fa9da779fafabd0edaad6a7abef5b2bd4a211fc7cada08334735baf320799b0cacdb9428dc3d77bdcdae5a
   languageName: node
   linkType: hard
 
@@ -29850,7 +29850,7 @@ __metadata:
     "@metamask/snaps-rpc-methods": "npm:^12.3.0"
     "@metamask/snaps-sdk": "npm:^6.24.0"
     "@metamask/snaps-utils": "npm:^9.3.0"
-    "@metamask/solana-wallet-snap": "npm:^1.30.4"
+    "@metamask/solana-wallet-snap": "npm:^1.31.0"
     "@metamask/solana-wallet-standard": "npm:^0.4.1"
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/test-bundler": "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6463,10 +6463,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/solana-wallet-snap@npm:^1.31.0":
-  version: 1.31.0
-  resolution: "@metamask/solana-wallet-snap@npm:1.31.0"
-  checksum: 10/7cedb9344dfb0f1d6c6dd03a43cf4390623886cf45fa9da779fafabd0edaad6a7abef5b2bd4a211fc7cada08334735baf320799b0cacdb9428dc3d77bdcdae5a
+"@metamask/solana-wallet-snap@npm:^1.31.1":
+  version: 1.31.1
+  resolution: "@metamask/solana-wallet-snap@npm:1.31.1"
+  checksum: 10/714d14591bf1c45d266139d1864a0428a0b799c71ae9efc2924d4b3e2ae3301a795b4ec321ef597984f0af991707e4d922d0f29912e214a81adcc123a52a61c7
   languageName: node
   linkType: hard
 
@@ -29850,7 +29850,7 @@ __metadata:
     "@metamask/snaps-rpc-methods": "npm:^12.3.0"
     "@metamask/snaps-sdk": "npm:^6.24.0"
     "@metamask/snaps-utils": "npm:^9.3.0"
-    "@metamask/solana-wallet-snap": "npm:^1.31.0"
+    "@metamask/solana-wallet-snap": "npm:^1.31.1"
     "@metamask/solana-wallet-standard": "npm:^0.4.1"
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/test-bundler": "npm:^1.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

https://github.com/MetaMask/snap-solana-wallet/releases/tag/v1.31.0

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33210?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
