### PR TITLE
fix: use activeQuote amounts when displaying approval banners cp-12.22.1

### DIFF
--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -1058,7 +1058,10 @@ const PrepareBridgePage = () => {
                     !selectedDestinationAccount
                   }
                 />
-                {activeQuote?.approval && fromAmount && fromToken ? (
+                {activeQuote &&
+                activeQuote.approval &&
+                activeQuote.sentAmount &&
+                activeQuote.quote.srcAsset?.symbol ? (
                   <Row justifyContent={JustifyContent.center} gap={1}>
                     <Text
                       color={TextColor.textAlternativeSoft}
@@ -1073,38 +1076,36 @@ const PrepareBridgePage = () => {
                           return t('willApproveAmountForSwapping', [
                             formatTokenAmount(
                               locale,
-                              fromAmount,
-                              fromToken.symbol,
+                              activeQuote.sentAmount.amount,
+                              activeQuote.quote.srcAsset.symbol,
                             ),
                           ]);
                         }
                         return t('willApproveAmountForBridging', [
                           formatTokenAmount(
                             locale,
-                            fromAmount,
-                            fromToken.symbol,
+                            activeQuote.sentAmount.amount,
+                            activeQuote.quote.srcAsset.symbol,
                           ),
                         ]);
                       })()}
                     </Text>
-                    {fromAmount && (
-                      <Tooltip
-                        display={Display.InlineBlock}
-                        position={PopoverPosition.Top}
-                        offset={[-48, 8]}
-                        title={t('grantExactAccess')}
-                      >
-                        {isUsingHardwareWallet
-                          ? t('bridgeApprovalWarningForHardware', [
-                              fromAmount,
-                              fromToken.symbol,
-                            ])
-                          : t('bridgeApprovalWarning', [
-                              fromAmount,
-                              fromToken.symbol,
-                            ])}
-                      </Tooltip>
-                    )}
+                    <Tooltip
+                      display={Display.InlineBlock}
+                      position={PopoverPosition.Top}
+                      offset={[-48, 8]}
+                      title={t('grantExactAccess')}
+                    >
+                      {isUsingHardwareWallet
+                        ? t('bridgeApprovalWarningForHardware', [
+                            activeQuote.sentAmount.amount,
+                            activeQuote.quote.srcAsset.symbol,
+                          ])
+                        : t('bridgeApprovalWarning', [
+                            activeQuote.sentAmount.amount,
+                            activeQuote.quote.srcAsset.symbol,
+                          ])}
+                    </Tooltip>
                   </Row>
                 ) : null}
               </Footer>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates approval banners to read and display sent amount from the active quote instead of the current input amount value. This fixes a bug in which the extension could crash if there is a quote and the user updates the src amount to just a decimal point

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34156?quickstart=1)

## **Changelog**



<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

Fixed

- Display sent amounts from the active swap quote when showing approval warnings to prevent parsing non-numerical inputs

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34157 , https://consensyssoftware.atlassian.net/browse/SWAPS-2612

## **Manual testing steps**

1. Request quotes for .001 arb:WBTC to eth:ETH
2. Delete last 3 characters of src amount
3. Page should not crash

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
