### PR TITLE
refactor: Consistently use redux to manage state for showing `<VisitSupportDataConsentModal />`

### DIFF
--- a/ui/pages/error-page/error-component.test.tsx
+++ b/ui/pages/error-page/error-component.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import '@testing-library/jest-dom';
 import browser from 'webextension-polyfill';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../test/lib/render-helpers';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../contexts/metametrics';
@@ -25,7 +25,6 @@ jest.mock('webextension-polyfill', () => ({
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
-  useDispatch: () => jest.fn(),
 }));
 
 describe('ErrorPage', () => {
@@ -149,7 +148,6 @@ describe('ErrorPage', () => {
       <MetaMetricsContext.Provider value={mockTrackEvent}>
         <ErrorPage error={MockError} />
       </MetaMetricsContext.Provider>,
-      // mockStore,
     );
     const tryAgainButton = getByTestId('error-page-try-again-button');
     fireEvent.click(tryAgainButton);
@@ -169,10 +167,6 @@ describe('ErrorPage', () => {
       'error-page-contact-support-button',
     );
     fireEvent.click(contactSupportButton);
-    waitFor(() =>
-      expect(
-        getByTestId('visit-support-data-consent-modal'),
-      ).toBeInTheDocument(),
-    );
+    expect(getByTestId('visit-support-data-consent-modal')).toBeInTheDocument();
   });
 });

--- a/ui/pages/error-page/error-component.test.tsx
+++ b/ui/pages/error-page/error-component.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import '@testing-library/jest-dom';
 import browser from 'webextension-polyfill';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../test/lib/render-helpers';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../contexts/metametrics';
@@ -25,6 +25,7 @@ jest.mock('webextension-polyfill', () => ({
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
+  useDispatch: () => jest.fn(),
 }));
 
 describe('ErrorPage', () => {
@@ -148,6 +149,7 @@ describe('ErrorPage', () => {
       <MetaMetricsContext.Provider value={mockTrackEvent}>
         <ErrorPage error={MockError} />
       </MetaMetricsContext.Provider>,
+      // mockStore,
     );
     const tryAgainButton = getByTestId('error-page-try-again-button');
     fireEvent.click(tryAgainButton);
@@ -167,6 +169,10 @@ describe('ErrorPage', () => {
       'error-page-contact-support-button',
     );
     fireEvent.click(contactSupportButton);
-    expect(getByTestId('visit-support-data-consent-modal')).toBeInTheDocument();
+    waitFor(() =>
+      expect(
+        getByTestId('visit-support-data-consent-modal'),
+      ).toBeInTheDocument(),
+    );
   });
 });

--- a/ui/pages/error-page/error-component.test.tsx
+++ b/ui/pages/error-page/error-component.test.tsx
@@ -149,13 +149,14 @@ describe('ErrorPage', () => {
       <MetaMetricsContext.Provider value={mockTrackEvent}>
         <ErrorPage error={MockError} />
       </MetaMetricsContext.Provider>,
+      // mockStore,
     );
     const tryAgainButton = getByTestId('error-page-try-again-button');
     fireEvent.click(tryAgainButton);
     expect(browser.runtime.reload).toHaveBeenCalled();
   });
 
