### PR TITLE
refactor: move translation related functions to `shared`

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -49,6 +49,7 @@ import {
 import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { createCaipStream } from '../../shared/modules/caip-stream';
 import getFetchWithTimeout from '../../shared/modules/fetch-with-timeout';
+import getFirstPreferredLangCode from '../../shared/lib/get-first-preferred-lang-code';
 import {
   METHOD_DISPLAY_STATE_CORRUPTION_ERROR,
   KNOWN_STATE_CORRUPTION_ERRORS,
@@ -68,7 +69,6 @@ import NotificationManager, {
 import MetamaskController, {
   METAMASK_CONTROLLER_EVENTS,
 } from './metamask-controller';
-import getFirstPreferredLangCode from './lib/get-first-preferred-lang-code';
 import getObjStructure from './lib/getObjStructure';
 import setupEnsIpfsResolver from './lib/ens-ipfs/setup';
 import {

--- a/app/scripts/controllers/push-notifications/get-notification-message.ts
+++ b/app/scripts/controllers/push-notifications/get-notification-message.ts
@@ -1,6 +1,6 @@
 import type { NotificationServicesController } from '@metamask/notification-services-controller';
 import { NotificationServicesPushController } from '@metamask/notification-services-controller';
-import { t as translate } from '../../translate';
+import { t as translate } from '../../../../shared/lib/translate';
 
 const t = (...args: Parameters<typeof translate>) => translate(...args) ?? '';
 

--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -13,7 +13,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
-import { t } from '../../translate';
+import { t } from '../../../../shared/lib/translate';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { IconName } from '../../../../ui/components/component-library/icon';

--- a/app/scripts/lib/state-corruption-errors.ts
+++ b/app/scripts/lib/state-corruption-errors.ts
@@ -14,7 +14,7 @@ import {
   CORRUPTION_BLOCK_CHECKSUM_MISMATCH,
 } from '../../../shared/constants/errors';
 import { switchDirectionForPreferredLocale } from '../../../shared/lib/switch-direction';
-import getFirstPreferredLangCode from './get-first-preferred-lang-code';
+import getFirstPreferredLangCode from '../../../shared/lib/get-first-preferred-lang-code';
 
 export type ErrorLike = {
   message: string;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -244,6 +244,7 @@ import { BRIDGE_API_BASE_URL } from '../../shared/constants/bridge';
 import { MultichainWalletSnapClient } from '../../shared/lib/accounts';
 import { SOLANA_WALLET_SNAP_ID } from '../../shared/lib/accounts/solana-wallet-snap';
 ///: END:ONLY_INCLUDE_IF
+import { updateCurrentLocale } from '../../shared/lib/translate';
 import { createTransactionEventFragmentWithTxId } from './lib/transaction/metrics';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { keyringSnapPermissionsBuilder } from './lib/snap-keyring/keyring-snaps-permissions';
@@ -317,7 +318,6 @@ import {
 import { MetaMetricsDataDeletionController } from './controllers/metametrics-data-deletion/metametrics-data-deletion';
 import { DataDeletionService } from './services/data-deletion-service';
 import createRPCMethodTrackingMiddleware from './lib/createRPCMethodTrackingMiddleware';
-import { updateCurrentLocale } from './translate';
 import { TrezorOffscreenBridge } from './lib/offscreen-bridge/trezor-offscreen-bridge';
 import { LedgerOffscreenBridge } from './lib/offscreen-bridge/ledger-offscreen-bridge';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -8,7 +8,7 @@ import { ENVIRONMENT_TYPE_BACKGROUND } from '../../../shared/constants/app';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { getURLHostName } from '../../../ui/helpers/utils/util';
-import { t } from '../translate';
+import { t } from '../../../shared/lib/translate';
 
 export default class ExtensionPlatform {
   //

--- a/shared/lib/error-utils.js
+++ b/shared/lib/error-utils.js
@@ -1,8 +1,6 @@
 import { memoize, escape as lodashEscape } from 'lodash';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import getFirstPreferredLangCode from '../../app/scripts/lib/get-first-preferred-lang-code';
 import { fetchLocale, loadRelativeTimeFormatLocaleData } from '../modules/i18n';
+import getFirstPreferredLangCode from './get-first-preferred-lang-code';
 import { switchDirectionForPreferredLocale } from './switch-direction';
 
 const defaultLocale = 'en';

--- a/shared/lib/get-first-preferred-lang-code.js
+++ b/shared/lib/get-first-preferred-lang-code.js
@@ -1,5 +1,7 @@
 import browser from 'webextension-polyfill';
-import allLocales from '../../_locales/index.json';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import allLocales from '../../app/_locales/index.json';
 
 // ensure that we default users with browser language code 'zh' to the supported 'zh_CN' language code
 const existingLocaleCodes = { zh: 'zh_CN' };

--- a/shared/lib/translate.test.ts
+++ b/shared/lib/translate.test.ts
@@ -1,5 +1,5 @@
 import { getMessage, fetchLocale, FALLBACK_LOCALE } from '../modules/i18n';
-import { t, updateCurrentLocale } from '../../shared/lib/translate';
+import { t, updateCurrentLocale } from './translate';
 
 const localeCodeMock = 'te';
 const keyMock = 'testKey';

--- a/shared/lib/translate.test.ts
+++ b/shared/lib/translate.test.ts
@@ -1,9 +1,5 @@
-import {
-  getMessage,
-  fetchLocale,
-  FALLBACK_LOCALE,
-} from '../../shared/modules/i18n';
-import { t, updateCurrentLocale } from './translate';
+import { getMessage, fetchLocale, FALLBACK_LOCALE } from '../modules/i18n';
+import { t, updateCurrentLocale } from '../../shared/lib/translate';
 
 const localeCodeMock = 'te';
 const keyMock = 'testKey';
@@ -12,8 +8,8 @@ const messageMock = 'testMessage';
 const messageMock2 = 'testMessage2';
 const alternateLocaleDataMock = { [keyMock]: { message: messageMock2 } };
 
-jest.mock('../../shared/modules/i18n');
-jest.mock('../_locales/en/messages.json', () => ({
+jest.mock('../modules/i18n');
+jest.mock('../../app/_locales/en/messages.json', () => ({
   [keyMock]: { message: messageMock },
 }));
 

--- a/shared/lib/translate.ts
+++ b/shared/lib/translate.ts
@@ -1,10 +1,12 @@
-import enTranslations from '../_locales/en/messages.json';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import enTranslations from '../../app/_locales/en/messages.json';
 import {
   FALLBACK_LOCALE,
   I18NMessageDict,
   fetchLocale,
   getMessage,
-} from '../../shared/modules/i18n';
+} from '../modules/i18n';
 
 let currentLocale: string = FALLBACK_LOCALE;
 let translations: I18NMessageDict = enTranslations;

--- a/ui/helpers/utils/accounts.js
+++ b/ui/helpers/utils/accounts.js
@@ -9,9 +9,7 @@ import {
 import { BackgroundColor } from '../constants/design-system';
 import { KeyringType } from '../../../shared/constants/keyring';
 import { HardwareKeyringNames } from '../../../shared/constants/hardware-wallets';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../app/scripts/translate';
+import { t } from '../../../shared/lib/translate';
 import { isSnapPreinstalled } from '../../../shared/lib/snaps/snaps';
 
 export function getAccountNameErrorMessage(

--- a/ui/pages/bridge/prepare/components/destination-account-picker.tsx
+++ b/ui/pages/bridge/prepare/components/destination-account-picker.tsx
@@ -22,8 +22,7 @@ import {
   JustifyContent,
   BackgroundColor,
 } from '../../../../helpers/constants/design-system';
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 import { DestinationAccount } from '../types';
 import { useExternalAccountResolution } from '../../hooks/useExternalAccountResolution';
 import DestinationSelectedAccountListItem from './destination-selected-account-list-item';

--- a/ui/pages/notifications/notification-components/erc1155-sent-received/erc1155-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc1155-sent-received/erc1155-sent-received.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import {

--- a/ui/pages/notifications/notification-components/erc20-sent-received/erc20-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc20-sent-received/erc20-sent-received.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import {

--- a/ui/pages/notifications/notification-components/erc721-sent-received/erc721-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/erc721-sent-received/erc721-sent-received.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import {

--- a/ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx
+++ b/ui/pages/notifications/notification-components/eth-sent-received/eth-sent-received.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import {

--- a/ui/pages/notifications/notification-components/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
+++ b/ui/pages/notifications/notification-components/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.tsx
@@ -14,9 +14,7 @@ import {
   NotificationDetailBlockExplorerButton,
   NotificationDetailAddress,
 } from '../../../../components/multichain';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 import {
   createTextItems,
   formatAmount,

--- a/ui/pages/notifications/notification-components/lido-withdrawal-requested/lido-withdrawal-requested.tsx
+++ b/ui/pages/notifications/notification-components/lido-withdrawal-requested/lido-withdrawal-requested.tsx
@@ -23,9 +23,7 @@ import {
   getNetworkDetailsByChainId,
   getUsdAmount,
 } from '../../../../helpers/utils/notification.util';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 import {
   TextVariant,
   BackgroundColor,

--- a/ui/pages/notifications/notification-components/stake/stake.tsx
+++ b/ui/pages/notifications/notification-components/stake/stake.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { type ExtractedNotification, isOfTypeNodeGuard } from '../node-guard';
 import {

--- a/ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx
+++ b/ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx
@@ -6,9 +6,7 @@ import {
   type NotificationComponent,
 } from '../types/notifications/notifications';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { t } from '../../../../../app/scripts/translate';
+import { t } from '../../../../../shared/lib/translate';
 
 import {
   NotificationListItem,


### PR DESCRIPTION

## **Description**

Translations functions are used by both `app` and `ui`, so they should be in `shared`. This PR moves _some_ of them. The `_locales` files are bit harder to move so I'm not doing that just yet.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33217?quickstart=1)
<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!--