### PR TITLE
chore: Make policy review tip visible again in identify-codeowners.ts

### DIFF
--- a/.github/scripts/identify-codeowners.ts
+++ b/.github/scripts/identify-codeowners.ts
@@ -232,14 +232,14 @@ function createCommentBody(teamFiles: TeamFiles, teamEmojis: TeamEmojis): string
     // List files in a simplified, but properly-indented format
     const dirTree = buildSimpleDirectoryTree(files);
 
-    if(team === '@MetaMask/policy-reviewers') {
-      commentBody += policyReviewInstructions
-    }
-
     commentBody += renderSimpleDirectoryTree(dirTree, '');
 
     // Close the details tag
     commentBody += `</details>\n`;
+
+    if(team === '@MetaMask/policy-reviewers') {
+      commentBody += policyReviewInstructions
+    }
 
     // Only add divider if not the last team
     if (index < sortedOwners.length - 1) {


### PR DESCRIPTION
## **Description**

Bringing back the visibility for process documentation since I'm getting direct pings for reviews based on codeowners again.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33828?quickstart=1)

## **Related issues**

caused by https://github.com/MetaMask/metamask-extension/pull/31378/files#diff-87bda53976e03a66441b6c9ba75ca54bf0771376b9b8226fe76d6e1d932c2a48

## **Manual testing steps**

1. see if work

## **Screenshots/Recordings**


### **Before**

Only visible if details opened, also - broken rendering of TIP

![Screenshot 2025-06-23 at 11-16-00 feat 2 0 added `OAuthService` for social logins by lwin-kyaw · Pull Request #33378 · MetaMask_metamask-extension](https://github.com/user-attachments/assets/5140ebac-e25f-4cc8-a93e-3d1cf5f78258)


### **After**

(with more context visible)

![Screenshot 2025-06-23 at 11-14-58 feat 2 0 added `OAuthService` for social logins by lwin-kyaw · Pull Request #33378 · MetaMask_metamask-extension](https://github.com/user-attachments/assets/4c76c48c-6a02-4e7f-81bc-55911595d4b0)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
