### PR TITLE
fix: Change tooltip position on network indicator

### DIFF
--- a/ui/components/multichain/account-network-indicator/account-network-indicator.tsx
+++ b/ui/components/multichain/account-network-indicator/account-network-indicator.tsx
@@ -41,7 +41,7 @@ export const AccountNetworkIndicator = ({ scopes }: { scopes: string[] }) => {
   return (
     <Box data-testid="account-network-indicator">
       <Tooltip
-        position="bottom"
+        position="left"
         html={
           <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
             <Box display={Display.Flex} flexDirection={FlexDirection.Column}>


### PR DESCRIPTION
## **Description**
We noticed that when having just few accounts there is an issue with displaying a tooltip with network list on a network indicator located within the account list item used for displaying account information in menus or similar.

This issue is present because sometimes tooltip doesn't have enough space to be displayed at the bottom position which was previously specified. This PR is changing position of the tooltip to the `left` as we always have enough space on the left side within the account list item component. 

Tooltip used is from Design System library and its behavior is inherited from there.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33880?quickstart=1)

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-286

## **Manual testing steps**
1. Go to account list menu and check network tooltip in multiple cases, like when there are few or many more accounts.

## **Screenshots/Recordings**
### **Before**
![image](https://github.com/user-attachments/assets/6dc14340-a9ee-469a-a7ab-6e2f26940cd7)

### **After**

https://github.com/user-attachments/assets/e9a25016-9b1b-42fd-96cc-6d12c89fda24

https://github.com/user-attachments/assets/ffd522dc-c696-4bc1-99e4-2e4e04e69bde

https://github.com/user-attachments/assets/4a43eef5-0e85-4910-9fc1-b0d96e9c1b2e


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.