### PR TITLE
feat: Add `FORCE_PREINSTALLED_SNAPS` environment variable for local preinstalled Snap development

### DIFF
--- a/app/scripts/controller-init/snaps/snap-controller-init.test.ts
+++ b/app/scripts/controller-init/snaps/snap-controller-init.test.ts
@@ -50,6 +50,7 @@ describe('SnapControllerInit', () => {
         rejectInvalidPlatformVersion: false,
         requireAllowlist: false,
         useCaip25Permission: true,
+        forcePreinstalledSnaps: false,
       },
       getFeatureFlags: expect.any(Function),
       getMnemonicSeed: expect.any(Function),

--- a/app/scripts/controller-init/snaps/snap-controller-init.ts
+++ b/app/scripts/controller-init/snaps/snap-controller-init.ts
@@ -56,6 +56,12 @@ export const SnapControllerInit: ControllerInitFunction<
     process.env.REJECT_INVALID_SNAPS_PLATFORM_VERSION,
   );
 
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  const forcePreinstalledSnaps = getBooleanFlag(
+    process.env.FORCE_PREINSTALLED_SNAPS,
+  );
+  ///: END:ONLY_INCLUDE_IF
+
   async function getMnemonicSeed() {
     const keyrings = initMessenger.call(
       'KeyringController:getKeyringsByType',
@@ -109,6 +115,9 @@ export const SnapControllerInit: ControllerInitFunction<
       allowLocalSnaps,
       requireAllowlist,
       rejectInvalidPlatformVersion,
+      ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+      forcePreinstalledSnaps,
+      ///: END:ONLY_INCLUDE_IF
       useCaip25Permission: true,
     },
 

--- a/builds.yml
+++ b/builds.yml
@@ -388,3 +388,8 @@ env:
   - SEEDLESS_ONBOARDING_ENABLED: 'false'
   - GOOGLE_CLIENT_ID: ''
   - APPLE_CLIENT_ID: ''
+
+  # Snaps
+  # This should only be used for local testing, and should not be enabled in any
+  # production builds (including beta and Flask).
+  - FORCE_PREINSTALLED_SNAPS: 'false'

--- a/shared/lib/snaps/snaps.ts
+++ b/shared/lib/snaps/snaps.ts
@@ -1,5 +1,6 @@
 import { SnapId } from '@metamask/snaps-sdk';
 
+///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 /**
  * Whether to force local Snaps to be treated as preinstalled Snaps.
  *
@@ -8,6 +9,7 @@ import { SnapId } from '@metamask/snaps-sdk';
  */
 const FORCE_PREINSTALLED_SNAPS =
   process.env.FORCE_PREINSTALLED_SNAPS === 'true';
+///: END:ONLY_INCLUDE_IF
 
 export const PREINSTALLED_SNAPS = [
   'npm:@metamask/message-signing-snap',

--- a/shared/lib/snaps/snaps.ts
+++ b/shared/lib/snaps/snaps.ts
@@ -1,5 +1,14 @@
 import { SnapId } from '@metamask/snaps-sdk';
 
+/**
+ * Whether to force local Snaps to be treated as preinstalled Snaps.
+ *
+ * This is used in development environments to allow Snaps to use features that
+ * are normally reserved for preinstalled Snaps.
+ */
+const FORCE_PREINSTALLED_SNAPS =
+  process.env.FORCE_PREINSTALLED_SNAPS === 'true';
+
 export const PREINSTALLED_SNAPS = [
   'npm:@metamask/message-signing-snap',
   'npm:@metamask/ens-resolver-snap',
@@ -17,5 +26,13 @@ export const PREINSTALLED_SNAPS = [
  * @returns True if Snap is a preinstalled Snap, false otherwise.
  */
 export function isSnapPreinstalled(snapId: SnapId) {
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  // For development purposes, allow local Snaps to be treated as preinstalled
+  // Snaps if the `FORCE_PREINSTALLED_SNAPS` environment variable is enabled.
+  if (FORCE_PREINSTALLED_SNAPS && snapId.startsWith('local:')) {
+    return true;
+  }
+  ///: END:ONLY_INCLUDE_IF
+
   return PREINSTALLED_SNAPS.some((snap) => snap === snapId);
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This introduces a new environment variable `FORCE_PREINSTALLED_SNAPS`, which can be used to simplify development of preinstalled Snaps. When enabled, all local Snaps will be treated as preinstalled Snaps, granting them access to RPC methods and other functionality normally restricted to preinstalled Snaps.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34022?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
