### PR TITLE
Proposal: Add Active Network indicator to Network Manager

### DIFF
--- a/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
+++ b/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
@@ -19,6 +19,7 @@ export const NetworkListItemMenu = ({
   onEditClick,
   onDeleteClick,
   onDiscoverClick,
+  onActivateNetworkClick,
   isOpen,
 }) => {
   const t = useI18nContext();
@@ -76,6 +77,18 @@ export const NetworkListItemMenu = ({
               <Text color={TextColor.errorDefault}>{t('delete')}</Text>
             </MenuItem>
           ) : null}
+          {onActivateNetworkClick ? (
+            <MenuItem
+              iconName={IconName.Connect}
+              onClick={(e) => {
+                e.stopPropagation();
+                onActivateNetworkClick();
+              }}
+              data-testid="network-list-item-options-activate"
+            >
+              <Text>Activate</Text>
+            </MenuItem>
+          ) : null}
         </Box>
       </ModalFocus>
     </Popover>
@@ -103,6 +116,10 @@ NetworkListItemMenu.propTypes = {
    * Function that executes when the Discover menu item is clicked
    */
   onDiscoverClick: PropTypes.func,
+  /**
+   * Function that executes when the Activate menu item is clicked
+   */
+  onActivateNetworkClick: PropTypes.func,
   /**
    * Represents if the menu is open or not
    *

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -52,6 +52,7 @@ import {
 import ColorIndicator from '../../ui/color-indicator';
 import { setActiveNetwork } from '../../../store/actions';
 import { FEATURED_NETWORK_CHAIN_IDS } from '../../../../shared/constants/network';
+import { getMultichainIsEvm } from '../../../selectors/multichain';
 
 // TODO: Consider increasing this. This tooltip is
 // rendering when it has enough room to see everything
@@ -103,8 +104,8 @@ export const NetworkListItem = ({
     getMultichainNetworkConfigurationsByChainId,
   );
   const currentCaipChainId = useSelector(getSelectedMultichainNetworkChainId);
-  const hexChainId = convertCaipToHexChainId(currentCaipChainId);
   const enabledNetworksByNamespace = useSelector(getEnabledNetworksByNamespace);
+  const isEvmNetworkSelected = useSelector(getMultichainIsEvm);
 
   const [networkListItemMenuElement, setNetworkListItemMenuElement] =
     useState();
@@ -168,6 +169,10 @@ export const NetworkListItem = ({
   }, [chainId, evmNetworks, dispatch]);
 
   const shouldShowActivateNetworkBtn = useMemo(() => {
+    if (!isEvmNetworkSelected) {
+      return false;
+    }
+    const hexChainId = convertCaipToHexChainId(currentCaipChainId);
     const listItemHexChainId = convertCaipToHexChainId(chainId as CaipChainId);
     const isPopular = FEATURED_NETWORK_CHAIN_IDS.includes(hexChainId);
     const isEnabled = Object.keys(enabledNetworksByNamespace).includes(
@@ -176,7 +181,12 @@ export const NetworkListItem = ({
     const isActive = currentCaipChainId === chainId;
 
     return isPopular && isEnabled && !isActive;
-  }, [chainId, hexChainId, enabledNetworksByNamespace, currentCaipChainId]);
+  }, [
+    isEvmNetworkSelected,
+    currentCaipChainId,
+    chainId,
+    enabledNetworksByNamespace,
+  ]);
 
   return (
     <Box

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -5,6 +5,7 @@ import {
 } from '@metamask/utils';
 import React, { memo, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { toHex } from '@metamask/controller-utils';
 import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
   FEATURED_RPCS,
@@ -54,7 +55,6 @@ import {
   getOrderedNetworksList,
   getMultichainNetworkConfigurationsByChainId,
 } from '../../../../../selectors';
-import { toHex } from '@metamask/controller-utils';
 
 const DefaultNetworks = memo(() => {
   const t = useI18nContext();

--- a/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
@@ -84,12 +84,17 @@ export const useNetworkChangeHandlers = () => {
     (chainId: CaipChainId) => {
       const { namespace } = parseCaipChainId(chainId);
       const hexChainId = convertCaipToHexChainId(chainId);
+      const hexCurrentChainId = convertCaipToHexChainId(currentChainId);
       const { defaultRpcEndpoint } = getRpcDataByChainId(chainId, evmNetworks);
       const finalNetworkClientId = defaultRpcEndpoint.networkClientId;
 
       const isPopularNetwork = FEATURED_NETWORK_CHAIN_IDS.includes(hexChainId);
+      const isGlobalNetworkPopularNetwork =
+        FEATURED_NETWORK_CHAIN_IDS.includes(hexCurrentChainId);
 
       if (!isPopularNetwork) {
+        dispatch(setActiveNetwork(finalNetworkClientId));
+      } else if (!isGlobalNetworkPopularNetwork) {
         dispatch(setActiveNetwork(finalNetworkClientId));
       }
 

--- a/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
@@ -87,9 +87,11 @@ export const useNetworkChangeHandlers = () => {
       const { defaultRpcEndpoint } = getRpcDataByChainId(chainId, evmNetworks);
       const finalNetworkClientId = defaultRpcEndpoint.networkClientId;
 
-      dispatch(setActiveNetwork(finalNetworkClientId));
-
       const isPopularNetwork = FEATURED_NETWORK_CHAIN_IDS.includes(hexChainId);
+
+      if (!isPopularNetwork) {
+        dispatch(setActiveNetwork(finalNetworkClientId));
+      }
 
       const enabledNetworkKeys = Object.keys(enabledNetworksByNamespace ?? {});
 

--- a/ui/components/multichain/network-manager/hooks/useNetworkItemCallbacks.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkItemCallbacks.ts
@@ -10,7 +10,11 @@ import {
   getRpcDataByChainId,
 } from '../../../../../shared/modules/network.utils';
 import { openWindow } from '../../../../helpers/utils/window';
-import { setEditedNetwork, showModal } from '../../../../store/actions';
+import {
+  setActiveNetwork,
+  setEditedNetwork,
+  showModal,
+} from '../../../../store/actions';
 import {
   getMultichainNetworkConfigurationsByChainId,
   getNetworkDiscoverButtonEnabled,


### PR DESCRIPTION
## **Description**

This PR proposes adding a visual network indicator next to a network list item if it is the currently selected global network in the background (the “active network”).

This change aims to address inconsistencies and feedback we’ve received from various stakeholders regarding network selection behavior and visibility.

**Recent feedback surfaced several concerns:**

1. It’s possible to enter a state with no networks selected — which should never happen.
2. Users want clearer visibility into which network is currently active, even if we handle a lot of this on their behalf. Some wanted a way to actively manage this on their own
3. We’re transitioning away from a UX that implies there’s always a single globally selected network, so we shouldn't emphasize global network as we did before.
4. Clicking a network list item still sets the global network in the background, even if the user is unselecting it — this feels counterintuitive.

**Proposed Solution:**

1. 	Introduce a subtle “Active Network” indicator next to the network that is globally selected.
2. 	Add a new menu item to each NetworkListItem dropdown: “Activate Network”.
3. 	This lets users manually assign the global network without conflating it with enablement.
4. 	It’s intentionally tucked away to signal the beginning of a UX shift away from global selection being front-and-center.
5. 	Prevent users from deselecting the currently active network, rather than entering an invalid state with no networks enabled. cc @hesterbruikman you suggested this once previously, and I think it's a good guardrail here

**Benefits:**

- This avoids the confusing UX of silently blocking a deselection action without explanation.
- Maintains backward compatibility with existing controller behavior.
- Helps users understand and control the concept of an “active” network while gradually de-emphasizing it.
- Prevents user confusion and invalid states during network deselection.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/33999?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/5a491862-2430-4e6c-a18e-f02c529bb4de

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
