### PR TITLE
fix: show tx alert when simulation error is ResultWithNegativeLamports

### DIFF
--- a/shared/modules/bridge-utils/security-alerts-api.util.ts
+++ b/shared/modules/bridge-utils/security-alerts-api.util.ts
@@ -217,10 +217,6 @@ export async function fetchTxAlerts({
 
   assert<MessageScanResponse, unknown>(respBody, MessageScanResponse);
 
-  if (respBody.error_details?.code === 'ResultWithNegativeLamports') {
-    return null;
-  }
-
   if (respBody.status === 'ERROR') {
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
     // eslint-disable-next-line camelcase, @typescript-eslint/naming-convention


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the tx simulator so that it doesn't filter out `ResultWithNegativeLamports` errors. During the initial implementation these alerts seemed to duplicate the balance check done by the UI. However, some providers (like Debridge) take fees which are not reflected in the src/dest amounts or in the estimated fees. Only simulations can detect whether these types of quotes will succeed so we need to propagate the errors

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34477?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-2666

## **Manual testing steps**

1. Select Solana swap input that is greater than the user's balance
2. A banner alert indicating the balance error should appear

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="513" height="835" alt="Screenshot 2025-07-21 at 12 57 52 PM" src="https://github.com/user-attachments/assets/f517f2b4-35a4-44bb-90e1-df75bacc8c57" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
