### PR TITLE
fix: handle Srp quiz words with non-unique words in confirm seed phrase

### DIFF
--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -25,9 +25,30 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+// click and answer the srp quiz
+const clickAndAnswerSrpQuiz = (quizUnansweredChips) => {
+  // sort the unanswered chips by testId
+  const sortedQuizWords = quizUnansweredChips
+    .map((chipElm) => {
+      // extract the testId number from the data-testid attribute, sample testId -> recovery-phrase-quiz-unanswered-[number]
+      const testIdNumber = chipElm.getAttribute('data-testid').split('-')[4];
+      return {
+        id: testIdNumber,
+        elm: chipElm,
+      };
+    })
+    .sort((a, b) => a.id - b.id);
+
+  sortedQuizWords.forEach((word) => {
+    // assert the unanswered chip is in the document
+    expect(word.elm).toBeInTheDocument();
+    fireEvent.click(word.elm);
+  });
+};
+
 describe('Confirm Recovery Phrase Component', () => {
   const TEST_SEED =
-    'debris dizzy just program just float decrease vacant alarm reduce speak stadium';
+    'debris dizzy just just just float just just just just speak just';
 
   const props = {
     secretRecoveryPhrase: TEST_SEED,
@@ -141,46 +162,37 @@ describe('Confirm Recovery Phrase Component', () => {
     expect(confirmRecoveryPhraseButton).toBeDisabled();
   });
 
-  it('should enable confirm recovery phrase with correct word inputs', async () => {
-    const { queryByTestId, queryAllByTestId, getByText } = renderWithProvider(
+  it('should enable confirm recovery phrase with correct word inputs', () => {
+    const { queryByTestId, queryAllByTestId, getByTestId } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,
       mockStore,
     );
 
-    const recoveryPhraseChips = queryAllByTestId(
+    const quizUnansweredChips = queryAllByTestId(
       /recovery-phrase-quiz-unanswered-/u,
     );
-    const quizWord1 = recoveryPhraseChips[0].textContent;
-    const quizWord2 = recoveryPhraseChips[1].textContent;
-    const quizWord3 = recoveryPhraseChips[2].textContent;
 
-    // sort the quiz words by index, and then click the chip in correct order
-    const seedArray = TEST_SEED.split(' ');
-    const quizWords = [
-      { index: seedArray.indexOf(quizWord1), elm: recoveryPhraseChips[0] },
-      { index: seedArray.indexOf(quizWord2), elm: recoveryPhraseChips[1] },
-      { index: seedArray.indexOf(quizWord3), elm: recoveryPhraseChips[2] },
-    ];
-    const sortedQuizWords = quizWords.sort((a, b) => a.index - b.index);
+    // click and answer the srp quiz
+    clickAndAnswerSrpQuiz(quizUnansweredChips);
 
-    sortedQuizWords.forEach((word) => {
-      fireEvent.click(word.elm);
-    });
+    // assert the unanswered chips are not in the document
+    const quizAnsweredChips = queryAllByTestId(
+      /recovery-phrase-quiz-answered-/u,
+    );
+    expect(quizAnsweredChips).toHaveLength(3);
 
-    await waitFor(() => {
-      const confirmRecoveryPhraseButton = queryByTestId(
-        'recovery-phrase-confirm',
-      );
-      expect(confirmRecoveryPhraseButton).not.toBeDisabled();
-      fireEvent.click(confirmRecoveryPhraseButton);
+    const confirmRecoveryPhraseButton = queryByTestId(
+      'recovery-phrase-confirm',
+    );
+    expect(confirmRecoveryPhraseButton).not.toBeDisabled();
+    fireEvent.click(confirmRecoveryPhraseButton);
 
-      const gotItButton = getByText('Got it');
-      expect(gotItButton).toBeInTheDocument();
-      fireEvent.click(gotItButton);
+    const gotItButton = getByTestId('confirm-srp-modal-button-success');
+    expect(gotItButton).toBeInTheDocument();
+    fireEvent.click(gotItButton);
 
-      expect(setSeedPhraseBackedUp).toHaveBeenCalledWith(true);
-      expect(mockHistoryPush).toHaveBeenCalledWith(ONBOARDING_METAMETRICS);
-    });
+    expect(setSeedPhraseBackedUp).toHaveBeenCalledWith(true);
+    expect(mockHistoryPush).toHaveBeenCalledWith(ONBOARDING_METAMETRICS);
   });
 
   it('should go to Onboarding Completion page as a next step in firefox', async () => {
@@ -188,41 +200,31 @@ describe('Confirm Recovery Phrase Component', () => {
       .spyOn(BrowserRuntimeUtils, 'getBrowserName')
       .mockReturnValue(PLATFORM_FIREFOX);
 
-    const { queryByTestId, queryAllByTestId, getByText } = renderWithProvider(
+    const { queryByTestId, queryAllByTestId, getByTestId } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,
       mockStore,
     );
 
-    const recoveryPhraseChips = queryAllByTestId(
+    const quizUnansweredChips = queryAllByTestId(
       /recovery-phrase-quiz-unanswered-/u,
     );
-    const quizWord1 = recoveryPhraseChips[0].textContent;
-    const quizWord2 = recoveryPhraseChips[1].textContent;
-    const quizWord3 = recoveryPhraseChips[2].textContent;
 
-    // sort the quiz words by index, and then click the chip in correct order
-    const seedArray = TEST_SEED.split(' ');
-    const quizWords = [
-      { index: seedArray.indexOf(quizWord1), elm: recoveryPhraseChips[0] },
-      { index: seedArray.indexOf(quizWord2), elm: recoveryPhraseChips[1] },
-      { index: seedArray.indexOf(quizWord3), elm: recoveryPhraseChips[2] },
-    ];
-    const sortedQuizWords = quizWords.sort((a, b) => a.index - b.index);
+    // click and answer the srp quiz
+    clickAndAnswerSrpQuiz(quizUnansweredChips);
 
-    sortedQuizWords.forEach((word) => {
-      fireEvent.click(word.elm);
-    });
+    const quizAnsweredChips = queryAllByTestId(
+      /recovery-phrase-quiz-answered-/u,
+    );
+    expect(quizAnsweredChips).toHaveLength(3);
 
     const confirmRecoveryPhraseButton = queryByTestId(
       'recovery-phrase-confirm',
     );
 
-    await waitFor(() => {
-      fireEvent.click(confirmRecoveryPhraseButton);
-      fireEvent.click(getByText('Got it'));
+    fireEvent.click(confirmRecoveryPhraseButton);
+    fireEvent.click(getByTestId('confirm-srp-modal-button-success'));
 
-      expect(setSeedPhraseBackedUp).toHaveBeenCalledWith(true);
-      expect(mockHistoryPush).toHaveBeenCalledWith(ONBOARDING_COMPLETION_ROUTE);
-    });
+    expect(setSeedPhraseBackedUp).toHaveBeenCalledWith(true);
+    expect(mockHistoryPush).toHaveBeenCalledWith(ONBOARDING_COMPLETION_ROUTE);
   });
 });

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.js
@@ -163,7 +163,7 @@ describe('Confirm Recovery Phrase Component', () => {
   });
 
   it('should enable confirm recovery phrase with correct word inputs', () => {
-    const { queryByTestId, queryAllByTestId, getByTestId } = renderWithProvider(
+    const { queryByTestId, queryAllByTestId, getByText } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,
       mockStore,
     );
@@ -187,7 +187,7 @@ describe('Confirm Recovery Phrase Component', () => {
     expect(confirmRecoveryPhraseButton).not.toBeDisabled();
     fireEvent.click(confirmRecoveryPhraseButton);
 
-    const gotItButton = getByTestId('confirm-srp-modal-button-success');
+    const gotItButton = getByText('Got it');
     expect(gotItButton).toBeInTheDocument();
     fireEvent.click(gotItButton);
 
@@ -200,7 +200,7 @@ describe('Confirm Recovery Phrase Component', () => {
       .spyOn(BrowserRuntimeUtils, 'getBrowserName')
       .mockReturnValue(PLATFORM_FIREFOX);
 
-    const { queryByTestId, queryAllByTestId, getByTestId } = renderWithProvider(
+    const { queryByTestId, queryAllByTestId, getByText } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,
       mockStore,
     );
@@ -222,7 +222,7 @@ describe('Confirm Recovery Phrase Component', () => {
     );
 
     fireEvent.click(confirmRecoveryPhraseButton);
-    fireEvent.click(getByTestId('confirm-srp-modal-button-success'));
+    fireEvent.click(getByText('Got it'));
 
     expect(setSeedPhraseBackedUp).toHaveBeenCalledWith(true);
     expect(mockHistoryPush).toHaveBeenCalledWith(ONBOARDING_COMPLETION_ROUTE);

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-srp-modal.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-srp-modal.tsx
@@ -81,7 +81,9 @@ export default function ConfirmSrpModal({
           </Text>
           <Box marginTop={6}>
             <Button
-              data-testid="confirm-srp-modal-button"
+              data-testid={`confirm-srp-modal-button-${
+                isError ? 'error' : 'success'
+              }`}
               variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
               onClick={handleContinue}

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-srp-modal.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-srp-modal.tsx
@@ -81,9 +81,7 @@ export default function ConfirmSrpModal({
           </Text>
           <Box marginTop={6}>
             <Button
-              data-testid={`confirm-srp-modal-button-${
-                isError ? 'error' : 'success'
-              }`}
+              data-testid="confirm-srp-modal-button"
               variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
               onClick={handleContinue}

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
@@ -43,9 +43,9 @@ export default function RecoveryPhraseChips({
   );
   const [quizAnswers, setQuizAnswers] = useState(
     indicesToCheck.map((index) => ({
-      index,
-      word: '',
-      answerIndex: -1, // the index of the answer in the secret recovery phrase chips UI
+      index, // the index in the SRP chips UI where the answer is inserted
+      word: '', // the answer value
+      actualIndexInSrp: -1, // the correct index of the answer value in the secret recovery phrase
     })),
   );
 
@@ -65,12 +65,16 @@ export default function RecoveryPhraseChips({
   );
 
   const addQuizWord = useCallback(
-    (word, answerIndex) => {
+    (word, actualIndexInSrp) => {
       const newQuizAnswers = [...quizAnswers];
       const targetIndex = newQuizAnswers.findIndex(
         (answer) => answer.index === indexToFocus,
       );
-      newQuizAnswers[targetIndex] = { index: indexToFocus, word, answerIndex };
+      newQuizAnswers[targetIndex] = {
+        index: indexToFocus,
+        word,
+        actualIndexInSrp,
+      };
       setQuizAnswers(newQuizAnswers);
       setIndexToFocus(setNextTargetIndex(newQuizAnswers));
     },
@@ -86,7 +90,7 @@ export default function RecoveryPhraseChips({
       newQuizAnswers[targetIndex] = {
         ...newQuizAnswers[targetIndex],
         word: '',
-        answerIndex: -1,
+        actualIndexInSrp: -1,
       };
 
       setQuizAnswers(newQuizAnswers);
@@ -104,7 +108,7 @@ export default function RecoveryPhraseChips({
       const newQuizAnswers = quizWords.map((word) => ({
         index: word.index,
         word: '',
-        answerIndex: -1,
+        actualIndexInSrp: -1,
       }));
       setQuizAnswers(newQuizAnswers);
       setIndexToFocus(setNextTargetIndex(newQuizAnswers));
@@ -232,14 +236,17 @@ export default function RecoveryPhraseChips({
       {quizWords.length === 3 && (
         <Box display={Display.Flex} gap={2} width={BlockSize.Full}>
           {quizWords.map((quizWord) => {
-            // check if the word is answered by checking if the word and index match
+            const actualIdxInSrp = quizWord.index;
+            // check if the quiz word has been added to the quizAnswers array
+            // here we are checking the answer's actual index in the secret recovery phrase
+            // to handle the case where the quiz words has the same value but different indexes
+            // e.g. the quiz words are ["one", "two", "one"]
             const isAnswered = quizAnswers.some(
-              (x) =>
-                x.word === quizWord.word && x.answerIndex === quizWord.index,
+              (answer) => answer.actualIndexInSrp === actualIdxInSrp,
             );
             return isAnswered ? (
               <ButtonBase
-                data-testid={`recovery-phrase-quiz-answered-${quizWord.index}`}
+                data-testid={`recovery-phrase-quiz-answered-${actualIdxInSrp}`}
                 key={quizWord.index}
                 color={TextColor.textAlternative}
                 borderRadius={BorderRadius.LG}
@@ -248,20 +255,20 @@ export default function RecoveryPhraseChips({
                   removeQuizWord(quizWord.word);
                 }}
               >
-                {quizWord.word}
+                {secretRecoveryPhrase[actualIdxInSrp]}
               </ButtonBase>
             ) : (
               <Button
-                data-testid={`recovery-phrase-quiz-unanswered-${quizWord.index}`}
+                data-testid={`recovery-phrase-quiz-unanswered-${actualIdxInSrp}`}
                 key={quizWord.index}
                 variant={ButtonVariant.Secondary}
                 borderRadius={BorderRadius.LG}
                 block
                 onClick={() => {
-                  addQuizWord(quizWord.word, quizWord.index);
+                  addQuizWord(quizWord.word, actualIdxInSrp);
                 }}
               >
-                {quizWord.word}
+                {secretRecoveryPhrase[actualIdxInSrp]}
               </Button>
             );
           })}

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
@@ -47,6 +47,10 @@ export default function RecoveryPhraseChips({
       word: '',
     })),
   );
+  const [indexToFocus, setIndexToFocus] = useState(
+    // sort the quiz words by index, and then get the index of the first quiz word
+    quizWords.sort((a, b) => a.index - b.index)[0].index,
+  );
 
   const setNextTargetIndex = (newQuizAnswers) => {
     const emptyAnswers = newQuizAnswers.reduce((acc, answer) => {
@@ -56,12 +60,8 @@ export default function RecoveryPhraseChips({
       return acc;
     }, []);
     const firstEmpty = emptyAnswers.length ? Math.min(...emptyAnswers) : -1;
-
     return firstEmpty;
   };
-  const [indexToFocus, setIndexToFocus] = useState(
-    setNextTargetIndex(quizAnswers),
-  );
 
   const addQuizWord = useCallback(
     (word) => {
@@ -96,17 +96,6 @@ export default function RecoveryPhraseChips({
   useEffect(() => {
     setInputValue?.(quizAnswers);
   }, [quizAnswers, setInputValue]);
-
-  useEffect(() => {
-    if (quizWords.length) {
-      const newQuizAnswers = quizWords.map((word) => ({
-        index: word.index,
-        word: '',
-      }));
-      setQuizAnswers(newQuizAnswers);
-      setIndexToFocus(setNextTargetIndex(newQuizAnswers));
-    }
-  }, [quizWords]);
 
   return (
     <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={4}>
@@ -229,7 +218,10 @@ export default function RecoveryPhraseChips({
       {quizWords.length > 0 && (
         <Box display={Display.Flex} gap={2} width={BlockSize.Full}>
           {quizWords.map((value) => {
-            const isAnswered = quizAnswers.some((x) => x.word === value.word);
+            // check if the word is answered by checking if the word and index match
+            const isAnswered = quizAnswers.some(
+              (x) => x.word === value.word && x.index === value.index,
+            );
             return isAnswered ? (
               <ButtonBase
                 data-testid={`recovery-phrase-quiz-answered-${value.index}`}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR addresses the flaky unit test `ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.js`.
The test flakiness is because of the two reasons:
- Missed to handle the two same-word scenario in the 3-word Srp Quiz (in the recovery-phrase-chips component).
- Design flaw in the unit test case

### Steps to reproduce the issue:
Sample seed phrase: `debris dizzy just just just float just just just just speak just`
Let's assume that in the 3-word SRP Quiz, the word `just` appears more than one time, which is a valid case, since the word, `just` appears multiple times in the seed phrase. 
When clicking on one of `just` chip, will disable the another chip in the quiz which has the same word, `just`.

### The fix:
- Update the `isAnswered` check by comparing both quiz word value and index, in the Quiz word render.
- Fixed the unit test to correctly fire a click action on the correct quiz word (chip element).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33781?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create a new wallet which generates a seed phrase which include identical word more than once (This is a bit hard to reproduce/simulate, just try to generate until u get one 😅 ) 
2. During the onboarding step, in Secure your wallet page, take the quiz and backup
3. User should be correct finish the Quiz, even If there're multiple occurrences of same word in the Seed phrase.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
