### PR TITLE
fix: remove currency suffix from account list item under multichain accounts tree

### DIFF
--- a/ui/components/multichain-accounts/multichain-accounts-components.scss
+++ b/ui/components/multichain-accounts/multichain-accounts-components.scss
@@ -1,0 +1,2 @@
+@import 'multichain-accounts-tree';
+@import 'multichain-account-list-menu';

--- a/ui/components/multichain-accounts/multichain-accounts-tree/index.scss
+++ b/ui/components/multichain-accounts/multichain-accounts-tree/index.scss
@@ -1,0 +1,5 @@
+.multichain-account-tree {
+  .currency-display-component__suffix {
+    display: none;
+  }
+}

--- a/ui/components/multichain-accounts/multichain-accounts-tree/multichain-accounts-tree.tsx
+++ b/ui/components/multichain-accounts/multichain-accounts-tree/multichain-accounts-tree.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { useHistory } from 'react-router-dom';
+import classnames from 'classnames';
 import { Box, ButtonLink, ButtonLinkSize, Text } from '../../component-library';
 import {
   AlignItems,
@@ -127,7 +128,10 @@ export const MultichainAccountsTree = ({
 
                 return (
                   <Box
-                    className="multichain-account-menu-popover__list--menu-item"
+                    className={classnames(
+                      'multichain-account-tree',
+                      'multichain-account-menu-popover__list--menu-item',
+                    )}
                     key={`box-${account.id}`}
                   >
                     <AccountListItem

--- a/ui/css/index.scss
+++ b/ui/css/index.scss
@@ -10,6 +10,7 @@
 @import '../components/app/app-components';
 @import '../components/ui/ui-components';
 @import '../components/multichain/multichain-components.scss';
+@import '../components/multichain-accounts/multichain-accounts-components';
 @import '../pages/pages';
 @import './errors.scss';
 @import './loading.scss';


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? The account list item in the account selector shouldn't be showing the currency suffix
2. What is the improvement/solution? Add css that turns the suffix part to display none. I considered adding a prop to the currency display component, but it would be a lot of prop drilling involved since the component is a bit deep in the tree from where we want the suffix to not be displayed and I would most likely have to change a few components around that touch other teams. This seemed to be the quickest and cleanest solution. I'm also not sure if the style in `MultichainAccountListMenu` was being applied since we didn't import it anywhere, so I added a `multichain-accounts-components` file cc: @david0xd. 

## **Manual testing steps**

1. Build from this branch
2. Navigate to the account selector
3. Observe that the suffix is no longer there e.g. "USD"

## **Screenshots/Recordings**

### **Before**

<img width="692" height="366" alt="image" src="https://github.com/user-attachments/assets/aa082a7c-1cd3-42aa-b74d-c2f7f8996899" />


### **After**

<img width="399" height="602" alt="Screenshot 2025-07-22 at 11 34 06 AM" src="https://github.com/user-attachments/assets/ee861be7-646a-49da-851f-d1a7793dbefc" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
