### PR TITLE
fix: missing property policies for firebase push notifications

### DIFF
--- a/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
@@ -36,7 +36,7 @@ export const NotificationServicesPushControllerInit: ControllerInitFunction<
       vapidKey: process.env.VAPID_KEY ?? '',
     },
     config: {
-      isPushFeatureEnabled: isManifestV3,
+      isPushFeatureEnabled: isManifestV3 && !process.env.IN_TEST,
       platform: 'extension',
       pushService: {
         createRegToken,

--- a/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
@@ -19,22 +19,24 @@ export const NotificationServicesPushControllerInit: ControllerInitFunction<
   NotificationServicesPushController,
   NotificationServicesPushControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
+  const env = {
+    apiKey: process.env.FIREBASE_API_KEY ?? '',
+    authDomain: process.env.FIREBASE_AUTH_DOMAIN ?? '',
+    storageBucket: process.env.FIREBASE_STORAGE_BUCKET ?? '',
+    projectId: process.env.FIREBASE_PROJECT_ID ?? '',
+    messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID ?? '',
+    appId: process.env.FIREBASE_APP_ID ?? '',
+    measurementId: process.env.FIREBASE_MEASUREMENT_ID ?? '',
+    vapidKey: process.env.VAPID_KEY ?? '',
+  };
+
   const controller = new NotificationServicesPushController({
     messenger: controllerMessenger,
     state: {
       ...defaultState,
       ...persistedState.NotificationServicesPushController,
     },
-    env: {
-      apiKey: process.env.FIREBASE_API_KEY ?? '',
-      authDomain: process.env.FIREBASE_AUTH_DOMAIN ?? '',
-      storageBucket: process.env.FIREBASE_STORAGE_BUCKET ?? '',
-      projectId: process.env.FIREBASE_PROJECT_ID ?? '',
-      messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID ?? '',
-      appId: process.env.FIREBASE_APP_ID ?? '',
-      measurementId: process.env.FIREBASE_MEASUREMENT_ID ?? '',
-      vapidKey: process.env.VAPID_KEY ?? '',
-    },
+    env,
     config: {
       isPushFeatureEnabled: isManifestV3,
       platform: 'extension',
@@ -51,6 +53,14 @@ export const NotificationServicesPushControllerInit: ControllerInitFunction<
       },
     },
   });
+
+  // Test example to run firebase and showcase this policy issue
+  // We should get a token back from `createRegToken`, but instead we get `null`.
+  console.log('TEST: START');
+  createRegToken(env)
+    .then((token) => console.log('TEST: HERE IS MY TOKEN', token))
+    .catch((e) => console.log('TEST: FAILURE', e))
+    .finally(() => console.log('TEST: END'));
 
   return {
     controller,

--- a/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
@@ -19,24 +19,22 @@ export const NotificationServicesPushControllerInit: ControllerInitFunction<
   NotificationServicesPushController,
   NotificationServicesPushControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const env = {
-    apiKey: process.env.FIREBASE_API_KEY ?? '',
-    authDomain: process.env.FIREBASE_AUTH_DOMAIN ?? '',
-    storageBucket: process.env.FIREBASE_STORAGE_BUCKET ?? '',
-    projectId: process.env.FIREBASE_PROJECT_ID ?? '',
-    messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID ?? '',
-    appId: process.env.FIREBASE_APP_ID ?? '',
-    measurementId: process.env.FIREBASE_MEASUREMENT_ID ?? '',
-    vapidKey: process.env.VAPID_KEY ?? '',
-  };
-
   const controller = new NotificationServicesPushController({
     messenger: controllerMessenger,
     state: {
       ...defaultState,
       ...persistedState.NotificationServicesPushController,
     },
-    env,
+    env: {
+      apiKey: process.env.FIREBASE_API_KEY ?? '',
+      authDomain: process.env.FIREBASE_AUTH_DOMAIN ?? '',
+      storageBucket: process.env.FIREBASE_STORAGE_BUCKET ?? '',
+      projectId: process.env.FIREBASE_PROJECT_ID ?? '',
+      messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID ?? '',
+      appId: process.env.FIREBASE_APP_ID ?? '',
+      measurementId: process.env.FIREBASE_MEASUREMENT_ID ?? '',
+      vapidKey: process.env.VAPID_KEY ?? '',
+    },
     config: {
       isPushFeatureEnabled: isManifestV3,
       platform: 'extension',
@@ -53,14 +51,6 @@ export const NotificationServicesPushControllerInit: ControllerInitFunction<
       },
     },
   });
-
-  // Test example to run firebase and showcase this policy issue
-  // We should get a token back from `createRegToken`, but instead we get `null`.
-  console.log('TEST: START');
-  createRegToken(env)
-    .then((token) => console.log('TEST: HERE IS MY TOKEN', token))
-    .catch((e) => console.log('TEST: FAILURE', e))
-    .finally(() => console.log('TEST: END'));
 
   return {
     controller,

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -656,6 +656,8 @@
         "Notification.maxActions": true,
         "Notification.permission": true,
         "Notification.requestPermission": true,
+        "PushManager.getSubscription": true,
+        "PushManager.subscribe": true,
         "PushSubscription.prototype.hasOwnProperty": true,
         "ServiceWorkerRegistration": true,
         "URL": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -656,6 +656,8 @@
         "Notification.maxActions": true,
         "Notification.permission": true,
         "Notification.requestPermission": true,
+        "PushManager.getSubscription": true,
+        "PushManager.subscribe": true,
         "PushSubscription.prototype.hasOwnProperty": true,
         "ServiceWorkerRegistration": true,
         "URL": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -656,6 +656,8 @@
         "Notification.maxActions": true,
         "Notification.permission": true,
         "Notification.requestPermission": true,
+        "PushManager.getSubscription": true,
+        "PushManager.subscribe": true,
         "PushSubscription.prototype.hasOwnProperty": true,
         "ServiceWorkerRegistration": true,
         "URL": true,

--- a/lavamoat/browserify/policy-override.json
+++ b/lavamoat/browserify/policy-override.json
@@ -121,6 +121,12 @@
         "crypto.getRandomValues": true
       }
     },
+    "@metamask/notification-services-controller>firebase>@firebase/messaging": {
+      "globals": {
+        "PushManager.getSubscription": true,
+        "PushManager.subscribe": true
+      }
+    },
     "@metamask/snaps-controllers>nanoid": {
       "globals": {
         "crypto.getRandomValues": true


### PR DESCRIPTION
## **Description**

Push notifications are failing to run on lavamoat builds due to a missing policy that `yarn lavamoat:auto` does not add.

Firebase Message (which we use under the hood for push notifications) uses the worker `PushManager`. See [here](https://github.com/firebase/firebase-js-sdk/blob/7fb64dd82118289950d62a64b2c4a77f00e15c4b/packages/messaging/src/api/isSupported.ts#L67).
The properties that it uses are: `PushManager.getSubscription` and `PushManager.subscribe`.

Because these properties are not in our `policy.json` files, we are unable to create push notifications.

See recording for this example PR demo:
https://www.loom.com/share/b8855e1983094867ba59db8637f6bb91?sid=a4095a19-14d3-46db-935c-1cc039655d07

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33665?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
