### PR TITLE
fix: prevent memory leaks in `useAsync` hooks

### DIFF
--- a/ui/hooks/useAsync.ts
+++ b/ui/hooks/useAsync.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, DependencyList, useRef, useMemo } from 'react';
+import { isEqual } from 'lodash';
 
 type Status = 'idle' | 'pending' | 'success' | 'error';
 
@@ -57,25 +58,6 @@ export function createErrorResult(error: Error): ResultError {
   return { ...RESULT_BASE, status: 'error', error };
 }
 
-function isDependencyListChanged(
-  deps: DependencyList,
-  prevDeps: DependencyList,
-) {
-  if (Object.is(prevDeps, deps)) {
-    return false;
-  }
-  if (prevDeps.length !== deps.length) {
-    return true;
-  }
-  for (let i = 0; i < deps.length; ++i) {
-    if (!Object.is(deps[i], prevDeps[i])) {
-      return true;
-    }
-  }
-  // TODO: If too expensive to perform on every render, replace with `return false;`
-  return JSON.stringify(deps) !== JSON.stringify(prevDeps);
-}
-
 /**
  * Hook that provides a callback for manual execution of an async function,
  * along with state management for the operation.
@@ -100,8 +82,7 @@ export function useAsyncCallback<T>(
   const asyncFnRef = useRef<typeof asyncFn | null>(asyncFn);
   const prevDepsRef = useRef<DependencyList>([]);
 
-  const isDepsChanged =
-    isInit || isDependencyListChanged(deps, prevDepsRef.current);
+  const isDepsChanged = isInit || !isEqual(deps, prevDepsRef.current);
 
   // Use ref instead of `useCallback`, which means the function reference
   // does not needs to be re-created on every deps change.

--- a/ui/hooks/useAsync.ts
+++ b/ui/hooks/useAsync.ts
@@ -87,6 +87,8 @@ export function useAsyncCallback<T>(
   asyncFn: () => Promise<T>,
   deps: DependencyList = [],
 ): [() => Promise<void>, AsyncResult<T>, boolean] {
+  'use no memo';
+
   const [result, setResult] = useState<AsyncResult<T>>(RESULT_IDLE);
 
   // Track component mount state
@@ -151,6 +153,8 @@ export function useAsyncResult<T>(
   asyncFn: () => Promise<T>,
   deps: DependencyList = [],
 ): AsyncResultNoIdle<T> {
+  'use no memo';
+
   const [execute, result, isDepsChanged] = useAsyncCallback(asyncFn, deps);
 
   useEffect(() => {
@@ -179,6 +183,8 @@ export function useAsyncResultOrThrow<T>(
   asyncFn: () => Promise<T>,
   deps: DependencyList = [],
 ): AsyncResultNoError<T> {
+  'use no memo';
+
   const result = useAsyncResult(asyncFn, deps);
 
   if (result.status === 'error') {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Implements manual, explicit management of cache/state cleanup in `useAsync{Callback,Result}` instead of relying on React hooks. The motivation is to prevent memory leaks especially from large/frequent fetch requests.

(This only pertains to memory managed by react, not e.g. IndexedDB buildup due to `fetchWithCache` calls or background caching.)

- Cleanup function guarantees that e.g. fetch results are not kept in closure causing memory leaks, and all related data and potentially long-lived processes are made available to garbage collection upon unmount.
- Wrap return array in `useMemo`. 
  - Mitigates issue of every `asyncFn`/`execute` call allocating a new output object/array and holding onto the reference, potentially leading to memory leaks. 
  - Prevent re-renders if `result` object reference has changed but its properties haven't.

Optimizations:

- The reference to the `execute` callback returned by `useAsyncCallback` never needs to change if both itself and the reference to `asyncFn` (its only reactive variable that is external to the hook) are managed with refs.
- `asyncFn`, `deps` passed to `useAsyncCallback` change reference on every re-render. Use refs to maintain stable references throughout lifecycle, and only update if deps have changed.

Once we get to React v19, we may consider migrating entirely to `use{,Transition,Optimistic,ActionState,FormStatus}`, under the assumption that they provide safer memory management.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33641?quickstart=1)

## **Related issues**

- `https://github.com/MetaMask/metamask-extension/issues/33466`
  - `https://github.com/MetaMask/metamask-extension/pull/33579`
  - `https://github.com/MetaMask/metamask-extension/pull/33577`

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
