### PR TITLE
feat: add support for showing srp from accounts details

### DIFF
--- a/ui/components/multichain-accounts/account-details-row/account-details-row.test.tsx
+++ b/ui/components/multichain-accounts/account-details-row/account-details-row.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ButtonIcon, ButtonIconSize } from '../../component-library';
 import { IconName } from '../../component-library/icon';
 import { IconColor } from '../../../helpers/constants/design-system';
@@ -51,6 +51,39 @@ describe('AccountDetailsRow', () => {
     });
   });
 
+  describe('Click Functionality', () => {
+    it('should call onClick when provided and row is clicked', () => {
+      const mockOnClick = jest.fn();
+      render(<AccountDetailsRow {...defaultProps} onClick={mockOnClick} />);
+
+      const row = screen.getByText('Test Label').closest('div');
+      if (row) {
+        fireEvent.click(row);
+      }
+
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call onClick when not provided', () => {
+      render(<AccountDetailsRow {...defaultProps} />);
+
+      const row = screen.getByText('Test Label').closest('div');
+      if (row) {
+        fireEvent.click(row);
+      }
+
+      // Should not throw any errors
+      expect(true).toBe(true);
+    });
+
+    it('should apply pointer cursor when onClick is provided', () => {
+      render(<AccountDetailsRow {...defaultProps} onClick={() => undefined} />);
+
+      const row = screen.getByText('Test Label').closest('div');
+      expect(row).toHaveStyle({ cursor: 'pointer' });
+    });
+  });
+
   describe('End Accessory Variations', () => {
     it('should render with edit button accessory', () => {
       const editButton = (
@@ -96,6 +129,29 @@ describe('AccountDetailsRow', () => {
 
       expect(screen.getByTestId('arrow-button')).toBeInTheDocument();
       expect(screen.getByLabelText('View details')).toBeInTheDocument();
+    });
+
+    it('should handle click events on endAccessory buttons', () => {
+      const mockButtonClick = jest.fn();
+      const endAccessory = (
+        <ButtonIcon
+          iconName={IconName.Edit}
+          color={IconColor.iconAlternative}
+          size={ButtonIconSize.Md}
+          ariaLabel="Edit"
+          data-testid="end-accessory-button"
+          onClick={mockButtonClick}
+        />
+      );
+
+      render(
+        <AccountDetailsRow {...defaultProps} endAccessory={endAccessory} />,
+      );
+
+      const button = screen.getByTestId('end-accessory-button');
+      fireEvent.click(button);
+
+      expect(mockButtonClick).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ui/components/multichain-accounts/account-details-row/account-details-row.tsx
+++ b/ui/components/multichain-accounts/account-details-row/account-details-row.tsx
@@ -13,6 +13,7 @@ type AccountDetailsRowProps = {
   label: string;
   value: string;
   endAccessory: React.ReactNode;
+  onClick?: () => void;
   style?: React.CSSProperties;
 };
 
@@ -21,16 +22,23 @@ export const AccountDetailsRow = ({
   value,
   endAccessory,
   style,
+  onClick,
 }: AccountDetailsRowProps) => {
   return (
     <Box
       backgroundColor={BackgroundColor.backgroundAlternative}
       display={Display.Flex}
       justifyContent={JustifyContent.spaceBetween}
-      style={{ ...style, height: '48px' }}
+      style={{
+        ...style,
+        height: '48px',
+        cursor: onClick ? 'pointer' : 'default',
+      }}
       paddingLeft={4}
       paddingRight={4}
       alignItems={AlignItems.center}
+      onClick={onClick}
+      className="multichain-account-details__row"
     >
       <Text
         color={TextColor.textDefault}

--- a/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.stories.tsx
+++ b/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.stories.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { StoryFn, Meta } from '@storybook/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { MOCK_ACCOUNT_EOA } from '../../../../test/data/mock-accounts';
+import { AccountShowSrpRow } from './account-show-srp-row';
+
+const middleware = [thunk];
+const mockStore = configureMockStore(middleware);
+
+const createMockState = (seedPhraseBackedUp = true, firstTimeFlowType = 'import') => ({
+  metamask: {
+    seedPhraseBackedUp,
+    firstTimeFlowType,
+    keyrings: [
+      {
+        type: 'HD Key Tree',
+        accounts: [MOCK_ACCOUNT_EOA.address],
+        metadata: {
+          id: 'mock-hd-keyring-id',
+          name: 'HD Key Tree',
+        },
+      },
+    ],
+  },
+});
+
+export default {
+  title: 'Components/MultichainAccounts/AccountShowSrpRow',
+  component: AccountShowSrpRow,
+  parameters: {
+    docs: {
+      description: {
+        component: 'A component that displays a Secret Recovery Phrase row with backup reminder functionality.',
+      },
+    },
+    controls: { sort: 'alpha' },
+  },
+  argTypes: {
+    account: {
+      control: 'object',
+      description: 'The account object containing metadata and options',
+    },
+  },
+  decorators: [
+    (Story: StoryFn) => (
+      <Provider store={mockStore(createMockState())}>
+        <MemoryRouter>
+          <div style={{ width: '360px', margin: '0 auto', padding: '20px' }}>
+            <Story />
+          </div>
+        </MemoryRouter>
+      </Provider>
+    ),
+  ],
+} as Meta<typeof AccountShowSrpRow>;
+
+const Template: StoryFn<typeof AccountShowSrpRow> = (args) => (
+  <AccountShowSrpRow {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  account: {
+    ...MOCK_ACCOUNT_EOA,
+    options: { ...MOCK_ACCOUNT_EOA.options, entropySource: 'mock-hd-keyring-id' },
+  },
+};
+Default.storyName = 'Default (Seed Phrase Backed Up)';
+
+export const WithBackupReminder = Template.bind({});
+WithBackupReminder.args = {
+  account: {
+    ...MOCK_ACCOUNT_EOA,
+    options: { ...MOCK_ACCOUNT_EOA.options, entropySource: 'mock-hd-keyring-id' },
+  },
+};
+WithBackupReminder.decorators = [
+  (Story: StoryFn) => (
+    <Provider store={mockStore(createMockState(false, 'create'))}>
+      <MemoryRouter>
+        <div style={{ width: '360px', margin: '0 auto', padding: '20px' }}>
+          <Story />
+        </div>
+      </MemoryRouter>
+    </Provider>
+  ),
+];
+WithBackupReminder.storyName = 'With Backup Reminder';

--- a/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.test.tsx
+++ b/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.test.tsx
@@ -24,6 +24,7 @@ jest.mock('../../../hooks/useI18nContext', () => ({
 }));
 
 jest.mock('../../app/srp-quiz-modal', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
     isOpen ? (

--- a/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.test.tsx
+++ b/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.test.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { renderWithProvider } from '../../../../test/jest';
+import { MOCK_ACCOUNT_EOA } from '../../../../test/data/mock-accounts';
+import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../helpers/constants/routes';
+import { AccountShowSrpRow } from './account-show-srp-row';
+
+const middleware = [thunk];
+const mockStore = configureMockStore(middleware);
+
+const mockPush = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) => key,
+}));
+
+jest.mock('../../app/srp-quiz-modal', () => ({
+  __esModule: true,
+  default: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+    isOpen ? (
+      <div data-testid="srp-quiz-modal">
+        <button onClick={onClose} data-testid="close-srp-quiz">
+          Close SRP Quiz
+        </button>
+      </div>
+    ) : null,
+}));
+
+const createMockState = (
+  seedPhraseBackedUp = true,
+  hdKeyrings = [
+    {
+      type: 'HD Key Tree',
+      accounts: [MOCK_ACCOUNT_EOA.address],
+      metadata: {
+        id: 'mock-hd-keyring-id',
+        name: 'HD Key Tree',
+      },
+    },
+  ],
+) => ({
+  metamask: {
+    seedPhraseBackedUp,
+    keyrings: hdKeyrings,
+  },
+});
+
+describe('AccountShowSrpRow', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  describe('Component Rendering', () => {
+    it('should render with basic props', () => {
+      const state = createMockState();
+      const store = mockStore(state);
+
+      renderWithProvider(
+        <MemoryRouter>
+          <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />
+        </MemoryRouter>,
+        store,
+      );
+
+      expect(screen.getByText('secretRecoveryPhrase')).toBeInTheDocument();
+      expect(screen.getByLabelText('next')).toBeInTheDocument();
+    });
+
+    it('should render with backup reminder when seed phrase is not backed up', () => {
+      const baseState = createMockState(false);
+      const state = {
+        ...baseState,
+        metamask: {
+          ...baseState.metamask,
+          firstTimeFlowType: 'create',
+        },
+      };
+      const store = mockStore(state);
+      const account = {
+        ...MOCK_ACCOUNT_EOA,
+        options: { ...MOCK_ACCOUNT_EOA.options, entropySource: 'mock-hd-keyring-id' },
+      };
+
+      renderWithProvider(
+        <MemoryRouter>
+          <AccountShowSrpRow account={account} />
+        </MemoryRouter>,
+        store,
+      );
+
+      expect(screen.getByText('secretRecoveryPhrase')).toBeInTheDocument();
+      expect(screen.getByText('backup')).toBeInTheDocument();
+      expect(screen.getByLabelText('next')).toBeInTheDocument();
+    });
+
+    it('should not show backup reminder when seed phrase is backed up', () => {
+      const state = createMockState(true);
+      const store = mockStore(state);
+
+      renderWithProvider(
+        <MemoryRouter>
+          <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />
+        </MemoryRouter>,
+        store,
+      );
+
+      expect(screen.getByText('secretRecoveryPhrase')).toBeInTheDocument();
+      expect(screen.queryByText('backup')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('next')).toBeInTheDocument();
+    });
+
+    it('should not show backup reminder for non-first HD keyring', () => {
+      const secondHdKeyring = {
+        type: 'HD Key Tree',
+        accounts: [MOCK_ACCOUNT_EOA.address],
+        metadata: {
+          id: 'second-hd-keyring-id',
+          name: 'HD Key Tree',
+        },
+      };
+      const state = createMockState(false, [secondHdKeyring]);
+      const store = mockStore(state);
+
+      const accountWithSecondKeyring = {
+        ...MOCK_ACCOUNT_EOA,
+        options: {
+          entropySource: 'second-hd-keyring-id',
+        },
+      };
+
+      renderWithProvider(
+        <MemoryRouter>
+          <AccountShowSrpRow account={accountWithSecondKeyring} />
+        </MemoryRouter>,
+        store,
+      );
+
+      expect(screen.getByText('secretRecoveryPhrase')).toBeInTheDocument();
+      expect(screen.queryByText('backup')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('next')).toBeInTheDocument();
+    });
+  });
+
+  describe('Click Functionality', () => {
+    it('should navigate to backup route when clicked and seed phrase not backed up', () => {
+      const baseState = createMockState(false);
+      const state = {
+        ...baseState,
+        metamask: {
+          ...baseState.metamask,
+          firstTimeFlowType: 'create',
+        },
+      };
+      const store = mockStore(state);
+      const account = {
+        ...MOCK_ACCOUNT_EOA,
+        options: { ...MOCK_ACCOUNT_EOA.options, entropySource: 'mock-hd-keyring-id' },
+      };
+
+      renderWithProvider(
+        <MemoryRouter>
+          <AccountShowSrpRow account={account} />
+        </MemoryRouter>,
+        store,
+      );
+
+      const row = screen.getByText('secretRecoveryPhrase').closest('div');
+      if (row) {
+        fireEvent.click(row);
+      }
+
+      expect(mockPush).toHaveBeenCalledWith(
+        `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`,
+      );
+    });
+
+    it('should open SRP quiz modal when clicked and seed phrase is backed up', () => {
+      const state = createMockState(true);
+      const store = mockStore(state);
+
+      renderWithProvider(
+        <MemoryRouter>
+          <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />
+        </MemoryRouter>,
+        store,
+      );
+
+      const row = screen.getByText('secretRecoveryPhrase').closest('div');
+      if (row) {
+        fireEvent.click(row);
+      }
+
+      expect(screen.getByTestId('srp-quiz-modal')).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle missing keyrings gracefully', () => {
+      const state = createMockState(true, []);
+      const store = mockStore(state);
+
+      renderWithProvider(
+        <MemoryRouter>
+          <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />
+        </MemoryRouter>,
+        store,
+      );
+
+      expect(screen.getByText('secretRecoveryPhrase')).toBeInTheDocument();
+      expect(screen.queryByText('backup')).not.toBeInTheDocument();
+    });
+
+    it('should handle non-HD keyring types gracefully', () => {
+      const nonHdKeyring = {
+        type: 'Snap Keyring',
+        accounts: [MOCK_ACCOUNT_EOA.address],
+        metadata: {
+          id: 'snap-keyring-id',
+          name: 'Snap Keyring',
+        },
+      };
+      const state = createMockState(false, [nonHdKeyring]);
+      const store = mockStore(state);
+
+      const accountWithSnapKeyring = {
+        ...MOCK_ACCOUNT_EOA,
+        options: {
+          entropySource: 'snap-keyring-id',
+        },
+      };
+
+      renderWithProvider(
+        <MemoryRouter>
+          <AccountShowSrpRow account={accountWithSnapKeyring} />
+        </MemoryRouter>,
+        store,
+      );
+
+      expect(screen.getByText('secretRecoveryPhrase')).toBeInTheDocument();
+      expect(screen.queryByText('backup')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.test.tsx
+++ b/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.test.tsx
@@ -87,7 +87,10 @@ describe('AccountShowSrpRow', () => {
       const store = mockStore(state);
       const account = {
         ...MOCK_ACCOUNT_EOA,
-        options: { ...MOCK_ACCOUNT_EOA.options, entropySource: 'mock-hd-keyring-id' },
+        options: {
+          ...MOCK_ACCOUNT_EOA.options,
+          entropySource: 'mock-hd-keyring-id',
+        },
       };
 
       renderWithProvider(
@@ -163,7 +166,10 @@ describe('AccountShowSrpRow', () => {
       const store = mockStore(state);
       const account = {
         ...MOCK_ACCOUNT_EOA,
-        options: { ...MOCK_ACCOUNT_EOA.options, entropySource: 'mock-hd-keyring-id' },
+        options: {
+          ...MOCK_ACCOUNT_EOA.options,
+          entropySource: 'mock-hd-keyring-id',
+        },
       };
 
       renderWithProvider(

--- a/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.tsx
+++ b/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.tsx
@@ -33,9 +33,14 @@ export const AccountShowSrpRow = ({ account }: AccountShowSrpRowProps) => {
   const [srpQuizModalVisible, setSrpQuizModalVisible] = useState(false);
   const seedPhraseBackedUp = useSelector(getIsPrimarySeedPhraseBackedUp);
   const hdKeyrings = useSelector(getMetaMaskHdKeyrings);
-  const keyringId = account.options.entropySource as string;
+  const keyringId =
+    account.options?.entropySource &&
+    typeof account.options.entropySource === 'string'
+      ? account.options.entropySource
+      : undefined;
   const isFirstHdKeyring = hdKeyrings[0]?.metadata?.id === keyringId;
-  const shouldShowBackupReminder = !seedPhraseBackedUp && isFirstHdKeyring;
+  const shouldShowBackupReminder =
+    !seedPhraseBackedUp && isFirstHdKeyring && keyringId;
 
   return (
     <>

--- a/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.tsx
+++ b/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { TextVariant, TextColor, Display, AlignItems, IconColor } from '../../../helpers/constants/design-system';
+import { AccountDetailsRow } from '../account-details-row/account-details-row';
+import { ButtonIcon, IconName, Text, Box, ButtonIconSize } from '../../../components/component-library';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { getIsPrimarySeedPhraseBackedUp } from '../../../ducks/metamask/metamask';
+import { getMetaMaskHdKeyrings } from '../../../selectors';
+import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../helpers/constants/routes';
+import SRPQuiz from '../../app/srp-quiz-modal';
+
+type AccountShowSrpRowProps = {
+  account: InternalAccount;
+};
+
+export const AccountShowSrpRow = ({ account }: AccountShowSrpRowProps) => {
+  const t = useI18nContext();
+  const history = useHistory();
+  const [srpQuizModalVisible, setSrpQuizModalVisible] = useState(false);
+  const seedPhraseBackedUp = useSelector(getIsPrimarySeedPhraseBackedUp);
+  const hdKeyrings = useSelector(getMetaMaskHdKeyrings);
+  const keyringId = account.options.entropySource as string;
+  const isFirstHdKeyring = hdKeyrings[0]?.metadata?.id === keyringId;
+  const shouldShowBackupReminder = !seedPhraseBackedUp && isFirstHdKeyring;
+
+  return (<>
+    <AccountDetailsRow
+      label={t('secretRecoveryPhrase')}
+      value={''}
+      endAccessory={
+        <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+          {shouldShowBackupReminder && (
+            <Text
+              variant={TextVariant.bodyMdMedium}
+              color={TextColor.errorDefault}
+            >
+              {t('backup')}
+            </Text>
+          )}
+          <ButtonIcon
+            iconName={IconName.ArrowRight}
+            ariaLabel={t('next')}
+            color={IconColor.iconAlternative}
+            size={ButtonIconSize.Md}
+          />
+        </Box>
+      }
+      onClick={() => {
+        if (shouldShowBackupReminder) {
+          const backUpSRPRoute = `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`;
+          history.push(backUpSRPRoute);
+        } else {
+          setSrpQuizModalVisible(true);
+        }
+      }}
+    />
+    {srpQuizModalVisible ? (
+       <SRPQuiz
+       keyringId={keyringId}
+       isOpen={srpQuizModalVisible}
+       onClose={() => setSrpQuizModalVisible(false)}
+       closeAfterCompleting
+     />
+    ) : null}
+  </>
+  );
+};

--- a/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.tsx
+++ b/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.tsx
@@ -1,11 +1,23 @@
 import React, { useState } from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { TextVariant, TextColor, Display, AlignItems, IconColor } from '../../../helpers/constants/design-system';
-import { AccountDetailsRow } from '../account-details-row/account-details-row';
-import { ButtonIcon, IconName, Text, Box, ButtonIconSize } from '../../../components/component-library';
-import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import {
+  TextVariant,
+  TextColor,
+  Display,
+  AlignItems,
+  IconColor,
+} from '../../../helpers/constants/design-system';
+import { AccountDetailsRow } from '../account-details-row/account-details-row';
+import {
+  ButtonIcon,
+  IconName,
+  Text,
+  Box,
+  ButtonIconSize,
+} from '../../component-library';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getIsPrimarySeedPhraseBackedUp } from '../../../ducks/metamask/metamask';
 import { getMetaMaskHdKeyrings } from '../../../selectors';
 import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../helpers/constants/routes';
@@ -25,45 +37,46 @@ export const AccountShowSrpRow = ({ account }: AccountShowSrpRowProps) => {
   const isFirstHdKeyring = hdKeyrings[0]?.metadata?.id === keyringId;
   const shouldShowBackupReminder = !seedPhraseBackedUp && isFirstHdKeyring;
 
-  return (<>
-    <AccountDetailsRow
-      label={t('secretRecoveryPhrase')}
-      value={''}
-      endAccessory={
-        <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
-          {shouldShowBackupReminder && (
-            <Text
-              variant={TextVariant.bodyMdMedium}
-              color={TextColor.errorDefault}
-            >
-              {t('backup')}
-            </Text>
-          )}
-          <ButtonIcon
-            iconName={IconName.ArrowRight}
-            ariaLabel={t('next')}
-            color={IconColor.iconAlternative}
-            size={ButtonIconSize.Md}
-          />
-        </Box>
-      }
-      onClick={() => {
-        if (shouldShowBackupReminder) {
-          const backUpSRPRoute = `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`;
-          history.push(backUpSRPRoute);
-        } else {
-          setSrpQuizModalVisible(true);
+  return (
+    <>
+      <AccountDetailsRow
+        label={t('secretRecoveryPhrase')}
+        value={''}
+        endAccessory={
+          <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+            {shouldShowBackupReminder && (
+              <Text
+                variant={TextVariant.bodyMdMedium}
+                color={TextColor.errorDefault}
+              >
+                {t('backup')}
+              </Text>
+            )}
+            <ButtonIcon
+              iconName={IconName.ArrowRight}
+              ariaLabel={t('next')}
+              color={IconColor.iconAlternative}
+              size={ButtonIconSize.Md}
+            />
+          </Box>
         }
-      }}
-    />
-    {srpQuizModalVisible ? (
-       <SRPQuiz
-       keyringId={keyringId}
-       isOpen={srpQuizModalVisible}
-       onClose={() => setSrpQuizModalVisible(false)}
-       closeAfterCompleting
-     />
-    ) : null}
-  </>
+        onClick={() => {
+          if (shouldShowBackupReminder) {
+            const backUpSRPRoute = `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`;
+            history.push(backUpSRPRoute);
+          } else {
+            setSrpQuizModalVisible(true);
+          }
+        }}
+      />
+      {srpQuizModalVisible ? (
+        <SRPQuiz
+          keyringId={keyringId}
+          isOpen={srpQuizModalVisible}
+          onClose={() => setSrpQuizModalVisible(false)}
+          closeAfterCompleting
+        />
+      ) : null}
+    </>
   );
 };

--- a/ui/pages/multichain-accounts/account-details/evm-account-details.tsx
+++ b/ui/pages/multichain-accounts/account-details/evm-account-details.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { BaseAccountDetails } from '../base-account-details/base-account-details';
+import { AccountShowSrpRow } from '../../../components/multichain-accounts/account-show-srp-row/account-show-srp-row';
+import { Box } from '../../../components/component-library';
 
 type EVMAccountDetailsProps = {
   address: string;
@@ -11,5 +13,11 @@ export const EVMAccountDetails = ({
   address,
   account,
 }: EVMAccountDetailsProps) => {
-  return <BaseAccountDetails address={address} account={account} />;
+  return (
+    <BaseAccountDetails address={address} account={account}>
+      <Box className="multichain-account-details__section">
+        <AccountShowSrpRow account={account} />
+      </Box>
+    </BaseAccountDetails>
+  );
 };

--- a/ui/pages/multichain-accounts/account-details/solana-account-details.tsx
+++ b/ui/pages/multichain-accounts/account-details/solana-account-details.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { BaseAccountDetails } from '../base-account-details/base-account-details';
+import { AccountShowSrpRow } from '../../../components/multichain-accounts/account-show-srp-row/account-show-srp-row';
+import { Box } from '../../../components/component-library';
 
 type SolanaAccountDetailsProps = {
   address: string;
@@ -11,5 +13,11 @@ export const SolanaAccountDetails = ({
   address,
   account,
 }: SolanaAccountDetailsProps) => {
-  return <BaseAccountDetails address={address} account={account} />;
+  return (
+    <BaseAccountDetails address={address} account={account}>
+      <Box className="multichain-account-details__section">
+        <AccountShowSrpRow account={account} />
+      </Box>
+    </BaseAccountDetails>
+  );
 };

--- a/ui/pages/multichain-accounts/base-account-details/base-account-details.scss
+++ b/ui/pages/multichain-accounts/base-account-details/base-account-details.scss
@@ -1,3 +1,20 @@
 .multichain-account-details-page {
   max-width: 600px;
+
+  .multichain-account-details__section {
+    .multichain-account-details__row {
+      margin-bottom: 1px;
+
+      &:first-of-type {
+        border-top-left-radius: 8px;
+        border-top-right-radius: 8px;
+      }
+
+      &:last-of-type {
+        border-bottom-left-radius: 8px;
+        border-bottom-right-radius: 8px;
+        margin-bottom: 0;
+      }
+    }
+  }
 }

--- a/ui/pages/multichain-accounts/base-account-details/base-account-details.tsx
+++ b/ui/pages/multichain-accounts/base-account-details/base-account-details.tsx
@@ -197,11 +197,6 @@ export const BaseAccountDetails = ({
                 marginLeft={2}
               />
             }
-            style={{
-              marginBottom: '1px',
-              borderTopLeftRadius: '8px',
-              borderTopRightRadius: '8px',
-            }}
           />
           <AccountDetailsRow
             label={t('address')}
@@ -216,9 +211,6 @@ export const BaseAccountDetails = ({
                 marginLeft={2}
               />
             }
-            style={{
-              marginBottom: '1px',
-            }}
           />
           <AccountDetailsRow
             label={t('wallet')}
@@ -235,10 +227,6 @@ export const BaseAccountDetails = ({
                 marginLeft={2}
               />
             }
-            style={{
-              borderBottomLeftRadius: '8px',
-              borderBottomRightRadius: '8px',
-            }}
           />
         </Box>
         {children}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds a new "Secret Recovery Phrase" row to the account details page that allows users to view their SRP. The component includes:

1. **Backup Reminder Functionality**: Shows a "backup" warning text when the seed phrase hasn't been backed up for the first HD keyring
2. **Click Navigation**: 
   - If seed phrase not backed up: navigates to the backup flow with reminder flag
   - If seed phrase backed up: opens SRP quiz modal
3. **Enhanced AccountDetailsRow**: Added onClick prop and pointer cursor styling for clickable rows
4. **Testing**: Added unit tests covering all functionality including click events, backup reminders, and error handling
5. **Storybook **: Added stories for both backed up and non-backed up states

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-307

## **Manual testing steps**

1. Go to Account Details page for HD or Solana account
2. Scroll down to see the new "Secret Recovery Phrase" row
3. If seed phrase not backed up: Click the row to navigate to backup flow
4. If seed phrase backed up: Click the row to open SRP quiz modal
5. Verify backup reminder text appears only for first HD keyring when not backed up
6. Test that non-HD keyrings don't show backup reminders

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

https://github.com/user-attachments/assets/c24ddf69-0d94-43a9-a9f8-a9cefff373c0


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
