### PR TITLE
fix:  cp-13.0.0 show solana connected state

### DIFF
--- a/ui/components/multichain/connected-site-menu/connected-site-menu.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.js
@@ -24,8 +24,9 @@ import {
   getSubjectMetadata,
 } from '../../../selectors';
 import { ConnectedSitePopover } from '../connected-site-popover';
+import { STATUS_CONNECTED } from '../../../helpers/constants/connected-sites';
 
-export const ConnectedSiteMenu = ({ className, disabled, onClick }) => {
+export const ConnectedSiteMenu = ({ className, disabled, onClick, status }) => {
   const [showPopover, setShowPopover] = useState(false);
 
   const referenceElement = useRef(null);
@@ -73,9 +74,10 @@ export const ConnectedSiteMenu = ({ className, disabled, onClick }) => {
         <ConnectedSitePopover
           referenceElement={referenceElement}
           isOpen={showPopover}
-          isConnected={!currentTabHasNoAccounts}
+          isConnected={status === STATUS_CONNECTED}
           onClick={onClick}
           onClose={() => setShowPopover(false)}
+          connectedOrigin={connectedOrigin}
         />
       )}
     </>
@@ -95,4 +97,8 @@ ConnectedSiteMenu.propTypes = {
    *  Disable the connected site menu if the account is non-evm
    */
   disabled: PropTypes.bool,
+  /**
+   * The status of the connected site menu
+   */
+  status: PropTypes.string,
 };

--- a/ui/components/multichain/connected-site-popover/connected-site-popover.test.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.test.tsx
@@ -10,6 +10,7 @@ const props = {
   isConnected: true,
   onClick: jest.fn(),
   onClose: jest.fn(),
+  connectedOrigin: 'https://metamask.github.io',
 };
 
 const render = () => {
@@ -17,6 +18,43 @@ const render = () => {
     metamask: {
       ...mockState.metamask,
       completedOnboarding: true,
+      // Add multichain network state
+      selectedMultichainNetworkChainId: 'eip155:5',
+      isEvmSelected: true,
+      multichainNetworkConfigurationsByChainId: {
+        ...mockState.metamask.multichainNetworkConfigurationsByChainId,
+        'eip155:5': {
+          chainId: 'eip155:5',
+          name: 'Goerli',
+          nativeCurrency: 'ETH',
+          isEvm: true,
+        },
+      },
+      // Add permissions for the test dapp
+      subjects: {
+        'https://metamask.github.io': {
+          permissions: {
+            'endowment:caip25': {
+              caveats: [
+                {
+                  type: 'authorizedScopes',
+                  value: {
+                    requiredScopes: {},
+                    optionalScopes: {
+                      'eip155:5': {
+                        accounts: [
+                          'eip155:5:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+                        ],
+                      },
+                    },
+                    isMultichainOrigin: false,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
     },
     activeTab: {
       id: 113,

--- a/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
@@ -59,13 +59,11 @@ export const ConnectedSitePopover = ({
   );
   const currentNetwork = useSelector(getSelectedMultichainNetworkConfiguration);
   const dispatch = useDispatch();
-  console.log(currentNetwork);
 
   // Check if current network is permitted for this dapp
   // Both currentChainId and permittedChainIds are in CAIP format, so we can compare directly
   const isCurrentNetworkPermitted = permittedChainIds.includes(currentChainId);
 
-  // Helper function to convert CAIP chain ID to the format expected by getImageForChainId
   const getChainIdForImage = (chainId: `${string}:${string}`): string => {
     const { namespace, reference } = parseCaipChainId(chainId);
     return namespace === 'eip155'

--- a/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, RefObject } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { parseCaipChainId } from '@metamask/utils';
 import {
   AvatarNetwork,
   AvatarNetworkSize,
@@ -19,7 +20,12 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { I18nContext } from '../../../contexts/i18n';
-import { getCurrentNetwork, getOriginOfCurrentTab } from '../../../selectors';
+import {
+  getOriginOfCurrentTab,
+  getAllPermittedChainsForSelectedTab,
+  getSelectedMultichainNetworkChainId,
+} from '../../../selectors';
+import { getSelectedMultichainNetworkConfiguration } from '../../../selectors/multichain/networks';
 import { getURLHost } from '../../../helpers/utils/util';
 import { getImageForChainId } from '../../../selectors/multichain';
 import { toggleNetworkMenu } from '../../../store/actions';
@@ -29,6 +35,7 @@ type ConnectedSitePopoverProps = {
   isConnected: boolean;
   onClick: () => void;
   onClose: () => void;
+  connectedOrigin: string;
   referenceElement?: RefObject<HTMLElement>;
 };
 
@@ -38,6 +45,7 @@ export const ConnectedSitePopover = ({
   onClick,
   onClose,
   referenceElement,
+  connectedOrigin,
 }: ConnectedSitePopoverProps) => {
   const t = useContext(I18nContext);
   const activeTabOrigin = useSelector(getOriginOfCurrentTab);
@@ -45,8 +53,25 @@ export const ConnectedSitePopover = ({
   // TODO: Replace it with networkClient Selector
   // const activeDomain = useSelector(getAllDomains);
   // const networkClientId = activeDomain?.[activeTabOrigin];
-  const currentNetwork = useSelector(getCurrentNetwork);
+  const currentChainId = useSelector(getSelectedMultichainNetworkChainId);
+  const permittedChainIds = useSelector((state) =>
+    getAllPermittedChainsForSelectedTab(state, connectedOrigin),
+  );
+  const currentNetwork = useSelector(getSelectedMultichainNetworkConfiguration);
   const dispatch = useDispatch();
+  console.log(currentNetwork);
+
+  // Check if current network is permitted for this dapp
+  // Both currentChainId and permittedChainIds are in CAIP format, so we can compare directly
+  const isCurrentNetworkPermitted = permittedChainIds.includes(currentChainId);
+
+  // Helper function to convert CAIP chain ID to the format expected by getImageForChainId
+  const getChainIdForImage = (chainId: `${string}:${string}`): string => {
+    const { namespace, reference } = parseCaipChainId(chainId);
+    return namespace === 'eip155'
+      ? `0x${parseInt(reference, 10).toString(16)}`
+      : chainId;
+  };
 
   return (
     <Popover
@@ -73,7 +98,7 @@ export const ConnectedSitePopover = ({
           paddingBottom={2}
         >
           <Text variant={TextVariant.bodyMdMedium}>{siteName}</Text>
-          {isConnected ? (
+          {isConnected && isCurrentNetworkPermitted ? (
             <Box
               display={Display.Flex}
               flexDirection={FlexDirection.Row}
@@ -84,10 +109,12 @@ export const ConnectedSitePopover = ({
                 size={AvatarNetworkSize.Xs}
                 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
                 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                name={currentNetwork?.nickname || ''}
+                name={currentNetwork?.name || ''}
                 src={
                   currentNetwork?.chainId
-                    ? getImageForChainId(currentNetwork.chainId)
+                    ? getImageForChainId(
+                        getChainIdForImage(currentNetwork.chainId),
+                      )
                     : undefined
                 }
               />
@@ -106,7 +133,7 @@ export const ConnectedSitePopover = ({
                   )
                 }
               >
-                {currentNetwork?.nickname}
+                {currentNetwork?.name}
               </ButtonLink>
             </Box>
           ) : (


### PR DESCRIPTION
This PR ensures that when Solana account is connected, it should render connected state in the dapp view


## **Related issues**

Fixes: #34239 

## **Manual testing steps**

1. Connect extension to Solana Dapp, check the connected popover renders correct network icon and connected state
2. Connect extension to Uniswap, check the connected popover renders correct network icon and connected state

## **Screenshots/Recordings**


### **Before**

NA
### **After**

https://github.com/user-attachments/assets/5f7a47b4-7f06-4272-8af7-add101d8be66



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
