### PR TITLE
release: add CHANGELOG to pull-request-template.md

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -13,6 +13,22 @@ Write a short description of the changes included in this pull request, also inc
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/PR?quickstart=1)
 
+## **Changelog**
+
+<!--
+If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
+1. Write `CHANGELOG entry: null`
+2. Label with `no-changelog`
+
+If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
+`CHANGELOG entry: Added a new tab for users to see their NFTs`
+`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`
+
+(This helps the Release Engineer do their job more quickly and accurately)
+-->
+
+CHANGELOG entry:
+
 ## **Related issues**
 
 Fixes:

--- a/.github/scripts/shared/template.ts
+++ b/.github/scripts/shared/template.ts
@@ -40,6 +40,7 @@ const bugReportIssueTemplateTitles = [
 // Titles of PR template
 const prTemplateTitles = [
   '## **Description**',
+  '## **Changelog**',
   '## **Related issues**',
   '## **Manual testing steps**',
   '## **Screenshots/Recordings**',


### PR DESCRIPTION
## **Description**

Add a `CHANGELOG entry:` field to `pull-request-template.md` in order to support future automations for the Release Engineer, and help them do their job more quickly and accurately.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->