### PR TITLE
feat: poll incoming transactions only when viewing transaction list

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -198,6 +198,10 @@ function getApi(
     getLayer1GasFee: controller.getLayer1GasFee.bind(controller),
     getTransactions: controller.getTransactions.bind(controller),
     isAtomicBatchSupported: controller.isAtomicBatchSupported.bind(controller),
+    startIncomingTransactionPolling:
+      controller.startIncomingTransactionPolling.bind(controller),
+    stopIncomingTransactionPolling:
+      controller.stopIncomingTransactionPolling.bind(controller),
     updateAtomicBatchData: controller.updateAtomicBatchData.bind(controller),
     updateBatchTransactions:
       controller.updateBatchTransactions.bind(controller),

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -237,20 +237,6 @@ const TEST_ADDRESS_3 = '0xeb9e64b93097bc15f01f13eae97015c57ab64823';
 const TEST_SEED_ALT =
   'setup olympic issue mobile velvet surge alcohol burger horse view reopen gentle';
 const TEST_ADDRESS_ALT = '0xc42edfcc21ed14dda456aa0756c153f7985d8813';
-const TEST_INTERNAL_ACCOUNT = {
-  id: '2d47e693-26c2-47cb-b374-6151199bbe3f',
-  address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-  metadata: {
-    name: 'Account 1',
-    keyring: {
-      type: 'HD Key Tree',
-    },
-    lastSelected: 0,
-  },
-  options: {},
-  methods: ETH_EOA_METHODS,
-  type: EthAccountType.Eoa,
-};
 
 const ALT_MAINNET_RPC_URL = 'http://localhost:8545';
 const POLYGON_RPC_URL = 'https://polygon.llamarpc.com';
@@ -3581,36 +3567,6 @@ describe('MetaMaskController', () => {
         );
 
         expect(tokenSymbol).toStrictEqual(null);
-      });
-    });
-
-    describe('incoming transactions', () => {
-      it('starts incoming transaction polling if useExternalServices is enabled for that chainId', async () => {
-        expect(
-          TransactionController.prototype.startIncomingTransactionPolling,
-        ).not.toHaveBeenCalled();
-
-        await simulatePreferencesChange({
-          useExternalServices: true,
-        });
-
-        expect(
-          TransactionController.prototype.startIncomingTransactionPolling,
-        ).toHaveBeenCalledTimes(1);
-      });
-
-      it('stops incoming transaction polling if useExternalServices is disabled for that chainId', async () => {
-        expect(
-          TransactionController.prototype.stopIncomingTransactionPolling,
-        ).not.toHaveBeenCalled();
-
-        await simulatePreferencesChange({
-          useExternalServices: false,
-        });
-
-        expect(
-          TransactionController.prototype.stopIncomingTransactionPolling,
-        ).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -391,10 +391,6 @@ describe('MetaMaskController', () => {
       jest.spyOn(MetaMaskController.prototype, 'resetStates');
 
       jest
-        .spyOn(TransactionController.prototype, 'updateIncomingTransactions')
-        .mockReturnValue();
-
-      jest
         .spyOn(
           TransactionController.prototype,
           'startIncomingTransactionPolling',
@@ -3614,35 +3610,6 @@ describe('MetaMaskController', () => {
 
         expect(
           TransactionController.prototype.stopIncomingTransactionPolling,
-        ).toHaveBeenCalledTimes(1);
-      });
-
-      it('updates incoming transactions when changing account', async () => {
-        expect(
-          TransactionController.prototype.updateIncomingTransactions,
-        ).not.toHaveBeenCalled();
-
-        metamaskController.controllerMessenger.publish(
-          'AccountsController:selectedAccountChange',
-          TEST_INTERNAL_ACCOUNT,
-        );
-
-        expect(
-          TransactionController.prototype.updateIncomingTransactions,
-        ).toHaveBeenCalledTimes(1);
-      });
-
-      it('updates incoming transactions when changing network', async () => {
-        expect(
-          TransactionController.prototype.updateIncomingTransactions,
-        ).not.toHaveBeenCalled();
-
-        await Messenger.prototype.subscribe.mock.calls
-          .filter((args) => args[0] === 'NetworkController:networkDidChange')
-          .slice(-1)[0][1]();
-
-        expect(
-          TransactionController.prototype.updateIncomingTransactions,
         ).toHaveBeenCalledTimes(1);
       });
     });

--- a/package.json
+++ b/package.json
@@ -331,7 +331,7 @@
     "@metamask/solana-wallet-snap": "^1.33.1",
     "@metamask/solana-wallet-standard": "^0.5.0",
     "@metamask/streams": "^0.2.0",
-    "@metamask/transaction-controller": "^57.4.0",
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@58.0.0-preview-08a4995",
     "@metamask/user-operation-controller": "^36.0.0",
     "@metamask/utils": "^11.1.0",
     "@ngraveio/bc-ur": "^1.1.13",

--- a/package.json
+++ b/package.json
@@ -331,7 +331,7 @@
     "@metamask/solana-wallet-snap": "^1.33.1",
     "@metamask/solana-wallet-standard": "^0.5.0",
     "@metamask/streams": "^0.2.0",
-    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@58.0.0-preview-08a4995",
+    "@metamask/transaction-controller": "^58.1.0",
     "@metamask/user-operation-controller": "^36.0.0",
     "@metamask/utils": "^11.1.0",
     "@ngraveio/bc-ur": "^1.1.13",

--- a/test/e2e/tests/settings/clear-activity.spec.ts
+++ b/test/e2e/tests/settings/clear-activity.spec.ts
@@ -10,8 +10,8 @@ import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow'
 describe('Clear account activity', function (this: Suite) {
   // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // When user get stuck with pending transactions, one can reset the account by clicking the 'Clear activity tab data' //
-  // button in settings, advanced tab. This functionality will clear all the send transactions history.                 //
-  // Note that the receive transactions history will be kept and it only only affects the current network.              //
+  // button in settings, advanced tab. This functionality will clear all the transactions history.                      //
+  // Note that it only only affects the current network.                                                                //
   // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   it('User can clear account activity via the advanced setting tab, ', async function () {
     await withFixtures(
@@ -42,9 +42,7 @@ describe('Clear account activity', function (this: Suite) {
         await advancedSettings.clearActivityTabData();
         await settingsPage.closeSettingsPage();
 
-        // Check send transaction history is cleared and receive transaction history is kept
-        await activityList.check_completedTxNumberDisplayedInActivity(1);
-        await activityList.check_txAction('Receive', 1);
+        await activityList.check_noTxInActivity();
       },
     );
   });

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -122,6 +122,10 @@ import {
   ENVIRONMENT_TYPE_POPUP,
 } from '../../../../shared/constants/app';
 import { NetworkFilterComponent } from '../../multichain/network-filter-menu';
+import {
+  startIncomingTransactionPolling,
+  stopIncomingTransactionPolling,
+} from '../../../store/controller-actions/transaction-controller';
 import NoTransactions from './no-transactions';
 
 const PAGE_INCREMENT = 10;
@@ -448,6 +452,18 @@ export default function TransactionList({
   const isFullScreen =
     windowType !== ENVIRONMENT_TYPE_NOTIFICATION &&
     windowType !== ENVIRONMENT_TYPE_POPUP;
+
+  useEffect(() => {
+    stopIncomingTransactionPolling();
+    startIncomingTransactionPolling();
+
+    return () => {
+      stopIncomingTransactionPolling();
+    };
+  }, [
+    // Required to restart polling on new account
+    selectedAccount,
+  ]);
 
   const renderDateStamp = (index, dateGroup) => {
     return index === 0 ? (

--- a/ui/components/app/transaction-list/transaction-list.test.js
+++ b/ui/components/app/transaction-list/transaction-list.test.js
@@ -22,9 +22,15 @@ import { formatBlockExplorerAddressUrl } from '../../../../shared/lib/multichain
 import { MOCK_TRANSACTION_BY_TYPE } from '../../../../.storybook/initial-states/transactions';
 import { createMockInternalAccount } from '../../../../test/jest/mocks';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
+import {
+  startIncomingTransactionPolling,
+  stopIncomingTransactionPolling,
+} from '../../../store/controller-actions/transaction-controller';
 import TransactionList, {
   filterTransactionsByToken,
 } from './transaction-list.component';
+
+jest.mock('../../../store/controller-actions/transaction-controller');
 
 const MOCK_INTERNAL_ACCOUNT = createMockInternalAccount({
   address: '0xefga64466f257793eaa52fcfff5066894b76a149',
@@ -188,6 +194,14 @@ const render = (state = defaultState) => {
 };
 
 describe('TransactionList', () => {
+  const startIncomingTransactionPollingMock = jest.mocked(
+    startIncomingTransactionPolling,
+  );
+
+  const stopIncomingTransactionPollingMock = jest.mocked(
+    stopIncomingTransactionPolling,
+  );
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -347,6 +361,26 @@ describe('TransactionList', () => {
       name: 'View on block explorer',
     });
     expect(viewOnExplorerBtn).toBeInTheDocument();
+  });
+
+  it('starts incoming transaction polling on mount', () => {
+    render();
+    expect(startIncomingTransactionPollingMock).toHaveBeenCalled();
+  });
+
+  it('stops incoming transaction polling on mount', () => {
+    render();
+    expect(stopIncomingTransactionPollingMock).toHaveBeenCalled();
+  });
+
+  it('stops incoming transaction polling on unmount', () => {
+    const { unmount } = render();
+
+    const count = stopIncomingTransactionPollingMock.mock.calls.length;
+
+    unmount();
+
+    expect(stopIncomingTransactionPollingMock).toHaveBeenCalledTimes(count + 1);
   });
 
   describe('keepOnlyNonEvmTransactionsForToken', () => {

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -26,6 +26,8 @@ jest.mock('../../../store/actions', () => ({
   tokenBalancesStopPollingByPollingToken: jest.fn(),
 }));
 
+jest.mock('../../../store/controller-actions/transaction-controller');
+
 // Mock the price chart
 jest.mock('react-chartjs-2', () => ({ Line: () => null }));
 

--- a/ui/store/controller-actions/transaction-controller.ts
+++ b/ui/store/controller-actions/transaction-controller.ts
@@ -13,6 +13,18 @@ export async function isAtomicBatchSupported(
   );
 }
 
+export async function startIncomingTransactionPolling() {
+  return await submitRequestToBackground<void>(
+    'startIncomingTransactionPolling',
+  );
+}
+
+export async function stopIncomingTransactionPolling() {
+  return await submitRequestToBackground<void>(
+    'stopIncomingTransactionPolling',
+  );
+}
+
 export async function updateAtomicBatchData(
   request: Parameters<TransactionController['updateAtomicBatchData']>[0],
 ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7122,9 +7122,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@58.0.0-preview-08a4995":
-  version: 58.0.0-preview-08a4995
-  resolution: "@metamask-previews/transaction-controller@npm:58.0.0-preview-08a4995"
+"@metamask/transaction-controller@npm:^58.1.0":
+  version: 58.1.0
+  resolution: "@metamask/transaction-controller@npm:58.1.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -7154,7 +7154,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^24.0.0
     "@metamask/network-controller": ^24.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 10/edde326a62d7403abc8930a7db4a18952e8adb194612c032a08971eb60ca93a34c2527d9098f60710bca0f0d751f9bd18fd6be69461b68337e2cd34035f686b3
+  checksum: 10/55eb5a88a09f5152b638975b85156817c012041a3c56e1552e1e21de3db8f63f1820d1fd14f8cfa2983bd019cb399c34a7c7e45875853a02f1606fdc804f3bc8
   languageName: node
   linkType: hard
 
@@ -30451,7 +30451,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.3.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.0"
     "@metamask/test-dapp-solana": "npm:^0.3.1"
-    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@58.0.0-preview-08a4995"
+    "@metamask/transaction-controller": "npm:^58.1.0"
     "@metamask/user-operation-controller": "npm:^36.0.0"
     "@metamask/utils": "npm:^11.1.0"
     "@ngraveio/bc-ur": "npm:^1.1.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7122,9 +7122,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^57.4.0":
-  version: 57.4.0
-  resolution: "@metamask/transaction-controller@npm:57.4.0"
+"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@58.0.0-preview-08a4995":
+  version: 58.0.0-preview-08a4995
+  resolution: "@metamask-previews/transaction-controller@npm:58.0.0-preview-08a4995"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -7148,13 +7148,13 @@ __metadata:
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@babel/runtime": ^7.0.0
-    "@metamask/accounts-controller": ^30.0.0
+    "@metamask/accounts-controller": ^31.0.0
     "@metamask/approval-controller": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-    "@metamask/gas-fee-controller": ^23.0.0
-    "@metamask/network-controller": ^23.0.0
+    "@metamask/gas-fee-controller": ^24.0.0
+    "@metamask/network-controller": ^24.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 10/6732d72253d39d4298e62d6be4c1755eb14f149381211f256f7462296e48cde6e4c905c06022117ca7ca9b4d79bf263fd4b663a569b85b06405500b8eae13452
+  checksum: 10/edde326a62d7403abc8930a7db4a18952e8adb194612c032a08971eb60ca93a34c2527d9098f60710bca0f0d751f9bd18fd6be69461b68337e2cd34035f686b3
   languageName: node
   linkType: hard
 
@@ -30451,7 +30451,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.3.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.0"
     "@metamask/test-dapp-solana": "npm:^0.3.1"
-    "@metamask/transaction-controller": "npm:^57.4.0"
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@58.0.0-preview-08a4995"
     "@metamask/user-operation-controller": "npm:^36.0.0"
     "@metamask/utils": "npm:^11.1.0"
     "@ngraveio/bc-ur": "npm:^1.1.13"


### PR DESCRIPTION
## **Description**

Poll incoming transactions from the accounts API only when viewing the transaction list.

Continue to stop polling when closing all popups as a safety measure.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33783?quickstart=1)

## **Related issues**

Fixes: [#5190](https://github.com/MetaMask/MetaMask-planning/issues/5190)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
