### PR TITLE
release: cp-12.23.0 bump @metamask/solana-wallet-standard to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,7 +337,7 @@
     "@metamask/snaps-sdk": "^9.1.0",
     "@metamask/snaps-utils": "^11.0.0",
     "@metamask/solana-wallet-snap": "^1.35.2",
-    "@metamask/solana-wallet-standard": "^0.5.0",
+    "@metamask/solana-wallet-standard": "^0.5.1",
     "@metamask/streams": "^0.2.0",
     "@metamask/transaction-controller": "^58.1.0",
     "@metamask/user-operation-controller": "^36.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7398,9 +7398,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/solana-wallet-standard@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@metamask/solana-wallet-standard@npm:0.5.0"
+"@metamask/solana-wallet-standard@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@metamask/solana-wallet-standard@npm:0.5.1"
   dependencies:
     "@solana/wallet-standard-chains": "npm:^1.1.1"
     "@solana/wallet-standard-features": "npm:^1.3.0"
@@ -7408,7 +7408,7 @@ __metadata:
     "@wallet-standard/features": "npm:^1.1.0"
     "@wallet-standard/wallet": "npm:^1.1.0"
     bs58: "npm:^6.0.0"
-  checksum: 10/061e6bf39e978c8a3d234b57b72a220d611c31a8b96e1cce14c6c68d8e975da7d5558ab9b619e41b17ebe0b45f9e95649ff7de404c5bbe066a675f70fa9f860c
+  checksum: 10/fed23c9507896c67a2efb3b55c26872c6d9172eb662a1ecbe081d8f78fa56d3393f59b3997726ccb459e026c04163354d30ca8d05e4b3f431026889878a1c3ba
   languageName: node
   linkType: hard
 
@@ -31850,7 +31850,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^9.1.0"
     "@metamask/snaps-utils": "npm:^11.0.0"
     "@metamask/solana-wallet-snap": "npm:^1.35.2"
-    "@metamask/solana-wallet-standard": "npm:^0.5.0"
+    "@metamask/solana-wallet-standard": "npm:^0.5.1"
     "@metamask/streams": "npm:^0.2.0"
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/test-bundler": "npm:^1.0.0"


### PR DESCRIPTION
## Original PR against main

https://github.com/MetaMask/metamask-extension/pull/34281

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR bumps @metamask/solana-wallet-standard to 0.5.1, to fix a bug that was causing disconnection of EVM scopes when removing Solana permissions while being connected with Wallet Standard.

The fix is to not call `wallet_revokeSession` when the Wallet Standard disconnection comes from an `accountsChanged` event.
Related change: https://github.com/MetaMask/solana-wallet-standard/pull/48

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34281?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5376
Contributes to fixing https://github.com/MetaMask/MetaMask-planning/issues/5158

## **Manual testing steps**

1. Go to https://metamask.github.io/test-dapp-solana/staging/
2. Connect with both an EVM and a Solana account
3. Disconnect the Solana account from MetaMask by editing the permissions
4. EVM account should still be connected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/5d94e168-167c-4e61-b41f-ed0d72b600ec

### **After**

https://github.com/user-attachments/assets/8f147b29-246d-47d9-a72c-d86523357c7c

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
