### PR TITLE
fix: add loader for onboarding unlock page cp-13.0.0

### DIFF
--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -48,7 +48,6 @@ import {
 } from '../../../components/component-library';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import PasswordForm from '../../../components/app/password-form/password-form';
-import LoadingScreen from '../../../components/ui/loading-screen';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
 import { resetOAuthLoginState } from '../../../store/actions';
@@ -422,7 +421,6 @@ export default function CreatePassword({
           data-testid="create-password-iframe"
         />
       ) : null}
-      {newAccountCreationInProgress && <LoadingScreen />}
     </Box>
   );
 }

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -78,6 +78,7 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../shared/constants/app';
 import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 import { getIsSeedlessOnboardingFeatureEnabled } from '../../../shared/modules/environment';
 import { TraceName, TraceOperation } from '../../../shared/lib/trace';
+import LoadingScreen from '../../components/ui/loading-screen';
 import OnboardingFlowSwitch from './onboarding-flow-switch/onboarding-flow-switch';
 import CreatePassword from './create-password/create-password';
 import ReviewRecoveryPhrase from './recovery-phrase/review-recovery-phrase';
@@ -99,6 +100,7 @@ const TWITTER_URL = 'https://twitter.com/MetaMask';
 
 export default function OnboardingFlow() {
   const [secretRecoveryPhrase, setSecretRecoveryPhrase] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
   const dispatch = useDispatch();
   const { pathname, search } = useLocation();
   const history = useHistory();
@@ -190,41 +192,51 @@ export default function OnboardingFlow() {
   }, [onboardingParentContext, bufferedTrace]);
 
   const handleCreateNewAccount = async (password) => {
-    let newSecretRecoveryPhrase;
-    if (
-      isSeedlessOnboardingFeatureEnabled &&
-      firstTimeFlowType === FirstTimeFlowType.socialCreate
-    ) {
-      newSecretRecoveryPhrase = await dispatch(
-        createNewVaultAndSyncWithSocial(password),
-      );
-    } else if (firstTimeFlowType === FirstTimeFlowType.create) {
-      newSecretRecoveryPhrase = await dispatch(
-        createNewVaultAndGetSeedPhrase(password),
-      );
-    }
+    try {
+      setIsLoading(true);
+      let newSecretRecoveryPhrase;
+      if (
+        isSeedlessOnboardingFeatureEnabled &&
+        firstTimeFlowType === FirstTimeFlowType.socialCreate
+      ) {
+        newSecretRecoveryPhrase = await dispatch(
+          createNewVaultAndSyncWithSocial(password),
+        );
+      } else if (firstTimeFlowType === FirstTimeFlowType.create) {
+        newSecretRecoveryPhrase = await dispatch(
+          createNewVaultAndGetSeedPhrase(password),
+        );
+      }
 
-    setSecretRecoveryPhrase(newSecretRecoveryPhrase);
+      setSecretRecoveryPhrase(newSecretRecoveryPhrase);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleUnlock = async (password) => {
-    let retrievedSecretRecoveryPhrase;
+    try {
+      setIsLoading(true);
+      let retrievedSecretRecoveryPhrase;
 
-    if (
-      isSeedlessOnboardingFeatureEnabled &&
-      firstTimeFlowType === FirstTimeFlowType.socialImport
-    ) {
-      retrievedSecretRecoveryPhrase = await dispatch(
-        restoreSocialBackupAndGetSeedPhrase(password),
-      );
-    } else {
-      retrievedSecretRecoveryPhrase = await dispatch(
-        unlockAndGetSeedPhrase(password),
-      );
+      if (
+        isSeedlessOnboardingFeatureEnabled &&
+        firstTimeFlowType === FirstTimeFlowType.socialImport
+      ) {
+        retrievedSecretRecoveryPhrase = await dispatch(
+          restoreSocialBackupAndGetSeedPhrase(password),
+        );
+      } else {
+        retrievedSecretRecoveryPhrase = await dispatch(
+          unlockAndGetSeedPhrase(password),
+        );
+      }
+
+      setSecretRecoveryPhrase(retrievedSecretRecoveryPhrase);
+      history.push(nextRoute);
+    } finally {
+      setIsLoading(false);
     }
-
-    setSecretRecoveryPhrase(retrievedSecretRecoveryPhrase);
-    history.push(nextRoute);
   };
 
   const handleImportWithRecoveryPhrase = async (password, srp) => {
@@ -416,6 +428,7 @@ export default function OnboardingFlow() {
           ])}
         </Button>
       )}
