### PR TITLE
chore: Migrate `tokenNetworkFilter` to `enabledNetworkMap`

### DIFF
--- a/app/scripts/controllers/network-order.ts
+++ b/app/scripts/controllers/network-order.ts
@@ -53,7 +53,11 @@ export type NetworkOrderControllerMessenger = RestrictedMessenger<
 // Default state for the controller
 const defaultState: NetworkOrderControllerState = {
   orderedNetworkList: [],
-  enabledNetworkMap: {},
+  enabledNetworkMap: {
+    '0x1': true,
+    '0xe708': true,
+    '0x2105': true,
+  },
 };
 
 // Metadata for the controller state

--- a/app/scripts/controllers/network-order.ts
+++ b/app/scripts/controllers/network-order.ts
@@ -53,11 +53,7 @@ export type NetworkOrderControllerMessenger = RestrictedMessenger<
 // Default state for the controller
 const defaultState: NetworkOrderControllerState = {
   orderedNetworkList: [],
-  enabledNetworkMap: {
-    '0x1': true,
-    '0xe708': true,
-    '0x2105': true,
-  },
+  enabledNetworkMap: {},
 };
 
 // Metadata for the controller state

--- a/app/scripts/migrations/168.test.ts
+++ b/app/scripts/migrations/168.test.ts
@@ -1,0 +1,341 @@
+import { migrate, version } from './168';
+
+const oldVersion = 167;
+
+describe('migration #168', () => {
+  beforeEach(() => {
+    // Mock global.sentry for tests
+    global.sentry = {
+      captureException: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    // Clean up the mock
+    delete global.sentry;
+  });
+
+  it('should update the version metadata', async () => {
+    const oldState = {
+      meta: {
+        version: oldVersion,
+      },
+      data: {
+        NetworkOrderController: {},
+        PreferencesController: {
+          preferences: {
+            tokenNetworkFilter: {
+              '0x1': true,
+            },
+          },
+        },
+      },
+    };
+
+    const newState = await migrate(oldState);
+
+    expect(newState.meta.version).toStrictEqual(version);
+  });
+
+  describe('when tokenNetworkFilter exists and has data', () => {
+    it('should migrate tokenNetworkFilter to enabledNetworkMap', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: {},
+          PreferencesController: {
+            preferences: {
+              tokenNetworkFilter: {
+                '0x1': true,
+                '0x89': false,
+                '0xa': true,
+              },
+            },
+          },
+        },
+      };
+
+      const newState = await migrate(oldState);
+
+      expect(
+        (newState.data.NetworkOrderController as any).enabledNetworkMap,
+      ).toStrictEqual({
+        '0x1': true,
+        '0x89': false,
+        '0xa': true,
+      });
+    });
+  });
+
+  describe('when tokenNetworkFilter does not exist', () => {
+    it('should return state unchanged', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: {},
+          PreferencesController: {
+            preferences: {},
+          },
+        },
+      };
+
+      const newState = await migrate(oldState);
+
+      expect(newState.data).toStrictEqual(oldState.data);
+    });
+  });
+
+  describe('when preferences does not exist', () => {
+    it('should return state unchanged', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: {},
+          PreferencesController: {},
+        },
+      };
+
+      const newState = await migrate(oldState);
+
+      expect(newState.data).toStrictEqual(oldState.data);
+    });
+  });
+
+  describe('when PreferencesController does not exist', () => {
+    it('should return state unchanged', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: {},
+        },
+      };
+
+      const newState = await migrate(oldState);
+
+      expect(newState.data).toStrictEqual(oldState.data);
+    });
+  });
+
+  describe('when NetworkOrderController does not exist', () => {
+    it('should return state unchanged and log warning', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          PreferencesController: {
+            preferences: {
+              tokenNetworkFilter: {
+                '0x1': true,
+              },
+            },
+          },
+        },
+      };
+
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      const newState = await migrate(oldState);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Migration 168: NetworkOrderController is not present',
+      );
+      expect(newState.data).toStrictEqual(oldState.data);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('when NetworkOrderController is not an object', () => {
+    it('should return state unchanged and capture exception', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: 'not an object',
+          PreferencesController: {
+            preferences: {
+              tokenNetworkFilter: {
+                '0x1': true,
+              },
+            },
+          },
+        },
+      };
+
+      const sentrySpy = jest
+        .spyOn(global.sentry, 'captureException')
+        .mockImplementation();
+
+      const newState = await migrate(oldState);
+
+      expect(sentrySpy).toHaveBeenCalledWith(
+        new Error(
+          "Migration 168: NetworkOrderController is type 'string', expected object.",
+        ),
+      );
+      expect(newState.data).toStrictEqual(oldState.data);
+
+      sentrySpy.mockRestore();
+    });
+  });
+
+  describe('when PreferencesController is not an object', () => {
+    it('should return state unchanged and capture exception', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: {},
+          PreferencesController: 'not an object',
+        },
+      };
+
+      const sentrySpy = jest
+        .spyOn(global.sentry, 'captureException')
+        .mockImplementation();
+
+      const newState = await migrate(oldState);
+
+      expect(sentrySpy).toHaveBeenCalledWith(
+        new Error(
+          "Migration 168: PreferencesController is type 'string', expected object.",
+        ),
+      );
+      expect(newState.data).toStrictEqual(oldState.data);
+
+      sentrySpy.mockRestore();
+    });
+  });
+
+  describe('when preferences is not an object', () => {
+    it('should return state unchanged and capture exception', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: {},
+          PreferencesController: {
+            preferences: 'not an object',
+          },
+        },
+      };
+
+      const sentrySpy = jest
+        .spyOn(global.sentry, 'captureException')
+        .mockImplementation();
+
+      const newState = await migrate(oldState);
+
+      expect(sentrySpy).toHaveBeenCalledWith(
+        new Error(
+          "Migration 168: preferences is type 'string', expected object.",
+        ),
+      );
+      expect(newState.data).toStrictEqual(oldState.data);
+
+      sentrySpy.mockRestore();
+    });
+  });
+
+  describe('when tokenNetworkFilter is not an object', () => {
+    it('should return state unchanged and capture exception', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: {},
+          PreferencesController: {
+            preferences: {
+              tokenNetworkFilter: 'not an object',
+            },
+          },
+        },
+      };
+
+      const sentrySpy = jest
+        .spyOn(global.sentry, 'captureException')
+        .mockImplementation();
+
+      const newState = await migrate(oldState);
+
+      expect(sentrySpy).toHaveBeenCalledWith(
+        new Error(
+          "Migration 168: tokenNetworkFilter is type 'string', expected object.",
+        ),
+      );
+      expect(newState.data).toStrictEqual(oldState.data);
+
+      sentrySpy.mockRestore();
+    });
+  });
+
+  describe('preserves other state', () => {
+    it('should not modify other parts of the state', async () => {
+      const oldState = {
+        meta: {
+          version: oldVersion,
+        },
+        data: {
+          NetworkOrderController: {
+            orderedNetworkList: ['0x1', '0x89'],
+            someOtherProperty: 'value',
+          },
+          PreferencesController: {
+            preferences: {
+              tokenNetworkFilter: {
+                '0x1': true,
+                '0x89': false,
+              },
+              someOtherPreference: 'value',
+            },
+            someOtherProperty: 'value',
+          },
+          SomeOtherController: {
+            someProperty: 'value',
+          },
+        },
+      };
+
+      const newState = await migrate(oldState);
+
+      // Check that enabledNetworkMap was set correctly
+      expect(
+        (newState.data.NetworkOrderController as any).enabledNetworkMap,
+      ).toStrictEqual({
+        '0x1': true,
+        '0x89': false,
+      });
+
+      // Check that other properties are preserved
+      expect(
+        (newState.data.NetworkOrderController as any).orderedNetworkList,
+      ).toStrictEqual(['0x1', '0x89']);
+      expect(
+        (newState.data.NetworkOrderController as any).someOtherProperty,
+      ).toStrictEqual('value');
+      expect(
+        (newState.data.PreferencesController as any).preferences
+          .someOtherPreference,
+      ).toStrictEqual('value');
+      expect(
+        (newState.data.PreferencesController as any).someOtherProperty,
+      ).toStrictEqual('value');
+      expect(
+        (newState.data.SomeOtherController as any).someProperty,
+      ).toStrictEqual('value');
+    });
+  });
+});

