### PR TITLE
ci: fix Crowdin translations workflow

### DIFF
--- a/.github/scripts/git-diff-default-branch.ts
+++ b/.github/scripts/git-diff-default-branch.ts
@@ -67,7 +67,7 @@ function writePrBodyAndInfoToFile(prInfo: PRInfo) {
   const labels = prInfo.labels.map((label) => label.name).join(', ');
   const updatedPrBody = `PR labels: {${labels}}\nPR base: {${
     prInfo.base.ref
-  }}\n${prInfo.body.trim()}`;
+  }}\n${prInfo.body?.trim()}`;
   fs.writeFileSync(prBodyPath, updatedPrBody);
   core.info(`PR body and info saved to ${prBodyPath}`);
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ node_modules/**/*
 /app/images/animations/**/*.json
 /app/vendor/**
 /builds/**/*
+/changed-files/**/*
 /coverage/**/*
 /development/chromereload.js
 /development/ts-migration-dashboard/filesToConvert.json


### PR DESCRIPTION
## **Description**

Fixes two problems with the Crowdin translations workflow:
1. Sometimes it tries to run prettier on the generated `changed-files/changed-files.json` and fails
2. If the PR body is blank, you can't `.trim()` it https://github.com/MetaMask/metamask-extension/actions/runs/15495451877/job/43631108440

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33519?quickstart=1)

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->