### PR TITLE
fix: copy and style fixes for unlock page and creation page cp-13.0.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2455,7 +2455,7 @@
     "message": "biometrics turned on"
   },
   "forgotPasswordSocialStep2": {
-    "message": "If you have your $1, you can reset your current wallet and reimport using $1.",
+    "message": "If you have your $1, you can reset your current wallet and reimport using Secret Recovery Phrase.",
     "description": "$1 is bold Secret Recovery Phrase"
   },
   "form": {
@@ -4237,7 +4237,7 @@
     "message": "Password"
   },
   "passwordChangedRecently": {
-    "message": "Your password changed"
+    "message": "Your password was changed"
   },
   "passwordChangedRecentlyDescription": {
     "message": "Enter your new password to stay logged into MetaMask."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2455,7 +2455,7 @@
     "message": "biometrics turned on"
   },
   "forgotPasswordSocialStep2": {
-    "message": "If you have your $1, you can reset your current wallet and reimport using $1.",
+    "message": "If you have your $1, you can reset your current wallet and reimport using Secret Recovery Phrase.",
     "description": "$1 is bold Secret Recovery Phrase"
   },
   "form": {
@@ -4237,7 +4237,7 @@
     "message": "Password"
   },
   "passwordChangedRecently": {
-    "message": "Your password changed"
+    "message": "Your password was changed"
   },
   "passwordChangedRecentlyDescription": {
     "message": "Enter your new password to stay logged into MetaMask."

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -18,6 +18,7 @@ import {
   FontWeight,
   TextColor,
   IconColor,
+  BackgroundColor,
 } from '../../../helpers/constants/design-system';
 import {
   Box,
@@ -202,6 +203,7 @@ export default function CreationSuccessful() {
               data-testid="manage-default-settings"
               borderRadius={BorderRadius.LG}
               width={BlockSize.Full}
+              backgroundColor={BackgroundColor.backgroundMuted}
               onClick={() => history.push(ONBOARDING_PRIVACY_SETTINGS_ROUTE)}
             >
               <Box display={Display.Flex} alignItems={AlignItems.center}>

--- a/ui/pages/unlock-page/index.scss
+++ b/ui/pages/unlock-page/index.scss
@@ -12,9 +12,5 @@
       right: 0;
     }
   }
-
-  &__help-text {
-    height: 40px;
-  }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
UI and copywriting polishing for:
1. Change `Your password changed` to `Your password was changed`
2. Update font style on Reset wallet modal
3. Fix background for `Manage default setting` button

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
4. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34511?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix copywriting and minor ui styles on Unlock page and creation page

## **Related issues**

Fixes:

## **Manual testing steps**

**Your password was changed**
1. Using same social account, login to two device or browser profile
2. Change password on device 1
3. Lock wallet on device 2 and then try to unlock using old password
4. Check the error message going to show.

_Note: change password modal will get same update because they are using same locale_

**Unlock page UI fixes**
1. Login using a social account and finish onboarding
2. Lock the wallet
3. Try unlocking using wrong password
4. Observe the space between error message and Unlock button

**Forgot your password** modal
1. Login using a social account and finish onboarding
2. Lock the wallet
3. Click on "Forgot password" 
4. Check text styles

**Creation page Manage default settings**
1. Create wallet using SRP and create password
2. Skip backup and continue until "Well remind you later" page
3. Check `Manage default settings` button

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
**Your password changed should change to `Your password was changed`**
<img width="756" height="486" alt="image" src="https://github.com/user-attachments/assets/58a1c962-3203-44d1-852b-0eb0a50ae89d" />
<img width="1482" height="892" alt="image" src="https://github.com/user-attachments/assets/6de285d4-e3e1-473e-b87e-45ac281c2863" />


**Unlock page space between error and unlock button should be smaller**
<img width="848" height="1024" alt="image" src="https://github.com/user-attachments/assets/50910088-4f94-4399-afcb-8f9fb82247d7" />


**Forgot password modal: Unbold the second `Secret Recovery Phrase`**
<img width="2024" height="1324" alt="image" src="https://github.com/user-attachments/assets/093b52cd-b43f-404b-97af-685280ccbefe" />


**Creation page button should be lighter as per design**
<img width="2024" height="1324" alt="image" src="https://github.com/user-attachments/assets/093b52cd-b43f-404b-97af-685280ccbefe" />

<!-- [screenshots/recordings] -->

### **After**
**Your password changed should change to `Your password was changed`**
<img width="426" height="570" alt="Screenshot 2025-07-22 at 9 33 32 PM" src="https://github.com/user-attachments/assets/3e645fc5-363a-46e0-b91b-86dce056228e" />
<img width="383" height="299" alt="Screenshot 2025-07-22 at 9 32 19 PM" src="https://github.com/user-attachments/assets/a0da96c4-89ed-4c0a-b390-19cb32677a86" />


**Unlock page space between error and unlock button should be smaller**
<img width="399" height="550" alt="Screenshot 2025-07-22 at 9 45 24 PM" src="https://github.com/user-attachments/assets/5cf1c0f5-3aa3-4370-961c-e6298bb89356" />


**Forgot password modal: Unbold the second `Secret Recovery Phrase`**
![Uploading Screenshot 2025-07-22 at 9.36.20 PM.png…]()


**Creation page button should be lighter as per design**
<img width="461" height="687" alt="Screenshot 2025-07-22 at 9 29 17 PM" src="https://github.com/user-attachments/assets/6bc40dd9-255f-4c63-8f1d-e8eb5de6d587" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
