### PR TITLE
fix: srp backup navigation and quiz cp-12.22.0

### DIFF
--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -15,8 +15,10 @@ import {
 } from '../../../helpers/constants/design-system';
 import {
   ONBOARDING_COMPLETION_ROUTE,
+  ONBOARDING_IMPORT_WITH_SRP_ROUTE,
   ONBOARDING_METAMETRICS,
   ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
+  ONBOARDING_WELCOME_ROUTE,
 } from '../../../helpers/constants/routes';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import {
@@ -86,12 +88,18 @@ export default function CreatePassword({
       } else {
         history.replace(ONBOARDING_SECURE_YOUR_WALLET_ROUTE);
       }
+    } else if (
+      firstTimeFlowType === FirstTimeFlowType.import &&
+      !secretRecoveryPhrase
+    ) {
+      history.replace(ONBOARDING_IMPORT_WITH_SRP_ROUTE);
     }
   }, [
     currentKeyring,
     history,
     firstTimeFlowType,
     newAccountCreationInProgress,
+    secretRecoveryPhrase,
   ]);
 
   const handleLearnMoreClick = (event) => {
@@ -134,9 +142,9 @@ export default function CreatePassword({
     });
 
     if (getBrowserName() === PLATFORM_FIREFOX) {
-      history.push(ONBOARDING_COMPLETION_ROUTE);
+      history.replace(ONBOARDING_COMPLETION_ROUTE);
     } else {
-      history.push(ONBOARDING_METAMETRICS);
+      history.replace(ONBOARDING_METAMETRICS);
     }
   };
 
@@ -164,7 +172,7 @@ export default function CreatePassword({
       },
     });
 
-    history.push(ONBOARDING_SECURE_YOUR_WALLET_ROUTE);
+    history.replace(ONBOARDING_SECURE_YOUR_WALLET_ROUTE);
   };
 
   const handleCreatePassword = async (event) => {
@@ -231,7 +239,11 @@ export default function CreatePassword({
             size={ButtonIconSize.Md}
             data-testid="create-password-back-button"
             type="button"
-            onClick={() => history.goBack()}
+            onClick={() =>
+              firstTimeFlowType === FirstTimeFlowType.import
+                ? history.replace(ONBOARDING_IMPORT_WITH_SRP_ROUTE)
+                : history.replace(ONBOARDING_WELCOME_ROUTE)
+            }
             ariaLabel={t('back')}
           />
         </Box>

--- a/ui/pages/onboarding-flow/create-password/create-password.test.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.js
@@ -10,13 +10,11 @@ import {
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import CreatePassword from './create-password';
 
-const mockHistoryPush = jest.fn();
 const mockHistoryReplace = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
-    push: mockHistoryPush,
     replace: mockHistoryReplace,
   }),
 }));
@@ -333,7 +331,7 @@ describe('Onboarding Create Password', () => {
       expect(mockCreateNewAccount).toHaveBeenCalledWith(password);
 
       await waitFor(() => {
-        expect(mockHistoryPush).toHaveBeenCalledWith(
+        expect(mockHistoryReplace).toHaveBeenCalledWith(
           ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
         );
       });
@@ -395,7 +393,7 @@ describe('Onboarding Create Password', () => {
       );
 
       await waitFor(() => {
-        expect(mockHistoryPush).toHaveBeenCalledWith(ONBOARDING_METAMETRICS);
+        expect(mockHistoryReplace).toHaveBeenCalledWith(ONBOARDING_METAMETRICS);
       });
     });
   });

--- a/ui/pages/onboarding-flow/import-srp/import-srp.js
+++ b/ui/pages/onboarding-flow/import-srp/import-srp.js
@@ -125,7 +125,9 @@ export default function ImportSRP({ submitSecretRecoveryPhrase }) {
             color={IconColor.iconDefault}
             size={ButtonIconSize.Md}
             data-testid="import-srp-back-button"
-            onClick={() => history.push(ONBOARDING_WELCOME_ROUTE)}
+            onClick={() => {
+              history.replace(ONBOARDING_WELCOME_ROUTE);
+            }}
             ariaLabel={t('back')}
           />
         </Box>

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -135,7 +135,11 @@ export default function OnboardingFlow() {
       }
     }
 
