### PR TITLE
feat: add e2e tests for Ledger personal sign functionality

### DIFF
--- a/test/e2e/tests/hardware-wallets/ledger-personal-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger-personal-sign.spec.ts
@@ -7,7 +7,7 @@ import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.fl
 import TestDappPage from '../../page-objects/pages/test-dapp';
 
 describe('Ledger Hardware Signatures', function (this: Suite) {
-  it('pseronal sign', async function () {
+  it('personal sign', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder()

--- a/test/e2e/tests/hardware-wallets/ledger-personal-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger-personal-sign.spec.ts
@@ -1,0 +1,34 @@
+import { Suite } from 'mocha';
+import { Driver } from '../../webdriver/driver';
+import FixtureBuilder from '../../fixture-builder';
+import { withFixtures } from '../../helpers';
+import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../stub/keyring-bridge';
+import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import TestDappPage from '../../page-objects/pages/test-dapp';
+
+describe('Ledger Hardware Signatures', function (this: Suite) {
+  it('pseronal sign', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withLedgerAccount()
+          .withPermissionControllerConnectedToTestDapp({
+            account: KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        dapp: true,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+        const testDappPage = new TestDappPage(driver);
+        await testDappPage.openTestDappPage();
+        await testDappPage.check_pageIsLoaded();
+        await testDappPage.personalSign();
+        await testDappPage.check_successPersonalSign(
+          KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+        );
+      },
+    );
+  });
+});

--- a/test/stub/keyring-bridge.js
+++ b/test/stub/keyring-bridge.js
@@ -3,12 +3,17 @@ import {
   LegacyTransaction,
   TransactionFactory,
 } from '@ethereumjs/tx';
-import { signTypedData, SignTypedDataVersion } from '@metamask/eth-sig-util';
+import {
+  signTypedData,
+  SignTypedDataVersion,
+  personalSign,
+} from '@metamask/eth-sig-util';
 import {
   bigIntToHex,
   bytesToBigInt,
   bytesToHex,
   remove0x,
+  add0x,
 } from '@metamask/utils';
 import { rlp } from 'ethereumjs-util';
 import { utils as EthersUtils } from 'ethers';
@@ -298,6 +303,22 @@ export class FakeLedgerBridge extends FakeKeyringBridge {
       version: SignTypedDataVersion.V4,
     });
     // signTypedData returns an hex, we need to split it into rsv format
+    const { r, s, v } = EthersUtils.splitSignature(signature);
+
+    // Split signature adds 0x prefixes for r and s, we need to strip them.
+    return {
+      r: remove0x(r),
+      s: remove0x(s),
+      v,
+    };
+  }
+
+  async deviceSignMessage(params) {
+    const { message } = params;
+    const signature = personalSign({
+      privateKey: KNOWN_PRIVATE_KEYS[0],
+      data: add0x(message),
+    });
     const { r, s, v } = EthersUtils.splitSignature(signature);
 
     // Split signature adds 0x prefixes for r and s, we need to strip them.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR will add personal sign happy path e2e tests for ledger hardware devices.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34002?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
