### PR TITLE
chore: Make accounts code owners more specific

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,9 +90,6 @@ app/scripts/lib/snap-keyring                        @MetaMask/accounts-engineers
 # Slack handle: @multichain-accounts-devs | Slack channel: #metamask-bip44-team
 **/multichain-accounts/**                           @MetaMask/accounts-engineers
 
-# Co-owned by accounts and wallet-ux
-ui/components/multichain/              @MetaMask/accounts-engineers @MetaMask/wallet-ux
-
 # Swaps-Bridge team to own code for the swaps folder
 ui/pages/swaps                                        @MetaMask/swaps-engineers
 app/scripts/controllers/swaps                         @MetaMask/swaps-engineers
@@ -117,6 +114,16 @@ ui/components/app/metamask-template-renderer @MetaMask/confirmations @MetaMask/s
 ui/components/app/whats-new-popup     @MetaMask/wallet-ux
 ui/css                                @MetaMask/wallet-ux
 ui/pages/home                         @MetaMask/wallet-ux
+ui/components/multichain/             @MetaMask/wallet-ux
+
+# Co-owned by accounts and wallet-ux
+ui/components/multichain/multi-srp/              @MetaMask/accounts-engineers @MetaMask/wallet-ux
+ui/components/multichain/account-picker/         @MetaMask/accounts-engineers @MetaMask/wallet-ux
+ui/components/multichain/account-details/        @MetaMask/accounts-engineers @MetaMask/wallet-ux
+ui/components/multichain/account-overview/       @MetaMask/accounts-engineers @MetaMask/wallet-ux
+ui/components/multichain/account-list-item/      @MetaMask/accounts-engineers @MetaMask/wallet-ux
+ui/components/multichain/account-list-menu/      @MetaMask/accounts-engineers @MetaMask/wallet-ux
+ui/components/multichain/account-list-item-menu/ @MetaMask/accounts-engineers @MetaMask/wallet-ux
 
 # Web3Auth / Onboarding
 ui/pages/onboarding-flow              @MetaMask/web3auth


### PR DESCRIPTION
## **Description**


1. What is the reason for the change?
- In a previous [PR](https://github.com/MetaMask/metamask-extension/pull/33598), I made the accounts code ownership all of `ui/components/multichain/` which is not accurate. This updates the code ownership for accounts to specific files. 
3. What is the improvement/solution?
- All of the following files are not owned by both wallet-ux and accounts
```
ui/components/multichain/multi-srp/              @MetaMask/accounts-engineers @MetaMask/wallet-ux
ui/components/multichain/account-picker/         @MetaMask/accounts-engineers @MetaMask/wallet-ux
ui/components/multichain/account-details/        @MetaMask/accounts-engineers @MetaMask/wallet-ux
ui/components/multichain/account-overview/       @MetaMask/accounts-engineers @MetaMask/wallet-ux
ui/components/multichain/account-list-item/      @MetaMask/accounts-engineers @MetaMask/wallet-ux
ui/components/multichain/account-list-menu/      @MetaMask/accounts-engineers @MetaMask/wallet-ux
ui/components/multichain/account-list-item-menu/ @MetaMask/accounts-engineers @MetaMask/wallet-ux
```
- wallet-ux now has ownership of the rest of the folder. This is how it was set before my previous change. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33651?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
5.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
