### PR TITLE
feat: Add alert for malicious batch transactions cp-12.18.3

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -372,6 +372,9 @@
   "alertActionUpdateGasFeeLevel": {
     "message": "Update gas options"
   },
+  "alertContentMultipleApprovals": {
+    "message": "You're giving someone else permission to withdraw your $1, even though it's not necessary for this transaction."
+  },
   "alertDisableTooltip": {
     "message": "This can be changed in \"Settings > Alerts\""
   },
@@ -434,6 +437,9 @@
   },
   "alertReasonInsufficientBalance": {
     "message": "Insufficient funds"
+  },
+  "alertReasonMultipleApprovals": {
+    "message": "Unnecessary permission"
   },
   "alertReasonNetworkBusy": {
     "message": "Network is busy"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -373,7 +373,7 @@
     "message": "Update gas options"
   },
   "alertContentMultipleApprovals": {
-    "message": "You're giving someone else permission to withdraw your $1, even though it's not necessary for this transaction."
+    "message": "You're giving someone else permission to withdraw your tokens, even though it's not necessary for this transaction."
   },
   "alertDisableTooltip": {
     "message": "This can be changed in \"Settings > Alerts\""

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -372,6 +372,9 @@
   "alertActionUpdateGasFeeLevel": {
     "message": "Update gas options"
   },
+  "alertContentMultipleApprovals": {
+    "message": "You're giving someone else permission to withdraw your $1, even though it's not necessary for this transaction."
+  },
   "alertDisableTooltip": {
     "message": "This can be changed in \"Settings > Alerts\""
   },
@@ -434,6 +437,9 @@
   },
   "alertReasonInsufficientBalance": {
     "message": "Insufficient funds"
+  },
+  "alertReasonMultipleApprovals": {
+    "message": "Unnecessary permission"
   },
   "alertReasonNetworkBusy": {
     "message": "Network is busy"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -373,7 +373,7 @@
     "message": "Update gas options"
   },
   "alertContentMultipleApprovals": {
-    "message": "You're giving someone else permission to withdraw your $1, even though it's not necessary for this transaction."
+    "message": "You're giving someone else permission to withdraw your tokens, even though it's not necessary for this transaction."
   },
   "alertDisableTooltip": {
     "message": "This can be changed in \"Settings > Alerts\""

--- a/shared/modules/transaction.utils.ts
+++ b/shared/modules/transaction.utils.ts
@@ -366,9 +366,6 @@ export function parseApprovalTransactionData(data: Hex):
     args?.increment ?? // Fiat Token V2 - increaseAllowance
     args?.amount; // Permit2 - approve
 
-  console.log({ args });
-  console.log('rawAmountOrTokenId', rawAmountOrTokenId);
-
   const amountOrTokenId = rawAmountOrTokenId
     ? new BigNumber(rawAmountOrTokenId?.toString())
     : undefined;

--- a/shared/modules/transaction.utils.ts
+++ b/shared/modules/transaction.utils.ts
@@ -366,6 +366,9 @@ export function parseApprovalTransactionData(data: Hex):
     args?.increment ?? // Fiat Token V2 - increaseAllowance
     args?.amount; // Permit2 - approve
 
+  console.log({ args });
+  console.log('rawAmountOrTokenId', rawAmountOrTokenId);
+
   const amountOrTokenId = rawAmountOrTokenId
     ? new BigNumber(rawAmountOrTokenId?.toString())
     : undefined;

--- a/ui/components/app/confirm/info/row/alert-row/alert-row.tsx
+++ b/ui/components/app/confirm/info/row/alert-row/alert-row.tsx
@@ -21,7 +21,7 @@ export type ConfirmInfoAlertRowProps = ConfirmInfoRowProps & {
   isShownWithAlertsOnly?: boolean;
 };
 
-function getAlertTextColors(
+export function getAlertTextColors(
   variant?: ConfirmInfoRowVariant | Severity,
 ): TextColor {
   switch (variant) {

--- a/ui/components/app/confirm/info/row/constants.ts
+++ b/ui/components/app/confirm/info/row/constants.ts
@@ -9,6 +9,7 @@ export enum RowAlertKey {
   Resimulation = 'resimulation',
   Speed = 'speed',
   InteractingWith = 'interactingWith',
+  EstimatedApprovalChanges = 'estimatedApprovalChanges',
 }
 
 export enum AlertActionKey {

--- a/ui/components/app/confirm/info/row/constants.ts
+++ b/ui/components/app/confirm/info/row/constants.ts
@@ -9,7 +9,7 @@ export enum RowAlertKey {
   Resimulation = 'resimulation',
   Speed = 'speed',
   InteractingWith = 'interactingWith',
-  EstimatedApprovalChanges = 'estimatedApprovalChanges',
+  EstimatedChangesStatic = 'estimatedChangesStatic',
 }
 
 export enum AlertActionKey {

--- a/ui/pages/confirmations/components/simulation-details/balance-change-list.tsx
+++ b/ui/pages/confirmations/components/simulation-details/balance-change-list.tsx
@@ -3,6 +3,7 @@ import { Box } from '../../../../components/component-library';
 import {
   Display,
   FlexDirection,
+  TextColor,
 } from '../../../../helpers/constants/design-system';
 import { BalanceChangeRow } from './balance-change-row';
 import { BalanceChange } from './types';
@@ -23,7 +24,8 @@ export const BalanceChangeList: React.FC<{
   heading: string;
   balanceChanges: BalanceChange[];
   testId?: string;
-}> = ({ heading, balanceChanges, testId }) => {
+  labelColor?: TextColor;
+}> = ({ heading, balanceChanges, testId, labelColor }) => {
   const sortedBalanceChanges = useMemo(() => {
     return sortBalanceChanges(balanceChanges);
   }, [balanceChanges]);
@@ -57,6 +59,7 @@ export const BalanceChangeList: React.FC<{
             label={index === 0 ? heading : undefined}
             balanceChange={balanceChange}
             showFiat={!showFiatTotal && !balanceChange.isUnlimitedApproval}
+            labelColor={labelColor}
           />
         ))}
       </Box>

--- a/ui/pages/confirmations/components/simulation-details/balance-change-list.tsx
+++ b/ui/pages/confirmations/components/simulation-details/balance-change-list.tsx
@@ -18,6 +18,7 @@ import { sortBalanceChanges } from './sortBalanceChanges';
  * @param props.heading
  * @param props.balanceChanges
  * @param props.testId
+ * @param props.labelColor
  * @returns
  */
 export const BalanceChangeList: React.FC<{

--- a/ui/pages/confirmations/components/simulation-details/balance-change-row.tsx
+++ b/ui/pages/confirmations/components/simulation-details/balance-change-row.tsx
@@ -5,6 +5,7 @@ import {
   FlexDirection,
   FlexWrap,
   IconColor,
+  TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import {
@@ -32,7 +33,8 @@ export const BalanceChangeRow: React.FC<{
   label?: string;
   showFiat?: boolean;
   balanceChange: BalanceChange;
-}> = ({ label, showFiat, balanceChange }) => {
+  labelColor?: TextColor;
+}> = ({ label, showFiat, balanceChange, labelColor }) => {
   const t = useI18nContext();
 
   const {
@@ -55,7 +57,11 @@ export const BalanceChangeRow: React.FC<{
       flexWrap={FlexWrap.Wrap}
     >
       {label && (
-        <Text style={{ whiteSpace: 'nowrap' }} variant={TextVariant.bodyMd}>
+        <Text
+          style={{ whiteSpace: 'nowrap' }}
+          color={labelColor}
+          variant={TextVariant.bodyMd}
+        >
           {label}
         </Text>
       )}

--- a/ui/pages/confirmations/components/simulation-details/balance-change-row.tsx
+++ b/ui/pages/confirmations/components/simulation-details/balance-change-row.tsx
@@ -28,6 +28,7 @@ import { IndividualFiatDisplay } from './fiat-display';
  * @param props.label
  * @param props.showFiat
  * @param props.balanceChange
+ * @param props.labelColor
  */
 export const BalanceChangeRow: React.FC<{
   label?: string;

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
@@ -1,19 +1,20 @@
-import configureStore from 'redux-mock-store';
-import React from 'react';
-import { screen } from '@testing-library/react';
 import {
   SimulationData,
   SimulationErrorCode,
   TransactionMeta,
 } from '@metamask/transaction-controller';
+import { screen } from '@testing-library/react';
 import { BigNumber } from 'bignumber.js';
-import { renderWithProvider } from '../../../../../test/lib/render-helpers';
-import mockState from '../../../../../test/data/mock-state.json';
+import React from 'react';
+import configureStore from 'redux-mock-store';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
-import { SimulationDetails, StaticRow } from './simulation-details';
-import { useBalanceChanges } from './useBalanceChanges';
+import mockState from '../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import { AlertMetricsProvider } from '../../../../components/app/alert-system/contexts/alertMetricsContext';
 import { BalanceChangeList } from './balance-change-list';
+import { SimulationDetails, StaticRow } from './simulation-details';
 import { BalanceChange } from './types';
+import { useBalanceChanges } from './useBalanceChanges';
 
 const store = configureStore()(mockState);
 
@@ -31,6 +32,7 @@ jest.mock(
   '../../../../components/app/confirm/info/row/alert-row/alert-row',
   () => ({
     ConfirmInfoAlertRow: jest.fn(({ label }) => <>{label}</>),
+    getAlertTextColors: jest.fn(() => 'textDefault'),
   }),
 );
 
@@ -46,17 +48,30 @@ const renderSimulationDetails = (
   simulationData?: Partial<SimulationData>,
   metricsOnly?: boolean,
   staticRows?: StaticRow[],
-) =>
-  renderWithProvider(
-    <SimulationDetails
-      transaction={
-        { id: 'testTransactionId', simulationData } as TransactionMeta
-      }
-      metricsOnly={metricsOnly}
-      staticRows={staticRows}
-    />,
+) => {
+  const trackAlertActionClicked = jest.fn();
+  const trackAlertRender = jest.fn();
+  const trackInlineAlertClicked = jest.fn();
+
+  return renderWithProvider(
+    <AlertMetricsProvider
+      metrics={{
+        trackAlertActionClicked,
+        trackAlertRender,
+        trackInlineAlertClicked,
+      }}
+    >
+      <SimulationDetails
+        transaction={
+          { id: 'testTransactionId', simulationData } as TransactionMeta
+        }
+        metricsOnly={metricsOnly}
+        staticRows={staticRows}
+      />
+    </AlertMetricsProvider>,
     store,
   );
+};
 
 describe('SimulationDetails', () => {
   beforeEach(() => {

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -382,12 +382,14 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
               balanceChanges={staticRow.balanceChanges}
               labelColor={getAlertTextColors(selectedAlertSeverity)}
             />
-            <Box marginLeft={1}>
-              <InlineAlert
-                onClick={handleInlineAlertClick}
-                severity={selectedAlertSeverity}
-              />
-            </Box>
+            {fieldAlerts.length > 0 && (
+              <Box marginLeft={1}>
+                <InlineAlert
+                  onClick={handleInlineAlertClick}
+                  severity={selectedAlertSeverity}
+                />
+              </Box>
+            )}
           </>
         ))}
         <BalanceChangeList

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -257,6 +257,49 @@ const SimulationDetailsLayout: React.FC<{
     </Box>
   );
 
+const BalanceChangesAlert = ({ transactionId }: { transactionId: string }) => {
+  const { getFieldAlerts } = useAlerts(transactionId);
+  const fieldAlerts = getFieldAlerts(RowAlertKey.EstimatedChangesStatic);
+  const selectedAlertSeverity = fieldAlerts[0]?.severity;
+  const selectedAlertKey = fieldAlerts[0]?.key;
+
+  const { trackInlineAlertClicked } = useAlertMetrics();
+
+  const [alertModalVisible, setAlertModalVisible] = useState<boolean>(false);
+
+  const handleModalClose = () => {
+    setAlertModalVisible(false);
+  };
+
+  const handleInlineAlertClick = () => {
+    setAlertModalVisible(true);
+    trackInlineAlertClicked(selectedAlertKey);
+  };
+
+  return (
+    <>
+      {fieldAlerts.length > 0 && (
+        <Box marginLeft={1}>
+          <InlineAlert
+            onClick={handleInlineAlertClick}
+            severity={selectedAlertSeverity}
+          />
+        </Box>
+      )}
+      {alertModalVisible && (
+        <MultipleAlertModal
+          alertKey={selectedAlertKey}
+          ownerId={transactionId}
+          onFinalAcknowledgeClick={handleModalClose}
+          onClose={handleModalClose}
+          showCloseIcon={false}
+          skipAlertNavigation={true}
+        />
+      )}
+    </>
+  );
+};
+
 /**
  * Preview of a transaction's effects using simulation data.
  *
@@ -292,22 +335,9 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
     transactionId,
   });
 
-  const { trackInlineAlertClicked } = useAlertMetrics();
-  const { getFieldAlerts } = useAlerts(transaction.id);
-  const fieldAlerts = getFieldAlerts(RowAlertKey.EstimatedApprovalChanges);
+  const { getFieldAlerts } = useAlerts(transactionId);
+  const fieldAlerts = getFieldAlerts(RowAlertKey.EstimatedChangesStatic);
   const selectedAlertSeverity = fieldAlerts[0]?.severity;
-  const selectedAlertKey = fieldAlerts[0]?.key;
-
-  const [alertModalVisible, setAlertModalVisible] = useState<boolean>(false);
-
-  const handleModalClose = () => {
-    setAlertModalVisible(false);
-  };
-
-  const handleInlineAlertClick = () => {
-    setAlertModalVisible(true);
-    trackInlineAlertClicked(selectedAlertKey);
-  };
 
   if (metricsOnly) {
     return null;
@@ -382,14 +412,7 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
               balanceChanges={staticRow.balanceChanges}
               labelColor={getAlertTextColors(selectedAlertSeverity)}
             />
-            {fieldAlerts.length > 0 && (
-              <Box marginLeft={1}>
-                <InlineAlert
-                  onClick={handleInlineAlertClick}
-                  severity={selectedAlertSeverity}
-                />
-              </Box>
-            )}
+            <BalanceChangesAlert transactionId={transactionId} />
           </>
         ))}
         <BalanceChangeList
@@ -402,16 +425,6 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
           balanceChanges={incoming}
           testId="simulation-rows-incoming"
         />
-        {alertModalVisible && (
-          <MultipleAlertModal
-            alertKey={selectedAlertKey}
-            ownerId={transaction.id}
-            onFinalAcknowledgeClick={handleModalClose}
-            onClose={handleModalClose}
-            showCloseIcon={false}
-            skipAlertNavigation={true}
-          />
-        )}
       </Box>
     </SimulationDetailsLayout>
   );

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -4,6 +4,9 @@ import {
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import React, { useState } from 'react';
+import { useAlertMetrics } from '../../../../components/app/alert-system/contexts/alertMetricsContext';
+import InlineAlert from '../../../../components/app/alert-system/inline-alert';
+import { MultipleAlertModal } from '../../../../components/app/alert-system/multiple-alert-modal';
 import {
   ConfirmInfoAlertRow,
   getAlertTextColors,
@@ -30,15 +33,12 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
+import useAlerts from '../../../../hooks/useAlerts';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { BalanceChangeList } from './balance-change-list';
+import { BalanceChange } from './types';
 import { useBalanceChanges } from './useBalanceChanges';
 import { useSimulationMetrics } from './useSimulationMetrics';
-import { BalanceChange } from './types';
-import { MultipleAlertModal } from '../../../../components/app/alert-system/multiple-alert-modal';
-import InlineAlert from '../../../../components/app/alert-system/inline-alert';
-import { useAlertMetrics } from '../../../../components/app/alert-system/contexts/alertMetricsContext';
-import useAlerts from '../../../../hooks/useAlerts';
 
 export type StaticRow = {
   label: string;

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
@@ -44,7 +44,7 @@ const CONTENT_MULTIPLE_APPROVALS_NFT =
   "You're giving someone else permission to withdraw your NFTs, even though it's not necessary for this transaction.";
 
 const createBatchTransaction = (
-  nestedTransactions: { data: Hex; to: Hex; value: string }[],
+  nestedTransactions: { data?: Hex; to?: Hex; value: string }[],
 ): TransactionMeta =>
   ({
     id: 'batch-123',
@@ -454,7 +454,7 @@ describe('useMultipleApprovalsAlerts', () => {
   describe('edge cases', () => {
     it('handles transactions without data field', () => {
       const nestedTx = {
-        to: TOKEN_ADDRESS_1,
+        to: TOKEN_ADDRESS_1 as Hex,
         value: '0x0',
         // no data field
       };

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
@@ -38,10 +38,8 @@ const SPENDER_ADDRESS = '0x3456789012345678901234567890123456789012';
 const AMOUNT_MOCK = 1000;
 
 const REASON_MULTIPLE_APPROVALS = tEn('alertReasonMultipleApprovals');
-const CONTENT_MULTIPLE_APPROVALS_ERC20 =
-  "You're giving someone else permission to withdraw your Tokens, even though it's not necessary for this transaction.";
-const CONTENT_MULTIPLE_APPROVALS_NFT =
-  "You're giving someone else permission to withdraw your NFTs, even though it's not necessary for this transaction.";
+const CONTENT_MULTIPLE_APPROVALS =
+  "You're giving someone else permission to withdraw your tokens, even though it's not necessary for this transaction.";
 
 const createBatchTransaction = (
   nestedTransactions: { data?: Hex; to?: Hex; value: string }[],
@@ -187,11 +185,11 @@ describe('useMultipleApprovalsAlerts', () => {
 
       expect(alerts).toEqual([
         {
-          field: RowAlertKey.EstimatedApprovalChanges,
+          field: RowAlertKey.EstimatedChangesStatic,
           isBlocking: false,
           key: 'multipleApprovals',
           reason: REASON_MULTIPLE_APPROVALS,
-          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          content: CONTENT_MULTIPLE_APPROVALS,
           severity: Severity.Danger,
         },
       ]);
@@ -254,11 +252,11 @@ describe('useMultipleApprovalsAlerts', () => {
 
       expect(alerts).toEqual([
         {
-          field: RowAlertKey.EstimatedApprovalChanges,
+          field: RowAlertKey.EstimatedChangesStatic,
           isBlocking: false,
           key: 'multipleApprovals',
           reason: REASON_MULTIPLE_APPROVALS,
-          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          content: CONTENT_MULTIPLE_APPROVALS,
           severity: Severity.Danger,
         },
       ]);
@@ -284,11 +282,11 @@ describe('useMultipleApprovalsAlerts', () => {
 
       expect(alerts).toEqual([
         {
-          field: RowAlertKey.EstimatedApprovalChanges,
+          field: RowAlertKey.EstimatedChangesStatic,
           isBlocking: false,
           key: 'multipleApprovals',
           reason: REASON_MULTIPLE_APPROVALS,
-          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          content: CONTENT_MULTIPLE_APPROVALS,
           severity: Severity.Danger,
         },
       ]);
@@ -314,11 +312,11 @@ describe('useMultipleApprovalsAlerts', () => {
 
       expect(alerts).toEqual([
         {
-          field: RowAlertKey.EstimatedApprovalChanges,
+          field: RowAlertKey.EstimatedChangesStatic,
           isBlocking: false,
           key: 'multipleApprovals',
           reason: REASON_MULTIPLE_APPROVALS,
-          content: CONTENT_MULTIPLE_APPROVALS_NFT,
+          content: CONTENT_MULTIPLE_APPROVALS,
           severity: Severity.Danger,
         },
       ]);
@@ -387,11 +385,11 @@ describe('useMultipleApprovalsAlerts', () => {
 
       expect(alerts).toEqual([
         {
-          field: RowAlertKey.EstimatedApprovalChanges,
+          field: RowAlertKey.EstimatedChangesStatic,
           isBlocking: false,
           key: 'multipleApprovals',
           reason: REASON_MULTIPLE_APPROVALS,
-          content: CONTENT_MULTIPLE_APPROVALS_NFT,
+          content: CONTENT_MULTIPLE_APPROVALS,
           severity: Severity.Danger,
         },
       ]);
@@ -440,11 +438,11 @@ describe('useMultipleApprovalsAlerts', () => {
 
       expect(alerts).toEqual([
         {
-          field: RowAlertKey.EstimatedApprovalChanges,
+          field: RowAlertKey.EstimatedChangesStatic,
           isBlocking: false,
           key: 'multipleApprovals',
           reason: REASON_MULTIPLE_APPROVALS,
-          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          content: CONTENT_MULTIPLE_APPROVALS,
           severity: Severity.Danger,
         },
       ]);
@@ -515,11 +513,11 @@ describe('useMultipleApprovalsAlerts', () => {
 
       expect(alerts).toEqual([
         {
-          field: RowAlertKey.EstimatedApprovalChanges,
+          field: RowAlertKey.EstimatedChangesStatic,
           isBlocking: false,
           key: 'multipleApprovals',
           reason: REASON_MULTIPLE_APPROVALS,
-          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          content: CONTENT_MULTIPLE_APPROVALS,
           severity: Severity.Danger,
         },
       ]);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
@@ -43,7 +43,9 @@ const CONTENT_MULTIPLE_APPROVALS_ERC20 =
 const CONTENT_MULTIPLE_APPROVALS_NFT =
   "You're giving someone else permission to withdraw your NFTs, even though it's not necessary for this transaction.";
 
-const createBatchTransaction = (nestedTransactions: any[]): TransactionMeta =>
+const createBatchTransaction = (
+  nestedTransactions: { data: Hex; to: Hex; value: string }[],
+): TransactionMeta =>
   ({
     id: 'batch-123',
     type: TransactionType.batch,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
@@ -1,0 +1,526 @@
+import { toHex } from '@metamask/controller-utils';
+import {
+  SimulationTokenStandard,
+  TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+import {
+  getMockConfirmState,
+  getMockConfirmStateForTransaction,
+} from '../../../../../../test/data/confirmations/helper';
+import { buildSetApproveForAllTransactionData } from '../../../../../../test/data/confirmations/set-approval-for-all';
+import {
+  buildApproveTransactionData,
+  buildIncreaseAllowanceTransactionData,
+  buildPermit2ApproveTransactionData,
+} from '../../../../../../test/data/confirmations/token-approve';
+import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { tEn } from '../../../../../../test/lib/i18n-helpers';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { useMultipleApprovalsAlerts } from './useMultipleApprovalsAlerts';
+
+jest.mock('../../../../../../shared/modules/transaction.utils', () => ({
+  parseApprovalTransactionData: jest.fn(),
+}));
+
+const mockParseApprovalTransactionData = jest.requireMock(
+  '../../../../../../shared/modules/transaction.utils',
+).parseApprovalTransactionData;
+
+const ACCOUNT_ADDRESS = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+const TOKEN_ADDRESS_1 = '0x1234567890123456789012345678901234567890';
+const TOKEN_ADDRESS_2 = '0x2345678901234567890123456789012345678901';
+const SPENDER_ADDRESS = '0x3456789012345678901234567890123456789012';
+const AMOUNT_MOCK = 1000;
+
+const REASON_MULTIPLE_APPROVALS = tEn('alertReasonMultipleApprovals');
+const CONTENT_MULTIPLE_APPROVALS_ERC20 =
+  "You're giving someone else permission to withdraw your Tokens, even though it's not necessary for this transaction.";
+const CONTENT_MULTIPLE_APPROVALS_NFT =
+  "You're giving someone else permission to withdraw your NFTs, even though it's not necessary for this transaction.";
+
+const createBatchTransaction = (nestedTransactions: any[]): TransactionMeta =>
+  ({
+    id: 'batch-123',
+    type: TransactionType.batch,
+    status: TransactionStatus.unapproved,
+    chainId: '0x1' as Hex,
+    networkClientId: 'mainnet',
+    time: Date.now(),
+    txParams: {
+      from: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc' as Hex,
+      to: '0x0000000000000000000000000000000000000000' as Hex,
+      value: '0x0' as Hex,
+    },
+    nestedTransactions,
+    simulationData: {
+      tokenBalanceChanges: [],
+    },
+  } as unknown as TransactionMeta);
+
+const createNestedTransaction = (data: Hex, to: Hex) => ({
+  data,
+  to,
+  value: '0x0',
+});
+
+function runHook({
+  currentConfirmation,
+}: {
+  currentConfirmation?: TransactionMeta;
+} = {}) {
+  const state = currentConfirmation
+    ? getMockConfirmStateForTransaction(currentConfirmation)
+    : getMockConfirmState();
+
+  const response = renderHookWithConfirmContextProvider(
+    useMultipleApprovalsAlerts,
+    state,
+  );
+
+  return response.result.current;
+}
+
+describe('useMultipleApprovalsAlerts', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns no alerts for non-batch transactions', () => {
+    const regularTransaction: TransactionMeta = {
+      id: 'regular-123',
+      type: TransactionType.contractInteraction,
+      chainId: '0x1',
+      txParams: {
+        from: ACCOUNT_ADDRESS,
+        to: TOKEN_ADDRESS_1,
+        value: '0x0',
+      },
+    } as unknown as TransactionMeta;
+
+    const alerts = runHook({ currentConfirmation: regularTransaction });
+    expect(alerts).toEqual([]);
+  });
+
+  it('returns no alerts when no confirmation', () => {
+    const alerts = runHook();
+    expect(alerts).toEqual([]);
+  });
+
+  it('returns no alerts for batch transaction without nested transactions', () => {
+    const batchTransaction = createBatchTransaction([]);
+    const alerts = runHook({ currentConfirmation: batchTransaction });
+    expect(alerts).toEqual([]);
+  });
+
+  it('returns no alerts when parseApprovalTransactionData returns null', () => {
+    mockParseApprovalTransactionData.mockReturnValue(null);
+
+    const nestedTx = createNestedTransaction(
+      buildApproveTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+      TOKEN_ADDRESS_1,
+    );
+    const batchTransaction = createBatchTransaction([nestedTx]);
+
+    const alerts = runHook({ currentConfirmation: batchTransaction });
+    expect(alerts).toEqual([]);
+  });
+
+  it('filters out revocation transactions (zero amounts)', () => {
+    mockParseApprovalTransactionData.mockReturnValue({
+      name: 'approve',
+      amountOrTokenId: new BigNumber(0),
+      isRevokeAll: false,
+      tokenAddress: undefined,
+    });
+
+    const nestedTx = createNestedTransaction(
+      buildApproveTransactionData(SPENDER_ADDRESS, 0),
+      TOKEN_ADDRESS_1,
+    );
+    const batchTransaction = createBatchTransaction([nestedTx]);
+
+    const alerts = runHook({ currentConfirmation: batchTransaction });
+    expect(alerts).toEqual([]);
+  });
+
+  it('filters out setApprovalForAll revocations', () => {
+    mockParseApprovalTransactionData.mockReturnValue({
+      name: 'setApprovalForAll',
+      amountOrTokenId: undefined,
+      isRevokeAll: true,
+      tokenAddress: undefined,
+    });
+
+    const nestedTx = createNestedTransaction(
+      buildSetApproveForAllTransactionData(SPENDER_ADDRESS, false),
+      TOKEN_ADDRESS_1,
+    );
+    const batchTransaction = createBatchTransaction([nestedTx]);
+
+    const alerts = runHook({ currentConfirmation: batchTransaction });
+    expect(alerts).toEqual([]);
+  });
+
+  describe('ERC20 approve transactions', () => {
+    it('detects unused ERC20 approvals', () => {
+      mockParseApprovalTransactionData.mockReturnValue({
+        name: 'approve',
+        amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+        isRevokeAll: false,
+        tokenAddress: undefined,
+      });
+
+      const nestedTx = createNestedTransaction(
+        buildApproveTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+        TOKEN_ADDRESS_1,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+
+      expect(alerts).toEqual([
+        {
+          field: RowAlertKey.EstimatedApprovalChanges,
+          isBlocking: false,
+          key: 'multipleApprovals',
+          reason: REASON_MULTIPLE_APPROVALS,
+          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+
+    it('does not alert when ERC20 approval has corresponding outflow', () => {
+      mockParseApprovalTransactionData.mockReturnValue({
+        name: 'approve',
+        amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+        isRevokeAll: false,
+        tokenAddress: undefined,
+      });
+
+      const nestedTx = createNestedTransaction(
+        buildApproveTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+        TOKEN_ADDRESS_1,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      // Add simulation data showing token outflow
+      batchTransaction.simulationData = {
+        tokenBalanceChanges: [
+          {
+            address: TOKEN_ADDRESS_1.toLowerCase() as Hex,
+            difference: toHex(100),
+            isDecrease: true,
+            standard: SimulationTokenStandard.erc20,
+            previousBalance: '0x0',
+            newBalance: '0x0',
+          },
+        ],
+      };
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+      expect(alerts).toEqual([]);
+    });
+  });
+
+  describe('Permit2 approve transactions', () => {
+    it('detects unused Permit2 approvals', () => {
+      mockParseApprovalTransactionData.mockReturnValue({
+        name: 'approve',
+        amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+        isRevokeAll: false,
+        tokenAddress: TOKEN_ADDRESS_1,
+      });
+
+      const nestedTx = createNestedTransaction(
+        buildPermit2ApproveTransactionData(
+          TOKEN_ADDRESS_1,
+          SPENDER_ADDRESS,
+          AMOUNT_MOCK,
+          1234567890,
+        ),
+        SPENDER_ADDRESS,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+
+      expect(alerts).toEqual([
+        {
+          field: RowAlertKey.EstimatedApprovalChanges,
+          isBlocking: false,
+          key: 'multipleApprovals',
+          reason: REASON_MULTIPLE_APPROVALS,
+          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+  });
+
+  describe('increaseAllowance transactions', () => {
+    it('detects unused increaseAllowance approvals', () => {
+      mockParseApprovalTransactionData.mockReturnValue({
+        name: 'increaseAllowance',
+        amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+        isRevokeAll: false,
+        tokenAddress: undefined,
+      });
+
+      const nestedTx = createNestedTransaction(
+        buildIncreaseAllowanceTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+        TOKEN_ADDRESS_1,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+
+      expect(alerts).toEqual([
+        {
+          field: RowAlertKey.EstimatedApprovalChanges,
+          isBlocking: false,
+          key: 'multipleApprovals',
+          reason: REASON_MULTIPLE_APPROVALS,
+          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+  });
+
+  describe('setApprovalForAll (NFT) transactions', () => {
+    it('detects unused NFT approvals', () => {
+      mockParseApprovalTransactionData.mockReturnValue({
+        name: 'setApprovalForAll',
+        amountOrTokenId: undefined,
+        isRevokeAll: false,
+        tokenAddress: undefined,
+      });
+
+      const nestedTx = createNestedTransaction(
+        buildSetApproveForAllTransactionData(SPENDER_ADDRESS, true),
+        TOKEN_ADDRESS_1,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+
+      expect(alerts).toEqual([
+        {
+          field: RowAlertKey.EstimatedApprovalChanges,
+          isBlocking: false,
+          key: 'multipleApprovals',
+          reason: REASON_MULTIPLE_APPROVALS,
+          content: CONTENT_MULTIPLE_APPROVALS_NFT,
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+
+    it('does not alert when NFT approval has corresponding outflow', () => {
+      mockParseApprovalTransactionData.mockReturnValue({
+        name: 'setApprovalForAll',
+        amountOrTokenId: undefined,
+        isRevokeAll: false,
+        tokenAddress: undefined,
+      });
+
+      const nestedTx = createNestedTransaction(
+        buildSetApproveForAllTransactionData(SPENDER_ADDRESS, true),
+        TOKEN_ADDRESS_1,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      // Add simulation data showing NFT outflow
+      batchTransaction.simulationData = {
+        tokenBalanceChanges: [
+          {
+            address: TOKEN_ADDRESS_1.toLowerCase() as Hex,
+            difference: toHex(1),
+            isDecrease: true,
+            standard: SimulationTokenStandard.erc20,
+            previousBalance: '0x0',
+            newBalance: '0x0',
+          },
+        ],
+      };
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+      expect(alerts).toEqual([]);
+    });
+  });
+
+  describe('multiple approvals scenarios', () => {
+    it('detects multiple unused approvals of different types', () => {
+      mockParseApprovalTransactionData
+        .mockReturnValueOnce({
+          name: 'approve',
+          amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+          isRevokeAll: false,
+          tokenAddress: undefined,
+        })
+        .mockReturnValueOnce({
+          name: 'setApprovalForAll',
+          amountOrTokenId: undefined,
+          isRevokeAll: false,
+          tokenAddress: undefined,
+        });
+
+      const nestedTx1 = createNestedTransaction(
+        buildApproveTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+        TOKEN_ADDRESS_1,
+      );
+      const nestedTx2 = createNestedTransaction(
+        buildSetApproveForAllTransactionData(SPENDER_ADDRESS, true),
+        TOKEN_ADDRESS_2,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx1, nestedTx2]);
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+
+      expect(alerts).toEqual([
+        {
+          field: RowAlertKey.EstimatedApprovalChanges,
+          isBlocking: false,
+          key: 'multipleApprovals',
+          reason: REASON_MULTIPLE_APPROVALS,
+          content: CONTENT_MULTIPLE_APPROVALS_NFT,
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+
+    it('handles mixed used and unused approvals', () => {
+      mockParseApprovalTransactionData
+        .mockReturnValueOnce({
+          name: 'approve',
+          amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+          isRevokeAll: false,
+          tokenAddress: undefined,
+        })
+        .mockReturnValueOnce({
+          name: 'approve',
+          amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+          isRevokeAll: false,
+          tokenAddress: undefined,
+        });
+
+      const nestedTx1 = createNestedTransaction(
+        buildApproveTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+        TOKEN_ADDRESS_1,
+      );
+      const nestedTx2 = createNestedTransaction(
+        buildApproveTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+        TOKEN_ADDRESS_2,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx1, nestedTx2]);
+
+      // Add simulation data showing only one token has outflow
+      batchTransaction.simulationData = {
+        tokenBalanceChanges: [
+          {
+            address: TOKEN_ADDRESS_1.toLowerCase() as Hex,
+            difference: toHex(100),
+            isDecrease: true,
+            standard: SimulationTokenStandard.erc20,
+            previousBalance: '0x0',
+            newBalance: '0x0',
+          },
+        ],
+      };
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+
+      expect(alerts).toEqual([
+        {
+          field: RowAlertKey.EstimatedApprovalChanges,
+          isBlocking: false,
+          key: 'multipleApprovals',
+          reason: REASON_MULTIPLE_APPROVALS,
+          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles transactions without data field', () => {
+      const nestedTx = {
+        to: TOKEN_ADDRESS_1,
+        value: '0x0',
+        // no data field
+      };
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+      expect(alerts).toEqual([]);
+    });
+
+    it('handles transactions without to field', () => {
+      const nestedTx = {
+        data: buildApproveTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+        value: '0x0',
+        // no to field
+      };
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+      expect(alerts).toEqual([]);
+    });
+
+    it('handles unknown approval function names', () => {
+      mockParseApprovalTransactionData.mockReturnValue({
+        name: 'unknownFunction',
+        amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+        isRevokeAll: false,
+        tokenAddress: undefined,
+      });
+
+      const nestedTx = createNestedTransaction(
+        '0x12345678' as Hex,
+        TOKEN_ADDRESS_1,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+      expect(alerts).toEqual([]);
+    });
+
+    it('handles missing simulation data', () => {
+      mockParseApprovalTransactionData.mockReturnValue({
+        name: 'approve',
+        amountOrTokenId: new BigNumber(AMOUNT_MOCK),
+        isRevokeAll: false,
+        tokenAddress: undefined,
+      });
+
+      const nestedTx = createNestedTransaction(
+        buildApproveTransactionData(SPENDER_ADDRESS, AMOUNT_MOCK),
+        TOKEN_ADDRESS_1,
+      );
+      const batchTransaction = createBatchTransaction([nestedTx]);
+
+      // Remove simulation data
+      delete batchTransaction.simulationData;
+
+      const alerts = runHook({ currentConfirmation: batchTransaction });
+
+      expect(alerts).toEqual([
+        {
+          field: RowAlertKey.EstimatedApprovalChanges,
+          isBlocking: false,
+          key: 'multipleApprovals',
+          reason: REASON_MULTIPLE_APPROVALS,
+          content: CONTENT_MULTIPLE_APPROVALS_ERC20,
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+  });
+});

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
@@ -4,7 +4,6 @@ import {
   SimulationTokenBalanceChange,
   SimulationTokenStandard,
   TransactionMeta,
-  TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
@@ -16,6 +15,7 @@ import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { getTokenStandardAndDetailsByChain } from '../../../../../store/actions';
+import { ApprovalBalanceChange } from '../../../components/confirm/info/hooks/useBatchApproveBalanceChanges';
 import { useMultipleApprovalsAlerts } from './useMultipleApprovalsAlerts';
 
 // Mock dependencies
@@ -59,6 +59,21 @@ const SPENDER_ADDRESS = '0x3456789012345678901234567890123456789012' as Hex;
 
 const mockT = (key: string) => key;
 
+// Mock approval balance change for tests
+const MOCK_APPROVAL_BALANCE_CHANGE: ApprovalBalanceChange = {
+  asset: {
+    address: TOKEN_ADDRESS_1,
+    chainId: '0x5',
+    standard: TokenStandard.ERC20,
+  },
+  amount: new BigNumber('1000'),
+  fiatAmount: null,
+  isApproval: true,
+  isAllApproval: false,
+  isUnlimitedApproval: false,
+  nestedTransactionIndex: 0,
+};
+
 const createMockNestedTransaction = (
   data: string,
   to: Hex,
@@ -91,7 +106,7 @@ function runHook({
   currentConfirmation?: Partial<TransactionMeta>;
   nestedTransactions?: NestedTransactionMetadata[];
   simulationData?: SimulationTokenBalanceChange[];
-  approveBalanceChanges?: any[];
+  approveBalanceChanges?: ApprovalBalanceChange[];
 } = {}) {
   const confirmation = currentConfirmation
     ? {
@@ -224,7 +239,7 @@ describe('useMultipleApprovalsAlerts', () => {
         },
         nestedTransactions,
         simulationData,
-        approveBalanceChanges: [{}], // non-empty to pass the check
+        approveBalanceChanges: [], // non-empty to pass the check
       });
 
       expect(alerts).toEqual([]);
@@ -251,7 +266,7 @@ describe('useMultipleApprovalsAlerts', () => {
         },
         nestedTransactions,
         simulationData: [], // no outflows
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toEqual([
@@ -286,7 +301,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1);
@@ -310,7 +325,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1);
@@ -334,7 +349,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1);
@@ -358,7 +373,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1);
@@ -384,7 +399,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [],
       });
 
       expect(alerts).toEqual([]);
@@ -412,7 +427,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [],
       });
 
       expect(alerts).toEqual([]);
@@ -448,7 +463,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1);
@@ -465,7 +480,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [],
       });
 
       expect(alerts).toEqual([]);
@@ -484,7 +499,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [],
       });
 
       expect(alerts).toEqual([]);
@@ -508,7 +523,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [],
       });
 
       expect(alerts).toEqual([]);
@@ -559,7 +574,7 @@ describe('useMultipleApprovalsAlerts', () => {
         },
         nestedTransactions,
         simulationData: [], // No outflows - should be unused
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1);
@@ -612,7 +627,7 @@ describe('useMultipleApprovalsAlerts', () => {
         },
         nestedTransactions,
         simulationData,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1);
@@ -642,7 +657,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       // Should still work with fallback to TokenStandard.none
@@ -662,7 +677,7 @@ describe('useMultipleApprovalsAlerts', () => {
       });
 
       mockGetTokenStandardAndDetailsByChain.mockResolvedValue({
-        standard: 'INVALID_STANDARD' as any,
+        standard: 'INVALID_STANDARD' as TokenStandard,
       });
 
       const alerts = runHook({
@@ -671,7 +686,7 @@ describe('useMultipleApprovalsAlerts', () => {
           chainId: '0x5',
         },
         nestedTransactions,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1);
@@ -709,7 +724,7 @@ describe('useMultipleApprovalsAlerts', () => {
         },
         nestedTransactions,
         simulationData,
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [],
       });
 
       expect(alerts).toEqual([]); // should match despite case difference
@@ -734,7 +749,7 @@ describe('useMultipleApprovalsAlerts', () => {
         },
         nestedTransactions,
         simulationData: undefined, // undefined simulation data
-        approveBalanceChanges: [{}],
+        approveBalanceChanges: [MOCK_APPROVAL_BALANCE_CHANGE],
       });
 
       expect(alerts).toHaveLength(1); // should treat as unused

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
@@ -1,0 +1,165 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+import { useMemo } from 'react';
+import { parseApprovalTransactionData } from '../../../../../../shared/modules/transaction.utils';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
+import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useConfirmContext } from '../../../context/confirm';
+
+interface ApprovalInfo {
+  tokenAddress: Hex;
+  spenderAddress?: Hex;
+  amount?: BigNumber;
+  isNFT: boolean;
+}
+
+interface TokenOutflow {
+  tokenAddress: Hex;
+  amount: BigNumber;
+  isDecrease: boolean;
+}
+
+export function useMultipleApprovalsAlerts(): Alert[] {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const isBatchTransaction = currentConfirmation?.type === 'batch';
+  const nestedTransactions = currentConfirmation?.nestedTransactions;
+  const simulationDataArray =
+    currentConfirmation?.simulationData?.tokenBalanceChanges;
+
+  console.log({ nestedTransactions, simulationDataArray });
+
+  // Extract all approvals from nested transactions
+  const approvals = useMemo((): ApprovalInfo[] => {
+    if (!isBatchTransaction || !nestedTransactions) {
+      return [];
+    }
+
+    const approvalsList: ApprovalInfo[] = [];
+
+    nestedTransactions.forEach((transaction) => {
+      const { data, to } = transaction;
+      if (!data || !to) return;
+
+      const parseResult = parseApprovalTransactionData(data);
+      if (!parseResult) return;
+
+      const { name, amountOrTokenId, tokenAddress } = parseResult;
+
+      // Skip revocations (zero amounts or setApprovalForAll with false)
+      if (
+        (amountOrTokenId && amountOrTokenId.isZero()) ||
+        parseResult.isRevokeAll
+      ) {
+        return;
+      }
+
+      let actualTokenAddress: Hex;
+      let spenderAddress: Hex | undefined;
+
+      switch (name) {
+        case 'approve':
+          if (tokenAddress) {
+            // Permit2 approve
+            actualTokenAddress = tokenAddress;
+            spenderAddress = to;
+          } else {
+            // Regular ERC20 approve
+            actualTokenAddress = to;
+          }
+          break;
+        case 'increaseAllowance':
+        case 'setApprovalForAll':
+          actualTokenAddress = to;
+          break;
+        default:
+          return;
+      }
+
+      const isNFT = name === 'setApprovalForAll';
+
+      approvalsList.push({
+        tokenAddress: actualTokenAddress,
+        spenderAddress,
+        amount: amountOrTokenId,
+        isNFT,
+      });
+    });
+
+    return approvalsList;
+  }, [isBatchTransaction, nestedTransactions]);
+
+  const tokenOutflows = useMemo((): TokenOutflow[] => {
+    if (!simulationDataArray) {
+      return [];
+    }
+
+    return simulationDataArray
+      .filter((change) => change.isDecrease)
+      .map((change) => ({
+        tokenAddress: change.address.toLowerCase() as Hex,
+        amount: new BigNumber(change.difference, 16),
+        isDecrease: change.isDecrease,
+      }));
+  }, [simulationDataArray]);
+
+  const unusedApprovals = useMemo(() => {
+    if (approvals.length === 0) {
+      return [];
+    }
+
+    return approvals.filter((approval) => {
+      if (approval.isNFT) {
+        const hasNFTOutflows = tokenOutflows.some(
+          (outflow) =>
+            outflow.tokenAddress.toLowerCase() ===
+            approval.tokenAddress.toLowerCase(),
+        );
+        return !hasNFTOutflows;
+      }
+
+      const tokenOutflow = tokenOutflows.find(
+        (outflow) =>
+          outflow.tokenAddress.toLowerCase() ===
+          approval.tokenAddress.toLowerCase(),
+      );
+
+      if (!tokenOutflow) {
+        return true;
+      }
+
+      // If there's an outflow but the approval amount is much larger than needed,
+      // we might still want to flag it, but for now we'll only flag completely unused approvals
+      return false;
+    });
+  }, [approvals, tokenOutflows]);
+
+  const shouldShowAlert = unusedApprovals.length > 0;
+
+  const hasUnusedNFTApprovals = unusedApprovals.some(
+    (approval) => approval.isNFT,
+  );
+
+  return useMemo(() => {
+    if (!shouldShowAlert) {
+      return [];
+    }
+
+    return [
+      {
+        field: RowAlertKey.EstimatedApprovalChanges,
+        isBlocking: false,
+        key: 'multipleApprovals',
+        reason: t('alertReasonMultipleApprovals'),
+        content: t('alertContentMultipleApprovals', [
+          hasUnusedNFTApprovals ? t('nfts') : t('tokens'),
+        ]),
+        severity: Severity.Danger,
+      },
+    ];
+  }, [shouldShowAlert, hasUnusedNFTApprovals, t]);
+}

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
@@ -1,19 +1,26 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  NestedTransactionMetadata,
+  SimulationTokenBalanceChange,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 import { useMemo } from 'react';
+import { TokenStandard } from '../../../../../../shared/constants/transaction';
 import { parseApprovalTransactionData } from '../../../../../../shared/modules/transaction.utils';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
+import { useAsyncResult } from '../../../../../hooks/useAsync';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { getTokenStandardAndDetailsByChain } from '../../../../../store/actions';
+import { useBatchApproveBalanceChanges } from '../../../components/confirm/info/hooks/useBatchApproveBalanceChanges';
 import { useConfirmContext } from '../../../context/confirm';
 
 type ApprovalInfo = {
   tokenAddress: Hex;
   spenderAddress?: Hex;
   amount?: BigNumber;
-  isNFT: boolean;
 };
 
 type TokenOutflow = {
@@ -22,126 +29,256 @@ type TokenOutflow = {
   isDecrease: boolean;
 };
 
-export function useMultipleApprovalsAlerts(): Alert[] {
-  const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+function getUniqueTokenAddresses(
+  nestedTransactions: NestedTransactionMetadata[],
+): Hex[] {
+  const addresses = new Set<Hex>();
 
-  const isBatchTransaction = currentConfirmation?.type === 'batch';
-  const nestedTransactions = currentConfirmation?.nestedTransactions;
-  const simulationDataArray =
-    currentConfirmation?.simulationData?.tokenBalanceChanges;
-
-  // Extract all approvals from nested transactions
-  const approvals = useMemo((): ApprovalInfo[] => {
-    if (!isBatchTransaction || !nestedTransactions) {
-      return [];
+  nestedTransactions.forEach((transaction) => {
+    const { data, to } = transaction;
+    if (!data || !to) {
+      return;
     }
 
-    const approvalsList: ApprovalInfo[] = [];
+    const parseResult = parseApprovalTransactionData(data);
+    if (!parseResult) {
+      return;
+    }
 
-    nestedTransactions.forEach((transaction) => {
-      const { data, to } = transaction;
-      if (!data || !to) {
+    const { name, tokenAddress } = parseResult;
+
+    let actualTokenAddress: Hex;
+    switch (name) {
+      case 'approve':
+        actualTokenAddress = tokenAddress || to;
+        break;
+      case 'increaseAllowance':
+      case 'setApprovalForAll':
+        actualTokenAddress = to;
+        break;
+      default:
         return;
-      }
+    }
 
-      const parseResult = parseApprovalTransactionData(data);
-      if (!parseResult) {
-        return;
-      }
+    addresses.add(actualTokenAddress);
+  });
 
-      const { name, amountOrTokenId, tokenAddress } = parseResult;
+  return Array.from(addresses);
+}
 
-      // Skip revocations (zero amounts or setApprovalForAll with false)
-      if (amountOrTokenId?.isZero() || parseResult.isRevokeAll) {
-        return;
-      }
+function shouldSkipApproval(
+  parseResult: ReturnType<typeof parseApprovalTransactionData>,
+  tokenStandards: Record<Hex, TokenStandard>,
+  tokenAddress: Hex,
+): boolean {
+  if (!parseResult) {
+    return true;
+  }
 
-      let actualTokenAddress: Hex;
-      let spenderAddress: Hex | undefined;
+  // Skip setApprovalForAll revocations
+  if (parseResult.isRevokeAll) {
+    return true;
+  }
 
-      switch (name) {
-        case 'approve':
-          if (tokenAddress) {
-            // Permit2 approve
-            actualTokenAddress = tokenAddress;
-            spenderAddress = to;
-          } else {
-            // Regular ERC20 approve
-            actualTokenAddress = to;
-          }
-          break;
-        case 'increaseAllowance':
-        case 'setApprovalForAll':
+  // Check if this is a revocation based on token standard
+  if (parseResult.amountOrTokenId?.isZero()) {
+    const tokenStandard = tokenStandards[tokenAddress];
+
+    // Only skip zero amounts for ERC20 tokens (revocations)
+    // For ERC721/ERC1155, token ID 0 is valid and should not be skipped
+    if (tokenStandard === TokenStandard.ERC20) {
+      return true;
+    }
+    // For unknown token standards or NFTs, we don't skip to avoid false negatives
+  }
+
+  return false;
+}
+
+function extractApprovals(
+  nestedTransactions: NestedTransactionMetadata[],
+  tokenStandards: Record<Hex, TokenStandard>,
+): ApprovalInfo[] {
+  const approvalsList: ApprovalInfo[] = [];
+
+  nestedTransactions.forEach((transaction) => {
+    const { data, to } = transaction;
+    if (!data || !to) {
+      return;
+    }
+
+    const parseResult = parseApprovalTransactionData(data);
+    if (!parseResult) {
+      return;
+    }
+
+    const { name, amountOrTokenId, tokenAddress } = parseResult;
+
+    let actualTokenAddress: Hex;
+    let spenderAddress: Hex | undefined;
+
+    switch (name) {
+      case 'approve':
+        if (tokenAddress) {
+          // Permit2 approve
+          actualTokenAddress = tokenAddress;
+          spenderAddress = to;
+        } else {
+          // Regular ERC20/ERC721 approve
           actualTokenAddress = to;
-          break;
-        default:
-          return;
-      }
-
-      const isNFT = name === 'setApprovalForAll';
-
-      approvalsList.push({
-        tokenAddress: actualTokenAddress,
-        spenderAddress,
-        amount: amountOrTokenId,
-        isNFT,
-      });
-    });
-
-    return approvalsList;
-  }, [isBatchTransaction, nestedTransactions]);
-
-  const tokenOutflows = useMemo((): TokenOutflow[] => {
-    if (!simulationDataArray) {
-      return [];
+        }
+        break;
+      case 'increaseAllowance':
+      case 'setApprovalForAll':
+        actualTokenAddress = to;
+        break;
+      default:
+        return;
     }
 
-    return simulationDataArray
-      .filter((change) => change.isDecrease)
+    if (shouldSkipApproval(parseResult, tokenStandards, actualTokenAddress)) {
+      return;
+    }
+
+    approvalsList.push({
+      tokenAddress: actualTokenAddress,
+      spenderAddress,
+      amount: amountOrTokenId,
+    });
+  });
+
+  return approvalsList;
+}
+
+function getTokensWithDecrease(
+  simulationDataArray: SimulationTokenBalanceChange[],
+): TokenOutflow[] {
+  return (
+    simulationDataArray
+      ?.filter((change) => change.isDecrease)
       .map((change) => ({
         tokenAddress: change.address.toLowerCase() as Hex,
         amount: new BigNumber(change.difference, 16),
         isDecrease: change.isDecrease,
-      }));
-  }, [simulationDataArray]);
+      })) ?? []
+  );
+}
 
-  const unusedApprovals = useMemo(() => {
-    if (approvals.length === 0) {
+function findUnusedApprovals(
+  approvals: ApprovalInfo[],
+  tokenOutflows: TokenOutflow[],
+): ApprovalInfo[] {
+  if (approvals.length === 0) {
+    return [];
+  }
+
+  return approvals.filter((approval) => {
+    const tokenOutflow = tokenOutflows.find(
+      (outflow) =>
+        outflow.tokenAddress.toLowerCase() ===
+        approval.tokenAddress.toLowerCase(),
+    );
+
+    if (!tokenOutflow) {
+      return true;
+    }
+
+    // If there's an outflow but the approval amount is much larger than needed,
+    // we might still want to flag it, but for now we'll only flag completely unused approvals
+    return false;
+  });
+}
+
+// Utility function to fetch token standards for addresses
+async function fetchTokenStandards(
+  tokenAddresses: Hex[],
+  chainId: string | undefined,
+  fromAddress: Hex | undefined,
+): Promise<Record<Hex, TokenStandard>> {
+  if (!tokenAddresses.length || !chainId || !fromAddress) {
+    return {};
+  }
+
+  const standards: Record<Hex, TokenStandard> = {};
+  await Promise.all(
+    tokenAddresses.map(async (address) => {
+      try {
+        const details = await getTokenStandardAndDetailsByChain(
+          address,
+          fromAddress,
+          undefined,
+          chainId,
+        );
+        // Safely cast the string to TokenStandard enum
+        const standard = details?.standard as TokenStandard;
+        standards[address] = Object.values(TokenStandard).includes(standard)
+          ? standard
+          : TokenStandard.none;
+      } catch (error) {
+        console.warn(`Failed to get token standard for ${address}:`, error);
+        standards[address] = TokenStandard.none;
+      }
+    }),
+  );
+
+  return standards;
+}
+
+export function useMultipleApprovalsAlerts(): Alert[] {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const { value: approveBalanceChanges } =
+    useBatchApproveBalanceChanges() ?? {};
+
+  const nestedTransactions = currentConfirmation?.nestedTransactions;
+  const simulationDataArray =
+    currentConfirmation?.simulationData?.tokenBalanceChanges;
+
+  const tokenAddresses = useMemo(() => {
+    if (!nestedTransactions?.length) {
+      return [];
+    }
+    return getUniqueTokenAddresses(nestedTransactions);
+  }, [nestedTransactions]);
+
+  const { value: tokenStandards } = useAsyncResult(async () => {
+    return fetchTokenStandards(
+      tokenAddresses,
+      currentConfirmation?.chainId,
+      currentConfirmation?.txParams?.from as Hex,
+    );
+  }, [
+    tokenAddresses,
+    currentConfirmation?.chainId,
+    currentConfirmation?.txParams?.from,
+  ]);
+
+  const approvals = useMemo((): ApprovalInfo[] => {
+    if (
+      !nestedTransactions?.length ||
+      !approveBalanceChanges?.length ||
+      !tokenStandards
+    ) {
       return [];
     }
 
-    return approvals.filter((approval) => {
-      if (approval.isNFT) {
-        const hasNFTOutflows = tokenOutflows.some(
-          (outflow) =>
-            outflow.tokenAddress.toLowerCase() ===
-            approval.tokenAddress.toLowerCase(),
-        );
-        return !hasNFTOutflows;
-      }
+    const approvalsList = extractApprovals(nestedTransactions, tokenStandards);
 
-      const tokenOutflow = tokenOutflows.find(
-        (outflow) =>
-          outflow.tokenAddress.toLowerCase() ===
-          approval.tokenAddress.toLowerCase(),
-      );
+    return approvalsList;
+  }, [approveBalanceChanges, nestedTransactions, tokenStandards]);
 
-      if (!tokenOutflow) {
-        return true;
-      }
+  const tokenOutflows = useMemo(() => {
+    if (!simulationDataArray) {
+      return [];
+    }
+    return getTokensWithDecrease(simulationDataArray);
+  }, [simulationDataArray]);
 
-      // If there's an outflow but the approval amount is much larger than needed,
-      // we might still want to flag it, but for now we'll only flag completely unused approvals
-      return false;
-    });
+  const unusedApprovals = useMemo(() => {
+    return findUnusedApprovals(approvals, tokenOutflows);
   }, [approvals, tokenOutflows]);
 
   const shouldShowAlert = unusedApprovals.length > 0;
-
-  const hasUnusedNFTApprovals = unusedApprovals.some(
-    (approval) => approval.isNFT,
-  );
 
   return useMemo(() => {
     if (!shouldShowAlert) {
@@ -150,15 +287,13 @@ export function useMultipleApprovalsAlerts(): Alert[] {
 
     return [
       {
-        field: RowAlertKey.EstimatedApprovalChanges,
+        field: RowAlertKey.EstimatedChangesStatic,
         isBlocking: false,
         key: 'multipleApprovals',
         reason: t('alertReasonMultipleApprovals'),
-        content: t('alertContentMultipleApprovals', [
-          hasUnusedNFTApprovals ? t('nfts') : t('tokens'),
-        ]),
+        content: t('alertContentMultipleApprovals'),
         severity: Severity.Danger,
       },
     ];
-  }, [shouldShowAlert, hasUnusedNFTApprovals, t]);
+  }, [shouldShowAlert, t]);
 }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
@@ -9,18 +9,18 @@ import { Severity } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
 
-interface ApprovalInfo {
+type ApprovalInfo = {
   tokenAddress: Hex;
   spenderAddress?: Hex;
   amount?: BigNumber;
   isNFT: boolean;
-}
+};
 
-interface TokenOutflow {
+type TokenOutflow = {
   tokenAddress: Hex;
   amount: BigNumber;
   isDecrease: boolean;
-}
+};
 
 export function useMultipleApprovalsAlerts(): Alert[] {
   const t = useI18nContext();
@@ -41,18 +41,19 @@ export function useMultipleApprovalsAlerts(): Alert[] {
 
     nestedTransactions.forEach((transaction) => {
       const { data, to } = transaction;
-      if (!data || !to) return;
+      if (!data || !to) {
+        return;
+      }
 
       const parseResult = parseApprovalTransactionData(data);
-      if (!parseResult) return;
+      if (!parseResult) {
+        return;
+      }
 
       const { name, amountOrTokenId, tokenAddress } = parseResult;
 
       // Skip revocations (zero amounts or setApprovalForAll with false)
-      if (
-        (amountOrTokenId && amountOrTokenId.isZero()) ||
-        parseResult.isRevokeAll
-      ) {
+      if (amountOrTokenId?.isZero() || parseResult.isRevokeAll) {
         return;
       }
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
@@ -31,8 +31,6 @@ export function useMultipleApprovalsAlerts(): Alert[] {
   const simulationDataArray =
     currentConfirmation?.simulationData?.tokenBalanceChanges;
 
-  console.log({ nestedTransactions, simulationDataArray });
-
   // Extract all approvals from nested transactions
   const approvals = useMemo((): ApprovalInfo[] => {
     if (!isBatchTransaction || !nestedTransactions) {

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
@@ -2,22 +2,23 @@ import { useMemo } from 'react';
 import { Alert } from '../../../ducks/confirm-alerts/confirm-alerts';
 import useAccountMismatchAlerts from './alerts/signatures/useAccountMismatchAlerts';
 import useDomainMismatchAlerts from './alerts/signatures/useDomainMismatchAlerts';
+import { useAccountTypeUpgrade } from './alerts/transactions/useAccountTypeUpgrade';
+import { useFirstTimeInteractionAlert } from './alerts/transactions/useFirstTimeInteractionAlert';
 import { useGasEstimateFailedAlerts } from './alerts/transactions/useGasEstimateFailedAlerts';
 import { useGasFeeLowAlerts } from './alerts/transactions/useGasFeeLowAlerts';
 import { useGasTooLowAlerts } from './alerts/transactions/useGasTooLowAlerts';
 import { useInsufficientBalanceAlerts } from './alerts/transactions/useInsufficientBalanceAlerts';
+import { useMultipleApprovalsAlerts } from './alerts/transactions/useMultipleApprovalsAlerts';
 import { useNetworkBusyAlerts } from './alerts/transactions/useNetworkBusyAlerts';
 import { useNoGasPriceAlerts } from './alerts/transactions/useNoGasPriceAlerts';
+import { useNonContractAddressAlerts } from './alerts/transactions/useNonContractAddressAlerts';
 import { usePendingTransactionAlerts } from './alerts/transactions/usePendingTransactionAlerts';
 import { useResimulationAlert } from './alerts/transactions/useResimulationAlert';
-import { useFirstTimeInteractionAlert } from './alerts/transactions/useFirstTimeInteractionAlert';
 import { useSigningOrSubmittingAlerts } from './alerts/transactions/useSigningOrSubmittingAlerts';
-import useConfirmationOriginAlerts from './alerts/useConfirmationOriginAlerts';
 import useBlockaidAlerts from './alerts/useBlockaidAlerts';
+import useConfirmationOriginAlerts from './alerts/useConfirmationOriginAlerts';
 import { useNetworkAndOriginSwitchingAlerts } from './alerts/useNetworkAndOriginSwitchingAlerts';
 import { useSelectedAccountAlerts } from './alerts/useSelectedAccountAlerts';
-import { useNonContractAddressAlerts } from './alerts/transactions/useNonContractAddressAlerts';
-import { useAccountTypeUpgrade } from './alerts/transactions/useAccountTypeUpgrade';
 
 function useSignatureAlerts(): Alert[] {
   const accountMismatchAlerts = useAccountMismatchAlerts();
@@ -42,6 +43,7 @@ function useTransactionAlerts(): Alert[] {
   const firstTimeInteractionAlert = useFirstTimeInteractionAlert();
   const signingOrSubmittingAlerts = useSigningOrSubmittingAlerts();
   const nonContractAddressAlerts = useNonContractAddressAlerts();
+  const multipleApprovalAlerts = useMultipleApprovalsAlerts();
 
   return useMemo(
     () => [
@@ -57,6 +59,7 @@ function useTransactionAlerts(): Alert[] {
       ...firstTimeInteractionAlert,
       ...signingOrSubmittingAlerts,
       ...nonContractAddressAlerts,
+      ...multipleApprovalAlerts,
     ],
     [
       accountTypeUpgradeAlerts,
@@ -71,6 +74,7 @@ function useTransactionAlerts(): Alert[] {
       firstTimeInteractionAlert,
       signingOrSubmittingAlerts,
       nonContractAddressAlerts,
+      multipleApprovalAlerts,
     ],
   );
 }

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
@@ -32,49 +32,49 @@ function useSignatureAlerts(): Alert[] {
 
 function useTransactionAlerts(): Alert[] {
   const accountTypeUpgradeAlerts = useAccountTypeUpgrade();
+  const firstTimeInteractionAlert = useFirstTimeInteractionAlert();
   const gasEstimateFailedAlerts = useGasEstimateFailedAlerts();
   const gasFeeLowAlerts = useGasFeeLowAlerts();
   const gasTooLowAlerts = useGasTooLowAlerts();
   const insufficientBalanceAlerts = useInsufficientBalanceAlerts();
+  const multipleApprovalAlerts = useMultipleApprovalsAlerts();
   const networkBusyAlerts = useNetworkBusyAlerts();
   const noGasPriceAlerts = useNoGasPriceAlerts();
+  const nonContractAddressAlerts = useNonContractAddressAlerts();
   const pendingTransactionAlerts = usePendingTransactionAlerts();
   const resimulationAlert = useResimulationAlert();
-  const firstTimeInteractionAlert = useFirstTimeInteractionAlert();
   const signingOrSubmittingAlerts = useSigningOrSubmittingAlerts();
-  const nonContractAddressAlerts = useNonContractAddressAlerts();
-  const multipleApprovalAlerts = useMultipleApprovalsAlerts();
 
   return useMemo(
     () => [
       ...accountTypeUpgradeAlerts,
+      ...firstTimeInteractionAlert,
       ...gasEstimateFailedAlerts,
       ...gasFeeLowAlerts,
       ...gasTooLowAlerts,
       ...insufficientBalanceAlerts,
+      ...multipleApprovalAlerts,
       ...networkBusyAlerts,
       ...noGasPriceAlerts,
+      ...nonContractAddressAlerts,
       ...pendingTransactionAlerts,
       ...resimulationAlert,
-      ...firstTimeInteractionAlert,
       ...signingOrSubmittingAlerts,
-      ...nonContractAddressAlerts,
-      ...multipleApprovalAlerts,
     ],
     [
       accountTypeUpgradeAlerts,
+      firstTimeInteractionAlert,
       gasEstimateFailedAlerts,
       gasFeeLowAlerts,
       gasTooLowAlerts,
       insufficientBalanceAlerts,
+      multipleApprovalAlerts,
       networkBusyAlerts,
       noGasPriceAlerts,
+      nonContractAddressAlerts,
       pendingTransactionAlerts,
       resimulationAlert,
-      firstTimeInteractionAlert,
       signingOrSubmittingAlerts,
-      nonContractAddressAlerts,
-      multipleApprovalAlerts,
     ],
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Introduces a new alert inside the simulations component that flags when a batch transaction includes token approvals but no balance from those tokens is spent on that batch. This works for these approvals:

- ERC20 Token Approval
- increaseAllowance
- Permit2 Approve
- NFT setApprovalForAll

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33237?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4959

## **Manual testing steps**

### ERC20 Token Approval (multiple tokens)

```javascript
await window.ethereum.request({
  method: "wallet_sendCalls",
  params: [
    {
      version: "2.0.0",
      from: <Your token address>,
      chainId: "0x1",
      atomicRequired: true,
      calls: [
        {
          to: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
          // For native transfers, data can be omitted or set to "0x"
          value: "0x38D7EA4C68000" // 1 BNB in wei
        },
        // 3. Unlimited approval of USDC to 0xE50a2dBc466D01a34c3e8b7e8e45Fce4f7da39e6
        {
          to: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
          data: "0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
          value: "0x0"
        },
        // 4. Unlimited approval of USDT to 0xE50a2dBc466D01a34c3e8b7e8e45Fce4f7da39e6
        {
          to: "0xdac17f958d2ee523a2206206994597c13d831ec7",
          data: "0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
          value: "0x0"
        },
        // 5. Unlimited approval of WETH to 0xE50a2dBc466D01a34c3e8b7e8e45Fce4f7da39e6
        {
          to: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
          data: "0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
          value: "0x0"
        }
      ]
    }
  ],
  jsonrpc: "2.0",
  id: 4031519715
});
```

### ERC20 Token Approval

```javascript
await window.ethereum.request({
  method: "wallet_sendCalls",
  params: [
    {
      version: "2.0.0",
      from: <Your token address>,
      chainId: "0xaa36a7",
      atomicRequired: true,
      calls: [
        {
          to: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
          // For native transfers, data can be omitted or set to "0x"
          value: "0x38D7EA4C68000" // 1 BNB in wei
        },
        // 3. Unlimited approval of USDC to 0xE50a2dBc466D01a34c3e8b7e8e45Fce4f7da39e6
        {
          to: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
          data: "0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
          value: "0x0"
        },
      ]
    }
  ],
  jsonrpc: "2.0",
  id: 4031519715
});
```

### ERC721 Approve (Token with ID #1)

```javascript
await window.ethereum.request({
  method: "wallet_sendCalls",
  params: [
    {
      version: "2.0.0",
      from: <Your token address>,
      chainId: "0xaa36a7",
      atomicRequired: true,
      calls: [
        {
          to: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
          // For native transfers, data can be omitted or set to "0x"
          value: "0x38D7EA4C68000" // 1 BNB in wei
        },
        // ERC721 Approve ID 1
        {
          to: "0x6fa2fc8ddcb2647fba3b5da7ae95cc9fed1f26c6",
          data: "0x095ea7b30000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef40000000000000000000000000000000000000000000000000000000000000001",
          value: "0x0",
}
      ]
    }
  ],
  jsonrpc: "2.0",
  id: 4031519715
});
```

### setApprovalForAll ERC721

```javascript
await window.ethereum.request({
  method: "wallet_sendCalls",
  params: [
    {
      version: "2.0.0",
      from: <Your token address>,
      chainId: "0xaa36a7",
      atomicRequired: true,
      calls: [
        {
          to: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
          // For native transfers, data can be omitted or set to "0x"
          value: "0x38D7EA4C68000" // 1 BNB in wei
        },
        // setApprovalForAll
        {
          to: "0x6fa2fc8ddcb2647fba3b5da7ae95cc9fed1f26c6",
          data: "0xa22cb4650000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef40000000000000000000000000000000000000000000000000000000000000001",
          value: "0x0",
}
      ]
    }
  ],
  jsonrpc: "2.0",
  id: 4031519715
});
```

### setApprovalForAll Revoke (doesn't bring up the alert)

```javascript
await window.ethereum.request({
  method: "wallet_sendCalls",
  params: [
    {
      version: "2.0.0",
      from: <Your token address>,
      chainId: "0xaa36a7",
      atomicRequired: true,
      calls: [
        {
          to: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
          // For native transfers, data can be omitted or set to "0x"
          value: "0x38D7EA4C68000" // 1 BNB in wei
        },
        // setApprovalForAll
        {
          to: "0x6fa2fc8ddcb2647fba3b5da7ae95cc9fed1f26c6",
          data: "0xa22cb4650000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef40000000000000000000000000000000000000000000000000000000000000000",
          value: "0x0",
}
      ]
    }
  ],
  jsonrpc: "2.0",
  id: 4031519715
});
```

### setApprovalForAll 1155

```javascript
await window.ethereum.request({
  method: "wallet_sendCalls",
  params: [
    {
      version: "2.0.0",
      from: <Your token address>,
      chainId: "0xaa36a7",
      atomicRequired: true,
      calls: [
        {
          to: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
          // For native transfers, data can be omitted or set to "0x"
          value: "0x38D7EA4C68000" // 1 BNB in wei
        },
        // setApprovalForAll 1155
        {
          to: "0x6fa2fc8ddcb2647fba3b5da7ae95cc9fed1f26c6",
          data: "0xa22cb4650000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef40000000000000000000000000000000000000000000000000000000000000001",
          value: "0x0",
}
      ]
    }
  ],
  jsonrpc: "2.0",
  id: 4031519715
});
```

### increaseAllowance

```javascript
await window.ethereum.request({
  method: "wallet_sendCalls",
  params: [
    {
      version: "2.0.0",
      from: <Your token address>,
      chainId: "0xaa36a7",
      atomicRequired: true,
      calls: [
        {
          to: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
          // For native transfers, data can be omitted or set to "0x"
          value: "0x38D7EA4C68000" // 1 BNB in wei
        },
        // 3. increaseAllowance
        {
          to: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
          data: "0x395093510000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef40000000000000000000000000000000000000000000000000000000000002710",
          value: "0x0"
        },
      ]
    }
  ],
  jsonrpc: "2.0",
  id: 4031519715
});
```

### Permit2

```javascript
await window.ethereum.request({
  method: "wallet_sendCalls",
  params: [
    {
      version: "2.0.0",
      from: <Your token address>,
      chainId: "0xaa36a7",
      atomicRequired: true,
      calls: [
        {
          to: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
          // For native transfers, data can be omitted or set to "0x"
          value: "0x38D7EA4C68000" // 1 BNB in wei
        },
        // 3. Unlimited approval of USDC to 0xE50a2dBc466D01a34c3e8b7e8e45Fce4f7da39e6
        {
          to: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
          data: "0x87517c45000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb000000000000000000000000000000000000000000000000000000000012C4B00000000000000000000000000000000000000000000000000000000068437af0",
          value: "0x0"
        },
      ]
    }
  ],
  jsonrpc: "2.0",
  id: 4031519715
});
```


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="512" alt="Screenshot 2025-05-28 at 14 08 50" src="https://github.com/user-attachments/assets/2744c168-5206-4625-873f-3dda63162e55" />
<img width="512" alt="Screenshot 2025-05-28 at 14 08 52" src="https://github.com/user-attachments/assets/71ec7aca-450f-4b93-a1b4-e5671494d6f5" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.