### PR TITLE
chore: Add buttons to test error capture

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4351,6 +4351,7 @@ export default class MetamaskController extends EventEmitter {
 
       // E2E testing
       throwTestError: this.throwTestError.bind(this),
+      captureTestError: this.captureTestError.bind(this),
 
       // NameController
       updateProposedNames: this.nameController.updateProposedNames.bind(
@@ -8400,6 +8401,21 @@ export default class MetamaskController extends EventEmitter {
       const error = new Error(message);
       error.name = 'TestError';
       throw error;
+    });
+  }
+
+  /**
+   * Capture an artificial error in a timeout handler for testing purposes.
+   *
+   * @param message - The error message.
+   * @deprecated This is only mean to facilitiate E2E testing. We should not
+   * use this for handling errors.
+   */
+  captureTestError(message) {
+    setTimeout(() => {
+      const error = new Error(message);
+      error.name = 'TestError';
+      global.sentry.captureException(error);
     });
   }
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -276,6 +276,8 @@ type StateHooks = {
   metamaskGetState?: () => Promise<any>;
   throwTestBackgroundError?: (msg?: string) => Promise<void>;
   throwTestError?: (msg?: string) => void;
+  captureTestError?: (msg?: string) => Promise<void>;
+  captureBackgroundError?: (msg?: string) => Promise<void>;
   /**
    * This is set in `app-init.js` to communicate why MetaMask installed or
    * updated. It is handled in `background.js`.

--- a/ui/index.js
+++ b/ui/index.js
@@ -325,9 +325,7 @@ function setupStateHooks(store) {
     window.stateHooks.captureBackgroundError = async function (
       msg = 'Test Error',
     ) {
-      const error = new Error(msg);
-      error.name = 'TestError';
-      await actions.captureTestBackgroundError(error);
+      await actions.captureTestBackgroundError(msg);
     };
   }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -294,6 +294,17 @@ function setupStateHooks(store) {
       throw error;
     };
     /**
+     * The following stateHook is a method intended to capture an error, used in
+     * our E2E test to ensure that errors are correctly sent to sentry.
+     *
+     * @param {string} [msg] - The error message to capture, defaults to 'Test Error'
+     */
+    window.stateHooks.captureTestError = async function (msg = 'Test Error') {
+      const error = new Error(msg);
+      error.name = 'TestError';
+      global.sentry.captureException(error);
+    };
+    /**
      * The following stateHook is a method intended to throw an error in the
      * background, used in our E2E test to ensure that errors are attempted to be
      * sent to sentry.
@@ -304,6 +315,19 @@ function setupStateHooks(store) {
       msg = 'Test Error',
     ) {
       await actions.throwTestBackgroundError(msg);
+    };
+    /**
+     * The following stateHook is a method intended to capture an error in the background, used
+     * in our E2E test to ensure that errors are correctly sent to sentry.
+     *
+     * @param {string} [msg] - The error message to capture, defaults to 'Test Error'
+     */
+    window.stateHooks.captureBackgroundError = async function (
+      msg = 'Test Error',
+    ) {
+      const error = new Error(msg);
+      error.name = 'TestError';
+      await actions.captureTestBackgroundError(error);
     };
   }
 

