### PR TITLE
fix: flaky test `Vault Corruption` on wait to disappear scroll button

### DIFF
--- a/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
@@ -39,7 +39,7 @@ class TermsOfUseUpdateModal {
 
   async confirmAcceptTermsOfUseUpdate() {
     console.log('Click to confirm acceptance of terms of use update');
-    await this.driver.clickElement(this.popoverScrollButton);
+    await this.driver.clickElementAndWaitToDisappear(this.popoverScrollButton, 10);
     await this.driver.clickElement(this.termsOfUseCheckbox);
     await this.driver.clickElementAndWaitToDisappear(this.acceptButton);
   }

--- a/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
@@ -39,7 +39,10 @@ class TermsOfUseUpdateModal {
 
   async confirmAcceptTermsOfUseUpdate() {
     console.log('Click to confirm acceptance of terms of use update');
-    await this.driver.clickElementAndWaitToDisappear(this.popoverScrollButton, 10);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.popoverScrollButton,
+      8000,
+    );
     await this.driver.clickElement(this.termsOfUseCheckbox);
     await this.driver.clickElementAndWaitToDisappear(this.acceptButton);
   }

--- a/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
@@ -39,7 +39,8 @@ class TermsOfUseUpdateModal {
 
   async confirmAcceptTermsOfUseUpdate() {
     console.log('Click to confirm acceptance of terms of use update');
-    await this.driver.clickElementAndWaitToDisappear(this.popoverScrollButton);
+    // TODO: sometime the scroll button doesn't appear. This needs to be fixed on the application side
+    await this.driver.clickElementSafe(this.popoverScrollButton);
     await this.driver.clickElement(this.termsOfUseCheckbox);
     await this.driver.clickElementAndWaitToDisappear(this.acceptButton);
   }

--- a/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
@@ -39,8 +39,7 @@ class TermsOfUseUpdateModal {
 
   async confirmAcceptTermsOfUseUpdate() {
     console.log('Click to confirm acceptance of terms of use update');
-    // TODO: sometime the scroll button doesn't appear. This needs to be fixed on the application side
-    await this.driver.clickElementSafe(this.popoverScrollButton);
+    await this.driver.clickElement(this.popoverScrollButton);
     await this.driver.clickElement(this.termsOfUseCheckbox);
     await this.driver.clickElementAndWaitToDisappear(this.acceptButton);
   }

--- a/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
@@ -41,7 +41,7 @@ class TermsOfUseUpdateModal {
     console.log('Click to confirm acceptance of terms of use update');
     await this.driver.clickElementAndWaitToDisappear(
       this.popoverScrollButton,
-      8000,
+      5000,
     );
     await this.driver.clickElement(this.termsOfUseCheckbox);
     await this.driver.clickElementAndWaitToDisappear(this.acceptButton);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The arrow for the scroll to bottom can take some time to disappear, specially on Firefox. The default timeout for waiting an element to disappear is 2 seconds. I'm increasing the timeout to 5 seconds for this particular action.




![test-failure-screenshot-2](https://github.com/user-attachments/assets/2e8964ba-fe6e-4f64-97c7-61bdd953c0c8)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33493?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
