### PR TITLE
fix: reduce chains.json fetches by moving hook to AssetList cp-12.20.0

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/Asset.tsx
@@ -18,7 +18,7 @@ type AssetProps = AssetWithDisplayData<NativeAsset | ERC20Asset> & {
   tooltipText?: string;
   assetItemProps?: Pick<
     React.ComponentProps<typeof TokenListItem>,
-    'isTitleNetworkName' | 'isTitleHidden'
+    'isTitleNetworkName' | 'isTitleHidden' | 'nativeCurrencySymbol'
   >;
 };
 

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
@@ -28,13 +28,13 @@ import {
   getMultichainSelectedAccountCachedBalance,
 } from '../../../../selectors/multichain';
 import { useMultichainSelector } from '../../../../hooks/useMultichainSelector';
-import AssetComponent from './Asset';
-import { AssetWithDisplayData, ERC20Asset, NFT, NativeAsset } from './types';
 import {
   type SafeChain,
   useSafeChains,
 } from '../../../../pages/settings/networks-tab/networks-form/use-safe-chains';
 import { hexToDecimal } from '../../../../../shared/modules/conversion.utils';
+import AssetComponent from './Asset';
+import { AssetWithDisplayData, ERC20Asset, NFT, NativeAsset } from './types';
 
 type AssetListProps = {
   handleAssetChange: (

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/AssetList.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import classnames from 'classnames';
 import {
   AddNetworkFields,
   NetworkConfiguration,
 } from '@metamask/network-controller';
-import type { CaipChainId } from '@metamask/utils';
+import { isStrictHexString, type CaipChainId } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { useCurrencyDisplay } from '../../../../hooks/useCurrencyDisplay';
 import { AssetType } from '../../../../../shared/constants/transaction';
@@ -30,6 +30,11 @@ import {
 import { useMultichainSelector } from '../../../../hooks/useMultichainSelector';
 import AssetComponent from './Asset';
 import { AssetWithDisplayData, ERC20Asset, NFT, NativeAsset } from './types';
+import {
+  type SafeChain,
+  useSafeChains,
+} from '../../../../pages/settings/networks-tab/networks-form/use-safe-chains';
+import { hexToDecimal } from '../../../../../shared/modules/conversion.utils';
 
 type AssetListProps = {
   handleAssetChange: (
@@ -91,6 +96,21 @@ export default function AssetList({
   const [secondaryCurrencyValue] = useCurrencyDisplay(balanceValue, {
     currency: nativeCurrency,
   });
+
+  const { safeChains } = useSafeChains();
+  const safeChainDetails: SafeChain | undefined = useMemo(
+    () =>
+      safeChains?.find((chain) => {
+        const decimalChainId =
+          isStrictHexString(chainId) && parseInt(hexToDecimal(chainId), 10);
+        if (typeof decimalChainId === 'number') {
+          return chain.chainId === decimalChainId.toString();
+        }
+        return undefined;
+      }),
+    [safeChains, chainId],
+  );
+  const nativeCurrencySymbol = safeChainDetails?.nativeCurrency?.symbol;
 
   return (
     <Box className="tokens-main-view-modal">
@@ -163,6 +183,7 @@ export default function AssetList({
                     tokenImage={token.image}
                     isPrimaryTokenSymbolHidden
                     tokenChainImage={getImageForChainId(token.chainId)}
+                    nativeCurrencySymbol={nativeCurrencySymbol}
                     {...assetItemProps}
                   />
                 ) : (
@@ -171,7 +192,10 @@ export default function AssetList({
                     tooltipText={
                       isDisabled ? 'swapTokenNotAvailable' : undefined
                     }
-                    assetItemProps={assetItemProps}
+                    assetItemProps={{
+                      ...assetItemProps,
+                      nativeCurrencySymbol,
+                    }}
                   />
                 )}
               </Box>

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/AssetList.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/AssetList.test.tsx.snap
@@ -1,44 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssetList should pass an empty nativeCurrencySymbol if the safe chains are not loaded 1`] = `
-[
-  [
-    {
-      "address": "0xToken1",
-      "assetItemProps": {
-        "nativeCurrencySymbol": undefined,
-      },
-      "balance": "0",
-      "chainId": "0x1",
-      "decimals": 18,
-      "image": "image1.png",
-      "string": "10",
-      "symbol": "TOKEN1",
-      "tooltipText": undefined,
-      "type": "TOKEN",
-    },
-    {},
-  ],
-  [
-    {
-      "address": "0xToken2",
-      "assetItemProps": {
-        "nativeCurrencySymbol": undefined,
-      },
-      "balance": "10",
-      "chainId": "0x1",
-      "decimals": 6,
-      "image": "image2.png",
-      "string": "20",
-      "symbol": "TOKEN2",
-      "tooltipText": undefined,
-      "type": "TOKEN",
-    },
-    {},
-  ],
-]
-`;
-
 exports[`AssetList should pass an undefined nativeCurrencySymbol if the safe chains are not loaded 1`] = `
 [
   [

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/AssetList.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/AssetList.test.tsx.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AssetList should pass an empty nativeCurrencySymbol if the safe chains are not loaded 1`] = `
+[
+  [
+    {
+      "address": "0xToken1",
+      "assetItemProps": {
+        "nativeCurrencySymbol": undefined,
+      },
+      "balance": "0",
+      "chainId": "0x1",
+      "decimals": 18,
+      "image": "image1.png",
+      "string": "10",
+      "symbol": "TOKEN1",
+      "tooltipText": undefined,
+      "type": "TOKEN",
+    },
+    {},
+  ],
+  [
+    {
+      "address": "0xToken2",
+      "assetItemProps": {
+        "nativeCurrencySymbol": undefined,
+      },
+      "balance": "10",
+      "chainId": "0x1",
+      "decimals": 6,
+      "image": "image2.png",
+      "string": "20",
+      "symbol": "TOKEN2",
+      "tooltipText": undefined,
+      "type": "TOKEN",
+    },
+    {},
+  ],
+]
+`;
+
+exports[`AssetList should pass an undefined nativeCurrencySymbol if the safe chains are not loaded 1`] = `
+[
+  [
+    {
+      "address": "0xToken1",
+      "assetItemProps": {
+        "nativeCurrencySymbol": "ETH",
+      },
+      "balance": "0",
+      "chainId": "0x1",
+      "decimals": 18,
+      "image": "image1.png",
+      "string": "10",
+      "symbol": "TOKEN1",
+      "tooltipText": undefined,
+      "type": "TOKEN",
+    },
+    {},
+  ],
+  [
+    {
+      "address": "0xToken2",
+      "assetItemProps": {
+        "nativeCurrencySymbol": "ETH",
+      },
+      "balance": "10",
+      "chainId": "0x1",
+      "decimals": 6,
+      "image": "image2.png",
+      "string": "20",
+      "symbol": "TOKEN2",
+      "tooltipText": undefined,
+      "type": "TOKEN",
+    },
+    {},
+  ],
+]
+`;
+
+exports[`AssetList should show the scam warning modal 1`] = `
+[
+  [
+    {
+      "address": "0xToken1",
+      "assetItemProps": {
+        "nativeCurrencySymbol": "ETH",
+      },
+      "balance": "0",
+      "chainId": "0x1",
+      "decimals": 18,
+      "image": "image1.png",
+      "string": "10",
+      "symbol": "TOKEN1",
+      "tooltipText": undefined,
+      "type": "TOKEN",
+    },
+    {},
+  ],
+  [
+    {
+      "address": "0xToken2",
+      "assetItemProps": {
+        "nativeCurrencySymbol": "ETH",
+      },
+      "balance": "10",
+      "chainId": "0x1",
+      "decimals": 6,
+      "image": "image2.png",
+      "string": "20",
+      "symbol": "TOKEN2",
+      "tooltipText": undefined,
+      "type": "TOKEN",
+    },
+    {},
+  ],
+]
+`;

--- a/ui/components/multichain/token-list-item/token-list-item.test.tsx
+++ b/ui/components/multichain/token-list-item/token-list-item.test.tsx
@@ -6,7 +6,6 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import { mockNetworkState } from '../../../../test/stub/networks';
-import { useSafeChains } from '../../../pages/settings/networks-tab/networks-form/use-safe-chains';
 import {
   getCurrencyRates,
   getNetworkConfigurationIdByChainId,
@@ -39,27 +38,12 @@ const state = {
   },
 };
 
-const safeChainDetails = {
-  chainId: '1',
-  nativeCurrency: {
-    symbol: 'ETH',
-  },
-};
-
 let openTabSpy: jest.SpyInstance<void, [opts: { url: string }], unknown>;
 
 jest.mock('../../../ducks/locale/locale', () => ({
   getIntlLocale: jest.fn(),
 }));
 
-jest.mock(
-  '../../../pages/settings/networks-tab/networks-form/use-safe-chains',
-  () => ({
-    useSafeChains: jest.fn().mockReturnValue({
-      safeChains: [safeChainDetails],
-    }),
-  }),
-);
 jest.mock('react-redux', () => {
   const actual = jest.requireActual('react-redux');
   return {
@@ -69,7 +53,6 @@ jest.mock('react-redux', () => {
 });
 
 const mockGetIntlLocale = getIntlLocale;
-const mockGetSafeChains = useSafeChains;
 
 describe('TokenListItem', () => {
   beforeAll(() => {
@@ -152,6 +135,7 @@ describe('TokenListItem', () => {
       title: '',
       tokenSymbol: 'SCAM_TOKEN',
       chainId: '0x1',
+      nativeCurrencySymbol: 'ETH',
     };
     const { getByTestId, getByText, container } = renderWithProvider(
       <TokenListItem {...propsToUse} />,
@@ -170,7 +154,6 @@ describe('TokenListItem', () => {
   });
 
   it('should display warning scam modal fallback when safechains fails to resolve correctly', () => {
-    (mockGetSafeChains as unknown as jest.Mock).mockReturnValue([]);
     const store = configureMockStore()(state);
     const propsToUse = {
       primary: '11.9751 ETH',
@@ -181,6 +164,7 @@ describe('TokenListItem', () => {
       title: '',
       tokenSymbol: 'SCAM_TOKEN',
       chainId: '0x1',
+      nativeCurrencySymbol: undefined,
     };
     const { getByTestId, getByText, container } = renderWithProvider(
       <TokenListItem {...propsToUse} />,

--- a/ui/components/multichain/token-list-item/token-list-item.tsx
+++ b/ui/components/multichain/token-list-item/token-list-item.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import { type Hex, isStrictHexString } from '@metamask/utils';
+import { type Hex } from '@metamask/utils';
 import {
   BackgroundColor,
   BlockSize,
@@ -49,13 +49,8 @@ import {
   CURRENCY_SYMBOLS,
   NON_EVM_CURRENCY_SYMBOLS,
 } from '../../../../shared/constants/network';
-import { hexToDecimal } from '../../../../shared/modules/conversion.utils';
 import { NETWORKS_ROUTE } from '../../../helpers/constants/routes';
 import { setEditedNetwork } from '../../../store/actions';
-import {
-  SafeChain,
-  useSafeChains,
-} from '../../../pages/settings/networks-tab/networks-form/use-safe-chains';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../shared/constants/bridge';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/selectors/networks';
 import { PercentageChange } from './price/percentage-change/percentage-change';
@@ -80,6 +75,7 @@ type TokenListItemProps = {
   showPercentage?: boolean;
   isPrimaryTokenSymbolHidden?: boolean;
   privacyMode?: boolean;
+  nativeCurrencySymbol?: string;
 };
 
 export const TokenListItemComponent = ({
@@ -101,21 +97,12 @@ export const TokenListItemComponent = ({
   address = null,
   showPercentage = false,
   privacyMode = false,
+  nativeCurrencySymbol,
 }: TokenListItemProps) => {
   const t = useI18nContext();
   const isEvm = useSelector(getMultichainIsEvm);
   const trackEvent = useContext(MetaMetricsContext);
-  const { safeChains } = useSafeChains();
   const currencyRates = useSelector(getCurrencyRates);
-
-  const safeChainDetails: SafeChain | undefined = safeChains?.find((chain) => {
-    const decimalChainId =
-      isStrictHexString(chainId) && parseInt(hexToDecimal(chainId), 10);
-    if (typeof decimalChainId === 'number') {
-      return chain.chainId === decimalChainId.toString();
-    }
-    return undefined;
-  });
 
   // We do not want to display any percentage with non-EVM since we don't have the data for this yet. So
   // we only use this option for EVM here:
@@ -379,7 +366,7 @@ export const TokenListItemComponent = ({
                 tokenSymbol,
                 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
                 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                safeChainDetails?.nativeCurrency?.symbol ||
+                nativeCurrencySymbol ||
                   t('nativeTokenScamWarningDescriptionExpectedTokenFallback'), // never render "undefined" string value
               ])}
             </ModalBody>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. 
-->

## **Description**
The `useSafeChains` hook in the TokenListItem component currently fetches `chains.json` once for every token in the AssetList, resulting in ~30 network calls when the asset-picker is opened. The chains.json responses also get retained in memory, which can take up `30 * 1.5` MB of memory

The result of https://chainid.network/chains.json is the same regardless of token so I moved it to the parent component. After this change, chains.json will only be fetched at most once when the AssetList is opened, and `safeChains` won't be retained in memory

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33577?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33466

## **Manual testing steps**

1. Use the Bridge page and asset pickers
2. Verify that chains.json gets called at most once per network switch
3. Take a memory snapshot
4. Verify that retained objects don't contain a `{ safeChains }` object

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1558" alt="Screenshot 2025-06-10 at 2 56 39 PM" src="https://github.com/user-attachments/assets/4712dfc6-90b4-4992-9ab6-8fdaccd1cd6b" />

<img width="1257" alt="Screenshot 2025-06-10 at 2 56 55 PM" src="https://github.com/user-attachments/assets/a0636f01-80d9-47bf-85d1-3a6daccf9198" />



### **After**

<img width="1535" alt="Screenshot 2025-06-10 at 3 03 01 PM" src="https://github.com/user-attachments/assets/85be0658-52ff-4d7a-be7a-ff7e13766cb7" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
