### PR TITLE
feat: authenticate users if basic functionality is enabled

### DIFF
--- a/ui/hooks/identity/useAuthentication/useAutoSignIn.test.tsx
+++ b/ui/hooks/identity/useAuthentication/useAutoSignIn.test.tsx
@@ -9,9 +9,6 @@ type ArrangeMocksMetamaskStateOverrides = {
   useExternalServices: boolean;
   isSignedIn: boolean;
   completedOnboarding: boolean;
-  isBackupAndSyncEnabled: boolean;
-  participateInMetaMetrics: boolean;
-  isNotificationServicesEnabled: boolean;
 };
 
 const arrangeMockState = (
@@ -39,16 +36,10 @@ const prerequisitesStateKeys = [
   'completedOnboarding',
 ];
 
-const authDependentFeaturesStateKeys = [
-  'isBackupAndSyncEnabled',
-  'participateInMetaMetrics',
-  'isNotificationServicesEnabled',
-];
-
 const shouldAutoSignInTestCases: ArrangeMocksMetamaskStateOverrides[] = [];
 const shouldNotAutoSignInTestCases: ArrangeMocksMetamaskStateOverrides[] = [];
 
-// We generate all possible combinations of the prerequisites and auth-dependent features here
+// We generate all possible combinations of the prerequisites here
 const generateCombinations = (keys: string[]) => {
   const result: ArrangeMocksMetamaskStateOverrides[] = [];
   const total = 2 ** keys.length;
@@ -65,42 +56,27 @@ const generateCombinations = (keys: string[]) => {
 };
 
 const prerequisiteCombinations = generateCombinations(prerequisitesStateKeys);
-const authDependentCombinations = generateCombinations(
-  authDependentFeaturesStateKeys,
-);
 
-prerequisiteCombinations.forEach((prerequisiteState) => {
-  authDependentCombinations.forEach((authDependentState) => {
-    const combinedState = {
-      ...prerequisiteState,
-      ...authDependentState,
-    };
-    if (
-      combinedState.isUnlocked &&
-      combinedState.useExternalServices &&
-      combinedState.completedOnboarding &&
-      !combinedState.isSignedIn &&
-      authDependentFeaturesStateKeys.some(
-        (key) => combinedState[key as keyof ArrangeMocksMetamaskStateOverrides],
-      )
-    ) {
-      shouldAutoSignInTestCases.push(combinedState);
-    } else {
-      shouldNotAutoSignInTestCases.push(combinedState);
-    }
-  });
+prerequisiteCombinations.forEach((combinedState) => {
+  if (
+    combinedState.isUnlocked &&
+    combinedState.useExternalServices &&
+    combinedState.completedOnboarding &&
+    !combinedState.isSignedIn
+  ) {
+    shouldAutoSignInTestCases.push(combinedState);
+  } else {
+    shouldNotAutoSignInTestCases.push(combinedState);
+  }
 });
 
 describe('useAutoSignIn', () => {
   it('should initialize correctly', () => {
     const state = arrangeMockState({
       isUnlocked: false,
-      isBackupAndSyncEnabled: false,
       isSignedIn: false,
       completedOnboarding: false,
-      participateInMetaMetrics: false,
       useExternalServices: false,
-      isNotificationServicesEnabled: false,
     });
     arrangeMocks();
     const hook = renderHookWithProviderTyped(

--- a/ui/hooks/identity/useAuthentication/useAutoSignIn.ts
+++ b/ui/hooks/identity/useAuthentication/useAutoSignIn.ts
@@ -6,12 +6,9 @@ import {
 } from '../../../ducks/metamask/metamask';
 import {
   getMetaMaskKeyrings,
-  getParticipateInMetaMetrics,
   getUseExternalServices,
 } from '../../../selectors';
 import { selectIsSignedIn } from '../../../selectors/identity/authentication';
-import { selectIsBackupAndSyncEnabled } from '../../../selectors/identity/backup-and-sync';
-import { selectIsMetamaskNotificationsEnabled } from '../../../selectors/metamask-notifications/metamask-notifications';
 import { useSignIn } from './useSignIn';
 
 /**
@@ -46,7 +43,7 @@ export function useAutoSignIn(): {
     }
   }, [keyrings.length]);
 
-  const areBasePrerequisitesMet = useMemo(
+  const shouldAutoSignIn = useMemo(
     () =>
       (!isSignedIn || hasNewKeyrings) &&
       isUnlocked &&
@@ -60,29 +57,6 @@ export function useAutoSignIn(): {
       hasNewKeyrings,
     ],
   );
-
-  // Auth dependent features
-  const isBackupAndSyncEnabled = useSelector(selectIsBackupAndSyncEnabled);
-  const isParticipateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
-  const isNotificationServicesEnabled = useSelector(
-    selectIsMetamaskNotificationsEnabled,
-  );
-
-  const isAtLeastOneAuthDependentFeatureEnabled = useMemo(
-    () =>
-      isBackupAndSyncEnabled ||
-      isParticipateInMetaMetrics ||
-      isNotificationServicesEnabled,
-    [
-      isBackupAndSyncEnabled,
-      isParticipateInMetaMetrics,
-      isNotificationServicesEnabled,
-    ],
-  );
-
-  const shouldAutoSignIn = useMemo(() => {
-    return areBasePrerequisitesMet && isAtLeastOneAuthDependentFeatureEnabled;
-  }, [areBasePrerequisitesMet, isAtLeastOneAuthDependentFeatureEnabled]);
 
   const autoSignIn = useCallback(async () => {
     if (shouldAutoSignIn) {


### PR DESCRIPTION
## **Description**

This PR changes the authentication pre-requisites.
Having one auth related feature enabled is not required anymore to be automatically signed in. Only having basic functionality enabled suffices to automatically sign a user in.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34176?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Related to: https://consensyssoftware.atlassian.net/browse/IDENTITY-169

## **Manual testing steps**

1. Onboarding with basic functionality (BF) off
2. Verify (in the dev tools network tab) that no call to the authentication API has been made
3. Onboarding with BF on, but MetaMetrics, Notifications and Backup & Sync DISABLED
4. Verify that successful calls to the authentication API have been made

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
