### PR TITLE
fix: Multi srp sync loading remove

### DIFF
--- a/ui/components/multichain/account-menu/account-menu.tsx
+++ b/ui/components/multichain/account-menu/account-menu.tsx
@@ -93,7 +93,6 @@ import { SrpList } from '../multi-srp/srp-list';
 import { INSTITUTIONAL_WALLET_SNAP_ID } from '../../../../shared/lib/accounts/institutional-wallet-snap';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 import { useSyncSRPs } from '../../../hooks/social-sync/useSyncSRPs';
-import Spinner from '../../ui/spinner';
 
 // TODO: Should we use an enum for this instead?
 export const ACTION_MODES = {
@@ -206,7 +205,9 @@ export const AccountMenu = ({
     getIsMultichainAccountsState1Enabled,
   );
 
-  const { loading: syncSRPsLoading } = useSyncSRPs();
+  // sync SRPs list when menu opens
+  useSyncSRPs();
+
   const [actionMode, setActionMode] = useState<ActionMode>(ACTION_MODES.LIST);
   const [previousActionMode, setPreviousActionMode] = useState<ActionMode>(
     ACTION_MODES.LIST,
@@ -677,57 +678,33 @@ export const AccountMenu = ({
         ) : null}
         {actionMode === ACTION_MODES.LIST ? (
           <>
-            {syncSRPsLoading ? (
+            {/* Menu content */}
+            {children}
+            {/* Add / Import / Hardware button */}
+            {showAccountCreation ? (
               <Box
-                display={Display.Flex}
-                flexDirection={FlexDirection.Column}
+                paddingTop={2}
+                paddingBottom={4}
+                paddingLeft={4}
+                paddingRight={4}
                 alignItems={AlignItems.center}
-                marginTop={12}
+                display={Display.Flex}
               >
-                <Spinner className="change-password__spinner" />
-                <Text variant={TextVariant.bodyLgMedium} marginBottom={4}>
-                  {t('syncingSeedPhrases')}
-                </Text>
-                <Text
-                  variant={TextVariant.bodySm}
-                  color={TextColor.textAlternative}
+                <ButtonSecondary
+                  startIconName={
+                    isMultichainAccountsState1Enabled ? undefined : IconName.Add
+                  }
+                  size={ButtonSecondarySize.Lg}
+                  block
+                  onClick={() => setActionMode(ACTION_MODES.MENU)}
+                  data-testid="multichain-account-menu-popover-action-button"
                 >
-                  {t('syncingSeedPhrasesNote')}
-                </Text>
+                  {isMultichainAccountsState1Enabled
+                    ? t('addAccountOrWallet')
+                    : t('addImportAccount')}
+                </ButtonSecondary>
               </Box>
-            ) : (
-              <>
-                {/* Menu content */}
-                {children}
-                {/* Add / Import / Hardware button */}
-                {showAccountCreation ? (
-                  <Box
-                    paddingTop={2}
-                    paddingBottom={4}
-                    paddingLeft={4}
-                    paddingRight={4}
-                    alignItems={AlignItems.center}
-                    display={Display.Flex}
-                  >
-                    <ButtonSecondary
-                      startIconName={
-                        isMultichainAccountsState1Enabled
-                          ? undefined
-                          : IconName.Add
-                      }
-                      size={ButtonSecondarySize.Lg}
-                      block
-                      onClick={() => setActionMode(ACTION_MODES.MENU)}
-                      data-testid="multichain-account-menu-popover-action-button"
-                    >
-                      {isMultichainAccountsState1Enabled
-                        ? t('addAccountOrWallet')
-                        : t('addImportAccount')}
-                    </ButtonSecondary>
-                  </Box>
-                ) : null}
-              </>
-            )}
+            ) : null}
           </>
         ) : null}
       </ModalContent>

--- a/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
@@ -128,11 +128,16 @@ export const SrpList = ({
                           button_type: 'details',
                         },
                       });
-                      setShowAccounts((prevState) =>
-                        prevState.map((value, i) =>
+                      setShowAccounts((prevState) => {
+                        const newState = prevState.map((value, i) =>
                           i === index ? !value : value,
-                        ),
-                      );
+                        );
+                        // if the newly synced account is selected, add it to the state
+                        if (index === prevState.length) {
+                          newState.push(true);
+                        }
+                        return newState;
+                      });
                     }}
                   >
                     {showHideText(index, keyring.accounts.length)}

--- a/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
@@ -129,14 +129,21 @@ export const SrpList = ({
                         },
                       });
                       setShowAccounts((prevState) => {
-                        const newState = prevState.map((value, i) =>
+                        const accountListLength =
+                          hdKeyringsWithSnapAccounts.length;
+                        let newState = prevState;
+                        if (accountListLength > prevState.length) {
+                          // Extend the state with `false` for new accounts
+                          newState = [
+                            ...prevState,
+                            ...Array(accountListLength - prevState.length).fill(
+                              false,
+                            ),
+                          ];
+                        }
+                        return newState.map((value, i) =>
                           i === index ? !value : value,
                         );
-                        // if the newly synced account is selected, add it to the state
-                        if (index === prevState.length) {
-                          newState.push(true);
-                        }
-                        return newState;
                       });
                     }}
                   >

