### PR TITLE
fix: remove warning from console due to duplicate key in security tab

### DIFF
--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -428,7 +428,7 @@ export default class SecurityTab extends PureComponent {
                 href={ZENDESK_URLS.SOLANA_ACCOUNTS}
                 target="_blank"
                 rel="noopener noreferrer"
-                key="cyn-consensys-privacy-link"
+                key="cyn-consensys-privacy-link-solana"
               >
                 {t('chooseYourNetworkDescriptionCallToAction')}
               </a>,


### PR DESCRIPTION
Just removes a console warning that appears on the security tab due to a duplicate `key` being used.

<!--
## **Description**
## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
-->