--- a/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
+++ b/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
@@ -349,6 +349,90 @@ exports[`Develop options tab should match snapshot 1`] = `
             class="settings-page__content-description"
           >
             <span>
+              Capture a 
+              <b>
+                TestError
+              </b>
+               in this window.
+            </span>
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
+          >
+            Capture UI Error
+          </button>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <div
+            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
+            style="height: 40px; width: 40px;"
+          >
+            <span
+              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
+              hidden=""
+              style="mask-image: url('./images/icons/check.svg');"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <div
+            class="settings-page__content-description"
+          >
+            <span>
+              Capture a 
+              <b>
+                TestError
+              </b>
+               in the service worker.
+            </span>
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
+          >
+            Capture Background Error
+          </button>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <div
+            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
+            style="height: 40px; width: 40px;"
+          >
+            <span
+              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
+              hidden=""
+              style="mask-image: url('./images/icons/check.svg');"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <div
+            class="settings-page__content-description"
+          >
+            <span>
               Generate a 
               <b>
                 Developer Test

--- a/ui/pages/settings/developer-options-tab/sentry-test.tsx
+++ b/ui/pages/settings/developer-options-tab/sentry-test.tsx
@@ -111,7 +111,6 @@ function CaptureUIError() {
         </span>
       }
       onClick={handleClick}
-      expectError
     />
   );
 }
@@ -132,7 +131,6 @@ function CaptureBackgroundError() {
         </span>
       }
       onClick={handleClick}
-      expectError
     />
   );
 }

--- a/ui/pages/settings/developer-options-tab/sentry-test.tsx
+++ b/ui/pages/settings/developer-options-tab/sentry-test.tsx
@@ -44,6 +44,8 @@ const SentryTest = () => {
       <div className="settings-page__content-padded">
         <GenerateUIError />
         <GenerateBackgroundError />
+        <CaptureUIError />
+        <CaptureBackgroundError />
         <GenerateTrace />
         <GeneratePageCrash currentLocale={currentLocale} />
       </div>
@@ -85,6 +87,48 @@ function GenerateBackgroundError() {
       description={
         <span>
           Generate an unhandled <b>TestError</b> in the service worker.
+        </span>
+      }
+      onClick={handleClick}
+      expectError
+    />
+  );
+}
+
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+// eslint-disable-next-line @typescript-eslint/naming-convention
+function CaptureUIError() {
+  const handleClick = useCallback(async () => {
+    await window.stateHooks.captureTestError?.('Developer Options');
+  }, []);
+
+  return (
+    <TestButton
+      name="Capture UI Error"
+      description={
+        <span>
+          Capture a <b>TestError</b> in this window.
+        </span>
+      }
+      onClick={handleClick}
+      expectError
+    />
+  );
+}
+
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+// eslint-disable-next-line @typescript-eslint/naming-convention
+function CaptureBackgroundError() {
+  const handleClick = useCallback(async () => {
+    await window.stateHooks.captureBackgroundError?.('Developer Options');
+  }, []);
+
+  return (
+    <TestButton
+      name="Capture Background Error"
+      description={
+        <span>
+          Capture a <b>TestError</b> in the service worker.
         </span>
       }
       onClick={handleClick}

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6248,6 +6248,19 @@ export async function throwTestBackgroundError(message: string): Promise<void> {
 }
 
 /**
+ * Capture an error in the background for testing purposes.
+ *
+ * @param message - The error message.
+ * @deprecated This is only meant to facilitiate E2E testing. We should not use
+ * this for handling errors.
+ */
+export async function captureTestBackgroundError(
+  message: string,
+): Promise<void> {
+  await submitRequestToBackground('captureTestError', [message]);
+}
+
+/**
  * Set status of popover warning for the first snap installation.
  *
  * @param shown - True if popover has been shown.


### PR DESCRIPTION
## **Description**

Add two buttons to the "Developer Options" settings page to test that captured Sentry errors work correctly (one button for the UI, one for the background).

We have two similar buttons already for unhandled errors, but not for explicitly handled errors.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34386?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

These will assist with manual testing for this bug: #34371

## **Manual testing steps**

1. Create a build with the following environment variables set in `.metamaskrc`:
  * `SENTRY_DSN` and `SENTRY_DSN_DEV` set to your personal Sentry DSN (see [these docs](https://github.com/MetaMask/metamask-extension/tree/main/development#sentry-ui-setup) for help setting that up)
  * `ENABLE_SETTINGS_PAGE_DEV_OPTIONS` set to `true`
2. Install the extension, ensuring to **opt-in** to metrics during onboarding
3. Navigate to the Settings => Developer Options page
4. Click the "Capture UI Error" and "Capture Background Error" buttons, monitoring in the Network tab of dev tools for each process to ensure it was sent to Sentry correctly (and/or check on your Sentry dashboard).

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

https://github.com/user-attachments/assets/ec1c21b7-89db-460b-8604-ad7b977d64a5


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