-  it('should open the support consent modal when the "Contact Support" button is clicked', async () => {
+  it('should open the support consent modal when the "Contact Support" button is clicked', () => {
     window.open = jest.fn();
 
     const { getByTestId } = renderWithProvider(
@@ -168,7 +169,7 @@ describe('ErrorPage', () => {
       'error-page-contact-support-button',
     );
     fireEvent.click(contactSupportButton);
-    await waitFor(() =>
+    waitFor(() =>
       expect(
         getByTestId('visit-support-data-consent-modal'),
       ).toBeInTheDocument(),

--- a/ui/pages/error-page/error-component.test.tsx
+++ b/ui/pages/error-page/error-component.test.tsx
@@ -149,14 +149,13 @@ describe('ErrorPage', () => {
       <MetaMetricsContext.Provider value={mockTrackEvent}>
         <ErrorPage error={MockError} />
       </MetaMetricsContext.Provider>,
-      // mockStore,
     );
     const tryAgainButton = getByTestId('error-page-try-again-button');
     fireEvent.click(tryAgainButton);
     expect(browser.runtime.reload).toHaveBeenCalled();
   });
 
-  it('should open the support consent modal when the "Contact Support" button is clicked', () => {
+  it('should open the support consent modal when the "Contact Support" button is clicked', async () => {
     window.open = jest.fn();
 
     const { getByTestId } = renderWithProvider(
@@ -169,7 +168,7 @@ describe('ErrorPage', () => {
       'error-page-contact-support-button',
     );
     fireEvent.click(contactSupportButton);
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         getByTestId('visit-support-data-consent-modal'),
       ).toBeInTheDocument(),

--- a/ui/pages/error-page/error-page.component.tsx
+++ b/ui/pages/error-page/error-page.component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import * as Sentry from '@sentry/browser';
 import browser from 'webextension-polyfill';
 
@@ -38,6 +38,8 @@ import { Textarea } from '../../components/component-library/textarea/textarea';
 import { TextareaResize } from '../../components/component-library/textarea/textarea.types';
 import { ButtonSize } from '../../components/component-library/button/button.types';
 import VisitSupportDataConsentModal from '../../components/app/modals/visit-support-data-consent-modal';
+import { getShowSupportDataConsentModal } from '../../ducks/app/app';
+import { setShowSupportDataConsentModal } from '../../store/actions';
 
 type ErrorPageProps = {
   error: {
@@ -50,13 +52,15 @@ type ErrorPageProps = {
 
 const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
   const t = useI18nContext();
+  const dispatch = useDispatch();
   const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const showSupportDataConsentModal = useSelector(
+    getShowSupportDataConsentModal,
+  );
 
   const [feedbackMessage, setFeedbackMessage] = useState('');
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
   const [isSuccessModalShown, setIsSuccessModalShown] = useState(false);
-  const [isSupportDataConsentModalOpen, setIsSupportDataConsentModalOpen] =
-    useState(false);
 
   const handleClickDescribeButton = (): void => {
     setIsFeedbackModalOpen(true);
@@ -112,7 +116,6 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
             {t('errorPageTitle')}
           </Text>
         </Box>
-
         <div className="error-page__banner-wrapper">
           <BannerAlert
             childrenWrapperProps={{ color: TextColor.inherit }}
@@ -121,11 +124,9 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
             {t('errorPageInfo')}
           </BannerAlert>
         </div>
-
         <Text color={TextColor.inherit} variant={TextVariant.bodyMd}>
           {t('errorPageMessageTitle')}
         </Text>
-
         <Box
           borderRadius={BorderRadius.LG}
           marginBottom={2}
@@ -184,7 +185,6 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
             </>
           ) : null}
         </Box>
-
         {isFeedbackModalOpen && (
           <Modal
             isOpen={isFeedbackModalOpen}
@@ -263,12 +263,12 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
             </ModalContent>
           </Modal>
         )}
-        {isSupportDataConsentModalOpen && (
-          <VisitSupportDataConsentModal
-            isOpen={isSupportDataConsentModalOpen}
-            onClose={() => setIsSupportDataConsentModalOpen(false)}
-          />
-        )}
+        (
+        <VisitSupportDataConsentModal
+          isOpen={showSupportDataConsentModal}
+          onClose={() => dispatch(setShowSupportDataConsentModal(false))}
+        />
+        )
         <Box
           width={BlockSize.Full}
           display={Display.Flex}
@@ -293,7 +293,7 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
             variant={ButtonVariant.Secondary}
             block
             data-testid="error-page-contact-support-button"
-            onClick={() => setIsSupportDataConsentModalOpen(true)}
+            onClick={() => dispatch(setShowSupportDataConsentModal(true))}
           >
             {t('errorPageContactSupport')}
           </Button>

--- a/ui/pages/settings/info-tab/index.js
+++ b/ui/pages/settings/info-tab/index.js
@@ -1,1 +1,1 @@
-export { default } from './info-tab.component';
+export { default } from './info-tab.container';

--- a/ui/pages/settings/info-tab/info-tab.component.js
+++ b/ui/pages/settings/info-tab/info-tab.component.js
@@ -15,17 +15,19 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import VisitSupportDataConsentModal from '../../../components/app/modals/visit-support-data-consent-modal';
 
 export default class InfoTab extends PureComponent {
   state = {
     version: process.env.METAMASK_VERSION,
-    isVisitSupportDataConsentModalOpen: false,
   };
 
   static contextTypes = {
     t: PropTypes.func,
     trackEvent: PropTypes.func,
+  };
+
+  static propTypes = {
+    setShowSupportDataConsentModal: PropTypes.func,
   };
 
   settingsRefs = Array(
@@ -45,13 +47,6 @@ export default class InfoTab extends PureComponent {
     const { t } = this.context;
     handleSettingsRefs(t, t('about'), this.settingsRefs);
   }
-
-  toggleVisitSupportDataConsentModal = () => {
-    this.setState((prevState) => ({
-      isVisitSupportDataConsentModalOpen:
-        !prevState.isVisitSupportDataConsentModalOpen,
-    }));
-  };
 
   renderInfoLinks() {
     const { t } = this.context;
@@ -117,7 +112,7 @@ export default class InfoTab extends PureComponent {
             target="_blank"
             rel="noopener noreferrer"
             className="info-tab__link-text"
-            onClick={this.toggleVisitSupportDataConsentModal}
+            onClick={() => this.props.setShowSupportDataConsentModal(true)}
           >
             {t('supportCenter')}
           </Button>
@@ -195,12 +190,6 @@ export default class InfoTab extends PureComponent {
             alt="MetaMask Logo"
           />
         </div>
-        {this.state.isVisitSupportDataConsentModalOpen && (
-          <VisitSupportDataConsentModal
-            isOpen={this.state.isVisitSupportDataConsentModalOpen}
-            onClose={this.toggleVisitSupportDataConsentModal}
-          />
-        )}
       </div>
     );
   }

--- a/ui/pages/settings/info-tab/info-tab.component.js
+++ b/ui/pages/settings/info-tab/info-tab.component.js
@@ -112,6 +112,7 @@ export default class InfoTab extends PureComponent {
             target="_blank"
             rel="noopener noreferrer"
             className="info-tab__link-text"
+            data-testid="info-tab-support-center-button"
             onClick={() => this.props.setShowSupportDataConsentModal(true)}
           >
             {t('supportCenter')}

--- a/ui/pages/settings/info-tab/info-tab.container.js
+++ b/ui/pages/settings/info-tab/info-tab.container.js
@@ -1,0 +1,27 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { setShowSupportDataConsentModal } from '../../../store/actions';
+import InfoTab from './info-tab.component';
+
+const mapStateToProps = (state) => {
+  const {
+    appState: { showSupportDataConsentModal },
+  } = state;
+
+  return {
+    showSupportDataConsentModal,
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    setShowSupportDataConsentModal: (show) =>
+      dispatch(setShowSupportDataConsentModal(show)),
+  };
+};
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps),
+)(InfoTab);

--- a/ui/pages/settings/info-tab/info-tab.container.ts
+++ b/ui/pages/settings/info-tab/info-tab.container.ts
@@ -2,9 +2,11 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { setShowSupportDataConsentModal } from '../../../store/actions';
+import type { MetaMaskReduxDispatch } from '../../../store/store';
+import type { AppSliceState } from '../../../ducks/app/app';
 import InfoTab from './info-tab.component';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state: AppSliceState) => {
   const {
     appState: { showSupportDataConsentModal },
   } = state;
@@ -14,9 +16,9 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = (dispatch: MetaMaskReduxDispatch) => {
   return {
-    setShowSupportDataConsentModal: (show) =>
+    setShowSupportDataConsentModal: (show: boolean) =>
       dispatch(setShowSupportDataConsentModal(show)),
   };
 };

--- a/ui/pages/settings/info-tab/info-tab.test.tsx
+++ b/ui/pages/settings/info-tab/info-tab.test.tsx
@@ -13,6 +13,7 @@ describe('InfoTab', () => {
     let getByTestId: (testId: string) => HTMLElement;
 
     beforeEach(() => {
+      // @ts-expect-error TODO: Remove this line once `InfoTab` has been converted to a functional component
       const renderResult = renderWithProvider(<InfoTab />, mockStore);
       getByText = renderResult.getByText;
       getByTestId = renderResult.getByTestId;

--- a/ui/pages/settings/info-tab/info-tab.test.tsx
+++ b/ui/pages/settings/info-tab/info-tab.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest/rendering';
 import mockState from '../../../../test/data/mock-state.json';
 import InfoTab from '.';
@@ -46,11 +46,9 @@ describe('InfoTab', () => {
     it('should trigger support modal when click support link', () => {
       const supportLink = getByText('Visit our support center');
       fireEvent.click(supportLink);
-      waitFor(() =>
-        expect(
-          getByTestId('visit-support-data-consent-modal'),
-        ).toBeInTheDocument(),
-      );
+      expect(
+        getByTestId('visit-support-data-consent-modal'),
+      ).toBeInTheDocument();
     });
 
     it('should have correct href for "Visit our website" link', () => {

--- a/ui/pages/settings/info-tab/info-tab.test.tsx
+++ b/ui/pages/settings/info-tab/info-tab.test.tsx
@@ -13,7 +13,7 @@ describe('InfoTab', () => {
     let getByTestId: (testId: string) => HTMLElement;
 
     beforeEach(() => {
-      // @ts-expect-error TODO: Remove this line once `InfoTab` has been converted to a functional component
+      // @ts-expect-error TODO: Remove this line once `react-redux` has been upgraded to `^8.0.0`, or `InfoTab` has been converted to a functional component.
       const renderResult = renderWithProvider(<InfoTab />, mockStore);
       getByText = renderResult.getByText;
       getByTestId = renderResult.getByTestId;

--- a/ui/pages/settings/info-tab/info-tab.test.tsx
+++ b/ui/pages/settings/info-tab/info-tab.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest/rendering';
 import mockState from '../../../../test/data/mock-state.json';
 import InfoTab from '.';
@@ -46,9 +46,11 @@ describe('InfoTab', () => {
     it('should trigger support modal when click support link', () => {
       const supportLink = getByText('Visit our support center');
       fireEvent.click(supportLink);
-      expect(
-        getByTestId('visit-support-data-consent-modal'),
-      ).toBeInTheDocument();
+      waitFor(() =>
+        expect(
+          getByTestId('visit-support-data-consent-modal'),
+        ).toBeInTheDocument(),
+      );
     });
 
     it('should have correct href for "Visit our website" link', () => {

--- a/ui/pages/settings/info-tab/info-tab.test.tsx
+++ b/ui/pages/settings/info-tab/info-tab.test.tsx
@@ -43,10 +43,10 @@ describe('InfoTab', () => {
       );
     });
 
-    it('should trigger support modal when click support link', async () => {
+    it('should trigger support modal when click support link', () => {
       const supportLink = getByText('Visit our support center');
       fireEvent.click(supportLink);
-      await waitFor(() =>
+      waitFor(() =>
         expect(
           getByTestId('visit-support-data-consent-modal'),
         ).toBeInTheDocument(),

--- a/ui/pages/settings/info-tab/info-tab.test.tsx
+++ b/ui/pages/settings/info-tab/info-tab.test.tsx
@@ -43,10 +43,10 @@ describe('InfoTab', () => {
       );
     });
 
-    it('should trigger support modal when click support link', () => {
+    it('should trigger support modal when click support link', async () => {
       const supportLink = getByText('Visit our support center');
       fireEvent.click(supportLink);
-      waitFor(() =>
+      await waitFor(() =>
         expect(
           getByTestId('visit-support-data-consent-modal'),
         ).toBeInTheDocument(),

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -214,6 +214,10 @@ class SettingsPage extends PureComponent {
             {this.renderContent()}
           </div>
         </div>
+        <VisitSupportDataConsentModal
+          isOpen={this.props.showSupportDataConsentModal}
+          onClose={() => this.props.setShowSupportDataConsentModal(false)}
+        />
       </div>
     );
   }
@@ -518,10 +522,6 @@ class SettingsPage extends PureComponent {
               lastFetchedConversionDate={this.state.lastFetchedConversionDate}
             />
           )}
-        />
-        <VisitSupportDataConsentModal
-          isOpen={this.props.showSupportDataConsentModal}
-          onClose={() => this.props.setShowSupportDataConsentModal(false)}
         />
       </Switch>
     );

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -50,6 +50,7 @@ import MetafoxLogo from '../../components/ui/metafox-logo';
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../shared/constants/app';
 import { SnapIcon } from '../../components/app/snaps/snap-icon';
+import VisitSupportDataConsentModal from '../../components/app/modals/visit-support-data-consent-modal';
 import { SnapSettingsRenderer } from '../../components/app/snaps/snap-settings-page';
 import PasswordOutdatedModal from '../../components/app/password-outdated-modal';
 import SettingsTab from './settings-tab';
@@ -83,7 +84,9 @@ class SettingsPage extends PureComponent {
     isSeedlessPasswordOutdated: PropTypes.bool,
     mostRecentOverviewPage: PropTypes.string.isRequired,
     pathnameI18nKey: PropTypes.string,
+    setShowSupportDataConsentModal: PropTypes.func,
     settingsPageSnaps: PropTypes.array,
+    showSupportDataConsentModal: PropTypes.bool,
     snapSettingsTitle: PropTypes.string,
     toggleNetworkMenu: PropTypes.func.isRequired,
     useExternalServices: PropTypes.bool,
@@ -515,6 +518,10 @@ class SettingsPage extends PureComponent {
               lastFetchedConversionDate={this.state.lastFetchedConversionDate}
             />
           )}
+        />
+        <VisitSupportDataConsentModal
+          isOpen={this.props.showSupportDataConsentModal}
+          onClose={() => this.props.setShowSupportDataConsentModal(false)}
         />
       </Switch>
     );

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -70,7 +70,7 @@ const ROUTES_TO_I18N_KEYS = {
 
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
-  const { pathname } = location;
+  const { pathname = '' } = location;
   const { ticker } = getProviderConfig(state);
   const {
     metamask: { currencyRates, socialLoginEmail },
@@ -80,7 +80,7 @@ const mapStateToProps = (state, ownProps) => {
   const snapsMetadata = getSnapsMetadata(state);
   const conversionDate = currencyRates[ticker]?.conversionDate;
 
-  const pathNameTail = pathname.match(/[^/]+$/u)[0];
+  const pathNameTail = (pathname.match(/[^/]+$/u) ?? [''])[0];
   const isAddressEntryPage = pathNameTail.includes('0x');
   const isAddContactPage = Boolean(pathname.match(CONTACT_ADD_ROUTE));
   const isEditContactPage = Boolean(pathname.match(CONTACT_EDIT_ROUTE));

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -70,7 +70,7 @@ const ROUTES_TO_I18N_KEYS = {
 
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
-  const { pathname = '' } = location;
+  const { pathname } = location;
   const { ticker } = getProviderConfig(state);
   const {
     metamask: { currencyRates, socialLoginEmail },
@@ -80,7 +80,7 @@ const mapStateToProps = (state, ownProps) => {
   const snapsMetadata = getSnapsMetadata(state);
   const conversionDate = currencyRates[ticker]?.conversionDate;
 
-  const pathNameTail = (pathname.match(/[^/]+$/u) ?? [''])[0];
+  const pathNameTail = pathname.match(/[^/]+$/u)[0];
   const isAddressEntryPage = pathNameTail.includes('0x');
   const isAddContactPage = Boolean(pathname.match(CONTACT_ADD_ROUTE));
   const isEditContactPage = Boolean(pathname.match(CONTACT_EDIT_ROUTE));

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -39,7 +39,10 @@ import {
   SECURITY_PASSWORD_CHANGE_ROUTE,
 } from '../../helpers/constants/routes';
 import { getProviderConfig } from '../../../shared/modules/selectors/networks';
-import { toggleNetworkMenu } from '../../store/actions';
+import {
+  setShowSupportDataConsentModal,
+  toggleNetworkMenu,
+} from '../../store/actions';
 import { getSnapName } from '../../helpers/utils/util';
 import { decodeSnapIdFromPathname } from '../../helpers/utils/snaps';
 import { getIsSeedlessPasswordOutdated } from '../../ducks/metamask/metamask';
@@ -71,6 +74,7 @@ const mapStateToProps = (state, ownProps) => {
   const { ticker } = getProviderConfig(state);
   const {
     metamask: { currencyRates, socialLoginEmail },
+    appState: { showSupportDataConsentModal },
   } = state;
   const settingsPageSnapsIds = getSettingsPageSnapsIds(state);
   const snapsMetadata = getSnapsMetadata(state);
@@ -154,6 +158,7 @@ const mapStateToProps = (state, ownProps) => {
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     pathnameI18nKey,
     settingsPageSnaps,
+    showSupportDataConsentModal,
     snapSettingsTitle,
     useExternalServices,
   };
@@ -161,6 +166,8 @@ const mapStateToProps = (state, ownProps) => {
 
 function mapDispatchToProps(dispatch) {
   return {
+    setShowSupportDataConsentModal: (show) =>
+      dispatch(setShowSupportDataConsentModal(show)),
     toggleNetworkMenu: (payload) => dispatch(toggleNetworkMenu(payload)),
   };
 }

--- a/ui/pages/settings/settings.test.js
+++ b/ui/pages/settings/settings.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../test/lib/render-helpers';
 import mockState from '../../../test/data/mock-state.json';
+import { ABOUT_US_ROUTE } from '../../helpers/constants/routes';
 import Settings from '.';
 import 'jest-canvas-mock';
 
@@ -41,5 +43,23 @@ describe('SettingsPage', () => {
     );
 
     expect(queryByPlaceholderText('Search')).toBeInTheDocument();
+  });
+
+  it('should trigger support modal when click support link', () => {
+    const { queryByTestId } = renderWithProvider(
+      <Settings {...props} />,
+      mockStore,
+      ABOUT_US_ROUTE,
+    );
+
+    const supportLink = queryByTestId('info-tab-support-center-button');
+    expect(supportLink).toBeInTheDocument();
+    fireEvent.click(supportLink);
+
+    waitFor(() =>
+      expect(
+        queryByTestId('visit-support-data-consent-modal'),
+      ).toBeInTheDocument(),
+    );
   });
 });

--- a/ui/pages/settings/settings.test.js
+++ b/ui/pages/settings/settings.test.js
@@ -45,7 +45,7 @@ describe('SettingsPage', () => {
     expect(queryByPlaceholderText('Search')).toBeInTheDocument();
   });
 
-  it('should trigger support modal when click support link', async () => {
+  it('should trigger support modal when click support link', () => {
     const { queryByTestId } = renderWithProvider(
       <Settings {...props} />,
       mockStore,
@@ -56,7 +56,7 @@ describe('SettingsPage', () => {
     expect(supportLink).toBeInTheDocument();
     fireEvent.click(supportLink);
 
-    await waitFor(() =>
+    waitFor(() =>
       expect(
         queryByTestId('visit-support-data-consent-modal'),
       ).toBeInTheDocument(),

--- a/ui/pages/settings/settings.test.js
+++ b/ui/pages/settings/settings.test.js
@@ -45,7 +45,7 @@ describe('SettingsPage', () => {
     expect(queryByPlaceholderText('Search')).toBeInTheDocument();
   });
 
-  it('should trigger support modal when click support link', () => {
+  it('should trigger support modal when click support link', async () => {
     const { queryByTestId } = renderWithProvider(
       <Settings {...props} />,
       mockStore,
@@ -56,7 +56,7 @@ describe('SettingsPage', () => {
     expect(supportLink).toBeInTheDocument();
     fireEvent.click(supportLink);
 
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         queryByTestId('visit-support-data-consent-modal'),
       ).toBeInTheDocument(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Consolidates local show state for `<VisitSupportDataConsentModal />` instances to be managed by the `appState` Redux slice's new `showSupportDataConsentModal` property. 

Updated components:
- `<ErrorPage />`
- `<InfoTab />`, `<SettingsPage />`

For context, see https://github.com/MetaMask/metamask-extension/pull/33658#discussion_r2192758189.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33969?quickstart=1)

## **Related issues**

- Fixes https://github.com/MetaMask/MetaMask-planning/issues/5163
- Follows https://github.com/MetaMask/metamask-extension/pull/33658

## **Manual testing steps**

A. No regressions in `<GlobalMenu />`:
  1. Click Global ("3-dot") menu - Support
  2. Verify that a modal titled "Share device details with support" appears. 
  3. Clicking outside of the modal should make it close.
  4. Clicking inside of the modal should not make it close.
  5. Clicking on either button in the modal should make it close and open a new tab showing the support page.

B. No regressions in `<InfoTab />`:
  1. Click Global ("3-dot") menu - Settings - About - "Visit our support center"
  2. Repeat steps A-2 to A-5. 

C. No regressions in `<ErrorPage />`:
  1. Click Global ("3-dot") menu - Settings - Developer Options - "Generate A Page Crash" - "Contact support"
  2. Repeat steps A-2 to A-5. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
