### PR TITLE
chore: fix toggle spacing

### DIFF
--- a/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
+++ b/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
@@ -67,7 +67,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-smart-account-optin"
     >
       <div
@@ -143,7 +143,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-dismiss-smart-account-suggestion-enabled"
     >
       <div
@@ -211,7 +211,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-enable-smart-transactions"
     >
       <div
@@ -291,7 +291,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-hex-data"
     >
       <div
@@ -357,7 +357,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-show-testnet-conversion"
     >
       <div
@@ -423,7 +423,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-show-testnet-conversion"
     >
       <div
@@ -489,7 +489,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-dismiss-reminder"
     >
       <div
@@ -555,7 +555,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-show-extension-in-full-size-view"
     >
       <div
@@ -703,7 +703,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--sm:gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       data-testid="advanced-setting-dismiss-reminder"
     >
       <div

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -240,7 +240,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
       >
         <div className="settings-page__content-item">
           <span> {t('useSmartAccountTitle')}</span>
@@ -281,7 +281,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
       >
         <div className="settings-page__content-item">
           <span> {t('dismissSmartAccountSuggestionEnabledTitle')}</span>
@@ -335,7 +335,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
       >
         <div className="settings-page__content-item">
           <span>{t('smartTransactions')}</span>
@@ -371,7 +371,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
         data-testid="advanced-setting-hex-data"
       >
         <div className="settings-page__content-item">
@@ -405,7 +405,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
         data-testid="advanced-setting-show-testnet-conversion"
       >
         <div className="settings-page__content-item">
@@ -442,7 +442,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
       >
         <div className="settings-page__content-item">
           <span>{t('showTestnetNetworks')}</span>
@@ -476,7 +476,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
       >
         <div className="settings-page__content-item">
           <span>{t('showExtensionInFullSizeView')}</span>
@@ -559,7 +559,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
       >
         <div className="settings-page__content-item">
           <span>{t('dismissReminderField')}</span>
@@ -663,7 +663,7 @@ export default class AdvancedTab extends PureComponent {
         display={Display.Flex}
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
-        gap={4}
+        gap={[null, 4]}
       >
         <div className="settings-page__content-item">
           <span>{t('manageInstitutionalWallets')}</span>


### PR DESCRIPTION
## **Description**

This PR fixes spacing issues in the Advanced Settings tab by implementing responsive gap values for toggle button layouts. The fix ensures proper spacing between content items and toggle buttons across different screen sizes.

**What is the reason for the change?**
- The Advanced Settings tab spacing between content items and toggle buttons was making it hard to distinguish which toggle was for which setting
- Fixed gap spacing was causing layout issues on smaller screen sizes
- Toggle buttons and their corresponding content needed responsive spacing to improve visual balance and usability

**What is the improvement/solution?**
- Updated all Box components in the Advanced Settings tab to use responsive gap values
- Changed `gap={4}` to `gap={[null, 4]}` to apply spacing only on larger screens
- This ensures no gap on mobile/small screens (null) and proper 16px gap (4 × 4px) on larger screens
- Affects 8 toggle button sections: Smart Account, Dismiss Smart Account Suggestion, Smart Transactions, Show Hex Data, Show Testnet Conversion, Show Testnet Networks, Full Size View, and Dismiss Reminder

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34536?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (UI improvement)

## **Manual testing steps**

1. Navigate to Settings → Advanced in the MetaMask extension
2. Test on different screen sizes (mobile width ~375px, tablet ~768px, desktop ~1200px)
3. Verify toggle button spacing looks appropriate on all screen sizes:
   - Mobile: No extra gap between content and toggle
   - Desktop: Proper 16px gap between content and toggle
  
## **Screenshots/Recordings**

### **Before**

Fixed 16px gap on all screen sizes causing cramped layouts on mobile devices.

<img width="250" height="1210" alt="Screenshot 2025-07-22 at 1 31 50 PM" src="https://github.com/user-attachments/assets/80ba6823-b10b-4775-929d-63478c996c95" />

### **After**

Responsive spacing:
- **Mobile/Small screens**: No gap (cleaner, more compact layout)
- **Larger screens**: 16px gap (better visual separation and balance)

https://github.com/user-attachments/assets/1f855292-e7dc-457a-9de9-c3bfa5493909

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (UI change, existing tests should cover functionality)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A for this change)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.