### PR TITLE
fix: enable multichain API connections in MV2 (webpack) builds

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1138,7 +1138,9 @@ export function setupController(
 
       connectEip1193(portStream, remotePort.sender);
 
-      if (isFirefox) {
+      // for firefox and manifest v2 (non production webpack builds)
+      // we expose the multichain provider via window.postMessage
+      if (isFirefox || !isManifestV3) {
         const mux = setupMultiplex(portStream);
         mux.ignoreStream(METAMASK_EIP_1193_PROVIDER);
 


### PR DESCRIPTION
## **Description**

Though there are no MV2 builds in production, for dev expediency we still use MV2 builds which are produced by webpack build process. Before this change we failed connect streams for non firefox Multichain API connections on MV2 builds.


## **Related issues**

Fixes:

## **Manual testing steps**

1. Build with `yarn webpack --watch`
2. Go to https://metamask.github.io/test-dapp-multichain/latest/ on chromium browser
3. click ![Screenshot 2025-06-12 at 4 49 47 PM](https://github.com/user-attachments/assets/d60f8a5d-1fdf-4a3e-85c3-e4cb581c6696)
4. Check boxes for several networks
5. Click ![Screenshot 2025-06-12 at 4 50 30 PM](https://github.com/user-attachments/assets/28f780c7-e191-4fe5-b541-14fd6d75b5ca)
6. You should be prompted to connect the wallet

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
