### PR TITLE
fix: cp-12.22.0 flaky `Token List` and `Token Details` specs

### DIFF
--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -87,7 +87,7 @@ class AssetListPage {
   private readonly tokenConfirmListItem =
     '.import-tokens-modal__confirm-token-list-item-wrapper';
 
-  private readonly tokenDecimals = {
+  private readonly tokenDecimalsTitle = {
     css: '.mm-label',
     text: 'Token decimal',
   };
@@ -258,7 +258,7 @@ class AssetListPage {
       await this.driver.fill(this.tokenSymbolInput, symbol);
     }
 
-    await this.driver.waitForSelector(this.tokenDecimals);
+    await this.driver.waitForSelector(this.tokenDecimalsTitle);
     await this.driver.clickElement(this.importTokensNextButton);
     await this.driver.waitForSelector(this.tokenConfirmListItem);
     await this.driver.clickElementAndWaitToDisappear(

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -88,7 +88,7 @@ class AssetListPage {
     '.import-tokens-modal__confirm-token-list-item-wrapper';
 
   private readonly tokenDecimals = {
-    tag: 'label',
+    css: '.mm-label',
     text: 'Token decimal',
   };
 
@@ -104,7 +104,7 @@ class AssetListPage {
     '[data-testid="asset-list-control-bar-action-button"]';
 
   private readonly tokenSymbolTitle = {
-    tag: 'label',
+    css: '.mm-label',
     text: 'Token symbol',
   };
 

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -228,10 +228,9 @@ class AssetListPage {
   }
 
   async importCustomTokenByChain(
-    tokenAddress: string,
-    symbol: string | undefined,
     chainId: string,
-    prefilledSymbol: boolean = false,
+    tokenAddress: string,
+    symbol?: string,
   ): Promise<void> {
     console.log(`Creating custom token ${symbol} on homepage`);
     await this.driver.clickElement(this.tokenOptionsButton);
@@ -245,7 +244,7 @@ class AssetListPage {
     );
     await this.driver.fill(this.tokenAddressInput, tokenAddress);
 
-    if (!prefilledSymbol && symbol) {
+    if (symbol) {
       // do not fill the form until the button is disabled, because there's a form re-render which can clear the input field causing flakiness
       await this.driver.waitForSelector(this.importTokensNextButton, {
         state: 'disabled',

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -84,6 +84,14 @@ class AssetListPage {
   private readonly tokenAddressInDetails =
     '[data-testid="address-copy-button-text"]';
 
+  private readonly tokenConfirmListItem =
+    '.import-tokens-modal__confirm-token-list-item-wrapper';
+
+  private readonly tokenDecimals = {
+    tag: 'label',
+    text: 'Token decimal',
+  };
+
   private readonly tokenNameInDetails = '[data-testid="asset-name"]';
 
   private readonly tokenImportedMessageCloseButton =
@@ -245,7 +253,9 @@ class AssetListPage {
       await this.driver.fill(this.tokenSymbolInput, symbol);
     }
 
+    await this.driver.waitForSelector(this.tokenDecimals);
     await this.driver.clickElement(this.importTokensNextButton);
+    await this.driver.waitForSelector(this.tokenConfirmListItem);
     await this.driver.clickElementAndWaitToDisappear(
       this.confirmImportTokenButton,
     );

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -235,6 +235,10 @@ class AssetListPage {
       this.tokenImportSelectNetwork(chainId),
     );
     await this.driver.fill(this.tokenAddressInput, tokenAddress);
+    await this.driver.waitForSelector(
+      this.importTokensNextButton,
+      { state: 'disabled'},
+    );
     await this.driver.fill(this.tokenSymbolInput, symbol);
     await this.driver.clickElement(this.importTokensNextButton);
     await this.driver.clickElementAndWaitToDisappear(

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -103,6 +103,11 @@ class AssetListPage {
   private readonly tokenOptionsButton =
     '[data-testid="asset-list-control-bar-action-button"]';
 
+  private readonly tokenSymbolTitle = {
+    tag: 'label',
+    text: 'Token symbol',
+  };
+
   private tokenImportSelectNetwork(chainId: string): string {
     return `[data-testid="select-network-item-${chainId}"]`;
   }
@@ -243,6 +248,7 @@ class AssetListPage {
       this.tokenImportSelectNetwork(chainId),
     );
     await this.driver.fill(this.tokenAddressInput, tokenAddress);
+    await this.driver.waitForSelector(this.tokenSymbolTitle);
 
     if (symbol) {
       // do not fill the form until the button is disabled, because there's a form re-render which can clear the input field causing flakiness

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -254,7 +254,7 @@ class AssetListPage {
       // do not fill the form until the button is disabled, because there's a form re-render which can clear the input field causing flakiness
       await this.driver.waitForSelector(this.importTokensNextButton, {
         state: 'disabled',
-        waitAtLeastGuard: 2000,
+        waitAtLeastGuard: 1000,
       });
       await this.driver.fill(this.tokenSymbolInput, symbol);
     }

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -235,6 +235,7 @@ class AssetListPage {
       this.tokenImportSelectNetwork(chainId),
     );
     await this.driver.fill(this.tokenAddressInput, tokenAddress);
+    // do not fill the form if the button is not disabled, otherwise there's a re-render which can clear the input field causing flakiness
     await this.driver.waitForSelector(
       this.importTokensNextButton,
       { state: 'disabled'},

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -254,6 +254,7 @@ class AssetListPage {
       // do not fill the form until the button is disabled, because there's a form re-render which can clear the input field causing flakiness
       await this.driver.waitForSelector(this.importTokensNextButton, {
         state: 'disabled',
+        waitAtLeastGuard: 1000,
       });
       await this.driver.fill(this.tokenSymbolInput, symbol);
     }

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -254,7 +254,7 @@ class AssetListPage {
       // do not fill the form until the button is disabled, because there's a form re-render which can clear the input field causing flakiness
       await this.driver.waitForSelector(this.importTokensNextButton, {
         state: 'disabled',
-        waitAtLeastGuard: 1000,
+        waitAtLeastGuard: 2000,
       });
       await this.driver.fill(this.tokenSymbolInput, symbol);
     }

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -236,10 +236,9 @@ class AssetListPage {
     );
     await this.driver.fill(this.tokenAddressInput, tokenAddress);
     // do not fill the form if the button is not disabled, otherwise there's a re-render which can clear the input field causing flakiness
-    await this.driver.waitForSelector(
-      this.importTokensNextButton,
-      { state: 'disabled'},
-    );
+    await this.driver.waitForSelector(this.importTokensNextButton, {
+      state: 'disabled',
+    });
     await this.driver.fill(this.tokenSymbolInput, symbol);
     await this.driver.clickElement(this.importTokensNextButton);
     await this.driver.clickElementAndWaitToDisappear(

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -221,8 +221,9 @@ class AssetListPage {
 
   async importCustomTokenByChain(
     tokenAddress: string,
-    symbol: string,
+    symbol: string | undefined,
     chainId: string,
+    prefilledSymbol: boolean = false,
   ): Promise<void> {
     console.log(`Creating custom token ${symbol} on homepage`);
     await this.driver.clickElement(this.tokenOptionsButton);
@@ -235,11 +236,15 @@ class AssetListPage {
       this.tokenImportSelectNetwork(chainId),
     );
     await this.driver.fill(this.tokenAddressInput, tokenAddress);
-    // do not fill the form if the button is not disabled, otherwise there's a re-render which can clear the input field causing flakiness
-    await this.driver.waitForSelector(this.importTokensNextButton, {
-      state: 'disabled',
-    });
-    await this.driver.fill(this.tokenSymbolInput, symbol);
+
+    if (!prefilledSymbol && symbol) {
+      // do not fill the form until the button is disabled, because there's a form re-render which can clear the input field causing flakiness
+      await this.driver.waitForSelector(this.importTokensNextButton, {
+        state: 'disabled',
+      });
+      await this.driver.fill(this.tokenSymbolInput, symbol);
+    }
+
     await this.driver.clickElement(this.importTokensNextButton);
     await this.driver.clickElementAndWaitToDisappear(
       this.confirmImportTokenButton,

--- a/test/e2e/tests/tokens/import-tokens.spec.ts
+++ b/test/e2e/tests/tokens/import-tokens.spec.ts
@@ -234,10 +234,13 @@ describe('Import flow', function () {
         await homePage.check_pageIsLoaded();
 
         const assetListPage = new AssetListPage(driver);
+
+        // the token symbol is prefilled because of the mock
         await assetListPage.importCustomTokenByChain(
           '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
           'USDT',
           '0x89',
+          true,
         );
         const tokenList = new AssetListPage(driver);
 

--- a/test/e2e/tests/tokens/import-tokens.spec.ts
+++ b/test/e2e/tests/tokens/import-tokens.spec.ts
@@ -237,10 +237,8 @@ describe('Import flow', function () {
 
         // the token symbol is prefilled because of the mock
         await assetListPage.importCustomTokenByChain(
-          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
-          'USDT',
           '0x89',
-          true,
+          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
         );
         const tokenList = new AssetListPage(driver);
 

--- a/test/e2e/tests/tokens/import-tokens.spec.ts
+++ b/test/e2e/tests/tokens/import-tokens.spec.ts
@@ -1,10 +1,11 @@
 import AssetListPage from '../../page-objects/pages/home/asset-list';
 import HomePage from '../../page-objects/pages/home/homepage';
 
-import { withFixtures, unlockWallet } from '../../helpers';
+import { withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import { Mockttp } from '../../mock-e2e';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 describe('Import flow', function () {
   async function mockPriceFetch(mockServer: Mockttp) {
@@ -83,7 +84,7 @@ describe('Import flow', function () {
         testSpecificMock: mockPriceFetch,
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);
         const assetListPage = new AssetListPage(driver);
@@ -157,7 +158,7 @@ describe('Import flow', function () {
         testSpecificMock: mockPriceFetch,
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);
         await homePage.check_pageIsLoaded();
@@ -228,7 +229,7 @@ describe('Import flow', function () {
         testSpecificMock: mockPriceFetch,
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);
         await homePage.check_pageIsLoaded();

--- a/test/e2e/tests/tokens/token-details.spec.ts
+++ b/test/e2e/tests/tokens/token-details.spec.ts
@@ -43,9 +43,9 @@ describe('Token Details', function () {
         const assetListPage = new AssetListPage(driver);
         await homePage.check_pageIsLoaded();
         await assetListPage.importCustomTokenByChain(
+          chainId,
           tokenAddress,
           symbol,
-          chainId,
         );
         await assetListPage.dismissTokenImportedMessage();
         await assetListPage.openTokenDetails(symbol);
@@ -93,9 +93,9 @@ describe('Token Details', function () {
         const assetListPage = new AssetListPage(driver);
         await homePage.check_pageIsLoaded();
         await assetListPage.importCustomTokenByChain(
+          chainId,
           tokenAddress,
           symbol,
-          chainId,
         );
         await assetListPage.dismissTokenImportedMessage();
         await assetListPage.openTokenDetails(symbol);

--- a/test/e2e/tests/tokens/token-details.spec.ts
+++ b/test/e2e/tests/tokens/token-details.spec.ts
@@ -3,7 +3,7 @@ import { Context } from 'mocha';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { formatCurrency } from '../../../../ui/helpers/utils/confirm-tx.util';
 import FixtureBuilder from '../../fixture-builder';
-import { unlockWallet, withFixtures } from '../../helpers';
+import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import HomePage from '../../page-objects/pages/home/homepage';
 import AssetListPage from '../../page-objects/pages/home/asset-list';
@@ -13,6 +13,7 @@ import {
   mockHistoricalPrices,
   mockSpotPrices,
 } from './utils/mocks';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 describe('Token Details', function () {
   const chainId = CHAIN_IDS.MAINNET;
@@ -37,7 +38,7 @@ describe('Token Details', function () {
         ],
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);
         const assetListPage = new AssetListPage(driver);
@@ -87,7 +88,7 @@ describe('Token Details', function () {
         ],
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);
         const assetListPage = new AssetListPage(driver);

--- a/test/e2e/tests/tokens/token-details.spec.ts
+++ b/test/e2e/tests/tokens/token-details.spec.ts
@@ -7,13 +7,13 @@ import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import HomePage from '../../page-objects/pages/home/homepage';
 import AssetListPage from '../../page-objects/pages/home/asset-list';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import {
   mockEmptyHistoricalPrices,
   mockEmptyPrices,
   mockHistoricalPrices,
   mockSpotPrices,
 } from './utils/mocks';
-import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 describe('Token Details', function () {
   const chainId = CHAIN_IDS.MAINNET;

--- a/test/e2e/tests/tokens/token-list.spec.ts
+++ b/test/e2e/tests/tokens/token-list.spec.ts
@@ -8,13 +8,13 @@ import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import HomePage from '../../page-objects/pages/home/homepage';
 import AssetListPage from '../../page-objects/pages/home/asset-list';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import {
   mockEmptyHistoricalPrices,
   mockEmptyPrices,
   mockHistoricalPrices,
   mockSpotPrices,
 } from './utils/mocks';
-import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
 

--- a/test/e2e/tests/tokens/token-list.spec.ts
+++ b/test/e2e/tests/tokens/token-list.spec.ts
@@ -49,9 +49,9 @@ describe('Token List', function () {
 
         await homePage.check_pageIsLoaded();
         await assetListPage.importCustomTokenByChain(
+          chainId,
           tokenAddress,
           symbol,
-          chainId,
         );
 
         await assetListPage.check_tokenGeneralChangePercentageNotPresent(
@@ -106,9 +106,9 @@ describe('Token List', function () {
 
         await homePage.check_pageIsLoaded();
         await assetListPage.importCustomTokenByChain(
+          chainId,
           tokenAddress,
           symbol,
-          chainId,
         );
 
         await assetListPage.check_tokenGeneralChangePercentage(

--- a/test/e2e/tests/tokens/token-list.spec.ts
+++ b/test/e2e/tests/tokens/token-list.spec.ts
@@ -4,7 +4,7 @@ import { zeroAddress } from 'ethereumjs-util';
 import { Browser } from 'selenium-webdriver';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import FixtureBuilder from '../../fixture-builder';
-import { unlockWallet, withFixtures } from '../../helpers';
+import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import HomePage from '../../page-objects/pages/home/homepage';
 import AssetListPage from '../../page-objects/pages/home/asset-list';
@@ -14,6 +14,7 @@ import {
   mockHistoricalPrices,
   mockSpotPrices,
 } from './utils/mocks';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
 
@@ -42,7 +43,7 @@ describe('Token List', function () {
         ],
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);
         const assetListPage = new AssetListPage(driver);
@@ -99,7 +100,7 @@ describe('Token List', function () {
         ],
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);
         const assetListPage = new AssetListPage(driver);

--- a/test/e2e/tests/tokens/token-sort.spec.ts
+++ b/test/e2e/tests/tokens/token-sort.spec.ts
@@ -32,9 +32,9 @@ describe('Token List Sorting', function () {
 
         await homePage.check_pageIsLoaded();
         await assetListPage.importCustomTokenByChain(
+          CHAIN_IDS.MAINNET,
           customTokenAddress,
           customTokenSymbol,
-          CHAIN_IDS.MAINNET,
         );
 
         await assetListPage.check_tokenExistsInList('Ethereum');

--- a/test/e2e/tests/tokens/token-sort.spec.ts
+++ b/test/e2e/tests/tokens/token-sort.spec.ts
@@ -1,10 +1,11 @@
 import { Context } from 'mocha';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import FixtureBuilder from '../../fixture-builder';
-import { unlockWallet, withFixtures, largeDelayMs } from '../../helpers';
+import { withFixtures, largeDelayMs } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import HomePage from '../../page-objects/pages/home/homepage';
 import AssetListPage from '../../page-objects/pages/home/asset-list';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 describe('Token List Sorting', function () {
   const mainnetChainId = CHAIN_IDS.MAINNET;
@@ -25,7 +26,7 @@ describe('Token List Sorting', function () {
         title: (this as Context).test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);
         const assetListPage = new AssetListPage(driver);

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -354,7 +354,7 @@ class Driver {
     // bucket that can include the state attribute to wait for elements that
     // match the selector to be removed from the DOM.
     let element;
-    if (!['visible', 'detached', 'enabled'].includes(state)) {
+    if (!['visible', 'detached', 'enabled', 'disabled'].includes(state)) {
       throw new Error(`Provided state selector ${state} is not supported`);
     }
     if (state === 'visible') {
@@ -370,6 +370,11 @@ class Driver {
     } else if (state === 'enabled') {
       element = await this.driver.wait(
         until.elementIsEnabled(await this.findElement(rawLocator)),
+        timeout,
+      );
+    } else if (state === 'disabled') {
+      element = await this.driver.wait(
+        until.elementIsDisabled(await this.findElement(rawLocator)),
         timeout,
       );
     }

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -348,11 +348,7 @@ class Driver {
    */
   async waitForSelector(
     rawLocator,
-    {
-      timeout = this.timeout,
-      state = 'visible',
-      waitAtLeastGuard = 0,
-    } = {},
+    { timeout = this.timeout, state = 'visible', waitAtLeastGuard = 0 } = {},
   ) {
     // Playwright has a waitForSelector method that will become a shallow
     // replacement for the implementation below. It takes an option options

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -342,17 +342,27 @@ class Driver {
    * @param {string} [options.state] - specifies the state of the element to wait for.
    * It defaults to 'visible', indicating that the method will wait until the element is visible on the page.
    * The other supported state is 'detached', which means waiting until the element is removed from the DOM.
+   * @param {number} [options.waitAtLeastGuard] - minimum milliseconds to wait before passing
    * @returns {Promise<WebElement>} promise resolving when the element meets the state or timeout occurs.
    * @throws {Error} Will throw an error if the element does not reach the specified state within the timeout period.
    */
   async waitForSelector(
     rawLocator,
-    { timeout = this.timeout, state = 'visible' } = {},
+    {
+      timeout = this.timeout,
+      state = 'visible',
+      waitAtLeastGuard = 0,
+    } = {},
   ) {
     // Playwright has a waitForSelector method that will become a shallow
     // replacement for the implementation below. It takes an option options
     // bucket that can include the state attribute to wait for elements that
     // match the selector to be removed from the DOM.
+    assert(timeout > waitAtLeastGuard);
+    if (waitAtLeastGuard > 0) {
+      await this.delay(waitAtLeastGuard);
+    }
+
     let element;
     if (!['visible', 'detached', 'enabled', 'disabled'].includes(state)) {
       throw new Error(`Provided state selector ${state} is not supported`);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Source of flakiness 1: re-render of the form
There is this race condition where, we fill the token decimals, but there is a re-render of the form component which clears the form and disables the Next button.
This is happening on the application side.
To avoid our value of being cleared and make the spec fail, a deterministic condition is to wait until the Next button is disabled (which is the state after the re-render) and then proceed with adding the decimals value, so the value is not cleared.


See how: 
1. We enter an address
2. The NExt button is Enabled for some brief moment
3. During that moment, we fill the decimals
4. Then there's a re-render, and the button is Disabled (as expected) and the value we entered is cleared

https://github.com/user-attachments/assets/7fa19107-1bef-497d-b3c1-28e430889534



### Source of flakiness 2: empty decimals
Once the above has been mitigated, I've seen one occurrence of a different issue.
The decimal value, should be automatically filled after adding the Symbol, however, in some instances, the decimal is empty, making that the Next button is never enabled and failing the spec.

We saw that this happened when the token list was not yet ready ([see](https://github.com/MetaMask/metamask-extension/pull/33248)). A way to mitigate this on the spec level is to `loginWithBalanceValidation`. When we wait for the native token balance to appear, the token list seems to implicitly be ready 100% of the times.



![test-failure-screenshot-1](https://github.com/user-attachments/assets/b755083f-da08-43fa-863a-8b358cfb0b66)

![Screenshot from 2025-06-20 10-46-20](https://github.com/user-attachments/assets/ae781aac-0f4b-4960-97e1-25967ddf9bc3)




[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33772?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33796 https://github.com/MetaMask/metamask-extension/issues/33797 https://github.com/MetaMask/metamask-extension/issues/33798

## **Manual testing steps**

1. Test should pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
