### PR TITLE
feat: disable enforced simulations

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5371,6 +5371,15 @@
   "simulationErrorMessageV2": {
     "message": "We were not able to estimate gas. There might be an error in the contract and this transaction may fail."
   },
+  "simulationSettingsModalEnforceToggle": {
+    "message": "Enforce balance changes"
+  },
+  "simulationSettingsModalEnforceToggleDescription": {
+    "message": "To keep your money safe, this transaction won't go through if the balance changes or the slippage tolerance isn't met."
+  },
+  "simulationSettingsModalTitle": {
+    "message": "Transaction settings"
+  },
   "simulationsSettingDescription": {
     "message": "Turn this on to estimate balance changes of transactions and signatures before you confirm them. This doesn't guarantee their final outcome. $1"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5371,6 +5371,15 @@
   "simulationErrorMessageV2": {
     "message": "We were not able to estimate gas. There might be an error in the contract and this transaction may fail."
   },
+  "simulationSettingsModalEnforceToggle": {
+    "message": "Enforce balance changes"
+  },
+  "simulationSettingsModalEnforceToggleDescription": {
+    "message": "To keep your money safe, this transaction won't go through if the balance changes or the slippage tolerance isn't met."
+  },
+  "simulationSettingsModalTitle": {
+    "message": "Transaction settings"
+  },
   "simulationsSettingDescription": {
     "message": "Turn this on to estimate balance changes of transactions and signatures before you confirm them. This doesn't guarantee their final outcome. $1"
   },

--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -60,6 +60,8 @@ export const SENTRY_BACKGROUND_STATE = {
     onboardingDate: false,
     currentExtensionPopupId: false,
     defaultHomeActiveTabName: true,
+    enableEnforcedSimulations: true,
+    enableEnforcedSimulationsForTransactions: false,
     fullScreenGasPollTokens: true,
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/app/scripts/controller-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/transaction-controller-messenger.ts
@@ -35,6 +35,7 @@ import {
   SwapsControllerSetApproveTxIdAction,
   SwapsControllerSetTradeTxIdAction,
 } from '../../controllers/swaps/swaps.types';
+import { AppStateControllerGetStateAction } from '../../controllers/app-state-controller';
 import {
   InstitutionalSnapControllerPublishHookAction,
   InstitutionalSnapControllerBeforeCheckPendingTransactionHookAction,
@@ -44,6 +45,7 @@ type MessengerActions =
   | ApprovalControllerActions
   | AccountsControllerGetSelectedAccountAction
   | AccountsControllerGetStateAction
+  | AppStateControllerGetStateAction
   | DelegationControllerSignDelegationAction
   | InstitutionalSnapControllerPublishHookAction
   | InstitutionalSnapControllerBeforeCheckPendingTransactionHookAction
@@ -117,6 +119,7 @@ export function getTransactionControllerInitMessenger(
       'ApprovalController:endFlow',
       'ApprovalController:startFlow',
       'ApprovalController:updateRequestState',
+      'AppStateController:getState',
       'DelegationController:signDelegation',
       'InstitutionalSnapController:beforeCheckPendingTransactionHook',
       'InstitutionalSnapController:publishHook',

--- a/app/scripts/controller-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/transaction-controller-messenger.ts
@@ -12,6 +12,7 @@ import {
 } from '@metamask/network-controller';
 import {
   TransactionControllerEstimateGasAction,
+  TransactionControllerGetStateAction,
   TransactionControllerMessenger,
   TransactionControllerPostTransactionBalanceUpdatedEvent,
   TransactionControllerTransactionApprovedEvent,
@@ -57,7 +58,8 @@ type MessengerActions =
   | RemoteFeatureFlagControllerGetStateAction
   | SwapsControllerSetApproveTxIdAction
   | SwapsControllerSetTradeTxIdAction
-  | TransactionControllerEstimateGasAction;
+  | TransactionControllerEstimateGasAction
+  | TransactionControllerGetStateAction;
 
 type MessengerEvents =
   | TransactionControllerTransactionApprovedEvent
@@ -130,6 +132,7 @@ export function getTransactionControllerInitMessenger(
       'SwapsController:setApproveTxId',
       'SwapsController:setTradeTxId',
       'TransactionController:estimateGas',
+      'TransactionController:getState',
     ],
   });
 }

--- a/app/scripts/controllers/app-state-controller.test.ts
+++ b/app/scripts/controllers/app-state-controller.test.ts
@@ -45,6 +45,8 @@ const extensionMock = {
   },
 } as unknown as jest.Mocked<Browser>;
 
+const TRANSACTION_ID_MOCK = '123-456';
+
 describe('AppStateController', () => {
   describe('setOutdatedBrowserWarningLastShown', () => {
     it('sets the last shown time', async () => {
@@ -606,6 +608,46 @@ describe('AppStateController', () => {
           expect(
             controller.getThrottledOriginState('example.com'),
           ).toStrictEqual({ rejections: 1, lastRejection: expect.any(Number) });
+        });
+      });
+    });
+  });
+
+  describe('setEnableEnforcedSimulations', () => {
+    it('updates the enableEnforcedSimulations state', async () => {
+      await withController(({ controller }) => {
+        controller.setEnableEnforcedSimulations(false);
+        expect(controller.state.enableEnforcedSimulations).toBe(false);
+
+        controller.setEnableEnforcedSimulations(true);
+        expect(controller.state.enableEnforcedSimulations).toBe(true);
+      });
+    });
+  });
+
+  describe('setEnableEnforcedSimulationsForTransaction', () => {
+    it('updates the enableEnforcedSimulationsForTransactions state', async () => {
+      await withController(({ controller }) => {
+        controller.setEnableEnforcedSimulationsForTransaction(
+          TRANSACTION_ID_MOCK,
+          true,
+        );
+
+        expect(
+          controller.state.enableEnforcedSimulationsForTransactions,
+        ).toStrictEqual({
+          [TRANSACTION_ID_MOCK]: true,
+        });
+
+        controller.setEnableEnforcedSimulationsForTransaction(
+          TRANSACTION_ID_MOCK,
+          false,
+        );
+
+        expect(
+          controller.state.enableEnforcedSimulationsForTransactions,
+        ).toStrictEqual({
+          [TRANSACTION_ID_MOCK]: false,
         });
       });
     });

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -90,6 +90,8 @@ export type AppStateControllerState = {
   isUpdateAvailable: boolean;
   updateModalLastDismissedAt: number | null;
   lastUpdatedAt: number | null;
+  enableEnforcedSimulations: boolean;
+  enableEnforcedSimulationsForTransactions: Record<string, boolean>;
 };
 
 const controllerName = 'AppStateController';
@@ -209,6 +211,8 @@ const getDefaultAppStateControllerState = (): AppStateControllerState => ({
   isUpdateAvailable: false,
   updateModalLastDismissedAt: null,
   lastUpdatedAt: null,
+  enableEnforcedSimulations: true,
+  enableEnforcedSimulationsForTransactions: {},
   ...getInitialStateOverrides(),
 });
 
@@ -384,6 +388,14 @@ const controllerMetadata = {
   },
   lastUpdatedAt: {
     persist: true,
+    anonymous: true,
+  },
+  enableEnforcedSimulations: {
+    persist: true,
+    anonymous: true,
+  },
+  enableEnforcedSimulationsForTransactions: {
+    persist: false,
     anonymous: true,
   },
 };
@@ -1119,6 +1131,21 @@ export class AppStateController extends BaseController<
   ): void {
     this.update((state) => {
       state.throttledOrigins[origin] = throttledOriginState;
+    });
+  }
+
+  setEnableEnforcedSimulations(enabled: boolean): void {
+    this.update((state) => {
+      state.enableEnforcedSimulations = enabled;
+    });
+  }
+
+  setEnableEnforcedSimulationsForTransaction(
+    transactionId: string,
+    enabled: boolean,
+  ): void {
+    this.update((state) => {
+      state.enableEnforcedSimulationsForTransactions[transactionId] = enabled;
     });
   }
 }

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -1,13 +1,10 @@
 import {
   SimulationData,
   SimulationTokenStandard,
-  TransactionContainerType,
-  TransactionController,
   TransactionMeta,
   TransactionParams,
 } from '@metamask/transaction-controller';
 import { Hex, createProjectLogger, hexToNumber } from '@metamask/utils';
