### PR TITLE
fix: cp-12.22.2 Fix crash on older browser versions

### DIFF
--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -3,8 +3,7 @@
 // We don't usually `import` files into `app-init.js` because we need to load
 // "chunks" via `importScripts`; but in this case `promise-with-resolvers` file
 // is so small we won't ever have a problem with these two files being "split".
-// Import to set up global `Promise.withResolvers` polyfill
-import '../../shared/lib/promise-with-resolvers';
+import { withResolvers } from '../../shared/lib/promise-with-resolvers';
 
 // Represents if importAllScripts has been run
 // eslint-disable-next-line
@@ -200,7 +199,7 @@ const registerInPageContentScript = async () => {
  *
  * @type {PromiseWithResolvers<chrome.runtime.InstalledDetails>}
  */
-const deferredOnInstalledListener = Promise.withResolvers();
+const deferredOnInstalledListener = withResolvers();
 globalThis.stateHooks.onInstalledListener = deferredOnInstalledListener.promise;
 
 /**

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -14,8 +14,7 @@ import browser from 'webextension-polyfill';
 import { isObject, hasProperty } from '@metamask/utils';
 import PortStream from 'extension-port-stream';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
-// Import to set up global `Promise.withResolvers` polyfill
-import '../../shared/lib/promise-with-resolvers';
+import { withResolvers } from '../../shared/lib/promise-with-resolvers';
 import { FirstTimeFlowType } from '../../shared/constants/onboarding';
 
 import {
@@ -200,7 +199,7 @@ let rejectInitialization;
  * state of application initialization (or re-initialization).
  */
 function setGlobalInitializers() {
-  const deferred = Promise.withResolvers();
+  const deferred = withResolvers();
   isInitialized = deferred.promise;
   resolveInitialization = deferred.resolve;
   rejectInitialization = deferred.reject;

--- a/app/scripts/lib/operation-safener.ts
+++ b/app/scripts/lib/operation-safener.ts
@@ -1,5 +1,6 @@
 import { type DebounceSettings, type DebouncedFunc, debounce } from 'lodash';
 import log from 'loglevel';
+import { withResolvers } from '../../../shared/lib/promise-with-resolvers';
 
 export type { DebounceSettings } from 'lodash';
 
@@ -115,7 +116,7 @@ export class OperationSafener<O extends Op = Op> {
       // rejection from running `this.#bouncer.flush()` *is* an unhandled
       // rejection; we want it to bubble up to the process/window's
       // `unhandledRejection` listener, i.e., Sentry.
-      const { promise, resolve } = Promise.withResolvers<void>();
+      const { promise, resolve } = withResolvers<void>();
       finalInvocation.finally(resolve);
       this.#evacuating = promise;
     } else {

--- a/app/scripts/lib/rpc-method-middleware/handlers/request-accounts.test.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/request-accounts.test.ts
@@ -105,7 +105,10 @@ describe('requestEthereumAccountsHandler', () => {
     it('blocks subsequent requests if there is currently a request waiting for the wallet to be unlocked', async () => {
       const { handler, getUnlockPromise, getAccounts, end, response } =
         createMockedHandler();
-      const { promise, resolve } = Promise.withResolvers<void>();
+      // `withResolvers` is supported by Node.js LTS. It's optional in global type due to older
+      // browser support.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const { promise, resolve } = Promise.withResolvers!<void>();
       getUnlockPromise.mockReturnValue(promise);
       getAccounts.mockReturnValue(['0xdead', '0xbeef']);
 

--- a/app/scripts/lib/util.test.js
+++ b/app/scripts/lib/util.test.js
@@ -3,8 +3,6 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-// Import to set up global `Promise.withResolvers` polyfill
-import '../../../shared/lib/promise-with-resolvers';
 import {
   ENVIRONMENT_TYPE_BACKGROUND,
   ENVIRONMENT_TYPE_FULLSCREEN,

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1,8 +1,6 @@
 /**
  * @jest-environment node
  */
-// Import to set up global `Promise.withResolvers` polyfill
-import '../../shared/lib/promise-with-resolvers';
 import { cloneDeep } from 'lodash';
 import nock from 'nock';
 import { obj as createThroughStream } from 'through2';

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -18,8 +18,6 @@ import browser from 'webextension-polyfill';
 import { StreamProvider } from '@metamask/providers';
 import { createIdRemapMiddleware } from '@metamask/json-rpc-engine';
 import log from 'loglevel';
-// Import to set up global `Promise.withResolvers` polyfill
-import '../../shared/lib/promise-with-resolvers';
 import launchMetaMaskUi, {
   updateBackgroundConnection,
   displayStateCorruptionError,

--- a/development/webpack/test/loaders.codeFenceLoader.test.ts
+++ b/development/webpack/test/loaders.codeFenceLoader.test.ts
@@ -26,7 +26,10 @@ console.log('I am Groot.');
       ? source.replace(`${fencedSource}\n`, '')
       : source;
 
-    const { promise, resolve } = Promise.withResolvers<CallbackArgs>();
+    // `withResolvers` is supported by Node.js LTS. It's optional in global type due to older
+    // browser support.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { promise, resolve } = Promise.withResolvers!<CallbackArgs>();
     const mockContext = {
       getOptions: () => {
         return {

--- a/development/webpack/test/loaders.swcLoader.test.ts
+++ b/development/webpack/test/loaders.swcLoader.test.ts
@@ -22,7 +22,10 @@ describe('swcLoader', () => {
     // swc doesn't use node's fs module, so we can't mock
     const resourcePath = 'test.ts';
 
-    const { promise, resolve } = Promise.withResolvers<CallbackArgs>();
+    // `withResolvers` is supported by Node.js LTS. It's optional in global type due to older
+    // browser support.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { promise, resolve } = Promise.withResolvers!<CallbackArgs>();
     const mockContext = {
       mode: 'production',
       sourceMap: true,

--- a/shared/lib/promise-with-resolvers.ts
+++ b/shared/lib/promise-with-resolvers.ts
@@ -24,4 +24,4 @@ const withResolversPonyfill = <ReturnType>() => {
 export const withResolvers =
   typeof Promise.withResolvers === 'undefined'
     ? withResolversPonyfill
-    : Promise.withResolvers;
+    : Promise.withResolvers.bind(Promise);

--- a/shared/lib/promise-with-resolvers.ts
+++ b/shared/lib/promise-with-resolvers.ts
@@ -1,19 +1,27 @@
-// this polyfill can be removed once we drop support for Firefox v121 (after
-// June 24 2025) Chrome v119 (after November 14, 2025). If you are removing
-// this, you should also remove the types polyfill for it in types/global.d.ts
-// and app/scripts/app-init.js
-if (typeof Promise.withResolvers === 'undefined') {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Promise.withResolvers = function withResolvers<T>() {
-    let resolve!: (value: T | PromiseLike<T>) => void;
-    let reject!: (reason?: unknown) => void;
-    const promise = new this<T>((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
-    return { promise, resolve, reject };
-  };
-}
+// This ponyfill can be removed once we drop support for Firefox v121 (after
+// June 24 2025) Chrome v119 (after November 14, 2025)
+const withResolversPonyfill = <ReturnType>() => {
+  let resolve!: (value: ReturnType | PromiseLike<ReturnType>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<ReturnType>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
 
-export {};
+/**
+ * Creates a new Promise and returns it in an object, along with its resolve and reject functions.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers
+ *
+ * @returns An object with the properties `promise`, `resolve`, and `reject`.
+ *
+ * ```ts
+ * const { promise, resolve, reject } = Promise.withResolvers<T>();
+ * ```
+ */
+export const withResolvers =
+  typeof Promise.withResolvers === 'undefined'
+    ? withResolversPonyfill
+    : Promise.withResolvers;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -351,7 +351,7 @@ export declare global {
      */
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    withResolvers<T>(): PromiseWithResolvers<T>;
+    withResolvers?: <T>() => PromiseWithResolvers<T>;
   }
 }
 // #endregion


### PR DESCRIPTION
## **Description**

Fix crash on older browser versions caused by broken polyfill. Affected browser versions were Chrome versions 109-118, and Firefox versions 102-120.

The error was caused by the `withResolvers` polyfill. The polyfill tried to add the `withResolvers` function to the `Promise` global if it was missing, but this is forbidden under SES lockdown and would fail in a production build.

I worked around this problem by converting the polyfill to a ponyfill that had to be imported, rather than mutating a global. This should work the same way but avoids the lockdown error.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34255?quickstart=1)

## **Changelog**

CHANGELOG entry: Fix crash on older browsers

## **Related issues**

Fixes #34235

## **Manual testing steps**

Test on affected browser ranges, and on newer browser versions. The extension should not start correctly if the failure case is hit. Check the background and UI consoles for errors just to be sure.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
