### PR TITLE
ci: fix FORCE_CLEANUP in generate-attributions.sh

### DIFF
--- a/development/generate-attributions.sh
+++ b/development/generate-attributions.sh
@@ -47,7 +47,7 @@ main() {
   yarn generate-attribution -o "${PROJECT_DIRECTORY}" -b "${PROJECT_DIRECTORY}"
 
   # Check if the script is running in a CI environment (GitHub Actions sets the CI variable to true)
-  if [ -z "${CI:-}" ] || [ "${FORCE_CLEANUP}" = "true" ]; then
+  if [ -z "${CI:-}" ] || [ "${FORCE_CLEANUP:-}" = "true" ]; then
     # If not running in CI, restore the allow-scripts plugin and development dependencies.
     cd "${PROJECT_DIRECTORY}"
     git checkout -- .yarnrc.yml .yarn package.json


### PR DESCRIPTION
## **Description**

Fixes this error by adding a `:-`

`./development/generate-attributions.sh: line 50: FORCE_CLEANUP: unbound variable`

## **Related issues**

Fixes: problem introduced in #33784

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->