### PR TITLE
feat: change to handle batched nested transactions as regular transaction

### DIFF
--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -127,19 +127,19 @@ export async function processSendCalls(
 
   let batchId: Hex;
   if (Object.keys(transactions).length === 1) {
-    const params = {
+    const trxnParams = {
       from,
       ...transactions[0].params,
       type: TransactionEnvelopeType.feeMarket,
     };
     const securityRequest: ValidateSecurityRequest = {
       method: 'eth_sendTransaction',
-      params: [params],
+      params: [trxnParams],
       origin,
     };
     validateSecurity(securityRequest, dappChainId);
     batchId = generateBatchId();
-    await addTransaction(params, {
+    await addTransaction(trxnParams, {
       networkClientId,
       origin,
       securityAlertResponse: { securityAlertId } as SecurityAlertResponse,

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -30,12 +30,12 @@ import {
   AccountsControllerGetStateAction,
 } from '@metamask/accounts-controller';
 import { KeyringTypes } from '@metamask/keyring-controller';
+import { parse, v4 } from 'uuid';
 
 import { EIP5792ErrorCode } from '../../../../shared/constants/transaction';
 import { KEYRING_TYPES_SUPPORTING_7702 } from '../../../../shared/constants/keyring';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { generateSecurityAlertId } from '../ppom/ppom-util';
-import { parse, v4 } from 'uuid';
 
 type Actions =
   | AccountsControllerGetStateAction

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -7,14 +7,16 @@ import {
   IsAtomicBatchSupportedResult,
   IsAtomicBatchSupportedResultEntry,
   Log,
+  SecurityAlertResponse,
   TransactionController,
   TransactionControllerGetStateAction,
+  TransactionEnvelopeType,
   TransactionMeta,
   TransactionReceipt,
   TransactionStatus,
   ValidateSecurityRequest,
 } from '@metamask/transaction-controller';
-import { Hex, JsonRpcRequest } from '@metamask/utils';
+import { bytesToHex, Hex, JsonRpcRequest } from '@metamask/utils';
 import { Messenger } from '@metamask/base-controller';
 import {
   GetCallsStatusCode,
@@ -33,6 +35,7 @@ import { EIP5792ErrorCode } from '../../../../shared/constants/transaction';
 import { KEYRING_TYPES_SUPPORTING_7702 } from '../../../../shared/constants/keyring';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { generateSecurityAlertId } from '../ppom/ppom-util';
+import { parse, v4 } from 'uuid';
 
 type Actions =
   | AccountsControllerGetStateAction
@@ -52,9 +55,21 @@ export enum AtomicCapabilityStatus {
 
 const VERSION = '2.0.0';
 
+/**
+ * Generate a transaction batch ID.
+ *
+ * @returns  A unique batch ID as a hexadecimal string.
+ */
+function generateBatchId(): Hex {
+  const idString = v4();
+  const idBytes = new Uint8Array(parse(idString));
+  return bytesToHex(idBytes);
+}
+
 export async function processSendCalls(
   hooks: {
     addTransactionBatch: TransactionController['addTransactionBatch'];
+    addTransaction: TransactionController['addTransaction'];
     getDismissSmartAccountSuggestionEnabled: () => boolean;
     isAtomicBatchSupported: TransactionController['isAtomicBatchSupported'];
     validateSecurity: (
@@ -69,6 +84,7 @@ export async function processSendCalls(
 ): Promise<SendCallsResult> {
   const {
     addTransactionBatch,
+    addTransaction,
     getDismissSmartAccountSuggestionEnabled,
     isAtomicBatchSupported,
     validateSecurity: validateSecurityHook,
@@ -109,16 +125,39 @@ export async function processSendCalls(
   const securityAlertId = generateSecurityAlertId();
   const validateSecurity = validateSecurityHook.bind(null, securityAlertId);
 
-  const { batchId: id } = await addTransactionBatch({
-    from,
-    networkClientId,
-    origin,
-    securityAlertId,
-    transactions,
-    validateSecurity,
-  });
+  let batchId: Hex;
+  if (Object.keys(transactions).length === 1) {
+    const params = {
+      from,
+      ...transactions[0].params,
+      type: TransactionEnvelopeType.feeMarket,
+    };
+    const securityRequest: ValidateSecurityRequest = {
+      method: 'eth_sendTransaction',
+      params: [params],
+      origin,
+    };
+    validateSecurity(securityRequest, dappChainId);
+    batchId = generateBatchId();
+    await addTransaction(params, {
+      networkClientId,
+      origin,
+      securityAlertResponse: { securityAlertId } as SecurityAlertResponse,
+      batchId,
+    });
+  } else {
+    const result = await addTransactionBatch({
+      from,
+      networkClientId,
+      origin,
+      securityAlertId,
+      transactions,
+      validateSecurity,
+    });
+    batchId = result.batchId;
+  }
 
-  return { id };
+  return { id: batchId };
 }
 
 export function getCallsStatus(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2076,6 +2076,9 @@ export default class MetamaskController extends EventEmitter {
           addTransactionBatch: this.txController.addTransactionBatch.bind(
             this.txController,
           ),
+          addTransaction: this.txController.addTransaction.bind(
+            this.txController,
+          ),
           getDismissSmartAccountSuggestionEnabled: () =>
             this.preferencesController.state.preferences
               .dismissSmartAccountSuggestionEnabled,


### PR DESCRIPTION
## **Description**
Handle wallet_sendCalls containing a single nested transaction as regular transaction.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4961

## **Manual testing steps**

1. Submit batched confirmation with single nested transaction
2. Check that it is treated as regular confirmation

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
