### PR TITLE
fix: Use transaction request network chainId for PPOM Validation

### DIFF
--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -2,12 +2,11 @@ import { type Hex, JsonRpcResponseStruct } from '@metamask/utils';
 import { detectSIWE, SIWEMessage } from '@metamask/controller-utils';
 
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-
 import {
   BlockaidReason,
   BlockaidResultType,
 } from '../../../../shared/constants/security-provider';
-import { mockNetworkState } from '../../../../test/stub/networks';
+import { flushPromises } from '../../../../test/lib/timer-helpers';
 import { createPPOMMiddleware, PPOMMiddlewareRequest } from './ppom-middleware';
 import {
   generateSecurityAlertId,
@@ -15,7 +14,6 @@ import {
   validateRequestWithPPOM,
 } from './ppom-util';
 import { SecurityAlertResponse } from './types';
-import { flushPromises } from '../../../../test/lib/timer-helpers';
 
 jest.mock('./ppom-util');
 jest.mock('@metamask/controller-utils', () => ({

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -5,6 +5,7 @@ import {
   NetworkController,
 } from '@metamask/network-controller';
 import {
+  Hex,
   Json,
   JsonRpcParams,
   JsonRpcRequest,
@@ -113,7 +114,7 @@ export function createPPOMMiddleware<
             ppomController,
             request: req,
             securityAlertId,
-            chainId,
+            chainId: chainId as Hex,
             updateSecurityAlertResponse,
           }),
       );

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -78,7 +78,7 @@ export function createPPOMMiddleware<
       const { chainId } =
         networkController.getNetworkConfigurationByNetworkClientId(
           req.networkClientId,
-        )!;
+        ) ?? {};
 
       if (
         !securityAlertsEnabled ||

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -1,6 +1,9 @@
 import { AccountsController } from '@metamask/accounts-controller';
 import { PPOMController } from '@metamask/ppom-validator';
-import { NetworkController } from '@metamask/network-controller';
+import {
+  NetworkClientId,
+  NetworkController,
+} from '@metamask/network-controller';
 import {
   Json,
   JsonRpcParams,
@@ -13,7 +16,6 @@ import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import { SIGNING_METHODS } from '../../../../shared/constants/transaction';
 import { PreferencesController } from '../../controllers/preferences-controller';
 import { AppStateController } from '../../controllers/app-state-controller';
-import { getProviderConfig } from '../../../../shared/modules/selectors/networks';
 import { trace, TraceContext, TraceName } from '../../../../shared/lib/trace';
 import { LOADING_SECURITY_ALERT_RESPONSE } from '../../../../shared/constants/security-provider';
 import {
@@ -34,6 +36,7 @@ export type PPOMMiddlewareRequest<
 > = Required<JsonRpcRequest<Params>> & {
   securityAlertResponse?: SecurityAlertResponse | undefined;
   traceContext?: TraceContext;
+  networkClientId: NetworkClientId;
 };
 
 /**
@@ -73,12 +76,9 @@ export function createPPOMMiddleware<
       const { securityAlertsEnabled } = preferencesController.state;
 
       const { chainId } =
-        getProviderConfig({
-          metamask: networkController.state,
-        }) ?? {};
-      if (!chainId) {
-        return;
-      }
+        networkController.getNetworkConfigurationByNetworkClientId(
+          req.networkClientId,
+        )!;
 
       if (
         !securityAlertsEnabled ||

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -81,6 +81,10 @@ export function createPPOMMiddleware<
           req.networkClientId,
         ) ?? {};
 
+      if (!chainId) {
+        throw Error('ChainID not found for networkClientId');
+      }
+
       if (
         !securityAlertsEnabled ||
         !CONFIRMATION_METHODS.includes(req.method)

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -85,10 +85,10 @@ export async function processSendCalls(
   const { networkClientId, origin } = req;
   const transactions = calls.map((call) => ({ params: call }));
 
-  const chainId = messenger.call(
+  const { chainId } = messenger.call(
     'NetworkController:getNetworkClientById',
     networkClientId,
-  ).configuration.chainId;
+  ).configuration;
 
   const from =
     paramFrom ??

--- a/app/scripts/lib/transaction/eip5792.ts
+++ b/app/scripts/lib/transaction/eip5792.ts
@@ -85,7 +85,7 @@ export async function processSendCalls(
   const { networkClientId, origin } = req;
   const transactions = calls.map((call) => ({ params: call }));
 
-  const dappChainId = messenger.call(
+  const chainId = messenger.call(
     'NetworkController:getNetworkClientById',
     networkClientId,
   ).configuration.chainId;
@@ -101,7 +101,7 @@ export async function processSendCalls(
   if (Object.keys(transactions).length === 1) {
     batchId = await processSingleTransaction({
       addTransaction,
-      chainId: dappChainId,
+      chainId,
       from,
       networkClientId,
       origin,
@@ -114,7 +114,7 @@ export async function processSendCalls(
     batchId = await processMultipleTransaction({
       addTransactionBatch,
       isAtomicBatchSupported,
-      chainId: dappChainId,
+      chainId,
       from,
       getDismissSmartAccountSuggestionEnabled,
       messenger,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6387,11 +6387,16 @@ export default class MetamaskController extends EventEmitter {
     dappRequest,
     ...otherParams
   }) {
+    const networkClientId =
+      dappRequest?.networkClientId ?? transactionOptions?.networkClientId;
+    const { chainId } =
+      this.networkController.getNetworkConfigurationByNetworkClientId(
+        networkClientId,
+      );
     return {
       internalAccounts: this.accountsController.listAccounts(),
       dappRequest,
-      networkClientId:
-        dappRequest?.networkClientId ?? transactionOptions?.networkClientId,
+      networkClientId,
       selectedAccount: this.accountsController.getAccountByAddress(
         transactionParams.from,
       ),
@@ -6399,7 +6404,7 @@ export default class MetamaskController extends EventEmitter {
       transactionOptions,
       transactionParams,
       userOperationController: this.userOperationController,
-      chainId: this.#getGlobalChainId(),
+      chainId,
       ppomController: this.ppomController,
       securityAlertsEnabled:
         this.preferencesController.state?.securityAlertsEnabled,

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -536,7 +536,10 @@ describe('MetaMaskController', () => {
     describe('#getAddTransactionRequest', () => {
       it('formats the transaction for submission', () => {
         const transactionParams = { from: '0xa', to: '0xb' };
-        const transactionOptions = { foo: true };
+        const transactionOptions = {
+          foo: true,
+          networkClientId: NETWORK_CONFIGURATION_ID_1,
+        };
         const result = metamaskController.getAddTransactionRequest({
           transactionParams,
           transactionOptions,
@@ -545,7 +548,7 @@ describe('MetaMaskController', () => {
           internalAccounts:
             metamaskController.accountsController.listAccounts(),
           dappRequest: undefined,
-          networkClientId: undefined,
+          networkClientId: NETWORK_CONFIGURATION_ID_1,
           selectedAccount:
             metamaskController.accountsController.getAccountByAddress(
               transactionParams.from,
@@ -562,7 +565,10 @@ describe('MetaMaskController', () => {
       });
       it('passes through any additional params to the object', () => {
         const transactionParams = { from: '0xa', to: '0xb' };
-        const transactionOptions = { foo: true };
+        const transactionOptions = {
+          foo: true,
+          networkClientId: NETWORK_CONFIGURATION_ID_1,
+        };
         const result = metamaskController.getAddTransactionRequest({
           transactionParams,
           transactionOptions,


### PR DESCRIPTION
## **Description**

Use chainId from transaction request for PPOM validation. Transaction request has networkClientId which can be used to derive chainId

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5299

## **Manual testing steps**

1. Go to test-dapp
2. Connect to a network
3. Switch to a different network in MM
4. Submit a confirmation and debug that while invoking PPOM validation correct chainId is used

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
