### PR TITLE
feat: discover accounts with testnet-only activity when testnets are enabled in the settings

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4825,16 +4825,17 @@ export default class MetamaskController extends EventEmitter {
       const btcClient = await this._getMultichainWalletSnapClient(
         BITCOIN_WALLET_SNAP_ID,
       );
-      const btcScope = BtcScope.Mainnet;
+      const btcScopes = [BtcScope.Mainnet];
       const btcAccounts = await btcClient.discoverAccounts(
         entropySource,
-        btcScope,
+        btcScopes,
       );
 
       // If none accounts got discovered, we still create the first (default) one.
+      // Also worth noting that in Bitcoin we only have one scope per account
       if (btcAccounts.length === 0) {
         await this._addSnapAccount(entropySource, btcClient, {
-          scope: btcScope,
+          scope: BtcScope.Mainnet,
           synchronize: true,
         });
       }
@@ -4844,16 +4845,20 @@ export default class MetamaskController extends EventEmitter {
       const solanaClient = await this._getMultichainWalletSnapClient(
         SOLANA_WALLET_SNAP_ID,
       );
-      const solScope = SolScope.Mainnet;
+      const areSolanaTestnetsEnabled =
+        this.preferencesController.state.preferences.showTestNetworks;
+      const solScopes = areSolanaTestnetsEnabled
+        ? [SolScope.Mainnet, SolScope.Devnet]
+        : [SolScope.Mainnet];
       const solanaAccounts = await solanaClient.discoverAccounts(
         entropySource,
-        solScope,
+        solScopes,
       );
 
       // If none accounts got discovered, we still create the first (default) one.
       if (solanaAccounts.length === 0) {
         await this._addSnapAccount(entropySource, solanaClient, {
-          scope: solScope,
+          scope: SolScope.Mainnet,
         });
       }
       ///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33536?quickstart=1)

## **Related issues**

n/a

## **Manual testing steps**

1. Setup the extension with any SRP
2. On the `Advanced` settings, enable the flag `Show test networks`
3. Import another SRP where you know there is testnet activity for its Bitcoin or Solana derived addresses
4. Confirm these testnets get discovered automatically. They should not be discovered automatically if the `Show test networks` toggle is not on.

## **Screenshots/Recordings**

### **Before**

n/a

### **After**

n/a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
