### PR TITLE
fix: do not show backup reminder/notification when using social account

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -163,7 +163,7 @@ export default class Home extends PureComponent {
     setBasicFunctionalityModalOpen: PropTypes.func,
     fetchBuyableChains: PropTypes.func.isRequired,
     isSeedlessPasswordOutdated: PropTypes.bool,
-    isSocialLoginEnabled: PropTypes.bool,
+    isPrimarySeedPhraseBackedUp: PropTypes.bool,
   };
 
   state = {
@@ -345,7 +345,7 @@ export default class Home extends PureComponent {
       setNewTokensImportedError,
       clearNewNetworkAdded,
       clearEditedNetwork,
-      isSocialLoginEnabled,
+      isPrimarySeedPhraseBackedUp,
     } = this.props;
 
     const onAutoHide = () => {
@@ -575,7 +575,7 @@ export default class Home extends PureComponent {
           checkboxTooltipText={t('canToggleInSettings')}
         />
       ) : null,
-      !isSocialLoginEnabled && shouldShowSeedPhraseReminder ? (
+      !isPrimarySeedPhraseBackedUp && shouldShowSeedPhraseReminder ? (
         <HomeNotification
           key="show-seed-phrase-reminder"
           descriptionText={t('backupApprovalNotice')}
@@ -790,7 +790,7 @@ export default class Home extends PureComponent {
       showMultiRpcModal,
       showUpdateModal,
       isSeedlessPasswordOutdated,
-      isSocialLoginEnabled,
+      isPrimarySeedPhraseBackedUp,
     } = this.props;
 
     if (forgottenPassword) {
@@ -845,7 +845,7 @@ export default class Home extends PureComponent {
           {showWhatsNew ? <WhatsNewModal onClose={hideWhatsNewPopup} /> : null}
           {!showWhatsNew &&
           showRecoveryPhraseReminder &&
-          !isSocialLoginEnabled ? (
+          !isPrimarySeedPhraseBackedUp ? (
             <RecoveryPhraseReminder
               onConfirm={this.onRecoveryPhraseReminderClose}
             />

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -163,6 +163,7 @@ export default class Home extends PureComponent {
     setBasicFunctionalityModalOpen: PropTypes.func,
     fetchBuyableChains: PropTypes.func.isRequired,
     isSeedlessPasswordOutdated: PropTypes.bool,
+    isSocialLoginEnabled: PropTypes.bool,
   };
 
   state = {
@@ -344,6 +345,7 @@ export default class Home extends PureComponent {
       setNewTokensImportedError,
       clearNewNetworkAdded,
       clearEditedNetwork,
+      isSocialLoginEnabled,
     } = this.props;
 
     const onAutoHide = () => {
@@ -573,7 +575,7 @@ export default class Home extends PureComponent {
           checkboxTooltipText={t('canToggleInSettings')}
         />
       ) : null,
-      shouldShowSeedPhraseReminder ? (
+      !isSocialLoginEnabled && shouldShowSeedPhraseReminder ? (
         <HomeNotification
           key="show-seed-phrase-reminder"
           descriptionText={t('backupApprovalNotice')}
@@ -788,6 +790,7 @@ export default class Home extends PureComponent {
       showMultiRpcModal,
       showUpdateModal,
       isSeedlessPasswordOutdated,
+      isSocialLoginEnabled,
     } = this.props;
 
     if (forgottenPassword) {
@@ -840,7 +843,9 @@ export default class Home extends PureComponent {
           {showMultiRpcEditModal && <MultiRpcEditModal />}
           {displayUpdateModal && <UpdateModal />}
           {showWhatsNew ? <WhatsNewModal onClose={hideWhatsNewPopup} /> : null}
-          {!showWhatsNew && showRecoveryPhraseReminder ? (
+          {!showWhatsNew &&
+          showRecoveryPhraseReminder &&
+          !isSocialLoginEnabled ? (
             <RecoveryPhraseReminder
               onConfirm={this.onRecoveryPhraseReminderClose}
             />

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -55,6 +55,7 @@ import {
   openBasicFunctionalityModal,
 } from '../../ducks/app/app';
 import {
+  getIsPrimarySeedPhraseBackedUp,
   getIsSeedlessPasswordOutdated,
   getWeb3ShimUsageAlertEnabledness,
 } from '../../ducks/metamask/metamask';
@@ -184,7 +185,7 @@ const mapStateToProps = (state) => {
     showMultiRpcModal: state.metamask.preferences.showMultiRpcModal,
     showUpdateModal: getShowUpdateModal(state),
     isSeedlessPasswordOutdated: getIsSeedlessPasswordOutdated(state),
-    isSocialLoginEnabled: getIsSocialLoginFlow(state),
+    isPrimarySeedPhraseBackedUp: getIsPrimarySeedPhraseBackedUp(state),
   };
 };
 

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -28,7 +28,6 @@ import {
   getIsSolanaSupportEnabled,
   ///: END:ONLY_INCLUDE_IF
   getShowUpdateModal,
-  getIsSocialLoginFlow,
 } from '../../selectors';
 import { getInfuraBlocked } from '../../../shared/modules/selectors/networks';
 import {

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -28,6 +28,7 @@ import {
   getIsSolanaSupportEnabled,
   ///: END:ONLY_INCLUDE_IF
   getShowUpdateModal,
+  getIsSocialLoginFlow,
 } from '../../selectors';
 import { getInfuraBlocked } from '../../../shared/modules/selectors/networks';
 import {
@@ -183,6 +184,7 @@ const mapStateToProps = (state) => {
     showMultiRpcModal: state.metamask.preferences.showMultiRpcModal,
     showUpdateModal: getShowUpdateModal(state),
     isSeedlessPasswordOutdated: getIsSeedlessPasswordOutdated(state),
+    isSocialLoginEnabled: getIsSocialLoginFlow(state),
   };
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
- Do not show backup reminder/notification when using social account, when user logs-in using social account it does not require backing-up SRP
- Do not show backup reminder/notification when SRP is backed-up already

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34142?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed backup reminder and notification are shown even with social accounts and even when SRP is backed-up already

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/34122
https://github.com/MetaMask/metamask-extension/issues/34121

## **Manual testing steps**

**Show Protect your wallet modal**
1. Login with social account and finish the onboarding
2. Leave account for few days
3. Open the tab again
4. Check the popup

**Show seedPhraseReminder notification**
1. Login with social account and finish the onboarding
2. Add balance to the account
3. Check notification

**Show Protect your wallet modal showing even if SRP is backed-up**
1. Login with SRP
2. Skip backup SRP
3. Complete onboarding
4. Leave account for a few days
5.  Check the popup
6. Start backup and finish it
7. Check if `Protect your wallet` modal is still showing

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

**Protect your wallet modal**
![Screenshot 2025-07-08 at 10 47 48 PM](https://github.com/user-attachments/assets/bdaa0694-31a6-43d8-b75d-bf53871d08d2)
**Backup SRP notification**
![Screenshot 2025-07-08 at 10 48 57 PM](https://github.com/user-attachments/assets/ce7319c5-77fb-44fd-bc44-1163a857da1d)


<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
