### PR TITLE
fix: regression of lanchdarkly flag key

### DIFF
--- a/ui/components/multichain/carousel/carousel.tsx
+++ b/ui/components/multichain/carousel/carousel.tsx
@@ -75,10 +75,10 @@ export const Carousel = React.forwardRef(
       })
       .sort((a, b) => {
         // Prioritize Contentful Priority slides
-        if (a.priorityPlacement === true) {
+        if (a.priorityPlacement === true && b.priorityPlacement !== true) {
           return -1;
         }
-        if (b.priorityPlacement === true) {
+        if (a.priorityPlacement !== true && b.priorityPlacement === true) {
           return 1;
         }
 

--- a/ui/components/multichain/carousel/carousel.tsx
+++ b/ui/components/multichain/carousel/carousel.tsx
@@ -81,9 +81,6 @@ export const Carousel = React.forwardRef(
         if (a.priorityPlacement !== true && b.priorityPlacement === true) {
           return 1;
         }
-        if (a.priorityPlacement === b.priorityPlacement) {
-          return 0;
-        }
 
         if (!useExternalServices) {
           if (a.id === BASIC_FUNCTIONALITY_SLIDE.id) {

--- a/ui/components/multichain/carousel/carousel.tsx
+++ b/ui/components/multichain/carousel/carousel.tsx
@@ -81,6 +81,9 @@ export const Carousel = React.forwardRef(
         if (a.priorityPlacement !== true && b.priorityPlacement === true) {
           return 1;
         }
+        if (a.priorityPlacement === b.priorityPlacement) {
+          return 0;
+        }
 
         if (!useExternalServices) {
           if (a.id === BASIC_FUNCTIONALITY_SLIDE.id) {


### PR DESCRIPTION
## **Description**
**Regression of the launchDarkly Flag key**
Contentful Flag should be `contentfulCarouselEnabled` instead of `contentfulCarouselIntegration` which was modified in a manual Cherry-pick. 

Where the LaunchDarkly flag was altered: https://github.com/MetaMask/metamask-extension/pull/34014

Before none of the Conentful Carousels were rendered:
![Screenshot 2025-07-03 at 11 49 13 AM](https://github.com/user-attachments/assets/5af262b1-5e7a-4899-9b0d-9e3560c69aa6)


With this PR Now contentful Carousels can be seen again: 
![Screenshot 2025-07-03 at 11 48 46 AM](https://github.com/user-attachments/assets/a6f9cdb1-e948-4f23-8228-97da42024a37)




<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34045?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
