### PR TITLE
style: fix `global.platform` type

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -58,6 +58,14 @@ export default class ExtensionPlatform {
     return browser.runtime.getManifest().version;
   }
 
+  /**
+   * Returns the absolute URL of the extension's home.html page, optionally with
+   * a route and query string.
+   *
+   * @param {string | null} route
+   * @param {string | null} queryString
+   * @returns { string }
+   */
   getExtensionURL(route = null, queryString = null) {
     let extensionURL = browser.runtime.getURL('home.html');
 
@@ -72,6 +80,12 @@ export default class ExtensionPlatform {
     return extensionURL;
   }
 
+  /**
+   *
+   * @param {string | null} route
+   * @param {string | null} queryString
+   * @param {boolean} [keepWindowOpen] - defaults to false
+   */
   openExtensionInBrowser(
     route = null,
     queryString = null,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -22,14 +22,7 @@ import {
   TrezorAction,
 } from '../shared/constants/offscreen-communication';
 import type { Preferences } from '../app/scripts/controllers/preferences-controller';
-
-declare class Platform {
-  openTab: (opts: { url: string }) => void;
-
-  closeCurrentWindow: () => void;
-
-  openExtensionInBrowser?: (_1?, _1?, condition?: boolean) => void;
-}
+import type ExtensionPlatform from '../app/scripts/platforms/extension';
 
 declare class MessageSender {
   documentId?: string;
@@ -276,7 +269,7 @@ type StateHooks = {
 };
 
 export declare global {
-  var platform: Platform;
+  var platform: ExtensionPlatform;
   // Sentry is undefined in dev, so use optional chaining
   var sentry: SentryObject | undefined;
 

--- a/ui/components/app/configure-snap-popup/configure-snap-popup.test.tsx
+++ b/ui/components/app/configure-snap-popup/configure-snap-popup.test.tsx
@@ -13,6 +13,7 @@ import ConfigureSnapPopup, {
 const mockOnClose = jest.fn();
 const mockStore = configureMockStore([])(mockState);
 describe('ConfigureSnapPopup', () => {
+  // @ts-expect-error mocking platform
   global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
 
   it('should show configure popup title and description', async () => {

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
@@ -10,6 +10,7 @@ import { MultichainNetworks } from '../../../../../shared/constants/multichain/n
 import { mockNetworkState } from '../../../../../test/stub/networks';
 import ConfirmRemoveAccount from '.';
 
+// @ts-expect-error mocking platform
 global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
 
 const mockAccount = createMockInternalAccount({

--- a/ui/components/app/modals/nickname-popovers/nickname-popovers.component.test.tsx
+++ b/ui/components/app/modals/nickname-popovers/nickname-popovers.component.test.tsx
@@ -72,6 +72,7 @@ describe('NicknamePopover', () => {
   });
 
   it('opens EVM block explorer', () => {
+    // @ts-expect-error mocking platform
     global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
 
     // Accounts controlelr addresses are lower cased but it gets converted to checksummed in this util
@@ -88,6 +89,7 @@ describe('NicknamePopover', () => {
   });
 
   it('opens non-EVM block explorer', () => {
+    // @ts-expect-error mocking platform
     global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
     const expectedExplorerUrl = formatBlockExplorerAddressUrl(
       MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.test.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.test.tsx
@@ -127,6 +127,7 @@ describe('Keyring Snap Remove Warning', () => {
   });
 
   it('opens block explorer for account', async () => {
+    // @ts-expect-error mocking platform
     global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
     const { getByText, getAllByTestId } = renderWithProvider(
       <KeyringSnapRemovalWarning {...defaultArgs} />,

--- a/ui/components/multichain/carousel/carousel.test.tsx
+++ b/ui/components/multichain/carousel/carousel.test.tsx
@@ -173,6 +173,7 @@ describe('Carousel', () => {
 
   it('should handle slide click with href', () => {
     const mockOpenTab = jest.fn();
+    // @ts-expect-error mocking platform
     global.platform = {
       openTab: mockOpenTab,
       closeCurrentWindow: jest.fn(),

--- a/ui/components/multichain/global-menu/global-menu.test.tsx
+++ b/ui/components/multichain/global-menu/global-menu.test.tsx
@@ -40,6 +40,7 @@ describe('Global Menu', () => {
   });
 
   it('opens the support site when item is clicked', async () => {
+    // @ts-expect-error mocking platform
     global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
 
     const { getByTestId } = render();
@@ -78,6 +79,7 @@ describe('Global Menu', () => {
   });
 
   it('expands metamask to tab when item is clicked', async () => {
+    // @ts-expect-error mocking platform
     global.platform = {
       openExtensionInBrowser: jest.fn(),
       openTab: jest.fn(),

--- a/ui/components/multichain/menu-items/view-explorer-menu-item.test.tsx
+++ b/ui/components/multichain/menu-items/view-explorer-menu-item.test.tsx
@@ -42,6 +42,7 @@ const render = (account = mockAccount) => {
 
 describe('ViewExplorerMenuItem', () => {
   it('renders "View on explorer"', () => {
+    // @ts-expect-error mocking platform
     global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
 
     const { getByText, getByTestId } = render();
@@ -60,6 +61,7 @@ describe('ViewExplorerMenuItem', () => {
       mockNonEvmAccount.address,
     );
     const expectedExplorerUrlHost = new URL(expectedExplorerUrl).host;
+    // @ts-expect-error mocking platform
     global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
 
     const { getByText, getByTestId } = render(mockNonEvmAccount);

--- a/ui/components/multichain/network-manager/components/additional-networks-info/additional-networks-info.test.tsx
+++ b/ui/components/multichain/network-manager/components/additional-networks-info/additional-networks-info.test.tsx
@@ -7,6 +7,7 @@ import { AdditionalNetworksInfo } from './additional-networks-info';
 
 // Mock the global platform.openTab
 const mockOpenTab = jest.fn();
+// @ts-expect-error mocking platform
 global.platform = {
   openTab: mockOpenTab,
   closeCurrentWindow: jest.fn(),

--- a/ui/components/multichain/token-list-item/token-list-item.test.tsx
+++ b/ui/components/multichain/token-list-item/token-list-item.test.tsx
@@ -56,7 +56,9 @@ const mockGetIntlLocale = getIntlLocale;
 
 describe('TokenListItem', () => {
   beforeAll(() => {
+    // @ts-expect-error mocking platform
     global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
+    // @ts-expect-error mocking platform
     openTabSpy = jest.spyOn(global.platform, 'openTab');
     (mockGetIntlLocale as unknown as jest.Mock).mockReturnValue('en-US');
   });

--- a/ui/components/ui/survey-toast/survey-toast.test.tsx
+++ b/ui/components/ui/survey-toast/survey-toast.test.tsx
@@ -64,6 +64,7 @@ describe('SurveyToast', () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
 
+    // @ts-expect-error mocking platform
     global.platform = {
       openTab: jest.fn(),
       closeCurrentWindow: jest.fn(),

--- a/ui/pages/confirmations/components/snap-account-error-message/SnapAccountErrorMessage.test.tsx
+++ b/ui/pages/confirmations/components/snap-account-error-message/SnapAccountErrorMessage.test.tsx
@@ -11,6 +11,7 @@ const store = configureStore({
 });
 
 // If you're using some kind of global variable (like `global.platform` in your component), you might want to mock it.
+// @ts-expect-error mocking platform
 global.platform = {
   openTab: jest.fn(),
   closeCurrentWindow: jest.fn(),

--- a/ui/pages/confirmations/components/snap-account-success-message/SnapAccountSuccessMessage.test.tsx
+++ b/ui/pages/confirmations/components/snap-account-success-message/SnapAccountSuccessMessage.test.tsx
@@ -8,6 +8,7 @@ import SnapAccountSuccessMessage from './SnapAccountSuccessMessage';
 const store = configureStore(mockState);
 
 // If you're using some kind of global variable (like `global.platform` in your component), you might want to mock it.
+// @ts-expect-error mocking platform
 global.platform = {
   openTab: jest.fn(),
   closeCurrentWindow: jest.fn(),

--- a/ui/pages/confirmations/hooks/useConfirmationAlertActions.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertActions.test.ts
@@ -1,7 +1,6 @@
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers';
 import mockState from '../../../../test/data/mock-state.json';
 import { AlertActionKey } from '../../../components/app/confirm/info/row/constants';
-import { Platform } from '../../../../types/global';
 import { useTransactionModalContext } from '../../../contexts/transaction-modal';
 import useConfirmationAlertActions from './useConfirmationAlertActions';
 
@@ -35,7 +34,8 @@ describe('useConfirmationAlertActions', () => {
       openModal: openModalMock,
     });
 
-    global.platform = { openTab: jest.fn() } as unknown as Platform;
+    // @ts-expect-error mocking platform
+    global.platform = { openTab: jest.fn() };
   });
 
   it('opens portfolio tab if action key is Buy', () => {

--- a/ui/pages/snap-account-redirect/create-snap-redirect.test.tsx
+++ b/ui/pages/snap-account-redirect/create-snap-redirect.test.tsx
@@ -12,6 +12,7 @@ const store = configureStore({
 });
 
 // If you're using some kind of global variable (like `global.platform` in your component), you might want to mock it.
+// @ts-expect-error mocking platform
 global.platform = {
   openTab: jest.fn(),
   closeCurrentWindow: jest.fn(),


### PR DESCRIPTION
Fixes the `global.platform` type. No runtime code changes.

<!--
## **Description**


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33632?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->