### PR TITLE
feat(identity): link metametrics event library and replace magic strings

### DIFF
--- a/app/scripts/controller-init/identity/user-storage-controller-init.ts
+++ b/app/scripts/controller-init/identity/user-storage-controller-init.ts
@@ -3,6 +3,9 @@ import {
   UserStorageControllerState,
   Controller as UserStorageController,
 } from '@metamask/profile-sync-controller/user-storage';
+import {
+  MetaMetrics,
+} from '@metamask/profile-sync-controller';
 import { captureException } from '@sentry/browser';
 import { ControllerInitFunction } from '../types';
 import { isProduction } from '../../../../shared/modules/environment';
@@ -34,18 +37,14 @@ export const UserStorageControllerInit: ControllerInitFunction<
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.AccountsSyncAdded,
-            properties: {
-              profile_id: profileId,
-            },
+            properties: MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_ADDED(profileId),
           });
         },
         onAccountNameUpdated: (profileId) => {
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.AccountsSyncNameUpdated,
-            properties: {
-              profile_id: profileId,
-            },
+            properties: MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_NAME_UPDATED(profileId),
           });
         },
         onAccountSyncErroneousSituation: (
@@ -60,10 +59,7 @@ export const UserStorageControllerInit: ControllerInitFunction<
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.AccountsSyncErroneousSituation,
-            properties: {
-              profile_id: profileId,
-              situation_message: situationMessage,
-            },
+            properties: MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_SYNC_ERROR(profileId, situationMessage),
           });
         },
       },
@@ -72,22 +68,14 @@ export const UserStorageControllerInit: ControllerInitFunction<
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.ProfileActivityUpdated,
-            properties: {
-              profile_id: profileId,
-              feature_name: 'Backup And Sync',
-              action: 'Contacts Sync Contact Updated',
-            },
+            properties: MetaMetrics.BackupAndSyncEventProperties.CONTACT_UPDATED(profileId),
           });
         },
         onContactDeleted: (profileId) => {
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.ProfileActivityUpdated,
-            properties: {
-              profile_id: profileId,
-              feature_name: 'Backup And Sync',
-              action: 'Contacts Sync Contact Deleted',
-            },
+            properties: MetaMetrics.BackupAndSyncEventProperties.CONTACT_DELETED(profileId),
           });
         },
         onContactSyncErroneousSituation: (
@@ -102,12 +90,7 @@ export const UserStorageControllerInit: ControllerInitFunction<
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.ProfileActivityUpdated,
-            properties: {
-              profile_id: profileId,
-              feature_name: 'Backup And Sync',
-              action: 'Contacts Sync Erroneous Situation',
-              additional_description: situationMessage,
-            },
+            properties: MetaMetrics.BackupAndSyncEventProperties.CONTACT_SYNC_ERROR(profileId, situationMessage),
           });
         },
       },

--- a/app/scripts/controller-init/identity/user-storage-controller-init.ts
+++ b/app/scripts/controller-init/identity/user-storage-controller-init.ts
@@ -3,9 +3,7 @@ import {
   UserStorageControllerState,
   Controller as UserStorageController,
 } from '@metamask/profile-sync-controller/user-storage';
-import {
-  MetaMetrics,
-} from '@metamask/profile-sync-controller';
+import { MetaMetrics } from '@metamask/profile-sync-controller';
 import { captureException } from '@sentry/browser';
 import { ControllerInitFunction } from '../types';
 import { isProduction } from '../../../../shared/modules/environment';
@@ -37,14 +35,18 @@ export const UserStorageControllerInit: ControllerInitFunction<
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.AccountsSyncAdded,
-            properties: MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_ADDED(profileId),
+            properties:
+              MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_ADDED(profileId),
           });
         },
         onAccountNameUpdated: (profileId) => {
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.AccountsSyncNameUpdated,
-            properties: MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_NAME_UPDATED(profileId),
+            properties:
+              MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_NAME_UPDATED(
+                profileId,
+              ),
           });
         },
         onAccountSyncErroneousSituation: (
@@ -59,7 +61,11 @@ export const UserStorageControllerInit: ControllerInitFunction<
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.AccountsSyncErroneousSituation,
-            properties: MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_SYNC_ERROR(profileId, situationMessage),
+            properties:
+              MetaMetrics.BackupAndSyncEventProperties.ACCOUNT_SYNC_ERROR(
+                profileId,
+                situationMessage,
+              ),
           });
         },
       },
