### PR TITLE
fix: Fix silently dropped errors in shared code cp-13.0.0

### DIFF
--- a/shared/lib/accounts/accounts.ts
+++ b/shared/lib/accounts/accounts.ts
@@ -12,7 +12,6 @@ import { Messenger } from '@metamask/base-controller';
 import { SnapId } from '@metamask/snaps-sdk';
 import { HandleSnapRequest as SnapControllerHandleRequest } from '@metamask/snaps-controllers';
 import { AccountsControllerGetNextAvailableAccountNameAction } from '@metamask/accounts-controller';
-import { captureException } from '@sentry/browser';
 ///: END:ONLY_INCLUDE_IF
 import { MultichainNetworks } from '../../constants/multichain/networks';
 import { BITCOIN_WALLET_SNAP_ID } from './bitcoin-wallet-snap';
@@ -237,7 +236,7 @@ export class MultichainWalletSnapClient implements WalletSnapClient {
             error,
           );
           // Still logging this one to sentry as this is a fairly new process for account discovery.
-          captureException(error);
+          global.sentry?.captureException?.(error);
         }
       }
     }

--- a/shared/lib/accounts/accounts.ts
+++ b/shared/lib/accounts/accounts.ts
@@ -14,9 +14,9 @@ import { HandleSnapRequest as SnapControllerHandleRequest } from '@metamask/snap
 import { AccountsControllerGetNextAvailableAccountNameAction } from '@metamask/accounts-controller';
 ///: END:ONLY_INCLUDE_IF
 import { MultichainNetworks } from '../../constants/multichain/networks';
+import { captureException } from '../sentry';
 import { BITCOIN_WALLET_SNAP_ID } from './bitcoin-wallet-snap';
 import { SOLANA_WALLET_SNAP_ID } from './solana-wallet-snap';
