### PR TITLE
fix: enable switching between accounts in Solana wallet dapp tests

### DIFF
--- a/test/e2e/flask/solana-wallet-standard/connect.spec.ts
+++ b/test/e2e/flask/solana-wallet-standard/connect.spec.ts
@@ -185,8 +185,7 @@ describe('Solana Wallet Standard - e2e tests', function () {
     });
   });
   describe('Given I have connected to one of my two accounts', function () {
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip('Switching between them should NOT reflect in the dapp', async function () {
+    it('Switching between them should NOT reflect in the dapp', async function () {
       await withSolanaAccountSnap(
         {
           ...DEFAULT_SOLANA_TEST_DAPP_FIXTURE_OPTIONS,
@@ -197,7 +196,12 @@ describe('Solana Wallet Standard - e2e tests', function () {
           const testDapp = new TestDappSolana(driver);
           await testDapp.openTestDappPage();
 
-          // By default, the connection is established with the second account, which is the last one selected in the UI.
+          // Explicitly select the second account before connecting
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
+          await switchToAccount(driver, 'Solana 2');
+          await testDapp.switchTo();
+
+          // Now connect with the currently selected account
           await connectSolanaTestDapp(driver, testDapp, {
             selectAllAccounts: false,
           });
@@ -208,9 +212,7 @@ describe('Solana Wallet Standard - e2e tests', function () {
           assertConnected(account, account2Short);
 
           // Now switch to the first account
-          await driver.switchToWindowWithTitle(
-            WINDOW_TITLES.ExtensionInFullScreenView,
-          );
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
           await switchToAccount(driver, 'Solana 1');
           await testDapp.switchTo();
           await driver.delay(regularDelayMs);
@@ -219,9 +221,7 @@ describe('Solana Wallet Standard - e2e tests', function () {
           assertConnected(account, account2Short);
 
           // Switch back to the second account
-          await driver.switchToWindowWithTitle(
-            WINDOW_TITLES.ExtensionInFullScreenView,
-          );
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
           await switchToAccount(driver, 'Solana 2');
           await testDapp.switchTo();
 

--- a/test/e2e/flask/solana-wallet-standard/connect.spec.ts
+++ b/test/e2e/flask/solana-wallet-standard/connect.spec.ts
@@ -197,7 +197,9 @@ describe('Solana Wallet Standard - e2e tests', function () {
           await testDapp.openTestDappPage();
 
           // Explicitly select the second account before connecting
-          await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.ExtensionInFullScreenView,
+          );
           await switchToAccount(driver, 'Solana 2');
           await testDapp.switchTo();
 
@@ -212,7 +214,9 @@ describe('Solana Wallet Standard - e2e tests', function () {
           assertConnected(account, account2Short);
 
           // Now switch to the first account
-          await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.ExtensionInFullScreenView,
+          );
           await switchToAccount(driver, 'Solana 1');
           await testDapp.switchTo();
           await driver.delay(regularDelayMs);
@@ -221,7 +225,9 @@ describe('Solana Wallet Standard - e2e tests', function () {
           assertConnected(account, account2Short);
 
           // Switch back to the second account
-          await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.ExtensionInFullScreenView,
+          );
           await switchToAccount(driver, 'Solana 2');
           await testDapp.switchTo();
 


### PR DESCRIPTION
Updated the e2e test for the Solana Wallet Standard to enable switching between connected and non-connected accounts. The test now correctly verifies that switching accounts does not reflect changes in the dapp, ensuring accurate account management during testing.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33247?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
