### PR TITLE
fix: Make X button functional on network loading screen with mainnet default

### DIFF
--- a/ui/components/app/loading-network-screen/loading-network-screen.component.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.component.js
@@ -41,6 +41,7 @@ export default class LoadingNetworkScreen extends PureComponent {
     setProviderArgs: PropTypes.array,
     setActiveNetwork: PropTypes.func,
     rollbackToPreviousProvider: PropTypes.func,
+    failoverToMainnet: PropTypes.func,
     isNetworkLoading: PropTypes.bool,
     showDeprecatedRpcUrlWarning: PropTypes.bool,
   };
@@ -187,7 +188,7 @@ export default class LoadingNetworkScreen extends PureComponent {
   };
 
   render() {
-    const { rollbackToPreviousProvider, showDeprecatedRpcUrlWarning } =
+    const { rollbackToPreviousProvider, failoverToMainnet, showDeprecatedRpcUrlWarning } =
       this.props;
 
     let loadingMessageToRender;
@@ -206,7 +207,18 @@ export default class LoadingNetworkScreen extends PureComponent {
         header={
           <div
             className="page-container__header-close"
-            onClick={rollbackToPreviousProvider}
+            onClick={() => {
+              try {
+                failoverToMainnet();
+              } catch (error) {
+                console.error('Error failing over to mainnet:', error);
+                try {
+                  rollbackToPreviousProvider();
+                } catch (rollbackError) {
+                  console.error('Error with both mainnet and rollback:', rollbackError);
+                }
+              }
+            }}
           />
         }
         showLoadingSpinner={!this.state.showErrorScreen}

--- a/ui/components/app/loading-network-screen/loading-network-screen.container.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.container.js
@@ -58,6 +58,9 @@ const mapDispatchToProps = (dispatch) => {
     },
     rollbackToPreviousProvider: () =>
       dispatch(actions.rollbackToPreviousProvider()),
+    failoverToMainnet: () => {
+      dispatch(actions.setActiveNetwork(NETWORK_TYPES.MAINNET));
+    },
     showNetworkDropdown: () => {
       return dispatch(actions.toggleNetworkMenu());
     },


### PR DESCRIPTION
 **Description**

  Fixes the non-functional X button on the network loading screen during
  RPC connection failures. Previously, when users encountered network
  connectivity issues, clicking the X button did nothing, leaving them
  stuck in an unusable state for minutes until connection timeout.

  This PR implements a mainnet failover mechanism that attempts to switch
  to Ethereum Mainnet (mainnet.infura.io) when the X button is clicked,
  providing a more reliable escape route than the previous rollback-only
  approach. If mainnet failover fails, it falls back to the original
  rollback behavior.

  What is the reason for the change?
  Users were getting locked out of the extension during network connection
  failures because the X button was completely unresponsive.

  What is the improvement/solution?
  - Made the X button functional by adding proper click handling
  - Implemented mainnet failover as the primary escape mechanism (more
  reliable than previous provider)
  - Maintained backward compatibility with rollback as secondary fallback

  **Changelog**

  CHANGELOG entry: Fixed non-functional X button on network loading screen
  and added mainnet failover

  **Related issues**
  #34499 

  Manual testing steps

  1. Switch to a network with a failing or very slow RPC endpoint
  2. Observe the network loading screen appears with spinning indicator
  3. Click the X button in the top-right corner
  4. Verify the extension switches to Ethereum Mainnet
  5. Test with a completely broken network to ensure fallback to previous
  provider works
  6. Verify error logging appears in console if both failover and rollback
  fail

  Screenshots/Recordings

  Before

  - X button was visible but completely unresponsive
  - Users stuck on loading screen until timeout
  - Extension became unusable during network issues

  After

  - X button successfully switches to mainnet
  - Provides immediate escape route during connection failures
  - Extension remains usable even with network problems

  Pre-merge author checklist

  - I've followed https://github.com/MetaMask/contributor-docs and
  https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelin
  es/CODING_GUIDELINES.md.
  - I've completed the PR template to the best of my ability
  - ~I've included tests if applicable~
  - ~I've documented my code using https://jsdoc.app/ format if applicable~
  - I've applied the right labels on the PR (see
  https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelin
  es/LABELING_GUIDELINES.md). Not required for external contributors.

  Pre-merge reviewer checklist

  - I've manually tested the PR (e.g. pull and build branch, run the app,
  test code being changed).
  - I confirm that this PR addresses all acceptance criteria described in
  the ticket it closes and includes the necessary testing evidence such as
  recordings and or screenshots.
