### PR TITLE
fix: first address interaction alert when trust signal is verified 

### DIFF
--- a/ui/hooks/useTrustSignals.test.ts
+++ b/ui/hooks/useTrustSignals.test.ts
@@ -21,7 +21,6 @@ jest.mock('../selectors', () => ({
 
 const VALUE_MOCK = '0x1234567890123456789012345678901234567890';
 const VALUE_MOCK_2 = '0x9876543210987654321098765432109876543210';
-const VARIATION_MOCK = '0x1';
 const TRUST_LABEL_MOCK = 'Malicious Address';
 const VERIFIED_LABEL_MOCK = 'Verified Contract';
 const WARNING_LABEL_MOCK = 'Suspicious Activity';
@@ -42,11 +41,7 @@ describe('useTrustSignals', () => {
         label: TRUST_LABEL_MOCK,
       });
 
-      const result = useTrustSignal(
-        VALUE_MOCK,
-        NameType.ETHEREUM_ADDRESS,
-        VARIATION_MOCK,
-      );
+      const result = useTrustSignal(VALUE_MOCK, NameType.ETHEREUM_ADDRESS);
 
       expect(result).toStrictEqual({
         state: TrustSignalDisplayState.Malicious,
@@ -67,7 +62,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -95,7 +89,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -118,7 +111,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -141,7 +133,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -164,7 +155,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -186,7 +176,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -208,7 +197,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -230,7 +218,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -250,7 +237,6 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -280,12 +266,10 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
           {
             value: VALUE_MOCK_2,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
         ];
 
@@ -333,12 +317,10 @@ describe('useTrustSignals', () => {
           {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
-            variation: VARIATION_MOCK,
           },
           {
             value: 'test.eth',
             type: NameType.ETHEREUM_ADDRESS, // Using ETHEREUM_ADDRESS as it's the only supported type
-            variation: VARIATION_MOCK,
           },
         ];
 

--- a/ui/hooks/useTrustSignals.ts
+++ b/ui/hooks/useTrustSignals.ts
@@ -8,7 +8,6 @@ import { SecurityAlertResponse } from '../pages/confirmations/types/confirm';
 export type UseTrustSignalRequest = {
   value: string;
   type: NameType;
-  variation: string;
 };
 
 export enum TrustSignalDisplayState {
@@ -28,9 +27,8 @@ export type TrustSignalResult = {
 export function useTrustSignal(
   value: string,
   type: NameType,
-  variation: string,
 ): TrustSignalResult {
-  return useTrustSignals([{ value, type, variation }])[0];
+  return useTrustSignals([{ value, type }])[0];
 }
 
 export function useTrustSignals(

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
@@ -9,7 +9,10 @@ import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { genUnapprovedTokenTransferConfirmation } from '../../../../../../test/data/confirmations/token-transfer';
-import { TrustSignalDisplayState } from '../../../../../hooks/useTrustSignals';
+import {
+  TrustSignalDisplayState,
+  useTrustSignal,
+} from '../../../../../hooks/useTrustSignals';
 import { useFirstTimeInteractionAlert } from './useFirstTimeInteractionAlert';
 
 const ACCOUNT_ADDRESS_MOCK = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
@@ -28,6 +31,14 @@ const TRANSACTION_META_MOCK = {
   },
   time: new Date().getTime() - 10000,
 } as TransactionMeta;
+
+jest.mock('../../../../../hooks/useTrustSignals', () => ({
+  useTrustSignal: jest.fn(),
+  TrustSignalDisplayState: {
+    Unknown: 'Unknown',
+    Verified: 'Verified',
+  },
+}));
 
 function runHook({
   currentConfirmation,
@@ -59,18 +70,12 @@ function runHook({
   return response.result.current;
 }
 
-jest.mock('../../../../../hooks/useTrustSignals');
-
 describe('useFirstTimeInteractionAlert', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    jest
-      .mocked(
-        jest.requireMock('../../../../../hooks/useTrustSignals').useTrustSignal,
-      )
-      .mockReturnValue({
-        state: TrustSignalDisplayState.Unknown,
-      });
+    (useTrustSignal as jest.Mock).mockReturnValue({
+      state: TrustSignalDisplayState.Unknown,
+    });
   });
 
   it('returns no alerts if no confirmation', () => {
@@ -157,13 +162,9 @@ describe('useFirstTimeInteractionAlert', () => {
   });
 
   it('returns no alerts if transaction destination is verified', () => {
-    jest
-      .mocked(
-        jest.requireMock('../../../../../hooks/useTrustSignals').useTrustSignal,
-      )
-      .mockReturnValue({
-        state: TrustSignalDisplayState.Verified,
-      });
+    (useTrustSignal as jest.Mock).mockReturnValue({
+      state: TrustSignalDisplayState.Verified,
+    });
 
     const firstTimeConfirmation = {
       ...TRANSACTION_META_MOCK,
@@ -183,13 +184,9 @@ describe('useFirstTimeInteractionAlert', () => {
   });
 
   it('returns no alerts if token transfer recipient is verified with different case', () => {
-    jest
-      .mocked(
-        jest.requireMock('../../../../../hooks/useTrustSignals').useTrustSignal,
-      )
-      .mockReturnValue({
-        state: TrustSignalDisplayState.Verified,
-      });
+    (useTrustSignal as jest.Mock).mockReturnValue({
+      state: TrustSignalDisplayState.Verified,
+    });
 
     const firstTimeConfirmation = {
       ...TRANSACTION_META_MOCK,
@@ -210,13 +207,9 @@ describe('useFirstTimeInteractionAlert', () => {
   });
 
   it('returns alert if isFirstTimeInteraction is true', () => {
-    jest
-      .mocked(
-        jest.requireMock('../../../../../hooks/useTrustSignals').useTrustSignal,
-      )
-      .mockReturnValue({
-        state: TrustSignalDisplayState.Unknown,
-      });
+    (useTrustSignal as jest.Mock).mockReturnValue({
+      state: TrustSignalDisplayState.Unknown,
+    });
 
     const firstTimeConfirmation = {
       ...TRANSACTION_META_MOCK,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
@@ -32,13 +32,13 @@ const TRANSACTION_META_MOCK = {
   time: new Date().getTime() - 10000,
 } as TransactionMeta;
 
-jest.mock('../../../../../hooks/useTrustSignals', () => ({
-  useTrustSignal: jest.fn(),
-  TrustSignalDisplayState: {
-    Unknown: 'Unknown',
-    Verified: 'Verified',
-  },
-}));
+jest.mock('../../../../../hooks/useTrustSignals', () => {
+  const actual = jest.requireActual('../../../../../hooks/useTrustSignals');
+  return {
+    ...actual,
+    useTrustSignal: jest.fn(),
+  };
+});
 
 function runHook({
   currentConfirmation,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
@@ -183,7 +183,7 @@ describe('useFirstTimeInteractionAlert', () => {
     ).toEqual([]);
   });
 
-  it('returns no alerts if token transfer recipient is verified with different case', () => {
+  it('returns no alerts if token transfer recipient is verified', () => {
     (useTrustSignal as jest.Mock).mockReturnValue({
       state: TrustSignalDisplayState.Verified,
     });

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
@@ -71,10 +71,12 @@ function runHook({
 }
 
 describe('useFirstTimeInteractionAlert', () => {
+  const mockUseTrustSignal = jest.mocked(useTrustSignal);
   beforeEach(() => {
     jest.resetAllMocks();
-    (useTrustSignal as jest.Mock).mockReturnValue({
+    mockUseTrustSignal.mockReturnValue({
       state: TrustSignalDisplayState.Unknown,
+      label: null,
     });
   });
 
@@ -162,8 +164,9 @@ describe('useFirstTimeInteractionAlert', () => {
   });
 
   it('returns no alerts if transaction destination is verified', () => {
-    (useTrustSignal as jest.Mock).mockReturnValue({
+    mockUseTrustSignal.mockReturnValue({
       state: TrustSignalDisplayState.Verified,
+      label: null,
     });
 
     const firstTimeConfirmation = {
@@ -184,8 +187,9 @@ describe('useFirstTimeInteractionAlert', () => {
   });
 
   it('returns no alerts if token transfer recipient is verified', () => {
-    (useTrustSignal as jest.Mock).mockReturnValue({
+    mockUseTrustSignal.mockReturnValue({
       state: TrustSignalDisplayState.Verified,
+      label: null,
     });
 
     const firstTimeConfirmation = {
@@ -207,10 +211,6 @@ describe('useFirstTimeInteractionAlert', () => {
   });
 
   it('returns alert if isFirstTimeInteraction is true', () => {
-    (useTrustSignal as jest.Mock).mockReturnValue({
-      state: TrustSignalDisplayState.Unknown,
-    });
-
     const firstTimeConfirmation = {
       ...TRANSACTION_META_MOCK,
       isFirstTimeInteraction: true,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
@@ -26,11 +26,7 @@ export function useFirstTimeInteractionAlert(): Alert[] {
     (account) => account.address?.toLowerCase() === to?.toLowerCase(),
   );
 
-  const { state } = useTrustSignal(
-    to || '',
-    NameType.ETHEREUM_ADDRESS,
-    currentConfirmation?.chainId as string,
-  );
+  const { state } = useTrustSignal(to || '', NameType.ETHEREUM_ADDRESS);
 
   const isVerifiedAddress = state === TrustSignalDisplayState.Verified;
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
@@ -26,9 +26,13 @@ export function useFirstTimeInteractionAlert(): Alert[] {
     (account) => account.address?.toLowerCase() === to?.toLowerCase(),
   );
 
-  const { state } = useTrustSignal(to || '', NameType.ETHEREUM_ADDRESS);
+  const { state: trustSignalDisplayState } = useTrustSignal(
+    to || '',
+    NameType.ETHEREUM_ADDRESS,
+  );
 
-  const isVerifiedAddress = state === TrustSignalDisplayState.Verified;
+  const isVerifiedAddress =
+    trustSignalDisplayState === TrustSignalDisplayState.Verified;
 
   const showAlert =
     !isInternalAccount && isFirstTimeInteraction && !isVerifiedAddress;

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { NameType } from '@metamask/name-controller';
 
 import { useSelector } from 'react-redux';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
@@ -9,6 +10,10 @@ import { RowAlertKey } from '../../../../../components/app/confirm/info/row/cons
 import { useConfirmContext } from '../../../context/confirm';
 import { getInternalAccounts } from '../../../../../selectors';
 import { useTransferRecipient } from '../../../components/confirm/info/hooks/useTransferRecipient';
+import {
+  useTrustSignal,
+  TrustSignalDisplayState,
+} from '../../../../../hooks/useTrustSignals';
 
 export function useFirstTimeInteractionAlert(): Alert[] {
   const t = useI18nContext();
@@ -21,7 +26,16 @@ export function useFirstTimeInteractionAlert(): Alert[] {
     (account) => account.address?.toLowerCase() === to?.toLowerCase(),
   );
 
-  const showAlert = !isInternalAccount && isFirstTimeInteraction;
+  const { state } = useTrustSignal(
+    to || '',
+    NameType.ETHEREUM_ADDRESS,
+    currentConfirmation?.chainId as string,
+  );
+
+  const isVerifiedAddress = state === TrustSignalDisplayState.Verified;
+
+  const showAlert =
+    !isInternalAccount && isFirstTimeInteraction && !isVerifiedAddress;
 
   return useMemo(() => {
     // If isFirstTimeInteraction is undefined that means it's either disabled or error in accounts API

--- a/ui/pages/confirmations/hooks/alerts/useTrustSignalAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useTrustSignalAlerts.test.ts
@@ -113,7 +113,6 @@ describe('useTrustSignalAlerts', () => {
       expect(mockUseTrustSignal).toHaveBeenCalledWith(
         MALICIOUS_ADDRESS,
         NameType.ETHEREUM_ADDRESS,
-        CHAIN_IDS.GOERLI,
       );
     });
 
@@ -141,7 +140,6 @@ describe('useTrustSignalAlerts', () => {
       expect(mockUseTrustSignal).toHaveBeenCalledWith(
         WARNING_ADDRESS,
         NameType.ETHEREUM_ADDRESS,
-        CHAIN_IDS.GOERLI,
       );
     });
 
@@ -196,7 +194,6 @@ describe('useTrustSignalAlerts', () => {
       expect(mockUseTrustSignal).toHaveBeenCalledWith(
         MALICIOUS_ADDRESS,
         NameType.ETHEREUM_ADDRESS,
-        unapprovedPersonalSignMsg.chainId,
       );
     });
 
@@ -250,7 +247,6 @@ describe('useTrustSignalAlerts', () => {
       expect(mockUseTrustSignal).toHaveBeenCalledWith(
         '',
         NameType.ETHEREUM_ADDRESS,
-        unapprovedPersonalSignMsg.chainId,
       );
     });
 
@@ -277,7 +273,6 @@ describe('useTrustSignalAlerts', () => {
       expect(mockUseTrustSignal).toHaveBeenCalledWith(
         '',
         NameType.ETHEREUM_ADDRESS,
-        unapprovedPersonalSignMsg.chainId,
       );
     });
   });

--- a/ui/pages/confirmations/hooks/alerts/useTrustSignalAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useTrustSignalAlerts.ts
@@ -45,12 +45,9 @@ export function useTrustSignalAlerts(): Alert[] {
     return null;
   }, [currentConfirmation]);
 
-  const chainId = currentConfirmation?.chainId as string;
-
   const { state: trustSignalDisplayState } = useTrustSignal(
     addressToCheck || '',
     NameType.ETHEREUM_ADDRESS,
-    chainId,
   );
 
   return useMemo(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request introduces updates to the `useFirstTimeInteractionAlert` hook and its associated tests to incorporate trust signal verification for Ethereum addresses. The changes ensure that alerts are not shown for verified addresses during first-time interactions.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33961?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="512" alt="Screenshot 2025-06-27 at 10 54 20 AM" src="https://github.com/user-attachments/assets/e05bf402-37c2-4721-916b-4793ec77ffbe" />


<!-- [screenshots/recordings] -->

### **After**

<img width="512" alt="Screenshot 2025-06-27 at 10 51 10 AM" src="https://github.com/user-attachments/assets/c4e207a9-dbca-4733-9161-8e96b5d3479d" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
