### PR TITLE
fix: cp-12.20.0 Fix scuttling error for `getSelection`

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -146,6 +146,8 @@ async function defineAndRunBuildTasks() {
       'sentryHooks',
       'sentry',
       'logEncryptedVault',
+      // Globals used by `react-dom`
+      'getSelection',
     ];
 
     if (
@@ -158,7 +160,6 @@ async function defineAndRunBuildTasks() {
         // in the future, more of the globals above can be put in this list
         'Proxy',
         'ret_nodes',
-        'getSelection',
 
         'browser', // for testing vault corruption
         'chrome', // for testing vault corruption


### PR DESCRIPTION
## **Description**

The React update to v17.0.2 in #31723 resulted in a console error in the Send flow when choosing the balance to send. It seems this error was found in testing, but an exception was only added for test builds.

The problem occurs in production builds as well, so the exception list was updated to allow `getSelection` in all build types.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33576?quickstart=1)

## **Related issues**

Fixes: #33589

## **Manual testing steps**

See testing steps in #33589

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
