### PR TITLE
fix: flaky test `Editing Confirm Transaction allows accessing advance gas fee popover from edit gas fee popover`

### DIFF
--- a/test/e2e/tests/transaction/edit-gas-fee.spec.js
+++ b/test/e2e/tests/transaction/edit-gas-fee.spec.js
@@ -1,10 +1,13 @@
 const { strict: assert } = require('assert');
 const {
+  loginWithBalanceValidation,
+} = require('../../page-objects/flows/login.flow');
+const {
   createInternalTransaction,
   createDappTransaction,
 } = require('../../page-objects/flows/transaction');
 
-const { withFixtures, unlockWallet, WINDOW_TITLES } = require('../../helpers');
+const { withFixtures, WINDOW_TITLES } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 
 const PREFERENCES_STATE_MOCK = {
@@ -24,7 +27,7 @@ describe('Editing Confirm Transaction', function () {
         title: this.test.fullTitle(),
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         await createInternalTransaction(driver);
 
@@ -100,8 +103,7 @@ describe('Editing Confirm Transaction', function () {
         title: this.test.fullTitle(),
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
-
+        await loginWithBalanceValidation(driver);
         await createInternalTransaction(driver);
 
         await driver.findElement({
@@ -179,7 +181,7 @@ describe('Editing Confirm Transaction', function () {
       },
       async ({ driver }) => {
         // login to extension
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         await createDappTransaction(driver, {
           maxFeePerGas: '0x2000000000',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This spec is flaky because we login and start a transaction right away, without waiting for the balance to be loaded, and then we cannot proceed as the input validation fails because it sees 0 balance.
A related issue was found in the past in other specs, where we started a tx without the balance and then no matter how long we wait, values were not updated (in that case, the gas limit), unless we start the tx flow again. We concluded that any test that starts a tx right away, should wait for the balance to load, before starting a tx, to avoid this sort of problems, until that's fixed on the wallet side (which is where the issue is).

See context here: https://github.com/MetaMask/metamask-extension/pull/24639

See artifacts

![test-failure-screenshot-1](https://github.com/user-attachments/assets/3956b054-d94e-421e-ac86-fe38470fe07d)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33954?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33953

## **Manual testing steps**

1. Tests should pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
