### PR TITLE
feat: replaced block explorer url link in view explorer menu item com…

### DIFF
--- a/test/e2e/tests/dapp-interactions/block-explorer.spec.ts
+++ b/test/e2e/tests/dapp-interactions/block-explorer.spec.ts
@@ -44,7 +44,7 @@ describe('Block Explorer', function () {
 
         // Verify block explorer
         await driver.waitForUrl({
-          url: `https://etherscan.io/address/${DEFAULT_FIXTURE_ACCOUNT}`,
+          url: `https://etherscan.io/address/${DEFAULT_FIXTURE_ACCOUNT}#asset-multichain`,
         });
         await new MockedPage(driver).check_displayedMessage(
           'Empty page by MetaMask',

--- a/ui/components/app/modals/nickname-popovers/nickname-popovers.component.test.tsx
+++ b/ui/components/app/modals/nickname-popovers/nickname-popovers.component.test.tsx
@@ -27,7 +27,10 @@ const mockNonEvmAccount = createMockInternalAccount({
   type: BtcAccountType.P2wpkh,
 });
 
-const mockEvmExplorer = 'http://mock-explorer.com';
+const mockEvmExplorer = (address: string) =>
+  `https://etherscan.io/address/${normalizeSafeAddress(
+    address,
+  )}#asset-multichain`;
 
 const render = (
   {
@@ -56,7 +59,7 @@ const render = (
       },
       ...mockNetworkState({
         chainId: '0x5',
-        blockExplorerUrl: mockEvmExplorer,
+        blockExplorerUrl: mockEvmExplorer(mockAccount.address),
       }),
       completedOnboarding: true,
     },
@@ -76,9 +79,7 @@ describe('NicknamePopover', () => {
     global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
 
     // Accounts controlelr addresses are lower cased but it gets converted to checksummed in this util
-    const expectedExplorerUrl = `${mockEvmExplorer}/address/${normalizeSafeAddress(
-      mockAccount.address,
-    )}`;
+    const expectedExplorerUrl = mockEvmExplorer(mockAccount.address);
     const { getByText } = render({ props: { address: mockAccount.address } });
 
     const viewExplorerButton = getByText('View on block explorer');

--- a/ui/helpers/utils/multichain/blockExplorer.test.ts
+++ b/ui/helpers/utils/multichain/blockExplorer.test.ts
@@ -63,7 +63,7 @@ describe('Block Explorer Tests', () => {
   describe('getMultichainAccountUrl', () => {
     it('returns the correct account URL for Ethereum mainnet', () => {
       const address = '0x1234567890abcdef';
-      const expectedUrl = `https://etherscan.io/address/${address}`;
+      const expectedUrl = `https://etherscan.io/address/${address}#asset-multichain`;
 
       const result = getMultichainAccountUrl(address, mockEvmNetwork);
 

--- a/ui/helpers/utils/multichain/blockExplorer.ts
+++ b/ui/helpers/utils/multichain/blockExplorer.ts
@@ -1,4 +1,3 @@
-import { getAccountLink } from '@metamask/etherscan-link';
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { MultichainNetwork } from '../../../selectors/multichain';
 // TODO: Remove restricted import
@@ -19,11 +18,8 @@ export const getMultichainAccountUrl = (
 ): string => {
   const { namespace } = parseCaipChainId(network.chainId);
   if (namespace === KnownCaipNamespace.Eip155) {
-    return getAccountLink(
-      normalizeSafeAddress(address),
-      network.network.chainId,
-      network.network?.rpcPrefs,
-    );
+    const normalizedAddress = normalizeSafeAddress(address);
+    return `https://etherscan.io/address/${normalizedAddress}#asset-multichain`;
   }
 
   // We're in a non-EVM context, so we assume we can use format URLs instead.


### PR DESCRIPTION
## **Description**

Issue: The block explorer only goes to the selected network. When the removal of the `GNS` goes live the block explorer needs to be dynamic

Solution: Show the multichain option for Etherscan

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33667?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4871

## **Manual testing steps**

1. Go account selector menu
2. Click on the more icon
3. Click on view explorer and observe you goto the multichain view on Etherscan
4. Goto global menu and click on the same item
5. Observe you goto the correct place

## **Screenshots/Recordings**

`-`

### **Before**

https://github.com/user-attachments/assets/73a31b69-8f08-48e1-8b3e-ce41e7e3ef6c

### **After**

https://github.com/user-attachments/assets/73d96d96-86f4-4579-8175-d0613baaaf2c

Uploading Screen Recording 2025-06-13 at 3.21.39 PM.mov…

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
