### PR TITLE
feat: removes bridge button when unified is enabled

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -398,7 +398,8 @@ const CoinButtons = ({
         }
         round={!displayNewIconButtons}
       />
-      {process.env.REMOVE_GNS ? null : (
+      {/* the bridge button is redundant if unified ui is enabled */}
+      {process.env.REMOVE_GNS || isUnifiedUIEnabled ? null : (
         <IconButton
           className={`${classPrefix}-overview__button`}
           disabled={


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

removes the bridge button when unified swaps is enabled as it is redundant. this change is necessary because the GNS removal + homepage redesign is being delayed.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33970?quickstart=1)

## **Related issues**

Closes: https://consensyssoftware.atlassian.net/browse/SWAPS-2541

## **Manual testing steps**

1. Go to the homepage or an asset page.
2. If unified is enabled, bridge button will not be visible, and the buttons should still be aligned correctly.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="399" alt="Screenshot 2025-06-27 at 2 10 35 PM" src="https://github.com/user-attachments/assets/8dca78b6-0256-4d32-b399-e62d58f7d405" />

<!-- [screenshots/recordings] -->

### **After**
<img width="396" alt="Screenshot 2025-06-27 at 2 10 12 PM" src="https://github.com/user-attachments/assets/2b018d6d-c1b7-4282-85ef-a6d1067c6574" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