+      {isLoading && <LoadingScreen />}
     </Box>
   );
 }

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -155,14 +155,8 @@ describe('Actions', () => {
 
       setBackgroundConnection(background);
 
-      const expectedActions = [
-        { type: 'SHOW_LOADING_INDICATION', payload: undefined },
-        { type: 'HIDE_LOADING_INDICATION' },
-      ];
-
       await store.dispatch(actions.createNewVaultAndSyncWithSocial('password'));
 
-      expect(store.getActions()).toStrictEqual(expectedActions);
       expect(getSeedPhraseStub.callCount).toStrictEqual(1);
       expect(createNewVaultAndKeychainStub.callCount).toStrictEqual(1);
       expect(
@@ -188,11 +182,6 @@ describe('Actions', () => {
 
       setBackgroundConnection(background);
 
-      const expectedActions = [
-        { type: 'SHOW_LOADING_INDICATION', payload: undefined },
-        { type: 'HIDE_LOADING_INDICATION' },
-      ];
-
       await store.dispatch(
         actions.restoreSocialBackupAndGetSeedPhrase('password'),
       );
@@ -200,7 +189,6 @@ describe('Actions', () => {
       expect(restoreSocialBackupAndGetSeedPhraseStub.callCount).toStrictEqual(
         1,
       );
-      expect(store.getActions()).toStrictEqual(expectedActions);
     });
 
     it('errors when fetchAndRestoreSeedPhrase throws', async () => {
@@ -212,11 +200,7 @@ describe('Actions', () => {
 
       setBackgroundConnection(background);
 
-      const expectedActions = [
-        { type: 'SHOW_LOADING_INDICATION', payload: undefined },
-        { type: 'HIDE_LOADING_INDICATION' },
-        { type: 'DISPLAY_WARNING', payload: 'error' },
-      ];
+      const expectedActions = [{ type: 'DISPLAY_WARNING', payload: 'error' }];
 
       await expect(
         store.dispatch(actions.restoreSocialBackupAndGetSeedPhrase('password')),

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -284,8 +284,6 @@ export function createNewVaultAndSyncWithSocial(
   password: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch: MetaMaskReduxDispatch) => {
-    dispatch(showLoadingIndication());
-
     try {
       const primaryKeyring = await createNewVault(password);
       if (!primaryKeyring) {
@@ -306,8 +304,6 @@ export function createNewVaultAndSyncWithSocial(
       } else {
         throw error;
       }
-    } finally {
-      dispatch(hideLoadingIndication());
     }
   };
 }
@@ -322,8 +318,6 @@ export function restoreSocialBackupAndGetSeedPhrase(
   password: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch: MetaMaskReduxDispatch) => {
-    dispatch(showLoadingIndication());
-
     try {
       // restore the vault using the seed phrase
       const mnemonic = await submitRequestToBackground(
@@ -332,11 +326,9 @@ export function restoreSocialBackupAndGetSeedPhrase(
       );
 
       await forceUpdateMetamaskState(dispatch);
-      dispatch(hideLoadingIndication());
       return mnemonic;
     } catch (error) {
       log.error('[restoreSocialBackupAndGetSeedPhrase] error', error);
-      dispatch(hideLoadingIndication());
       dispatch(displayWarning(error.message));
       throw error;
     }
@@ -609,7 +601,6 @@ export function createNewVaultAndGetSeedPhrase(
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
-    dispatch(showLoadingIndication());
     try {
       await createNewVault(password);
       const seedPhrase = await getSeedPhrase(password);
@@ -621,8 +612,6 @@ export function createNewVaultAndGetSeedPhrase(
       } else {
         throw error;
       }
-    } finally {
-      dispatch(hideLoadingIndication());
     }
   };
 }
@@ -633,8 +622,6 @@ export function unlockAndGetSeedPhrase(
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
-    dispatch(showLoadingIndication());
-
     try {
       await submitPassword(password);
       const seedPhrase = await getSeedPhrase(password);
@@ -647,8 +634,6 @@ export function unlockAndGetSeedPhrase(
       } else {
         throw error;
       }
-    } finally {
-      dispatch(hideLoadingIndication());
     }
   };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Add loader for onboarding unlock. Use this loader for create-account page also so there will be one loader which can be used for onboarding flow.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34518?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added loader for onboarding unlock

## **Related issues**

Fixes:

## **Manual testing steps**

1. Login with social account with existing wallet
2. Unlock the wallet
3. Check if there is a loader showing when entering password

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Importing a social account unlock page does not show loader on form submit
https://github.com/user-attachments/assets/f6a88fe0-6fa6-4ee9-8616-4a15a18ab92b

<!-- [screenshots/recordings] -->

### **After**
**Added a loader**
https://github.com/user-attachments/assets/1cf888af-b87e-42fb-b23c-557e4df202a9
**Use the same loader for create-password for new account**
https://github.com/user-attachments/assets/954c8db3-a752-4752-84fd-9d16d62ef513



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