-import { captureException } from '../sentry';
 
 /**
  * Supported non-EVM Snaps.

--- a/shared/lib/accounts/accounts.ts
+++ b/shared/lib/accounts/accounts.ts
@@ -16,6 +16,7 @@ import { AccountsControllerGetNextAvailableAccountNameAction } from '@metamask/a
 import { MultichainNetworks } from '../../constants/multichain/networks';
 import { BITCOIN_WALLET_SNAP_ID } from './bitcoin-wallet-snap';
 import { SOLANA_WALLET_SNAP_ID } from './solana-wallet-snap';
+import { captureException } from '../sentry';
 
 /**
  * Supported non-EVM Snaps.
@@ -236,7 +237,7 @@ export class MultichainWalletSnapClient implements WalletSnapClient {
             error,
           );
           // Still logging this one to sentry as this is a fairly new process for account discovery.
-          global.sentry?.captureException?.(error);
+          captureException(error);
         }
       }
     }

--- a/shared/lib/sentry.test.ts
+++ b/shared/lib/sentry.test.ts
@@ -1,0 +1,86 @@
+import { captureException, captureMessage } from './sentry';
+
+describe('Sentry', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('captureException', () => {
+    it('prints a console error when Sentry is not initialized', () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(jest.fn());
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(jest.fn());
+      jest.replaceProperty(globalThis, 'sentry', undefined);
+      const testError = new Error('Test error');
+
+      captureException(testError, { extra: { foo: 'bar' } });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Sentry not initialized');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(testError, {
+        extra: { foo: 'bar' },
+      });
+    });
+
+    it('calls global Sentry captureException', () => {
+      const captureExceptionSpy = jest.spyOn(
+        globalThis.sentry,
+        'captureException',
+      );
+      const testError = new Error('Test error');
+
+      captureException(testError);
+
+      expect(captureExceptionSpy).toHaveBeenCalledWith(testError);
+    });
+
+    it('calls global Sentry captureException with extra data', () => {
+      const captureExceptionSpy = jest.spyOn(
+        globalThis.sentry,
+        'captureException',
+      );
+      const testError = new Error('Test error');
+
+      captureException(testError, { extra: { foo: 'bar' } });
+
+      expect(captureExceptionSpy).toHaveBeenCalledWith(testError, {
+        extra: { foo: 'bar' },
+      });
+    });
+  });
+
+  describe('captureMessage', () => {
+    it('prints a console log when Sentry is not initialized', () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(jest.fn());
+      const consoleLogSpy = jest
+        .spyOn(console, 'log')
+        .mockImplementation(jest.fn());
+      jest.replaceProperty(globalThis, 'sentry', undefined);
+
+      captureMessage('Test message', 'info');
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Sentry not initialized');
+      expect(consoleLogSpy).toHaveBeenCalledWith('Test message', 'info');
+    });
+
+    it('calls global Sentry captureMessage', () => {
+      const captureMessageSpy = jest.spyOn(globalThis.sentry, 'captureMessage');
+
+      captureMessage('Test message');
+
+      expect(captureMessageSpy).toHaveBeenCalledWith('Test message');
+    });
+
+    it('calls global Sentry captureMessage with severity level/context', () => {
+      const captureMessageSpy = jest.spyOn(globalThis.sentry, 'captureMessage');
+
+      captureMessage('Test message', 'info');
+
+      expect(captureMessageSpy).toHaveBeenCalledWith('Test message', 'info');
+    });
+  });
+});

--- a/shared/lib/sentry.ts
+++ b/shared/lib/sentry.ts
@@ -3,8 +3,8 @@ import type * as Sentry from '@sentry/browser';
 /**
  * Captures an exception event and sends it to Sentry.
  *
- * @param exception The exception to capture.
- * @param hint Optional additional data to attach to the Sentry event.
+ * @param exception -The exception to capture.
+ * @param hint - Optional additional data to attach to the Sentry event.
  * @returns the id of the captured Sentry event, or `undefined` if Sentry is not initialized.
  */
 export function captureException(
@@ -14,7 +14,7 @@ export function captureException(
   if (!globalThis.sentry?.captureException) {
     console.warn('Sentry not initialized');
     console.error(exception, ...(hint ? [hint] : []));
-    return;
+    return undefined;
   }
   return globalThis.sentry.captureException(exception, ...(hint ? [hint] : []));
 }
@@ -22,8 +22,8 @@ export function captureException(
 /**
  * Captures a message event and sends it to Sentry.
  *
- * @param message The message to send to Sentry.
- * @param captureContext Define the level of the message or pass in additional data to attach to the message.
+ * @param message - The message to send to Sentry.
+ * @param captureContext - Define the level of the message or pass in additional data to attach to the message.
  * @returns the id of the captured message, or `undefined` if Sentry is not initialized.
  */
 export function captureMessage(
@@ -33,7 +33,7 @@ export function captureMessage(
   if (!globalThis.sentry?.captureMessage) {
     console.warn('Sentry not initialized');
     console.log(message, ...(captureContext ? [captureContext] : []));
-    return;
+    return undefined;
   }
   return globalThis.sentry.captureMessage(
     message,

--- a/shared/lib/sentry.ts
+++ b/shared/lib/sentry.ts
@@ -1,0 +1,42 @@
+import type * as Sentry from '@sentry/browser';
+
+/**
+ * Captures an exception event and sends it to Sentry.
+ *
+ * @param exception The exception to capture.
+ * @param hint Optional additional data to attach to the Sentry event.
+ * @returns the id of the captured Sentry event, or `undefined` if Sentry is not initialized.
+ */
+export function captureException(
+  exception: unknown,
+  hint?: Parameters<(typeof Sentry)['captureException']>[1],
+): string | undefined {
+  if (!globalThis.sentry?.captureException) {
+    console.warn('Sentry not initialized');
+    console.error(exception, ...(hint ? [hint] : []));
+    return;
+  }
+  return globalThis.sentry.captureException(exception, ...(hint ? [hint] : []));
+}
+
+/**
+ * Captures a message event and sends it to Sentry.
+ *
+ * @param message The message to send to Sentry.
+ * @param captureContext Define the level of the message or pass in additional data to attach to the message.
+ * @returns the id of the captured message, or `undefined` if Sentry is not initialized.
+ */
+export function captureMessage(
+  message: string,
+  captureContext?: Parameters<(typeof Sentry)['captureMessage']>[1],
+): string | undefined {
+  if (!globalThis.sentry?.captureMessage) {
+    console.warn('Sentry not initialized');
+    console.log(message, ...(captureContext ? [captureContext] : []));
+    return;
+  }
+  return globalThis.sentry.captureMessage(
+    message,
+    ...(captureContext ? [captureContext] : []),
+  );
+}

--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -1,22 +1,19 @@
-import {
-  setMeasurement,
-  Span,
-  startSpan,
-  startSpanManual,
-  withIsolationScope,
-} from '@sentry/browser';
+import type * as Sentry from '@sentry/browser';
 import { endTrace, trace, TraceName } from './trace';
 
-jest.mock('@sentry/browser', () => ({
+jest.replaceProperty(global, 'sentry', {
   withIsolationScope: jest.fn(),
   startSpan: jest.fn(),
   startSpanManual: jest.fn(),
   setMeasurement: jest.fn(),
-}));
+});
+
+const { setMeasurement, startSpan, startSpanManual, withIsolationScope } =
+  global.sentry as typeof Sentry;
 
 const NAME_MOCK = TraceName.Transaction;
 const ID_MOCK = 'testId';
-const PARENT_CONTEXT_MOCK = {} as Span;
+const PARENT_CONTEXT_MOCK = {} as Sentry.Span;
 
 const TAGS_MOCK = {
   tag1: 'value1',
@@ -47,10 +44,10 @@ describe('Trace', () => {
       setMeasurement: setMeasurementMock,
     };
 
-    startSpanMock.mockImplementation((_, fn) => fn({} as Span));
+    startSpanMock.mockImplementation((_, fn) => fn({} as Sentry.Span));
 
     startSpanManualMock.mockImplementation((_, fn) =>
-      fn({} as Span, () => {
+      fn({} as Sentry.Span, () => {
         // Intentionally empty
       }),
     );
@@ -197,7 +194,7 @@ describe('Trace', () => {
   describe('endTrace', () => {
     it('ends Sentry span matching name and specified ID', () => {
       const spanEndMock = jest.fn();
-      const spanMock = { end: spanEndMock } as unknown as Span;
+      const spanMock = { end: spanEndMock } as unknown as Sentry.Span;
 
       startSpanManualMock.mockImplementationOnce((_, fn) =>
         fn(spanMock, () => {
@@ -220,7 +217,7 @@ describe('Trace', () => {
 
     it('ends Sentry span matching name and default ID', () => {
       const spanEndMock = jest.fn();
-      const spanMock = { end: spanEndMock } as unknown as Span;
+      const spanMock = { end: spanEndMock } as unknown as Sentry.Span;
 
       startSpanManualMock.mockImplementationOnce((_, fn) =>
         fn(spanMock, () => {
@@ -242,7 +239,7 @@ describe('Trace', () => {
 
     it('ends Sentry span with custom timestamp', () => {
       const spanEndMock = jest.fn();
-      const spanMock = { end: spanEndMock } as unknown as Span;
+      const spanMock = { end: spanEndMock } as unknown as Sentry.Span;
 
       startSpanManualMock.mockImplementationOnce((_, fn) =>
         fn(spanMock, () => {
@@ -266,7 +263,7 @@ describe('Trace', () => {
 
     it('does not end Sentry span if name and ID does not match', () => {
       const spanEndMock = jest.fn();
-      const spanMock = { end: spanEndMock } as unknown as Span;
+      const spanMock = { end: spanEndMock } as unknown as Sentry.Span;
 
       startSpanManualMock.mockImplementationOnce((_, fn) =>
         fn(spanMock, () => {

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser';
+import type * as Sentry from '@sentry/browser';
 import { MeasurementUnit, Span, StartSpanOptions } from '@sentry/types';
 import { createModuleLogger } from '@metamask/utils';
 // TODO: Remove restricted import

--- a/test/helpers/setup-helper.js
+++ b/test/helpers/setup-helper.js
@@ -23,6 +23,22 @@ global.chrome = {
   },
 };
 
+// Stub for Sentry global
+global.sentry = {
+  captureException: () => {
+    // no-op
+  },
+  captureFeedback: () => {
+    // no-op
+  },
+  captureMessage: () => {
+    // no-op
+  },
+  lastEventId: () => {
+    // no-op
+  },
+};
+
 nock.disableNetConnect();
 nock.enableNetConnect('localhost');
 if (typeof beforeEach === 'function') {


### PR DESCRIPTION
## **Description**

Update all shared Sentry calls to use `global.Sentry` instead of imported library functions.

The imported functions do not work in production builds because they refer to a copy of that code run in a Compartment (by LavaMoat), which is never initialized. The Sentry client we initialize is not in a compartment.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34382?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Relates to https://github.com/MetaMask/metamask-extension/issues/34371

## **Manual testing steps**

I don't know the manual steps needed to trigger each of these errors. The manual testing steps for `global.sentry` are in this PR though: https://github.com/MetaMask/metamask-extension/pull/34386

And in this branch I added additional buttons to confirm that `captureException` wasn't working as-is: https://github.com/MetaMask/metamask-extension/compare/test-sentry-error-capture-methods?expand=1

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
