### PR TITLE
fix: prevent infinite render in `WalletDetails`

### DIFF
--- a/ui/pages/multichain-accounts/wallet-details/wallet-details.component.tsx
+++ b/ui/pages/multichain-accounts/wallet-details/wallet-details.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import {
@@ -70,12 +70,15 @@ const WalletDetails = () => {
     [accountBalances],
   );
 
-  const handleBalanceUpdate = (accountId: string, balance: string | number) => {
-    setAccountBalances((prev) => ({
-      ...prev,
-      [accountId]: balance,
-    }));
-  };
+  const handleBalanceUpdate = useCallback(
+    (accountId: string, balance: string | number) => {
+      setAccountBalances((prev) => ({
+        ...prev,
+        [accountId]: balance,
+      }));
+    },
+    [],
+  );
 
   const handleAccountClick = (account: { id: string; address: string }) => {
     dispatch(setAccountDetailsAddress(account.address));


### PR DESCRIPTION
## **Description**

**Problem:** The wallet details page was causing an infinite render loop with "Maximum update depth exceeded" error from `HeaderBase` component. 

- `WalletDetailsAccountItem` has a `useEffect` that calls `onBalanceUpdate` whenever the balance or callback changes

- `handleBalanceUpdate` in `WalletDetails` was not memoized, so it was recreated on every render

- This created an infinite cycle: callback changes → useEffect runs → state updates → component re-renders → new callback → repeat

**Solution:** Use `useCallback` to create a stable reference for the function.

## **Manual testing steps**

1. Build from this branch.
2. Navigate to wallet details and open the console.
3. Observe that there isn't an infinite render error.

## **Screenshots/Recordings**

### **Before**

![image](https://github.com/user-attachments/assets/a00ea41d-e257-49d3-b10f-e1e1007c872b)


### **After**

<img width="700" alt="Screenshot 2025-07-01 at 5 35 02 PM" src="https://github.com/user-attachments/assets/b4df9367-ae52-48bd-9194-07e8d920d941" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
