### PR TITLE
chore: updating z-indexes for headers

### DIFF
--- a/ui/components/ui/loading-screen/index.scss
+++ b/ui/components/ui/loading-screen/index.scss
@@ -1,7 +1,9 @@
+@use "design-system";
+
 .loading-overlay {
   top: 0;
   left: 0;
-  z-index: 55;
+  z-index: design-system.$loading-overlay-z-index;
   position: fixed;
   flex-direction: column;
   display: flex;

--- a/ui/css/design-system/_z-index.scss
+++ b/ui/css/design-system/_z-index.scss
@@ -3,9 +3,9 @@
 */
 $dropdown-z-index: 30;
 $main-container-z-index: 18;
-$mobile-header-z-index: 26;
 $toast-z-index: 200;
 $header-z-index: 300;
+$loading-overlay-z-index: 400;
 $modal-z-index: 1050;
 $popover-in-modal-z-index: 1051;
 $onboarding-app-header-z-index: 50;

--- a/ui/pages/onboarding-flow/onboarding-app-header/index.scss
+++ b/ui/pages/onboarding-flow/onboarding-app-header/index.scss
@@ -12,7 +12,7 @@
   }
 
   @include design-system.screen-sm-max {
-    z-index: design-system.$mobile-header-z-index;
+    z-index: design-system.$header-z-index;
   }
 
   @include design-system.screen-sm-min {


### PR DESCRIPTION
## **Description**

This PR fixes a z-index issue with the header and loading overlay which was introduced in https://github.com/MetaMask/metamask-extension/pull/33133. This effects how the loader looks during onboarding and network switching.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34154?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34077

## **Manual testing steps**

1. Build and run the extension
2. Go between logging in and locking the extension
3. See the loading screen is now correctly overlayed above the header

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Onboarding creating a password

https://github.com/user-attachments/assets/bc5e7c50-3a84-4005-9db0-24202607d5e0

Changing between networks


https://github.com/user-attachments/assets/a561ea91-801e-4af6-9c81-e574d6cebd81


Asset modal (just checking other instances where `LoadingScreen` is used

<img width="1504" alt="Screenshot 2025-07-09 at 12 27 22 PM" src="https://github.com/user-attachments/assets/915ad138-0a36-4cdd-903d-9410c5276e58" />


### **After**
Onboarding creating a password

https://github.com/user-attachments/assets/a76c0f0b-618b-4be6-9922-3f69e4189855

Changing between networks

https://github.com/user-attachments/assets/7ebe31a8-8f16-484f-9302-2ca7848bad3f

Asset modal (just checking other instances where `LoadingScreen` is used

<img width="1512" alt="Screenshot 2025-07-09 at 12 17 42 PM" src="https://github.com/user-attachments/assets/f2b8a458-b735-4582-84e2-5b2952a2a11e" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
