### PR TITLE
fix: error text should not be dimmed when text field is disabled cp-13.0.0

### DIFF
--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -476,6 +476,9 @@ class UnlockPage extends Component {
                 'data-testid': 'unlock-password',
                 'aria-label': t('password'),
               }}
+              textFieldProps={{
+                disabled: isLocked,
+              }}
               onChange={(event) => this.handleInputChange(event)}
               type={TextFieldType.Password}
               value={password}
@@ -483,7 +486,6 @@ class UnlockPage extends Component {
               helpText={this.renderHelpText()}
               autoComplete
               autoFocus
-              disabled={isLocked}
               width={BlockSize.Full}
               marginBottom={4}
             />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Error text should not be dimmed when the TextField is disabled since it should be emphasized.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34545?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Password field error text will not be dimmed when field is disabled

## **Related issues**

Fixes:

## **Manual testing steps**

1. Login with existing social account
2. On unlock page, submit incorrect password until `Too many failed attemps` error show
3. The error text should not be dimmed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="384" height="536" alt="Screenshot 2025-07-23 at 3 32 00 PM" src="https://github.com/user-attachments/assets/50e80e02-c626-4cb4-9a8c-0f15a17e313c" />

<!-- [screenshots/recordings] -->

### **After**
<img width="442" height="573" alt="Screenshot 2025-07-23 at 2 43 22 PM" src="https://github.com/user-attachments/assets/d7763070-a944-4699-94c7-74c20da7412a" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
