### PR TITLE
fix: Fix cronjob controller migration for state without `events`

### DIFF
--- a/app/scripts/migrations/165.test.ts
+++ b/app/scripts/migrations/165.test.ts
@@ -121,6 +121,93 @@ describe(`migration #${version}`, () => {
       });
     });
 
+    it("works if the state doesn't have an `events` property", async () => {
+      const oldStorage = {
+        meta: { version: oldVersion },
+        data: {
+          CronjobController: {
+            jobs: {
+              [`${MOCK_SNAP_ID}-0`]: {
+                lastRun: Date.now() - inMilliseconds(1, Duration.Day),
+              },
+              [`${MOCK_SNAP_ID}-1`]: {
+                lastRun: Date.now() - inMilliseconds(1, Duration.Day),
+              },
+            },
+          },
+
+          PermissionController: {
+            subjects: {
+              [MOCK_SNAP_ID]: {
+                origin: MOCK_SNAP_ID,
+                permissions: {
+                  [SnapEndowments.Cronjob]: {
+                    caveats: [
+                      {
+                        type: SnapCaveatType.SnapCronjob,
+                        value: {
+                          jobs: [
+                            {
+                              expression: '*/30 * * * * *',
+                              request: {
+                                method: 'foo',
+                                params: { bar: 'baz' },
+                              },
+                            },
+                            {
+                              expression: '0 0 0 * 11 *',
+                              request: {
+                                method: 'foo',
+                                params: { bar: 'baz' },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                    date: 1664187844588,
+                    id: 'izn0WGUO8cvq_jqvLQuQP',
+                    invoker: MOCK_ORIGIN,
+                    parentCapability: SnapEndowments.EthereumProvider,
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const newStorage = await migrate(oldStorage);
+      expect(newStorage.data.CronjobController).toStrictEqual({
+        events: {
+          [`cronjob-${MOCK_SNAP_ID}-0`]: {
+            id: `cronjob-${MOCK_SNAP_ID}-0`,
+            recurring: true,
+            date: '2023-09-30T23:59:00.000Z',
+            schedule: '*/30 * * * * *',
+            scheduledAt: '2023-10-01T00:00:00.000Z',
+            snapId: MOCK_SNAP_ID,
+            request: {
+              method: 'foo',
+              params: { bar: 'baz' },
+            },
+          },
+          [`cronjob-${MOCK_SNAP_ID}-1`]: {
+            id: `cronjob-${MOCK_SNAP_ID}-1`,
+            recurring: true,
+            date: '2023-11-01T00:00:00.000Z',
+            schedule: '0 0 0 * 11 *',
+            scheduledAt: '2023-10-01T00:00:00.000Z',
+            snapId: MOCK_SNAP_ID,
+            request: {
+              method: 'foo',
+              params: { bar: 'baz' },
+            },
+          },
+        },
+      });
+    });
+
     it('updates legacy events in the `events` property', async () => {
       const oldStorage = {
         meta: { version: oldVersion },

--- a/app/scripts/migrations/165.ts
+++ b/app/scripts/migrations/165.ts
@@ -255,7 +255,7 @@ function transformState(
 
   // New events object created from the legacy events.
   const eventsFromLegacyEvents = Object.fromEntries(
-    Object.entries(cronjobControllerState.events).map(
+    Object.entries(cronjobControllerState.events ?? {}).map(
       ([id, event]): [string, BackgroundEvent] => {
         return [
           id,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This fixes migration 165 for the cronjob controller in the case where the previous state doesn't have an `events` property. The migration currently assumes for `events` to always be defined.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33652?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
