### PR TITLE
fix: cp-12.22.3 Stop persisting `permissionActivityLog` state

### DIFF
--- a/app/scripts/migrations/168.1.test.ts
+++ b/app/scripts/migrations/168.1.test.ts
@@ -1,0 +1,79 @@
+import { migrate, version } from './168.1';
+
+const oldVersion = 168;
+
+describe(`migration #${version}`, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+  });
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('warns of migration skip when PermissionLogController state is missing', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        PreferencesController: {
+          foo: 'bar',
+        },
+      },
+    };
+    const expectedData = {
+      PreferencesController: {
+        foo: 'bar',
+      },
+    };
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(expectedData);
+    expect(console.warn).toHaveBeenCalledWith(
+      `Migration ${version}: 'PermissionLogController.permissionActivityLog' state not found, skipping migration.`,
+    );
+  });
+
+  it('warns of migration skip when PermissionLogController.permissionActivityLog state is missing', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        PermissionLogController: {
+          foo: 'bar',
+        },
+      },
+    };
+    const expectedData = {
+      PermissionLogController: {
+        foo: 'bar',
+      },
+    };
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(expectedData);
+    expect(console.warn).toHaveBeenCalledWith(
+      `Migration ${version}: 'PermissionLogController.permissionActivityLog' state not found, skipping migration.`,
+    );
+  });
+
+  it('deletes PermissionLogController.permissionActivityLog state', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        PermissionLogController: {
+          permissionActivityLog: [{ foo: 'bar' }],
+        },
+      },
+    };
+    const expectedData = {
+      PermissionLogController: {},
+    };
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(expectedData);
+  });
+});

--- a/app/scripts/migrations/168.1.ts
+++ b/app/scripts/migrations/168.1.ts
@@ -1,0 +1,43 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 168.1;
+
+/**
+ * This migration removes the `permissionActivityLog` state
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly
+ * what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by
+ * controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (
+    hasProperty(state, 'PermissionLogController') &&
+    isObject(state.PermissionLogController) &&
+    hasProperty(state.PermissionLogController, 'permissionActivityLog')
+  ) {
+    delete state.PermissionLogController.permissionActivityLog;
+  } else {
+    console.warn(
+      `Migration ${version}: 'PermissionLogController.permissionActivityLog' state not found, skipping migration.`,
+    );
+  }
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -199,6 +199,7 @@ const migrations = [
   require('./166'),
   require('./167'),
   require('./168'),
+  require('./168.1'),
   require('./169'),
   require('./170'),
   require('./170.1'),

--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
     "@metamask/object-multiplex": "^2.0.0",
     "@metamask/obs-store": "^9.0.0",
     "@metamask/permission-controller": "^11.0.6",
-    "@metamask/permission-log-controller": "^3.0.3",
+    "@metamask/permission-log-controller": "^4.0.0",
     "@metamask/phishing-controller": "^12.6.0",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/ppom-validator": "0.36.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6925,14 +6925,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-log-controller@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "@metamask/permission-log-controller@npm:3.0.3"
+"@metamask/permission-log-controller@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@metamask/permission-log-controller@npm:4.0.0"
   dependencies:
-    "@metamask/base-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^8.0.1"
     "@metamask/json-rpc-engine": "npm:^10.0.3"
-    "@metamask/utils": "npm:^11.1.0"
-  checksum: 10/bc59c20c37631260c5f8d101be074eb429955ee283f45a685cdd403e3963078269b2f1d707e301f8939921d49942359d22b98ecc566a825a9f34c25e95f3919b
+    "@metamask/utils": "npm:^11.4.2"
+  checksum: 10/aa30d84c27a742cf410d28d5a8c8d7d1c52d4ae6430cd89808386c78bc80ffce51870d3ea0222c40acff9a1b6ad747cb297b2a00dde57a512bfea68e3b536051
   languageName: node
   linkType: hard
 
@@ -32014,7 +32014,7 @@ __metadata:
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/obs-store": "npm:^9.0.0"
     "@metamask/permission-controller": "npm:^11.0.6"
-    "@metamask/permission-log-controller": "npm:^3.0.3"
+    "@metamask/permission-log-controller": "npm:^4.0.0"
     "@metamask/phishing-controller": "npm:^12.6.0"
     "@metamask/phishing-warning": "npm:^5.0.0"
     "@metamask/post-message-stream": "npm:^10.0.0"


### PR DESCRIPTION
## **Description**

Stop persisting `PermissionLogController.permissionActivityLog` state. This state is not particularly important to persist across sessions, and it was connected to some performance issues.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34465?quickstart=1)

## **Changelog**

CHANGELOG entry: Prevent frequent writes while the wallet UI is closed

## **Related issues**

Relates to #33879

## **Manual testing steps**

To test the reduction in writes while idle:

1. Proceed through onboarding
2. Close all UI instances
3. Monitor the background console, putting a logpoint here conditional on `this.persist` being `true`: https://github.com/MetaMask/metamask-extension/blob/f2104e923f463bd85a5950ea030fc00726a319f4/app/scripts/lib/ComposableObservableStore.js#L111

~Note that these testing steps will not work without the changes in https://github.com/MetaMask/metamask-extension/pull/34506~ That is now merged, and this branch has been updated.

To test the migration:
* Install the extension from a directory with a build of v12.22.2 or earlier.
* Proceed through onboarding, then wait a few seconds to make sure it has had enough time to persist
* Update that directory with a build from this PR.
* Start the extension, and review the logs. You should see a log showing that migration 168.1 was run. If you see a warning that it was skipped, that suggests something went wrong.
* Check your state to ensure `permissionActivityLog` is not present (e.g. using `window.stateHooks.getPersistedState()`)

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
