### PR TITLE
refactor: Remove extraneous code fence

### DIFF
--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -82,22 +82,18 @@ export const AccountPicker = ({
           alignItems={AlignItems.center}
           gap={process.env.REMOVE_GNS ? 0 : 2}
         >
-          {
-            process.env.REMOVE_GNS ? null : (
-              ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-              <AvatarAccount
-                variant={
-                  useBlockie
-                    ? AvatarAccountVariant.Blockies
-                    : AvatarAccountVariant.Jazzicon
-                }
-                address={address}
-                size={showAddress ? Size.MD : Size.XS}
-                borderColor={BackgroundColor.backgroundDefault} // we currently don't have white color for border hence using backgroundDefault as the border
-              />
-            )
-            ///: END:ONLY_INCLUDE_IF
-          }
+          {process.env.REMOVE_GNS ? null : (
+            <AvatarAccount
+              variant={
+                useBlockie
+                  ? AvatarAccountVariant.Blockies
+                  : AvatarAccountVariant.Jazzicon
+              }
+              address={address}
+              size={showAddress ? Size.MD : Size.XS}
+              borderColor={BackgroundColor.backgroundDefault} // we currently don't have white color for border hence using backgroundDefault as the border
+            />
+          )}
           <Text
             as="span"
             ellipsis


### PR DESCRIPTION
## **Description**

Removes an extraneous code fence that would never be removed in practice since the MMI build type was removed. If the fence ever was removed, it would cause a syntax error (unclosed left paren).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33546?quickstart=1)

## **Manual testing steps**

Look at `builds.yml` and deduce that at least one of the features named by this fence will always be enabled.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
