### PR TITLE
fix: check if metametrics is done before redirecting to page on social cp-13.0.0

### DIFF
--- a/ui/selectors/first-time-flow.js
+++ b/ui/selectors/first-time-flow.js
@@ -38,7 +38,8 @@ export const getIsSocialLoginFlow = (state) => {
  * @returns {string} Route to redirect the user to
  */
 export function getFirstTimeFlowTypeRouteAfterUnlock(state) {
-  const { firstTimeFlowType } = state.metamask;
+  const { firstTimeFlowType, participateInMetaMetrics } = state.metamask;
+  const hasSetMetaMetrics = participateInMetaMetrics !== null;
 
   if (firstTimeFlowType === FirstTimeFlowType.create) {
     return ONBOARDING_CREATE_PASSWORD_ROUTE;
@@ -47,12 +48,16 @@ export function getFirstTimeFlowTypeRouteAfterUnlock(state) {
   } else if (firstTimeFlowType === FirstTimeFlowType.restore) {
     return ONBOARDING_METAMETRICS;
   } else if (firstTimeFlowType === FirstTimeFlowType.socialCreate) {
-    return ONBOARDING_METAMETRICS;
+    return hasSetMetaMetrics
+      ? ONBOARDING_COMPLETION_ROUTE
+      : ONBOARDING_METAMETRICS;
   } else if (firstTimeFlowType === FirstTimeFlowType.socialImport) {
     if (getBrowserName() === PLATFORM_FIREFOX) {
       return ONBOARDING_PIN_EXTENSION_ROUTE;
     }
-    return ONBOARDING_METAMETRICS;
+    return hasSetMetaMetrics
+      ? ONBOARDING_COMPLETION_ROUTE
+      : ONBOARDING_METAMETRICS;
   }
   return DEFAULT_ROUTE;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This fixes some cases where the app is redirected to metametrics screen, even if user has set metametrics preference already.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34438?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed app redirecting to metametrics page even if the user is done setting it.

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-extension/issues/34444

## **Manual testing steps**

1. Create a new wallet using social login
2. Continue onboarding and set metametrics preference
3. Open a new metamask instance (shown on attached video)
4. Unlock the app
5. App should not redirect to metametrics page, instead app should go to Completion page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/4ba95260-36aa-4e37-af5b-2ac93a76cf9a

### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/9c624abe-7089-4b2c-b469-de2f87ec6394

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
