### PR TITLE
ci: add `bump` and `release` to conventional commit types

### DIFF
--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -11,5 +11,20 @@ jobs:
     steps:
       # this is a hash for amannn/action-semantic-pull-request@v5.4.0
       - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+            bump
+            release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## **Description**

Add `bump` and `release` to conventional commit types

Uses the configuration options of [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request).  We had to specify the full default list and then add the two new types.

<!-- ## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->