### PR TITLE
release(cp): use activeQuote amounts when displaying approval banners cp-12.22.1

### DIFF
--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -1001,7 +1001,10 @@ const PrepareBridgePage = () => {
                     !selectedDestinationAccount
                   }
                 />
-                {activeQuote?.approval && fromAmount && fromToken ? (
+                {activeQuote &&
+                activeQuote.approval &&
+                activeQuote.sentAmount &&
+                activeQuote.quote.srcAsset?.symbol ? (
                   <Row justifyContent={JustifyContent.center} gap={1}>
                     <Text
                       color={TextColor.textAlternativeSoft}
@@ -1013,29 +1016,27 @@ const PrepareBridgePage = () => {
                         : t('willApproveAmountForBridging', [
                             formatTokenAmount(
                               locale,
-                              fromAmount,
-                              fromToken.symbol,
+                              activeQuote.sentAmount.amount,
+                              activeQuote.quote.srcAsset.symbol,
                             ),
                           ])}
                     </Text>
-                    {fromAmount && (
-                      <Tooltip
-                        display={Display.InlineBlock}
-                        position={PopoverPosition.Top}
-                        offset={[-48, 8]}
-                        title={t('grantExactAccess')}
-                      >
-                        {isUsingHardwareWallet
-                          ? t('bridgeApprovalWarningForHardware', [
-                              fromAmount,
-                              fromToken.symbol,
-                            ])
-                          : t('bridgeApprovalWarning', [
-                              fromAmount,
-                              fromToken.symbol,
-                            ])}
-                      </Tooltip>
-                    )}
+                    <Tooltip
+                      display={Display.InlineBlock}
+                      position={PopoverPosition.Top}
+                      offset={[-48, 8]}
+                      title={t('grantExactAccess')}
+                    >
+                      {isUsingHardwareWallet
+                        ? t('bridgeApprovalWarningForHardware', [
+                            activeQuote.sentAmount.amount,
+                            activeQuote.quote.srcAsset.symbol,
+                          ])
+                        : t('bridgeApprovalWarning', [
+                            activeQuote.sentAmount.amount,
+                            activeQuote.quote.srcAsset.symbol,
+                          ])}
+                    </Tooltip>
                   </Row>
                 ) : null}
               </Footer>


### PR DESCRIPTION
## **Description**

Updates approval banners to read and display sent amount from the active quote instead of the current input amount value. This fixes a bug in which the extension could crash if there is a quote and the user updates the src amount to just a decimal point

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34156?quickstart=1)

## **Changelog**

CHANGELOG entry: Display sent amounts from the active swap quote when showing approval warnings to prevent parsing non-numerical inputs

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34157 , https://consensyssoftware.atlassian.net/browse/SWAPS-2612

## **Manual testing steps**

1. Request quotes for .001 arb:WBTC to eth:ETH
2. Delete last 3 characters of src amount
3. Page should not crash

## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**