### PR TITLE
test: enable network manager tests

### DIFF
--- a/test/e2e/page-objects/pages/network-manager.ts
+++ b/test/e2e/page-objects/pages/network-manager.ts
@@ -1,5 +1,16 @@
 import { Driver } from '../../webdriver/driver';
 
+export enum NetworkId {
+  ETHEREUM = 'eip155:1',
+  LINEA = 'eip155:59144',
+  ARBITRUM = 'eip155:42161',
+  AVALANCHE = 'eip155:43114',
+  BSC = 'eip155:56',
+  BASE = 'eip155:8453',
+  OPTIMISM = 'eip155:10',
+  POLYGON = 'eip155:137',
+}
+
 class NetworkManager {
   protected readonly driver: Driver;
 


### PR DESCRIPTION
## **Description**

Cleanup and enable network manager tests.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34366?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: test: enable NetworkManager tests

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
