### PR TITLE
bump keyring controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "@metamask/kernel-shims": "^0.2.0",
     "@metamask/kernel-utils": "^0.1.0",
     "@metamask/keyring-api": "^18.0.0",
-    "@metamask/keyring-controller": "^22.0.2",
+    "@metamask/keyring-controller": "npm:@metamask-previews/keyring-controller@22.0.2-preview-a272c5e1",
     "@metamask/keyring-internal-api": "^6.2.0",
     "@metamask/keyring-internal-snap-client": "^4.1.0",
     "@metamask/keyring-snap-client": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6090,9 +6090,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-controller@npm:^22.0.2":
-  version: 22.0.2
-  resolution: "@metamask/keyring-controller@npm:22.0.2"
+"@metamask/keyring-controller@npm:@metamask-previews/keyring-controller@22.0.2-preview-a272c5e1":
+  version: 22.0.2-preview-a272c5e1
+  resolution: "@metamask-previews/keyring-controller@npm:22.0.2-preview-a272c5e1"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@keystonehq/metamask-airgapped-keyring": "npm:^0.14.1"
@@ -6109,7 +6109,7 @@ __metadata:
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
     ulid: "npm:^2.3.0"
-  checksum: 10/917c61b3322b4ff4d2236f64b6f4e4e9aab26dd19644fc5f130abb55fbdac3f34e693ac81ed196049291953d5c66bbab996ebf24d4a04d9d666f128ed1085a08
+  checksum: 10/c510b93e88d08db67abfc81c9a47445e555a1e91a2d4e167a6ef8fc4c75b57f73ac33b590bd606d9ad45a25c583fab670a533ae60718e9b7f34b7bceb1fb9a42
   languageName: node
   linkType: hard
 
@@ -30358,7 +30358,7 @@ __metadata:
     "@metamask/kernel-shims": "npm:^0.2.0"
     "@metamask/kernel-utils": "npm:^0.1.0"
     "@metamask/keyring-api": "npm:^18.0.0"
-    "@metamask/keyring-controller": "npm:^22.0.2"
+    "@metamask/keyring-controller": "npm:@metamask-previews/keyring-controller@22.0.2-preview-a272c5e1"
     "@metamask/keyring-internal-api": "npm:^6.2.0"
     "@metamask/keyring-internal-snap-client": "npm:^4.1.0"
     "@metamask/keyring-snap-client": "npm:^5.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Testing update of `@metamask/keyring-controller` (https://github.com/MetaMask/core/pull/5940).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33656?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
