### PR TITLE
chore: Update code owners for accounts components 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,6 +90,9 @@ app/scripts/lib/snap-keyring                        @MetaMask/accounts-engineers
 # Slack handle: @multichain-accounts-devs | Slack channel: #metamask-bip44-team
 **/multichain-accounts/**                           @MetaMask/accounts-engineers
 
+# Co-owned by accounts and wallet-ux
+ui/components/multichain/              @MetaMask/accounts-engineers @MetaMask/wallet-ux
+
 # Swaps-Bridge team to own code for the swaps folder
 ui/pages/swaps                                        @MetaMask/swaps-engineers
 app/scripts/controllers/swaps                         @MetaMask/swaps-engineers
@@ -111,7 +114,6 @@ app/scripts/constants/snaps.ts       @MetaMask/snaps-devs
 ui/components/app/metamask-template-renderer @MetaMask/confirmations @MetaMask/snaps-devs
 
 # Wallet UX
-ui/components/multichain              @MetaMask/wallet-ux
 ui/components/app/whats-new-popup     @MetaMask/wallet-ux
 ui/css                                @MetaMask/wallet-ux
 ui/pages/home                         @MetaMask/wallet-ux


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. What is the reason for the change?
- with all the work being done from the accounts team AND the wallet ux team on the accounts list and account selector, having the code owners be set to only the wallet-ux team was becoming a bottle neck.
2. What is the improvement/solution?
- This change updates the code ownership for the the path `ui/components/multichain/` to be both the accounts team and the wallet-ux team. This is where the account selector and account list/account list item live.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33598?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
