### PR TITLE
fix: Fixing migration to be cherry-picked into version 12.23.0

### DIFF
--- a/app/scripts/migrations/170.1.test.ts
+++ b/app/scripts/migrations/170.1.test.ts
@@ -1,6 +1,6 @@
-import { migrate, version } from './172';
+import { migrate, version } from './170.1.1';
 
-const oldVersion = 171;
+const oldVersion = 170;
 
 describe(`migration #${version}`, () => {
   it('updates the version metadata', async () => {

--- a/app/scripts/migrations/170.1.test.ts
+++ b/app/scripts/migrations/170.1.test.ts
@@ -1,4 +1,4 @@
-import { migrate, version } from './170.1.1';
+import { migrate, version } from './170.1';
 
 const oldVersion = 170;
 

--- a/app/scripts/migrations/170.1.ts
+++ b/app/scripts/migrations/170.1.ts
@@ -6,7 +6,7 @@ type VersionedData = {
   data: Record<string, unknown>;
 };
 
-export const version = 172;
+export const version = 170.1;
 
 /**
  * This migration deletes the preference `smartAccountOptInForAccounts`.

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -201,8 +201,8 @@ const migrations = [
   require('./168'),
   require('./169'),
   require('./170'),
-  require('./171'),
   require('./170.1'),
+  require('./171'),
 ];
 
 export default migrations;

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -202,7 +202,7 @@ const migrations = [
   require('./169'),
   require('./170'),
   require('./171'),
-  require('./172'),
+  require('./170.1'),
 ];
 
 export default migrations;


### PR DESCRIPTION
## **Description**

Migration needs re-ordering to be cherry-picked 
https://github.com/MetaMask/metamask-extension/pull/34219

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Related to: https://github.com/MetaMask/MetaMask-planning/issues/5316
Related to: https://github.com/MetaMask/MetaMask-planning/issues/5310

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
