### PR TITLE
fix: carousel slide improved validation for zero balance

### DIFF
--- a/ui/hooks/useCarouselManagement/useCarouselManagement.test.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.test.ts
@@ -296,6 +296,18 @@ describe('useCarouselManagement', () => {
 
       expect(updatedSlides[0].undismissable).toBe(true);
     });
+
+    it('should mark fund slide as undismissable when using the hex 0x00 for zero balance', async () => {
+      mockGetSelectedAccountCachedBalance.mockReturnValue('0x00');
+      renderHook(() => useCarouselManagement({ testDate: validTestDate }));
+
+      await waitFor(() => expect(mockUpdateSlides).toHaveBeenCalled());
+      const updatedSlides: CarouselSlide[] = mockUpdateSlides.mock.calls[0][0];
+
+      const fundsSlide = updatedSlides.find((s) => s.id === FUND_SLIDE.id);
+      expect(fundsSlide).toBeDefined();
+      expect(fundsSlide?.undismissable).toBe(true);
+    });
   });
 
   describe('zero funds, remote on, sweepstakes off', () => {

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import log from 'loglevel';
+import { BigNumber } from 'bignumber.js';
 import { isSolanaAddress } from '../../../shared/lib/multichain/accounts';
 import type { CarouselSlide } from '../../../shared/constants/app-state';
 import { updateSlides } from '../../store/actions';
@@ -68,7 +69,9 @@ export const useCarouselManagement = ({
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const prevSlidesRef = useRef<CarouselSlide[]>();
 
-  const hasZeroBalance = totalBalance === ZERO_BALANCE;
+  const hasZeroBalance = new BigNumber(totalBalance ?? ZERO_BALANCE).eq(
+    ZERO_BALANCE,
+  );
 
   useEffect(() => {
     const defaultSlides: CarouselSlide[] = [];
@@ -129,8 +132,7 @@ export const useCarouselManagement = ({
     }
     // Handle Contentful Data
     const maybeFetchContentful = async () => {
-      const contentfulEnabled =
-        remoteFeatureFlags?.contentfulCarouselEnabled ?? false;
+      const contentfulEnabled = false;
 
       if (contentfulEnabled) {
         try {

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.ts
@@ -132,7 +132,8 @@ export const useCarouselManagement = ({
     }
     // Handle Contentful Data
     const maybeFetchContentful = async () => {
-      const contentfulEnabled = false;
+      const contentfulEnabled =
+        remoteFeatureFlags?.contentfulCarouselEnabled ?? false;
 
       if (contentfulEnabled) {
         try {


### PR DESCRIPTION
## **Description**

I'm not sure of the root cause, but the account tracker controller balance hex was `0x00`, because of this the default string check for `0x0` fails.

We have now improved this by using a BigNumber hex validation for zero balance.

![Screenshot 2025-05-28 at 16 17 41](https://github.com/user-attachments/assets/c8ca9283-ab81-4416-8aa1-affb92328257)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33243?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33234

## **Manual testing steps**

See issue.
1. Select account with zero balance, see carousel is undismissible
2. Select account with balance, see carousel is dismissible

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/ae353487843c4625a21b5999348ab03f?sid=0aba9b26-d291-49cb-814b-6efe5ad6a864

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
