### PR TITLE
chore: replacing deprecated button with component library version

### DIFF
--- a/ui/components/app/modals/hide-token-confirmation-modal/__snapshots__/hide-token-confirmation-modal.test.js.snap
+++ b/ui/components/app/modals/hide-token-confirmation-modal/__snapshots__/hide-token-confirmation-modal.test.js.snap
@@ -65,17 +65,18 @@ exports[`Hide Token Confirmation Modal should match snapshot 1`] = `
       You can add this token back in the future by going to “Import token” in your accounts options menu.
     </div>
     <div
-      class="hide-token-confirmation__buttons"
+      class="mm-box mm-box--margin-top-4 mm-box--display-flex mm-box--gap-4 mm-box--width-full"
     >
       <button
-        class="button btn-secondary hide-token-confirmation__button"
+        class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-base--block mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-xl mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
         data-testid="hide-token-confirmation__cancel"
       >
         Cancel
       </button>
       <button
-        class="button btn-primary hide-token-confirmation__button"
+        class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-base--block mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-xl"
         data-testid="hide-token-confirmation__hide"
+        data-theme="light"
       >
         Hide
       </button>

--- a/ui/components/app/modals/hide-token-confirmation-modal/hide-token-confirmation-modal.js
+++ b/ui/components/app/modals/hide-token-confirmation-modal/hide-token-confirmation-modal.js
@@ -3,7 +3,13 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../../../../store/actions';
 import Identicon from '../../../ui/identicon';
-import Button from '../../../ui/button';
+import { Button, ButtonVariant, Box } from '../../../component-library';
+import {
+  Display,
+  JustifyContent,
+  AlignItems,
+  BlockSize,
+} from '../../../../helpers/constants/design-system';
 import { DEFAULT_ROUTE } from '../../../../helpers/constants/routes';
 import {
   MetaMetricsEventCategory,
@@ -92,18 +98,25 @@ class HideTokenConfirmationModal extends Component {
         <div className="hide-token-confirmation__copy">
           {this.context.t('readdToken')}
         </div>
-        <div className="hide-token-confirmation__buttons">
+        <Box
+          display={Display.Flex}
+          justifyContent={JustifyContent.Center}
+          alignItems={AlignItems.Center}
+          gap={4}
+          marginTop={4}
+          width={BlockSize.Full}
+        >
           <Button
-            type="secondary"
-            className="hide-token-confirmation__button"
+            variant={ButtonVariant.Secondary}
+            block
             data-testid="hide-token-confirmation__cancel"
             onClick={() => hideModal()}
           >
             {this.context.t('cancel')}
           </Button>
           <Button
-            type="primary"
-            className="hide-token-confirmation__button"
+            variant={ButtonVariant.Primary}
+            block
             data-testid="hide-token-confirmation__hide"
             onClick={() => {
               this.context.trackEvent({
@@ -121,7 +134,7 @@ class HideTokenConfirmationModal extends Component {
           >
             {this.context.t('hide')}
           </Button>
-        </div>
+        </Box>
       </div>
     );
   }

--- a/ui/components/app/modals/hide-token-confirmation-modal/index.scss
+++ b/ui/components/app/modals/hide-token-confirmation-modal/index.scss
@@ -43,16 +43,4 @@
     color: var(--color-text-alternative);
     text-align: center;
   }
-
-  &__buttons {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    margin-top: 15px;
-    width: 100%;
-  }
-
-  &__button {
-    margin: 0 5px;
-  }
 }

--- a/ui/components/app/modals/new-account-modal/new-account-modal.component.js
+++ b/ui/components/app/modals/new-account-modal/new-account-modal.component.js
@@ -1,7 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Button from '../../../ui/button/button.component';
-import { ButtonIcon, IconName } from '../../../component-library';
+import {
+  Button,
+  ButtonVariant,
+  ButtonIcon,
+  IconName,
+} from '../../../component-library';
 
 export default class NewAccountModal extends Component {
   static contextTypes = {
@@ -64,11 +68,16 @@ export default class NewAccountModal extends Component {
           />
         </div>
         <div className="new-account-modal__footer">
-          <Button type="secondary" onClick={this.props.hideModal}>
+          <Button
+            variant={ButtonVariant.Secondary}
+            block
+            onClick={this.props.hideModal}
+          >
             {t('cancel')}
           </Button>
           <Button
-            type="primary"
+            variant={ButtonVariant.Primary}
+            block
             onClick={this.onSubmit}
             disabled={!this.state.alias}
           >

--- a/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
+++ b/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
@@ -4,20 +4,23 @@ import { useHistory } from 'react-router-dom';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 // Components
 import Box from '../../ui/box';
-import Button from '../../ui/button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  Text,
+} from '../../component-library';
 import Popover from '../../ui/popover';
 // Helpers
 import {
   DISPLAY,
   TextAlign,
   TextVariant,
-  BLOCK_SIZES,
   FontWeight,
   JustifyContent,
   TextColor,
 } from '../../../helpers/constants/design-system';
 import { ONBOARDING_UNLOCK_ROUTE } from '../../../helpers/constants/routes';
-import { Text } from '../../component-library';
 
 export default function RecoveryPhraseReminder({ onConfirm, hasBackedUp }) {
   const t = useI18nContext();
@@ -61,12 +64,9 @@ export default function RecoveryPhraseReminder({ onConfirm, hasBackedUp }) {
                   {t('recoveryPhraseReminderHasNotBackedUp')}
                   <Box display={DISPLAY.INLINE_BLOCK} marginLeft={1}>
                     <Button
-                      type="link"
+                      variant={ButtonVariant.Link}
                       onClick={handleBackUp}
-                      style={{
-                        fontSize: 'inherit',
-                        padding: 0,
-                      }}
+                      size={ButtonSize.Inherit}
                     >
                       {t('recoveryPhraseReminderBackupStart')}
                     </Button>
@@ -77,11 +77,9 @@ export default function RecoveryPhraseReminder({ onConfirm, hasBackedUp }) {
           </ul>
         </Box>
         <Box justifyContent={JustifyContent.center}>
-          <Box width={BLOCK_SIZES.TWO_FIFTHS}>
-            <Button type="primary" onClick={onConfirm}>
-              {t('recoveryPhraseReminderConfirm')}
-            </Button>
-          </Box>
+          <Button variant={ButtonVariant.Primary} block onClick={onConfirm}>
+            {t('recoveryPhraseReminderConfirm')}
+          </Button>
         </Box>
       </Box>
     </Popover>

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-gas-limit/advanced-gas-fee-gas-limit.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-gas-limit/advanced-gas-fee-gas-limit.js
@@ -5,11 +5,15 @@ import { bnGreaterThan, bnLessThan } from '../../../../../helpers/utils/util';
 import { TextVariant } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { MAX_GAS_LIMIT_DEC } from '../../../send/send.constants';
-import Button from '../../../../../components/ui/button';
 import FormField from '../../../../../components/ui/form-field';
 
 import { useAdvancedGasFeePopoverContext } from '../context';
-import { Text } from '../../../../../components/component-library';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  Text,
+} from '../../../../../components/component-library';
 import { IGNORE_GAS_LIMIT_CHAIN_IDS } from '../../../constants';
 import { hexToDecimal } from '../../../../../../shared/modules/conversion.utils';
 
@@ -102,7 +106,8 @@ const AdvancedGasFeeGasLimit = () => {
         data-testid="advanced-gas-fee-edit"
         className="advanced-gas-fee-gas-limit__edit-link"
         onClick={() => setEditing(true)}
-        type="link"
+        variant={ButtonVariant.Link}
+        size={ButtonSize.Inherit}
       >
         {t('edit')}
       </Button>

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-gas-limit/advanced-gas-fee-gas-limit.stories.tsx
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-gas-limit/advanced-gas-fee-gas-limit.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import testData from '../../../../../../.storybook/test-data';
+import configureStore from '../../../../../store/store';
+import { AdvancedGasFeePopoverContextProvider } from '../context';
+import { GasFeeContextProvider } from '../../../../../contexts/gasFee';
+import AdvancedGasFeeGasLimit from './advanced-gas-fee-gas-limit';
+
+const store = configureStore(testData);
+
+const meta: Meta<typeof AdvancedGasFeeGasLimit> = {
+  title: 'Pages/Confirmations/Components/AdvancedGasFeePopover/AdvancedGasFeeGasLimit',
+  component: AdvancedGasFeeGasLimit,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <GasFeeContextProvider
+          transaction={{
+            userFeeLevel: 'custom',
+            txParams: { gas: '0x5208' }, // 21000 in hex
+            chainId: '0x1',
+            originalGasEstimate: '0x5208',
+          }}
+        >
+          <AdvancedGasFeePopoverContextProvider>
+              <Story />
+          </AdvancedGasFeePopoverContextProvider>
+        </GasFeeContextProvider>
+      </Provider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AdvancedGasFeeGasLimit>;
+
+export const Default: Story = {};

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-save/advanced-gas-fee-save.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-save/advanced-gas-fee-save.js
@@ -1,12 +1,14 @@
 import React from 'react';
-
 import { PriorityLevels } from '../../../../../../shared/constants/gas';
 import { decGWEIToHexWEI } from '../../../../../../shared/modules/conversion.utils';
 import { useTransactionModalContext } from '../../../../../contexts/transaction-modal';
 import { useGasFeeContext } from '../../../../../contexts/gasFee';
 import { useTransactionEventFragment } from '../../../hooks/useTransactionEventFragment';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import Button from '../../../../../components/ui/button';
+import {
+  Button,
+  ButtonVariant,
+} from '../../../../../components/component-library';
 
 import { useAdvancedGasFeePopoverContext } from '../context';
 
@@ -34,7 +36,12 @@ const AdvancedGasFeeSaveButton = () => {
   };
 
   return (
-    <Button type="primary" disabled={hasErrors} onClick={onSave}>
+    <Button
+      variant={ButtonVariant.Primary}
+      disabled={hasErrors}
+      onClick={onSave}
+      block
+    >
       {t('save')}
     </Button>
   );

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-save/advanced-gas-fee-save.stories.tsx
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-save/advanced-gas-fee-save.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import testData from '../../../../../../.storybook/test-data';
+import configureStore from '../../../../../store/store';
+import { AdvancedGasFeePopoverContextProvider } from '../context';
+import { GasFeeContextProvider } from '../../../../../contexts/gasFee';
+import { TransactionModalContextProvider } from '../../../../../contexts/transaction-modal';
+import AdvancedGasFeeSaveButton from './advanced-gas-fee-save';
+
+const store = configureStore(testData);
+
+const meta: Meta<typeof AdvancedGasFeeSaveButton> = {
+  title:
+    'Pages/Confirmations/Components/AdvancedGasFeePopover/AdvancedGasFeeSaveButton',
+  component: AdvancedGasFeeSaveButton,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <TransactionModalContextProvider>
+          <GasFeeContextProvider
+            transaction={{
+              userFeeLevel: 'custom',
+              txParams: { gas: '0x5208' },
+              chainId: '0x1',
+            }}
+          >
+            <AdvancedGasFeePopoverContextProvider>
+              <Story />
+            </AdvancedGasFeePopoverContextProvider>
+          </GasFeeContextProvider>
+        </TransactionModalContextProvider>
+      </Provider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AdvancedGasFeeSaveButton>;
+
+export const Default: Story = {};

--- a/ui/pages/confirmations/components/edit-gas-display/edit-gas-display.component.js
+++ b/ui/pages/confirmations/components/edit-gas-display/edit-gas-display.component.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import BigNumber from 'bignumber.js';
 import { EditGasModes } from '../../../../../shared/constants/gas';
 
-import Button from '../../../../components/ui/button';
-
 import {
   TextAlign,
   FontWeight,
@@ -13,7 +11,11 @@ import {
   TextVariant,
   Severity,
 } from '../../../../helpers/constants/design-system';
-import { BannerAlert, Text } from '../../../../components/component-library';
+import {
+  BannerAlert,
+  Text,
+  ButtonBase,
+} from '../../../../components/component-library';
 import { areDappSuggestedAndTxParamGasFeesTheSame } from '../../../../helpers/utils/confirm-tx.util';
 
 import InfoTooltip from '../../../../components/ui/info-tooltip';
@@ -111,12 +113,12 @@ export default function EditGasDisplay({
           {estimatedMinimumNative}
         </Text>
         {requireDappAcknowledgement && (
-          <Button
+          <ButtonBase
             className="edit-gas-display__dapp-acknowledgement-button"
             onClick={() => setDappSuggestedGasFeeAcknowledged(true)}
           >
             {t('gasDisplayAcknowledgeDappButtonText')}
-          </Button>
+          </ButtonBase>
         )}
         {!requireDappAcknowledgement && (
           <AdvancedGasControls

--- a/ui/pages/confirmations/components/edit-gas-display/index.scss
+++ b/ui/pages/confirmations/components/edit-gas-display/index.scss
@@ -20,6 +20,16 @@
     text-transform: unset;
     width: auto;
     background: transparent;
+
+    &:hover {
+      color: var(--color-warning-default);
+      border: 1px solid var(--color-warning-default);
+      background-color: var(--color-background-hover);
+    }
+
+    &:active {
+      background-color: var(--color-background-pressed);
+    }
   }
 
   .radio-group {

--- a/ui/pages/connected-sites/connected-sites.component.js
+++ b/ui/pages/connected-sites/connected-sites.component.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ConnectedSitesList from '../../components/app/connected-sites-list';
 import Popover from '../../components/ui/popover/popover.component';
-import Button from '../../components/ui/button';
+import { Button, ButtonVariant } from '../../components/component-library';
 
 export default class ConnectedSites extends Component {
   static contextTypes = {
@@ -130,10 +130,18 @@ export default class ConnectedSites extends Component {
         footer={
           <>
             <div className="connected-sites__footer-row">
-              <Button type="secondary" onClick={this.clearPendingDisconnect}>
+              <Button
+                variant={ButtonVariant.Secondary}
+                onClick={this.clearPendingDisconnect}
+                block
+              >
                 {t('cancel')}
               </Button>
-              <Button type="primary" onClick={this.disconnectAccount}>
+              <Button
+                variant={ButtonVariant.Primary}
+                onClick={this.disconnectAccount}
+                block
+              >
                 {t('disconnect')}
               </Button>
             </div>

--- a/ui/pages/create-account/connect-hardware/account-list.js
+++ b/ui/pages/create-account/connect-hardware/account-list.js
@@ -2,7 +2,11 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { getAccountLink } from '@metamask/etherscan-link';
 
-import Button from '../../../components/ui/button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '../../../components/component-library';
 import Checkbox from '../../../components/ui/check-box';
 import Dropdown from '../../../components/ui/dropdown';
 
@@ -205,16 +209,17 @@ class AccountList extends Component {
     return (
       <div className="new-external-account-form__buttons">
         <Button
-          type="secondary"
-          large
-          className="new-external-account-form__button"
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
+          block
           onClick={this.props.onCancel.bind(this)}
         >
           {this.context.t('cancel')}
         </Button>
         <Button
-          type="primary"
-          large
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          block
           className="new-external-account-form__button unlock"
           disabled={disabled}
           onClick={this.props.onUnlockAccounts.bind(

--- a/ui/pages/create-account/connect-hardware/index.scss
+++ b/ui/pages/create-account/connect-hardware/index.scss
@@ -270,10 +270,7 @@
     display: flex;
     width: 100%;
     justify-content: space-between;
-  }
-
-  &__button:not(:last-child) {
-    margin-right: 16px;
+    gap: 16px;
   }
 }
 

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -1,7 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect, useHistory } from 'react-router-dom';
-import Button from '../../../../components/ui/button/button.component';
 import TextField from '../../../../components/ui/text-field';
 import PageContainerFooter from '../../../../components/ui/page-container/page-container-footer';
 import {
@@ -9,6 +8,8 @@ import {
   isValidHexAddress,
 } from '../../../../../shared/modules/hexstring-utils';
 import {
+  Button,
+  ButtonVariant,
   AvatarAccount,
   AvatarAccountSize,
   AvatarNetwork,
@@ -107,7 +108,8 @@ const EditContact = ({
         </Box>
         <Box className="settings-page__address-book-button">
           <Button
-            type="link"
+            variant={ButtonVariant.Link}
+            danger
             style={{ display: 'contents' }}
             onClick={async () => {
               await removeFromAddressBook(contactChainId, address);

--- a/ui/pages/settings/contact-list-tab/view-contact/view-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/view-contact/view-contact.component.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
 
-import Button from '../../../../components/ui/button/button.component';
-
 import {
+  Button,
+  ButtonVariant,
   AvatarAccount,
   AvatarAccountSize,
   Box,
@@ -66,7 +66,7 @@ function ViewContact({
         </Box>
         <div className="address-book__view-contact__group">
           <Button
-            type="secondary"
+            variant={ButtonVariant.Secondary}
             onClick={() => {
               history.push(`${editRoute}/${address}`);
             }}

--- a/ui/pages/swaps/select-quote-popover/select-quote-popover.js
+++ b/ui/pages/swaps/select-quote-popover/select-quote-popover.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { I18nContext } from '../../../contexts/i18n';
 import Popover from '../../../components/ui/popover';
-import Button from '../../../components/ui/button';
+import { Button, ButtonVariant } from '../../../components/component-library';
 import QuoteDetails from './quote-details';
 import SortList from './sort-list';
 import { QUOTE_DATA_ROWS_PROPTYPES_SHAPE } from './select-quote-popover-constants';
@@ -59,7 +59,7 @@ const SelectQuotePopover = ({
   const footer = (
     <>
       <Button
-        type="secondary"
+        variant={ButtonVariant.Secondary}
         className="page-container__footer-button select-quote-popover__button"
         onClick={onClose}
       >
@@ -67,7 +67,7 @@ const SelectQuotePopover = ({
       </Button>
 
       <Button
-        type="primary"
+        variant={ButtonVariant.Primary}
         className="page-container__footer-button select-quote-popover__button"
         onClick={onSubmitClick}
       >


### PR DESCRIPTION
## **Description**

This PR replaces the deprecated `ui/components/ui/button` components to the component library `Button` component across multiple files. Once this PR is merged we can delete `ui/components/ui/button` in another PR which will significantly help with future Button iterations as well as [updating the buttons to monochome](https://github.com/MetaMask/metamask-extension/pull/33847)

**Reason for the change:**
The old button component has been deprecated in favor of the component library Button(and soon the monorepo component) which provides better TypeScript support, improved accessibility features, and consistent styling aligned with the MetaMask design system.

**What is the improvement/solution:**
- Replaced 11 instances of deprecated button imports with new component library imports
- Updated button props from `type` to `variant` using `ButtonVariant` enum
- Converted danger buttons to use the `danger` prop instead of `type="danger"`
- Updated test snapshots to reflect new button class names and structure
- Maintained all existing functionality while improving code consistency

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33854?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/18896

## **Manual testing steps**

1. View various file updates in storybook
2. Confirm visual changes

## **Screenshots/Recordings**

Before and after screenshots added in code comments for easier review

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.