-import { cloneDeep } from 'lodash';
 import { TransactionControllerInitMessenger } from '../../../controller-init/messengers/transaction-controller-messenger';
 import {
   DeleGatorEnvironment,
@@ -23,60 +20,11 @@ import {
   UnsignedDelegation,
   encodeRedeemDelegations,
 } from '../../../../../shared/lib/delegation/delegation';
-import { applyTransactionContainers } from './util';
 
 const log = createProjectLogger('enforced-simulations');
 
 const MOCK_DELEGATION_SIGNATURE =
   '0x2261a7810ed3e9cde160895909e138e2f68adb2da86fcf98ea0840701df107721fb369ab9b52550ea98832c09f8185284aca4c94bd345e867a4f4461868dd7751b';
-
-export async function enforceSimulationsForTransaction({
-  transactionId,
-  messenger,
-  updateEditableParams,
-}: {
-  transactionId: Hex;
-  messenger: TransactionControllerInitMessenger;
-  updateEditableParams: TransactionController['updateEditableParams'];
-}) {
-  const transactionControllerState = await messenger.call(
-    'TransactionController:getState',
-  );
-
-  const transactionMeta = transactionControllerState.transactions.find(
-    (tx) => tx.id === transactionId,
-  );
-
-  if (!transactionMeta) {
-    throw new Error(`Transaction with ID ${transactionId} not found.`);
-  }
-
-  const { containerTypes = [] } = transactionMeta;
-
-  const newContainerTypes = [
-    ...containerTypes,
-    TransactionContainerType.EnforcedSimulations,
-  ];
-
-  const { updateTransaction } = await applyTransactionContainers({
-    isApproved: false,
-    messenger,
-    transactionMeta,
-    types: newContainerTypes,
-  });
-
-  const newTransactionMeta = cloneDeep(transactionMeta);
-
-  updateTransaction(newTransactionMeta);
-
-  updateEditableParams(transactionId, {
-    containerTypes: newContainerTypes,
-    data: newTransactionMeta.txParams.data,
-    gas: newTransactionMeta.txParams.gas,
-    to: newTransactionMeta.txParams.to,
-    value: newTransactionMeta.txParams.value,
-  });
-}
 
 export async function enforceSimulations({
   chainId,

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -1,10 +1,13 @@
 import {
   SimulationData,
   SimulationTokenStandard,
+  TransactionContainerType,
+  TransactionController,
   TransactionMeta,
   TransactionParams,
 } from '@metamask/transaction-controller';
 import { Hex, createProjectLogger, hexToNumber } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
 import { TransactionControllerInitMessenger } from '../../../controller-init/messengers/transaction-controller-messenger';
 import {
   DeleGatorEnvironment,
@@ -20,11 +23,60 @@ import {
   UnsignedDelegation,
   encodeRedeemDelegations,
 } from '../../../../../shared/lib/delegation/delegation';
+import { applyTransactionContainers } from './util';
 
 const log = createProjectLogger('enforced-simulations');
 
 const MOCK_DELEGATION_SIGNATURE =
   '0x2261a7810ed3e9cde160895909e138e2f68adb2da86fcf98ea0840701df107721fb369ab9b52550ea98832c09f8185284aca4c94bd345e867a4f4461868dd7751b';
+
+export async function enforceSimulationsForTransaction({
+  transactionId,
+  messenger,
+  updateEditableParams,
+}: {
+  transactionId: Hex;
+  messenger: TransactionControllerInitMessenger;
+  updateEditableParams: TransactionController['updateEditableParams'];
+}) {
+  const transactionControllerState = await messenger.call(
+    'TransactionController:getState',
+  );
+
+  const transactionMeta = transactionControllerState.transactions.find(
+    (tx) => tx.id === transactionId,
+  );
+
+  if (!transactionMeta) {
+    throw new Error(`Transaction with ID ${transactionId} not found.`);
+  }
+
+  const { containerTypes = [] } = transactionMeta;
+
+  const newContainerTypes = [
+    ...containerTypes,
+    TransactionContainerType.EnforcedSimulations,
+  ];
+
+  const { updateTransaction } = await applyTransactionContainers({
+    isApproved: false,
+    messenger,
+    transactionMeta,
+    types: newContainerTypes,
+  });
+
+  const newTransactionMeta = cloneDeep(transactionMeta);
+
+  updateTransaction(newTransactionMeta);
+
+  updateEditableParams(transactionId, {
+    containerTypes: newContainerTypes,
+    data: newTransactionMeta.txParams.data,
+    gas: newTransactionMeta.txParams.gas,
+    to: newTransactionMeta.txParams.to,
+    value: newTransactionMeta.txParams.value,
+  });
+}
 
 export async function enforceSimulations({
   chainId,
@@ -106,7 +158,7 @@ function generateDelegation({
   return delegation;
 }
 
-export function generateCalldata({
+function generateCalldata({
   transaction,
   delegation,
 }: {

--- a/app/scripts/lib/transaction/containers/util.test.ts
+++ b/app/scripts/lib/transaction/containers/util.test.ts
@@ -60,7 +60,6 @@ describe('Container Utils', () => {
 
     enforceSimulationsMock.mockResolvedValue({
       updateTransaction: (tx) => {
-        tx.chainId = CHAIN_ID_MOCK;
         tx.txParams.data = NEW_DATA_MOCK;
       },
     });
@@ -82,7 +81,7 @@ describe('Container Utils', () => {
       const transactionToUpdate = cloneDeep(TRANSACTION_META_MOCK);
       updateTransaction(transactionToUpdate);
 
-      expect(transactionToUpdate.chainId).toBe(CHAIN_ID_MOCK);
+      expect(transactionToUpdate.txParams.data).toBe(NEW_DATA_MOCK);
     });
 
     it('updates gas if not approved', async () => {

--- a/app/scripts/lib/transaction/containers/util.test.ts
+++ b/app/scripts/lib/transaction/containers/util.test.ts
@@ -1,29 +1,41 @@
 import {
   TransactionContainerType,
   TransactionControllerEstimateGasAction,
+  TransactionControllerGetStateAction,
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import { cloneDeep } from 'lodash';
 import { Messenger } from '@metamask/base-controller';
 import { TransactionControllerInitMessenger } from '../../../controller-init/messengers/transaction-controller-messenger';
-import { applyTransactionContainers } from './util';
+import {
+  applyTransactionContainers,
+  applyTransactionContainersExisting,
+} from './util';
 import { enforceSimulations } from './enforced-simulations';
 
 jest.mock('./enforced-simulations');
 
-const TRANSACTION_META_MOCK = { txParams: {} } as TransactionMeta;
+const TRANSACTION_ID_MOCK = '123-456';
 const CHAIN_ID_MOCK = '0x123' as const;
 const ESTIMATE_GAS_MOCK = '0x456' as const;
+const NEW_DATA_MOCK = '0x789' as const;
+
+const TRANSACTION_META_MOCK = {
+  id: TRANSACTION_ID_MOCK,
+  txParams: {},
+} as TransactionMeta;
 
 describe('Container Utils', () => {
   const enforceSimulationsMock = jest.mocked(enforceSimulations);
+  const getTransactionControllerStateMock = jest.fn();
   let messenger: TransactionControllerInitMessenger;
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     const baseMessenger = new Messenger<
-      TransactionControllerEstimateGasAction,
+      | TransactionControllerEstimateGasAction
+      | TransactionControllerGetStateAction,
       never
     >();
 
@@ -32,16 +44,29 @@ describe('Container Utils', () => {
       async () => ({ gas: ESTIMATE_GAS_MOCK, simulationFails: { debug: {} } }),
     );
 
+    baseMessenger.registerActionHandler(
+      'TransactionController:getState',
+      getTransactionControllerStateMock,
+    );
+
     messenger = baseMessenger.getRestricted({
       name: 'TransactionControllerInitMessenger',
-      allowedActions: ['TransactionController:estimateGas'],
+      allowedActions: [
+        'TransactionController:estimateGas',
+        'TransactionController:getState',
+      ],
       allowedEvents: [],
     });
 
     enforceSimulationsMock.mockResolvedValue({
       updateTransaction: (tx) => {
         tx.chainId = CHAIN_ID_MOCK;
+        tx.txParams.data = NEW_DATA_MOCK;
       },
+    });
+
+    getTransactionControllerStateMock.mockReturnValue({
+      transactions: [],
     });
   });
 
@@ -88,6 +113,45 @@ describe('Container Utils', () => {
       expect(transactionToUpdate.containerTypes).toStrictEqual([
         TransactionContainerType.EnforcedSimulations,
       ]);
+    });
+  });
+
+  describe('applyTransactionContainersExisting', () => {
+    it('throws if transaction not found', async () => {
+      const updateEditableParams = jest.fn();
+
+      await expect(
+        applyTransactionContainersExisting({
+          transactionId: TRANSACTION_ID_MOCK,
+          messenger,
+          updateEditableParams,
+        }),
+      ).rejects.toThrow(
+        `Transaction with ID ${TRANSACTION_ID_MOCK} not found.`,
+      );
+    });
+
+    it('calls updateEditableParams with new parameters', async () => {
+      getTransactionControllerStateMock.mockReturnValue({
+        transactions: [TRANSACTION_META_MOCK],
+      });
+
+      const updateEditableParams = jest.fn();
+
+      await applyTransactionContainersExisting({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+        updateEditableParams,
+      });
+
+      expect(updateEditableParams).toHaveBeenCalledWith(
+        TRANSACTION_ID_MOCK,
+        expect.objectContaining({
+          containerTypes: [TransactionContainerType.EnforcedSimulations],
+          data: NEW_DATA_MOCK,
+          gas: ESTIMATE_GAS_MOCK,
+        }),
+      );
     });
   });
 });

--- a/app/scripts/lib/transaction/containers/util.test.ts
+++ b/app/scripts/lib/transaction/containers/util.test.ts
@@ -122,6 +122,7 @@ describe('Container Utils', () => {
 
       await expect(
         applyTransactionContainersExisting({
+          containerTypes: [TransactionContainerType.EnforcedSimulations],
           transactionId: TRANSACTION_ID_MOCK,
           messenger,
           updateEditableParams,
@@ -139,6 +140,7 @@ describe('Container Utils', () => {
       const updateEditableParams = jest.fn();
 
       await applyTransactionContainersExisting({
+        containerTypes: [TransactionContainerType.EnforcedSimulations],
         transactionId: TRANSACTION_ID_MOCK,
         messenger,
         updateEditableParams,

--- a/app/scripts/lib/transaction/containers/util.test.ts
+++ b/app/scripts/lib/transaction/containers/util.test.ts
@@ -16,7 +16,6 @@ import { enforceSimulations } from './enforced-simulations';
 jest.mock('./enforced-simulations');
 
 const TRANSACTION_ID_MOCK = '123-456';
-const CHAIN_ID_MOCK = '0x123' as const;
 const ESTIMATE_GAS_MOCK = '0x456' as const;
 const NEW_DATA_MOCK = '0x789' as const;
 

--- a/app/scripts/lib/transaction/containers/util.ts
+++ b/app/scripts/lib/transaction/containers/util.ts
@@ -82,10 +82,12 @@ export async function applyTransactionContainers({
 }
 
 export async function applyTransactionContainersExisting({
+  containerTypes,
   transactionId,
   messenger,
   updateEditableParams,
 }: {
+  containerTypes: TransactionContainerType[];
   transactionId: string;
   messenger: TransactionControllerInitMessenger;
   updateEditableParams: TransactionController['updateEditableParams'];
@@ -102,18 +104,11 @@ export async function applyTransactionContainersExisting({
     throw new Error(`Transaction with ID ${transactionId} not found.`);
   }
 
-  const { containerTypes = [] } = transactionMeta;
-
-  const newContainerTypes = [
-    ...containerTypes,
-    TransactionContainerType.EnforcedSimulations,
-  ];
-
   const { updateTransaction } = await applyTransactionContainers({
     isApproved: false,
     messenger,
     transactionMeta,
-    types: newContainerTypes,
+    types: containerTypes,
   });
 
   const newTransactionMeta = cloneDeep(transactionMeta);
@@ -121,7 +116,7 @@ export async function applyTransactionContainersExisting({
   updateTransaction(newTransactionMeta);
 
   updateEditableParams(transactionId, {
-    containerTypes: newContainerTypes,
+    containerTypes,
     data: newTransactionMeta.txParams.data,
     gas: newTransactionMeta.txParams.gas,
     to: newTransactionMeta.txParams.to,

--- a/app/scripts/lib/transaction/hooks/enforce-simulation-hook.ts
+++ b/app/scripts/lib/transaction/hooks/enforce-simulation-hook.ts
@@ -42,12 +42,19 @@ export class EnforceSimulationHook {
     const {
       containerTypes,
       delegationAddress,
+      id: transactionId,
       origin,
       simulationData,
       txParamsOriginal,
     } = transactionMeta;
 
-    if (!process.env.ENABLE_ENFORCED_SIMULATIONS) {
+    const appState = this.#messenger.call('AppStateController:getState');
+
+    const isUserEnabled =
+      appState?.enableEnforcedSimulationsForTransactions[transactionId] ??
+      appState?.enableEnforcedSimulations;
+
+    if (!process.env.ENABLE_ENFORCED_SIMULATIONS || !isUserEnabled) {
       log('Skipping as enforced simulations are disabled');
       return {};
     }

--- a/app/scripts/lib/transaction/hooks/enforce-simulation-hook.ts
+++ b/app/scripts/lib/transaction/hooks/enforce-simulation-hook.ts
@@ -56,7 +56,9 @@ export class EnforceSimulationHook {
 
     if (!process.env.ENABLE_ENFORCED_SIMULATIONS || !isUserEnabled) {
       log('Skipping as enforced simulations are disabled');
-      return {};
+      return {
+        skipSimulation: false,
+      };
     }
 
     if (
@@ -69,12 +71,16 @@ export class EnforceSimulationHook {
 
     if (!origin || origin === ORIGIN_METAMASK) {
       log('Skipping as internal transaction');
-      return {};
+      return {
+        skipSimulation: false,
+      };
     }
 
     if (!delegationAddress) {
       log('Skipping as not upgraded account');
-      return {};
+      return {
+        skipSimulation: false,
+      };
     }
 
     if (
@@ -82,7 +88,9 @@ export class EnforceSimulationHook {
       !simulationData?.tokenBalanceChanges?.length
     ) {
       log('Skipping as no simulation changes');
-      return {};
+      return {
+        skipSimulation: false,
+      };
     }
 
     if (isFinal && !txParamsOriginal) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -424,6 +424,7 @@ import { AccountTreeControllerInit } from './controller-init/accounts/account-tr
 import OAuthService from './services/oauth/oauth-service';
 import { webAuthenticatorFactory } from './services/oauth/web-authenticator-factory';
 import { SeedlessOnboardingControllerInit } from './controller-init/seedless-onboarding/seedless-onboarding-controller-init';
+import { enforceSimulationsForTransaction } from './lib/transaction/containers/enforced-simulations';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -4385,10 +4386,19 @@ export default class MetamaskController extends EventEmitter {
         this.metaMetricsDataDeletionController.updateDataDeletionTaskStatus.bind(
           this.metaMetricsDataDeletionController,
         ),
+
       // Other
       endTrace,
       isRelaySupported,
       requestSafeReload: this.requestSafeReload.bind(this),
+      enforceSimulationsForTransaction: (transactionId) =>
+        enforceSimulationsForTransaction({
+          messenger: this.controllerMessenger,
+          transactionId,
+          updateEditableParams: this.txController.updateEditableParams.bind(
+            this.txController,
+          ),
+        }),
     };
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -424,7 +424,7 @@ import { AccountTreeControllerInit } from './controller-init/accounts/account-tr
 import OAuthService from './services/oauth/oauth-service';
 import { webAuthenticatorFactory } from './services/oauth/web-authenticator-factory';
 import { SeedlessOnboardingControllerInit } from './controller-init/seedless-onboarding/seedless-onboarding-controller-init';
-import { enforceSimulationsForTransaction } from './lib/transaction/containers/enforced-simulations';
+import { applyTransactionContainersExisting } from './lib/transaction/containers/util';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -4391,8 +4391,9 @@ export default class MetamaskController extends EventEmitter {
       endTrace,
       isRelaySupported,
       requestSafeReload: this.requestSafeReload.bind(this),
-      enforceSimulationsForTransaction: (transactionId) =>
-        enforceSimulationsForTransaction({
+      applyTransactionContainersExisting: (transactionId, containerTypes) =>
+        applyTransactionContainersExisting({
+          containerTypes,
           messenger: this.controllerMessenger,
           transactionId,
           updateEditableParams: this.txController.updateEditableParams.bind(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3794,6 +3794,14 @@ export default class MetamaskController extends EventEmitter {
         ),
       updateSlides: appStateController.updateSlides.bind(appStateController),
       removeSlide: appStateController.removeSlide.bind(appStateController),
+      setEnableEnforcedSimulations:
+        appStateController.setEnableEnforcedSimulations.bind(
+          appStateController,
+        ),
+      setEnableEnforcedSimulationsForTransaction:
+        appStateController.setEnableEnforcedSimulationsForTransaction.bind(
+          appStateController,
+        ),
 
       // EnsController
       tryReverseResolveAddress:

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -134,6 +134,8 @@ export type ControllerStatePropertiesEnumerated = {
   updateModalLastDismissedAt: AppStateControllerState['updateModalLastDismissedAt'];
   lastUpdatedAt: AppStateControllerState['lastUpdatedAt'];
   throttledOrigins: AppStateControllerState['throttledOrigins'];
+  enableEnforcedSimulations: AppStateControllerState['enableEnforcedSimulations'];
+  enableEnforcedSimulationsForTransactions: AppStateControllerState['enableEnforcedSimulationsForTransactions'];
   quoteRequest: BridgeControllerState['quoteRequest'];
   quotes: BridgeControllerState['quotes'];
   quotesInitialLoadTime: BridgeControllerState['quotesInitialLoadTime'];

--- a/test/data/confirmations/contract-interaction.ts
+++ b/test/data/confirmations/contract-interaction.ts
@@ -4,7 +4,9 @@ import {
   CHAIN_IDS,
   GasFeeToken,
   SimulationData,
+  TransactionContainerType,
   TransactionMeta,
+  TransactionParams,
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
@@ -27,25 +29,30 @@ export const CHAIN_ID = CHAIN_IDS.GOERLI;
 export const genUnapprovedContractInteractionConfirmation = ({
   address = CONTRACT_INTERACTION_SENDER_ADDRESS,
   authorizationList = undefined,
+  containerTypes = undefined,
   txData = DEPOSIT_METHOD_DATA,
   chainId = CHAIN_ID,
   nestedTransactions,
   simulationData,
   gasFeeTokens,
   selectedGasFeeToken,
+  txParamsOriginal,
 }: {
   address?: Hex;
   authorizationList?: AuthorizationList;
+  containerTypes?: TransactionContainerType[];
   txData?: Hex;
   chainId?: string;
   nestedTransactions?: BatchTransactionParams[];
   gasFeeTokens?: GasFeeToken[];
   selectedGasFeeToken?: Hex;
   simulationData?: SimulationData;
+  txParamsOriginal?: TransactionParams;
 } = {}): Confirmation => {
   const confirmation: Confirmation = {
     actionId: String(400855682),
     chainId,
+    containerTypes,
     dappSuggestedGasFees: {
       gas: '0xab77',
     },
@@ -182,6 +189,7 @@ export const genUnapprovedContractInteractionConfirmation = ({
       value: '0x3782dace9d900000',
     },
     gasLimitNoBuffer: '0xab77',
+    txParamsOriginal,
     type: TransactionType.contractInteraction,
     userEditedGasLimit: false,
     userFeeLevel: 'medium',

--- a/test/data/confirmations/contract-interaction.ts
+++ b/test/data/confirmations/contract-interaction.ts
@@ -30,6 +30,8 @@ export const genUnapprovedContractInteractionConfirmation = ({
   address = CONTRACT_INTERACTION_SENDER_ADDRESS,
   authorizationList = undefined,
   containerTypes = undefined,
+  delegationAddress = undefined,
+  origin,
   txData = DEPOSIT_METHOD_DATA,
   chainId = CHAIN_ID,
   nestedTransactions,
@@ -41,6 +43,8 @@ export const genUnapprovedContractInteractionConfirmation = ({
   address?: Hex;
   authorizationList?: AuthorizationList;
   containerTypes?: TransactionContainerType[];
+  delegationAddress?: Hex;
+  origin?: string;
   txData?: Hex;
   chainId?: string;
   nestedTransactions?: BatchTransactionParams[];
@@ -62,6 +66,7 @@ export const genUnapprovedContractInteractionConfirmation = ({
       maxFeePerGas: '0xaa350353',
       maxPriorityFeePerGas: '0x59682f00',
     },
+    delegationAddress,
     gasFeeEstimatesLoaded: true,
     gasFeeTokens,
     history: [
@@ -157,7 +162,7 @@ export const genUnapprovedContractInteractionConfirmation = ({
     ],
     id: '1d7c08c0-fe54-11ee-9243-91b1e533746a',
     nestedTransactions,
-    origin: 'https://metamask.github.io',
+    origin: origin ?? 'https://metamask.github.io',
     securityAlertResponse: {
       features: [],
       reason: '',

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -61,6 +61,8 @@
   },
   "metamask": {
     "allTokens": {},
+    "enableEnforcedSimulations": true,
+    "enableEnforcedSimulationsForTransactions": {},
     "tokenBalances": {},
     "use4ByteResolution": true,
     "ipfsGateway": "dweb.link",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -58,7 +58,9 @@
     "switchedNetworkDetails": null,
     "currentExtensionPopupId": "number",
     "termsOfUseLastAgreed": "number",
-    "snapsInstallPrivacyWarningShown": true
+    "snapsInstallPrivacyWarningShown": true,
+    "enableEnforcedSimulations": true,
+    "enableEnforcedSimulationsForTransactions": "object"
   },
   "ApprovalController": {
     "pendingApprovals": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -370,7 +370,9 @@
     "encryptionKey": "string",
     "encryptionSalt": "string",
     "socialBackupsMetadata": "object",
-    "srpSessionData": "object"
+    "srpSessionData": "object",
+    "enableEnforcedSimulations": true,
+    "enableEnforcedSimulationsForTransactions": "object"
   },
   "ramps": "object",
   "send": "object",

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -86,6 +86,8 @@
   "detectedTokens": [],
   "dismissSeedBackUpReminder": false,
   "domains": {},
+  "enableEnforcedSimulations": "boolean",
+  "enableEnforcedSimulationsForTransactions": "object",
   "enableMV3TimestampSave": true,
   "enabledNetworkMap": {
     "eip155": {

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -372,33 +372,37 @@ exports[`Info renders info section for contract interaction request 1`] = `
         class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
       >
         <div
-          class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-          style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
+          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--align-items-center"
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
             >
-              <p
-                class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+              <div
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
               >
-                Estimated changes
-              </p>
-              <div>
-                <div
-                  aria-describedby="tippy-tooltip-4"
-                  class=""
-                  data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
-                  data-tooltipped=""
-                  style="display: flex;"
-                  tabindex="0"
+                <p
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
                 >
-                  <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
-                    style="mask-image: url('./images/icons/question.svg');"
-                  />
+                  Estimated changes
+                </p>
+                <div>
+                  <div
+                    aria-describedby="tippy-tooltip-4"
+                    class=""
+                    data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
+                    data-tooltipped=""
+                    style="display: flex;"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      style="mask-image: url('./images/icons/question.svg');"
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
@@ -15,33 +15,37 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
         class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
       >
         <div
-          class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-          style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
+          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--align-items-center"
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
             >
-              <p
-                class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+              <div
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
               >
-                Estimated changes
-              </p>
-              <div>
-                <div
-                  aria-describedby="tippy-tooltip-1"
-                  class=""
-                  data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
-                  data-tooltipped=""
-                  style="display: flex;"
-                  tabindex="0"
+                <p
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
                 >
-                  <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
-                    style="mask-image: url('./images/icons/question.svg');"
-                  />
+                  Estimated changes
+                </p>
+                <div>
+                  <div
+                    aria-describedby="tippy-tooltip-1"
+                    class=""
+                    data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
+                    data-tooltipped=""
+                    style="display: flex;"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      style="mask-image: url('./images/icons/question.svg');"
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -128,33 +128,37 @@ exports[`NativeTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
       >
         <div
-          class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-          style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
+          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--align-items-center"
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
             >
-              <p
-                class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+              <div
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
               >
-                Estimated changes
-              </p>
-              <div>
-                <div
-                  aria-describedby="tippy-tooltip-1"
-                  class=""
-                  data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
-                  data-tooltipped=""
-                  style="display: flex;"
-                  tabindex="0"
+                <p
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
                 >
-                  <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
-                    style="mask-image: url('./images/icons/question.svg');"
-                  />
+                  Estimated changes
+                </p>
+                <div>
+                  <div
+                    aria-describedby="tippy-tooltip-1"
+                    class=""
+                    data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
+                    data-tooltipped=""
+                    style="display: flex;"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      style="mask-image: url('./images/icons/question.svg');"
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -158,33 +158,37 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
       >
         <div
-          class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-          style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
+          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--align-items-center"
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
             >
-              <p
-                class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+              <div
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
               >
-                Estimated changes
-              </p>
-              <div>
-                <div
-                  aria-describedby="tippy-tooltip-1"
-                  class=""
-                  data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
-                  data-tooltipped=""
-                  style="display: flex;"
-                  tabindex="0"
+                <p
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
                 >
-                  <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
-                    style="mask-image: url('./images/icons/question.svg');"
-                  />
+                  Estimated changes
+                </p>
+                <div>
+                  <div
+                    aria-describedby="tippy-tooltip-1"
+                    class=""
+                    data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
+                    data-tooltipped=""
+                    style="display: flex;"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      style="mask-image: url('./images/icons/question.svg');"
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -139,33 +139,37 @@ exports[`TokenTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
       >
         <div
-          class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-          style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
+          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; padding-left: 0px; padding-right: 0px;"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--align-items-center"
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
             >
-              <p
-                class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+              <div
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
               >
-                Estimated changes
-              </p>
-              <div>
-                <div
-                  aria-describedby="tippy-tooltip-2"
-                  class=""
-                  data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
-                  data-tooltipped=""
-                  style="display: flex;"
-                  tabindex="0"
+                <p
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
                 >
-                  <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
-                    style="mask-image: url('./images/icons/question.svg');"
-                  />
+                  Estimated changes
+                </p>
+                <div>
+                  <div
+                    aria-describedby="tippy-tooltip-2"
+                    class=""
+                    data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
+                    data-tooltipped=""
+                    style="display: flex;"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      style="mask-image: url('./images/icons/question.svg');"
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.stories.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import configureStore from '../../../../../store/store';
+import { ConfirmContextProvider } from '../../../context/confirm';
+
+import { SimulationSettingsModal } from './simulation-settings-modal';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+
+const store = configureStore(
+  getMockConfirmStateForTransaction(
+    genUnapprovedContractInteractionConfirmation({
+    }),
+    {
+      metamask: {
+      },
+    },
+  ),
+);
+
+const Story = {
+  title: 'Confirmations/Components/Modals/SimulationSettingsModal',
+  component: SimulationSettingsModal,
+  decorators: [
+    (story: any) => (
+      <Provider store={store}>
+        <ConfirmContextProvider>{story()}</ConfirmContextProvider>
+      </Provider>
+    ),
+  ],
+};
+
+export default Story;
+
+export const DefaultStory = () => <SimulationSettingsModal onClose={() => {}} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.test.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
-import { SimulationSettingsModal } from './simulation-settings-modal';
+import { Json } from '@metamask/utils';
+import { act } from 'react-dom/test-utils';
+import {
+  CHAIN_IDS,
+  TransactionContainerType,
+  TransactionParams,
+} from '@metamask/transaction-controller';
 import configureStore from '../../../../../store/store';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
-import { Json } from '@metamask/utils';
 import {
   applyTransactionContainersExisting,
   setEnableEnforcedSimulationsForTransaction,
   updateEditableParams,
 } from '../../../../../store/actions';
 import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
-import { act } from 'react-dom/test-utils';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
-import {
-  CHAIN_IDS,
-  TransactionContainerType,
-  TransactionParams,
-} from '@metamask/transaction-controller';
+import { SimulationSettingsModal } from './simulation-settings-modal';
 
 jest.mock('../../../../../store/actions');
 
@@ -161,7 +161,7 @@ describe('SimulationSettingsModal', () => {
         getByTestId('simulation-settings-modal-update').click();
       });
 
-      expect(applyTransactionContainersExisting).toHaveBeenCalledWith(
+      expect(applyTransactionContainersExistingMock).toHaveBeenCalledWith(
         TRANSACTION_ID_MOCK,
         [TransactionContainerType.EnforcedSimulations],
       );
@@ -189,7 +189,7 @@ describe('SimulationSettingsModal', () => {
         getByTestId('simulation-settings-modal-update').click();
       });
 
-      expect(applyTransactionContainersExisting).toHaveBeenCalledWith(
+      expect(applyTransactionContainersExistingMock).toHaveBeenCalledWith(
         TRANSACTION_ID_MOCK,
         [],
       );

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { SimulationSettingsModal } from './simulation-settings-modal';
+import configureStore from '../../../../../store/store';
+import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { Json } from '@metamask/utils';
+import {
+  enforceSimulationsForTransaction,
+  setEnableEnforcedSimulationsForTransaction,
+  updateEditableParams,
+} from '../../../../../store/actions';
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { act } from 'react-dom/test-utils';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+import {
+  CHAIN_IDS,
+  TransactionContainerType,
+  TransactionParams,
+} from '@metamask/transaction-controller';
+
+jest.mock('../../../../../store/actions');
+
+const TRANSACTION_ID_MOCK = '1d7c08c0-fe54-11ee-9243-91b1e533746a';
+
+function render({
+  containerTypes,
+  metamaskState = {},
+  txParamsOriginal,
+}: {
+  containerTypes?: TransactionContainerType[];
+  metamaskState?: Record<string, Json>;
+  txParamsOriginal?: Partial<TransactionParams>;
+} = {}) {
+  const contractInteraction = genUnapprovedContractInteractionConfirmation({
+    chainId: CHAIN_IDS.GOERLI,
+    containerTypes,
+    txParamsOriginal: txParamsOriginal as TransactionParams,
+  });
+
+  const store = configureStore(
+    getMockConfirmStateForTransaction(contractInteraction, {
+      metamask: metamaskState,
+    }),
+  );
+
+  return renderWithConfirmContextProvider(<SimulationSettingsModal />, store);
+}
+
+describe('SimulationSettingsModal', () => {
+  const setEnableEnforcedSimulationsForTransactionMock = jest.mocked(
+    setEnableEnforcedSimulationsForTransaction,
+  );
+
+  const enforceSimulationsForTransactionMock = jest.mocked(
+    enforceSimulationsForTransaction,
+  );
+
+  const updateEditableParamsMock = jest.mocked(updateEditableParams);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    updateEditableParamsMock.mockReturnValue(async () => ({} as never));
+  });
+
+  describe('renders', () => {
+    it('enforced simulations toggle as enabled if default', () => {
+      const { getByTestId } = render({
+        metamaskState: { enableEnforcedSimulations: true },
+      });
+
+      expect(
+        getByTestId('simulation-settings-modal-enable-enforced').getAttribute(
+          'value',
+        ),
+      ).toBe('true');
+    });
+
+    it('enforced simulations toggle as enabled if overridden', () => {
+      const { getByTestId } = render({
+        metamaskState: {
+          enableEnforcedSimulations: false,
+          enableEnforcedSimulationsForTransactions: {
+            [TRANSACTION_ID_MOCK]: true,
+          },
+        },
+      });
+
+      expect(
+        getByTestId('simulation-settings-modal-enable-enforced').getAttribute(
+          'value',
+        ),
+      ).toBe('true');
+    });
+
+    it('enforced simulations toggle as disabled if default', () => {
+      const { getByTestId } = render({
+        metamaskState: {
+          enableEnforcedSimulations: false,
+        },
+      });
+
+      expect(
+        getByTestId('simulation-settings-modal-enable-enforced').getAttribute(
+          'value',
+        ),
+      ).toBe('false');
+    });
+
+    it('enforced simulations toggle as disabled if overridden', () => {
+      const { getByTestId } = render({
+        metamaskState: {
+          enableEnforcedSimulations: true,
+          enableEnforcedSimulationsForTransactions: {
+            [TRANSACTION_ID_MOCK]: false,
+          },
+        },
+      });
+
+      expect(
+        getByTestId('simulation-settings-modal-enable-enforced').getAttribute(
+          'value',
+        ),
+      ).toBe('false');
+    });
+  });
+
+  describe('on update click', () => {
+    it('sets enforced simulations enabled', async () => {
+      const { getByTestId } = render({
+        metamaskState: {
+          enableEnforcedSimulations: true,
+          enableEnforcedSimulationsForTransactions: {},
+        },
+      });
+
+      await act(async () => {
+        getByTestId('simulation-settings-modal-enable-enforced').click();
+      });
+
+      await act(async () => {
+        getByTestId('simulation-settings-modal-update').click();
+      });
+
+      expect(
+        setEnableEnforcedSimulationsForTransactionMock,
+      ).toHaveBeenCalledWith(TRANSACTION_ID_MOCK, false);
+    });
+
+    it('applies enforced simulations if enabled and not already applied', async () => {
+      const { getByTestId } = render({
+        metamaskState: {
+          enableEnforcedSimulations: false,
+          enableEnforcedSimulationsForTransactions: {},
+        },
+      });
+
+      await act(async () => {
+        getByTestId('simulation-settings-modal-enable-enforced').click();
+      });
+
+      await act(async () => {
+        getByTestId('simulation-settings-modal-update').click();
+      });
+
+      expect(enforceSimulationsForTransactionMock).toHaveBeenCalledWith(
+        TRANSACTION_ID_MOCK,
+      );
+    });
+
+    it('reverts to original parameters if enforced simulations disabled but applied', async () => {
+      const { getByTestId } = render({
+        containerTypes: [TransactionContainerType.EnforcedSimulations],
+        metamaskState: {
+          enableEnforcedSimulations: true,
+          enableEnforcedSimulationsForTransactions: {},
+        },
+        txParamsOriginal: {
+          data: '0x1',
+          gas: '0x2',
+          to: '0x3',
+        },
+      });
+
+      await act(async () => {
+        getByTestId('simulation-settings-modal-enable-enforced').click();
+      });
+
+      await act(async () => {
+        getByTestId('simulation-settings-modal-update').click();
+      });
+
+      expect(updateEditableParamsMock).toHaveBeenCalledWith(
+        TRANSACTION_ID_MOCK,
+        {
+          containerTypes: [],
+          data: '0x1',
+          gas: '0x2',
+          to: '0x3',
+        },
+      );
+    });
+  });
+});

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.test.tsx
@@ -4,7 +4,7 @@ import configureStore from '../../../../../store/store';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { Json } from '@metamask/utils';
 import {
-  enforceSimulationsForTransaction,
+  applyTransactionContainersExisting,
   setEnableEnforcedSimulationsForTransaction,
   updateEditableParams,
 } from '../../../../../store/actions';
@@ -50,8 +50,8 @@ describe('SimulationSettingsModal', () => {
     setEnableEnforcedSimulationsForTransaction,
   );
 
-  const enforceSimulationsForTransactionMock = jest.mocked(
-    enforceSimulationsForTransaction,
+  const applyTransactionContainersExistingMock = jest.mocked(
+    applyTransactionContainersExisting,
   );
 
   const updateEditableParamsMock = jest.mocked(updateEditableParams);
@@ -161,8 +161,9 @@ describe('SimulationSettingsModal', () => {
         getByTestId('simulation-settings-modal-update').click();
       });
 
-      expect(enforceSimulationsForTransactionMock).toHaveBeenCalledWith(
+      expect(applyTransactionContainersExisting).toHaveBeenCalledWith(
         TRANSACTION_ID_MOCK,
+        [TransactionContainerType.EnforcedSimulations],
       );
     });
 
@@ -188,14 +189,9 @@ describe('SimulationSettingsModal', () => {
         getByTestId('simulation-settings-modal-update').click();
       });
 
-      expect(updateEditableParamsMock).toHaveBeenCalledWith(
+      expect(applyTransactionContainersExisting).toHaveBeenCalledWith(
         TRANSACTION_ID_MOCK,
-        {
-          containerTypes: [],
-          data: '0x1',
-          gas: '0x2',
-          to: '0x3',
-        },
+        [],
       );
     });
   });

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.test.tsx
@@ -58,7 +58,7 @@ describe('SimulationSettingsModal', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    updateEditableParamsMock.mockReturnValue(async () => ({} as never));
+    updateEditableParamsMock.mockReturnValue(async () => ({}) as never);
   });
 
   describe('renders', () => {

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
@@ -1,9 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import {
   AlignItems,
+  BackgroundColor,
+  BorderRadius,
   Display,
   FlexDirection,
   JustifyContent,
+  TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import {
@@ -101,26 +104,37 @@ export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
     >
       <ModalOverlay data-testid="modal-overlay" />
       <ModalContent size={ModalContentSize.Md}>
-        <ModalHeader onClose={onClose}>Simulation settings</ModalHeader>
+        <ModalHeader onClose={onClose}>Transaction settings</ModalHeader>
         <ModalBody
           display={Display.Flex}
           flexDirection={FlexDirection.Column}
           gap={3}
         >
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Row}
-            justifyContent={JustifyContent.spaceBetween}
-            alignItems={AlignItems.center}
-            style={{ marginRight: '-12px' }}
-          >
-            <Text variant={TextVariant.bodyMd}>Enforced simulations</Text>
-            <ToggleButton
-              dataTestId="simulation-settings-modal-enable-enforced"
-              value={enabled}
-              onToggle={() => setEnabled(!enabled)}
-            />
-          </Box>
+          <Section>
+            <Box
+              display={Display.Flex}
+              flexDirection={FlexDirection.Row}
+              justifyContent={JustifyContent.spaceBetween}
+              alignItems={AlignItems.center}
+              style={{ marginRight: '-12px' }}
+            >
+              <Text variant={TextVariant.bodyMdMedium}>
+                Enforce balance changes
+              </Text>
+              <ToggleButton
+                dataTestId="simulation-settings-modal-enable-enforced"
+                value={enabled}
+                onToggle={() => setEnabled(!enabled)}
+              />
+            </Box>
+            <Text
+              variant={TextVariant.bodyMd}
+              color={TextColor.textAlternativeSoft}
+            >
+              To protect your funds, this transaction will fail if the displayed
+              balance changes and slippage tolerance are not fulfilled.
+            </Text>
+          </Section>
           <ButtonPrimary
             onClick={handleUpdateClick}
             data-testid="simulation-settings-modal-update"
@@ -130,5 +144,20 @@ export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
         </ModalBody>
       </ModalContent>
     </Modal>
+  );
+}
+
+function Section({ children }: { children: React.ReactNode | string }) {
+  return (
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+      backgroundColor={BackgroundColor.backgroundAlternative}
+      borderRadius={BorderRadius.MD}
+      padding={2}
+      gap={2}
+    >
+      {children}
+    </Box>
   );
 }

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
@@ -3,7 +3,7 @@ import {
   TransactionContainerType,
   TransactionMeta,
 } from '@metamask/transaction-controller';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   AlignItems,
   BackgroundColor,
@@ -37,14 +37,8 @@ import { ConfirmMetamaskState } from '../../../types/confirm';
 
 export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
   const t = useI18nContext();
-  const dispatch = useDispatch();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
-
-  const {
-    containerTypes,
-    id: transactionId,
-    txParamsOriginal,
-  } = currentConfirmation || {};
+  const { containerTypes, id: transactionId } = currentConfirmation || {};
 
   const isEnforcedSimulationsEnabled = useSelector(
     (state: ConfirmMetamaskState) =>
@@ -84,11 +78,11 @@ export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
 
     onClose?.();
   }, [
-    dispatch,
+    containerTypes,
     enabled,
     isEnforcedSimulationApplied,
+    onClose,
     transactionId,
-    txParamsOriginal,
   ]);
 
   return (
@@ -105,7 +99,9 @@ export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
     >
       <ModalOverlay data-testid="modal-overlay" />
       <ModalContent size={ModalContentSize.Md}>
-        <ModalHeader onClose={onClose}>Transaction settings</ModalHeader>
+        <ModalHeader onClose={onClose}>
+          {t('simulationSettingsModalTitle')}
+        </ModalHeader>
         <ModalBody
           display={Display.Flex}
           flexDirection={FlexDirection.Column}
@@ -120,7 +116,7 @@ export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
               style={{ marginRight: '-12px' }}
             >
               <Text variant={TextVariant.bodyMdMedium}>
-                Enforce balance changes
+                {t('simulationSettingsModalEnforceToggle')}
               </Text>
               <ToggleButton
                 dataTestId="simulation-settings-modal-enable-enforced"
@@ -132,8 +128,7 @@ export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
               variant={TextVariant.bodyMd}
               color={TextColor.textAlternativeSoft}
             >
-              To protect your funds, this transaction will fail if the displayed
-              balance changes and slippage tolerance are not fulfilled.
+              {t('simulationSettingsModalEnforceToggleDescription')}
             </Text>
           </Section>
           <ButtonPrimary

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
@@ -116,11 +116,15 @@ export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
           >
             <Text variant={TextVariant.bodyMd}>Enforced simulations</Text>
             <ToggleButton
+              dataTestId="simulation-settings-modal-enable-enforced"
               value={enabled}
               onToggle={() => setEnabled(!enabled)}
             />
           </Box>
-          <ButtonPrimary onClick={handleUpdateClick}>
+          <ButtonPrimary
+            onClick={handleUpdateClick}
+            data-testid="simulation-settings-modal-update"
+          >
             {t('update')}
           </ButtonPrimary>
         </ModalBody>

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
@@ -1,0 +1,120 @@
+import React, { useCallback, useState } from 'react';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+  JustifyContent,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
+import {
+  Box,
+  ButtonPrimary,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalContentSize,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '../../../../../components/component-library';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import ToggleButton from '../../../../../components/ui/toggle-button';
+import { useConfirmContext } from '../../../context/confirm';
+import {
+  TransactionContainerType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import {
+  setEnableEnforcedSimulationsForTransaction,
+  updateEditableParams,
+} from '../../../../../store/actions';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectEnableEnforcedSimulations } from '../../../selectors';
+import { ConfirmMetamaskState } from '../../../types/confirm';
+
+export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const {
+    id: transactionId,
+    containerTypes,
+    txParamsOriginal,
+  } = currentConfirmation || {};
+
+  const isEnforcedSimulationsEnabled = useSelector(
+    (state: ConfirmMetamaskState) =>
+      selectEnableEnforcedSimulations(state, transactionId),
+  );
+
+  const isEnforcedSimulationApplied = containerTypes?.includes(
+    TransactionContainerType.EnforcedSimulations,
+  );
+
+  const [enabled, setEnabled] = useState(isEnforcedSimulationsEnabled);
+
+  const handleUpdateClick = useCallback(async () => {
+    if (!enabled && isEnforcedSimulationApplied) {
+      await dispatch(
+        updateEditableParams(transactionId, {
+          data: txParamsOriginal?.data,
+          gas: txParamsOriginal?.gas,
+          to: txParamsOriginal?.to,
+          value: txParamsOriginal?.value,
+        }),
+      );
+    }
+
+    await setEnableEnforcedSimulationsForTransaction(transactionId, enabled);
+
+    onClose?.();
+  }, [
+    dispatch,
+    enabled,
+    isEnforcedSimulationApplied,
+    transactionId,
+    txParamsOriginal,
+  ]);
+
+  return (
+    <Modal
+      isOpen={true}
+      onClose={
+        onClose ??
+        (() => {
+          // Intentionally empty
+        })
+      }
+      isClosedOnOutsideClick={false}
+      isClosedOnEscapeKey={false}
+    >
+      <ModalOverlay data-testid="modal-overlay" />
+      <ModalContent size={ModalContentSize.Md}>
+        <ModalHeader onClose={onClose}>Simulation settings</ModalHeader>
+        <ModalBody
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          gap={3}
+        >
+          <Box
+            display={Display.Flex}
+            flexDirection={FlexDirection.Row}
+            justifyContent={JustifyContent.spaceBetween}
+            alignItems={AlignItems.center}
+            style={{ marginRight: '-12px' }}
+          >
+            <Text variant={TextVariant.bodyMd}>Enforced simulations</Text>
+            <ToggleButton
+              value={enabled}
+              onToggle={() => setEnabled(!enabled)}
+            />
+          </Box>
+          <ButtonPrimary onClick={handleUpdateClick}>
+            {t('update')}
+          </ButtonPrimary>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useState } from 'react';
 import {
+  TransactionContainerType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import { useDispatch, useSelector } from 'react-redux';
+import {
   AlignItems,
   BackgroundColor,
   BorderRadius,
@@ -24,14 +29,9 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import ToggleButton from '../../../../../components/ui/toggle-button';
 import { useConfirmContext } from '../../../context/confirm';
 import {
-  TransactionContainerType,
-  TransactionMeta,
-} from '@metamask/transaction-controller';
-import {
   applyTransactionContainersExisting,
   setEnableEnforcedSimulationsForTransaction,
 } from '../../../../../store/actions';
-import { useDispatch, useSelector } from 'react-redux';
 import { selectEnableEnforcedSimulations } from '../../../selectors';
 import { ConfirmMetamaskState } from '../../../types/confirm';
 

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
@@ -35,6 +35,21 @@ import {
 import { selectEnableEnforcedSimulations } from '../../../selectors';
 import { ConfirmMetamaskState } from '../../../types/confirm';
 
+const Section = ({ children }: { children: React.ReactNode | string }) => {
+  return (
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+      backgroundColor={BackgroundColor.backgroundAlternative}
+      borderRadius={BorderRadius.MD}
+      padding={2}
+      gap={2}
+    >
+      {children}
+    </Box>
+  );
+};
+
 export const SimulationSettingsModal = ({
   onClose,
 }: {
@@ -144,20 +159,5 @@ export const SimulationSettingsModal = ({
         </ModalBody>
       </ModalContent>
     </Modal>
-  );
-};
-
-const Section = ({ children }: { children: React.ReactNode | string }) => {
-  return (
-    <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      backgroundColor={BackgroundColor.backgroundAlternative}
-      borderRadius={BorderRadius.MD}
-      padding={2}
-      gap={2}
-    >
-      {children}
-    </Box>
   );
 };

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
@@ -35,7 +35,11 @@ import {
 import { selectEnableEnforcedSimulations } from '../../../selectors';
 import { ConfirmMetamaskState } from '../../../types/confirm';
 
-export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
+export const SimulationSettingsModal = ({
+  onClose,
+}: {
+  onClose?: () => void;
+}) => {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { containerTypes, id: transactionId } = currentConfirmation || {};
@@ -141,9 +145,9 @@ export function SimulationSettingsModal({ onClose }: { onClose?: () => void }) {
       </ModalContent>
     </Modal>
   );
-}
+};
 
-function Section({ children }: { children: React.ReactNode | string }) {
+const Section = ({ children }: { children: React.ReactNode | string }) => {
   return (
     <Box
       display={Display.Flex}
@@ -156,4 +160,4 @@ function Section({ children }: { children: React.ReactNode | string }) {
       {children}
     </Box>
   );
-}
+};

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -43,7 +43,7 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { selectTransactionMetadata } from '../../../../selectors';
 import { SimulationSettingsModal } from '../modals/simulation-settings-modal/simulation-settings-modal';
 import { selectConfirmationAdvancedDetailsOpen } from '../../selectors/preferences';
-import { useIsEnforcedSimulationsSupported } from '../../hooks/useIsEnforcedSimulationsSupported';
+import { useIsEnforcedSimulationsSupported } from '../../hooks/transactions/useIsEnforcedSimulationsSupported';
 import { BalanceChangeList } from './balance-change-list';
 import { BalanceChange } from './types';
 import { useBalanceChanges } from './useBalanceChanges';

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -17,6 +17,8 @@ import { RowAlertKey } from '../../../../components/app/confirm/info/row/constan
 import { ConfirmInfoSection } from '../../../../components/app/confirm/info/row/section';
 import {
   Box,
+  ButtonIcon,
+  ButtonIconSize,
   Icon,
   IconName,
   IconSize,
@@ -26,6 +28,7 @@ import Preloader from '../../../../components/ui/icon/preloader/preloader-icon.c
 import Tooltip from '../../../../components/ui/tooltip';
 import {
   AlignItems,
+  BlockSize,
   BorderColor,
   BorderRadius,
   Display,
@@ -38,6 +41,9 @@ import {
 import useAlerts from '../../../../hooks/useAlerts';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { selectTransactionMetadata } from '../../../../selectors';
+import { SimulationSettingsModal } from '../modals/simulation-settings-modal/simulation-settings-modal';
+import { selectConfirmationAdvancedDetailsOpen } from '../../selectors/preferences';
+import { useIsEnforcedSimulationsSupported } from '../../hooks/useIsEnforcedSimulationsSupported';
 import { BalanceChangeList } from './balance-change-list';
 import { BalanceChange } from './types';
 import { useBalanceChanges } from './useBalanceChanges';
@@ -117,6 +123,11 @@ const EmptyContent: React.FC = () => {
 
 const HeaderWithAlert = ({ transactionId }: { transactionId: string }) => {
   const t = useI18nContext();
+  const isEnforcedSimulationsSupported = useIsEnforcedSimulationsSupported();
+
+  const showAdvancedDetails = useSelector(
+    selectConfirmationAdvancedDetailsOpen,
+  );
 
   const transactionMetadata = useSelector((state) =>
     selectTransactionMetadata(state, transactionId),
@@ -134,19 +145,47 @@ const HeaderWithAlert = ({ transactionId }: { transactionId: string }) => {
     ? t('simulationDetailsTitleTooltipEnforced')
     : t('simulationDetailsTitleTooltip');
 
+  const [settingsModalVisible, setSettingsModalVisible] =
+    useState<boolean>(false);
+
+  const showSettingsIcon =
+    showAdvancedDetails && isEnforcedSimulationsSupported;
+
   return (
-    <ConfirmInfoAlertRow
-      alertKey={RowAlertKey.Resimulation}
-      label={label}
-      ownerId={transactionId}
-      tooltip={tooltip}
-      tooltipIcon={isEnforced && IconName.SecurityTick}
-      tooltipIconColor={isEnforced && IconColor.infoDefault}
-      style={{
-        paddingLeft: 0,
-        paddingRight: 0,
-      }}
-    />
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      justifyContent={JustifyContent.spaceBetween}
+      width={BlockSize.Full}
+      alignItems={AlignItems.center}
+    >
+      <ConfirmInfoAlertRow
+        alertKey={RowAlertKey.Resimulation}
+        label={label}
+        ownerId={transactionId}
+        tooltip={tooltip}
+        tooltipIcon={isEnforced && IconName.SecurityTick}
+        tooltipIconColor={isEnforced && IconColor.infoDefault}
+        style={{
+          paddingLeft: 0,
+          paddingRight: 0,
+        }}
+      />
+      {showSettingsIcon && (
+        <ButtonIcon
+          iconName={IconName.Setting}
+          size={ButtonIconSize.Sm}
+          color={IconColor.iconMuted}
+          ariaLabel="simulation-settings"
+          onClick={() => setSettingsModalVisible(true)}
+        />
+      )}
+      {settingsModalVisible && (
+        <SimulationSettingsModal
+          onClose={() => setSettingsModalVisible(false)}
+        />
+      )}
+    </Box>
   );
 };
 

--- a/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.test.ts
@@ -39,6 +39,10 @@ function renderHook({
 }
 
 describe('useIsEnforcedSimulationsSupported', () => {
+  beforeEach(() => {
+    process.env.ENABLE_ENFORCED_SIMULATIONS = true as never;
+  });
+
   it('returns true if supported', () => {
     const { result } = renderHook();
     expect(result.current).toBe(true);

--- a/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.test.ts
@@ -1,0 +1,63 @@
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
+import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
+import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { useIsEnforcedSimulationsSupported } from './useIsEnforcedSimulationsSupported';
+import { SimulationData } from '@metamask/transaction-controller';
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+
+function renderHook({
+  isUpgraded = true,
+  origin = 'test.com',
+  simulationData = {
+    nativeBalanceChange: {
+      difference: '0x1',
+      isDecrease: false,
+      previousBalance: '0x0',
+      newBalance: '0x1',
+    },
+    tokenBalanceChanges: [],
+  },
+}: {
+  isUpgraded?: boolean;
+  origin?: string;
+  simulationData?: SimulationData;
+} = {}) {
+  const state = getMockConfirmStateForTransaction(
+    genUnapprovedContractInteractionConfirmation({
+      delegationAddress: isUpgraded ? '0x123' : undefined,
+      origin,
+      simulationData,
+    }),
+  );
+
+  const result = renderHookWithConfirmContextProvider(
+    useIsEnforcedSimulationsSupported,
+    state,
+  );
+
+  return result;
+}
+
+describe('useIsEnforcedSimulationsSupported', () => {
+  it('returns true if supported', () => {
+    const { result } = renderHook();
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false if not upgraded', () => {
+    const { result } = renderHook({ isUpgraded: false });
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false if internal origin', () => {
+    const { result } = renderHook({ origin: ORIGIN_METAMASK });
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false if no balance changes', () => {
+    const { result } = renderHook({
+      simulationData: { tokenBalanceChanges: [] },
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.test.ts
@@ -1,9 +1,9 @@
+import { SimulationData } from '@metamask/transaction-controller';
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
 import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
 import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
 import { useIsEnforcedSimulationsSupported } from './useIsEnforcedSimulationsSupported';
-import { SimulationData } from '@metamask/transaction-controller';
-import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 
 function renderHook({
   isUpgraded = true,

--- a/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.ts
+++ b/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.ts
@@ -13,5 +13,10 @@ export function useIsEnforcedSimulationsSupported() {
     Boolean(simulationData?.nativeBalanceChange) ||
     Boolean(simulationData?.tokenBalanceChanges?.length);
 
-  return !isInternalOrigin && isUpgraded && hasBalanceChanges;
+  return (
+    process.env.ENABLE_ENFORCED_SIMULATIONS &&
+    !isInternalOrigin &&
+    isUpgraded &&
+    hasBalanceChanges
+  );
 }

--- a/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.ts
+++ b/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.ts
@@ -1,6 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
-import { useConfirmContext } from '../../context/confirm';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+import { useConfirmContext } from '../../context/confirm';
 
 export function useIsEnforcedSimulationsSupported() {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();

--- a/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.ts
+++ b/ui/pages/confirmations/hooks/transactions/useIsEnforcedSimulationsSupported.ts
@@ -1,5 +1,5 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
-import { useConfirmContext } from '../context/confirm';
+import { useConfirmContext } from '../../context/confirm';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 
 export function useIsEnforcedSimulationsSupported() {

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsSupported.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsSupported.ts
@@ -1,0 +1,17 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { useConfirmContext } from '../context/confirm';
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+
+export function useIsEnforcedSimulationsSupported() {
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const { delegationAddress, origin, simulationData } = currentConfirmation;
+
+  const isInternalOrigin = !origin || origin === ORIGIN_METAMASK;
+  const isUpgraded = Boolean(delegationAddress);
+
+  const hasBalanceChanges =
+    Boolean(simulationData?.nativeBalanceChange) ||
+    Boolean(simulationData?.tokenBalanceChanges?.length);
+
+  return !isInternalOrigin && isUpgraded && hasBalanceChanges;
+}

--- a/ui/pages/confirmations/selectors/confirm.test.ts
+++ b/ui/pages/confirmations/selectors/confirm.test.ts
@@ -39,6 +39,8 @@ describe('confirm selectors', () => {
         },
       },
       approvalFlows: [],
+      enableEnforcedSimulations: false,
+      enableEnforcedSimulationsForTransactions: {},
     },
   };
 

--- a/ui/pages/confirmations/selectors/confirm.ts
+++ b/ui/pages/confirmations/selectors/confirm.ts
@@ -36,3 +36,13 @@ export const oldestPendingConfirmationSelector = createDeepEqualSelector(
   firstPendingConfirmationSelector,
   (firstPendingConfirmation) => firstPendingConfirmation,
 );
+
+export function selectEnableEnforcedSimulations(
+  state: ConfirmMetamaskState,
+  transactionId: string,
+): boolean {
+  return (
+    state.metamask.enableEnforcedSimulationsForTransactions[transactionId] ??
+    state.metamask.enableEnforcedSimulations
+  );
+}

--- a/ui/pages/confirmations/types/confirm.ts
+++ b/ui/pages/confirmations/types/confirm.ts
@@ -51,5 +51,7 @@ export type ConfirmMetamaskState = {
     pendingApprovals: ApprovalControllerState['pendingApprovals'];
     approvalFlows: ApprovalControllerState['approvalFlows'];
     signatureSecurityAlertResponses?: Record<string, SecurityAlertResponse>;
+    enableEnforcedSimulations: boolean;
+    enableEnforcedSimulationsForTransactions: Record<string, boolean>;
   };
 };

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -36,6 +36,7 @@ import {
   UpdateProposedNamesResult,
 } from '@metamask/name-controller';
 import {
+  TransactionContainerType,
   TransactionController,
   TransactionMeta,
   TransactionParams,
@@ -7041,9 +7042,12 @@ export async function requestSafeReload() {
   return await submitRequestToBackground('requestSafeReload');
 }
 
-export async function enforceSimulationsForTransaction(transactionId: string) {
+export async function applyTransactionContainersExisting(
+  transactionId: string,
+  containerTypes: TransactionContainerType[],
+) {
   return await submitRequestToBackground<void>(
-    'enforceSimulationsForTransaction',
-    [transactionId],
+    'applyTransactionContainersExisting',
+    [transactionId, containerTypes],
   );
 }

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -36,6 +36,7 @@ import {
   UpdateProposedNamesResult,
 } from '@metamask/name-controller';
 import {
+  TransactionController,
   TransactionMeta,
   TransactionParams,
   TransactionType,
@@ -1230,8 +1231,7 @@ export function updatePreviousGasParams(
 }
 
 export function updateEditableParams(
-  txId: string,
-  editableParams: Partial<TransactionParams>,
+  ...args: Parameters<TransactionController['updateEditableParams']>
 ): ThunkAction<
   Promise<TransactionMeta>,
   MetaMaskReduxState,
@@ -1240,15 +1240,17 @@ export function updateEditableParams(
 > {
   return async (dispatch: MetaMaskReduxDispatch) => {
     let updatedTransaction: TransactionMeta;
+
     try {
       updatedTransaction = await submitRequestToBackground(
         'updateEditableParams',
-        [txId, editableParams],
+        args,
       );
     } catch (error) {
       logErrorWithMessage(error);
       throw error;
     }
+
     await forceUpdateMetamaskState(dispatch);
     return updatedTransaction;
   };
@@ -7037,4 +7039,11 @@ export function setSkipDeepLinkInterstitial(value: boolean) {
  */
 export async function requestSafeReload() {
   return await submitRequestToBackground('requestSafeReload');
+}
+
+export async function enforceSimulationsForTransaction(transactionId: string) {
+  return await submitRequestToBackground<void>(
+    'enforceSimulationsForTransaction',
+    [transactionId],
+  );
 }

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1356,6 +1356,21 @@ export function setSmartAccountOptInForAccounts(accounts: Hex[]): void {
   }
 }
 
+export async function setEnableEnforcedSimulationsForTransaction(
+  transactionId: string,
+  enable: boolean,
+): void {
+  try {
+    await submitRequestToBackground(
+      'setEnableEnforcedSimulationsForTransaction',
+      [transactionId, enable],
+    );
+  } catch (error) {
+    logErrorWithMessage(error);
+    throw error;
+  }
+}
+
 // TODO: Not a thunk, but rather a wrapper around a background call
 export function updateTransactionGasFees(
   txId: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7487,11 +7487,11 @@ __metadata:
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@babel/runtime": ^7.0.0
-    "@metamask/accounts-controller": ^30.0.0
+    "@metamask/accounts-controller": ^31.0.0
     "@metamask/approval-controller": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-    "@metamask/gas-fee-controller": ^23.0.0
-    "@metamask/network-controller": ^23.0.0
+    "@metamask/gas-fee-controller": ^24.0.0
+    "@metamask/network-controller": ^24.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
   checksum: 10/55eb5a88a09f5152b638975b85156817c012041a3c56e1552e1e21de3db8f63f1820d1fd14f8cfa2983bd019cb399c34a7c7e45875853a02f1606fdc804f3bc8
   languageName: node

--- a/yarn.lock
+++ b/yarn.lock
@@ -7487,11 +7487,11 @@ __metadata:
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@babel/runtime": ^7.0.0
-    "@metamask/accounts-controller": ^31.0.0
+    "@metamask/accounts-controller": ^30.0.0
     "@metamask/approval-controller": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-    "@metamask/gas-fee-controller": ^24.0.0
-    "@metamask/network-controller": ^24.0.0
+    "@metamask/gas-fee-controller": ^23.0.0
+    "@metamask/network-controller": ^23.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
   checksum: 10/55eb5a88a09f5152b638975b85156817c012041a3c56e1552e1e21de3db8f63f1820d1fd14f8cfa2983bd019cb399c34a7c7e45875853a02f1606fdc804f3bc8
   languageName: node


### PR DESCRIPTION
## **Description**

Support disabling enforced simulations via a new simulation settings modal.

Specifically:

- Add `enableEnforcedSimulations` and `enableEnforcedSimulationsForTransactions` to `AppStateController`.
- Add `applyTransactionContainersExisting` utility method to apply transaction containers to an existing transaction.
- Add `SimulationSettingsModal` component to configure enforced simulation settings.
- Add `useIsEnforcedSimulationsSupported` hook to determine if settings should be displayed.
- Check `AppStateController` state in `EnforceSimulationHook`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33802?quickstart=1)

## **Related issues**

Fixes: [#5173](https://github.com/MetaMask/MetaMask-planning/issues/5173)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="393" alt="Modal" src="https://github.com/user-attachments/assets/fc5b8703-c853-4a9e-8d67-9b31337ed68d" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
