### PR TITLE
fix: hides fiat amount string until token is entered

### DIFF
--- a/ui/pages/bridge/__snapshots__/index.test.tsx.snap
+++ b/ui/pages/bridge/__snapshots__/index.test.tsx.snap
@@ -135,9 +135,7 @@ exports[`Bridge renders the component with initial props 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
-                >
-                  $0.00
-                </p>
+                />
               </div>
               <p
                 class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative-soft"

--- a/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
@@ -84,9 +84,7 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
         >
           <p
             class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
-          >
-            $0.00
-          </p>
+          />
         </div>
         <p
           class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative-soft"
@@ -277,9 +275,7 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
         >
           <p
             class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
-          >
-            $0.00
-          </p>
+          />
         </div>
         <p
           class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative-soft"

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -607,7 +607,12 @@ const PrepareBridgePage = () => {
           onMaxButtonClick={(value: string) => {
             dispatch(setFromTokenInputValue(value));
           }}
-          amountInFiat={fromAmountInCurrency.valueInCurrency.toString()}
+          // Hides fiat amount string before a token quantity is entered.
+          amountInFiat={
+            fromAmountInCurrency.valueInCurrency.gt(0)
+              ? fromAmountInCurrency.valueInCurrency.toString()
+              : undefined
+          }
           balanceAmount={srcTokenBalance}
           amountFieldProps={{
             testId: 'from-amount',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Currently, the '$' symbol and amount is shown before the token quantity is inputted by the user, which is confusing to users. Updates the UI to only display the '$' symbol and amount after the token quantity has been entered.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33242?quickstart=1)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMS-2531?atlOrigin=eyJpIjoiZjVmOWE4ZWMzZWEwNDhjNGJiZTA5N2IyMGNmYjM4ODkiLCJwIjoiaiJ9

## **Manual testing steps**

1. Go to the bridge page or swap page on solana.
2. notice the price label only shows up when a quantity is entered

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="395" alt="Screenshot 2025-05-28 at 9 37 05 AM" src="https://github.com/user-attachments/assets/ba5d09cc-669e-400c-a343-5734b21a16fc" />
<img width="397" alt="Screenshot 2025-05-28 at 9 37 27 AM" src="https://github.com/user-attachments/assets/2697ef74-5426-46da-a9ec-60bed789b253" />


<!-- [screenshots/recordings] -->

### **After**
<img width="399" alt="Screenshot 2025-05-28 at 9 36 43 AM" src="https://github.com/user-attachments/assets/38f98b16-7154-41af-8ff9-37ec769af52f" />
<img width="397" alt="Screenshot 2025-05-28 at 9 36 51 AM" src="https://github.com/user-attachments/assets/13dae96e-638e-4b2e-9dc6-3ebb5a6aa06f" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
