### PR TITLE
fix: creation page button login with social copy cp-13.0.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5145,7 +5145,7 @@
     "message": "Reduce your chances of joining unsafe networks and protect your accounts"
   },
   "securityLoginWithSocial": {
-    "message": "Login with $1",
+    "message": "Log in with $1",
     "description": "The $1 is the text 'Google' or 'Apple'"
   },
   "securityLoginWithSrpBackedUp": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5145,7 +5145,7 @@
     "message": "Reduce your chances of joining unsafe networks and protect your accounts"
   },
   "securityLoginWithSocial": {
-    "message": "Login with $1",
+    "message": "Log in with $1",
     "description": "The $1 is the text 'Google' or 'Apple'"
   },
   "securityLoginWithSrpBackedUp": {

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -199,6 +199,33 @@ export default function CreationSuccessful() {
             className="creation-successful__settings-actions"
             gap={4}
           >
+            <Button
+              variant={ButtonVariant.Secondary}
+              data-testid="manage-default-settings"
+              borderRadius={BorderRadius.LG}
+              width={BlockSize.Full}
+              onClick={() => history.push(ONBOARDING_PRIVACY_SETTINGS_ROUTE)}
+            >
+              <Box display={Display.Flex} alignItems={AlignItems.center}>
+                <Icon
+                  name={IconName.Setting}
+                  size={IconSize.Md}
+                  marginInlineEnd={3}
+                />
+                <Text
+                  variant={TextVariant.bodyMd}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {t('manageDefaultSettings')}
+                </Text>
+              </Box>
+              <Icon
+                name={IconName.ArrowRight}
+                color={IconColor.iconAlternative}
+                size={IconSize.Sm}
+              />
+            </Button>
+
             <ButtonBase
               data-testid="manage-default-settings"
               borderRadius={BorderRadius.LG}

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -18,14 +18,12 @@ import {
   FontWeight,
   TextColor,
   IconColor,
-  BackgroundColor,
 } from '../../../helpers/constants/design-system';
 import {
   Box,
   Text,
   IconName,
   IconSize,
-  ButtonBase,
   Icon,
   ButtonLink,
   ButtonLinkSize,
@@ -225,33 +223,6 @@ export default function CreationSuccessful() {
                 size={IconSize.Sm}
               />
             </Button>
-
-            <ButtonBase
-              data-testid="manage-default-settings"
-              borderRadius={BorderRadius.LG}
-              width={BlockSize.Full}
-              backgroundColor={BackgroundColor.backgroundMuted}
-              onClick={() => history.push(ONBOARDING_PRIVACY_SETTINGS_ROUTE)}
-            >
-              <Box display={Display.Flex} alignItems={AlignItems.center}>
-                <Icon
-                  name={IconName.Setting}
-                  size={IconSize.Md}
-                  marginInlineEnd={3}
-                />
-                <Text
-                  variant={TextVariant.bodyMd}
-                  fontWeight={FontWeight.Medium}
-                >
-                  {t('manageDefaultSettings')}
-                </Text>
-              </Box>
-              <Icon
-                name={IconName.ArrowRight}
-                color={IconColor.iconAlternative}
-                size={IconSize.Sm}
-              />
-            </ButtonBase>
           </Box>
         )}
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix button without hover effect on creation page and fix copywriting for Login with Social

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34598?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix button without hover effect on creation page and fix copywriting for Login with Social

## **Related issues**

Fixes:

## **Manual testing steps**

**Test creation page button**
1. Install metamask
2. Create account with SRP
3. Skip SRP backup
4. On `We’ll remind you later` page, check hover effect on `Manage default settings` button

**Testing Log in with Google**
1. Login with social account
2. Go to Menu > Settings > Security & privacy
3. Scroll to Secret Recovery Phrase section
4. Check Alert component

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://github.com/user-attachments/assets/cb693158-47d3-453a-8d94-c13b393e7a99


<img width="386" height="187" alt="Screenshot 2025-07-24 at 9 51 59 PM" src="https://github.com/user-attachments/assets/7736064c-8352-46a2-bbf4-68fa3248975a" />

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/0742d270-6c3b-4ef6-afaf-4f2dc2b5b2b4


<img width="316" height="113" alt="Screenshot 2025-07-24 at 9 53 53 PM" src="https://github.com/user-attachments/assets/9350e750-82cc-4b31-85b8-bc1f7c150bcc" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
