### PR TITLE
fix: clicking normal buttons auto submit form

### DIFF
--- a/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
+++ b/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
@@ -57,6 +57,7 @@ exports[`Unlock Page should match snapshot 1`] = `
         <button
           class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--margin-bottom-6 mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
           data-testid="unlock-forgot-password-button"
+          type="button"
         >
           Forgot password?
         </button>
@@ -71,6 +72,7 @@ exports[`Unlock Page should match snapshot 1`] = `
               href="https://support.metamask.io"
               rel="noopener noreferrer"
               target="_blank"
+              type="button"
             >
               MetaMask support
             </a>

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -323,6 +323,7 @@ export default class UnlockPage extends Component {
               variant={ButtonVariant.Link}
               data-testid="unlock-forgot-password-button"
               key="import-account"
+              type="button"
               onClick={() => this.onForgotPassword()}
               marginBottom={6}
             >
@@ -334,6 +335,7 @@ export default class UnlockPage extends Component {
                 <Button
                   variant={ButtonVariant.Link}
                   href={SUPPORT_LINK}
+                  type="button"
                   target="_blank"
                   rel="noopener noreferrer"
                   key="need-help-link"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR add `type="button"` to non submit buttons inside the `form` to avoid submitting unlock form unintentionally.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33979?quickstart=1)

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/33973

## **Manual testing steps**

1. Create or start with an account.
2. Lock metamask
3. On unlock page, input your password and click on `forgot password` button text or `Metamask support` button text.
- it shouldn't trigger submitting the form

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Check video here: https://github.com/MetaMask/metamask-extension/issues/33973
<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/4d14f347-fb34-4907-9271-3b2148935f0e

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
