### PR TITLE
fix: ellipses on long label names in destination acct picker

### DIFF
--- a/ui/pages/bridge/prepare/components/destination-account-list-item.tsx
+++ b/ui/pages/bridge/prepare/components/destination-account-list-item.tsx
@@ -157,15 +157,28 @@ const DestinationAccountListItem: React.FC<DestinationAccountListItemProps> = ({
         <Box
           display={Display.Flex}
           justifyContent={JustifyContent.spaceBetween}
+          gap={2}
+          style={{ width: '100%' }}
         >
-          <Text variant={TextVariant.bodyMdMedium}>
-            {account.metadata.name}
-          </Text>
+          <Box
+            display={Display.Flex}
+            alignItems={AlignItems.center}
+            style={{ minWidth: 0, flex: '1 1 auto', overflow: 'hidden' }}
+          >
+            <Text
+              variant={TextVariant.bodyMdMedium}
+              ellipsis
+              style={{ maxWidth: '200px' }}
+            >
+              {account.metadata.name}
+            </Text>
+          </Box>
           <Box
             display={Display.Flex}
             alignItems={AlignItems.center}
             justifyContent={JustifyContent.flexEnd}
             gap={1}
+            style={{ minWidth: 'fit-content', flexShrink: 0 }}
           >
             {/* <AvatarToken
               src={primaryTokenImage}
@@ -179,8 +192,8 @@ const DestinationAccountListItem: React.FC<DestinationAccountListItemProps> = ({
               flexDirection={FlexDirection.Row}
               alignItems={AlignItems.center}
               justifyContent={JustifyContent.flexEnd}
-              ellipsis
               textAlign={TextAlign.End}
+              style={{ whiteSpace: 'nowrap' }}
             >
               <UserPreferencedCurrencyDisplay
                 ethNumberOfDecimals={MAXIMUM_CURRENCY_DECIMALS}

--- a/ui/pages/bridge/prepare/components/destination-account-picker.tsx
+++ b/ui/pages/bridge/prepare/components/destination-account-picker.tsx
@@ -91,6 +91,7 @@ export const DestinationAccountPicker = ({
         <Box
           className="destination-account-picker__selected"
           width={BlockSize.Full}
+          style={{ flex: 1, minWidth: 0 }}
         >
           <DestinationSelectedAccountListItem
             account={selectedSwapToAccount}

--- a/ui/pages/bridge/prepare/components/destination-selected-account-list-item.tsx
+++ b/ui/pages/bridge/prepare/components/destination-selected-account-list-item.tsx
@@ -62,7 +62,10 @@ const DestinationSelectedAccountListItem: React.FC<
         marginInlineEnd={2}
       />
 
-      <Box display={Display.Flex} style={{ flexDirection: 'column' }}>
+      <Box
+        display={Display.Flex}
+        style={{ flexDirection: 'column', maxWidth: 'calc(100% - 60px)' }}
+      >
         <Text
           variant={TextVariant.bodySmMedium}
           color={TextColor.textAlternative}
@@ -72,7 +75,7 @@ const DestinationSelectedAccountListItem: React.FC<
           {t('destinationAccountPickerReceiveAt')}
         </Text>
 
-        <Text variant={TextVariant.bodyMdMedium} marginBottom={1}>
+        <Text variant={TextVariant.bodyMdMedium} marginBottom={1} ellipsis>
           {(() => {
             if (isExternalAccount) {
               if (account.metadata.name.endsWith('.eth')) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Custom account names were overflowing in the destination account picker when doing a multichain bridge. This PR adds ellipses when account names get too long to prevent this in the selected list item and the list item components.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34309?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="381" height="318" alt="Screenshot 2025-07-15 at 5 36 57 PM" src="https://github.com/user-attachments/assets/80d739df-8cd9-4a7e-990e-cd2af93fc823" />
<img width="392" height="101" alt="Screenshot 2025-07-15 at 5 37 01 PM" src="https://github.com/user-attachments/assets/62fed6f1-d6cf-4dbd-9cd6-cb4fe821fd62" />


<!-- [screenshots/recordings] -->

### **After**

<img width="393" height="338" alt="Screenshot 2025-07-15 at 5 35 36 PM" src="https://github.com/user-attachments/assets/cf6d931a-8bda-48d7-a0fd-b9b0ff9678c0" />
<img width="388" height="143" alt="Screenshot 2025-07-15 at 5 35 40 PM" src="https://github.com/user-attachments/assets/040076ad-e1d2-4fa4-bc99-4d35d4309ab6" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
