### PR TITLE
fix: handle if srp length pasted is not equal to defined srp lengths cp-12.23.0

### DIFF
--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -79,6 +79,14 @@ export default function SrpInputImport({ onChange }: SrpInputImportProps) {
       active: false,
     }));
 
+    if (!SRP_LENGTHS.includes(finalSplittedSrp.length)) {
+      newDraftSrp.push({
+        word: '',
+        id: uuidv4(),
+        active: true,
+      });
+    }
+
     setDraftSrp(newDraftSrp);
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
`SRP_LENGTHS = [12, 15, 18, 21, 24]`
if the srp pasted is correct length, we show all input fields in password type
if the srp pasted is not correct length, we add empty active textfield at the end
if srp length is more than max (24), we cut excess words and show all fields in password type

This solves situation when user imports an SRP and accidentally, paste copy/paste less than 12 words, the SRP only shows the entered fields, making impossible for the user to introduce the remaining words, unless it clears all the fields.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34183?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improve handling of non-exact SRP lengths during import flow

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/34031

## **Manual testing steps**

1. Install new metamask app
2. Start import SRP flow
3. On SRP import page, paste non-exact SRP length (any length aside from this 12, 15, 18, 21, 24) 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
https://www.loom.com/share/e88635df8620445283982b3e48dcf7f7

### **After**

<!-- [screenshots/recordings] -->
**Less that 24 words**
https://github.com/user-attachments/assets/29dc0223-19c9-4ed8-98ad-c74b10685834

**More than 24 words**
https://github.com/user-attachments/assets/ad397f6f-46f9-497d-9d85-aad331881d60


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