-    if (isPrimarySeedPhraseBackedUp && isSRPBackupRoute) {
+    if (
+      isPrimarySeedPhraseBackedUp &&
+      isSRPBackupRoute &&
+      completedOnboarding
+    ) {
       history.replace(isFromSettingsSecurity ? SECURITY_ROUTE : DEFAULT_ROUTE);
     }
 

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -21,9 +21,11 @@ import {
   ONBOARDING_METAMETRICS,
   ONBOARDING_ACCOUNT_EXIST,
   ONBOARDING_ACCOUNT_NOT_FOUND,
+  SECURITY_ROUTE,
 } from '../../helpers/constants/routes';
 import {
   getCompletedOnboarding,
+  getIsPrimarySeedPhraseBackedUp,
   getIsUnlocked,
 } from '../../ducks/metamask/metamask';
 import {
@@ -91,9 +93,15 @@ export default function OnboardingFlow() {
   const completedOnboarding = useSelector(getCompletedOnboarding);
   const nextRoute = useSelector(getFirstTimeFlowTypeRouteAfterUnlock);
   const isFromReminder = new URLSearchParams(search).get('isFromReminder');
+  const isFromSettingsSecurity = new URLSearchParams(search).get(
+    'isFromSettingsSecurity',
+  );
   const trackEvent = useContext(MetaMetricsContext);
   const isUnlocked = useSelector(getIsUnlocked);
   const showTermsOfUse = useSelector(getShowTermsOfUse);
+  const isPrimarySeedPhraseBackedUp = useSelector(
+    getIsPrimarySeedPhraseBackedUp,
+  );
 
   const envType = getEnvironmentType();
   const isPopup = envType === ENVIRONMENT_TYPE_POPUP;
@@ -115,17 +123,22 @@ export default function OnboardingFlow() {
   }, [history, completedOnboarding, isFromReminder]);
 
   useEffect(() => {
-    if (isUnlocked && !completedOnboarding && !secretRecoveryPhrase) {
-      const needsSRP = [
-        ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
-        ONBOARDING_REVIEW_SRP_ROUTE,
-        ONBOARDING_CONFIRM_SRP_ROUTE,
-      ].some((route) => pathname.startsWith(route));
+    const isSRPBackupRoute = [
+      ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
+      ONBOARDING_REVIEW_SRP_ROUTE,
+      ONBOARDING_CONFIRM_SRP_ROUTE,
+    ].some((route) => pathname.startsWith(route));
 
-      if (needsSRP) {
+    if (isUnlocked && !completedOnboarding && !secretRecoveryPhrase) {
+      if (isSRPBackupRoute) {
         history.push(ONBOARDING_UNLOCK_ROUTE);
       }
     }
+
+    if (isPrimarySeedPhraseBackedUp && isSRPBackupRoute) {
+      history.replace(isFromSettingsSecurity ? SECURITY_ROUTE : DEFAULT_ROUTE);
+    }
+
     if (pathname === ONBOARDING_WELCOME_ROUTE) {
       setWelcomePageState(
         showTermsOfUse ? WelcomePageState.Banner : WelcomePageState.Login,
@@ -140,6 +153,8 @@ export default function OnboardingFlow() {
     pathname,
     history,
     showTermsOfUse,
+    isPrimarySeedPhraseBackedUp,
+    isFromSettingsSecurity,
   ]);
 
   const handleCreateNewAccount = async (password) => {

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -127,7 +127,7 @@ export default function OnboardingFlow() {
       ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
       ONBOARDING_REVIEW_SRP_ROUTE,
       ONBOARDING_CONFIRM_SRP_ROUTE,
-    ].some((route) => pathname.startsWith(route));
+    ].some((route) => pathname?.startsWith(route));
 
     if (isUnlocked && !completedOnboarding && !secretRecoveryPhrase) {
       if (isSRPBackupRoute) {

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.js
@@ -103,7 +103,7 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
 
   useEffect(() => {
     if (!secretRecoveryPhrase) {
-      history.push(
+      history.replace(
         `${ONBOARDING_REVIEW_SRP_ROUTE}${
           nextRouteQueryString ? `?${nextRouteQueryString}` : ''
         }`,
@@ -153,7 +153,7 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
         ? ONBOARDING_COMPLETION_ROUTE
         : ONBOARDING_METAMETRICS;
 
-    history.push(
+    history.replace(
       `${nextRoute}${nextRouteQueryString ? `?${nextRouteQueryString}` : ''}`,
     );
   }, [

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.js
@@ -17,11 +17,12 @@ jest.mock('../../../store/actions.ts', () => ({
   setSeedPhraseBackedUp: jest.fn().mockReturnValue(jest.fn()),
 }));
 
-const mockHistoryPush = jest.fn();
+const mockHistoryReplace = jest.fn();
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
-    push: mockHistoryPush,
+    replace: mockHistoryReplace,
   }),
 }));
 
@@ -192,7 +193,7 @@ describe('Confirm Recovery Phrase Component', () => {
     fireEvent.click(gotItButton);
 
     expect(setSeedPhraseBackedUp).toHaveBeenCalledWith(true);
-    expect(mockHistoryPush).toHaveBeenCalledWith(ONBOARDING_METAMETRICS);
+    expect(mockHistoryReplace).toHaveBeenCalledWith(ONBOARDING_METAMETRICS);
   });
 
   it('should go to Onboarding Completion page as a next step in firefox', async () => {
@@ -212,6 +213,8 @@ describe('Confirm Recovery Phrase Component', () => {
     // click and answer the srp quiz
     clickAndAnswerSrpQuiz(quizUnansweredChips);
 
+    console.log('quizUnansweredChips', quizUnansweredChips);
+
     const quizAnsweredChips = queryAllByTestId(
       /recovery-phrase-quiz-answered-/u,
     );
@@ -225,6 +228,8 @@ describe('Confirm Recovery Phrase Component', () => {
     fireEvent.click(getByText('Got it'));
 
     expect(setSeedPhraseBackedUp).toHaveBeenCalledWith(true);
-    expect(mockHistoryPush).toHaveBeenCalledWith(ONBOARDING_COMPLETION_ROUTE);
+    expect(mockHistoryReplace).toHaveBeenCalledWith(
+      ONBOARDING_COMPLETION_ROUTE,
+    );
   });
 });

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
@@ -94,7 +94,7 @@ export default function RecoveryPhraseChips({
       };
 
       setQuizAnswers(newQuizAnswers);
-      setIndexToFocus(setNextTargetIndex(newQuizAnswers));
+      setIndexToFocus(newQuizAnswers[targetIndex].index);
     },
     [quizAnswers],
   );

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -63,7 +63,7 @@ export default function OnboardingWelcome({
   const onCreateClick = useCallback(async () => {
     setIsLoggingIn(true);
     setNewAccountCreationInProgress(true);
-    dispatch(setFirstTimeFlowType(FirstTimeFlowType.create));
+    await dispatch(setFirstTimeFlowType(FirstTimeFlowType.create));
     trackEvent({
       category: MetaMetricsEventCategory.Onboarding,
       event: MetaMetricsEventName.WalletSetupStarted,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes navigation issues on Backup SRP flow and setting active textfield while doing confirm SRP.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33922?quickstart=1)

## **Related issues**

Fixes:
Bug link: https://github.com/MetaMask/metamask-extension/issues/33914
This happens because when user remove a quizWork by clicking second TextField the app selects the first empty word on the list which is wrong. Solution is to select the index of the word removed from the quiz to be active.

Bug link: https://github.com/MetaMask/metamask-extension/issues/33823
We don't have control on the route history if user is using browser's back/prev buttons. To solve this, we should not allow users to go to any SRP backup pages if the SRP has been backed up already.

Bug link: https://github.com/MetaMask/metamask-extension/issues/33862
**Import flow**: This happens because when user refresh page on `create-wallet` page we lose the imported SRP which is just saved on app state. The solution is if the SRP is not present on the app state then we will redirect user to import page again to do the import. 

Now, everytime the user is in the `create wallet` page during import flow it only means he has SRP saved on state, and the flow will continue correctly.

## **Manual testing steps**

1. Refer to bug links

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Refer to the links
https://github.com/MetaMask/metamask-extension/issues/33914
https://github.com/MetaMask/metamask-extension/issues/33823
https://github.com/MetaMask/metamask-extension/issues/33862

<!-- [screenshots/recordings] -->

### **After**
Fix for adding/removing quiz words issue
https://github.com/MetaMask/metamask-extension/issues/33914
https://github.com/user-attachments/assets/686a390b-4ec2-42b3-8063-a4a2df7c846e

Fix for incorrect navigation when refreshing on create-wallet page
https://github.com/MetaMask/metamask-extension/issues/33862
https://github.com/user-attachments/assets/e9a60d3c-c9be-439b-ab03-c9fff196f519

Fix for preventing user to go back to SRP backup flow when SRP is backed up already
https://github.com/MetaMask/metamask-extension/issues/33823
https://github.com/user-attachments/assets/65121efa-947f-428f-88f1-3437289eb1c6

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
