### PR TITLE
fix: fix missing notification services controller selectors

### DIFF
--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
@@ -72,7 +72,7 @@ describe('BackupAndSyncToggle', () => {
         settings_type: 'main',
         old_value: true,
         new_value: false,
-        was_notifications_on: undefined,
+        was_notifications_on: false,
       },
     });
   });

--- a/ui/selectors/metamask-notifications/metamask-notifications.test.ts
+++ b/ui/selectors/metamask-notifications/metamask-notifications.test.ts
@@ -1,4 +1,9 @@
-import { NotificationServicesController } from '@metamask/notification-services-controller';
+import {
+  NotificationServicesControllerState,
+  INotification as Notification,
+  processNotification,
+} from '@metamask/notification-services-controller/notification-services';
+import { createMockNotificationEthReceived } from '@metamask/notification-services-controller/notification-services/mocks';
 import {
   selectIsMetamaskNotificationsEnabled,
   getMetamaskNotifications,
@@ -8,16 +13,16 @@ import {
   getValidNotificationAccounts,
 } from './metamask-notifications';
 
-type Notification = NotificationServicesController.Types.INotification;
+type AppState = {
+  metamask: Partial<NotificationServicesControllerState>;
+};
 
 const mockNotifications: Notification[] = [
-  NotificationServicesController.Processors.processNotification(
-    NotificationServicesController.Mocks.createMockNotificationEthReceived(),
-  ),
+  processNotification(createMockNotificationEthReceived()),
 ];
 
 describe('Metamask Notifications Selectors', () => {
-  const mockState = {
+  const mockState = (): AppState => ({
     metamask: {
       subscriptionAccountsSeen: [] as string[],
       isMetamaskNotificationsFeatureSeen: true,
@@ -25,45 +30,52 @@ describe('Metamask Notifications Selectors', () => {
       isFeatureAnnouncementsEnabled: true,
       metamaskNotificationsList: mockNotifications,
       metamaskNotificationsReadList: [],
-      isBackupAndSyncUpdateLoading: false,
       isFetchingMetamaskNotifications: false,
       isUpdatingMetamaskNotifications: false,
       isUpdatingMetamaskNotificationsAccount: [],
       isCheckingAccountsPresence: false,
     },
-  };
+  });
 
   it('should select the isMetamaskNotificationsFeatureSeen state', () => {
-    expect(selectIsMetamaskNotificationsEnabled(mockState)).toBe(true);
+    expect(selectIsMetamaskNotificationsEnabled(mockState())).toBe(true);
   });
 
   it('should select the isMetamaskNotificationsEnabled state', () => {
-    expect(selectIsMetamaskNotificationsEnabled(mockState)).toBe(true);
+    expect(selectIsMetamaskNotificationsEnabled(mockState())).toBe(true);
   });
 
   it('should select the metamaskNotificationsList from state', () => {
-    expect(getMetamaskNotifications(mockState)).toEqual(mockNotifications);
+    expect(getMetamaskNotifications(mockState())).toStrictEqual(
+      mockNotifications,
+    );
+  });
+
+  it('should handle missing metamaskNotificationsList state', () => {
+    const state = mockState();
+    delete state.metamask.metamaskNotificationsList;
+    expect(getMetamaskNotifications(state)).toStrictEqual([]);
   });
 
   it('should select the metamaskNotificationsReadList from state', () => {
-    expect(getMetamaskNotificationsReadList(mockState)).toEqual([]);
+    expect(getMetamaskNotificationsReadList(mockState())).toStrictEqual([]);
   });
 
   it('should select the count of unread MetaMask notifications from state', () => {
     const expectedUnreadNotificationsCount = mockNotifications.filter(
       (notification) => !notification.isRead,
     ).length;
-    expect(getMetamaskNotificationsUnreadCount(mockState)).toEqual(
+    expect(getMetamaskNotificationsUnreadCount(mockState())).toStrictEqual(
       expectedUnreadNotificationsCount,
     );
   });
 
   it('should select the isFeatureAnnouncementsEnabled state', () => {
-    expect(selectIsFeatureAnnouncementsEnabled(mockState)).toBe(true);
+    expect(selectIsFeatureAnnouncementsEnabled(mockState())).toBe(true);
   });
 
   it('should select the valid accounts that can enable notifications', () => {
-    const state = { ...mockState };
+    const state = mockState();
     state.metamask.subscriptionAccountsSeen = ['0x1111'];
     expect(getValidNotificationAccounts(state)).toStrictEqual(['0x1111']);
   });

--- a/ui/selectors/metamask-notifications/metamask-notifications.ts
+++ b/ui/selectors/metamask-notifications/metamask-notifications.ts
@@ -1,16 +1,21 @@
+// @ts-check
 import { createSelector } from 'reselect';
-import { NotificationServicesController } from '@metamask/notification-services-controller';
+import {
+  NotificationServicesControllerState,
+  INotification as Notification,
+  TRIGGER_TYPES,
+  defaultState,
+} from '@metamask/notification-services-controller/notification-services';
 import { createDeepEqualSelector } from '../../../shared/modules/selectors/util';
 
-const { TRIGGER_TYPES } = NotificationServicesController.Constants;
-
-type Notification = NotificationServicesController.Types.INotification;
-
 type AppState = {
-  metamask: NotificationServicesController.NotificationServicesControllerState;
+  metamask: Partial<NotificationServicesControllerState>;
 };
 
-const getMetamask = (state: AppState) => state.metamask;
+const getMetamask = (state: AppState) => ({
+  ...defaultState,
+  ...state.metamask,
+});
 
 /**
  * Selector to get the list of MetaMask notifications.
@@ -20,7 +25,7 @@ const getMetamask = (state: AppState) => state.metamask;
  */
 export const getMetamaskNotifications = createSelector(
   [getMetamask],
-  (metamask) => metamask.metamaskNotificationsList,
+  (metamask): Notification[] => metamask.metamaskNotificationsList,
 );
 
 /**
@@ -44,11 +49,11 @@ export const getMetamaskNotificationById = (id: string) => {
  * Selector to get the list of read MetaMask notifications.
  *
  * @param {AppState} state - The current state of the Redux store.
- * @returns {Notification[]} An array of notifications that have been read.
+ * @returns {string[]} An array of notifications that have been read.
  */
 export const getMetamaskNotificationsReadList = createSelector(
   [getMetamask],
-  (metamask) => metamask.metamaskNotificationsReadList,
+  (metamask): string[] => metamask.metamaskNotificationsReadList,
 );
 
 /**
@@ -59,7 +64,7 @@ export const getMetamaskNotificationsReadList = createSelector(
  */
 export const getMetamaskNotificationsUnreadCount = createSelector(
   [getMetamaskNotifications],
-  (notifications: Notification[]) => {
+  (notifications: Notification[]): number => {
     return notifications
       ? notifications.filter((notification) => !notification.isRead).length
       : 0;
@@ -74,7 +79,7 @@ export const getMetamaskNotificationsUnreadCount = createSelector(
  */
 export const getFeatureAnnouncementsUnreadCount = createSelector(
   [getMetamaskNotifications],
-  (notifications: Notification[]) => {
+  (notifications: Notification[]): number => {
     return notifications
       ? notifications.filter(
           (notification) =>
@@ -112,7 +117,7 @@ export const getFeatureAnnouncementsReadCount = createSelector(
  */
 export const getSnapNotificationsUnreadCount = createSelector(
   [getMetamaskNotifications],
-  (notifications: Notification[]) => {
+  (notifications: Notification[]): number => {
     return notifications
       ? notifications.filter(
           (notification) =>
@@ -148,7 +153,7 @@ export const getSnapNotificationsReadCount = createSelector(
  */
 export const getOnChainMetamaskNotificationsUnreadCount = createSelector(
   [getMetamaskNotifications],
-  (notifications: Notification[]) => {
+  (notifications: Notification[]): number => {
     return notifications
       ? notifications.filter(
           (notification) =>
@@ -168,7 +173,7 @@ export const getOnChainMetamaskNotificationsUnreadCount = createSelector(
  */
 export const getOnChainMetamaskNotificationsReadCount = createSelector(
   [getMetamaskNotifications],
-  (notifications: Notification[]) => {
+  (notifications: Notification[]): number => {
     return notifications
       ? notifications.filter(
           (notification) =>
@@ -199,7 +204,7 @@ export const selectIsMetamaskNotificationsFeatureSeen = createSelector(
  */
 export const selectIsMetamaskNotificationsEnabled = createSelector(
   [getMetamask],
-  (metamask) => metamask.isNotificationServicesEnabled,
+  (metamask): boolean => metamask.isNotificationServicesEnabled,
 );
 
 /**
@@ -210,7 +215,7 @@ export const selectIsMetamaskNotificationsEnabled = createSelector(
  */
 export const selectIsFeatureAnnouncementsEnabled = createSelector(
   [getMetamask],
-  (metamask) => metamask.isFeatureAnnouncementsEnabled,
+  (metamask): boolean => metamask.isFeatureAnnouncementsEnabled,
 );
 
 /**
@@ -224,7 +229,7 @@ export const selectIsFeatureAnnouncementsEnabled = createSelector(
  */
 export const getIsUpdatingMetamaskNotifications = createSelector(
   [getMetamask],
-  (metamask) => metamask.isUpdatingMetamaskNotifications,
+  (metamask): boolean => metamask.isUpdatingMetamaskNotifications,
 );
 
 /**
@@ -238,7 +243,7 @@ export const getIsUpdatingMetamaskNotifications = createSelector(
  */
 export const isFetchingMetamaskNotifications = createSelector(
   [getMetamask],
-  (metamask) => metamask.isFetchingMetamaskNotifications,
+  (metamask): boolean => metamask.isFetchingMetamaskNotifications,
 );
 
 /**
@@ -248,11 +253,11 @@ export const isFetchingMetamaskNotifications = createSelector(
  * It uses the `createSelector` function from 'reselect' for memoization, improving performance by avoiding unnecessary recalculations.
  *
  * @param {AppState} state - The current state of the Redux store.
- * @returns {boolean} Returns true if the MetaMask notifications account is being updated, false otherwise.
+ * @returns {string[]} Returns list of accounts that are currently being updated.
  */
 export const getIsUpdatingMetamaskNotificationsAccount = createSelector(
   [getMetamask],
-  (metamask) => {
+  (metamask): string[] => {
     return metamask.isUpdatingMetamaskNotificationsAccount;
   },
 );
@@ -268,10 +273,10 @@ export const getIsUpdatingMetamaskNotificationsAccount = createSelector(
  */
 export const getIsCheckingAccountsPresence = createSelector(
   [getMetamask],
-  (metamask) => metamask.isCheckingAccountsPresence,
+  (metamask): boolean => metamask.isCheckingAccountsPresence,
 );
 
 export const getValidNotificationAccounts = createSelector(
   [getMetamask],
-  (metamask) => metamask.subscriptionAccountsSeen,
+  (metamask): string[] => metamask.subscriptionAccountsSeen,
 );


### PR DESCRIPTION
## **Description**

Our notification selectors did not respect that they might be used before migrations & controller initialisation has filled state.
For example in the attached Sentry Issue: [METAMASK-XCED](https://metamask.sentry.io/issues/6010243560/?referrer=github_integration), this user was starting the app from `12.10.3` and did not have any `NotificationServicesController` state.

Now we ensure that our selectors correctly fallback to the default controller state it not initialised.

DEV NOTE - I'm unsure how this user managed to have missing notification state. 12.10.3 should have had notifications. And when the controller is initialised it has a default state.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33708?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/28047

## **Manual testing steps**

I have not been able to test this, as I'm unsure how Sentry Issue: [METAMASK-XCED](https://metamask.sentry.io/issues/6010243560/?referrer=github_integration) managed to have this missing controller state (notifications were released, and should have had some default state).

However unit tests provide some safety here.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
