### PR TITLE
test: move the  home page validation to the `loginWithoutBalanceValidation`

### DIFF
--- a/test/e2e/page-objects/flows/login.flow.ts
+++ b/test/e2e/page-objects/flows/login.flow.ts
@@ -19,6 +19,10 @@ export const loginWithoutBalanceValidation = async (
   const loginPage = new LoginPage(driver);
   await loginPage.check_pageIsLoaded();
   await loginPage.loginToHomepage(password);
+
+  // user should land on homepage after successfully logging in with password
+  const homePage = new HomePage(driver);
+  await homePage.check_pageIsLoaded();
 };
 
 /**
@@ -34,9 +38,7 @@ export const loginWithBalanceValidation = async (
   password?: string,
 ) => {
   await loginWithoutBalanceValidation(driver, password);
-  // user should land on homepage after successfully logging in with password
   const homePage = new HomePage(driver);
-  await homePage.check_pageIsLoaded();
 
   // Verify the expected balance on the homepage
   if (localNode) {

--- a/test/e2e/snaps/test-snap-lifecycle.spec.ts
+++ b/test/e2e/snaps/test-snap-lifecycle.spec.ts
@@ -3,7 +3,7 @@ import { TestSnaps } from '../page-objects/pages/test-snaps';
 import SnapInstall from '../page-objects/pages/dialog/snap-install';
 import FixtureBuilder from '../fixture-builder';
 import { loginWithoutBalanceValidation } from '../page-objects/flows/login.flow';
-import { withFixtures, WINDOW_TITLES } from '../helpers';
+import { unlockWallet, withFixtures, WINDOW_TITLES } from '../helpers';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
 import { mockLifecycleHooksSnap } from '../mock-response-data/snaps/snap-binary-mocks';
 
@@ -51,7 +51,7 @@ describe('Test Snap Lifecycle Hooks', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        await unlockWallet(driver);
 
         const snapInstall = new SnapInstall(driver);
 

--- a/test/e2e/tests/onboarding/onboarding.spec.ts
+++ b/test/e2e/tests/onboarding/onboarding.spec.ts
@@ -18,7 +18,6 @@ import OnboardingPrivacySettingsPage from '../../page-objects/pages/onboarding/o
 import OnboardingSrpPage from '../../page-objects/pages/onboarding/onboarding-srp-page';
 import SecureWalletPage from '../../page-objects/pages/onboarding/secure-wallet-page';
 import StartOnboardingPage from '../../page-objects/pages/onboarding/start-onboarding-page';
-import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
 import {
   completeCreateNewWalletOnboardingFlow,
   completeImportSRPOnboardingFlow,
@@ -309,7 +308,7 @@ describe('MetaMask onboarding', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        await unlockWallet(driver);
         // First screen we should be on is MetaMetrics
         const onboardingMetricsPage = new OnboardingMetricsPage(driver);
         await onboardingMetricsPage.check_pageIsLoaded();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR moves the home page validation after login in, into the `loginWithoutBalanceValidation`. This way, we get the home page validation in both `loginWithoutBalanceValidation` and `loginWithBalanceValidation`, making the first method more robust.

This issue was spotted by @davidmurdoch 


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33836?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. All tests should continue to pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
