### PR TITLE
test: Add e2e tests for the new account tree menu

### DIFF
--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -21,6 +21,9 @@ class AccountListPage {
   private readonly accountListItem =
     '.multichain-account-menu-popover__list--menu-item';
 
+  private readonly walletHeader =
+    '[data-testid="multichain-account-tree-wallet-header"]';
+
   private readonly accountMenuButton =
     '[data-testid="account-list-menu-details"]';
 
@@ -60,6 +63,11 @@ class AccountListPage {
 
   private readonly addSnapAccountButton = {
     text: 'Add account Snap',
+    tag: 'button',
+  };
+
+  private readonly walletDetailsButton = {
+    text: 'Details',
     tag: 'button',
   };
 
@@ -621,6 +629,27 @@ class AccountListPage {
       css: this.accountListItem,
       text: expectedLabel,
     });
+  }
+
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  async check_walletDisplayedInAccountListMenu(
+    expectedLabel: string = 'Wallet',
+  ): Promise<void> {
+    console.log(
+      `Check that wallet label ${expectedLabel} is displayed in account list menu`,
+    );
+    await this.driver.waitForSelector({
+      css: this.walletHeader,
+      text: expectedLabel,
+    });
+  }
+
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  async check_walletDetailsButtonIsDisplayed(): Promise<void> {
+    console.log('Check wallet details button is displayed');
+    await this.driver.waitForSelector(this.walletDetailsButton);
   }
 
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860

--- a/test/e2e/tests/multichain-accounts/common.ts
+++ b/test/e2e/tests/multichain-accounts/common.ts
@@ -1,0 +1,65 @@
+import { Mockttp } from 'mockttp';
+import { Driver } from '../../webdriver/driver';
+import FixtureBuilder from '../../fixture-builder';
+import { withFixtures } from '../../helpers';
+import AccountListPage from '../../page-objects/pages/account-list-page';
+import HeaderNavbar from '../../page-objects/pages/header-navbar';
+import HomePage from '../../page-objects/pages/home/homepage';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+import { MockedEndpoint } from '../../mock-e2e';
+
+const FEATURE_FLAGS_URL = 'https://client-config.api.cx.metamask.io/v1/flags';
+
+export const mockMultichainAccountsFeatureFlag = (mockServer: Mockttp) =>
+  mockServer
+    .forGet(FEATURE_FLAGS_URL)
+    .withQuery({
+      client: 'extension',
+      distribution: 'main',
+      environment: 'dev',
+    })
+    .thenCallback(() => {
+      return {
+        ok: true,
+        statusCode: 200,
+        json: [
+          {
+            enableMultichainAccounts: {
+              enabled: true,
+              featureVersion: '1',
+              minimumVersion: '12.19.0',
+            },
+          },
+        ],
+      };
+    });
+
+export async function withMultichainAccountsDesignEnabled(
+  {
+    title,
+    testSpecificMock = mockMultichainAccountsFeatureFlag,
+  }: {
+    title?: string;
+    testSpecificMock?: (mockServer: Mockttp) => Promise<MockedEndpoint>;
+  },
+  test: (driver: Driver) => Promise<void>,
+) {
+  await withFixtures(
+    {
+      fixtures: new FixtureBuilder().withKeyringControllerMultiSRP().build(),
+      testSpecificMock,
+      title,
+      dapp: true,
+    },
+    async ({ driver }: { driver: Driver; mockServer: Mockttp }) => {
+      await loginWithBalanceValidation(driver);
+      const homePage = new HomePage(driver);
+      await homePage.check_pageIsLoaded();
+      const headerNavbar = new HeaderNavbar(driver);
+      await headerNavbar.openAccountMenu();
+      const accountListPage = new AccountListPage(driver);
+      await accountListPage.check_pageIsLoaded();
+      await test(driver);
+    },
+  );
+}

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -1,0 +1,40 @@
+import { Suite } from 'mocha';
+import AccountListPage from '../../page-objects/pages/account-list-page';
+import { Driver } from '../../webdriver/driver';
+import { withMultichainAccountsDesignEnabled } from './common';
+
+describe('Multichain Accounts - Account tree', function (this: Suite) {
+  it('should display basic wallets and accounts', async function () {
+    await withMultichainAccountsDesignEnabled(
+      {
+        title: this.test?.fullTitle(),
+      },
+      async (driver: Driver) => {
+        const accountListPage = new AccountListPage(driver);
+        await accountListPage.check_pageIsLoaded();
+
+        // Ensure that wallet information is displayed
+        await accountListPage.check_walletDisplayedInAccountListMenu(
+          'Wallet 1',
+        );
+        await accountListPage.check_walletDisplayedInAccountListMenu(
+          'Wallet 2',
+        );
+        await accountListPage.check_walletDetailsButtonIsDisplayed();
+
+        // Ensure that accounts within the wallets are displayed
+        await accountListPage.check_accountAddressDisplayedInAccountList(
+          '0x5CfE7...6a7e1',
+        );
+        await accountListPage.check_accountAddressDisplayedInAccountList(
+          '0xc6D5a...874bf',
+        );
+        await accountListPage.check_accountBalanceDisplayed('$42,500.00');
+        await accountListPage.check_accountBalanceDisplayed('$0.00');
+        await accountListPage.check_accountDisplayedInAccountList('Account 1');
+        await accountListPage.check_accountDisplayedInAccountList('Account 2');
+        await accountListPage.check_numberOfAvailableAccounts(2);
+      },
+    );
+  });
+});

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -1,7 +1,16 @@
 import { Suite } from 'mocha';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import { Driver } from '../../webdriver/driver';
