### PR TITLE
Actually correct invalid selectedNetworkClientId

### DIFF
--- a/.yarn/patches/@metamask-network-controller-npm-23.2.1-backport-52eed19c47.patch
+++ b/.yarn/patches/@metamask-network-controller-npm-23.2.1-backport-52eed19c47.patch
@@ -10,7 +10,7 @@ index 0000000000000000000000000000000000000000..ce3b18534f055ee00aa5821793f855fd
 +You can see the changes before compilation on this branch: https://github.com/MetaMask/core/compare/pnf/ext-23622-review?expand=1
 \ No newline at end of file
 diff --git a/dist/NetworkController.cjs b/dist/NetworkController.cjs
-index ca0fdc1a5984b51ba6d2cc50655c2b8c789a6be2..efda018e73b86bf681438f17b7cbb4285c76164c 100644
+index ca0fdc1a5984b51ba6d2cc50655c2b8c789a6be2..de196cee61386c8a5ab5720bcc5822f305533a30 100644
 --- a/dist/NetworkController.cjs
 +++ b/dist/NetworkController.cjs
 @@ -45,6 +45,7 @@ const eth_query_1 = __importDefault(require("@metamask/eth-query"));
@@ -76,10 +76,19 @@ index ca0fdc1a5984b51ba6d2cc50655c2b8c789a6be2..efda018e73b86bf681438f17b7cbb428
          };
 -        validateNetworkControllerState(initialState);
 +        validateInitialState(initialState);
-+        correctInitialState(initialState, captureException);
++        const correctedInitialState = correctInitialState(initialState, captureException);
          if (!infuraProjectId || typeof infuraProjectId !== 'string') {
              throw new Error('Invalid Infura project ID');
          }
+@@ -368,7 +385,7 @@ class NetworkController extends base_controller_1.BaseController {
+                 },
+             },
+             messenger,
+-            state: initialState,
++            state: correctedInitialState,
+         });
+         _NetworkController_instances.add(this);
+         _NetworkController_ethQuery.set(this, void 0);
 @@ -515,7 +532,6 @@ class NetworkController extends base_controller_1.BaseController {
       */
      async initializeProvider() {
@@ -89,7 +98,7 @@ index ca0fdc1a5984b51ba6d2cc50655c2b8c789a6be2..efda018e73b86bf681438f17b7cbb428
      /**
       * Refreshes the network meta with EIP-1559 support and the network status
 diff --git a/dist/NetworkController.mjs b/dist/NetworkController.mjs
-index 0efca6773120ea8be324446febfbcee68ca4281d..8b50f352c6b620a090f95f83fe8878b1ccabd518 100644
+index 0efca6773120ea8be324446febfbcee68ca4281d..bd47f0d796322a62bde9a6eec6cb5333b7f5b925 100644
 --- a/dist/NetworkController.mjs
 +++ b/dist/NetworkController.mjs
 @@ -25,6 +25,7 @@ import { createEventEmitterProxy } from "@metamask/swappable-obj-proxy";
@@ -155,10 +164,19 @@ index 0efca6773120ea8be324446febfbcee68ca4281d..8b50f352c6b620a090f95f83fe8878b1
          };
 -        validateNetworkControllerState(initialState);
 +        validateInitialState(initialState);
-+        correctInitialState(initialState, captureException);
++        const correctedInitialState = correctInitialState(initialState, captureException);
          if (!infuraProjectId || typeof infuraProjectId !== 'string') {
              throw new Error('Invalid Infura project ID');
          }
+@@ -344,7 +361,7 @@ export class NetworkController extends BaseController {
+                 },
+             },
+             messenger,
+-            state: initialState,
++            state: correctedInitialState,
+         });
+         _NetworkController_instances.add(this);
+         _NetworkController_ethQuery.set(this, void 0);
 @@ -491,7 +508,6 @@ export class NetworkController extends BaseController {
       */
      async initializeProvider() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,7 +6133,7 @@ __metadata:
 
 "@metamask/network-controller@patch:@metamask/network-controller@npm%3A23.2.1-backport#~/.yarn/patches/@metamask-network-controller-npm-23.2.1-backport-52eed19c47.patch":
   version: 23.2.1-backport
-  resolution: "@metamask/network-controller@patch:@metamask/network-controller@npm%3A23.2.1-backport#~/.yarn/patches/@metamask-network-controller-npm-23.2.1-backport-52eed19c47.patch::version=23.2.1-backport&hash=dacdaf"
+  resolution: "@metamask/network-controller@patch:@metamask/network-controller@npm%3A23.2.1-backport#~/.yarn/patches/@metamask-network-controller-npm-23.2.1-backport-52eed19c47.patch::version=23.2.1-backport&hash=f7da9d"
   dependencies:
     "@metamask/base-controller": "npm:^8.0.0"
     "@metamask/controller-utils": "npm:^11.7.1-backport"
@@ -6153,7 +6153,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/5eccb272e546547da3ac340eac755e91b694db65a22340512ac7dbc9604beb712ca121934fb06a4f506e30b18fcca021abd0a24dace9b9617955945bda204391
+  checksum: 10/c07cb1e69a98b79e4d4d8f130fcb6a9d2dabbb2c066451818f31de54b313138cd172f14cb07ffd439a3a6c5e8082511a9b518a3e4e9c6c37815f2e059f79fd20
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

A previous commit attempted to auto-correct `selectedNetworkClientId` if it was invalid, but upon investigation it was found that this fix was faulty and no state was changed. This commit fixes the fix.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33350?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check out this branch.
2. Run `yarn webpack --watch`.
3. We now have to force the initial state to be invalid. Open `Engine.ts`, scroll down to where NetworkController is initialized, and apply these changes:
    ``` diff
          this.networkController = new NetworkController({
            messenger: networkControllerMessenger,
    -       state: initialNetworkControllerState,
    +       state: {
    +         ...initialNetworkControllerState,
    +         selectedNetworkClientId: "asldadsfl",
    +       },
            infuraProjectId: opts.infuraProjectId,
            getRpcServiceOptions: () => ({
              fetch: globalThis.fetch.bind(globalThis),
              btoa: globalThis.btoa.bind(globalThis),
            }),
            additionalDefaultNetworks,
            captureException,
          });
    +     console.log('selectedNetworkClientId', this.networkController.state.selectedNetworkClientId);
    ```
3. Open the background or service worker view.
4. Load the extension, onboarding if necessary.
5. You should be able to get to the home screen without issues. If you check DevTools you should see a line that says `selectedNetworkClientId mainnet`. This proves that although the initial `selectedNetworkClientId` was invalid, it was auto-corrected to "mainnet".

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
