### PR TITLE
fix: flaky test `Settings - general tab validate "Magyar" language change on hypertext`

### DIFF
--- a/test/e2e/page-objects/pages/settings/general-settings.ts
+++ b/test/e2e/page-objects/pages/settings/general-settings.ts
@@ -64,11 +64,10 @@ class GeneralSettings {
       'on general settings page',
     );
     await this.check_noLoadingOverlaySpinner();
-    await this.driver.clickElement(this.selectLanguageField);
-    await this.driver.clickElement({
-      text: languageToSelect,
-      tag: 'option',
-    });
+    // We use send keys, because clicking the dropdown causes flakiness, if it's not auto closed after selecting the language
+    const dropdown =
+      await this.driver.findElement(this.selectLanguageField);
+    await dropdown.sendKeys(languageToSelect);
     await this.check_noLoadingOverlaySpinner();
   }
 

--- a/test/e2e/page-objects/pages/settings/general-settings.ts
+++ b/test/e2e/page-objects/pages/settings/general-settings.ts
@@ -65,8 +65,7 @@ class GeneralSettings {
     );
     await this.check_noLoadingOverlaySpinner();
     // We use send keys, because clicking the dropdown causes flakiness, if it's not auto closed after selecting the language
-    const dropdown =
-      await this.driver.findElement(this.selectLanguageField);
+    const dropdown = await this.driver.findElement(this.selectLanguageField);
     await dropdown.sendKeys(languageToSelect);
     await this.check_noLoadingOverlaySpinner();
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a race condition with all the Change language specs, which after we select the language, we click Close settings and then we look for the Home page Send element, but it can't be found:

`TimeoutError: Waiting for element to be located By(css selector, [data-testid="eth-overview-send"])`

What is happening is that after clicking Close settings, we remain at the Settings page, because after switching languages, the dropdown menu sometimes remains open, causing a subsequent click to have no effect.

Given that we should perform an extra click to avoid this race condition, instead we just switch language by sending keys, to avoid the flakiness of  the dropdown menu not auto-closing (on the app side).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34169?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34168

## **Manual testing steps**

1. Tests should pass

## **Screenshots/Recordings**
See how after selecting the Magyar language, the dropdown remained opened, causing the Close settings action to take no effect.

![Screenshot from 2025-07-09 10-41-52](https://github.com/user-attachments/assets/84740237-f5c2-4fc7-9771-f8ffcb2dcbf8)

After: we don't have the conflicting dropdown open anymore

https://github.com/user-attachments/assets/abebd20e-489f-4e34-b06c-03d14881a1c1




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
