### PR TITLE
fix: flaky test `Vault Corruption` loading increase time

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -43,6 +43,10 @@ class HomePage {
     testId: 'asset-list-control-bar-action-button',
   };
 
+  private readonly loadingOverlay = {
+    text: 'Connecting to Localhost 8545',
+  };
+
   private readonly nftTab = {
     testId: 'account-overview__nfts-tab',
   };
@@ -152,6 +156,14 @@ class HomePage {
 
   async togglePrivacyBalance(): Promise<void> {
     await this.driver.clickElement(this.privacyBalanceToggle);
+  }
+
+   async waitForLoadingOverlayToDisappear(): Promise<void> {
+    console.log(`Wait for loading overlay to disappear`);
+    await this.driver.assertElementNotPresent(this.loadingOverlay, {
+      waitAtLeastGuard: 1000,
+      timeout: 10000,
+    });
   }
 
   /**

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -158,7 +158,7 @@ class HomePage {
     await this.driver.clickElement(this.privacyBalanceToggle);
   }
 
-   async waitForLoadingOverlayToDisappear(): Promise<void> {
+  async waitForLoadingOverlayToDisappear(): Promise<void> {
     console.log(`Wait for loading overlay to disappear`);
     await this.driver.assertElementNotPresent(this.loadingOverlay, {
       waitAtLeastGuard: 1000,

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -9,6 +9,7 @@ import HomePage from '../../page-objects/pages/home/homepage';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import AccountDetailsModal from '../../page-objects/pages/dialog/account-details-modal';
+import LoginPage from '../../page-objects/pages/login-page';
 
 describe('Vault Corruption', function () {
   /**
@@ -129,7 +130,7 @@ describe('Vault Corruption', function () {
       // reload and check title as quickly a possible, forever
       { interval: 0, timeout: Infinity },
     );
-    await driver.assertElementNotPresent('.loading-logo', { timeout: 15000 });
+    await driver.assertElementNotPresent('.loading-logo', { timeout: 10000 });
   }
 
   /**
@@ -152,11 +153,13 @@ describe('Vault Corruption', function () {
     await onboard(driver);
 
     const homePage = new HomePage(driver);
-    homePage.check_pageIsLoaded();
+    await homePage.check_pageIsLoaded();
 
     const headerNavbar = new HeaderNavbar(driver);
     const firstAddress = await getFirstAddress(driver, headerNavbar);
     await headerNavbar.lockMetaMask();
+    const loginPage = new LoginPage(driver);
+    await loginPage.check_pageIsLoaded();
 
     // use the home page to destroy the vault
     await driver.executeAsyncScript(script);

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -154,6 +154,7 @@ describe('Vault Corruption', function () {
 
     const homePage = new HomePage(driver);
     await homePage.check_pageIsLoaded();
+    await homePage.waitForLoadingOverlayToDisappear();
 
     const headerNavbar = new HeaderNavbar(driver);
     const firstAddress = await getFirstAddress(driver, headerNavbar);

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -129,7 +129,7 @@ describe('Vault Corruption', function () {
       // reload and check title as quickly a possible, forever
       { interval: 0, timeout: Infinity },
     );
-    await driver.assertElementNotPresent('.loading-logo', { timeout: 10000 });
+    await driver.assertElementNotPresent('.loading-logo', { timeout: 15000 });
   }
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The spec is flaky as it seems that if we don't make sure we properly landed at the home page, and ensure things are loaded (loading spinner is not there), then we cannot restore the vault.

It seems unlikely a user could encounter this as the steps are very fast, but we could investigate further on the app side.

For now, adding deterministic conditions to ensure we login and out properly, fixes the flakiness.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33916?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33918

## **Manual testing steps**

1. Tests should continue to work

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

![test-failure-screenshot-2](https://github.com/user-attachments/assets/4b5cd703-7182-4a4b-b5d1-0b1e69607536)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
