### PR TITLE
fix: cp-12.22.0 resubscribe notifications v2 on app startup.

### DIFF
--- a/ui/contexts/metamask-notifications/metamask-notifications.test.ts
+++ b/ui/contexts/metamask-notifications/metamask-notifications.test.ts
@@ -1,0 +1,380 @@
+import { waitFor } from '@testing-library/react';
+import * as ReactRedux from 'react-redux';
+import * as NotificationHooks from '../../hooks/metamask-notifications/useNotifications';
+import * as NotificationsSelectors from '../../selectors/metamask-notifications/metamask-notifications';
+import * as Selectors from '../../selectors/selectors';
+import * as MetamaskDucks from '../../ducks/metamask/metamask';
+import * as AuthenticationSelectors from '../../selectors/identity/authentication';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers';
+import {
+  useBasicFunctionalityDisableEffect,
+  useFetchInitialNotificationsEffect,
+} from './metamask-notifications'; // Adjust path as needed
+
+describe('useBasicFunctionalityDisableEffect', () => {
+  const arrangeHooks = () => {
+    const mockDisableNotifications = jest.fn();
+    const mockListNotifications = jest.fn();
+
+    const mockUseDisableNotifications = jest.spyOn(
+      NotificationHooks,
+      'useDisableNotifications',
+    );
+    const mockUseListNotifications = jest.spyOn(
+      NotificationHooks,
+      'useListNotifications',
+    );
+
+    mockUseDisableNotifications.mockReturnValue({
+      disableNotifications: mockDisableNotifications,
+      error: null,
+    });
+
+    mockUseListNotifications.mockReturnValue({
+      listNotifications: mockListNotifications,
+      notificationsData: [],
+      isLoading: false,
+      error: undefined,
+    });
+
+    return {
+      disableNotifications: mockDisableNotifications,
+      listNotifications: mockListNotifications,
+      mockUseDisableNotifications,
+      mockUseListNotifications,
+    };
+  };
+
+  const arrangeSelectors = () => {
+    const mockGetUseExternalServices = jest
+      .spyOn(Selectors, 'getUseExternalServices')
+      .mockReturnValue(true);
+
+    const mockIsNotifsEnabled = jest
+      .spyOn(NotificationsSelectors, 'selectIsMetamaskNotificationsEnabled')
+      .mockReturnValue(true);
+
+    return {
+      mockGetUseExternalServices,
+      mockIsNotifsEnabled,
+    };
+  };
+
+  const arrange = () => {
+    return {
+      hooks: arrangeHooks(),
+      selectors: arrangeSelectors(),
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should disable notifications when basic functionality is disabled and notifications are enabled', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(false);
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+
+    renderHookWithProvider(() => useBasicFunctionalityDisableEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.disableNotifications).toHaveBeenCalledTimes(1);
+      expect(mocks.hooks.listNotifications).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should not disable notifications when basic functionality is enabled', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+
+    renderHookWithProvider(() => useBasicFunctionalityDisableEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.disableNotifications).not.toHaveBeenCalled();
+      expect(mocks.hooks.listNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not disable notifications when notifications are already disabled', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(false);
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(false);
+
+    renderHookWithProvider(() => useBasicFunctionalityDisableEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.disableNotifications).not.toHaveBeenCalled();
+      expect(mocks.hooks.listNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should handle errors gracefully', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(false);
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+    mocks.hooks.disableNotifications.mockRejectedValueOnce(
+      new Error('Disable failed'),
+    );
+
+    renderHookWithProvider(() => useBasicFunctionalityDisableEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.disableNotifications).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.hooks.listNotifications).not.toHaveBeenCalled();
+  });
+
+  it('should re-run effect when dependencies change', async () => {
+    const mocks = arrange();
+
+    // Mocking useSelector so it does not memoize the selectors passed in.
+    const originalUseSelector = ReactRedux.useSelector;
+    jest.spyOn(ReactRedux, 'useSelector').mockImplementation((selector) => {
+      // Ensure the selector input is a new reference
+      const wrappedSelector = (state: unknown) => selector(state);
+      return originalUseSelector(wrappedSelector);
+    });
+
+    // First render - conditions not met
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+
+    const { rerender } = renderHookWithProvider(
+      () => useBasicFunctionalityDisableEffect(),
+      {},
+    );
+
+    // Second render - conditions met
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(false);
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+
+    rerender();
+
+    await waitFor(() => {
+      expect(mocks.hooks.disableNotifications).toHaveBeenCalledTimes(1);
+      expect(mocks.hooks.listNotifications).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('useFetchInitialNotificationsEffect', () => {
+  const arrangeHooks = () => {
+    const mockEnableNotifications = jest.fn();
+    const mockListNotifications = jest.fn();
+
+    const mockUseEnableNotifications = jest.spyOn(
+      NotificationHooks,
+      'useEnableNotifications',
+    );
+    const mockUseListNotifications = jest.spyOn(
+      NotificationHooks,
+      'useListNotifications',
+    );
+
+    mockUseEnableNotifications.mockReturnValue({
+      enableNotifications: mockEnableNotifications,
+      error: null,
+    });
+
+    mockUseListNotifications.mockReturnValue({
+      listNotifications: mockListNotifications,
+      notificationsData: [],
+      isLoading: false,
+      error: undefined,
+    });
+
+    return {
+      enableNotifications: mockEnableNotifications,
+      listNotifications: mockListNotifications,
+      mockUseEnableNotifications,
+      mockUseListNotifications,
+    };
+  };
+
+  const arrangeSelectors = () => {
+    const mockIsNotifsEnabled = jest
+      .spyOn(NotificationsSelectors, 'selectIsMetamaskNotificationsEnabled')
+      .mockReturnValue(true);
+
+    const mockGetUseExternalServices = jest
+      .spyOn(Selectors, 'getUseExternalServices')
+      .mockReturnValue(true);
+
+    const mockGetIsUnlocked = jest
+      .spyOn(MetamaskDucks, 'getIsUnlocked')
+      .mockReturnValue(true);
+
+    const mockSelectIsSignedIn = jest
+      .spyOn(AuthenticationSelectors, 'selectIsSignedIn')
+      .mockReturnValue(true);
+
+    return {
+      mockIsNotifsEnabled,
+      mockGetUseExternalServices,
+      mockGetIsUnlocked,
+      mockSelectIsSignedIn,
+    };
+  };
+
+  const arrange = () => {
+    return {
+      hooks: arrangeHooks(),
+      selectors: arrangeSelectors(),
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should enable and fetch notifications when all conditions are met', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(true);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(true);
+
+    renderHookWithProvider(() => useFetchInitialNotificationsEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.enableNotifications).toHaveBeenCalledTimes(1);
+      expect(mocks.hooks.listNotifications).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should not fetch notifications when basic functionality is disabled', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(false);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(true);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(true);
+
+    renderHookWithProvider(() => useFetchInitialNotificationsEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.enableNotifications).not.toHaveBeenCalled();
+      expect(mocks.hooks.listNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not fetch notifications when notifications are disabled', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(false);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(true);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(true);
+
+    renderHookWithProvider(() => useFetchInitialNotificationsEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.enableNotifications).not.toHaveBeenCalled();
+      expect(mocks.hooks.listNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not fetch notifications when user is not signed in', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(true);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(false);
+
+    renderHookWithProvider(() => useFetchInitialNotificationsEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.enableNotifications).not.toHaveBeenCalled();
+      expect(mocks.hooks.listNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not fetch notifications when wallet is locked', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(false);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(true);
+
+    renderHookWithProvider(() => useFetchInitialNotificationsEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.enableNotifications).not.toHaveBeenCalled();
+      expect(mocks.hooks.listNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should handle errors gracefully', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(true);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(true);
+    mocks.hooks.enableNotifications.mockRejectedValueOnce(
+      new Error('Enable failed'),
+    );
+
+    renderHookWithProvider(() => useFetchInitialNotificationsEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.enableNotifications).toHaveBeenCalledTimes(1);
+    });
+    // Should not throw error
+  });
+
+  it('should handle listNotifications error gracefully', async () => {
+    const mocks = arrange();
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(true);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(true);
+    mocks.hooks.listNotifications.mockRejectedValueOnce(
+      new Error('List failed'),
+    );
+
+    renderHookWithProvider(() => useFetchInitialNotificationsEffect(), {});
+
+    await waitFor(() => {
+      expect(mocks.hooks.enableNotifications).toHaveBeenCalledTimes(1);
+      expect(mocks.hooks.listNotifications).toHaveBeenCalledTimes(1);
+    });
+    // Should not throw error
+  });
+
+  it('should re-run effect when dependencies change', async () => {
+    const mocks = arrange();
+
+    // Mocking useSelector so it does not memoize the selectors passed in.
+    const originalUseSelector = ReactRedux.useSelector;
+    jest.spyOn(ReactRedux, 'useSelector').mockImplementation((selector) => {
+      // Ensure the selector input is a new reference
+      const wrappedSelector = (state: unknown) => selector(state);
+      return originalUseSelector(wrappedSelector);
+    });
+
+    // First render - conditions not met
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(false);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(true);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(true);
+
+    const { rerender } = renderHookWithProvider(
+      () => useFetchInitialNotificationsEffect(),
+      {},
+    );
+
+    // Second render - conditions met
+    mocks.selectors.mockIsNotifsEnabled.mockReturnValue(true);
+    mocks.selectors.mockGetUseExternalServices.mockReturnValue(true);
+    mocks.selectors.mockGetIsUnlocked.mockReturnValue(true);
+    mocks.selectors.mockSelectIsSignedIn.mockReturnValue(true);
+
+    rerender();
+
+    await waitFor(() => {
+      expect(mocks.hooks.enableNotifications).toHaveBeenCalledTimes(1);
+      expect(mocks.hooks.listNotifications).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## **Description**

This ensures that we subscribe users to notification v2 subscriptions. Pretty nice especially when we want to ensure that users have up-to-date subscriptions.

Long term, we can think about moving this into the controller directly.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33805?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33801

## **Manual testing steps**

See issue repro steps
0. Install an older extension and enable notifications
1. Install this change, open background script to monitor network
2. Unlock app - EXPECTED, should see a call to the `https://trigger.api.cx.metamask.io/v2` endpoint 
  - this resubscribes the users notifications to the v2 architecture.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/6cb1ab53c39b4ceba0420cd92358a4f0

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
