### PR TITLE
fix: use div instead of input text on reveal srp

### DIFF
--- a/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/recovery-phrase-chips.test.js.snap
+++ b/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/recovery-phrase-chips.test.js.snap
@@ -15,7 +15,8 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
         data-testid="recovery-phrase-chips"
       >
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-0"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -23,18 +24,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             1
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-0"
-            focused="false"
-            readonly=""
-            type="text"
-            value="debris"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            debris
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-1"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -42,18 +40,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             2
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-1"
-            focused="false"
-            readonly=""
-            type="text"
-            value="dizzy"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            dizzy
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-2"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -61,18 +56,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             3
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-2"
-            focused="false"
-            readonly=""
-            type="text"
-            value="just"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            just
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-3"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -80,18 +72,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             4
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-3"
-            focused="false"
-            readonly=""
-            type="text"
-            value="program"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            program
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-4"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -99,18 +88,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             5
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-4"
-            focused="false"
-            readonly=""
-            type="text"
-            value="just"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            just
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-5"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -118,18 +104,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             6
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-5"
-            focused="false"
-            readonly=""
-            type="text"
-            value="float"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            float
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-6"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -137,18 +120,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             7
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-6"
-            focused="false"
-            readonly=""
-            type="text"
-            value="decrease"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            decrease
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-7"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -156,18 +136,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             8
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-7"
-            focused="false"
-            readonly=""
-            type="text"
-            value="vacant"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            vacant
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-8"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -175,18 +152,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             9
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-8"
-            focused="false"
-            readonly=""
-            type="text"
-            value="alarm"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            alarm
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-9"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -194,18 +168,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             10
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-9"
-            focused="false"
-            readonly=""
-            type="text"
-            value="reduce"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            reduce
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-10"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -213,18 +184,15 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             11
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-10"
-            focused="false"
-            readonly=""
-            type="text"
-            value="speak"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            speak
+          </p>
         </div>
         <div
-          class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+          class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+          data-testid="recovery-phrase-chip-11"
         >
           <p
             class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -232,15 +200,11 @@ exports[`Recovery Phrase Chips Component should match snapshot 1`] = `
             12
             .
           </p>
-          <input
-            autocomplete="off"
-            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-            data-testid="recovery-phrase-chip-11"
-            focused="false"
-            readonly=""
-            type="text"
-            value="stadium"
-          />
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            stadium
+          </p>
         </div>
       </div>
     </div>
@@ -277,7 +241,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-0"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="debris"
           />
@@ -297,7 +260,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-1"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="dizzy"
           />
@@ -317,7 +279,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-2"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="just"
           />
@@ -337,7 +298,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-3"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="program"
           />
@@ -357,7 +317,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-4"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="just"
           />
@@ -377,7 +336,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-5"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="float"
           />
@@ -397,7 +355,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-6"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="decrease"
           />
@@ -417,7 +374,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-7"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="vacant"
           />
@@ -437,7 +393,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-8"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="alarm"
           />
@@ -457,7 +412,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-9"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="reduce"
           />
@@ -477,7 +431,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-10"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="speak"
           />
@@ -497,7 +450,6 @@ exports[`Recovery Phrase Chips Component should match snapshot of confirm recove
             data-testid="recovery-phrase-chip-11"
             disabled=""
             focused="false"
-            readonly=""
             type="password"
             value="stadium"
           />

--- a/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.js.snap
+++ b/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.js.snap
@@ -75,7 +75,8 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
             data-testid="recovery-phrase-chips"
           >
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-0"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -83,19 +84,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 1
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-0"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="debris"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                debris
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-1"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -103,19 +100,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 2
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-1"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="dizzy"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                dizzy
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-2"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -123,19 +116,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 3
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-2"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="just"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                just
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-3"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -143,19 +132,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 4
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-3"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="program"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                program
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-4"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -163,19 +148,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 5
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-4"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="just"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                just
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-5"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -183,19 +164,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 6
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-5"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="float"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                float
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-6"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -203,19 +180,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 7
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-6"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="decrease"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                decrease
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-7"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -223,19 +196,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 8
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-7"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="vacant"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                vacant
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-8"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -243,19 +212,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 9
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-8"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="alarm"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                alarm
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-9"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -263,19 +228,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 10
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-9"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="reduce"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                reduce
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-10"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -283,19 +244,15 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 11
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-10"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="speak"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                speak
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--disabled mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-11"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -303,16 +260,11 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
                 12
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-11"
-                disabled=""
-                focused="false"
-                readonly=""
-                type="text"
-                value="stadium"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                stadium
+              </p>
             </div>
           </div>
           <div
