### PR TITLE
feat: add ledger e2e tests for ERC20 deployment

### DIFF
--- a/test/e2e/page-objects/flows/login.flow.ts
+++ b/test/e2e/page-objects/flows/login.flow.ts
@@ -31,11 +31,13 @@ export const loginWithoutBalanceValidation = async (
  * @param driver - The webdriver instance.
  * @param localNode - The local node server instance
  * @param password - The password used to unlock the wallet.
+ * @param value - The balance value to be checked
  */
 export const loginWithBalanceValidation = async (
   driver: Driver,
   localNode?: Ganache | Anvil,
   password?: string,
+  value?: string,
 ) => {
   await loginWithoutBalanceValidation(driver, password);
   const homePage = new HomePage(driver);
@@ -44,6 +46,6 @@ export const loginWithBalanceValidation = async (
   if (localNode) {
     await homePage.check_localNodeBalanceIsDisplayed(localNode);
   } else {
-    await homePage.check_expectedBalanceIsDisplayed();
+    await homePage.check_expectedBalanceIsDisplayed(value);
   }
 };

--- a/test/e2e/page-objects/pages/test-dapp.ts
+++ b/test/e2e/page-objects/pages/test-dapp.ts
@@ -557,6 +557,19 @@ class TestDapp {
   }
 
   /**
+   * Checks the value of a token address once created.
+   *
+   * @param value - The address to be checked
+   */
+  async check_TokenAddressesValue(value: string) {
+    console.log('Verify token address');
+    await this.driver.waitForSelector({
+      css: this.erc20TokenAddresses,
+      text: value,
+    });
+  }
+
+  /**
    * Checks the count of token addresses.
    *
    * @param expectedCount - The expected count of token addresses.

--- a/test/e2e/page-objects/pages/test-dapp.ts
+++ b/test/e2e/page-objects/pages/test-dapp.ts
@@ -74,6 +74,8 @@ class TestDapp {
 
   private readonly erc1155WatchButton = '#watchAssetButton';
 
+  private readonly erc20CreateTokenButton = '#createToken';
+
   private readonly erc20TokenAddresses = '#erc20TokenAddresses';
 
   private readonly erc20TokenTransferButton = '#transferTokens';
@@ -717,6 +719,10 @@ class TestDapp {
 
   async clickERC1155WatchButton() {
     await this.driver.clickElement(this.erc1155WatchButton);
+  }
+
+  async clickERC20CreateTokenButton() {
+    await this.driver.clickElement(this.erc20CreateTokenButton);
   }
 
   async clickERC20TokenTransferButton() {

--- a/test/e2e/tests/hardware-wallets/ledger-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger-erc20.spec.ts
@@ -35,7 +35,10 @@ describe('Ledger Hardware', function (this: Suite) {
         const createContractModal = new CreateContractModal(driver);
         await createContractModal.check_pageIsLoaded();
         await createContractModal.clickConfirm();
-        await driver.delay(100000000);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDappPage.check_TokenAddressesValue(
+          '0xcB17707e0623251182A654BEdaE16429C78A7424',
+        );
       },
     );
   });

--- a/test/e2e/tests/hardware-wallets/ledger-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger-erc20.spec.ts
@@ -1,0 +1,42 @@
+import { Suite } from 'mocha';
+import { Driver } from '../../webdriver/driver';
+import TestDappPage from '../../page-objects/pages/test-dapp';
+import FixtureBuilder from '../../fixture-builder';
+import { WINDOW_TITLES, withFixtures } from '../../helpers';
+import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../stub/keyring-bridge';
+import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import CreateContractModal from '../../page-objects/pages/dialog/create-contract';
+
+describe('Ledger Hardware', function (this: Suite) {
+  it('can create an ERC20 token', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withLedgerAccount()
+          .withPermissionControllerConnectedToTestDapp({
+            account: KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        dapp: true,
+      },
+      async ({ driver, localNodes }) => {
+        (await localNodes?.[0]?.setAccountBalance(
+          KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+          '0x100000000000000000000',
+        )) ?? console.error('localNodes is undefined or empty');
+        await loginWithoutBalanceValidation(driver);
+        const testDappPage = new TestDappPage(driver);
+        await testDappPage.openTestDappPage();
+        await testDappPage.check_pageIsLoaded();
+        await testDappPage.clickERC20CreateTokenButton();
+        // Confirm token creation
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        const createContractModal = new CreateContractModal(driver);
+        await createContractModal.check_pageIsLoaded();
+        await createContractModal.clickConfirm();
+        await driver.delay(100000000);
+      },
+    );
+  });
+});

--- a/test/e2e/tests/hardware-wallets/ledger-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger-erc20.spec.ts
@@ -1,10 +1,9 @@
 import { Suite } from 'mocha';
-import { Driver } from '../../webdriver/driver';
 import TestDappPage from '../../page-objects/pages/test-dapp';
 import FixtureBuilder from '../../fixture-builder';
 import { WINDOW_TITLES, withFixtures } from '../../helpers';
 import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../stub/keyring-bridge';
-import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import CreateContractModal from '../../page-objects/pages/dialog/create-contract';
 
 describe('Ledger Hardware', function (this: Suite) {
@@ -25,7 +24,12 @@ describe('Ledger Hardware', function (this: Suite) {
           KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
           '0x100000000000000000000',
         )) ?? console.error('localNodes is undefined or empty');
-        await loginWithoutBalanceValidation(driver);
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '1208925.8196',
+        );
         const testDappPage = new TestDappPage(driver);
         await testDappPage.openTestDappPage();
         await testDappPage.check_pageIsLoaded();

--- a/test/stub/keyring-bridge.js
+++ b/test/stub/keyring-bridge.js
@@ -235,6 +235,7 @@ export class FakeLedgerBridge extends FakeKeyringBridge {
         chainId: parsedChainId,
         networkId: parsedChainId,
       },
+      chainId: parsedChainId,
       // Ensure hardfork is appropriate for the transaction type
       hardfork: txType === 2 ? 'london' : 'muirGlacier',
     });

--- a/test/stub/keyring-utils.js
+++ b/test/stub/keyring-utils.js
@@ -80,6 +80,25 @@ export class Common {
   isActivatedEIP() {
     return true;
   }
+
+  /**
+   * Returns the value of a parameter for the current hardfork.
+   * This is a minimal implementation that returns default values for common parameters.
+   *
+   * @param {string} param - The parameter name.
+   * @returns {any} The parameter value.
+   */
+  param(param) {
+    // Return default values for common parameters that @ethereumjs/tx might request
+    const defaults = {
+      gasLimitBoundDivisor: 1024,
+      baseFeeChangeDenominator: 8,
+      elasticityMultiplier: 2,
+      maxPriorityFeePerGas: 0,
+      maxFeePerGas: 0,
+    };
+    return defaults[param] || 0;
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Adds ledger e2e test for the following scenario:

- ERC20 token creation from **test-dapp**

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33898?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/948

## **Manual testing steps**

**Locally:**
```
yarn start:test
# wait for end of build
yarn test:e2e:single test/e2e/tests/hardware-wallets/ledger-erc20.spec.ts
```
**On CI**, check e2e tests job

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
