### PR TITLE
release: auto-update for PR targeting release branch

### DIFF
--- a/.github/workflows/auto-update-pr-targeting-release.yml
+++ b/.github/workflows/auto-update-pr-targeting-release.yml
@@ -1,0 +1,76 @@
+name: Auto-update for PR targeting release branch
+
+on:
+  pull_request:
+    branches:
+      - Version-v*
+
+jobs:
+  auto-update:
+    name: Auto-update
+    runs-on: ubuntu-latest
+    env:
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      YARN_ENABLE_HARDENED_MODE: false
+      INFURA_PROJECT_ID: 00000000000
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      # We don't want to use action-checkout-and-setup here because it forces `yarn --immutable`
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Use PAT to ensure that the commit later can trigger status check workflows
+          token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      # Prevent loops on this action by checking if the last commit author is the bot itself
+      - name: Prevent loops
+        id: prevent-loops
+        run: |
+          author_name=$(git log -1 --pretty=format:'%an')
+          if [ "$author_name" = "MetaMask Bot" ]; then
+            echo "The author of the most recent commit is MetaMask Bot. Exiting the workflow."
+            echo "stop_loop=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "The author of the most recent commit is *not* MetaMask Bot, continuing..."
+            echo "stop_loop=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - run: corepack enable
+        if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}
+
+      - name: Set up Node.js
+        if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - run: yarn dedupe
+        if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}
+
+      - name: Update all LavaMoat policies
+        if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}
+        run: yarn lavamoat:auto
+
+      - name: Update attributions
+        if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}
+        run: yarn attributions:generate
+        env:
+          CI: false # We want it to restore the allow-scripts plugin and development dependencies
+
+      - name: Commit if there are changes
+        if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}
+        run: |
+          if git diff --exit-code
+          then
+            echo "No changes detected"
+          else
+            echo "Changes detected, committing..."
+            git config --global user.name 'MetaMask Bot'
+            git config --global user.email 'metamaskbot@users.noreply.github.com'
+            git commit -am "release: dedupe, update LavaMoat policies, update attributions"
+            git push
+          fi

--- a/.github/workflows/auto-update-pr-targeting-release.yml
+++ b/.github/workflows/auto-update-pr-targeting-release.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}
         run: yarn attributions:generate
         env:
-          CI: false # We want it to restore the allow-scripts plugin and development dependencies
+          FORCE_CLEANUP: true # We want it to restore the allow-scripts plugin and development dependencies
 
       - name: Commit if there are changes
         if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}

--- a/development/generate-attributions.sh
+++ b/development/generate-attributions.sh
@@ -47,7 +47,7 @@ main() {
   yarn generate-attribution -o "${PROJECT_DIRECTORY}" -b "${PROJECT_DIRECTORY}"
 
   # Check if the script is running in a CI environment (GitHub Actions sets the CI variable to true)
-  if [ -z "${CI:-}" ] || [ "${CI}" = "false" ]; then
+  if [ -z "${CI:-}" ] || [ "${FORCE_CLEANUP}" = "true" ]; then
     # If not running in CI, restore the allow-scripts plugin and development dependencies.
     cd "${PROJECT_DIRECTORY}"
     git checkout -- .yarnrc.yml .yarn package.json

--- a/development/generate-attributions.sh
+++ b/development/generate-attributions.sh
@@ -47,7 +47,7 @@ main() {
   yarn generate-attribution -o "${PROJECT_DIRECTORY}" -b "${PROJECT_DIRECTORY}"
 
   # Check if the script is running in a CI environment (GitHub Actions sets the CI variable to true)
-  if [ -z "${CI:-}" ]; then
+  if [ -z "${CI:-}" ] || [ "${CI}" = "false" ]; then
     # If not running in CI, restore the allow-scripts plugin and development dependencies.
     cd "${PROJECT_DIRECTORY}"
     git checkout -- .yarnrc.yml .yarn package.json


### PR DESCRIPTION
## **Description**

Automates a task that frequently has to be done by the Release Engineer after a cherry-pick comes in.  The action will not get stuck in a loop because it checks if the last commit author is the bot itself.

Runs the following:
```
yarn dedupe
yarn attributions:generate
yarn lavamoat:auto
```
...then commits and pushes if there are changes.

It runs with these options so that it's allowed to solve certain types of `yarn.lock` merge conflicts all by itself:
```
YARN_ENABLE_IMMUTABLE_INSTALLS: false
YARN_ENABLE_HARDENED_MODE: false
```

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->