### PR TITLE
feat: Adding details about alternateGasFees in wallet_getCapabilities

### DIFF
--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -186,23 +186,23 @@ async function getAlternateGasFeesCapability(
 
   const updatedBatchSupport = batchSupport.map((batchSupport, index) => ({
     ...batchSupport,
-    isRelaySupported: relaySupportedChains[index],
+    relaySupportedForChain: relaySupportedChains[index],
   }));
 
   return chainIds.reduce<GetCapabilitiesResult>((acc, chainId) => {
     const chainBatchSupport = (updatedBatchSupport.find(
       ({ chainId: batchChainId }) => batchChainId === chainId,
     ) ?? {}) as IsAtomicBatchSupportedResultEntry & {
-      isRelaySupported: boolean;
+      relaySupportedForChain: boolean;
     };
 
-    const { isSupported = false, isRelaySupported } = chainBatchSupport;
+    const { isSupported = false, relaySupportedForChain } = chainBatchSupport;
 
     const isSmartTransaction = getIsSmartTransaction(chainId);
 
     const alternateGasFees =
       simulationEnabled &&
-      (isSmartTransaction || (isSupported && isRelaySupported));
+      (isSmartTransaction || (isSupported && relaySupportedForChain));
 
     if (alternateGasFees) {
       acc[chainId as Hex] = {

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -184,8 +184,8 @@ async function getAlternateGasFeesCapability(
       .map((chainId) => isRelaySupported(chainId)),
   );
 
-  const updatedBatchSupport = batchSupport.map((batchSupport, index) => ({
-    ...batchSupport,
+  const updatedBatchSupport = batchSupport.map((support, index) => ({
+    ...support,
     relaySupportedForChain: relaySupportedChains[index],
   }));
 

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -1,5 +1,4 @@
 import {
-  NetworkConfiguration,
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetStateAction,
 } from '@metamask/network-controller';

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -184,13 +184,13 @@ async function getAlternateGasFeesCapability(
       .map((chainId) => isRelaySupported(chainId)),
   );
 
-  batchSupport = batchSupport.map((batchSupport, index) => ({
+  const updatedBatchSupport = batchSupport.map((batchSupport, index) => ({
     ...batchSupport,
     isRelaySupported: relaySupportedChains[index],
   }));
 
   return chainIds.reduce<GetCapabilitiesResult>((acc, chainId) => {
-    const chainBatchSupport = (batchSupport.find(
+    const chainBatchSupport = (updatedBatchSupport.find(
       ({ chainId: batchChainId }) => batchChainId === chainId,
     ) ?? {}) as IsAtomicBatchSupportedResultEntry & {
       isRelaySupported: boolean;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2071,16 +2071,16 @@ export default class MetamaskController extends EventEmitter {
           getDismissSmartAccountSuggestionEnabled: () =>
             this.preferencesController.state.preferences
               .dismissSmartAccountSuggestionEnabled,
+          getIsSmartTransaction: (chainId) =>
+            getIsSmartTransaction(this._getMetaMaskState(), chainId),
+          getSupportedNetworks: () =>
+            this.networkController.state.networkConfigurationsByChainId,
           isAtomicBatchSupported: this.txController.isAtomicBatchSupported.bind(
             this.txController,
           ),
+          isRelaySupported,
           isSimulationEnabled: () =>
             this.preferencesController.state.useTransactionSimulations,
-          getIsSmartTransaction: (chainId) =>
-            getIsSmartTransaction(this._getMetaMaskState(), chainId),
-          isRelaySupported,
-          getSupportedNetworks: () =>
-            this.networkController.state.networkConfigurationsByChainId,
         },
         this.controllerMessenger,
       ),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2074,6 +2074,13 @@ export default class MetamaskController extends EventEmitter {
           isAtomicBatchSupported: this.txController.isAtomicBatchSupported.bind(
             this.txController,
           ),
+          isSimulationEnabled: () =>
+            this.preferencesController.state.useTransactionSimulations,
+          getIsSmartTransaction: (chainId) =>
+            getIsSmartTransaction(this._getMetaMaskState(), chainId),
+          isRelaySupported,
+          getSupportedNetworks: () =>
+            this.networkController.state.networkConfigurationsByChainId,
         },
         this.controllerMessenger,
       ),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2073,14 +2073,10 @@ export default class MetamaskController extends EventEmitter {
               .dismissSmartAccountSuggestionEnabled,
           getIsSmartTransaction: (chainId) =>
             getIsSmartTransaction(this._getMetaMaskState(), chainId),
-          getSupportedNetworks: () =>
-            this.networkController.state.networkConfigurationsByChainId,
           isAtomicBatchSupported: this.txController.isAtomicBatchSupported.bind(
             this.txController,
           ),
           isRelaySupported,
-          isSimulationEnabled: () =>
-            this.preferencesController.state.useTransactionSimulations,
         },
         this.controllerMessenger,
       ),


### PR DESCRIPTION
## **Description**

Return in `wallet_getCapabilities` of gasless is supported for an account.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5080

## **Manual testing steps**

1. Go to test-dapp
2. Check capabilities in 5792 section
3.

## **Screenshots/Recordings**
<img width="478" alt="Screenshot 2025-06-09 at 8 27 38 PM" src="https://github.com/user-attachments/assets/3d3977ce-61ef-4d9a-88a4-f1ecd8b8570d" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
