### PR TITLE
fix: read isSingleSwapBridgeButtonEnabled flag to show unified swaps cp-12.23.0

### DIFF
--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -721,8 +721,8 @@ export const getIsUnifiedUIEnabled = createSelector(
       ? Boolean(
           'isSingleSwapBridgeButtonEnabled' in
             bridgeFeatureFlags.chains[caipChainId]
-            ? bridgeFeatureFlags.chains[caipChainId]
-                .isSingleSwapBridgeButtonEnabled
+            ? (bridgeFeatureFlags.chains[caipChainId]
+                .isSingleSwapBridgeButtonEnabled as unknown as boolean)
             : false,
         )
       : false;

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -722,7 +722,7 @@ export const getIsUnifiedUIEnabled = createSelector(
           'isSingleSwapBridgeButtonEnabled' in
             bridgeFeatureFlags.chains[caipChainId]
             ? (
-                bridgeFeatureFlags.chains[caipChainId] as {
+                bridgeFeatureFlags.chains[caipChainId] as unknown as {
                   isSingleSwapBridgeButtonEnabled: boolean;
                 }
               ).isSingleSwapBridgeButtonEnabled

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -717,8 +717,14 @@ export const getIsUnifiedUIEnabled = createSelector(
     const caipChainId = formatChainIdToCaip(chainId);
 
     // TODO remove this when bridge-controller's types are updated
-    return bridgeFeatureFlags?.chains?.[caipChainId] ? Boolean(
-       'isSingleSwapBridgeButtonEnabled' in bridgeFeatureFlags.chains[caipChainId] ? bridgeFeatureFlags.chains[caipChainId].isSingleSwapBridgeButtonEnabled : false,
-    ) : false;
+    return bridgeFeatureFlags?.chains?.[caipChainId]
+      ? Boolean(
+          'isSingleSwapBridgeButtonEnabled' in
+            bridgeFeatureFlags.chains[caipChainId]
+            ? bridgeFeatureFlags.chains[caipChainId]
+                .isSingleSwapBridgeButtonEnabled
+            : false,
+        )
+      : false;
   },
 );

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -721,8 +721,11 @@ export const getIsUnifiedUIEnabled = createSelector(
       ? Boolean(
           'isSingleSwapBridgeButtonEnabled' in
             bridgeFeatureFlags.chains[caipChainId]
-            ? (bridgeFeatureFlags.chains[caipChainId]
-                .isSingleSwapBridgeButtonEnabled as unknown as boolean)
+            ? (
+                bridgeFeatureFlags.chains[caipChainId] as {
+                  isSingleSwapBridgeButtonEnabled: boolean;
+                }
+              ).isSingleSwapBridgeButtonEnabled
             : false,
         )
       : false;

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -716,8 +716,9 @@ export const getIsUnifiedUIEnabled = createSelector(
 
     const caipChainId = formatChainIdToCaip(chainId);
 
-    return Boolean(
-      bridgeFeatureFlags?.chains?.[caipChainId]?.isUnifiedUIEnabled,
-    );
+    // TODO remove this when bridge-controller's types are updated
+    return bridgeFeatureFlags?.chains?.[caipChainId] ? Boolean(
+       'isSingleSwapBridgeButtonEnabled' in bridgeFeatureFlags.chains[caipChainId] ? bridgeFeatureFlags.chains[caipChainId].isSingleSwapBridgeButtonEnabled : false,
+    ) : false;
   },
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This changes the Unified flag to `isSingleSwapBridgeButtonEnabled` flag to avoid impacting older extension versions when the flag is enabled in v12.23.0


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34153?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34150

## **Manual testing steps**

1. Open extension
2. Verify that Bridge button is hidden
3. Clicking on Swap button should open the Unified swaps experience

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
