### PR TITLE
feat: Add new warning modal for removing accounts

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4670,6 +4670,14 @@
   "removeAccountDescription": {
     "message": "This account will be removed from your wallet. Please make sure you have the original Secret Recovery Phrase or private key for this imported account before continuing. You can import or create accounts again from the account drop-down. "
   },
+  "removeAccountModalBannerDescription": {
+    "message": "Make sure you have the Secret Recovery Phrase or private key for this account before removing.",
+    "description": "Make sure you have the Secret Recovery Phrase or private key for this account before removing."
+  },
+  "removeAccountModalBannerTitle": {
+    "message": "This account will be removed from MetaMask.",
+    "description": "Title of a banner alert used on account remove modal."
+  },
   "removeKeyringSnap": {
     "message": "Removing this Snap removes these accounts from MetaMask:"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4670,6 +4670,14 @@
   "removeAccountDescription": {
     "message": "This account will be removed from your wallet. Please make sure you have the original Secret Recovery Phrase or private key for this imported account before continuing. You can import or create accounts again from the account drop-down. "
   },
+  "removeAccountModalBannerDescription": {
+    "message": "Make sure you have the Secret Recovery Phrase or private key for this account before removing.",
+    "description": "Make sure you have the Secret Recovery Phrase or private key for this account before removing."
+  },
+  "removeAccountModalBannerTitle": {
+    "message": "This account will be removed from MetaMask.",
+    "description": "Title of a banner alert used on account remove modal."
+  },
   "removeKeyringSnap": {
     "message": "Removing this Snap removes these accounts from MetaMask:"
   },

--- a/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.stories.tsx
+++ b/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.stories.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { StoryFn, Meta } from '@storybook/react';
+import {
+  AccountRemoveModal,
+  AccountRemoveModalProps,
+} from './account-remove-modal';
+import { Button } from '../../component-library';
+
+export default {
+  title: 'Components/MultichainAccounts/AccountRemoveModal',
+  component: AccountRemoveModal,
+  parameters: {
+    docs: {
+      description: {
+        component: 'A modal for confirming account removal action.',
+      },
+    },
+  },
+  argTypes: {
+    onClose: {
+      action: 'closed',
+      description: 'Function called when the modal is closed',
+    },
+    onSubmit: {
+      action: 'submitted',
+      description: 'Function called when the removal is confirmed',
+    },
+  },
+} as Meta<AccountRemoveModalProps>;
+
+const DefaultTemplate: StoryFn<AccountRemoveModalProps> = (args) => (
+  <AccountRemoveModal {...args} />
+);
+
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  isOpen: true,
+  onClose: () => console.log('Modal closed'),
+  onSubmit: () => console.log('Account removal confirmed'),
+  accountName: 'Ledger EVM Account',
+  accountAddress: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
+};
+
+const InteractiveTemplate: StoryFn = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+  const handleSubmit = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Open Remove Account Modal</Button>
+      <AccountRemoveModal
+        isOpen={isOpen}
+        onClose={handleClose}
+        onSubmit={handleSubmit}
+        accountName="Ledger EVM Account"
+        accountAddress="0x5CfE73b6021E818B776b421B1c4Db2474086a7e1"
+      />
+    </>
+  );
+};
+
+export const Interactive = InteractiveTemplate.bind({});
+Interactive.parameters = {
+  docs: {
+    description: {
+      story: 'Interactive modal.',
+    },
+  },
+};