-import { AccountType, withMultichainAccountsDesignEnabled } from './common';
+import { mockSimpleKeyringSnap } from '../../mock-response-data/snaps/snap-binary-mocks';
+import { installSnapSimpleKeyring } from '../../page-objects/flows/snap-simple-keyring.flow';
+import SnapSimpleKeyringPage from '../../page-objects/pages/snap-simple-keyring-page';
+import { WINDOW_TITLES } from '../../helpers';
+import HeaderNavbar from '../../page-objects/pages/header-navbar';
+import {
+  AccountType,
+  mockMultichainAccountsFeatureFlag,
+  withMultichainAccountsDesignEnabled,
+} from './common';
 
 describe('Multichain Accounts - Account tree', function (this: Suite) {
   it('should display basic wallets and accounts', async function () {
@@ -67,6 +76,47 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
         await accountListPage.check_accountDisplayedInAccountList('Account 1');
         await accountListPage.check_accountDisplayedInAccountList('Ledger 1');
         await accountListPage.check_numberOfAvailableAccounts(2);
+      },
+    );
+  });
+
+  it('should display wallet for Snap Keyring', async function () {
+    await withMultichainAccountsDesignEnabled(
+      {
+        title: this.test?.fullTitle(),
+        accountType: AccountType.SSK,
+        testSpecificMock: async (mockServer) => {
+          await mockSimpleKeyringSnap(mockServer);
+          return mockMultichainAccountsFeatureFlag(mockServer);
+        },
+      },
+      async (driver: Driver) => {
+        await installSnapSimpleKeyring(driver);
+        const snapSimpleKeyringPage = new SnapSimpleKeyringPage(driver);
+        await snapSimpleKeyringPage.createNewAccount();
+
+        // Check snap account is displayed after adding the snap account.
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+        const headerNavbar = new HeaderNavbar(driver);
+        await headerNavbar.check_accountLabel('SSK Account');
+
+        const accountListPage = new AccountListPage(driver);
+        await accountListPage.check_pageIsLoaded();
+
+        // Ensure that wallet information is displayed
+        await accountListPage.check_walletDisplayedInAccountListMenu(
+          'Snap: MetaMask Simple Snap Keyring',
+        );
+        await accountListPage.check_walletDetailsButtonIsDisplayed();
+
+        // Ensure that an SSK account within the wallet is displayed
+        await accountListPage.check_accountBalanceDisplayed('$0.00');
+        await accountListPage.check_accountDisplayedInAccountList(
+          'SSK Account',
+        );
+        await accountListPage.check_numberOfAvailableAccounts(3);
       },
     );
   });

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -1,7 +1,7 @@
 import { Suite } from 'mocha';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import { Driver } from '../../webdriver/driver';