--- a/app/scripts/migrations/168.test.ts
+++ b/app/scripts/migrations/168.test.ts
@@ -60,7 +60,8 @@ describe('migration #168', () => {
       const newState = await migrate(oldState);
 
       expect(
-        (newState.data.NetworkOrderController as any).enabledNetworkMap,
+        (newState.data.NetworkOrderController as Record<string, unknown>)
+          .enabledNetworkMap,
       ).toStrictEqual({
         '0x1': true,
         '0x89': false,
@@ -313,7 +314,8 @@ describe('migration #168', () => {
 
       // Check that enabledNetworkMap was set correctly
       expect(
-        (newState.data.NetworkOrderController as any).enabledNetworkMap,
+        (newState.data.NetworkOrderController as Record<string, unknown>)
+          .enabledNetworkMap,
       ).toStrictEqual({
         '0x1': true,
         '0x89': false,
@@ -321,20 +323,26 @@ describe('migration #168', () => {
 
       // Check that other properties are preserved
       expect(
-        (newState.data.NetworkOrderController as any).orderedNetworkList,
+        (newState.data.NetworkOrderController as Record<string, unknown>)
+          .orderedNetworkList,
       ).toStrictEqual(['0x1', '0x89']);
       expect(
-        (newState.data.NetworkOrderController as any).someOtherProperty,
+        (newState.data.NetworkOrderController as Record<string, unknown>)
+          .someOtherProperty,
       ).toStrictEqual('value');
       expect(
-        (newState.data.PreferencesController as any).preferences
-          .someOtherPreference,
+        (
+          (newState.data.PreferencesController as Record<string, unknown>)
+            .preferences as Record<string, unknown>
+        ).someOtherPreference,
       ).toStrictEqual('value');
       expect(
-        (newState.data.PreferencesController as any).someOtherProperty,
+        (newState.data.PreferencesController as Record<string, unknown>)
+          .someOtherProperty,
       ).toStrictEqual('value');
       expect(
-        (newState.data.SomeOtherController as any).someProperty,
+        (newState.data.SomeOtherController as Record<string, unknown>)
+          .someProperty,
       ).toStrictEqual('value');
     });
   });

--- a/app/scripts/migrations/168.ts
+++ b/app/scripts/migrations/168.ts
@@ -1,0 +1,117 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 168;
+
+/**
+ * This migration migrates tokenNetworkFilter from preferences to enabledNetworkMap.
+ *
+ * For existing users with tokenNetworkFilter:
+ * - The tokenNetworkFilter data will be migrated to enabledNetworkMap
+ *
+ * For users without tokenNetworkFilter:
+ * - No migration will occur (enabledNetworkMap will remain unchanged)
+ *
+ * @param originalVersionedData - The versioned extension state.
+ * @returns The updated versioned extension state with enabledNetworkMap populated from tokenNetworkFilter.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+
+  versionedData.data = transformState(versionedData.data);
+
+  return versionedData;
+}
+
+function transformState(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  // Check if NetworkOrderController exists
+  if (!hasProperty(state, 'NetworkOrderController')) {
+    console.warn(`Migration ${version}: NetworkOrderController is not present`);
+    return state;
+  }
+
+  const networkOrderControllerState = state.NetworkOrderController;
+
+  // If NetworkOrderController is not an object, log error and return state
+  if (!isObject(networkOrderControllerState)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `Migration ${version}: NetworkOrderController is type '${typeof networkOrderControllerState}', expected object.`,
+      ),
+    );
+    return state;
+  }
+
+  // Check if PreferencesController exists
+  if (!hasProperty(state, 'PreferencesController')) {
+    console.warn(`Migration ${version}: PreferencesController is not present`);
+    return state;
+  }
+
+  const preferencesControllerState = state.PreferencesController;
+
+  // If PreferencesController is not an object, log error and return state
+  if (!isObject(preferencesControllerState)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `Migration ${version}: PreferencesController is type '${typeof preferencesControllerState}', expected object.`,
+      ),
+    );
+    return state;
+  }
+
+  // Check if preferences exist
+  if (!hasProperty(preferencesControllerState, 'preferences')) {
+    console.warn(
+      `Migration ${version}: preferences is not present in PreferencesController`,
+    );
+    return state;
+  }
+
+  const preferences = preferencesControllerState.preferences;
+
+  // If preferences is not an object, log error and return state
+  if (!isObject(preferences)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `Migration ${version}: preferences is type '${typeof preferences}', expected object.`,
+      ),
+    );
+    return state;
+  }
+
+  // Check if tokenNetworkFilter exists
+  if (!hasProperty(preferences, 'tokenNetworkFilter')) {
+    console.warn(
+      `Migration ${version}: tokenNetworkFilter is not present in preferences`,
+    );
+    return state;
+  }
+
+  const tokenNetworkFilter = preferences.tokenNetworkFilter;
+
+  // If tokenNetworkFilter is not an object, log error and return state
+  if (!isObject(tokenNetworkFilter)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `Migration ${version}: tokenNetworkFilter is type '${typeof tokenNetworkFilter}', expected object.`,
+      ),
+    );
+    return state;
+  }
+
+  // Migrate tokenNetworkFilter to enabledNetworkMap
+  networkOrderControllerState.enabledNetworkMap = { ...tokenNetworkFilter };
+
+  return state;
+}

--- a/app/scripts/migrations/168.ts
+++ b/app/scripts/migrations/168.ts
@@ -40,7 +40,7 @@ function transformState(
     return state;
   }
 
-  const networkOrderControllerState = state.NetworkOrderController;
+  const { NetworkOrderController: networkOrderControllerState } = state;
 
   // If NetworkOrderController is not an object, log error and return state
   if (!isObject(networkOrderControllerState)) {
@@ -58,7 +58,7 @@ function transformState(
     return state;
   }
 
-  const preferencesControllerState = state.PreferencesController;
+  const { PreferencesController: preferencesControllerState } = state;
 
   // If PreferencesController is not an object, log error and return state
   if (!isObject(preferencesControllerState)) {
@@ -78,7 +78,7 @@ function transformState(
     return state;
   }
 
-  const preferences = preferencesControllerState.preferences;
+  const { preferences } = preferencesControllerState;
 
   // If preferences is not an object, log error and return state
   if (!isObject(preferences)) {
@@ -98,7 +98,7 @@ function transformState(
     return state;
   }
 
-  const tokenNetworkFilter = preferences.tokenNetworkFilter;
+  const { tokenNetworkFilter } = preferences;
 
   // If tokenNetworkFilter is not an object, log error and return state
   if (!isObject(tokenNetworkFilter)) {

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -198,6 +198,7 @@ const migrations = [
   require('./165'),
   require('./166'),
   require('./167'),
+  require('./168'),
 ];
 
 export default migrations;


### PR DESCRIPTION
## **Description**

For new users, we should default enabledNetworks to Ethereum Mainnet, Linea Mainnet, and Base

For exsiting users, `enabledNetworkMap` should have the same chains enabled as `tokenNetworkFilter`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33715?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
