### PR TITLE
fix: flaky test `Vault Corruption` on loading restore page

### DIFF
--- a/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
@@ -44,7 +44,10 @@ class TermsOfUseUpdateModal {
       5000,
     );
     await this.driver.clickElement(this.termsOfUseCheckbox);
-    await this.driver.clickElementAndWaitToDisappear(this.acceptButton);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.acceptButton,
+      5000,
+    );
   }
 }
 

--- a/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/terms-of-use-update-modal.ts
@@ -44,10 +44,7 @@ class TermsOfUseUpdateModal {
       5000,
     );
     await this.driver.clickElement(this.termsOfUseCheckbox);
-    await this.driver.clickElementAndWaitToDisappear(
-      this.acceptButton,
-      5000,
-    );
+    await this.driver.clickElementAndWaitToDisappear(this.acceptButton, 5000);
   }
 }
 

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -129,6 +129,7 @@ describe('Vault Corruption', function () {
       // reload and check title as quickly a possible, forever
       { interval: 0, timeout: Infinity },
     );
+    await driver.assertElementNotPresent('.loading-logo');
   }
 
   /**

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -129,10 +129,7 @@ describe('Vault Corruption', function () {
       // reload and check title as quickly a possible, forever
       { interval: 0, timeout: Infinity },
     );
-    await driver.assertElementNotPresent(
-      '.loading-logo',
-      { timeout: 10000 },
-    );
+    await driver.assertElementNotPresent('.loading-logo', { timeout: 10000 });
   }
 
   /**

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -129,7 +129,10 @@ describe('Vault Corruption', function () {
       // reload and check title as quickly a possible, forever
       { interval: 0, timeout: Infinity },
     );
-    await driver.assertElementNotPresent('.loading-logo');
+    await driver.assertElementNotPresent(
+      '.loading-logo',
+      { timeout: 10000 },
+    );
   }
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There's another point of flakiness in the `Vault Corruption` spec, which happens as follows:
1. We navigate to the MM home page
2. We wait until the title is the correct MetaMask title
3. We find the recover button and click on it `await clickRecover({ driver, confirm: true });`

The problem is that between steps 2 and 3, there is a gap of some seconds, between we are already in the MetaMask title but the button is not yet clickable, as first there is the loading MM logo.
Also the button won't be clickable right away as we need to sum some seconds, where the button is disabled.

All this makes that if the test is slow, we never find the clickable element as we are still in the loading logo phase.

The fix is to add an extra step between 2 and 3, to wait until the logo disappers, and then we look for the button, to prevent the findClickableElement timing out bc the button is not there (we are in the logo loading phase).


![Screenshot from 2025-06-11 15-35-39](https://github.com/user-attachments/assets/1ce51725-94f1-4250-9ffc-5414cca60bf4)




[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33591?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run spec locally `yarn test:e2e:single test/e2e/tests/vault-corruption/vault-corruption.spec.ts --browser=chrome --leave-running=true`


## **Screenshots/Recordings**
See how many seconds can pass between finding the correct title and finding the clickable element:

https://github.com/user-attachments/assets/3d1b8eb0-9d10-4a4a-bc9c-784a437fbd66



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
