### PR TITLE
fix(snaps): Adjust `SnapUIAccountSelector` height

### DIFF
--- a/ui/components/app/snaps/snap-ui-account-selector/index.scss
+++ b/ui/components/app/snaps/snap-ui-account-selector/index.scss
@@ -2,6 +2,10 @@
   .multichain-account-list-item {
     padding: 0;
 
+    &:hover {
+      background-color: var(--transparent) !important;
+    }
+
     & > div:first-child {
       align-items: center;
       margin-right: 0;
@@ -12,6 +16,10 @@
 .snap-ui-renderer__account-selector-item {
   .multichain-account-list-item {
     padding: 0;
+
+    &:hover {
+      background-color: var(--transparent) !important;
+    }
 
     & > div:first-child {
       align-items: center;

--- a/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
+++ b/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
@@ -113,10 +113,10 @@ export const SnapUIAccountSelector: FunctionComponent<
       onSelect={handleSelect}
       disabled={disabled || accounts.length === 0}
       style={{
-        maxHeight: '82px',
+        maxHeight: '89px',
       }}
       itemStyle={{
-        maxHeight: '82px',
+        maxHeight: '89px',
       }}
     />
   );

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
@@ -18,7 +18,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
         >
           <button
             class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-base--ellipsis snap-ui-renderer__selector snap-ui-renderer__account-selector mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-2 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--gap-2 mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-default mm-box--rounded-lg"
-            style="justify-content: inherit; text-align: inherit; height: inherit; min-height: 48px; max-height: 82px;"
+            style="justify-content: inherit; text-align: inherit; height: inherit; min-height: 48px; max-height: 89px;"
           >
             <span
               class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--width-full mm-box--color-text-default"
@@ -325,7 +325,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
           </label>
           <button
             class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-base--ellipsis snap-ui-renderer__selector snap-ui-renderer__account-selector mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-2 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--gap-2 mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-default mm-box--rounded-lg"
-            style="justify-content: inherit; text-align: inherit; height: inherit; min-height: 48px; max-height: 82px;"
+            style="justify-content: inherit; text-align: inherit; height: inherit; min-height: 48px; max-height: 89px;"
           >
             <span
               class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--width-full mm-box--color-text-default"


### PR DESCRIPTION
## **Description**

This PR adjust the size of the `SnapUIAccountSelector` to avoid squishing the content when the account has a label.

I also included a small fix to disable the hover background color of the `AccountListItem`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33514?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enter two SRP in the extension
2. Use the Account Selector in Snaps UI
3. Ensure that the content doesn't get squished

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/user-attachments/assets/685d610b-58bb-483a-9bdc-89d5a4568eb1)
![image](https://github.com/user-attachments/assets/07f7b622-cb71-4274-ac0f-cca042d5a5c5)

### **After**

![image](https://github.com/user-attachments/assets/a51832ca-ed16-4a1d-b0bf-9e0db304227f)
![image](https://github.com/user-attachments/assets/04033060-0ab7-4440-ad70-3e6d9c1bc686)


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
