### PR TITLE
chore: Improve accuracy of test error inline comments

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4368,7 +4368,7 @@ export default class MetamaskController extends EventEmitter {
           notificationServicesController,
         ),
 
-      // E2E testing
+      // Testing
       throwTestError: this.throwTestError.bind(this),
       captureTestError: this.captureTestError.bind(this),
 
@@ -8493,7 +8493,7 @@ export default class MetamaskController extends EventEmitter {
    * Throw an artificial error in a timeout handler for testing purposes.
    *
    * @param message - The error message.
-   * @deprecated This is only mean to facilitiate E2E testing. We should not
+   * @deprecated This is only mean to facilitiate manual and E2E testing. We should not
    * use this for handling errors.
    */
   throwTestError(message) {
@@ -8508,7 +8508,7 @@ export default class MetamaskController extends EventEmitter {
    * Capture an artificial error in a timeout handler for testing purposes.
    *
    * @param message - The error message.
-   * @deprecated This is only mean to facilitiate E2E testing. We should not
+   * @deprecated This is only mean to facilitiate manual and E2E tests testing. We should not
    * use this for handling errors.
    */
   captureTestError(message) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -8493,7 +8493,7 @@ export default class MetamaskController extends EventEmitter {
    * Throw an artificial error in a timeout handler for testing purposes.
    *
    * @param message - The error message.
-   * @deprecated This is only mean to facilitiate manual and E2E testing. We should not
+   * @deprecated This is only meant to facilitate manual and E2E testing. We should not
    * use this for handling errors.
    */
   throwTestError(message) {
@@ -8508,7 +8508,7 @@ export default class MetamaskController extends EventEmitter {
    * Capture an artificial error in a timeout handler for testing purposes.
    *
    * @param message - The error message.
-   * @deprecated This is only mean to facilitiate manual and E2E tests testing. We should not
+   * @deprecated This is only meant to facilitate manual and E2E tests testing. We should not
    * use this for handling errors.
    */
   captureTestError(message) {

--- a/ui/index.js
+++ b/ui/index.js
@@ -289,7 +289,7 @@ function setupStateHooks(store) {
   ) {
     /**
      * The following stateHook is a method intended to throw an error, used in
-     * our E2E test to ensure that errors are attempted to be sent to sentry.
+     * manual and E2E tests to ensure that errors are attempted to be sent to sentry.
      *
      * @param {string} [msg] - The error message to throw, defaults to 'Test Error'
      */
@@ -300,7 +300,7 @@ function setupStateHooks(store) {
     };
     /**
      * The following stateHook is a method intended to capture an error, used in
-     * our E2E test to ensure that errors are correctly sent to sentry.
+     * manual and E2E tests to ensure that errors are correctly sent to sentry.
      *
      * @param {string} [msg] - The error message to capture, defaults to 'Test Error'
      */
@@ -311,7 +311,7 @@ function setupStateHooks(store) {
     };
     /**
      * The following stateHook is a method intended to throw an error in the
-     * background, used in our E2E test to ensure that errors are attempted to be
+     * background, used in manual and E2E tests to ensure that errors are attempted to be
      * sent to sentry.
      *
      * @param {string} [msg] - The error message to throw, defaults to 'Test Error'
@@ -323,7 +323,7 @@ function setupStateHooks(store) {
     };
     /**
      * The following stateHook is a method intended to capture an error in the background, used
-     * in our E2E test to ensure that errors are correctly sent to sentry.
+     * in manual and E2E tests to ensure that errors are correctly sent to sentry.
      *
      * @param {string} [msg] - The error message to capture, defaults to 'Test Error'
      */

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6269,7 +6269,7 @@ export async function updateDataDeletionTaskStatus() {
  * Throw an error in the background for testing purposes.
  *
  * @param message - The error message.
- * @deprecated This is only meant to facilitiate manual and E2E tests testing. We should not use
+ * @deprecated This is only meant to facilitate manual and E2E tests testing. We should not use
  * this for handling errors.
  */
 export async function throwTestBackgroundError(message: string): Promise<void> {
@@ -6280,7 +6280,7 @@ export async function throwTestBackgroundError(message: string): Promise<void> {
  * Capture an error in the background for testing purposes.
  *
  * @param message - The error message.
- * @deprecated This is only meant to facilitiate manual and E2E tests testing. We should not use
+ * @deprecated This is only meant to facilitate manual and E2E tests testing. We should not use
  * this for handling errors.
  */
 export async function captureTestBackgroundError(

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6269,7 +6269,7 @@ export async function updateDataDeletionTaskStatus() {
  * Throw an error in the background for testing purposes.
  *
  * @param message - The error message.
- * @deprecated This is only meant to facilitiate E2E testing. We should not use
+ * @deprecated This is only meant to facilitiate manual and E2E tests testing. We should not use
  * this for handling errors.
  */
 export async function throwTestBackgroundError(message: string): Promise<void> {
@@ -6280,7 +6280,7 @@ export async function throwTestBackgroundError(message: string): Promise<void> {
  * Capture an error in the background for testing purposes.
  *
  * @param message - The error message.
- * @deprecated This is only meant to facilitiate E2E testing. We should not use
+ * @deprecated This is only meant to facilitiate manual and E2E tests testing. We should not use
  * this for handling errors.
  */
 export async function captureTestBackgroundError(


### PR DESCRIPTION
## **Description**

The inline comments on functions relating to "test errors" have been updated to clarify that they're used in both manual and E2E testing, not just E2E testing. This better explains why they're not enabled only in test builds.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34404?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes a problem that was expanded and commented upon in #34386

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
