### PR TITLE
ci: overnight cron job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ on:
     branches-ignore:
       - master
   merge_group:
+  schedule:
+    # Run the full suite "overnight," once every half hour from 1:00am UTC until 2:59am UTC.
+    # This helps with "Top 10 failed tests on the metamask-extension repository main branch,"
+    # especially the Monday morning list, which is otherwise usually a fake empty.
+    - cron: '0,30 1-2 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## **Description**

Re-establishes the "overnight" cron job we used to have on CircleCI.

It runs the full suite "overnight," once every half hour from 1:00am UTC until 2:59am UTC.

This helps with "Top 10 failed tests on the metamask-extension repository main branch," especially the Monday morning list, which is otherwise usually a fake empty.

<!-- ## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->