### PR TITLE
fix: flaky test 'Custom RPC history deletes a custom RPC'

### DIFF
--- a/test/e2e/tests/network/custom-rpc-history.spec.ts
+++ b/test/e2e/tests/network/custom-rpc-history.spec.ts
@@ -233,6 +233,8 @@ describe('Custom RPC history', function (this: Suite) {
         );
 
         // Check custom network http://127.0.0.1:8545/2 is removed from network list
+        // need a hard delay to avoid the background error message "network configuration not found" for removed network
+        await driver.delay(2000);
         await headerNavbar.clickSwitchNetworkDropDown();
         await selectNetworkDialog.check_pageIsLoaded();
         await selectNetworkDialog.check_networkOptionIsDisplayed(


### PR DESCRIPTION
## **Description**

This PR addresses a flaky test `Custom RPC history deletes a custom RPC`. The test occasionally failed due to a race condition where the dropdown is interacted with before the network removal is fully processed in the background. So a background error `network configuration not found` can occur. 
It happens only in automated test due to fast execution speed and is not reproducible during manual testing.
The fix is a hard delay after deleting network because no other UI condition can check. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33730?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

Check e2e is successful

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
