### PR TITLE
fix: Prevent invalid selectedNetworkClientId on startup

### DIFF
--- a/.yarn/patches/@metamask-network-controller-npm-23.5.0-56b87eea93.patch
+++ b/.yarn/patches/@metamask-network-controller-npm-23.5.0-56b87eea93.patch
@@ -1,6 +1,6 @@
 diff --git a/PATCH.txt b/PATCH.txt
 new file mode 100644
-index 0000000000000000000000000000000000000000..ce3b18534f055ee00aa5821793f855fd300fb72c
+index 0000000000000000000000000000000000000000..376255036ca54b83a3f3c3e0277c2666473df30e
 --- /dev/null
 +++ b/PATCH.txt
 @@ -0,0 +1,4 @@
@@ -8,12 +8,81 @@ index 0000000000000000000000000000000000000000..ce3b18534f055ee00aa5821793f855fd
 +The network lookup is done after onboarding is completed, and when the extension reloads if onboarding has been completed.
 +This patch is part of a temporary fix that will be reverted soon to make way for a more permanent solution. https://github.com/MetaMask/metamask-extension/pull/23005
 +You can see the changes before compilation on this branch: https://github.com/MetaMask/core/compare/pnf/ext-23622-review?expand=1
-\ No newline at end of file
 diff --git a/dist/NetworkController.cjs b/dist/NetworkController.cjs
-index 00b24d49acfd88df1d26ba31dcba47927e2471aa..164d7cbc710ba3272c09a3956cb15e4bd6a715e8 100644
+index 00b24d49acfd88df1d26ba31dcba47927e2471aa..51c9de66f978190e4b17e57127b4d649288bbacd 100644
 --- a/dist/NetworkController.cjs
 +++ b/dist/NetworkController.cjs
