### PR TITLE
fix: header titles in unified asset picker cp-13.0.0

### DIFF
--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -651,7 +651,7 @@ const PrepareBridgePage = () => {
 
   const getFromInputHeader = () => {
     if (isUnifiedUIEnabled) {
-      return t('yourNetworks');
+      return t('swapSelectToken');
     }
     return isSwap ? t('swapSwapFrom') : t('bridgeFrom');
   };
@@ -921,7 +921,7 @@ const PrepareBridgePage = () => {
                         });
                       dispatch(setToChainId(networkConfig.chainId));
                     },
-                    header: getToInputHeader(),
+                    header: t('yourNetworks'),
                     shouldDisableNetwork: isUnifiedUIEnabled
                       ? undefined
                       : ({ chainId }) => chainId === fromChain?.chainId,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes copy in the unified asset picker flow for to and from tokens

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34365?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed copy in the unified swaps flow asset picker to be more intuitive

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to the unified swaps flow
2. from and to token asset picker labels should be more intuitive

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

#### fromToken

<img width="396" height="595" alt="Screenshot 2025-07-17 at 10 29 38 AM" src="https://github.com/user-attachments/assets/ef1c6ca5-5f53-4316-80c4-f1f137092488" />
<img width="396" height="599" alt="Screenshot 2025-07-17 at 10 29 34 AM" src="https://github.com/user-attachments/assets/c370a5ec-68a2-46b1-b9c6-394083e9adca" />

#### toToken

<img width="398" height="598" alt="Screenshot 2025-07-17 at 10 29 46 AM" src="https://github.com/user-attachments/assets/bec316f6-0cb0-46a1-95a0-26777fd1da0c" />
<img width="399" height="599" alt="Screenshot 2025-07-17 at 10 29 43 AM" src="https://github.com/user-attachments/assets/aae44327-de66-4e71-afb2-448e62c49c45" />

<!-- [screenshots/recordings] -->

### **After**

#### fromToken
<img width="396" height="597" alt="Screenshot 2025-07-17 at 10 27 24 AM" src="https://github.com/user-attachments/assets/b5f4ecff-4bd0-4e98-a3a9-7d76aa934a0c" />
<img width="398" height="596" alt="Screenshot 2025-07-17 at 10 27 19 AM" src="https://github.com/user-attachments/assets/276a06f4-1eda-4459-a68e-ce65492f34ee" />

#### toToken
<img width="397" height="599" alt="Screenshot 2025-07-17 at 10 27 33 AM" src="https://github.com/user-attachments/assets/c3ac5312-4dcf-48d3-ad5e-2de8d86dccef" />
<img width="398" height="600" alt="Screenshot 2025-07-17 at 10 27 29 AM" src="https://github.com/user-attachments/assets/bb671809-365f-4958-bf7a-b1289e4e73ea" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