@@ -68,14 +74,20 @@ export const UserStorageControllerInit: ControllerInitFunction<
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.ProfileActivityUpdated,
-            properties: MetaMetrics.BackupAndSyncEventProperties.CONTACT_UPDATED(profileId),
+            properties:
+              MetaMetrics.BackupAndSyncEventProperties.CONTACT_UPDATED(
+                profileId,
+              ),
           });
         },
         onContactDeleted: (profileId) => {
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.ProfileActivityUpdated,
-            properties: MetaMetrics.BackupAndSyncEventProperties.CONTACT_DELETED(profileId),
+            properties:
+              MetaMetrics.BackupAndSyncEventProperties.CONTACT_DELETED(
+                profileId,
+              ),
           });
         },
         onContactSyncErroneousSituation: (
@@ -90,7 +102,11 @@ export const UserStorageControllerInit: ControllerInitFunction<
           trackEvent({
             category: MetaMetricsEventCategory.BackupAndSync,
             event: MetaMetricsEventName.ProfileActivityUpdated,
-            properties: MetaMetrics.BackupAndSyncEventProperties.CONTACT_SYNC_ERROR(profileId, situationMessage),
+            properties:
+              MetaMetrics.BackupAndSyncEventProperties.CONTACT_SYNC_ERROR(
+                profileId,
+                situationMessage,
+              ),
           });
         },
       },

--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/ppom-validator": "0.36.0",
     "@metamask/preinstalled-example-snap": "^0.4.0",
-    "@metamask/profile-sync-controller": "^18.0.0",
+    "@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@19.0.0-preview-f9a5dd05",
     "@metamask/providers": "^22.1.0",
     "@metamask/rate-limit-controller": "^6.0.3",
     "@metamask/remote-feature-flag-controller": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6943,9 +6943,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/profile-sync-controller@npm:^18.0.0":
-  version: 18.0.0
-  resolution: "@metamask/profile-sync-controller@npm:18.0.0"
+"@metamask/profile-sync-controller@npm:@metamask-previews/profile-sync-controller@19.0.0-preview-f9a5dd05":
+  version: 19.0.0-preview-f9a5dd05
+  resolution: "@metamask-previews/profile-sync-controller@npm:19.0.0-preview-f9a5dd05"
   dependencies:
     "@metamask/base-controller": "npm:^8.0.1"
     "@metamask/snaps-sdk": "npm:^7.1.0"
@@ -6956,13 +6956,13 @@ __metadata:
     loglevel: "npm:^1.8.1"
     siwe: "npm:^2.3.2"
   peerDependencies:
-    "@metamask/accounts-controller": ^30.0.0
+    "@metamask/accounts-controller": ^31.0.0
     "@metamask/keyring-controller": ^22.0.0
-    "@metamask/network-controller": ^23.0.0
+    "@metamask/network-controller": ^24.0.0
     "@metamask/providers": ^22.0.0
     "@metamask/snaps-controllers": ^12.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/b38d07a283fb61268132a9659d177b219b762b7d0b3446c4b40b4cbc555d492c307c4aa7fe76655dbd2f8323c28c56762e37f5f2caaa48db0721467cfc0aba59
+  checksum: 10/b743c4b6d4716ba3ea7b112bf64f71130a72482d2414f2f977d068af2b12317c2825676976db2b06b94b315047871624eca1cf31202cb6ebe8c1cf262a387cce
   languageName: node
   linkType: hard
 
@@ -31642,7 +31642,7 @@ __metadata:
     "@metamask/ppom-validator": "npm:0.36.0"
     "@metamask/preferences-controller": "npm:^17.0.0"
     "@metamask/preinstalled-example-snap": "npm:^0.4.0"
-    "@metamask/profile-sync-controller": "npm:^18.0.0"
+    "@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@19.0.0-preview-f9a5dd05"
     "@metamask/providers": "npm:^22.1.0"
     "@metamask/rate-limit-controller": "npm:^6.0.3"
     "@metamask/remote-feature-flag-controller": "npm:^1.6.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the extension to use the new MetaMetrics library from the profile-sync-controller core package, whose purpose is to get rid of magic strings in `trackEvent` calls and ensure consistency across clients.

## **Related issues**

N/A

From Jira: https://consensyssoftware.atlassian.net/browse/IDENTITY-142

## **Manual testing steps**

1. Build and run the extension
2. Verify that Backup & Sync functionality still works correctly
3. Check that MetaMetrics events are still being tracked properly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.