### PR TITLE
fix: password change rollback cp-13.0.0

### DIFF
--- a/ui/components/app/password-outdated-modal/password-outdated-modal.tsx
+++ b/ui/components/app/password-outdated-modal/password-outdated-modal.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../component-library';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { lockMetamask } from '../../../store/actions';
+import { setShowPasswordChangeToast } from '../toast-master/utils';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -68,8 +69,10 @@ export default function PasswordOutdatedModal() {
               data-testid="password-changed"
               size={ButtonSize.Lg}
               block
-              onClick={() => {
-                dispatch(lockMetamask());
+              onClick={async () => {
+                // remove the password change toast from the app state
+                await dispatch(setShowPasswordChangeToast(null));
+                await dispatch(lockMetamask());
                 history.push(DEFAULT_ROUTE);
               }}
             >

--- a/ui/components/app/toast-master/utils.ts
+++ b/ui/components/app/toast-master/utils.ts
@@ -77,7 +77,9 @@ export function setShowNewSrpAddedToast(value: boolean) {
   };
 }
 
-export function setShowPasswordChangeToast(value: PasswordChangeToastType) {
+export function setShowPasswordChangeToast(
+  value: PasswordChangeToastType | null,
+) {
   return {
     type: SET_SHOW_PASSWORD_CHANGE_TOAST,
     payload: value,

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -266,6 +266,42 @@ describe('Actions', () => {
         storeKeyringEncryptionKeyStub.calledOnceWith('encryption-key'),
       ).toStrictEqual(true);
     });
+
+    it('should revert the keyring password change if socialSyncChangePassword fails', async () => {
+      const store = mockStore({
+        metamask: {
+          ...defaultState.metamask,
+          firstTimeFlowType: FirstTimeFlowType.socialCreate,
+        },
+      });
+      const oldPassword = 'old-password';
+      const newPassword = 'new-password';
+
+      const socialSyncChangePasswordStub = sinon
+        .stub()
+        .rejects(new Error('error'));
+      const keyringChangePasswordStub = sinon.stub().resolves();
+      const exportEncryptionKeyStub = sinon.stub().resolves('encryption-key');
+      const storeKeyringEncryptionKeyStub = sinon.stub().resolves();
+
+      background.getApi.returns({
+        socialSyncChangePassword: socialSyncChangePasswordStub,
+        keyringChangePassword: keyringChangePasswordStub,
+        exportEncryptionKey: exportEncryptionKeyStub,
+        storeKeyringEncryptionKey: storeKeyringEncryptionKeyStub,
+      });
+
+      await setBackgroundConnection(background.getApi());
+
+      await expect(
+        store.dispatch(actions.changePassword(newPassword, oldPassword)),
+      ).rejects.toThrow('error');
+      expect(keyringChangePasswordStub.callCount).toStrictEqual(2);
+      expect(exportEncryptionKeyStub.callCount).toStrictEqual(1);
+      expect(
+        storeKeyringEncryptionKeyStub.calledOnceWith('encryption-key'),
+      ).toStrictEqual(true);
+    });
   });
 
   describe('#tryUnlockMetamask', () => {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -395,6 +395,8 @@ export function changePassword(
         } catch (error) {
           // revert the keyring password change
           await keyringChangePassword(oldPassword);
+          const revertedKeyringEncryptionKey = await exportEncryptionKey();
+          await storeKeyringEncryptionKey(revertedKeyringEncryptionKey);
           throw error;
         }
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR fixes a bug in the Password Change Rollback.
When user does the password change, we change password for both Keyring and Seedless Onboarding Controller. 
The keyring password change goes first then followed by the seedless onboarding password change. If the seedless onboarding password change is failed, we revert the keyring password change with the old password, so that user won't encounter the logged out dead end.

However, we found out that the keyring password change wasn't properly revert and this PR fixes it by properly revert back both keyring password and encryption key.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34520?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**
> To simulate the password sync across multiple devices, we can use the two different browsers (with different profiles).

1. On device A (browser A), create (or login to) wallet with social account and do not lock the wallet.
2. On device B (browser B), use the same social account to login.
3. On device B (browser B), change the wallet password to new password (`Password-A`).
4. On device A (browser A), change the wallet password and the operation should fail coz the device A password isn't latest anymore and user should be automatically logged out to enter the new password.
5. On device A (browser A), if user enters the original password, user should see `Password changed recently` error message
6. On device A (browser A), if user enters the new password (`Password-A`), user should be able to unlock the wallet.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
