### PR TITLE
fix: update explorer button text in address qr code page to reflect the network's explorer name

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7111,11 +7111,9 @@
   "viewActivity": {
     "message": "View activity"
   },
-  "viewAddressOnEtherscan": {
-    "message": "View on Etherscan"
-  },
-  "viewAddressOnSolscan": {
-    "message": "View on Solscan"
+  "viewAddressOnExplorer": {
+    "message": "View on $1",
+    "description": "$1 is the block explorer name"
   },
   "viewAllQuotes": {
     "message": "view all quotes"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7111,6 +7111,12 @@
   "viewActivity": {
     "message": "View activity"
   },
+  "viewAddressOnEtherscan": {
+    "message": "View on Etherscan"
+  },
+  "viewAddressOnSolscan": {
+    "message": "View on Solscan"
+  },
   "viewAllQuotes": {
     "message": "view all quotes"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7111,11 +7111,9 @@
   "viewActivity": {
     "message": "View activity"
   },
-  "viewAddressOnEtherscan": {
-    "message": "View on Etherscan"
-  },
-  "viewAddressOnSolscan": {
-    "message": "View on Solscan"
+  "viewAddressOnExplorer": {
+    "message": "View on $1",
+    "description": "$1 is the block explorer name"
   },
   "viewAllQuotes": {
     "message": "view all quotes"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7111,6 +7111,12 @@
   "viewActivity": {
     "message": "View activity"
   },
+  "viewAddressOnEtherscan": {
+    "message": "View on Etherscan"
+  },
+  "viewAddressOnSolscan": {
+    "message": "View on Solscan"
+  },
   "viewAllQuotes": {
     "message": "view all quotes"
   },

--- a/test/e2e/tests/multichain-accounts/account-details.spec.ts
+++ b/test/e2e/tests/multichain-accounts/account-details.spec.ts
@@ -282,7 +282,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
 
           const viewOnExplorerButton = await driver.findElement({
             css: 'button',
-            text: 'View on explorer',
+            text: 'View on Etherscan',
           });
 
           const explorerLink =

--- a/ui/pages/multichain-accounts/address-qr-code/address-qr-code.test.tsx
+++ b/ui/pages/multichain-accounts/address-qr-code/address-qr-code.test.tsx
@@ -47,6 +47,8 @@ jest.mock('../../../hooks/useI18nContext', () => ({
     const translations: Record<string, string> = {
       address: '[address]',
       viewOnExplorer: 'View on explorer',
+      viewAddressOnEtherscan: 'View on Etherscan',
+      viewAddressOnSolscan: 'View on Solscan',
     };
     return translations[key] || key;
   },
@@ -151,11 +153,11 @@ describe('AddressQRCode', () => {
       expect(screen.getByLabelText('Back')).toBeInTheDocument();
     });
 
-    it('should render view on explorer button', () => {
+    it('should render view on etherscan button', () => {
       renderComponent();
 
       const explorerButton = screen.getByRole('button', {
-        name: 'View on explorer',
+        name: 'View on Etherscan',
       });
       expect(explorerButton).toBeInTheDocument();
     });
@@ -175,11 +177,11 @@ describe('AddressQRCode', () => {
   });
 
   describe('Block Explorer Integration', () => {
-    it('should open block explorer when view on explorer button is clicked', async () => {
+    it('should open block explorer when view on etherscan button is clicked', async () => {
       renderComponent();
 
       const explorerButton = screen.getByRole('button', {
-        name: 'View on explorer',
+        name: 'View on Etherscan',
       });
       fireEvent.click(explorerButton);
 

--- a/ui/pages/multichain-accounts/address-qr-code/address-qr-code.test.tsx
+++ b/ui/pages/multichain-accounts/address-qr-code/address-qr-code.test.tsx
@@ -40,12 +40,11 @@ jest.mock('react-router-dom', () => ({
 
 // Mock i18n
 jest.mock('../../../hooks/useI18nContext', () => ({
-  useI18nContext: () => (key: string) => {
+  useI18nContext: () => (key: string, substitutions?: string[]) => {
     const translations: Record<string, string> = {
       address: '[address]',
       viewOnExplorer: 'View on explorer',
-      viewAddressOnEtherscan: 'View on Etherscan',
-      viewAddressOnSolscan: 'View on Solscan',
+      viewAddressOnExplorer: `View on ${substitutions?.[0]}`,
     };
     return translations[key] || key;
   },

--- a/ui/pages/multichain-accounts/address-qr-code/address-qr-code.tsx
+++ b/ui/pages/multichain-accounts/address-qr-code/address-qr-code.tsx
@@ -73,9 +73,9 @@ export const AddressQRCode = () => {
   const getExplorerButtonText = (): string => {
     switch (getAccountTypeCategory(account)) {
       case 'evm':
-        return t('viewAddressOnEtherscan');
+        return t('viewAddressOnExplorer', ['Etherscan']);
       case 'solana':
-        return t('viewAddressOnSolscan');
+        return t('viewAddressOnExplorer', ['Solscan']);
       default:
         return t('viewOnExplorer');
     }

--- a/ui/pages/multichain-accounts/address-qr-code/address-qr-code.tsx
+++ b/ui/pages/multichain-accounts/address-qr-code/address-qr-code.tsx
@@ -32,6 +32,7 @@ import {
   MetaMetricsEventName,
   MetaMetricsEventCategory,
 } from '../../../../shared/constants/metametrics';
+import { getAccountTypeCategory } from '../account-details';
 
 export const AddressQRCode = () => {
   const t = useI18nContext();
@@ -70,6 +71,17 @@ export const AddressQRCode = () => {
     openBlockExplorer(addressLink, metricsLocation, trackEvent);
   }, [chainId, trackEvent, addressLink]);
 
+  const getExplorerButtonText = (): string => {
+    switch (getAccountTypeCategory(account)) {
+      case 'evm':
+        return t('viewAddressOnEtherscan');
+      case 'solana':
+        return t('viewAddressOnSolscan');
+      default:
+        return t('viewOnExplorer');
+    }
+  };
+
   return (
     <Page className="address-qr-code-page">
       <Header
@@ -104,7 +116,7 @@ export const AddressQRCode = () => {
             width: '100%',
           }}
         >
-          {t('viewOnExplorer')}
+          {getExplorerButtonText()}
         </ButtonSecondary>
       </Footer>
     </Page>


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? To align the explorer button text with the name of the actual explorer tied to the account.
2. What is the improvement/solution? Add a function that returns the correct text based on account type.

## **Manual testing steps**

1. Build from this branch.
2. Navigate to a solana account or evm account's address qr code page.
3. Observe that the explorer button's text is either "View on Etherscan" or "View on Solscan"

## **Screenshots/Recordings**

### **Before**

<img width="407" height="601" alt="image" src="https://github.com/user-attachments/assets/2a2910d3-abb7-4d79-bb16-f1ae32a4d8aa" />

### **After**

https://github.com/user-attachments/assets/9f503ecb-d678-4d3a-a6a3-386adff87f4f

https://github.com/user-attachments/assets/5cb30951-2611-4853-b234-de6bdfd275b1

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
