### PR TITLE
chore(deps): bump @metamask/message-signing-snap to v1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
     "@metamask/logging-controller": "^6.0.4",
     "@metamask/logo": "^4.0.0",
     "@metamask/message-manager": "^12.0.1",
-    "@metamask/message-signing-snap": "1.1.2",
+    "@metamask/message-signing-snap": "1.1.3",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/multichain-api-client": "^0.6.4",
     "@metamask/multichain-api-middleware": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6624,10 +6624,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/message-signing-snap@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@metamask/message-signing-snap@npm:1.1.2"
-  checksum: 10/99970642e6bbcb4dbfeb9defbc286ce92f992d11c542000ea761c5c892b2fbac5fdee9d5c6c8f8df05666322848ab7bb510289780959a14fbb390d556fd63f19
+"@metamask/message-signing-snap@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@metamask/message-signing-snap@npm:1.1.3"
+  checksum: 10/9601a6e83c1759badf8c906128c27bc0d7206ae8aa5e75f45493b6b5782bcf1b139bd0570d46926d7feb416999e43c889080950d11a8b74c9f8585a32f8d627f
   languageName: node
   linkType: hard
 
@@ -31949,7 +31949,7 @@ __metadata:
     "@metamask/logging-controller": "npm:^6.0.4"
     "@metamask/logo": "npm:^4.0.0"
     "@metamask/message-manager": "npm:^12.0.1"
-    "@metamask/message-signing-snap": "npm:1.1.2"
+    "@metamask/message-signing-snap": "npm:1.1.3"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/multichain-api-client": "npm:^0.6.4"
     "@metamask/multichain-api-middleware": "npm:0.4.0"


### PR DESCRIPTION
## **Description**

This is a version bump for the preinstalled @metamask/message-signing-snap to v1.1.3

This version solves some security vulnerabilities caused by out of date dependencies.

## **Related issues**

Relates to: https://github.com/MetaMask/message-signing-snap/pull/131
Required by: https://github.com/MetaMask/snap-7715-permissions/pull/112

## **Manual testing steps**

No user facing tests


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
