### PR TITLE
fix: cp-12.22.3 Stop polling multichain rates while idle

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1075,6 +1075,10 @@ export function setupController(
       const portStream =
         overrides?.getPortStream?.(remotePort) || new PortStream(remotePort);
       // communication with popup
+      if (!controller.isClientOpen) {
+        controller.onClientOpened();
+      }
+
       controller.isClientOpen = true;
       controller.setupTrustedCommunication(portStream, remotePort.sender);
       trackAppOpened(processName);

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1075,10 +1075,6 @@ export function setupController(
       const portStream =
         overrides?.getPortStream?.(remotePort) || new PortStream(remotePort);
       // communication with popup
-      if (!controller.isClientOpen) {
-        controller.onClientOpened();
-      }
-
       controller.isClientOpen = true;
       controller.setupTrustedCommunication(portStream, remotePort.sender);
       trackAppOpened(processName);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3170,7 +3170,8 @@ export default class MetamaskController extends EventEmitter {
     if (
       !isEvmAccountType(
         this.accountsController.getSelectedMultichainAccount().type,
-      )
+      ) &&
+      this._isClientOpen
     ) {
       this.multichainRatesController.start();
     }
@@ -3178,7 +3179,7 @@ export default class MetamaskController extends EventEmitter {
     this.controllerMessenger.subscribe(
       'AccountsController:selectedAccountChange',
       (selectedAccount) => {
-        if (isEvmAccountType(selectedAccount.type)) {
+        if (!this._isClientOpen || isEvmAccountType(selectedAccount.type)) {
           this.multichainRatesController.stop();
           return;
         }
@@ -8607,6 +8608,27 @@ export default class MetamaskController extends EventEmitter {
       this.appStateController.clearPollingTokens();
       this.accountTrackerController.stopAllPolling();
       this.deFiPositionsController.stopAllPolling();
+      this.multichainRatesController.stop();
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  /**
+   * A method that is called the first time the UI is opened after the client is closed.
+   *
+   * Currently used to start polling on older controllers. Newer controllers activate polling in
+   * the UI.
+   */
+  onClientOpened() {
+    try {
+      if (
+        !isEvmAccountType(
+          this.accountsController.getSelectedMultichainAccount().type,
+        )
+      ) {
+        this.multichainRatesController.start();
+      }
     } catch (error) {
       console.error(error);
     }

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -3610,94 +3610,121 @@ describe('MetaMaskController', () => {
         jest.clearAllMocks();
       });
 
-      it('starts MultichainRatesController if selected account is changed to non-EVM', async () => {
-        expect(
-          metamaskController.multichainRatesController.start,
-        ).not.toHaveBeenCalled();
-
-        metamaskController.controllerMessenger.publish(
-          'AccountsController:selectedAccountChange',
-          mockNonEvmAccount,
-        );
-
-        expect(
-          metamaskController.multichainRatesController.start,
-        ).toHaveBeenCalledTimes(1);
-      });
-
-      it('stops MultichainRatesController if selected account is changed to EVM', async () => {
-        expect(
-          metamaskController.multichainRatesController.start,
-        ).not.toHaveBeenCalled();
-
-        metamaskController.controllerMessenger.publish(
-          'AccountsController:selectedAccountChange',
-          mockNonEvmAccount,
-        );
-
-        expect(
-          metamaskController.multichainRatesController.start,
-        ).toHaveBeenCalledTimes(1);
-
-        metamaskController.controllerMessenger.publish(
-          'AccountsController:selectedAccountChange',
-          mockEvmAccount,
-        );
-        expect(
-          metamaskController.multichainRatesController.start,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          metamaskController.multichainRatesController.stop,
-        ).toHaveBeenCalledTimes(1);
-      });
-
-      it('does not start MultichainRatesController if selected account is changed to EVM', async () => {
-        expect(
-          metamaskController.multichainRatesController.start,
-        ).not.toHaveBeenCalled();
-
-        metamaskController.controllerMessenger.publish(
-          'AccountsController:selectedAccountChange',
-          mockEvmAccount,
-        );
-
-        expect(
-          metamaskController.multichainRatesController.start,
-        ).not.toHaveBeenCalled();
-      });
-
-      it('starts MultichainRatesController if selected account is non-EVM account during initialization', async () => {
-        jest.spyOn(RatesController.prototype, 'start');
-        const localMetamaskController = new MetaMaskController({
-          showUserConfirmation: noop,
-          encryptor: mockEncryptor,
-          initState: {
-            ...cloneDeep(firstTimeState),
-            AccountsController: {
-              internalAccounts: {
-                accounts: {
-                  [mockNonEvmAccount.id]: mockNonEvmAccount,
-                  [mockEvmAccount.id]: mockEvmAccount,
-                },
-                selectedAccount: mockNonEvmAccount.id,
-              },
-            },
-          },
-          initLangCode: 'en_US',
-          platform: {
-            showTransactionNotification: () => undefined,
-            getVersion: () => 'foo',
-          },
-          browser: browserPolyfillMock,
-          infuraProjectId: 'foo',
-          isFirstMetaMaskControllerSetup: true,
-          cronjobControllerStorageManager:
-            createMockCronjobControllerStorageManager(),
+      describe('client is open', () => {
+        beforeEach(() => {
+          jest.replaceProperty(
+            metamaskController,
+            'activeControllerConnections',
+            1,
+          );
         });
 
-        expect(
-          localMetamaskController.multichainRatesController.start,
-        ).toHaveBeenCalled();
+        it('starts MultichainRatesController if selected account is changed to non-EVM', async () => {
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).not.toHaveBeenCalled();
+
+          metamaskController.controllerMessenger.publish(
+            'AccountsController:selectedAccountChange',
+            mockNonEvmAccount,
+          );
+
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).toHaveBeenCalledTimes(1);
+        });
+
+        it('stops MultichainRatesController if selected account is changed to EVM', async () => {
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).not.toHaveBeenCalled();
+
+          metamaskController.controllerMessenger.publish(
+            'AccountsController:selectedAccountChange',
+            mockNonEvmAccount,
+          );
+
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).toHaveBeenCalledTimes(1);
+
+          metamaskController.controllerMessenger.publish(
+            'AccountsController:selectedAccountChange',
+            mockEvmAccount,
+          );
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            metamaskController.multichainRatesController.stop,
+          ).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not start MultichainRatesController if selected account is changed to EVM', async () => {
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).not.toHaveBeenCalled();
+
+          metamaskController.controllerMessenger.publish(
+            'AccountsController:selectedAccountChange',
+            mockEvmAccount,
+          );
+
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('client is closed', () => {
+        beforeEach(() => {
+          jest.replaceProperty(
+            metamaskController,
+            'activeControllerConnections',
+            0,
+          );
+        });
+
+        it('does not start MultichainRatesController if selected account is changed to non-EVM', async () => {
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).not.toHaveBeenCalled();
+
+          metamaskController.controllerMessenger.publish(
+            'AccountsController:selectedAccountChange',
+            mockNonEvmAccount,
+          );
+
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).not.toHaveBeenCalled();
+        });
+
+        it('stops MultichainRatesController if selected account is changed to EVM', async () => {
+          metamaskController.controllerMessenger.publish(
+            'AccountsController:selectedAccountChange',
+            mockEvmAccount,
+          );
+
+          expect(
+            metamaskController.multichainRatesController.stop,
+          ).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not start MultichainRatesController if selected account is changed to EVM', async () => {
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).not.toHaveBeenCalled();
+
+          metamaskController.controllerMessenger.publish(
+            'AccountsController:selectedAccountChange',
+            mockEvmAccount,
+          );
+
+          expect(
+            metamaskController.multichainRatesController.start,
+          ).not.toHaveBeenCalled();
+        });
       });
 
       it('calls setFiatCurrency when the `currentCurrency` has changed', async () => {


### PR DESCRIPTION
## **Description**

The `MultichainRatesController` now stops polling when the UI is closed, and starts up again when the first UI instance is opened (conditionally, if a non-EVM account is selected).

The method for starting polling is slightly different from other polling controllers because this controller doesn't use the same polling mixin as elsewhere. This controller is deprecated and soon to be removed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34474?quickstart=1)

## **Changelog**

CHANGELOG entry: Prevent frequent writes while the wallet UI is closed

## **Related issues**

Relates to #33879

## **Manual testing steps**

1. Proceed through onboarding
2. Close all UI instances
3. Monitor the background console, putting a logpoint here conditional on `this.persist` being `true`: https://github.com/MetaMask/metamask-extension/blob/f2104e923f463bd85a5950ea030fc00726a319f4/app/scripts/lib/ComposableObservableStore.js#L111

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