--- a/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.test.tsx
+++ b/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import configureStore from '../../../store/store';
+import { renderWithProvider } from '../../../../test/jest';
+import { AccountRemoveModal } from './account-remove-modal';
+
+describe('AccountRemoveModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    onSubmit: jest.fn(),
+    accountName: 'Ledger EVM Account',
+    accountAddress: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
+  };
+
+  const renderComponent = (props = {}) => {
+    const store = configureStore({});
+    return renderWithProvider(
+      <AccountRemoveModal {...defaultProps} {...props} />,
+      store,
+    );
+  };
+
+  it('renders modal content when isOpen is true', () => {
+    renderComponent();
+
+    expect(screen.getByText('Remove account')).toBeInTheDocument();
+    expect(screen.getByText('Ledger EVM Account')).toBeInTheDocument();
+    expect(screen.getByText('0x5CfE7...6a7e1')).toBeInTheDocument();
+    expect(
+      screen.getByText('This account will be removed from MetaMask.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Make sure you have the Secret Recovery Phrase or private key for this account before removing.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Remove')).toBeInTheDocument();
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderComponent({ isOpen: false });
+
+    expect(screen.queryByText('Remove account')).not.toBeInTheDocument();
+  });
+
+  it('calls appropriate handlers when buttons are clicked', () => {
+    renderComponent();
+
+    screen.getByText('Cancel').click();
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+
+    screen.getByText('Remove').click();
+    expect(defaultProps.onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.tsx
+++ b/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+import { useSelector } from 'react-redux';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarAccountVariant,
+  BannerAlert,
+  BannerAlertSeverity,
+  Box,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '../../component-library';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  AlignItems,
+  BorderColor,
+  Display,
+  FlexDirection,
+  FontWeight,
+  JustifyContent,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import { getUseBlockie } from '../../../selectors';
+import { AddressCopyButton } from '../../multichain';
+
+export type AccountRemoveModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  accountName: string;
+  accountAddress: string;
+};
+
+export const AccountRemoveModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  accountName,
+  accountAddress,
+}: AccountRemoveModalProps) => {
+  const t = useI18nContext();
+  const useBlockie = useSelector(getUseBlockie);
+
+  return (
+    <Modal onClose={onClose} isOpen={isOpen}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onClose={onClose}>{t('removeAccount')}</ModalHeader>
+        <ModalBody>
+          <Box
+            display={Display.Flex}
+            justifyContent={JustifyContent.center}
+            alignItems={AlignItems.center}
+            flexDirection={FlexDirection.Column}
+          >
+            <AvatarAccount
+              borderColor={BorderColor.transparent}
+              size={AvatarAccountSize.Md}
+              address={accountAddress}
+              variant={
+                useBlockie
+                  ? AvatarAccountVariant.Blockies
+                  : AvatarAccountVariant.Jazzicon
+              }
+            />
+            <Text
+              variant={TextVariant.bodyLgMedium}
+              marginTop={2}
+              marginBottom={2}
+            >
+              {accountName}
+            </Text>
+            <AddressCopyButton address={accountAddress} shorten />
+          </Box>
+          <BannerAlert
+            severity={BannerAlertSeverity.Danger}
+            marginTop={6}
+            marginBottom={2}
+          >
+            <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Bold}>
+              {t('removeAccountModalBannerTitle')}
+            </Text>
+            <Text variant={TextVariant.bodyMd}>
+              {t('removeAccountModalBannerDescription')}
+            </Text>
+          </BannerAlert>
+        </ModalBody>
+        <ModalFooter
+          onCancel={onClose}
+          onSubmit={onSubmit}
+          submitButtonProps={{
+            children: t('remove'),
+            danger: true,
+          }}
+        />
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/ui/components/multichain-accounts/account-remove-modal/index.ts
+++ b/ui/components/multichain-accounts/account-remove-modal/index.ts
@@ -1,0 +1,1 @@
+export { AccountRemoveModal } from './account-remove-modal';


### PR DESCRIPTION
## **Description**
As a part of the new account removal process, we need new modal with warning message and other information. This PR adds new modal component for this purpose.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33962?quickstart=1)

## **Related issues**
Related task: https://consensyssoftware.atlassian.net/browse/MUL-172

## **Figma designs**
https://www.figma.com/design/nmBs86I42Cp0T39BlRdX7x/Network-Expansion-Specs?node-id=4415-54406&m=dev

## **Manual testing steps**
1. Go to storybook and search for `Components/MultichainAccounts/AccountRemoveModal`
2. Make sure that designs are correct

## **Screenshots/Recordings**
### **Before**
This is completely new modal for the new accounts UX. Nothing to show here.

### **After**
<img width="485" alt="Screenshot 2025-06-27 at 17 04 28" src="https://github.com/user-attachments/assets/52a12315-156d-4f89-9a96-50ac7ba32b8c" />


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.