@@ -434,7 +386,8 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
             data-testid="recovery-phrase-chips"
           >
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-0"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -442,18 +395,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 1
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-0"
-                focused="false"
-                readonly=""
-                type="text"
-                value="debris"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                debris
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-1"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -461,18 +411,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 2
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-1"
-                focused="false"
-                readonly=""
-                type="text"
-                value="dizzy"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                dizzy
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-2"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -480,18 +427,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 3
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-2"
-                focused="false"
-                readonly=""
-                type="text"
-                value="just"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                just
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-3"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -499,18 +443,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 4
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-3"
-                focused="false"
-                readonly=""
-                type="text"
-                value="program"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                program
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-4"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -518,18 +459,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 5
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-4"
-                focused="false"
-                readonly=""
-                type="text"
-                value="just"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                just
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-5"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -537,18 +475,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 6
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-5"
-                focused="false"
-                readonly=""
-                type="text"
-                value="float"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                float
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-6"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -556,18 +491,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 7
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-6"
-                focused="false"
-                readonly=""
-                type="text"
-                value="decrease"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                decrease
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-7"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -575,18 +507,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 8
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-7"
-                focused="false"
-                readonly=""
-                type="text"
-                value="vacant"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                vacant
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-8"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -594,18 +523,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 9
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-8"
-                focused="false"
-                readonly=""
-                type="text"
-                value="alarm"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                alarm
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-9"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -613,18 +539,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 10
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-9"
-                focused="false"
-                readonly=""
-                type="text"
-                value="reduce"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                reduce
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-10"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -632,18 +555,15 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 11
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-10"
-                focused="false"
-                readonly=""
-                type="text"
-                value="speak"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                speak
+              </p>
             </div>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+              class="mm-box recovery-phrase__text mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+              data-testid="recovery-phrase-chip-11"
             >
               <p
                 class="mm-box mm-text recovery-phrase__word-index mm-text--body-md mm-box--color-text-alternative"
@@ -651,15 +571,11 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
                 12
                 .
               </p>
-              <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
-                data-testid="recovery-phrase-chip-11"
-                focused="false"
-                readonly=""
-                type="text"
-                value="stadium"
-              />
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+              >
+                stadium
+              </p>
             </div>
           </div>
         </div>

--- a/ui/pages/onboarding-flow/recovery-phrase/index.scss
+++ b/ui/pages/onboarding-flow/recovery-phrase/index.scss
@@ -41,6 +41,9 @@
     // SRP_OVERRIDE: END
   }
 
+  &__text {
+    height: 40px;
+  }
 
   &__word-index {
     width: 20px;

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
@@ -25,6 +25,7 @@ import {
   JustifyContent,
   AlignItems,
   BackgroundColor,
+  BorderColor,
 } from '../../../helpers/constants/design-system';
 
 export default function RecoveryPhraseChips({
@@ -142,7 +143,7 @@ export default function RecoveryPhraseChips({
             const wordToDisplay = isQuizWord
               ? quizAnswers.find((answer) => answer.index === index)?.word || ''
               : word;
-            return (
+            return confirmPhase ? (
               <TextField
                 testId={
                   confirmPhase && isQuizWord
@@ -164,7 +165,6 @@ export default function RecoveryPhraseChips({
                   </Text>
                 }
                 type={confirmPhase && !isQuizWord ? 'password' : 'text'}
-                readOnly
                 disabled={
                   (confirmPhase && !isQuizWord) ||
                   (!confirmPhase && !phraseRevealed)
@@ -180,6 +180,27 @@ export default function RecoveryPhraseChips({
                   }
                 }}
               />
+            ) : (
+              <Box
+                className="recovery-phrase__text"
+                display={Display.Flex}
+                alignItems={AlignItems.center}
+                backgroundColor={BackgroundColor.backgroundDefault}
+                borderColor={BorderColor.borderMuted}
+                borderRadius={BorderRadius.XL}
+                paddingInline={2}
+                paddingTop={1}
+                paddingBottom={1}
+                gap={1}
+              >
+                <Text
+                  color={TextColor.textAlternative}
+                  className="recovery-phrase__word-index"
+                >
+                  {index + 1}.
+                </Text>
+                <Text>{word}</Text>
+              </Box>
             );
           })}
         </Box>

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
@@ -182,6 +182,7 @@ export default function RecoveryPhraseChips({
               />
             ) : (
               <Box
+                data-testid={`recovery-phrase-chip-${index}`}
                 className="recovery-phrase__text"
                 display={Display.Flex}
                 alignItems={AlignItems.center}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
**Replace reveal srp `input` fields with `p`**
![Screenshot 2025-06-27 at 3 30 37 PM](https://github.com/user-attachments/assets/a7489068-137a-43b2-8b91-333e507fa299)

**Confirm phase with stay the same.** 
- `quiz words` will be `input:text` and `non-quiz words` will be `input:password`
![Screenshot 2025-06-27 at 3 31 30 PM](https://github.com/user-attachments/assets/36b8df06-f3be-471b-8296-533c0a76cc2d)
![Screenshot 2025-06-27 at 3 31 44 PM](https://github.com/user-attachments/assets/5161072d-d22e-4146-a1e1-f7ab95a96b3c)

https://github.com/user-attachments/assets/565235a2-c467-4f28-97a8-30dfdbaf9756

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33947?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
