### PR TITLE
fix: Display "Switch back" instead of "Switch" for smart accounts - extension 

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6258,6 +6258,9 @@
   "switch": {
     "message": "Switch"
   },
+  "switchBack": {
+    "message": "Switch back"
+  },
   "switchEthereumChainConfirmationDescription": {
     "message": "This will switch the selected network within MetaMask to a previously added network:"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6258,6 +6258,9 @@
   "switch": {
     "message": "Switch"
   },
+  "switchBack": {
+    "message": "Switch back"
+  },
   "switchEthereumChainConfirmationDescription": {
     "message": "This will switch the selected network within MetaMask to a previously added network:"
   },

--- a/ui/pages/confirmations/components/confirm/smart-account-tab/account-network/account-network.test.tsx
+++ b/ui/pages/confirmations/components/confirm/smart-account-tab/account-network/account-network.test.tsx
@@ -52,12 +52,12 @@ describe('AccountNetwork', () => {
 
     expect(getByText('Sepolia')).toBeInTheDocument();
     expect(getByText('Smart Account')).toBeInTheDocument();
-    expect(getByText('Switch')).toBeInTheDocument();
+    expect(getByText('Switch back')).toBeInTheDocument();
   });
 
   it('click on switch should call downgradeAccount method for smart accounts', async () => {
     const { getByText } = renderComponent();
-    fireEvent.click(getByText('Switch'));
+    fireEvent.click(getByText('Switch back'));
 
     expect(mockDowngradeAccount).toHaveBeenCalled();
   });

--- a/ui/pages/confirmations/components/confirm/smart-account-tab/account-network/account-network.tsx
+++ b/ui/pages/confirmations/components/confirm/smart-account-tab/account-network/account-network.tsx
@@ -115,7 +115,7 @@ export const AccountNetwork = ({
         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         <ButtonLink onClick={onSwitch} data-testid={`switch_account-${name}`}>
-          {t('switch')}
+          {addressSupportSmartAccount ? t('switchBack') : t('switch')}
         </ButtonLink>
       )}
     </Box>


### PR DESCRIPTION
## **Description**

Display "Switch back" instead of "Switch" for smart accounts - extension 

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5178

## **Manual testing steps**

1. Open account modal
2. Check Switch / Switch back labels 

## **Screenshots/Recordings**
<img width="542" alt="Screenshot 2025-06-18 at 2 31 16 PM" src="https://github.com/user-attachments/assets/e01b4cb0-fe94-4f12-a243-45a2fa5b4c2b" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
