### PR TITLE
fix: Enable correct networks in devbuilds

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1034,9 +1034,18 @@ export default class MetamaskController extends EventEmitter {
 
     let initialNetworkOrderControllerState;
 
-    if (
-      process.env.METAMASK_DEBUG ||
-      !process.env.METAMASK_ENVIRONMENT === 'test'
+    if (process.env.IN_TEST) {
+      initialNetworkOrderControllerState = {
+        orderedNetworkList: [],
+        enabledNetworkMap: {
+          [KnownCaipNamespace.Eip155]: {
+            [CHAIN_IDS.LOCALHOST]: true,
+          },
+        },
+      };
+    } else if (
+      process.env.METAMASK_DEBUG &&
+      process.env.METAMASK_ENVIRONMENT === 'development'
     ) {
       initialNetworkOrderControllerState = {
         orderedNetworkList: [],

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1034,7 +1034,10 @@ export default class MetamaskController extends EventEmitter {
 
     let initialNetworkOrderControllerState;
 
-    if (process.env.METAMASK_DEBUG) {
+    if (
+      process.env.METAMASK_DEBUG ||
+      !process.env.METAMASK_ENVIRONMENT === 'test'
+    ) {
       initialNetworkOrderControllerState = {
         orderedNetworkList: [],
         enabledNetworkMap: {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1064,66 +1064,6 @@ export default class MetamaskController extends EventEmitter {
       state: initialNetworkOrderControllerState,
     });
 
-    if (!initialNetworkOrderControllerState) {
-      initialNetworkControllerState = getDefaultNetworkControllerState(
-        additionalDefaultNetworks,
-      );
-
-      /** @type {import('@metamask/network-controller').NetworkState['networkConfigurationsByChainId']} */
-      const networks =
-        initialNetworkControllerState.networkConfigurationsByChainId;
-
-      // TODO: Consider changing `getDefaultNetworkControllerState` on the
-      // controller side to include some of these tweaks.
-
-      Object.values(networks).forEach((network) => {
-        const id = network.rpcEndpoints[0].networkClientId;
-        // Process only if the default network has a corresponding networkClientId in BlockExplorerUrl.
-        if (hasProperty(BlockExplorerUrl, id)) {
-          network.blockExplorerUrls = [BlockExplorerUrl[id]];
-        }
-        network.defaultBlockExplorerUrlIndex = 0;
-      });
-
-      // Add failovers for default Infura RPC endpoints
-      networks[CHAIN_IDS.MAINNET].rpcEndpoints[0].failoverUrls =
-        getFailoverUrlsForInfuraNetwork('ethereum-mainnet');
-      networks[CHAIN_IDS.LINEA_MAINNET].rpcEndpoints[0].failoverUrls =
-        getFailoverUrlsForInfuraNetwork('linea-mainnet');
-      networks[CHAIN_IDS.BASE].rpcEndpoints[0].failoverUrls =
-        getFailoverUrlsForInfuraNetwork('base-mainnet');
-
-      let network;
-      if (process.env.IN_TEST) {
-        network = {
-          chainId: CHAIN_IDS.LOCALHOST,
-          name: 'Localhost 8545',
-          nativeCurrency: 'ETH',
-          blockExplorerUrls: [],
-          defaultRpcEndpointIndex: 0,
-          rpcEndpoints: [
-            {
-              networkClientId: 'networkConfigurationId',
-              url: 'http://localhost:8545',
-              type: 'custom',
-              failoverUrls: [],
-            },
-          ],
-        };
-        networks[CHAIN_IDS.LOCALHOST] = network;
-      } else if (
-        process.env.METAMASK_DEBUG ||
-        process.env.METAMASK_ENVIRONMENT === 'test'
-      ) {
-        network = networks[CHAIN_IDS.SEPOLIA];
-      } else {
-        network = networks[CHAIN_IDS.MAINNET];
-      }
-
-      initialNetworkControllerState.selectedNetworkClientId =
-        network.rpcEndpoints[network.defaultRpcEndpointIndex].networkClientId;
-    }
-
     const accountOrderMessenger = this.controllerMessenger.getRestricted({
       name: 'AccountOrderController',
     });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1033,19 +1033,10 @@ export default class MetamaskController extends EventEmitter {
     });
 
     let initialNetworkOrderControllerState;
-
-    if (process.env.IN_TEST) {
-      initialNetworkOrderControllerState = {
-        orderedNetworkList: [],
-        enabledNetworkMap: {
-          [KnownCaipNamespace.Eip155]: {
-            [CHAIN_IDS.LOCALHOST]: true,
-          },
-        },
-      };
-    } else if (
+    if (
       process.env.METAMASK_DEBUG &&
-      process.env.METAMASK_ENVIRONMENT === 'development'
+      process.env.METAMASK_ENVIRONMENT === 'development' &&
+      !process.env.IN_TEST
     ) {
       initialNetworkOrderControllerState = {
         orderedNetworkList: [],

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1034,16 +1034,7 @@ export default class MetamaskController extends EventEmitter {
 
     let initialNetworkOrderControllerState;
 
-    if (process.env.IN_TEST) {
-      initialNetworkOrderControllerState = {
-        orderedNetworkList: [],
-        enabledNetworkMap: {
-          [KnownCaipNamespace.Eip155]: {
-            [CHAIN_IDS.LOCALHOST]: true,
-          },
-        },
-      };
-    } else if (
+    if (
       process.env.METAMASK_DEBUG ||
       process.env.METAMASK_ENVIRONMENT === 'test'
     ) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1034,10 +1034,7 @@ export default class MetamaskController extends EventEmitter {
 
     let initialNetworkOrderControllerState;
 
-    if (
-      process.env.METAMASK_DEBUG ||
-      process.env.METAMASK_ENVIRONMENT === 'test'
-    ) {
+    if (process.env.METAMASK_DEBUG) {
       initialNetworkOrderControllerState = {
         orderedNetworkList: [],
         enabledNetworkMap: {


### PR DESCRIPTION
## **Description**

When loading up a new wallet in a dev build, we want to enable Sepolia, so that we see Sepolia tokens when it gets loaded into the UI.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33971?quickstart=1)

## **Related issues**

Fixes:

https://github.com/MetaMask/metamask-extension/issues/33934
https://consensyssoftware.atlassian.net/browse/ASSETS-943

## **Manual testing steps**

1. Create a new Account in Dev, should default to Sepolia network
2. Create a new build in Prod, should default to Mainnet, Linea, and Base

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
