### PR TITLE
fix: use origin instead of mainFrameOrigin in trust signals middleware

### DIFF
--- a/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.test.ts
@@ -39,13 +39,13 @@ const MOCK_SCAN_RESPONSES = {
 const createMockRequest = (
   method: string,
   params: Json[] = [],
-  mainFrameOrigin: string = 'https://example.com',
-): JsonRpcRequest & { mainFrameOrigin?: string } => ({
+  origin: string = 'https://example.com',
+): JsonRpcRequest & { origin?: string } => ({
   method,
   params,
   id: 1,
   jsonrpc: '2.0',
-  mainFrameOrigin,
+  origin,
 });
 
 const createMockResponse = (): JsonRpcResponse => ({
@@ -175,9 +175,7 @@ describe('createTrustSignalsMiddleware', () => {
         appStateController,
         networkController,
       );
-      expect(phishingController.scanUrl).toHaveBeenCalledWith(
-        req.mainFrameOrigin,
-      );
+      expect(phishingController.scanUrl).toHaveBeenCalledWith(req.origin);
       expect(next).toHaveBeenCalled();
     });
 
@@ -561,12 +559,12 @@ describe('createTrustSignalsMiddleware', () => {
   });
 
   describe('eth_accounts', () => {
-    it('scans URL when mainFrameOrigin is present', async () => {
+    it('scans URL when origin is present', async () => {
       const { middleware, phishingController } = createMiddleware();
-      const mainFrameOrigin = 'https://example.com';
+      const origin = 'https://example.com';
       const req = {
         ...createMockRequest(MESSAGE_TYPE.ETH_ACCOUNTS),
-        mainFrameOrigin,
+        origin,
       };
       const res = createMockResponse();
       const next = jest.fn();
@@ -579,14 +577,14 @@ describe('createTrustSignalsMiddleware', () => {
 
       await middleware(req, res, next);
 
-      expect(phishingController.scanUrl).toHaveBeenCalledWith(mainFrameOrigin);
+      expect(phishingController.scanUrl).toHaveBeenCalledWith(origin);
       expect(next).toHaveBeenCalled();
     });
 
-    it('does not scan URL when mainFrameOrigin is not present', async () => {
+    it('does not scan URL when origin is not present', async () => {
       const { middleware, phishingController } = createMiddleware();
       const req = createMockRequest(MESSAGE_TYPE.ETH_ACCOUNTS);
-      req.mainFrameOrigin = undefined;
+      req.origin = undefined;
       const res = createMockResponse();
       const next = jest.fn();
 
@@ -598,10 +596,10 @@ describe('createTrustSignalsMiddleware', () => {
 
     it('handles phishing scan errors gracefully', async () => {
       const { middleware, phishingController } = createMiddleware();
-      const mainFrameOrigin = 'https://malicious.com';
+      const origin = 'https://malicious.com';
       const req = {
         ...createMockRequest(MESSAGE_TYPE.ETH_ACCOUNTS),
-        mainFrameOrigin,
+        origin,
       };
       const res = createMockResponse();
       const next = jest.fn();
@@ -615,7 +613,7 @@ describe('createTrustSignalsMiddleware', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(phishingController.scanUrl).toHaveBeenCalledWith(mainFrameOrigin);
+      expect(phishingController.scanUrl).toHaveBeenCalledWith(origin);
       expect(next).toHaveBeenCalled();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.ts
@@ -22,7 +22,7 @@ export function createTrustSignalsMiddleware(
   preferencesController: PreferencesController,
 ) {
   return async (
-    req: JsonRpcRequest & { mainFrameOrigin?: string },
+    req: JsonRpcRequest & { origin?: string },
     _res: JsonRpcResponse,
     next: () => void,
   ) => {
@@ -52,11 +52,11 @@ export function createTrustSignalsMiddleware(
 }
 
 function scanUrl(
-  req: JsonRpcRequest & { mainFrameOrigin?: string },
+  req: JsonRpcRequest & { origin?: string },
   phishingController: PhishingController,
 ) {
-  if (req.mainFrameOrigin) {
-    phishingController.scanUrl(req.mainFrameOrigin).catch((error) => {
+  if (req.origin) {
+    phishingController.scanUrl(req.origin).catch((error) => {
       console.error('[createTrustSignalsMiddleware] error:', error);
     });
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Updates the trust signals middleware to scan `origin` instead of `mainFrameOrigin` for URL phishing detection to align with what users see in the confirmation screens. This change ensures we are scanning the same value `origin` that is actually displayed to users in the confirmation screen.

This fix also potentially addresses a bypass scenario involving iframe requests, where phishing attempts could be missed if we only scanned ‎`mainFrameOrigin`.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34459?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
