### PR TITLE
fix: fixed incorrect navigation upon clicking back/refresh actions from browser cp-13.0.0

### DIFF
--- a/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.js
+++ b/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.js
@@ -24,13 +24,17 @@ import {
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app'; // eslint-disable-line no-unused-vars
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
 ///: END:ONLY_INCLUDE_IF
-import { getIsParticipateInMetaMetricsSet } from '../../../selectors';
+import {
+  getIsParticipateInMetaMetricsSet,
+  getIsSocialLoginFlow,
+} from '../../../selectors';
 
 export default function OnboardingFlowSwitch() {
   /* eslint-disable prefer-const */
   const completedOnboarding = useSelector(getCompletedOnboarding);
   const isInitialized = useSelector(getIsInitialized);
   const seedPhraseBackedUp = useSelector(getSeedPhraseBackedUp);
+  const isSocialLoginFlow = useSelector(getIsSocialLoginFlow);
   const isUnlocked = useSelector(getIsUnlocked);
   const isParticipateInMetaMetricsSet = useSelector(
     getIsParticipateInMetaMetricsSet,
@@ -53,6 +57,19 @@ export default function OnboardingFlowSwitch() {
   }
 
   if (isUnlocked) {
+    // if the vault is already unlocked and the user is in a social login flow but the onboarding is not completed,
+    // we need to redirect to the onboarding completion route
+    if (isSocialLoginFlow && !completedOnboarding) {
+      return (
+        <Redirect
+          to={{
+            pathname: isParticipateInMetaMetricsSet
+              ? ONBOARDING_COMPLETION_ROUTE
+              : ONBOARDING_METAMETRICS,
+          }}
+        />
+      );
+    }
     return <Redirect to={{ pathname: LOCK_ROUTE }} />;
   }
 

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -224,7 +224,7 @@ export default function OnboardingFlow() {
     }
 
     setSecretRecoveryPhrase(retrievedSecretRecoveryPhrase);
-    history.push(nextRoute);
+    history.replace(nextRoute);
   };
 
   const handleImportWithRecoveryPhrase = async (password, srp) => {


### PR DESCRIPTION
…wser back button

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes incorrect onboarding navigation on browser back/refresh actions in social login flow.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34541?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34439

## **Manual testing steps**

1. Login to existing social account by selecting `I have an existing wallet` login option.
2. Unlock the wallet by entering correct password.
3. After the successful unlock, click `back` button in the browser
4. We should not see the `Unlock` page again.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