-@@ -549,7 +549,6 @@ class NetworkController extends base_controller_1.BaseController {
+@@ -46,6 +46,7 @@ const rpc_errors_1 = require("@metamask/rpc-errors");
+ const swappable_obj_proxy_1 = require("@metamask/swappable-obj-proxy");
+ const utils_1 = require("@metamask/utils");
+ const fast_deep_equal_1 = __importDefault(require("fast-deep-equal"));
++const immer_1 = require("immer");
+ const lodash_1 = require("lodash");
+ const reselect_1 = require("reselect");
+ const URI = __importStar(require("uri-js"));
+@@ -300,7 +301,7 @@ function deriveInfuraNetworkNameFromRpcEndpointUrl(rpcEndpointUrl) {
+  * @param state - The NetworkController state to verify.
+  * @throws if the state is invalid in some way.
+  */
+-function validateNetworkControllerState(state) {
++function validateInitialState(state) {
+     const networkConfigurationEntries = Object.entries(state.networkConfigurationsByChainId);
+     const networkClientIds = getAvailableNetworkClientIds(getNetworkConfigurations(state));
+     if (networkConfigurationEntries.length === 0) {
+@@ -324,12 +325,27 @@ function validateNetworkControllerState(state) {
+     if ([...new Set(networkClientIds)].length < networkClientIds.length) {
+         throw new Error('NetworkController state has invalid `networkConfigurationsByChainId`: Every RPC endpoint across all network configurations must have a unique `networkClientId`');
+     }
+-    if (!networkClientIds.includes(state.selectedNetworkClientId)) {
+-        throw new Error(
+-        // This ESLint rule mistakenly produces an error.
+-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+-        `NetworkController state is invalid: \`selectedNetworkClientId\` '${state.selectedNetworkClientId}' does not refer to an RPC endpoint within a network configuration`);
+-    }
++}
++/**
++ * Checks that the given initial NetworkController state is internally
++ * consistent similar to `validateInitialState`, but if an anomaly is detected,
++ * it does its best to correct the state and logs an error to Sentry.
++ *
++ * @param state - The NetworkController state to verify.
++ * @param messenger - The NetworkController messenger.
++ * @returns The corrected state.
++ */
++function correctInitialState(state, messenger) {
++    const networkConfigurationsSortedByChainId = getNetworkConfigurations(state).sort((a, b) => a.chainId.localeCompare(b.chainId));
++    const networkClientIds = getAvailableNetworkClientIds(networkConfigurationsSortedByChainId);
++    return (0, immer_1.produce)(state, (newState) => {
++        if (!networkClientIds.includes(state.selectedNetworkClientId)) {
++            const firstNetworkConfiguration = networkConfigurationsSortedByChainId[0];
++            const newSelectedNetworkClientId = firstNetworkConfiguration.rpcEndpoints[firstNetworkConfiguration.defaultRpcEndpointIndex].networkClientId;
++            messenger.call('ErrorReportingService:captureException', new Error(`\`selectedNetworkClientId\` '${state.selectedNetworkClientId}' does not refer to an RPC endpoint within a network configuration; correcting to '${newSelectedNetworkClientId}'`));
++            newState.selectedNetworkClientId = newSelectedNetworkClientId;
++        }
++    });
+ }
+ /**
+  * Transforms a map of chain ID to network configuration to a map of network
+@@ -361,7 +377,8 @@ class NetworkController extends base_controller_1.BaseController {
+             ...getDefaultNetworkControllerState(additionalDefaultNetworks),
+             ...state,
+         };
+-        validateNetworkControllerState(initialState);
++        validateInitialState(initialState);
++        const correctedInitialState = correctInitialState(initialState, messenger);
+         if (!infuraProjectId || typeof infuraProjectId !== 'string') {
+             throw new Error('Invalid Infura project ID');
+         }
+@@ -382,7 +399,7 @@ class NetworkController extends base_controller_1.BaseController {
+                 },
+             },
+             messenger,
+-            state: initialState,
++            state: correctedInitialState,
+         });
+         _NetworkController_instances.add(this);
+         _NetworkController_ethQuery.set(this, void 0);
+@@ -549,7 +566,6 @@ class NetworkController extends base_controller_1.BaseController {
       */
      async initializeProvider() {
          __classPrivateFieldGet(this, _NetworkController_instances, "m", _NetworkController_applyNetworkSelection).call(this, this.state.selectedNetworkClientId);
@@ -22,10 +91,80 @@ index 00b24d49acfd88df1d26ba31dcba47927e2471aa..164d7cbc710ba3272c09a3956cb15e4b
      /**
       * Refreshes the network meta with EIP-1559 support and the network status
 diff --git a/dist/NetworkController.mjs b/dist/NetworkController.mjs
-index 3a2341a661225d48317c53cbc2e076633eb2157f..444f6f28f0a65fef746e2fe289666fe8c07f048e 100644
+index 3a2341a661225d48317c53cbc2e076633eb2157f..230cbcc9a5eebe97813275df4fb5b6e17d8a1481 100644
 --- a/dist/NetworkController.mjs
 +++ b/dist/NetworkController.mjs
-@@ -525,7 +525,6 @@ export class NetworkController extends BaseController {
+@@ -25,6 +25,7 @@ import { createEventEmitterProxy } from "@metamask/swappable-obj-proxy";
+ import { hasProperty, isPlainObject, isStrictHexString } from "@metamask/utils";
+ import $deepEqual from "fast-deep-equal";
+ const deepEqual = $importDefault($deepEqual);
++import { produce } from "immer";
+ import $lodash from "lodash";
+ const { cloneDeep } = $lodash;
+ import { createSelector } from "reselect";
+@@ -276,7 +277,7 @@ function deriveInfuraNetworkNameFromRpcEndpointUrl(rpcEndpointUrl) {
+  * @param state - The NetworkController state to verify.
+  * @throws if the state is invalid in some way.
+  */
+-function validateNetworkControllerState(state) {
++function validateInitialState(state) {
+     const networkConfigurationEntries = Object.entries(state.networkConfigurationsByChainId);
+     const networkClientIds = getAvailableNetworkClientIds(getNetworkConfigurations(state));
+     if (networkConfigurationEntries.length === 0) {
+@@ -300,12 +301,27 @@ function validateNetworkControllerState(state) {
+     if ([...new Set(networkClientIds)].length < networkClientIds.length) {
+         throw new Error('NetworkController state has invalid `networkConfigurationsByChainId`: Every RPC endpoint across all network configurations must have a unique `networkClientId`');
+     }
+-    if (!networkClientIds.includes(state.selectedNetworkClientId)) {
+-        throw new Error(
+-        // This ESLint rule mistakenly produces an error.
+-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+-        `NetworkController state is invalid: \`selectedNetworkClientId\` '${state.selectedNetworkClientId}' does not refer to an RPC endpoint within a network configuration`);
+-    }
++}
++/**
++ * Checks that the given initial NetworkController state is internally
++ * consistent similar to `validateInitialState`, but if an anomaly is detected,
++ * it does its best to correct the state and logs an error to Sentry.
++ *
++ * @param state - The NetworkController state to verify.
++ * @param messenger - The NetworkController messenger.
++ * @returns The corrected state.
++ */
++function correctInitialState(state, messenger) {
++    const networkConfigurationsSortedByChainId = getNetworkConfigurations(state).sort((a, b) => a.chainId.localeCompare(b.chainId));
++    const networkClientIds = getAvailableNetworkClientIds(networkConfigurationsSortedByChainId);
++    return produce(state, (newState) => {
++        if (!networkClientIds.includes(state.selectedNetworkClientId)) {
++            const firstNetworkConfiguration = networkConfigurationsSortedByChainId[0];
++            const newSelectedNetworkClientId = firstNetworkConfiguration.rpcEndpoints[firstNetworkConfiguration.defaultRpcEndpointIndex].networkClientId;
++            messenger.call('ErrorReportingService:captureException', new Error(`\`selectedNetworkClientId\` '${state.selectedNetworkClientId}' does not refer to an RPC endpoint within a network configuration; correcting to '${newSelectedNetworkClientId}'`));
++            newState.selectedNetworkClientId = newSelectedNetworkClientId;
++        }
++    });
+ }
+ /**
+  * Transforms a map of chain ID to network configuration to a map of network
+@@ -337,7 +353,8 @@ export class NetworkController extends BaseController {
+             ...getDefaultNetworkControllerState(additionalDefaultNetworks),
+             ...state,
+         };
+-        validateNetworkControllerState(initialState);
++        validateInitialState(initialState);
++        const correctedInitialState = correctInitialState(initialState, messenger);
+         if (!infuraProjectId || typeof infuraProjectId !== 'string') {
+             throw new Error('Invalid Infura project ID');
+         }
+@@ -358,7 +375,7 @@ export class NetworkController extends BaseController {
+                 },
+             },
+             messenger,
+-            state: initialState,
++            state: correctedInitialState,
+         });
+         _NetworkController_instances.add(this);
+         _NetworkController_ethQuery.set(this, void 0);
+@@ -525,7 +542,6 @@ export class NetworkController extends BaseController {
       */
      async initializeProvider() {
          __classPrivateFieldGet(this, _NetworkController_instances, "m", _NetworkController_applyNetworkSelection).call(this, this.state.selectedNetworkClientId);

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1894,6 +1894,7 @@
         "@metamask/utils": true,
         "addons-linter>deepmerge": true,
         "eslint>fast-deep-equal": true,
+        "immer": true,
         "lodash": true,
         "reselect": true,
         "uri-js": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1894,6 +1894,7 @@
         "@metamask/utils": true,
         "addons-linter>deepmerge": true,
         "eslint>fast-deep-equal": true,
+        "immer": true,
         "lodash": true,
         "reselect": true,
         "uri-js": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1894,6 +1894,7 @@
         "@metamask/utils": true,
         "addons-linter>deepmerge": true,
         "eslint>fast-deep-equal": true,
+        "immer": true,
         "lodash": true,
         "reselect": true,
         "uri-js": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6081,7 +6081,7 @@ __metadata:
 
 "@metamask/network-controller@patch:@metamask/network-controller@npm%3A23.5.0#~/.yarn/patches/@metamask-network-controller-npm-23.5.0-56b87eea93.patch":
   version: 23.5.0
-  resolution: "@metamask/network-controller@patch:@metamask/network-controller@npm%3A23.5.0#~/.yarn/patches/@metamask-network-controller-npm-23.5.0-56b87eea93.patch::version=23.5.0&hash=f907f3"
+  resolution: "@metamask/network-controller@patch:@metamask/network-controller@npm%3A23.5.0#~/.yarn/patches/@metamask-network-controller-npm-23.5.0-56b87eea93.patch::version=23.5.0&hash=63d932"
   dependencies:
     "@metamask/base-controller": "npm:^8.0.1"
     "@metamask/controller-utils": "npm:^11.9.0"
@@ -6101,7 +6101,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/6d0679a931a0949ee29c41f21076802a43bdb2f59378451fe145bb8edf65880bcf86f9883e33fc8605628b618532ac7728534daba752ebad1b4cd12714a01616
+  checksum: 10/24a86bdf48eb755c67a25c8121a3011a9e8b3501bc8b0510b30d052ddb5ba05ae0a36136badb3b7a956edcca4f52bbdf5c1c4c045d890df9652b71e3239f3e8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

If `selectedNetworkClientId` in NetworkController state does not point to an RPC endpoint and therefore does not also point to a network client, then we automatically correct it to point to the default RPC endpoint of the first network (sorted by chain ID). This allows the wallet to start normally.

This change is being added as a patch because we do not want to upgrade to 23.5.1, as doing so would fix another unrelated bug, and we want to limit the scope of the change.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33480?quickstart=1)

## **Related issues**

See https://github.com/MetaMask/core/pull/5851 for the equivalent changes to network-controller that were copied here.

Also see https://github.com/MetaMask/metamask-mobile/pull/15941 for a similar fix on the mobile side.

## **Manual testing steps**

1. Check out this branch.
2. Run `yarn start`.
3. Open the extension, and go through onboarding.
4. Close the UI.
5. Find the extension and open the service worker.
6. Navigate to the Application tab.
7. Click on "Extension storage", then "Local".
8. Click on the value for "data".
9. Look in the preview pane below (rendered JSON), right-click and choose "Copy value".
10. Paste the value in another screen such as TextEdit.
11. Look for `selectedNetworkClientId` and change it to something invalid.
12. Reload the extension.
13. The extension should still load successfully.
14. Go back to the service worker. You should still be on the Application tab, and the preview should have been updated so that `selectedNetworkClientId` should no longer be invalid.
15. Repeat the same steps, except run `yarn webpack --watch` instead of `yarn start` (to test MV2).

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
