### PR TITLE
fix: `clipboardRead` permission request in Firefox

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -9,3 +9,9 @@ global.platform = {
   // Required for: settings info tab
   getVersion: () => '<version>',
 };
+
+global.browser = {
+  permissions: {
+    request: jest.fn().mockResolvedValue(true),
+  },
+};

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -17,6 +17,7 @@ import {
   EthereumSignTypedDataTypes,
 } from '@trezor/connect-web';
 import type { Provider } from '@metamask/network-controller';
+import * as Browser from 'webextension-polyfill';
 import {
   OffscreenCommunicationTarget,
   TrezorAction,
@@ -278,6 +279,8 @@ export declare global {
   var ethereumProvider: Provider;
 
   var stateHooks: StateHooks;
+
+  var browser: Browser;
 
   namespace jest {
     // The interface is being used for declaration merging, which is an acceptable exception to this rule.

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import * as browserRuntime from '../../../../shared/modules/browser-runtime.utils';
+import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import SrpInputImport from './srp-input-import';
+
+const mockClipboardReadText = jest.fn().mockResolvedValue('some mock text');
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: {
+    readText: mockClipboardReadText,
+  },
+});
+
+describe('SrpInputImport', () => {
+  it('should render', () => {
+    const { getByTestId } = renderWithProvider(
+      <SrpInputImport onChange={jest.fn()} />,
+    );
+    expect(getByTestId('srp-input-import__srp-note')).toBeInTheDocument();
+  });
+
+  it('should ask for explicit permission to read the clipboard in firefox', async () => {
+    jest
+      .spyOn(browserRuntime, 'getBrowserName')
+      .mockReturnValue(PLATFORM_FIREFOX);
+
+    const { getByTestId } = renderWithProvider(
+      <SrpInputImport onChange={jest.fn()} />,
+    );
+    const pasteButton = getByTestId('srp-input-import__paste-button');
+    fireEvent.click(pasteButton);
+
+    await waitFor(() => {
+      expect(browser.permissions.request).toHaveBeenCalledWith({
+        permissions: ['clipboardRead'],
+      });
+      expect(mockClipboardReadText).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -187,21 +187,18 @@ export default function SrpInputImport({ onChange }: SrpInputImportProps) {
 
   // in firefox, we do need to request permission explicitly, to read the clipboard
   const requestPermissionAndTriggerPasteFireFox = async () => {
-    const newSrp = await new Promise<string>((resolve) => {
-      browser.permissions
-        .request({
-          permissions: ['clipboardRead'],
-        })
-        .then(async (granted: boolean) => {
-          if (granted) {
-            const srp = await navigator.clipboard.readText();
-            resolve(srp);
-          }
-          // TODO: handle permission denied?
-        });
-    });
-    if (newSrp.trim().match(/\s/u)) {
-      onSrpPaste(newSrp);
+    try {
+      const permissionGranted = await browser.permissions.request({
+        permissions: ['clipboardRead'],
+      });
+      if (permissionGranted) {
+        const newSrp = await navigator.clipboard.readText();
+        if (newSrp.trim().match(/\s/u)) {
+          onSrpPaste(newSrp);
+        }
+      }
+    } catch (error) {
+      console.error('Error requesting clipboard permission', error);
     }
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Fix `clipboardRead` permission in firefox by making explicit request using `browser.permissions` API.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33701?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Select `Import using Secret Recovery Phrase` in welcome page
2. Copy SRP and click on Paste Button
3. Permission request dialog should be displayed
4. Upon allowing the permission, the SRP note should be filled with correct values

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


https://github.com/user-attachments/assets/d4d5f146-65b6-47ca-a34b-55f6522ff47e


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
