### PR TITLE
fix: Prevent redundant persist store updates

### DIFF
--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -134,7 +134,7 @@ export default class ComposableObservableStore extends ObservableStore {
   #changedPersistedProperty(metadata, patches) {
     return patches.some((patch) => {
       // Complete state replacement
-      if (patch.path.lenght === 0) {
+      if (patch.path.length === 0) {
         return true;
       }
       const topLevelProperty = patch.path[0];

--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -127,8 +127,8 @@ export default class ComposableObservableStore extends ObservableStore {
    * Note that we assume at least one property is persisted, so a complete replacement patch
    * always returns true.
    *
-   * @param {StateMetadataConstraint} metadata
-   * @param {Patch[]} patches
+   * @param {StateMetadataConstraint} metadata - Controller metadata.
+   * @param {Patch[]} patches - A list of patches, corresponding to a single state update.
    */
   #changedPersistedProperty(metadata, patches) {
     return patches.some((patch) => {

--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -129,6 +129,7 @@ export default class ComposableObservableStore extends ObservableStore {
    *
    * @param {StateMetadataConstraint} metadata - Controller metadata.
    * @param {Patch[]} patches - A list of patches, corresponding to a single state update.
+   * @returns True if the patches contain a change to persisted state, false otherwise.
    */
   #changedPersistedProperty(metadata, patches) {
     return patches.some((patch) => {

--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -3,6 +3,8 @@ import { getPersistentState } from '@metamask/base-controller';
 
 /**
  * @typedef {import('@metamask/base-controller').Messenger} Messenger
+ * @typedef {import('@metamask/base-controller').StateMetadataConstraint} StateMetadataConstraint
+ * @typedef {import('immer').Patch} Patch
  */
 
 /**
@@ -61,16 +63,22 @@ export default class ComposableObservableStore extends ObservableStore {
         config[key].subscribe((state) => {
           this.#onStateChange(key, state);
         });
+      } else if (this.persist) {
+        this.controllerMessenger.subscribe(
+          `${store.name}:stateChange`,
+          (state, patches) => {
+            if (this.#changedPersistedProperty(config[key].metadata, patches)) {
+              this.#onStateChange(
+                key,
+                getPersistentState(state, config[key].metadata),
+              );
+            }
+          },
+        );
       } else {
         this.controllerMessenger.subscribe(
           `${store.name}:stateChange`,
-          (state) => {
-            let updatedState = state;
-            if (this.persist) {
-              updatedState = getPersistentState(state, config[key].metadata);
-            }
-            this.#onStateChange(key, updatedState);
-          },
+          (state) => this.#onStateChange(key, state),
         );
       }
 
@@ -111,5 +119,29 @@ export default class ComposableObservableStore extends ObservableStore {
     this.updateState({ [controllerKey]: newState });
 
     this.emit('stateChange', { oldState, newState, controllerKey });
+  }
+
+  /**
+   * Returns true if the given set of patches makes changes to a persisted property.
+   *
+   * Note that we assume at least one property is persisted, so a complete replacement patch
+   * always returns true.
+   *
+   * @param {StateMetadataConstraint} metadata
+   * @param {Patch[]} patches
+   */
+  #changedPersistedProperty(metadata, patches) {
+    return patches.some((patch) => {
+      // Complete state replacement
+      if (patch.path.lenght === 0) {
+        return true;
+      }
+      const topLevelProperty = patch.path[0];
+      // Missing metadata, return true out of caution
+      if (!metadata[topLevelProperty]) {
+        return true;
+      }
+      return metadata[topLevelProperty].persist;
+    });
   }
 }

--- a/app/scripts/lib/ComposableObservableStore.test.js
+++ b/app/scripts/lib/ComposableObservableStore.test.js
@@ -27,6 +27,12 @@ class ExampleController extends BaseController {
       state.bar = contents;
     });
   }
+
+  updateBaz(contents) {
+    this.update((state) => {
+      state.baz = contents;
+    });
+  }
 }
 
 describe('ComposableObservableStore', () => {
@@ -137,27 +143,99 @@ describe('ComposableObservableStore', () => {
     });
   });
 
-  it('should strip non-persisted state from initial state with all three types of stores', () => {
-    const messenger = new Messenger();
-    const exampleStore = new ObservableStore();
-    const exampleController = new ExampleController({
-      messenger,
+  describe('not persist', () => {
+    it('should emit state change when any state changes', () => {
+      const messenger = new Messenger();
+      const exampleController = new ExampleController({
+        messenger,
+      });
+      const store = new ComposableObservableStore({
+        controllerMessenger: messenger,
+      });
+      store.updateStructure({
+        Example: exampleController,
+      });
+      const onStateChange = jest.fn();
+      store.subscribe(onStateChange);
+
+      exampleController.updateBar('update');
+      exampleController.updateBaz('update');
+
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(onStateChange).toHaveBeenNthCalledWith(1, {
+        Example: { bar: 'update', baz: 'baz' },
+      });
+      expect(onStateChange).toHaveBeenNthCalledWith(2, {
+        Example: { bar: 'update', baz: 'update' },
+      });
     });
-    exampleStore.putState('state');
-    exampleController.updateBar('state');
-    const store = new ComposableObservableStore({
-      controllerMessenger: messenger,
-      persist: true,
+  });
+
+  describe('persisted', () => {
+    it('should emit state change with just persisted state', () => {
+      const messenger = new Messenger();
+      const exampleController = new ExampleController({
+        messenger,
+      });
+      const store = new ComposableObservableStore({
+        controllerMessenger: messenger,
+        persist: true,
+      });
+      store.updateStructure({
+        Example: exampleController,
+      });
+      const onStateChange = jest.fn();
+      store.subscribe(onStateChange);
+
+      exampleController.updateBar('update');
+
+      expect(onStateChange).toHaveBeenCalledWith({
+        Example: { bar: 'update' },
+      });
     });
 
-    store.updateStructure({
-      Example: exampleController,
-      Store: exampleStore,
+    it('should not emit state change when only non-persisted state changes', () => {
+      const messenger = new Messenger();
+      const exampleController = new ExampleController({
+        messenger,
+      });
+      const store = new ComposableObservableStore({
+        controllerMessenger: messenger,
+        persist: true,
+      });
+      store.updateStructure({
+        Example: exampleController,
+      });
+      const onStateChange = jest.fn();
+      store.subscribe(onStateChange);
+
+      exampleController.updateBaz('update');
+
+      expect(onStateChange).not.toHaveBeenCalled();
     });
 
-    expect(store.getState()).toStrictEqual({
-      Example: { bar: 'state' },
-      Store: 'state',
+    it('should strip non-persisted state from initial state with all three types of stores', () => {
+      const messenger = new Messenger();
+      const exampleStore = new ObservableStore();
+      const exampleController = new ExampleController({
+        messenger,
+      });
+      exampleStore.putState('state');
+      exampleController.updateBar('state');
+      const store = new ComposableObservableStore({
+        controllerMessenger: messenger,
+        persist: true,
+      });
+
+      store.updateStructure({
+        Example: exampleController,
+        Store: exampleStore,
+      });
+
+      expect(store.getState()).toStrictEqual({
+        Example: { bar: 'state' },
+        Store: 'state',
+      });
     });
   });
 

--- a/app/scripts/lib/ComposableObservableStore.test.js
+++ b/app/scripts/lib/ComposableObservableStore.test.js
@@ -33,6 +33,16 @@ class ExampleController extends BaseController {
       state.baz = contents;
     });
   }
+
+  replaceState(state) {
+    this.update(() => state);
+  }
+
+  updatePropertyMissingFromMetadata(contents) {
+    this.update((state) => {
+      state.missing = contents;
+    });
+  }
 }
 
 describe('ComposableObservableStore', () => {
@@ -191,6 +201,50 @@ describe('ComposableObservableStore', () => {
 
       expect(onStateChange).toHaveBeenCalledWith({
         Example: { bar: 'update' },
+      });
+    });
+
+    it('should emit state change when there is a complete state replacement', () => {
+      const messenger = new Messenger();
+      const exampleController = new ExampleController({
+        messenger,
+      });
+      const store = new ComposableObservableStore({
+        controllerMessenger: messenger,
+        persist: true,
+      });
+      store.updateStructure({
+        Example: exampleController,
+      });
+      const onStateChange = jest.fn();
+      store.subscribe(onStateChange);
+
+      exampleController.replaceState({ baz: 'update', bar: 'update' });
+
+      expect(onStateChange).toHaveBeenCalledWith({
+        Example: { bar: 'update' },
+      });
+    });
+
+    it('should emit state change when there is an update to a property missing from metadata', () => {
+      const messenger = new Messenger();
+      const exampleController = new ExampleController({
+        messenger,
+      });
+      const store = new ComposableObservableStore({
+        controllerMessenger: messenger,
+        persist: true,
+      });
+      store.updateStructure({
+        Example: exampleController,
+      });
+      const onStateChange = jest.fn();
+      store.subscribe(onStateChange);
+
+      exampleController.updatePropertyMissingFromMetadata('update');
+
+      expect(onStateChange).toHaveBeenCalledWith({
+        Example: { bar: 'bar' },
       });
     });
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -112,9 +112,11 @@ function* ulidGenerator(ulids = mockULIDs) {
 
 /**
  * Generate mock patches for a complete state replacement.
+ *
+ * @returns A list of mock patches.
  */
 function getMockPatches() {
-  return[{ op: 'replace', path: [], value: {} }];
+  return [{ op: 'replace', path: [], value: {} }];
 }
 
 let mockUlidGenerator = ulidGenerator();
@@ -387,7 +389,7 @@ describe('MetaMaskController', () => {
       metamaskController.controllerMessenger.publish(
         'PreferencesController:stateChange',
         preferences,
-        getMockPatches()
+        getMockPatches(),
       );
       await flushPromises();
     }
@@ -3767,7 +3769,7 @@ describe('MetaMaskController', () => {
         metamaskController.controllerMessenger.publish(
           'CurrencyRateController:stateChange',
           { currentCurrency: mockCurrency },
-          getMockPatches()
+          getMockPatches(),
         );
 
         expect(

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -110,6 +110,13 @@ function* ulidGenerator(ulids = mockULIDs) {
   throw new Error('should not be called after exhausting provided IDs');
 }
 
+/**
+ * Generate mock patches for a complete state replacement.
+ */
+function getMockPatches() {
+  return[{ op: 'replace', path: [], value: {} }];
+}
+
 let mockUlidGenerator = ulidGenerator();
 
 jest.mock('ulid', () => ({
@@ -380,6 +387,7 @@ describe('MetaMaskController', () => {
       metamaskController.controllerMessenger.publish(
         'PreferencesController:stateChange',
         preferences,
+        getMockPatches()
       );
       await flushPromises();
     }
@@ -3759,6 +3767,7 @@ describe('MetaMaskController', () => {
         metamaskController.controllerMessenger.publish(
           'CurrencyRateController:stateChange',
           { currentCurrency: mockCurrency },
+          getMockPatches()
         );
 
         expect(


### PR DESCRIPTION
## **Description**

The `ComposableObservableStore` class has been updated to prevent no-op state updates in cases where a non-persisted property is updated. The store now introspects patches to see if any of them impact any persisted property.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34506?quickstart=1)

## **Changelog**

CHANGELOG entry: Prevent frequent writes while the wallet UI is closed

## **Related issues**

Relates to #33879

## **Manual testing steps**

This problem was discovered when testing https://github.com/MetaMask/metamask-extension/pull/34465

You can test this by merging the two changes, then following the manual testing instructions on that PR. I have combined the two PRs here in this draft for convenience: https://github.com/MetaMask/metamask-extension/pull/34486

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
