### PR TITLE
fix: unlock page many attempts error time format and copywriting cp-13.0.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7028,7 +7028,7 @@
     "message": "Password is incorrect. Please try again."
   },
   "unlockPageTooManyFailedAttempts": {
-    "message": "Too many failed attempts. Please try again in "
+    "message": "Too many attempts. Try again in "
   },
   "unpin": {
     "message": "Unpin"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7028,7 +7028,7 @@
     "message": "Password is incorrect. Please try again."
   },
   "unlockPageTooManyFailedAttempts": {
-    "message": "Too many failed attempts. Please try again in "
+    "message": "Too many attempts. Try again in "
   },
   "unpin": {
     "message": "Unpin"

--- a/ui/pages/unlock-page/formatted-counter.tsx
+++ b/ui/pages/unlock-page/formatted-counter.tsx
@@ -4,18 +4,14 @@ import { Text } from '../../components/component-library';
 
 const formatTimeToUnlock = (timeInSeconds: number) => {
   if (timeInSeconds <= 60) {
-    return `${timeInSeconds}s.`;
-  } else if (timeInSeconds < 3600) {
-    const minutes = Math.floor(timeInSeconds / 60);
-    const seconds = timeInSeconds % 60;
-    return `${minutes}m:${seconds.toString().padStart(2, '0')}s.`;
+    return `${timeInSeconds} seconds.`;
   }
   const hours = Math.floor(timeInSeconds / 3600);
   const minutes = Math.floor((timeInSeconds % 3600) / 60);
   const seconds = timeInSeconds % 60;
-  return `${hours}hr:${minutes.toString().padStart(2, '0')}m:${seconds
+  return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds
     .toString()
-    .padStart(2, '0')}s.`;
+    .padStart(2, '0')}.`;
 };
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Update Unlock pages error message for too many attempts and time format

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34577?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update Unlock pages error message for too many attempts and time format


## **Related issues**

Fixes:

## **Manual testing steps**

1. Login using existing social account
2. Continue upto Unlock page
3. Try incorrect passwords for more than 3x until `Too many attempts error shows`
4. Check countdown format and copywriting

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img height="350" alt="old-sec" src="https://github.com/user-attachments/assets/33081c8d-3ae9-4bba-953a-ca5be2dd1d7e" />
<img height="350" alt="old-min" src="https://github.com/user-attachments/assets/beadb3d0-c4e4-4754-ad7d-41f8d7ae4e74" />
<img height="350" alt="old-hours" src="https://github.com/user-attachments/assets/3d69ef49-cdf4-4075-b408-00f896197beb" />



<!-- [screenshots/recordings] -->

### **After**
<img height="350" alt="new-sec" src="https://github.com/user-attachments/assets/2fde1d74-313e-42e3-8d51-6cd68d75a8d8" />
<img height="350" alt="new-min" src="https://github.com/user-attachments/assets/803c3909-0e85-4ecf-bcf1-ec91ca4a1e1a" />
<img height="350" alt="new-hours" src="https://github.com/user-attachments/assets/adb08312-70df-4941-a25d-e5914134df5f" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
