### PR TITLE
feat: add ledger e2e tests for ERC-721 deployment

### DIFF
--- a/test/e2e/page-objects/pages/test-dapp.ts
+++ b/test/e2e/page-objects/pages/test-dapp.ts
@@ -87,6 +87,8 @@ class TestDapp {
 
   private readonly erc20WatchAssetButton = '#watchAssets';
 
+  private readonly erc721TokenAddresses = '#erc721TokenAddresses';
+
   private readonly erc721DeployButton = '#deployNFTsButton';
 
   private readonly erc721MintButton = '#mintButton';
@@ -590,6 +592,19 @@ class TestDapp {
 
       return addresses.length === expectedCount;
     }, 10000);
+  }
+
+  /**
+   * Checks the value of a ERC-721 token address once created.
+   *
+   * @param value - The address to be checked
+   */
+  async check_ERC721TokenAddressesValue(value: string) {
+    console.log('Verify ERC-721 token address');
+    await this.driver.waitForSelector({
+      css: this.erc721TokenAddresses,
+      text: value,
+    });
   }
 
   async verify_successSignTypedDataResult(result: string) {

--- a/test/e2e/tests/hardware-wallets/ledger-erc721.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger-erc721.spec.ts
@@ -1,0 +1,45 @@
+import { Suite } from 'mocha';
+import { Driver } from '../../webdriver/driver';
+import TestDappPage from '../../page-objects/pages/test-dapp';
+import FixtureBuilder from '../../fixture-builder';
+import { WINDOW_TITLES, withFixtures } from '../../helpers';
+import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../stub/keyring-bridge';
+import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import CreateContractModal from '../../page-objects/pages/dialog/create-contract';
+
+describe('Ledger Hardware', function (this: Suite) {
+  it('can create an ERC-721 token', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withLedgerAccount()
+          .withPermissionControllerConnectedToTestDapp({
+            account: KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        dapp: true,
+      },
+      async ({ driver, localNodes }) => {
+        (await localNodes?.[0]?.setAccountBalance(
+          KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+          '0x100000000000000000000',
+        )) ?? console.error('localNodes is undefined or empty');
+        await loginWithoutBalanceValidation(driver);
+        const testDappPage = new TestDappPage(driver);
+        await testDappPage.openTestDappPage();
+        await testDappPage.check_pageIsLoaded();
+        await testDappPage.clickERC721DeployButton();
+        // Confirm token creation
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        const createContractModal = new CreateContractModal(driver);
+        await createContractModal.check_pageIsLoaded();
+        await createContractModal.clickConfirm();
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDappPage.check_ERC721TokenAddressesValue(
+          '0xcB17707e0623251182A654BEdaE16429C78A7424',
+        );
+      },
+    );
+  });
+});

--- a/test/e2e/tests/hardware-wallets/ledger-erc721.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger-erc721.spec.ts
@@ -1,10 +1,9 @@
 import { Suite } from 'mocha';
-import { Driver } from '../../webdriver/driver';
 import TestDappPage from '../../page-objects/pages/test-dapp';
 import FixtureBuilder from '../../fixture-builder';
 import { WINDOW_TITLES, withFixtures } from '../../helpers';
 import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../stub/keyring-bridge';
-import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import CreateContractModal from '../../page-objects/pages/dialog/create-contract';
 
 describe('Ledger Hardware', function (this: Suite) {
@@ -25,7 +24,12 @@ describe('Ledger Hardware', function (this: Suite) {
           KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
           '0x100000000000000000000',
         )) ?? console.error('localNodes is undefined or empty');
-        await loginWithoutBalanceValidation(driver);
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '1208925.8196',
+        );
         const testDappPage = new TestDappPage(driver);
         await testDappPage.openTestDappPage();
         await testDappPage.check_pageIsLoaded();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Adds ledger e2e test for the following scenario:

- ERC-721 token deployment from **test-dapp**

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33898?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/950

## **Manual testing steps**

**Locally:**
```
yarn start:test
# wait for end of build
yarn test:e2e:single test/e2e/tests/hardware-wallets/ledger-erc721.spec.ts
```
**On CI**, check e2e tests job

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
