### PR TITLE
feat: add MultichainAddressRow component with stories and tests

### DIFF
--- a/ui/components/multichain-accounts/multichain-address-row/index.ts
+++ b/ui/components/multichain-accounts/multichain-address-row/index.ts
@@ -1,0 +1,1 @@
+export { MultichainAddressRow } from './multichain-address-row';

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.stories.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { KnownCaipNamespace, CaipChainId } from '@metamask/utils';
+import { MultichainAddressRow } from './multichain-address-row';
+
+const meta: Meta<typeof MultichainAddressRow> = {
+  title: 'Components/Multichain/MultichainAddressRow',
+  component: MultichainAddressRow,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A component that displays a network icon, network name, truncated address, and action buttons (copy and QR code).',
+      },
+    },
+  },
+  argTypes: {
+    network: {
+      control: 'object',
+      description: 'MultichainNetwork object containing nickname, chainId, and rpcPrefs with imageUrl',
+    },
+    address: {
+      control: 'text',
+      description: 'Address string to display (will be truncated)',
+    },
+    className: {
+      control: 'text',
+      description: 'Optional className for additional styling',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    network: {
+      nickname: 'Ethereum Mainnet',
+      isEvmNetwork: true,
+      chainId: `${KnownCaipNamespace.Eip155}:1` as CaipChainId,
+      network: {
+        type: 'mainnet',
+        chainId: '0x1',
+        ticker: 'ETH',
+        rpcPrefs: {
+          imageUrl: './images/eth_logo.svg',
+        },
+      },
+    },
+    address: '0x1234567890123456789012345678901234567890',
+    className: '',
+  },
+};
+
+export const WithLongNetworkName: Story = {
+  args: {
+    network: {
+      nickname: 'Polygon Mumbai Testnet',
+      isEvmNetwork: true,
+      chainId: `${KnownCaipNamespace.Eip155}:80001` as CaipChainId,
+      network: {
+        type: 'rpc',
+        chainId: '0x13881',
+        ticker: 'MATIC',
+        rpcPrefs: {
+          imageUrl: './images/pol-token.svg',
+        },
+      },
+    },
+    address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+    className: '',
+  },
+};
+
+export const WithoutNetworkImage: Story = {
+  args: {
+    network: {
+      nickname: 'Custom Network',
+      isEvmNetwork: true,
+      chainId: `${KnownCaipNamespace.Eip155}:1337` as CaipChainId,
+      network: {
+        type: 'rpc',
+        chainId: '0x539',
+        ticker: 'ETH',
+        rpcPrefs: {},
+      },
+    },
+    address: '0x9876543210987654321098765432109876543210',
+    className: '',
+  },
+};
+
+export const ArbitrumNetwork: Story = {
+  args: {
+    network: {
+      nickname: 'Arbitrum One',
+      isEvmNetwork: true,
+      chainId: `${KnownCaipNamespace.Eip155}:42161` as CaipChainId,
+      network: {
+        type: 'rpc',
+        chainId: '0xa4b1',
+        ticker: 'ETH',
+        rpcPrefs: {
+          imageUrl: './images/arbitrum.svg',
+        },
+      },
+    },
+    address: '0x0123456789abcdef0123456789abcdef01234567',
+    className: '',
+  },
+};

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { KnownCaipNamespace, CaipChainId } from '@metamask/utils';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import configureStore from '../../../store/store';
+import mockState from '../../../../test/data/mock-state.json';
+import { MultichainNetwork } from '../../../selectors/multichain';
+import { MultichainAddressRow } from './multichain-address-row';
+
+const mockHandleCopy = jest.fn();
+
+jest.mock('../../../hooks/useCopyToClipboard', () => ({
+  useCopyToClipboard: jest.fn(),
+}));
+
+// Get the mocked function after the mock is set up
+const { useCopyToClipboard: mockUseCopyToClipboard } = require('../../../hooks/useCopyToClipboard');
+
+const mockNetwork: MultichainNetwork = {
+  nickname: 'Ethereum Mainnet',
+  isEvmNetwork: true,
+  chainId: `${KnownCaipNamespace.Eip155}:1` as CaipChainId,
+  network: {
+    type: 'mainnet',
+    chainId: '0x1',
+    ticker: 'ETH',
+    rpcPrefs: {
+      imageUrl: './images/eth_logo.svg',
+    },
+  },
+};
+
+const mockAddress = '0x1234567890123456789012345678901234567890';
+
+const render = (props = {}) => {
+  const store = configureStore(mockState);
+  return renderWithProvider(
+    <MultichainAddressRow network={mockNetwork} address={mockAddress} {...props} />,
+    store,
+  );
+};
+
+describe('MultichainAddressRow', () => {
+  beforeEach(() => {
+    mockHandleCopy.mockClear();
+    mockUseCopyToClipboard.mockClear();
+    mockUseCopyToClipboard.mockReturnValue([false, mockHandleCopy]);
+  });
+
+  it('renders correctly with all elements', () => {
+    render();
+
+    expect(
+      screen.getByTestId('multichain-address-row-network-name'),
+    ).toHaveTextContent('Ethereum Mainnet');
+
+    expect(
+      screen.getByTestId('multichain-address-row-address'),
+    ).toHaveTextContent('0x12345...67890');
+
+    expect(
+      screen.getByTestId('multichain-address-row-copy-button'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId('multichain-address-row-qr-button'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId('multichain-address-row-network-icon'),
+    ).toBeInTheDocument();
+  });
+
+  it('handles copy button click', () => {
+    render();
+
+    const copyButton = screen.getByTestId('multichain-address-row-copy-button');
+    fireEvent.click(copyButton);
+
+    expect(mockHandleCopy).toHaveBeenCalledWith(mockAddress);
+  });
+
+  it('renders correctly without network image', () => {
+    const networkWithoutImage: MultichainNetwork = {
+      nickname: 'Custom Network',
+      isEvmNetwork: true,
+      chainId: `${KnownCaipNamespace.Eip155}:1337` as CaipChainId,
+      network: {
+        type: 'rpc',
+        chainId: '0x539',
+        ticker: 'ETH',
+        rpcPrefs: {},
+      },
+    };
+
+    render({ network: networkWithoutImage });
+
+    expect(
+      screen.getByTestId('multichain-address-row-network-name'),
+    ).toHaveTextContent('Custom Network');
+    expect(
+      screen.getByTestId('multichain-address-row-network-icon'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows copy success icon when copied is true', () => {
+    mockUseCopyToClipboard.mockReturnValueOnce([true, mockHandleCopy]);
+
+    render();
+
+    const copyButton = screen.getByTestId('multichain-address-row-copy-button');
+
+    expect(copyButton).toBeInTheDocument();
+  });
+
+  it('handles networks with different image source', () => {
+    const networkWithDifferentImage: MultichainNetwork = {
+      nickname: 'Test Network',
+      isEvmNetwork: true,
+      chainId: `${KnownCaipNamespace.Eip155}:1` as CaipChainId,
+      network: {
+        type: 'mainnet',
+        chainId: '0x1',
+        ticker: 'ETH',
+        rpcPrefs: {
+          imageUrl: './images/test-icon.svg',
+        },
+      },
+    };
+
+    render({ network: networkWithDifferentImage });
+
+    expect(
+      screen.getByTestId('multichain-address-row-network-name'),
+    ).toHaveTextContent('Test Network');
+    expect(
+      screen.getByTestId('multichain-address-row-network-icon'),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
@@ -5,16 +5,13 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 import { MultichainNetwork } from '../../../selectors/multichain';
+import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { MultichainAddressRow } from './multichain-address-row';
-
-const mockHandleCopy = jest.fn();
 
 jest.mock('../../../hooks/useCopyToClipboard', () => ({
   useCopyToClipboard: jest.fn(),
 }));
-
-// Get the mocked function after the mock is set up
-const { useCopyToClipboard: mockUseCopyToClipboard } = require('../../../hooks/useCopyToClipboard');
+const mockHandleCopy = jest.fn();
 
 const mockNetwork: MultichainNetwork = {
   nickname: 'Ethereum Mainnet',
@@ -35,7 +32,11 @@ const mockAddress = '0x1234567890123456789012345678901234567890';
 const render = (props = {}) => {
   const store = configureStore(mockState);
   return renderWithProvider(
-    <MultichainAddressRow network={mockNetwork} address={mockAddress} {...props} />,
+    <MultichainAddressRow
+      network={mockNetwork}
+      address={mockAddress}
+      {...props}
+    />,
     store,
   );
 };
@@ -43,8 +44,7 @@ const render = (props = {}) => {
 describe('MultichainAddressRow', () => {
   beforeEach(() => {
     mockHandleCopy.mockClear();
-    mockUseCopyToClipboard.mockClear();
-    mockUseCopyToClipboard.mockReturnValue([false, mockHandleCopy]);
+    (useCopyToClipboard as jest.Mock).mockReturnValue([false, mockHandleCopy]);
   });
 
   it('renders correctly with all elements', () => {
@@ -104,7 +104,10 @@ describe('MultichainAddressRow', () => {
   });
 
   it('shows copy success icon when copied is true', () => {
-    mockUseCopyToClipboard.mockReturnValueOnce([true, mockHandleCopy]);
+    (useCopyToClipboard as jest.Mock).mockReturnValueOnce([
+      true,
+      mockHandleCopy,
+    ]);
 
     render();
 

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import {
+  AlignItems,
+  BorderRadius,
+  Display,
+  FlexDirection,
+  IconColor,
+  JustifyContent,
+  TextColor,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  Text,
+} from '../../component-library';
+import { shortenAddress } from '../../../helpers/utils/util';
+import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
+import { MultichainNetwork } from '../../../selectors/multichain';
+
+type MultichainAddressRowProps = {
+  /**
+   * Network object containing nickname, chainId, and rpcPrefs with imageUrl
+   */
+  network: MultichainNetwork;
+  /**
+   * Address string to display (will be truncated)
+   */
+  address: string;
+  /**
+   * Optional className for additional styling
+   */
+  className?: string;
+};
+
+export const MultichainAddressRow = ({
+  network,
+  address,
+  className = '',
+}: MultichainAddressRowProps) => {
+  const [copied, handleCopy] = useCopyToClipboard();
+
+  const networkImageSrc = network.network.rpcPrefs?.imageUrl;
+  const truncatedAddress = shortenAddress(address);
+
+  const handleCopyClick = () => {
+    handleCopy(address);
+  };
+
+  const handleQrClick = () => {
+    console.log('QR code clicked for address:', address);
+  };
+
+  return (
+    <Box
+      className={`multichain-address-row ${className}`}
+      display={Display.Flex}
+      alignItems={AlignItems.center}
+      justifyContent={JustifyContent.spaceBetween}
+      padding={4}
+      gap={4}
+      data-testid="multichain-address-row"
+    >
+      <AvatarNetwork
+        size={AvatarNetworkSize.Md}
+        name={network.nickname}
+        src={networkImageSrc}
+        borderRadius={BorderRadius.LG}
+        data-testid="multichain-address-row-network-icon"
+      />
+
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Column}
+        alignItems={AlignItems.flexStart}
+        style={{ flex: 1 }}
+      >
+        <Text
+          variant={TextVariant.bodyMdMedium}
+          color={TextColor.textDefault}
+          data-testid="multichain-address-row-network-name"
+        >
+          {network.nickname}
+        </Text>
+        <Text
+          variant={TextVariant.bodySm}
+          color={TextColor.textAlternative}
+          data-testid="multichain-address-row-address"
+        >
+          {truncatedAddress}
+        </Text>
+      </Box>
+
+      {/* Action buttons */}
+      <Box display={Display.Flex} alignItems={AlignItems.center} gap={4}>
+        <ButtonIcon
+          iconName={copied ? IconName.CopySuccess : IconName.Copy}
+          size={ButtonIconSize.Md}
+          onClick={handleCopyClick}
+          ariaLabel="Copy address"
+          color={IconColor.iconDefault}
+          data-testid="multichain-address-row-copy-button"
+        />
+
+        <ButtonIcon
+          iconName={IconName.QrCode}
+          size={ButtonIconSize.Md}
+          onClick={handleQrClick}
+          ariaLabel="Show QR code"
+          color={IconColor.iconDefault}
+          data-testid="multichain-address-row-qr-button"
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default MultichainAddressRow;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces a new `MultichainAddressRow` component for displaying network information and addresses in MetaMask's multichain interface. The component provides a clean, consistent way to show network icons, names, truncated addresses, and action buttons (copy and QR code) across the application.

**What is the reason for the change?**
As part of the multichain accounts feature development, we need a reusable component to display network-address pairs in a standardized format throughout the UI.

**What is the improvement/solution?**
The new `MultichainAddressRow` component:
- Displays network icon using `AvatarNetwork` component
- Shows network name and truncated address in a two-line layout
- Provides copy-to-clipboard functionality with visual feedback
- Includes QR code button for address sharing
- Integrates with the existing `MultichainNetwork` type system

**Out of scope**
- QR code button click implementation

## **Changelog**

CHANGELOG entry: Added MultichainAddressRow component for displaying network information and addresses in multichain interface

## **Related issues**

Fixes:
Jita ticket: https://consensyssoftware.atlassian.net/browse/MUL-424

## **Manual testing steps**

1. Run Storybook: `yarn storybook`
2. Navigate to `Components/Multichain/MultichainAddressRow`
3. Verify all story variants render correctly:
   - Default (Ethereum Mainnet)
   - WithLongNetworkName (Polygon Mumbai Testnet)
   - WithoutNetworkImage (Custom Network)
   - ArbitrumNetwork
4. Test copy button functionality - should copy address to clipboard

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->
<img width="1012" height="455" alt="Screenshot 2025-07-16 at 13 34 19" src="https://github.com/user-attachments/assets/8fe21f03-2e16-41d8-93ed-f6692edf1f4d" />
<img width="1006" height="353" alt="Screenshot 2025-07-16 at 13 35 51" src="https://github.com/user-attachments/assets/744f36ed-9f81-4a17-9656-5f5518646cde" />

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
