### PR TITLE
test: skip flaky vault e2e test on firefox

### DIFF
--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -252,6 +252,10 @@ describe('Vault Corruption', function () {
   }
 
   it('recovers metamask vault when primary database is broken but backup is intact', async function () {
+    if (process.env.SELENIUM_BROWSER === 'firefox') {
+      // currently very flaky on Firefox, so skip it temporarily
+      this.skip();
+    }
     await withFixtures(
       getConfig(this.test?.title),
       async ({ driver }: { driver: Driver }) => {
@@ -307,6 +311,10 @@ describe('Vault Corruption', function () {
     // is intact` test verifies that *first* attempts at recovery work, this
     // test verifies that not recovering, then trying to recovering again later
     // works too.
+    if (process.env.SELENIUM_BROWSER === 'firefox') {
+      // currently very flaky on Firefox, so skip it temporarily
+      this.skip();
+    }
     await withFixtures(
       getConfig(this.test?.title),
       async ({ driver }: { driver: Driver }) => {
@@ -344,6 +352,10 @@ describe('Vault Corruption', function () {
 
   it('restores a backup that is missing its `meta` property successfully', async function () {
     // this test will run all migrations
+    if (process.env.SELENIUM_BROWSER === 'firefox') {
+      // currently very flaky on Firefox, so skip it temporarily
+      this.skip();
+    }
     await withFixtures(
       getConfig(this.test?.title),
       async ({ driver }: { driver: Driver }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Skip following 3 testcases on firefox as they are very flaky on CI. Since we only skip on firefox and still execute them on Chrome, we don't loose full coverage.

- `recovers metamask vault when primary database is broken but backup is intact`
- `does *not* reset metamask state when recovery is *not* confirmed`
- `restores a backup that is missing its meta property successfully`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33494?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