-import { withMultichainAccountsDesignEnabled } from './common';
+import { AccountType, withMultichainAccountsDesignEnabled } from './common';
 
 describe('Multichain Accounts - Account tree', function (this: Suite) {
   it('should display basic wallets and accounts', async function () {
@@ -33,6 +33,39 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
         await accountListPage.check_accountBalanceDisplayed('$0.00');
         await accountListPage.check_accountDisplayedInAccountList('Account 1');
         await accountListPage.check_accountDisplayedInAccountList('Account 2');
+        await accountListPage.check_numberOfAvailableAccounts(2);
+      },
+    );
+  });
+
+  it('should display wallet and accounts for hardware wallet', async function () {
+    await withMultichainAccountsDesignEnabled(
+      {
+        title: this.test?.fullTitle(),
+        accountType: AccountType.HardwareWallet,
+      },
+      async (driver: Driver) => {
+        const accountListPage = new AccountListPage(driver);
+        await accountListPage.check_pageIsLoaded();
+
+        // Ensure that wallet information is displayed
+        await accountListPage.check_walletDisplayedInAccountListMenu(
+          'Wallet 1',
+        );
+        await accountListPage.check_walletDisplayedInAccountListMenu('Ledger');
+        await accountListPage.check_walletDetailsButtonIsDisplayed();
+
+        // Ensure that accounts within the wallets are displayed
+        await accountListPage.check_accountAddressDisplayedInAccountList(
+          '0x5CfE7...6a7e1',
+        );
+        await accountListPage.check_accountAddressDisplayedInAccountList(
+          '0xF6846...8223c',
+        );
+        await accountListPage.check_accountBalanceDisplayed('$42,500.00');
+        await accountListPage.check_accountBalanceDisplayed('$0.00');
+        await accountListPage.check_accountDisplayedInAccountList('Account 1');
+        await accountListPage.check_accountDisplayedInAccountList('Ledger 1');
         await accountListPage.check_numberOfAvailableAccounts(2);
       },
     );

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -107,12 +107,17 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
 
         // Ensure that wallet information is displayed
         await accountListPage.check_walletDisplayedInAccountListMenu(
+          'Wallet 1',
+        );
+        await accountListPage.check_walletDisplayedInAccountListMenu(
           'Snap: MetaMask Simple Snap Keyring',
         );
         await accountListPage.check_walletDetailsButtonIsDisplayed();
 
         // Ensure that an SSK account within the wallet is displayed
+        await accountListPage.check_accountBalanceDisplayed('$42,500.00');
         await accountListPage.check_accountBalanceDisplayed('$0.00');
+        await accountListPage.check_accountDisplayedInAccountList('Account 1');
         await accountListPage.check_accountDisplayedInAccountList(
           'SSK Account',
         );

--- a/ui/components/multichain-accounts/multichain-accounts-tree/multichain-accounts-tree.tsx
+++ b/ui/components/multichain-accounts/multichain-accounts-tree/multichain-accounts-tree.tsx
@@ -68,6 +68,7 @@ export const MultichainAccountsTree = ({
         const walletHeader = (
           <Box
             key={`wallet-header-${walletId}`}
+            data-testid="multichain-account-tree-wallet-header"
             display={Display.Flex}
             justifyContent={JustifyContent.spaceBetween}
             alignItems={AlignItems.center}


### PR DESCRIPTION
## **Description**
This PR adds e2e tests for new multichain account list menu displayed as account/wallet tree.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34172?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-228

## **Manual testing steps**
No need for manual testing steps as this is e2e test.

## **Screenshots/Recordings**

### **Before**
n/a

### **After**
n/a

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.