### PR TITLE
fix: error logic for importing private keys

### DIFF
--- a/ui/components/multichain/import-account/private-key.js
+++ b/ui/components/multichain/import-account/private-key.js
@@ -49,7 +49,7 @@ export default function PrivateKeyImportView({
         size={TextFieldSize.Lg}
         autoFocus
         helpText={warning}
-        error
+        error={Boolean(warning)}
         label={t('pastePrivateKey')}
         value={privateKey}
         onChange={(event) => setPrivateKey(event.target.value)}


### PR DESCRIPTION
## **Description**
This PR adds fix to resolve an issue where private key import field was always in error state indicated by the red border outline.

#### Cause of the issue
- Input field had `error` property which always enabled error state for the field (always set to `true`).

#### Solution
- The error state of the input field is now tied to the presence of the warning message, which indicates error returned from the Keyring controller on failed private key import.
- If the warning message is present, set `error` state of the field to `true`

#### Notes
- The complete validation of the private key is done on import within Keyring Controller: https://github.com/MetaMask/core/blob/f083f657b942f8172e3c2162d427cbfa9e25e787/packages/keyring-controller/src/KeyringController.ts#L1073
- Future advice: consider having way to proactively validate private key on text input by exposing complete validation functionality to the outside of the Keyring controller as an utility function or similar.
- Future advice:  Consider re-visiting UX/UI around private key import and updating (refactoring) the entire component stack to a newer versions.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34050?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing private key import field to always be in error state

## **Related issues**
Fixes: https://github.com/MetaMask/metamask-extension/issues/33957
Related jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-333

## **Manual testing steps**
1. Try to import private key
2. Notice that field does not have red outline indicating error state
3. Try importing string that is not a private key
4. Notice that error state on the field is enabled alongside error message below input field

## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/d5fd77c0-343e-4869-bd03-32dfc8daf9c5

### **After**

https://github.com/user-attachments/assets/0cd8c516-3e9a-4705-94bf-139ba9d2199f

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
