### PR TITLE
fix: flaky tests `Gas Fee Tokens - EIP-7702`

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -23,6 +23,8 @@ class TransactionConfirmation extends Confirmation {
 
   private gasFeeText: RawLocator;
 
+  private gasFeeToastMessage: RawLocator;
+
   private gasFeeTokenArrow: RawLocator;
 
   private gasFeeTokenFeeText: RawLocator;
@@ -55,6 +57,10 @@ class TransactionConfirmation extends Confirmation {
       '[data-testid="advanced-details-transaction-hex"]';
     this.gasFeeFiatText = '[data-testid="native-currency"]';
     this.gasFeeText = '[data-testid="first-gas-field"]';
+    this.gasFeeToastMessage = {
+      css: '[aria-label="Close"]',
+      tag: 'button',
+    }
     this.gasFeeTokenArrow = '[data-testid="selected-gas-fee-token-arrow"]';
     this.gasFeeTokenFeeText = '[data-testid="gas-fee-token-fee"]';
     this.gasFeeTokenPill = '[data-testid="selected-gas-fee-token"]';
@@ -102,6 +108,10 @@ class TransactionConfirmation extends Confirmation {
 
   async clickGasFeeTokenPill() {
     await this.driver.clickElement(this.gasFeeTokenArrow);
+  }
+
+  async closeGasFeeToastMessage() {
+    await this.driver.clickElementSafe(this.gasFeeToastMessage);
   }
 
   async verifyAdvancedDetailsIsDisplayed(type: string) {

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -110,10 +110,7 @@ class TransactionConfirmation extends Confirmation {
 
   async closeGasFeeToastMessage() {
     // the toast message automatically disappears after some seconds, so we need to use clickElementSafe to prevent race conditions
-    await this.driver.clickElementSafe(
-      this.gasFeeCloseToastMessage,
-      5000,
-    );
+    await this.driver.clickElementSafe(this.gasFeeCloseToastMessage, 5000);
   }
 
   async verifyAdvancedDetailsIsDisplayed(type: string) {

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -55,7 +55,8 @@ class TransactionConfirmation extends Confirmation {
       '[data-testid="advanced-details-data-param-0"]';
     this.advancedDetailsHexData =
       '[data-testid="advanced-details-transaction-hex"]';
-    this.gasFeeCloseToastMessage = '.toasts-container__banner-base button[aria-label="Close"]';
+    this.gasFeeCloseToastMessage =
+      '.toasts-container__banner-base button[aria-label="Close"]';
     this.gasFeeFiatText = '[data-testid="native-currency"]';
     this.gasFeeText = '[data-testid="first-gas-field"]';
     this.gasFeeTokenArrow = '[data-testid="selected-gas-fee-token-arrow"]';
@@ -109,7 +110,10 @@ class TransactionConfirmation extends Confirmation {
 
   async closeGasFeeToastMessage() {
     // the toast message automatically disappears after some seconds, so we need to use clickElementSafe to prevent race conditions
-    await this.driver.clickElementSafe(this.gasFeeCloseToastMessage);
+    await this.driver.clickElementSafe(
+      this.gasFeeCloseToastMessage,
+      5000,
+    );
   }
 
   async verifyAdvancedDetailsIsDisplayed(type: string) {

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -55,7 +55,7 @@ class TransactionConfirmation extends Confirmation {
       '[data-testid="advanced-details-data-param-0"]';
     this.advancedDetailsHexData =
       '[data-testid="advanced-details-transaction-hex"]';
-    this.gasFeeCloseToastMessage = '[aria-label="Close"]';
+    this.gasFeeCloseToastMessage = '.toasts-container__banner-base button[aria-label="Close"]';
     this.gasFeeFiatText = '[data-testid="native-currency"]';
     this.gasFeeText = '[data-testid="first-gas-field"]';
     this.gasFeeTokenArrow = '[data-testid="selected-gas-fee-token-arrow"]';

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -60,7 +60,7 @@ class TransactionConfirmation extends Confirmation {
     this.gasFeeToastMessage = {
       css: '[aria-label="Close"]',
       tag: 'button',
-    }
+    };
     this.gasFeeTokenArrow = '[data-testid="selected-gas-fee-token-arrow"]';
     this.gasFeeTokenFeeText = '[data-testid="gas-fee-token-fee"]';
     this.gasFeeTokenPill = '[data-testid="selected-gas-fee-token"]';

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -55,7 +55,7 @@ class TransactionConfirmation extends Confirmation {
       '[data-testid="advanced-details-data-param-0"]';
     this.advancedDetailsHexData =
       '[data-testid="advanced-details-transaction-hex"]';
-    this.gasFeeCloseToastMessage = '[aria-label="Close"]',
+    this.gasFeeCloseToastMessage = '[aria-label="Close"]';
     this.gasFeeFiatText = '[data-testid="native-currency"]';
     this.gasFeeText = '[data-testid="first-gas-field"]';
     this.gasFeeTokenArrow = '[data-testid="selected-gas-fee-token-arrow"]';

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -55,10 +55,7 @@ class TransactionConfirmation extends Confirmation {
       '[data-testid="advanced-details-data-param-0"]';
     this.advancedDetailsHexData =
       '[data-testid="advanced-details-transaction-hex"]';
-    this.gasFeeCloseToastMessage = {
-      css: '[aria-label="Close"]',
-      tag: 'button',
-    };
+    this.gasFeeCloseToastMessage = '[aria-label="Close"]',
     this.gasFeeFiatText = '[data-testid="native-currency"]';
     this.gasFeeText = '[data-testid="first-gas-field"]';
     this.gasFeeTokenArrow = '[data-testid="selected-gas-fee-token-arrow"]';

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -108,7 +108,7 @@ class TransactionConfirmation extends Confirmation {
   }
 
   async closeGasFeeToastMessage() {
-    // the toast message disappears after some seconds so we need to use clickElementSafe to prevent race conditions
+    // the toast message automatically disappears after some seconds, so we need to use clickElementSafe to prevent race conditions
     await this.driver.clickElementSafe(this.gasFeeCloseToastMessage);
   }
 

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -111,6 +111,7 @@ class TransactionConfirmation extends Confirmation {
   }
 
   async closeGasFeeToastMessage() {
+    // the toast message disappears after some seconds so we need to use clickElementSafe to prevent race conditions
     await this.driver.clickElementSafe(this.gasFeeToastMessage);
   }
 

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -23,7 +23,7 @@ class TransactionConfirmation extends Confirmation {
 
   private gasFeeText: RawLocator;
 
-  private gasFeeToastMessage: RawLocator;
+  private gasFeeCloseToastMessage: RawLocator;
 
   private gasFeeTokenArrow: RawLocator;
 
@@ -55,12 +55,12 @@ class TransactionConfirmation extends Confirmation {
       '[data-testid="advanced-details-data-param-0"]';
     this.advancedDetailsHexData =
       '[data-testid="advanced-details-transaction-hex"]';
-    this.gasFeeFiatText = '[data-testid="native-currency"]';
-    this.gasFeeText = '[data-testid="first-gas-field"]';
-    this.gasFeeToastMessage = {
+    this.gasFeeCloseToastMessage = {
       css: '[aria-label="Close"]',
       tag: 'button',
     };
+    this.gasFeeFiatText = '[data-testid="native-currency"]';
+    this.gasFeeText = '[data-testid="first-gas-field"]';
     this.gasFeeTokenArrow = '[data-testid="selected-gas-fee-token-arrow"]';
     this.gasFeeTokenFeeText = '[data-testid="gas-fee-token-fee"]';
     this.gasFeeTokenPill = '[data-testid="selected-gas-fee-token"]';
@@ -112,7 +112,7 @@ class TransactionConfirmation extends Confirmation {
 
   async closeGasFeeToastMessage() {
     // the toast message disappears after some seconds so we need to use clickElementSafe to prevent race conditions
-    await this.driver.clickElementSafe(this.gasFeeToastMessage);
+    await this.driver.clickElementSafe(this.gasFeeCloseToastMessage);
   }
 
   async verifyAdvancedDetailsIsDisplayed(type: string) {

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -115,6 +115,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         const transactionConfirmation = new TransactionConfirmation(driver);
+        await transactionConfirmation.closeGasFeeToastMessage();
         await transactionConfirmation.clickGasFeeTokenPill();
 
         const gasFeeTokenModal = new GasFeeTokenModal(driver);

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -65,6 +65,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
         await gasFeeTokenModal.check_AmountToken('USDC', '1.23 USDC');
         await gasFeeTokenModal.check_Balance('USDC', '$5.00');
         await gasFeeTokenModal.clickToken('USDC');
+        await transactionConfirmation.closeGasFeeToastMessage();
 
         await transactionConfirmation.check_gasFeeSymbol('USDC');
         await transactionConfirmation.check_gasFeeFiat('$1.23');
@@ -85,7 +86,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
     );
   });
 
-  it.only('fails transaction if error', async function () {
+  it('fails transaction if error', async function () {
     await withFixtures(
       {
         dapp: true,
@@ -118,10 +119,9 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
 
         const gasFeeTokenModal = new GasFeeTokenModal(driver);
         await gasFeeTokenModal.clickToken('USDC');
+        await transactionConfirmation.closeGasFeeToastMessage();
 
         await transactionConfirmation.check_gasFeeSymbol('USDC');
-
-        await transactionConfirmation.closeGasFeeToastMessage();
 
         await transactionConfirmation.clickFooterConfirmButton();
 

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -53,6 +53,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         const transactionConfirmation = new TransactionConfirmation(driver);
+        await transactionConfirmation.closeGasFeeToastMessage();
         await transactionConfirmation.clickAdvancedDetailsButton();
         await transactionConfirmation.clickGasFeeTokenPill();
 

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -53,8 +53,8 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         const transactionConfirmation = new TransactionConfirmation(driver);
-        await transactionConfirmation.closeGasFeeToastMessage();
         await transactionConfirmation.clickAdvancedDetailsButton();
+        await transactionConfirmation.closeGasFeeToastMessage();
         await transactionConfirmation.clickGasFeeTokenPill();
 
         const gasFeeTokenModal = new GasFeeTokenModal(driver);

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -54,7 +54,6 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
 
         const transactionConfirmation = new TransactionConfirmation(driver);
         await transactionConfirmation.clickAdvancedDetailsButton();
-        await transactionConfirmation.closeGasFeeToastMessage();
         await transactionConfirmation.clickGasFeeTokenPill();
 
         const gasFeeTokenModal = new GasFeeTokenModal(driver);
@@ -117,7 +116,6 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
 
         const transactionConfirmation = new TransactionConfirmation(driver);
         await transactionConfirmation.clickGasFeeTokenPill();
-        await transactionConfirmation.closeGasFeeToastMessage();
 
         const gasFeeTokenModal = new GasFeeTokenModal(driver);
         await gasFeeTokenModal.clickToken('USDC');

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -122,7 +122,6 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
         await transactionConfirmation.closeGasFeeToastMessage();
 
         await transactionConfirmation.check_gasFeeSymbol('USDC');
-
         await transactionConfirmation.clickFooterConfirmButton();
 
         await driver.switchToWindowWithTitle(

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -54,6 +54,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
 
         const transactionConfirmation = new TransactionConfirmation(driver);
         await transactionConfirmation.clickAdvancedDetailsButton();
+        await transactionConfirmation.closeGasFeeToastMessage();
         await transactionConfirmation.clickGasFeeTokenPill();
 
         const gasFeeTokenModal = new GasFeeTokenModal(driver);

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -85,7 +85,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
     );
   });
 
-  it('fails transaction if error', async function () {
+  it.only('fails transaction if error', async function () {
     await withFixtures(
       {
         dapp: true,
@@ -120,6 +120,9 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
         await gasFeeTokenModal.clickToken('USDC');
 
         await transactionConfirmation.check_gasFeeSymbol('USDC');
+
+        await transactionConfirmation.closeGasFeeToastMessage();
+
         await transactionConfirmation.clickFooterConfirmButton();
 
         await driver.switchToWindowWithTitle(

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -117,6 +117,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
 
         const transactionConfirmation = new TransactionConfirmation(driver);
         await transactionConfirmation.clickGasFeeTokenPill();
+        await transactionConfirmation.closeGasFeeToastMessage();
 
         const gasFeeTokenModal = new GasFeeTokenModal(driver);
         await gasFeeTokenModal.clickToken('USDC');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This test is flaky, with the error:

```javascript
ElementClickInterceptedError: Element <span class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"> is not clickable at point (353,514) because another element <div class="mm-box mm-banner-base toasts-container__banner-base undefined mm-box--padding-3 mm-box--display-flex mm-box--gap-2 mm-box--background-color-background-default"> obscures it
```

The problem is that anytime we select a token for paying gas fees, a toast appears informing about that. This toast is automatically closed after some seconds.
If it's closed fast enough, we can proceed with the next steps, but if it takes a bit too long, the toast obscures the other elements, and the spec fails.

The fix is to click the close button if the toast is there, using `clickElementSafe`. This way we mitigate race conditions around this behaviour.


![test-failure-screenshot-3](https://github.com/user-attachments/assets/e38f0a20-8f21-4d54-9bda-c09c02cdc73c)






[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33694?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. All tests should pass

## **Screenshots/Recordings**

See the behavior, where the toast message automatically disappears after some seconds after selecting a token

https://github.com/user-attachments/assets/cf421abd-922a-4a1c-8040-b8078b99e798

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
