### PR TITLE
fix: cp-12.22.0 Prevent cronjob state from getting out of sync 

### DIFF
--- a/.yarn/patches/@metamask-snaps-controllers-npm-13.1.1-02f9bdb989.patch
+++ b/.yarn/patches/@metamask-snaps-controllers-npm-13.1.1-02f9bdb989.patch
@@ -1,0 +1,46 @@
+diff --git a/dist/cronjob/CronjobController.cjs b/dist/cronjob/CronjobController.cjs
+index 0e8feebadcaf91dcf2fb248f78df0433c16aff38..2bf546a8f1691f145dbbcf669e72dc09ef01f937 100644
+--- a/dist/cronjob/CronjobController.cjs
++++ b/dist/cronjob/CronjobController.cjs
+@@ -39,9 +39,18 @@ class CronjobController extends base_controller_1.BaseController {
+         this.messagingSystem.subscribe('SnapController:snapEnabled', this.#handleSnapEnabledEvent);
+         this.messagingSystem.subscribe('SnapController:snapDisabled', this.#handleSnapDisabledEvent);
+         this.messagingSystem.subscribe('SnapController:snapUpdated', this.#handleSnapUpdatedEvent);
++        this.messagingSystem.registerActionHandler(`${controllerName}:init`, (...args) => this.init(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:schedule`, (...args) => this.schedule(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:cancel`, (...args) => this.cancel(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:get`, (...args) => this.get(...args));
++    }
++    /**
++     * Initialize the CronjobController.
++     *
++     * This starts the daily timer, clears out expired events
++     * and reschedules any remaining events.
++     */
++    init() {
+         this.#start();
+         this.#clear();
+         this.#reschedule();
+diff --git a/dist/cronjob/CronjobController.mjs b/dist/cronjob/CronjobController.mjs
+index e3f025c419fa6f4683de678fb6d415b0f3a12782..b90b08f8ec394f0a7e994721f5b8942da5279650 100644
+--- a/dist/cronjob/CronjobController.mjs
++++ b/dist/cronjob/CronjobController.mjs
+@@ -36,9 +36,18 @@ export class CronjobController extends BaseController {
+         this.messagingSystem.subscribe('SnapController:snapEnabled', this.#handleSnapEnabledEvent);
+         this.messagingSystem.subscribe('SnapController:snapDisabled', this.#handleSnapDisabledEvent);
+         this.messagingSystem.subscribe('SnapController:snapUpdated', this.#handleSnapUpdatedEvent);
++        this.messagingSystem.registerActionHandler(`${controllerName}:init`, (...args) => this.init(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:schedule`, (...args) => this.schedule(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:cancel`, (...args) => this.cancel(...args));
+         this.messagingSystem.registerActionHandler(`${controllerName}:get`, (...args) => this.get(...args));
++    }
++    /**
++     * Initialize the CronjobController.
++     *
++     * This starts the daily timer, clears out expired events
++     * and reschedules any remaining events.
++     */
++    init() {
+         this.#start();
+         this.#clear();
+         this.#reschedule();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1920,10 +1920,10 @@ export default class MetamaskController extends EventEmitter {
       InstitutionalSnapController: InstitutionalSnapControllerInit,
       RateLimitController: RateLimitControllerInit,
       SnapsRegistry: SnapsRegistryInit,
+      CronjobController: CronjobControllerInit,
       SnapController: SnapControllerInit,
       SnapInsightsController: SnapInsightsControllerInit,
       SnapInterfaceController: SnapInterfaceControllerInit,
-      CronjobController: CronjobControllerInit,
       WebSocketService: WebSocketServiceInit,
       PPOMController: PPOMControllerInit,
       TransactionController: TransactionControllerInit,
@@ -2001,6 +2001,7 @@ export default class MetamaskController extends EventEmitter {
 
     this.notificationServicesController.init();
     this.snapController.init();
+    this.cronjobController.init();
 
     this.controllerMessenger.subscribe(
       'TransactionController:transactionStatusUpdated',

--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "@metamask/selected-network-controller": "^22.1.0",
     "@metamask/signature-controller": "^30.0.0",
     "@metamask/smart-transactions-controller": "^16.4.0",
-    "@metamask/snaps-controllers": "^13.1.1",
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A13.1.1#~/.yarn/patches/@metamask-snaps-controllers-npm-13.1.1-02f9bdb989.patch",
     "@metamask/snaps-execution-environments": "^9.1.0",
     "@metamask/snaps-rpc-methods": "^13.1.0",
     "@metamask/snaps-sdk": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7123,7 +7123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^13.1.1":
+"@metamask/snaps-controllers@npm:13.1.1":
   version: 13.1.1
   resolution: "@metamask/snaps-controllers@npm:13.1.1"
   dependencies:
@@ -7161,6 +7161,47 @@ __metadata:
     "@metamask/snaps-execution-environments":
       optional: true
   checksum: 10/baee4268e5dcdfddfa9f2a5230ec7a8a7328706c453717976ad0d41d6e3e6ebc00c988650b01759673b456aa233306e1266017d15a9719739fb334361289d6ff
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A13.1.1#~/.yarn/patches/@metamask-snaps-controllers-npm-13.1.1-02f9bdb989.patch":
+  version: 13.1.1
+  resolution: "@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A13.1.1#~/.yarn/patches/@metamask-snaps-controllers-npm-13.1.1-02f9bdb989.patch::version=13.1.1&hash=139d08"
+  dependencies:
+    "@metamask/approval-controller": "npm:^7.1.3"
+    "@metamask/base-controller": "npm:^8.0.1"
+    "@metamask/json-rpc-engine": "npm:^10.0.2"
+    "@metamask/json-rpc-middleware-stream": "npm:^8.0.7"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/object-multiplex": "npm:^2.1.0"
+    "@metamask/permission-controller": "npm:^11.0.6"
+    "@metamask/phishing-controller": "npm:^12.6.0"
+    "@metamask/post-message-stream": "npm:^10.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-registry": "npm:^3.2.3"
+    "@metamask/snaps-rpc-methods": "npm:^13.1.0"
+    "@metamask/snaps-sdk": "npm:^8.1.0"
+    "@metamask/snaps-utils": "npm:^10.1.0"
+    "@metamask/utils": "npm:^11.4.0"
+    "@xstate/fsm": "npm:^2.0.0"
+    async-mutex: "npm:^0.5.0"
+    concat-stream: "npm:^2.0.0"
+    cron-parser: "npm:^4.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    get-npm-tarball-url: "npm:^2.0.3"
+    immer: "npm:^9.0.6"
+    luxon: "npm:^3.5.0"
+    nanoid: "npm:^3.3.10"
+    readable-stream: "npm:^3.6.2"
+    readable-web-to-node-stream: "npm:^3.0.2"
+    semver: "npm:^7.5.4"
+    tar-stream: "npm:^3.1.7"
+  peerDependencies:
+    "@metamask/snaps-execution-environments": ^9.1.0
+  peerDependenciesMeta:
+    "@metamask/snaps-execution-environments":
+      optional: true
+  checksum: 10/752369b384dbaae8c44ca90855b2bfc6d96eb299d9a51e69353a06ec02fe5851477b12dc4e872773e44b92c1b1f4f4a35f4b2856aeeeb236361397c06c097e6c
   languageName: node
   linkType: hard
 
@@ -31612,7 +31653,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^22.1.0"
     "@metamask/signature-controller": "npm:^30.0.0"
     "@metamask/smart-transactions-controller": "npm:^16.4.0"
-    "@metamask/snaps-controllers": "npm:^13.1.1"
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A13.1.1#~/.yarn/patches/@metamask-snaps-controllers-npm-13.1.1-02f9bdb989.patch"
     "@metamask/snaps-execution-environments": "npm:^9.1.0"
     "@metamask/snaps-rpc-methods": "npm:^13.1.0"
     "@metamask/snaps-sdk": "npm:^8.1.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevent the `CronjobController` state from getting out of sync by initializing the controller before the `SnapController` allowing it to subscribe to the controller events. Additionally introduce a `init` function that handles the side-effects previously present in the `CronjobController` constructor.

Since this is a release blocker, this upstream change was patched in: https://github.com/MetaMask/snaps/commit/a9f0277aba928d9980f7ff827b1879535f2dda4b

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33923?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33920

## **Manual testing steps**

1. Downgrade Solana Snap to 1.30.3
2. Create a fresh MetaMask instance
3. Upgrade Solana Snap to 1.30.4 and reload the client
4. Wait a couple minutes
5. Notice that there are no errors in the console
