### PR TITLE
fix: show avatar account on all screens except header

### DIFF
--- a/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
+++ b/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
@@ -13,8 +13,19 @@ exports[`AccountPicker renders properly 1`] = `
         class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--color-text-default"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--gap-0 mm-box--flex-direction-column mm-box--align-items-center"
+          class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center"
         >
+          <div
+            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+          >
+            <img
+              alt=""
+              height="16"
+              src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMTM5IDg5JSA1OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzMjEgOTIlIDU2JSkiIGQ9Ik0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0zLDJoMXYxaC0xek00LDJoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0zLDZoMXYxaC0xek00LDZoMXYxaC0xek0wLDdoMXYxaC0xek03LDdoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjUgNDclIDU1JSkiIGQ9Ik0xLDBoMXYxaC0xek02LDBoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xeiIvPjwvc3ZnPg=="
+              style="border-radius: 50%;"
+              width="16"
+            />
+          </div>
           <span
             class="mm-box mm-text multichain-account-picker__label mm-text--body-md mm-text--ellipsis mm-box--color-text-default"
           >

--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { useSelector } from 'react-redux';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import {
+  AvatarAccount,
+  AvatarAccountVariant,
   Box,
   ButtonBase,
   ButtonBaseSize,
@@ -22,6 +25,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { shortenAddress } from '../../../helpers/utils/util';
 import { trace, TraceName } from '../../../../shared/lib/trace';
+import { getUseBlockie } from '../../../selectors';
 
 export const AccountPicker = ({
   address,
@@ -33,9 +37,16 @@ export const AccountPicker = ({
   labelProps = {},
   textProps = {},
   className = '',
+  showAvatarAccount = true,
   ...props
 }) => {
-  const shortenedAddress = shortenAddress(toChecksumHexAddress(address));
+  AccountPicker.propTypes = {
+    showAvatarAccount: PropTypes.bool,
+  };
+  const useBlockie = useSelector(getUseBlockie);
+  const shortenedAddress = address
+    ? shortenAddress(toChecksumHexAddress(address))
+    : '';
 
   return (
     <Box
@@ -71,10 +82,24 @@ export const AccountPicker = ({
       >
         <Box
           display={Display.Flex}
-          flexDirection={FlexDirection.Column}
+          flexDirection={
+            showAvatarAccount ? FlexDirection.Row : FlexDirection.Column
+          }
           alignItems={AlignItems.center}
-          gap={0}
+          gap={showAvatarAccount ? 2 : 0}
         >
+          {showAvatarAccount ? (
+            <AvatarAccount
+              variant={
+                useBlockie
+                  ? AvatarAccountVariant.Blockies
+                  : AvatarAccountVariant.Jazzicon
+              }
+              address={address}
+              size={showAddress ? Size.MD : Size.XS}
+              borderColor={BackgroundColor.backgroundDefault} // we currently don't have white color for border hence using backgroundDefault as the border
+            />
+          ) : null}
           <Text
             as="span"
             ellipsis

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -190,6 +190,7 @@ export const AppHeaderUnlockedContent = ({
             <AccountPicker
               address={internalAccount.address}
               name={internalAccount.metadata.name}
+              showAvatarAccount={false}
               onClick={() => {
                 dispatch(toggleAccountMenu());
 

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -62,8 +62,51 @@ exports[`SendPage render and initialization should render correctly even when a 
                 class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--width-full mm-box--color-text-default"
               >
                 <div
-                  class="mm-box mm-box--display-flex mm-box--gap-0 mm-box--flex-direction-column mm-box--align-items-center"
+                  class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center"
                 >
+                  <div
+                    class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+                  >
+                    <div
+                      class="mm-avatar-account__jazzicon"
+                    >
+                      <div
+                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 151, 242);"
+                      >
+                        <svg
+                          height="32"
+                          width="32"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#2362E1"
+                            height="32"
+                            transform="translate(3.589330184792517 -5.334310623233522) rotate(458.4 16 16)"
+                            width="32"
+                            x="0"
+                            y="0"
+                          />
+                          <rect
+                            fill="#F94301"
+                            height="32"
+                            transform="translate(-15.363459289650208 7.992351635486631) rotate(268.8 16 16)"
+                            width="32"
+                            x="0"
+                            y="0"
+                          />
+                          <rect
+                            fill="#FA7900"
+                            height="32"
+                            transform="translate(-9.076254079301423 29.480015880683375) rotate(117.3 16 16)"
+                            width="32"
+                            x="0"
+                            y="0"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
                   <span
                     class="mm-box mm-text multichain-account-picker__label multichain-send-page__account-picker__label mm-text--body-md mm-text--ellipsis mm-box--padding-inline-start-1 mm-box--color-text-default"
                     style="flex-grow: 1; text-align: start;"

--- a/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
@@ -25,8 +25,51 @@ exports[`SendPageAccountPicker render renders correctly 1`] = `
           class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--width-full mm-box--color-text-default"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-0 mm-box--flex-direction-column mm-box--align-items-center"
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center"
           >
+            <div
+              class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+            >
+              <div
+                class="mm-avatar-account__jazzicon"
+              >
+                <div
+                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
+                >
+                  <svg
+                    height="32"
+                    width="32"
+                    x="0"
+                    y="0"
+                  >
+                    <rect
+                      fill="#18CDF2"
+                      height="32"
+                      transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                      width="32"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#035E56"
+                      height="32"
+                      transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                      width="32"
+                      x="0"
+                      y="0"
+                    />
+                    <rect
+                      fill="#F26602"
+                      height="32"
+                      transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                      width="32"
+                      x="0"
+                      y="0"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
             <span
               class="mm-box mm-text multichain-account-picker__label multichain-send-page__account-picker__label mm-text--body-md mm-text--ellipsis mm-box--padding-inline-start-1 mm-box--color-text-default"
               style="flex-grow: 1; text-align: start;"


### PR DESCRIPTION
This PR ensures that avatar account is rendered in account picker component on all the screens except header

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Show avatar account is send account picker

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
![Screenshot 2025-07-15 at 12 37 34 PM](https://github.com/user-attachments/assets/de4bd014-b02c-4b42-9b5e-afd047a6ac71)

<!-- [screenshots/recordings] -->

### **After**

![Screenshot 2025-07-15 at 12 35 05 PM](https://github.com/user-attachments/assets/427c1777-1f4e-4f33-91f3-fa42c913f5bd)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
