### PR TITLE
fix: (dev-only) ensure NetworkOrderController isn't reset when extension is reloaded

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1051,8 +1051,9 @@ export default class MetamaskController extends EventEmitter {
       ],
     });
 
-    let initialNetworkOrderControllerState;
+    let initialNetworkOrderControllerState = initState.NetworkOrderController;
     if (
+      !initialNetworkOrderControllerState &&
       process.env.METAMASK_DEBUG &&
       process.env.METAMASK_ENVIRONMENT === 'development' &&
       !process.env.IN_TEST
@@ -1068,8 +1069,6 @@ export default class MetamaskController extends EventEmitter {
           },
         },
       };
-    } else {
-      initialNetworkOrderControllerState = initState.NetworkOrderController;
     }
 
     this.networkOrderController = new NetworkOrderController({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This is a development only bug, when the extension was reloaded, it reset the NetworkOrderController back to sepolia.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34320?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: ensure NetworkOrderController is not reset on extension reload.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34322 https://github.com/MetaMask/metamask-extension/issues/34318

## **Manual testing steps**

1. Set enabled networks
2. Refresh & Open extension
3. See if enabled networks have not changed. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/20540d2dc2ae4b4596c669812f88b7e7?sid=0d4c6941-b54d-4ec2-93d5-9a60a43d200e

https://www.loom.com/share/e27e6ffa34d94e39a7525f88bb645211?sid=0b4cbe4d-2bdc-4ab2-a3e2-d343ff927e89

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
