### PR TITLE
fix: password form terms social and srp

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4250,6 +4250,9 @@
     "message": "A strong password can improve the security of your wallet should your device be stolen or compromised."
   },
   "passwordTermsWarning": {
+    "message": "If I forget this password, MetaMask can’t reset it for me."
+  },
+  "passwordTermsWarningSocial": {
     "message": "If I forget this password, I’ll lose access to my wallet permanently. MetaMask can’t reset it for me."
   },
   "passwordToggleHide": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4250,6 +4250,9 @@
     "message": "A strong password can improve the security of your wallet should your device be stolen or compromised."
   },
   "passwordTermsWarning": {
+    "message": "If I forget this password, MetaMask can’t reset it for me."
+  },
+  "passwordTermsWarningSocial": {
     "message": "If I forget this password, I’ll lose access to my wallet permanently. MetaMask can’t reset it for me."
   },
   "passwordToggleHide": {

--- a/ui/components/app/password-form/password-form.tsx
+++ b/ui/components/app/password-form/password-form.tsx
@@ -190,7 +190,6 @@ export default function PasswordForm({
         }}
         helpText={confirmPasswordError}
         value={confirmPassword}
-        disabled={password.length < PASSWORD_MIN_LENGTH}
         inputProps={{
           'data-testid':
             confirmPwdInputTestId || 'create-password-confirm-input',

--- a/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.js.snap
+++ b/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.js.snap
@@ -81,7 +81,7 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-form-text-field mm-form-text-field--disabled mm-box--margin-top-4 mm-box--display-flex mm-box--flex-direction-column"
+          class="mm-box mm-form-text-field mm-box--margin-top-4 mm-box--display-flex mm-box--flex-direction-column"
         >
           <label
             class="mm-box mm-text mm-label mm-label--html-for mm-form-text-field__label mm-text--body-md mm-text--font-weight-medium mm-box--margin-bottom-1 mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
@@ -90,13 +90,12 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
             Confirm password
           </label>
           <div
-            class="mm-box mm-text-field mm-text-field--size-lg mm-text-field--disabled mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-4 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
+            class="mm-box mm-text-field mm-text-field--size-lg mm-text-field--truncate mm-form-text-field__text-field mm-box--padding-right-4 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-lg mm-box--border-width-1 box--border-style-solid"
           >
             <input
               autocomplete="on"
-              class="mm-box mm-text mm-input mm-input--disable-state-styles mm-input--disabled mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+              class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
               data-testid="create-password-confirm-input"
-              disabled=""
               focused="false"
               id="create-password-confirm"
               type="password"
@@ -133,7 +132,7 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
             />
           </span>
           <span>
-            If I forget this password, I’ll lose access to my wallet permanently. MetaMask can’t reset it for me.
+            If I forget this password, MetaMask can’t reset it for me.
              
             <a
               href="https://support.metamask.io/getting-started/user-guide-secret-recovery-phrase-password-and-private-keys/"

--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -324,7 +324,9 @@ export default function CreatePassword({
             }}
             label={
               <>
-                {t('passwordTermsWarning')}
+                {isSocialLoginFlow
+                  ? t('passwordTermsWarningSocial')
+                  : t('passwordTermsWarning')}
                 &nbsp;
                 {createPasswordLink}
               </>

--- a/ui/pages/settings/security-tab/change-password/change-password.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password.tsx
@@ -234,7 +234,9 @@ const ChangePassword = () => {
                 }}
                 label={
                   <>
-                    {t('passwordTermsWarning')}
+                    {isSocialLoginFlow
+                      ? t('passwordTermsWarningSocial')
+                      : t('passwordTermsWarning')}
                     &nbsp;
                     {createPasswordLink}
                   </>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. Show different password terms copywriting for social and srp users. Current terms copy is not applicable for SRP users.
2. Always enable confirm password field to be inline with mobile.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34350?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show different password terms copy for Social and SRP accounts and always enable confirm password field

## **Related issues**

Fixes:

## **Manual testing steps**

SRP
1. Create new account with SRP
2. Check `create password` page

Social
1. Create new account with social login
2. Check `create password` page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
_Confirm password field is disabled when password is less than 8 chars_
_Terms is same for srp and social users_
<img width="469" height="652" alt="Screenshot 2025-07-17 at 4 44 45 PM" src="https://github.com/user-attachments/assets/6b540a16-4938-4eb1-a033-e93bc0826c73" />


<!-- [screenshots/recordings] -->

### **After**
**SRP User**
<img width="731" height="673" alt="Screenshot 2025-07-17 at 3 32 24 PM" src="https://github.com/user-attachments/assets/97a3d988-be55-4647-a56e-2310489e7ceb" />
**Social User**
<img width="624" height="665" alt="Screenshot 2025-07-17 at 3 33 55 PM" src="https://github.com/user-attachments/assets/0edc77c6-76f7-4c49-8910-6ca1b0d12d0a" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
