### PR TITLE
fix: show network manager if network not reached

### DIFF
--- a/ui/components/app/loading-network-screen/loading-network-screen.container.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.container.js
@@ -4,6 +4,7 @@ import * as actions from '../../../store/actions';
 import {
   getAllEnabledNetworks,
   getNetworkIdentifier,
+  isGlobalNetworkSelectorRemoved,
 } from '../../../selectors';
 import {
   getProviderConfig,
@@ -59,6 +60,9 @@ const mapDispatchToProps = (dispatch) => {
     rollbackToPreviousProvider: () =>
       dispatch(actions.rollbackToPreviousProvider()),
     showNetworkDropdown: () => {
+      if (isGlobalNetworkSelectorRemoved) {
+        return dispatch(actions.showModal({ name: 'NETWORK_MANAGER' }));
+      }
       return dispatch(actions.toggleNetworkMenu());
     },
   };

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -277,9 +277,11 @@ const DefaultNetworks = memo(() => {
           paddingTop={4}
           paddingLeft={4}
         >
-          <ButtonLink onClick={selectAllDefaultNetworks}>
-            {t('selectAll')}
-          </ButtonLink>
+          {isEvmNetworkSelected ? (
+            <ButtonLink onClick={selectAllDefaultNetworks}>
+              {t('selectAll')}
+            </ButtonLink>
+          ) : null}
         </Box>
         {networkListItems}
         {isEvmNetworkSelected && (

--- a/ui/components/multichain/network-manager/network-manager.test.tsx
+++ b/ui/components/multichain/network-manager/network-manager.test.tsx
@@ -4,8 +4,8 @@ import { RpcEndpointType } from '@metamask/network-controller';
 import { renderWithProvider } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
-import { NetworkManager } from './network-manager';
 import { SOLANA_WALLET_SNAP_ID } from '../../../../shared/lib/accounts';
+import { NetworkManager } from './network-manager';
 
 // Mock the store actions
 jest.mock('../../../store/actions', () => ({

--- a/ui/components/multichain/network-manager/network-manager.test.tsx
+++ b/ui/components/multichain/network-manager/network-manager.test.tsx
@@ -5,6 +5,7 @@ import { renderWithProvider } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 import { NetworkManager } from './network-manager';
+import { SOLANA_WALLET_SNAP_ID } from '../../../../shared/lib/accounts';
 
 // Mock the store actions
 jest.mock('../../../store/actions', () => ({
@@ -124,6 +125,46 @@ describe('NetworkManager Component', () => {
     return renderWithProvider(<NetworkManager />, store);
   };
 
+  const renderNetworkManagerWithNonEvmNetworkSelected = () => {
+    const store = configureStore({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        selectedNetworkClientId: 'mainnet',
+        multichainNetworkConfigurationsByChainId: {
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+            chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            isEvm: false,
+            name: 'Solana Mainnet',
+            nativeCurrency:
+              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          },
+        },
+      },
+      enabledNetworkMap: {
+        solana: {
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': true,
+        },
+      },
+      internalAccounts: {
+        accounts: {
+          'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3': {
+            address: '0x0',
+            id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+            type: 'solana:data-account',
+            metadata: {
+              snap: {
+                id: SOLANA_WALLET_SNAP_ID,
+              },
+            },
+          },
+        },
+        selectedAccount: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+      },
+    });
+    return renderWithProvider(<NetworkManager />, store);
+  };
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -141,6 +182,11 @@ describe('NetworkManager Component', () => {
     expect(screen.getByText('Optimism')).toBeInTheDocument();
     expect(screen.getByText('Avalanche')).toBeInTheDocument();
     expect(screen.getByText('Base')).toBeInTheDocument();
+  });
+
+  it('should not render select all button when non-EVM network is selected', () => {
+    renderNetworkManagerWithNonEvmNetworkSelected();
+    expect(screen.queryByText('Select all')).not.toBeInTheDocument();
   });
 
   it('switches tab when tab is clicked', () => {

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -620,6 +620,7 @@ export default class Routes extends Component {
         <Box className="main-container-wrapper">
           {isLoadingShown ? <Loading loadingMessage={loadMessage} /> : null}
           {!isLoading &&
+          isUnlocked &&
           isNetworkLoading &&
           completedOnboarding &&
           !isShowingDeepLinkRoute ? (

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   type UpdateNetworkFields,
+  NetworkConfiguration,
   RpcEndpointType,
 } from '@metamask/network-controller';
 import { Hex, isStrictHexString, parseCaipChainId } from '@metamask/utils';
@@ -72,7 +73,6 @@ import {
 } from '../../../../components/multichain/dropdown-editor/dropdown-editor';
 import {
   getIsRpcFailoverEnabled,
-  getNetworkConfigurationIdByChainId,
   getTokenNetworkFilter,
 } from '../../../../selectors';
 import { onlyKeepHost } from '../../../../../shared/lib/only-keep-host';
@@ -100,9 +100,6 @@ export const NetworksForm = ({
   const t = useI18nContext();
   const dispatch = useDispatch();
   const trackEvent = useContext(MetaMetricsContext);
-  const networkConfigurationIdsByChainId = useSelector(
-    getNetworkConfigurationIdByChainId,
-  );
   const scrollableRef = useRef<HTMLDivElement>(null);
   const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
   const isRpcFailoverEnabled = useSelector(getIsRpcFailoverEnabled);
@@ -311,16 +308,16 @@ export const NetworksForm = ({
             );
           }
         } else {
-          await dispatch(addNetwork(networkPayload));
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          if (networkConfigurationIdsByChainId?.[chainIdHex]) {
-            const networkClientId =
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              networkConfigurationIdsByChainId?.[chainIdHex];
-            await dispatch(setActiveNetwork(networkClientId));
-          }
+          const addedNetworkConfiguration = (await dispatch(
+            addNetwork(networkPayload),
+          )) as unknown as NetworkConfiguration;
+
+          const networkClientId =
+            addedNetworkConfiguration?.rpcEndpoints?.[
+              addedNetworkConfiguration.defaultRpcEndpointIndex
+            ]?.networkClientId;
+
+          await dispatch(setActiveNetwork(networkClientId));
           await dispatch(
             setEnabledNetworks([networkPayload.chainId], namespace),
           );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

the infinite loader is caused by the fact the the setActiveNetwork is not call after network beeing added 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34131?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->


## **Related issues**

Fixes: #34088 #34093 #34189

## **Manual testing steps**

1. Go to network manager
2. add local network
3. kill the instance
4. you should see the loader
5. you should see switch modal
6. switch/add network should make the loader hidden

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/367b8aaa-512e-44aa-a218-dc75fa143d38


### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/3605594d-5bec-4547-9890-1eae713c04d3




https://github.com/user-attachments/assets/7b49a852-03c1-4bc5-b654-5d1b88ed0898


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
