### PR TITLE
fix: changes in send call validations when batch confirmation is treated as regular send transaction

### DIFF
--- a/app/scripts/lib/transaction/eip5792.test.ts
+++ b/app/scripts/lib/transaction/eip5792.test.ts
@@ -375,7 +375,7 @@ describe('EIP-5792', () => {
       ).rejects.toThrow('EIP-7702 upgrade disabled by the user');
     });
 
-    it('does not throws if user enabled preference to dismiss option to upgrade account for single nested transaction', async () => {
+    it('does not throw if user enabled preference to dismiss option to upgrade account for single nested transaction', async () => {
       getDismissSmartAccountSuggestionEnabledMock.mockReturnValue(true);
 
       const result = await processSendCalls(

--- a/app/scripts/lib/transaction/eip5792.test.ts
+++ b/app/scripts/lib/transaction/eip5792.test.ts
@@ -23,7 +23,6 @@ import {
 } from '@metamask/accounts-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
-import * as MMUtils from '@metamask/utils';
 
 import {
   PreferencesControllerGetStateAction,

--- a/app/scripts/lib/transaction/eip5792.test.ts
+++ b/app/scripts/lib/transaction/eip5792.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@metamask/accounts-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
+import * as MMUtils from '@metamask/utils';
 
 import {
   PreferencesControllerGetStateAction,
@@ -325,6 +326,16 @@ describe('EIP-5792', () => {
           REQUEST_MOCK,
         ),
       ).toStrictEqual({ id: BATCH_ID_MOCK });
+    });
+
+    it('does not validate send call if there is only 1 nested transaction', async () => {
+      const result = await processSendCalls(
+        sendCallsHooks,
+        messenger,
+        { ...SEND_CALLS_MOCK, calls: [{ to: '0x123' }], version: '1.0' },
+        REQUEST_MOCK,
+      );
+      expect(result.id).toBeDefined();
     });
 
     it('throws if version not supported', async () => {

--- a/app/scripts/lib/transaction/eip5792.test.ts
+++ b/app/scripts/lib/transaction/eip5792.test.ts
@@ -327,14 +327,15 @@ describe('EIP-5792', () => {
       ).toStrictEqual({ id: BATCH_ID_MOCK });
     });
 
-    it('does not validate send call if there is only 1 nested transaction', async () => {
-      const result = await processSendCalls(
-        sendCallsHooks,
-        messenger,
-        { ...SEND_CALLS_MOCK, calls: [{ to: '0x123' }], version: '1.0' },
-        REQUEST_MOCK,
-      );
-      expect(result.id).toBeDefined();
+    it('throws if version not supported for single nested transaction', async () => {
+      await expect(
+        processSendCalls(
+          sendCallsHooks,
+          messenger,
+          { ...SEND_CALLS_MOCK, calls: [{ to: '0x123' }], version: '1.0' },
+          REQUEST_MOCK,
+        ),
+      ).rejects.toThrow(`Version not supported: Got 1.0, expected 2.0.0`);
     });
 
     it('throws if version not supported', async () => {
@@ -374,6 +375,18 @@ describe('EIP-5792', () => {
       ).rejects.toThrow('EIP-7702 upgrade disabled by the user');
     });
 
+    it('does not throws if user enabled preference to dismiss option to upgrade account for single nested transaction', async () => {
+      getDismissSmartAccountSuggestionEnabledMock.mockReturnValue(true);
+
+      const result = await processSendCalls(
+        sendCallsHooks,
+        messenger,
+        { ...SEND_CALLS_MOCK, calls: [{ to: '0x123' }] },
+        REQUEST_MOCK,
+      );
+      expect(result.id).toBeDefined();
+    });
+
     it('does not throw if user enabled preference to dismiss option to upgrade account if already upgraded', async () => {
       getDismissSmartAccountSuggestionEnabledMock.mockReturnValue(true);
 
@@ -402,6 +415,25 @@ describe('EIP-5792', () => {
           messenger,
           {
             ...SEND_CALLS_MOCK,
+            capabilities: {
+              test: {},
+              test2: { optional: true },
+              test3: { optional: false },
+            },
+          },
+          REQUEST_MOCK,
+        ),
+      ).rejects.toThrow('Unsupported non-optional capabilities: test, test3');
+    });
+
+    it('throws if top-level capability is required for single nested transaction', async () => {
+      await expect(
+        processSendCalls(
+          sendCallsHooks,
+          messenger,
+          {
+            ...SEND_CALLS_MOCK,
+            calls: [{ to: '0x123' }],
             capabilities: {
               test: {},
               test2: { optional: true },

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -57,113 +57,6 @@ export enum AtomicCapabilityStatus {
 
 const VERSION = '2.0.0';
 
-async function processSingleTransaction({
-  addTransaction,
-  chainId,
-  from,
-  networkClientId,
-  origin,
-  securityAlertId,
-  sendCalls,
-  transactions,
-  validateSecurity,
-}: {
-  addTransaction: TransactionController['addTransaction'];
-  chainId: Hex;
-  from: Hex;
-  networkClientId: string;
-  origin?: string;
-  securityAlertId: string;
-  sendCalls: SendCalls;
-  transactions: { params: BatchTransactionParams }[];
-  validateSecurity: (
-    securityRequest: ValidateSecurityRequest,
-    chainId: Hex,
-  ) => void;
-}) {
-  validateSingleSendCall(sendCalls, chainId);
-
-  const txParams = {
-    from,
-    ...transactions[0].params,
-    type: TransactionEnvelopeType.feeMarket,
-  };
-
-  const securityRequest: ValidateSecurityRequest = {
-    method: MESSAGE_TYPE.ETH_SEND_TRANSACTION,
-    params: [txParams],
-    origin,
-  };
-  validateSecurity(securityRequest, chainId);
-
-  const batchId = generateBatchId();
-
-  await addTransaction(txParams, {
-    networkClientId,
-    origin,
-    securityAlertResponse: { securityAlertId } as SecurityAlertResponse,
-    batchId,
-  });
-  return batchId;
-}
-
-async function processMultipleTransaction({
-  addTransactionBatch,
-  isAtomicBatchSupported,
-  chainId,
-  from,
-  getDismissSmartAccountSuggestionEnabled,
-  keyringType,
-  networkClientId,
-  origin,
-  sendCalls,
-  securityAlertId,
-  transactions,
-  validateSecurity,
-}: {
-  addTransactionBatch: TransactionController['addTransactionBatch'];
-  isAtomicBatchSupported: TransactionController['isAtomicBatchSupported'];
-  chainId: Hex;
-  from: Hex;
-  getDismissSmartAccountSuggestionEnabled: () => boolean;
-  keyringType: KeyringTypes;
-  networkClientId: string;
-  origin?: string;
-  sendCalls: SendCalls;
-  securityAlertId: string;
-  transactions: { params: BatchTransactionParams }[];
-  validateSecurity: (
-    securityRequest: ValidateSecurityRequest,
-    chainId: Hex,
-  ) => Promise<void>;
-}) {
-  const batchSupport = await isAtomicBatchSupported({
-    address: from,
-    chainIds: [chainId],
-  });
-
-  const chainBatchSupport = batchSupport?.[0];
-
-  const dismissSmartAccountSuggestionEnabled =
-    getDismissSmartAccountSuggestionEnabled();
-  validateSendCalls(
-    sendCalls,
-    chainId,
-    dismissSmartAccountSuggestionEnabled,
-    chainBatchSupport,
-    keyringType,
-  );
-  const result = await addTransactionBatch({
-    from,
-    networkClientId,
-    origin,
-    securityAlertId,
-    transactions,
-    validateSecurity,
-  });
-  return result.batchId;
-}
-
 export async function processSendCalls(
   hooks: {
     addTransactionBatch: TransactionController['addTransactionBatch'];
@@ -201,8 +94,6 @@ export async function processSendCalls(
     paramFrom ??
     (messenger.call('AccountsController:getSelectedAccount').address as Hex);
 
-  const keyringType = getAccountKeyringType(from, messenger);
-
   const securityAlertId = generateSecurityAlertId();
   const validateSecurity = validateSecurityHook.bind(null, securityAlertId);
 
@@ -226,7 +117,7 @@ export async function processSendCalls(
       chainId: dappChainId,
       from,
       getDismissSmartAccountSuggestionEnabled,
-      keyringType,
+      messenger,
       networkClientId,
       origin,
       sendCalls: params,
@@ -283,55 +174,6 @@ export function getCallsStatus(
     status,
     receipts,
   };
-}
-
-async function getAlternateGasFeesCapability(
-  chainIds: Hex[],
-  batchSupport: IsAtomicBatchSupportedResult,
-  getIsSmartTransaction: (chainId: Hex) => boolean,
-  isRelaySupported: (chainId: Hex) => Promise<boolean>,
-  messenger: EIP5792Messenger,
-) {
-  const simulationEnabled = messenger.call(
-    'PreferencesController:getState',
-  ).useTransactionSimulations;
-
-  const relaySupportedChains = await Promise.all(
-    batchSupport
-      .map(({ chainId }) => chainId)
-      .map((chainId) => isRelaySupported(chainId)),
-  );
-
-  const updatedBatchSupport = batchSupport.map((support, index) => ({
-    ...support,
-    relaySupportedForChain: relaySupportedChains[index],
-  }));
-
-  return chainIds.reduce<GetCapabilitiesResult>((acc, chainId) => {
-    const chainBatchSupport = (updatedBatchSupport.find(
-      ({ chainId: batchChainId }) => batchChainId === chainId,
-    ) ?? {}) as IsAtomicBatchSupportedResultEntry & {
-      relaySupportedForChain: boolean;
-    };
-
-    const { isSupported = false, relaySupportedForChain } = chainBatchSupport;
-
-    const isSmartTransaction = getIsSmartTransaction(chainId);
-
-    const alternateGasFees =
-      simulationEnabled &&
-      (isSmartTransaction || (isSupported && relaySupportedForChain));
-
-    if (alternateGasFees) {
-      acc[chainId as Hex] = {
-        alternateGasFees: {
-          supported: true,
-        },
-      };
-    }
-
-    return acc;
-  }, {});
 }
 
 export async function getCapabilities(
@@ -420,6 +262,115 @@ export async function getCapabilities(
 
     return acc;
   }, alternateGasFeesAcc);
+}
+
+async function processSingleTransaction({
+  addTransaction,
+  chainId,
+  from,
+  networkClientId,
+  origin,
+  securityAlertId,
+  sendCalls,
+  transactions,
+  validateSecurity,
+}: {
+  addTransaction: TransactionController['addTransaction'];
+  chainId: Hex;
+  from: Hex;
+  networkClientId: string;
+  origin?: string;
+  securityAlertId: string;
+  sendCalls: SendCalls;
+  transactions: { params: BatchTransactionParams }[];
+  validateSecurity: (
+    securityRequest: ValidateSecurityRequest,
+    chainId: Hex,
+  ) => void;
+}) {
+  validateSingleSendCall(sendCalls, chainId);
+
+  const txParams = {
+    from,
+    ...transactions[0].params,
+    type: TransactionEnvelopeType.feeMarket,
+  };
+
+  const securityRequest: ValidateSecurityRequest = {
+    method: MESSAGE_TYPE.ETH_SEND_TRANSACTION,
+    params: [txParams],
+    origin,
+  };
+  validateSecurity(securityRequest, chainId);
+
+  const batchId = generateBatchId();
+
+  await addTransaction(txParams, {
+    networkClientId,
+    origin,
+    securityAlertResponse: { securityAlertId } as SecurityAlertResponse,
+    batchId,
+  });
+  return batchId;
+}
+
+async function processMultipleTransaction({
+  addTransactionBatch,
+  isAtomicBatchSupported,
+  chainId,
+  from,
+  getDismissSmartAccountSuggestionEnabled,
+  networkClientId,
+  messenger,
+  origin,
+  sendCalls,
+  securityAlertId,
+  transactions,
+  validateSecurity,
+}: {
+  addTransactionBatch: TransactionController['addTransactionBatch'];
+  isAtomicBatchSupported: TransactionController['isAtomicBatchSupported'];
+  chainId: Hex;
+  from: Hex;
+  getDismissSmartAccountSuggestionEnabled: () => boolean;
+  messenger: EIP5792Messenger;
+  networkClientId: string;
+  origin?: string;
+  sendCalls: SendCalls;
+  securityAlertId: string;
+  transactions: { params: BatchTransactionParams }[];
+  validateSecurity: (
+    securityRequest: ValidateSecurityRequest,
+    chainId: Hex,
+  ) => Promise<void>;
+}) {
+  const batchSupport = await isAtomicBatchSupported({
+    address: from,
+    chainIds: [chainId],
+  });
+
+  const chainBatchSupport = batchSupport?.[0];
+
+  const keyringType = getAccountKeyringType(from, messenger);
+
+  const dismissSmartAccountSuggestionEnabled =
+    getDismissSmartAccountSuggestionEnabled();
+  validateSendCalls(
+    sendCalls,
+    chainId,
+    dismissSmartAccountSuggestionEnabled,
+    chainBatchSupport,
+    keyringType,
+  );
+  const result = await addTransactionBatch({
+    from,
+    networkClientId,
+    origin,
+    securityAlertId,
+    transactions,
+    validateSecurity,
+  });
+  return result.batchId;
 }
 
 /**
@@ -543,6 +494,55 @@ function validateUpgrade(
       'EIP-7702 upgrade not supported on account',
     );
   }
+}
+
+async function getAlternateGasFeesCapability(
+  chainIds: Hex[],
+  batchSupport: IsAtomicBatchSupportedResult,
+  getIsSmartTransaction: (chainId: Hex) => boolean,
+  isRelaySupported: (chainId: Hex) => Promise<boolean>,
+  messenger: EIP5792Messenger,
+) {
+  const simulationEnabled = messenger.call(
+    'PreferencesController:getState',
+  ).useTransactionSimulations;
+
+  const relaySupportedChains = await Promise.all(
+    batchSupport
+      .map(({ chainId }) => chainId)
+      .map((chainId) => isRelaySupported(chainId)),
+  );
+
+  const updatedBatchSupport = batchSupport.map((support, index) => ({
+    ...support,
+    relaySupportedForChain: relaySupportedChains[index],
+  }));
+
+  return chainIds.reduce<GetCapabilitiesResult>((acc, chainId) => {
+    const chainBatchSupport = (updatedBatchSupport.find(
+      ({ chainId: batchChainId }) => batchChainId === chainId,
+    ) ?? {}) as IsAtomicBatchSupportedResultEntry & {
+      relaySupportedForChain: boolean;
+    };
+
+    const { isSupported = false, relaySupportedForChain } = chainBatchSupport;
+
+    const isSmartTransaction = getIsSmartTransaction(chainId);
+
+    const alternateGasFees =
+      simulationEnabled &&
+      (isSmartTransaction || (isSupported && relaySupportedForChain));
+
+    if (alternateGasFees) {
+      acc[chainId as Hex] = {
+        alternateGasFees: {
+          supported: true,
+        },
+      };
+    }
+
+    return acc;
+  }, {});
 }
 
 function getStatusCode(transactionMeta: TransactionMeta) {

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -355,6 +355,7 @@ async function processMultipleTransaction({
 
   const dismissSmartAccountSuggestionEnabled =
     getDismissSmartAccountSuggestionEnabled();
+
   validateSendCalls(
     sendCalls,
     chainId,
@@ -362,6 +363,7 @@ async function processMultipleTransaction({
     chainBatchSupport,
     keyringType,
   );
+
   const result = await addTransactionBatch({
     from,
     networkClientId,

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -140,9 +140,6 @@ export async function processSendCalls(
     paramFrom ??
     (messenger.call('AccountsController:getSelectedAccount').address as Hex);
 
-  const dismissSmartAccountSuggestionEnabled =
-    getDismissSmartAccountSuggestionEnabled();
-
   const batchSupport = await isAtomicBatchSupported({
     address: from,
     chainIds: [dappChainId],
@@ -150,14 +147,6 @@ export async function processSendCalls(
 
   const chainBatchSupport = batchSupport?.[0];
   const keyringType = getAccountKeyringType(from, messenger);
-
-  validateSendCalls(
-    params,
-    dappChainId,
-    dismissSmartAccountSuggestionEnabled,
-    chainBatchSupport,
-    keyringType,
-  );
 
   const securityAlertId = generateSecurityAlertId();
   const validateSecurity = validateSecurityHook.bind(null, securityAlertId);
@@ -175,6 +164,15 @@ export async function processSendCalls(
       validateSecurity,
     });
   } else {
+    const dismissSmartAccountSuggestionEnabled =
+      getDismissSmartAccountSuggestionEnabled();
+    validateSendCalls(
+      params,
+      dappChainId,
+      dismissSmartAccountSuggestionEnabled,
+      chainBatchSupport,
+      keyringType,
+    );
     const result = await addTransactionBatch({
       from,
       networkClientId,

--- a/ui/pages/confirmations/components/confirm/info/batch/nested-transaction-data/nested-transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/nested-transaction-data/nested-transaction-data.tsx
@@ -14,6 +14,7 @@ import {
   ConfirmInfoRowText,
 } from '../../../../../../../components/app/confirm/info/row';
 import { ConfirmInfoRowCurrency } from '../../../../../../../components/app/confirm/info/row/currency';
+import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { useNestedTransactionLabels } from '../../hooks/useNestedTransactionLabels';
 
 export function NestedTransactionData() {
@@ -44,6 +45,7 @@ function NestedTransaction({
   index: number;
   nestedTransaction: BatchTransactionParams;
 }) {
+  const t = useI18nContext();
   const { data, to, value } = nestedTransaction;
 
   const label = useNestedTransactionLabels({
@@ -59,7 +61,7 @@ function NestedTransaction({
           <>
             {to && <RecipientRow recipient={to} />}
             {value && (
-              <ConfirmInfoRow label="Amount">
+              <ConfirmInfoRow label={t('amount')}>
                 <ConfirmInfoRowCurrency value={value} />
               </ConfirmInfoRow>
             )}
@@ -70,7 +72,7 @@ function NestedTransaction({
                 noPadding
                 nestedTransactionIndex={index}
               />
-            )}{' '}
+            )}
           </>
         }
       >


### PR DESCRIPTION
## **Description**

If batched confirmation has only 1 nested transaction we treat it as regular confirmation and not do validations which are done for send calls.

## **Related issues**

Ref: https://github.com/MetaMask/MetaMask-planning/issues/5261

## **Manual testing steps**

1. Submit send call with 1 nested transaction and  wrong version
2. Check that confirmation is treated as regular transaction

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
