### PR TITLE
fix: flaky test `Lock and unlock successfully unlocks after lock`

### DIFF
--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -61,6 +61,9 @@ class HeaderNavbar {
   }
 
   async lockMetaMask(): Promise<void> {
+    // We need a delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked'
+    // This delay will be changed for a deterministic condition with this ticket (#33725)
+    await this.driver.delay(5000);
     await this.openThreeDotMenu();
     await this.driver.clickElement(this.lockMetaMaskButton);
   }

--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -61,9 +61,6 @@ class HeaderNavbar {
   }
 
   async lockMetaMask(): Promise<void> {
-    // We need a delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked'
-    // This delay will be changed for a deterministic condition with this ticket (#33725)
-    await this.driver.delay(5000);
     await this.openThreeDotMenu();
     await this.driver.clickElement(this.lockMetaMaskButton);
   }

--- a/test/e2e/tests/account/forgot-password.spec.ts
+++ b/test/e2e/tests/account/forgot-password.spec.ts
@@ -30,8 +30,6 @@ describe('Forgot password', function () {
         // Lock Wallet
         const homePage = new HomePage(driver);
         await homePage.headerNavbar.check_pageIsLoaded();
-        // We need a bigger delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked' (#33725)
-        await driver.delay(5000);
         await homePage.headerNavbar.lockMetaMask();
 
         // Click forgot password button and reset password

--- a/test/e2e/tests/account/forgot-password.spec.ts
+++ b/test/e2e/tests/account/forgot-password.spec.ts
@@ -30,7 +30,7 @@ describe('Forgot password', function () {
         // Lock Wallet
         const homePage = new HomePage(driver);
         await homePage.headerNavbar.check_pageIsLoaded();
-        // We need a bigger delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked'
+        // We need a bigger delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked' (#33725)
         await driver.delay(5000);
         await homePage.headerNavbar.lockMetaMask();
 

--- a/test/e2e/tests/account/forgot-password.spec.ts
+++ b/test/e2e/tests/account/forgot-password.spec.ts
@@ -1,3 +1,5 @@
+import { Mockttp } from 'mockttp';
+import { MockedEndpoint } from '../../mock-e2e';
 import { withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import { Driver } from '../../webdriver/driver';
@@ -11,23 +13,42 @@ import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow'
 
 const newPassword = 'this is the best password ever';
 
+async function seeAuthenticationRequest(mockServer: Mockttp) {
+  return await mockServer
+    .forPost('https://authentication.api.cx.metamask.io/api/v2/srp/login')
+    // the goal is to know when this request happens, not to mock any specific response
+    .thenPassThrough();
+}
+
 describe('Forgot password', function () {
   it('resets password and then unlock wallet with new password', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),
+        testSpecificMock: seeAuthenticationRequest,
         title: this.test?.fullTitle(),
       },
       async ({
         driver,
         localNodes,
+        mockedEndpoint,
       }: {
         driver: Driver;
         localNodes: Anvil[] | Ganache[] | undefined[];
+        mockedEndpoint: MockedEndpoint;
       }) => {
         await loginWithBalanceValidation(driver, localNodes[0]);
 
         // Lock Wallet
+        // We need to wait for this request to happen, before locking the wallet, to avoid the error 'unable to proceed, wallet is locked'
+        // https://github.com/MetaMask/core/blob/main/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts#L263
+        await driver.waitUntil(
+          async () => {
+            const requests = await mockedEndpoint.getSeenRequests();
+            return requests.length > 0;
+          },
+          { interval: 200, timeout: 10000 },
+        );
         const homePage = new HomePage(driver);
         await homePage.headerNavbar.check_pageIsLoaded();
         await homePage.headerNavbar.lockMetaMask();

--- a/test/e2e/tests/account/forgot-password.spec.ts
+++ b/test/e2e/tests/account/forgot-password.spec.ts
@@ -17,7 +17,11 @@ async function seeAuthenticationRequest(mockServer: Mockttp) {
   return await mockServer
     .forPost('https://authentication.api.cx.metamask.io/api/v2/srp/login')
     // the goal is to know when this request happens, not to mock any specific response
-    .thenPassThrough();
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+      };
+    });
 }
 
 describe('Forgot password', function () {

--- a/test/e2e/tests/account/lock-account.spec.ts
+++ b/test/e2e/tests/account/lock-account.spec.ts
@@ -11,7 +11,11 @@ async function seeAuthenticationRequest(mockServer: Mockttp) {
   return await mockServer
     .forPost('https://authentication.api.cx.metamask.io/api/v2/srp/login')
     // the goal is to know when this request happens, not to mock any specific response
-    .thenPassThrough();
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+      };
+    });
 }
 
 describe('Lock and unlock', function (this: Suite) {

--- a/test/e2e/tests/account/lock-account.spec.ts
+++ b/test/e2e/tests/account/lock-account.spec.ts
@@ -1,19 +1,45 @@
 import { Suite } from 'mocha';
+import { Mockttp } from 'mockttp';
+import { MockedEndpoint } from '../../mock-e2e';
 import { withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import HomePage from '../../page-objects/pages/home/homepage';
 import { Driver } from '../../webdriver/driver';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
+async function seeAuthenticationRequest(mockServer: Mockttp) {
+  return await mockServer
+    .forPost('https://authentication.api.cx.metamask.io/api/v2/srp/login')
+    // the goal is to know when this request happens, not to mock any specific response
+    .thenPassThrough();
+}
+
 describe('Lock and unlock', function (this: Suite) {
   it('successfully unlocks after lock', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),
+        testSpecificMock: seeAuthenticationRequest,
         title: this.test?.fullTitle(),
       },
-      async ({ driver }: { driver: Driver }) => {
+      async ({
+        driver,
+        mockedEndpoint,
+      }: {
+        driver: Driver;
+        mockedEndpoint: MockedEndpoint;
+      }) => {
         await loginWithBalanceValidation(driver);
+
+        // We need to wait for this request to happen, before locking the wallet, to avoid the error 'unable to proceed, wallet is locked'
+        // https://github.com/MetaMask/core/blob/main/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts#L263
+        await driver.waitUntil(
+          async () => {
+            const requests = await mockedEndpoint.getSeenRequests();
+            return requests.length > 0;
+          },
+          { interval: 200, timeout: 10000 },
+        );
         const homePage = new HomePage(driver);
         await homePage.headerNavbar.lockMetaMask();
         await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/account/lock-account.spec.ts
+++ b/test/e2e/tests/account/lock-account.spec.ts
@@ -14,8 +14,6 @@ describe('Lock and unlock', function (this: Suite) {
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithBalanceValidation(driver);
-        // We need a bigger delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked' (#33725)
-        await driver.delay(5000);
         const homePage = new HomePage(driver);
         await homePage.headerNavbar.lockMetaMask();
         await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/account/lock-account.spec.ts
+++ b/test/e2e/tests/account/lock-account.spec.ts
@@ -14,6 +14,8 @@ describe('Lock and unlock', function (this: Suite) {
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithBalanceValidation(driver);
+        // We need a bigger delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked' (#33725)
+        await driver.delay(5000);
         const homePage = new HomePage(driver);
         await homePage.headerNavbar.lockMetaMask();
         await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/account/migrate-old-vault.spec.ts
+++ b/test/e2e/tests/account/migrate-old-vault.spec.ts
@@ -12,7 +12,11 @@ async function seeAuthenticationRequest(mockServer: Mockttp) {
   return await mockServer
     .forPost('https://authentication.api.cx.metamask.io/api/v2/srp/login')
     // the goal is to know when this request happens, not to mock any specific response
-    .thenPassThrough();
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+      };
+    });
 }
 
 describe('Migrate vault with old encryption', function (this: Suite) {

--- a/test/e2e/tests/account/migrate-old-vault.spec.ts
+++ b/test/e2e/tests/account/migrate-old-vault.spec.ts
@@ -17,7 +17,7 @@ describe('Migrate vault with old encryption', function (this: Suite) {
         await loginWithBalanceValidation(driver);
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.check_pageIsLoaded();
-        // We need a bigger delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked'
+        // We need a bigger delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked' (#33725)
         await driver.delay(5000);
         await headerNavbar.lockMetaMask();
         const loginPage = new LoginPage(driver);

--- a/test/e2e/tests/account/migrate-old-vault.spec.ts
+++ b/test/e2e/tests/account/migrate-old-vault.spec.ts
@@ -1,4 +1,6 @@
 import { Suite } from 'mocha';
+import { Mockttp } from 'mockttp';
+import { MockedEndpoint } from '../../mock-e2e';
 import { withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import { Driver } from '../../webdriver/driver';
@@ -6,15 +8,40 @@ import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import LoginPage from '../../page-objects/pages/login-page';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
+async function seeAuthenticationRequest(mockServer: Mockttp) {
+  return await mockServer
+    .forPost('https://authentication.api.cx.metamask.io/api/v2/srp/login')
+    // the goal is to know when this request happens, not to mock any specific response
+    .thenPassThrough();
+}
+
 describe('Migrate vault with old encryption', function (this: Suite) {
   it('successfully unlocks an old vault, locks it, and unlocks again', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().withKeyringControllerOldVault().build(),
+        testSpecificMock: seeAuthenticationRequest,
         title: this.test?.fullTitle(),
       },
-      async ({ driver }: { driver: Driver }) => {
+      async ({
+        driver,
+        mockedEndpoint,
+      }: {
+        driver: Driver;
+        mockedEndpoint: MockedEndpoint;
+      }) => {
         await loginWithBalanceValidation(driver);
+
+        // We need to wait for this request to happen, before locking the wallet, to avoid the error 'unable to proceed, wallet is locked'
+        // https://github.com/MetaMask/core/blob/main/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts#L263
+        await driver.waitUntil(
+          async () => {
+            const requests = await mockedEndpoint.getSeenRequests();
+            return requests.length > 0;
+          },
+          { interval: 200, timeout: 10000 },
+        );
+
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.check_pageIsLoaded();
         await headerNavbar.lockMetaMask();

--- a/test/e2e/tests/account/migrate-old-vault.spec.ts
+++ b/test/e2e/tests/account/migrate-old-vault.spec.ts
@@ -17,8 +17,6 @@ describe('Migrate vault with old encryption', function (this: Suite) {
         await loginWithBalanceValidation(driver);
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.check_pageIsLoaded();
-        // We need a bigger delay before locking the wallet to avoid the error '#snapGetPublicKey - unable to proceed, wallet is locked' (#33725)
-        await driver.delay(5000);
         await headerNavbar.lockMetaMask();
         const loginPage = new LoginPage(driver);
         await loginPage.check_pageIsLoaded();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This spec also has the same race condition than the previous two, which is that whenever we login into the home screen, if the next action we perform is to lock the wallet, this  can throw the error `#snapGetPublicKey - unable to proceed, wallet is locked`.

![Screenshot from 2025-06-19 09-23-22](https://github.com/user-attachments/assets/187e8f93-0d2f-47e2-8bb3-59f291ad2823)


Investigation: the Profile Sync feature calls this method `assertIsUnlocked`, which throws the above error if the wallet is locked.
The problem is that when this method is called, the wallet is already locked, due to the lock action. So the deterministic condition is to wait until that method is called before locking the wallet, to avoid the error.
To ensure that indirectly, we can wait until the authentication request for the Profile Sync feature happens. This is deterministic and fixes all the affected specs.

![Screenshot from 2025-06-19 09-34-11](https://github.com/user-attachments/assets/dc584a11-f4d1-4440-a50b-d88a4566ba5a)



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33763?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33725

## **Manual testing steps**

1. Test should pass



## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