--- a/ui/pages/settings/security-tab/reveal-srp-list/reveal-srp-list.tsx
+++ b/ui/pages/settings/security-tab/reveal-srp-list/reveal-srp-list.tsx
@@ -32,7 +32,6 @@ import {
 } from '../../../../selectors';
 import Card from '../../../../components/ui/card';
 import { useSyncSRPs } from '../../../../hooks/social-sync/useSyncSRPs';
-import Spinner from '../../../../components/ui/spinner';
 
 export const RevealSrpList = () => {
   const t = useI18nContext();
@@ -42,7 +41,9 @@ export const RevealSrpList = () => {
   const isSocialLoginFlow = useSelector(getIsSocialLoginFlow);
   const socialLoginType = useSelector(getSocialLoginType);
   const socialLoginEmail = useSelector(getSocialLoginEmail);
-  const { loading: syncSRPsLoading } = useSyncSRPs();
+
+  // sync SRPs list when page loads
+  useSyncSRPs();
 
   const onSrpActionComplete = (keyringId: string, triggerBackup?: boolean) => {
     if (triggerBackup) {
@@ -149,32 +150,11 @@ export const RevealSrpList = () => {
         >
           {t('securitySrpLabel')}
         </Text>
-        {syncSRPsLoading && (
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Column}
-            alignItems={AlignItems.center}
-            marginTop={12}
-          >
-            <Spinner className="change-password__spinner" />
-            <Text variant={TextVariant.bodyLgMedium} marginBottom={4}>
-              {t('syncingSeedPhrases')}
-            </Text>
-            <Text
-              variant={TextVariant.bodySm}
-              color={TextColor.textAlternative}
-            >
-              {t('syncingSeedPhrasesNote')}
-            </Text>
-          </Box>
-        )}
-        {!syncSRPsLoading && (
-          <SrpList
-            onActionComplete={onSrpActionComplete}
-            hideShowAccounts={false}
-            isSettingsPage={true}
-          />
-        )}
+        <SrpList
+          onActionComplete={onSrpActionComplete}
+          hideShowAccounts={false}
+          isSettingsPage={true}
+        />
       </Box>
       {srpQuizModalVisible && selectedKeyringId && (
         <SRPQuizModal

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -3224,10 +3224,7 @@ describe('Actions', () => {
       background.syncSeedPhrases.resolves();
       setBackgroundConnection(background);
 
-      const expectedActions = [
-        { type: 'SHOW_LOADING_INDICATION', payload: undefined },
-        { type: 'HIDE_LOADING_INDICATION' },
-      ];
+      const expectedActions = [];
 
       await store.dispatch(actions.syncSeedPhrases());
 
@@ -3243,9 +3240,7 @@ describe('Actions', () => {
       setBackgroundConnection(background);
 
       const expectedActions = [
-        { type: 'SHOW_LOADING_INDICATION', payload: undefined },
         { type: 'DISPLAY_WARNING', payload: errorMessage },
-        { type: 'HIDE_LOADING_INDICATION' },
       ];
 
       await expect(store.dispatch(actions.syncSeedPhrases())).rejects.toThrow(
@@ -3269,10 +3264,6 @@ describe('Actions', () => {
         // Expected to throw
       }
 
-      const actionsList = store.getActions();
-      const lastAction = actionsList[actionsList.length - 1];
-
-      expect(lastAction.type).toBe('HIDE_LOADING_INDICATION');
       expect(background.syncSeedPhrases.calledOnceWith()).toBe(true);
     });
   });

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -328,16 +328,12 @@ export function syncSeedPhrases(): ThunkAction<
   AnyAction
 > {
   return async (dispatch: MetaMaskReduxDispatch) => {
-    dispatch(showLoadingIndication());
-
     try {
       await submitRequestToBackground('syncSeedPhrases');
     } catch (error) {
       log.error('[syncSeedPhrases] error', error);
       dispatch(displayWarning(error.message));
       throw error;
-    } finally {
-      dispatch(hideLoadingIndication());
     }
   };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Previously in social login flow with multi SRP sync when opening the screen where SRPs are being synced, user will see loading indicator blocking whole SRP list until synchronization finish even when other SRP in local state hence user can't interact with available SRP in local state and must wait for the sync to finish
- This PR remove the loading indicator and let user interact with SRP in local state, SRP sync will come in at the bottom of the list when it's ready

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34226?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Remove app loading indicator and list loading indicator that hide SRP list during sync SRP in account menu and reveal srp list page in settings

## **Related issues**

Fixes:

## **Manual testing steps**

1. Log in to a wallet using social account
2. In another wallet instance with same social account logged in, add new SRP to the account
3. In the original wallet instance, click on account list and see the account sync coming in at the bottom after a while

1. Login to a social account on 2 wallet instances
2. Add a private key to 1 instance
3. On the other instance open account list, the new imported private key should be synced

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/d1d005ca-ba1a-4f50-b7dd-9edcb3b0e2c6



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/5d4db077-e991-44a9-b990-1b75fd6dfe3b



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
