### PR TITLE
feat: add ledger sign typed v4 e2e tests

### DIFF
--- a/test/e2e/tests/hardware-wallets/ledger-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger-sign.spec.ts
@@ -1,0 +1,34 @@
+import { Suite } from 'mocha';
+import { Driver } from '../../webdriver/driver';
+import FixtureBuilder from '../../fixture-builder';
+import { withFixtures } from '../../helpers';
+import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../stub/keyring-bridge';
+import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import TestDappPage from '../../page-objects/pages/test-dapp';
+
+describe('Ledger Hardware Signatures', function (this: Suite) {
+  it('sign typed v4', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withLedgerAccount()
+          .withPermissionControllerConnectedToTestDapp({
+            account: KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        dapp: true,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+        const testDappPage = new TestDappPage(driver);
+        await testDappPage.openTestDappPage();
+        await testDappPage.check_pageIsLoaded();
+        await testDappPage.signTypedDataV4();
+        await testDappPage.check_successSignTypedDataV4(
+          KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+        );
+      },
+    );
+  });
+});


### PR DESCRIPTION


## **Description**

Adds ledger e2e test for the following scenario:
- Sign typed v4 message from `test-dapp`


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33832?quickstart=1)

## **Related issues**

Relates to: https://github.com/MetaMask/accounts-planning/issues/942

## **Manual testing steps**

Locally:
- run `yarn start:test` and wait for end of build
- run `yarn test:e2e:single test/e2e/tests/hardware-wallets/ledger-sign.spec.ts`

On CI, check e2e tests job

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
