### PR TITLE
fix: dependent/dependency usage in `ts-migration-dashboard`

### DIFF
--- a/development/ts-migration-dashboard/app/components/App.tsx
+++ b/development/ts-migration-dashboard/app/components/App.tsx
@@ -148,10 +148,11 @@ export default function App() {
             You can hover over a box to see the name of the file that it
             represents. You can also click on a box to see connections between
             other files;{' '}
-            <strong className="module-connection__dependency">red</strong> lines
-            lead to dependencies (other files that import the file);{' '}
-            <strong className="module-connection__dependent">blue</strong> lines
-            lead to dependents (other files that are imported by the file).
+            <strong className="module-connection__dependent">red</strong> lines
+            lead to dependents (other files that import the file);{' '}
+            <strong className="module-connection__dependency">blue</strong>
+            lines lead to dependencies (other files that are imported by the
+            file).
           </p>
 
           <p>

--- a/development/ts-migration-dashboard/app/styles/custom-elements.scss
+++ b/development/ts-migration-dashboard/app/styles/custom-elements.scss
@@ -151,34 +151,34 @@ Disabling Stylelint's hex color rule here because the TypeScript migration dashb
 }
 
 .module-connection {
-  &__dependency-arrowhead {
+  &__dependent-arrowhead {
     fill: var(--red);
   }
 
-  &__dependency {
+  &__dependent {
     fill: none;
     stroke: var(--red);
     color: var(--red);
     stroke-width: 2px;
   }
 
-  &__dependency-point {
+  &__dependent-point {
     fill: var(--red);
     r: 3px;
   }
 
-  &__dependent-arrowhead {
+  &__dependency-arrowhead {
     fill: var(--blue);
   }
 
-  &__dependent {
+  &__dependency {
     fill: none;
     stroke: var(--blue);
     color: var(--blue);
     stroke-width: 2px;
   }
 
-  &__dependent-point {
+  &__dependency-point {
     fill: var(--blue);
     r: 3px;
   }

--- a/development/ts-migration-dashboard/common/build-module-partitions.ts
+++ b/development/ts-migration-dashboard/common/build-module-partitions.ts
@@ -276,8 +276,8 @@ function buildModulesWithLevels(
       if (existingDependencyModule === undefined) {
         existingDependencyModule = {
           id: dependencyModuleId,
-          dependents: [currentModule],
-          dependencies: [],
+          dependents: [],
+          dependencies: [currentModule],
           level: currentModule.level + 1,
           isExternal: Boolean(npmPackageMatch),
           hasBeenConverted: /\.tsx?$/u.test(dependencyModuleId),
@@ -296,19 +296,19 @@ function buildModulesWithLevels(
       }
 
       if (
-        !existingDependencyModule.dependents.some(
+        !existingDependencyModule.dependencies.some(
           (m) => m.id === currentModule.id,
         )
       ) {
-        existingDependencyModule.dependents.push(currentModule);
+        existingDependencyModule.dependencies.push(currentModule);
       }
 
       if (
-        !currentModule.dependencies.some(
+        !currentModule.dependents.some(
           (m) => m.id === existingDependencyModule.id,
         )
       ) {
-        currentModule.dependencies.push(existingDependencyModule);
+        currentModule.dependents.push(existingDependencyModule);
       }
     }
     if (dependencyModulesToFill.length > 0) {

--- a/development/ts-migration-dashboard/common/build-module-partitions.ts
+++ b/development/ts-migration-dashboard/common/build-module-partitions.ts
@@ -14,7 +14,8 @@ import {
  *
  * @property id - If an NPM package, then the name of the package; otherwise the
  * path to a file within the project.
- * @property dependents - The modules which are imported by this module.
+ * @property dependents - The modules which import this module.
+ * @property dependencies - The modules which are imported by this module.
  * @property level - How many modules it takes to import this module (from the
  * root of the dependency tree).
  * @property isExternal - Whether the module refers to a NPM package.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

For a given module A, its dependencies are upstream modules that are imported by A, while its dependents or "reverse dependencies" are downstream modules that import A (i.e. modules that have A as a dependency). 

The usage of this terminology is inconsistent in the UI and source code of the extension TypeScript migration dashboard. This commit fixes the erroneous usages.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34231?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
