### PR TITLE
fix: Patch lodash.memoize to use globalThis

### DIFF
--- a/.yarn/patches/lodash.memoize-npm-4.1.2-0e6250041f.patch
+++ b/.yarn/patches/lodash.memoize-npm-4.1.2-0e6250041f.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index 282ed310d1bb5e704b9a8cb637a9680c756955d5..a409fce8fcffa5f94daae8c0cf1455a7f48ce3d6 100644
+--- a/index.js
++++ b/index.js
+@@ -27,7 +27,7 @@ var reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+ var reIsHostCtor = /^\[object .+?Constructor\]$/;
+ 
+ /** Detect free variable `global` from Node.js. */
+-var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
++var freeGlobal = typeof globalThis == 'object' && globalThis && globalThis.Object === Object && globalThis;
+ 
+ /** Detect free variable `self`. */
+ var freeSelf = typeof self == 'object' && self && self.Object === Object && self;

--- a/package.json
+++ b/package.json
@@ -232,7 +232,8 @@
     "@keystonehq/metamask-airgapped-keyring": "patch:@keystonehq/metamask-airgapped-keyring@npm%3A0.15.2#~/.yarn/patches/@keystonehq-metamask-airgapped-keyring-npm-0.15.2-94dd4b40d7.patch",
     "@trezor/connect-web": "~9.4.7",
     "nanoid@npm:^5.1.5": "^3.3.8",
-    "tar-fs@npm:^2.1.0": "^2.1.3"
+    "tar-fs@npm:^2.1.0": "^2.1.3",
+    "lodash.memoize@npm:^4.1.2": "patch:lodash.memoize@npm%3A4.1.2#~/.yarn/patches/lodash.memoize-npm-4.1.2-0e6250041f.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30783,7 +30783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.memoize@npm:^4.1.2":
+"lodash.memoize@npm:4.1.2":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
   checksum: 10/192b2168f310c86f303580b53acf81ab029761b9bd9caa9506a019ffea5f3363ea98d7e39e7e11e6b9917066c9d36a09a11f6fe16f812326390d8f3a54a1a6da
@@ -30794,6 +30794,13 @@ __metadata:
   version: 3.0.4
   resolution: "lodash.memoize@npm:3.0.4"
   checksum: 10/fc52e0916b896fa79d6b85fbeaa0e44a381b70f1fcab7acab10188aaeeb2107e21b9b992bff560f405696e0a6e3bb5c08af18955d628a1e8ab6b11df14ff6172
+  languageName: node
+  linkType: hard
+
+"lodash.memoize@patch:lodash.memoize@npm%3A4.1.2#~/.yarn/patches/lodash.memoize-npm-4.1.2-0e6250041f.patch":
+  version: 4.1.2
+  resolution: "lodash.memoize@patch:lodash.memoize@npm%3A4.1.2#~/.yarn/patches/lodash.memoize-npm-4.1.2-0e6250041f.patch::version=4.1.2&hash=33dafa"
+  checksum: 10/64cb8f11ad29e40e5873750991765ac03c95727a86f814a3870d228a5ddfeec55d8c716e15519c5ab1bf4f36e77e1b0e6e96e348b3f2d04281835b756cb4534a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The latest version of `metamask/utils` adds `lodash.memoize` which doesn't work in Firefox since it references `global`. This PR patches the module to use `globalThis` instead.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34047?quickstart=1)
