### PR TITLE
fix: removed 'Use a different login method' for non-social-login flow cp-13.0.0

### DIFF
--- a/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
+++ b/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
@@ -59,7 +59,7 @@ exports[`Unlock Page should match snapshot 1`] = `
           data-testid="unlock-forgot-password-button"
           type="button"
         >
-          Use a different login method
+          Forgot password?
         </button>
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -392,7 +392,9 @@ class UnlockPage extends Component {
   onForgotPasswordOrLoginWithDiffMethods = () => {
     const { isSocialLoginFlow, history, isOnboardingCompleted } = this.props;
 
-    if (!isOnboardingCompleted) {
+    // in `onboarding_unlock` route, if the user is on a social login flow and onboarding is not completed,
+    // we can redirect to `onboarding_welcome` route to select a different login method
+    if (!isOnboardingCompleted && isSocialLoginFlow) {
       history.replace(ONBOARDING_WELCOME_ROUTE);
       return;
     }
@@ -423,7 +425,7 @@ class UnlockPage extends Component {
 
   render() {
     const { password, error, isLocked, showResetPasswordModal } = this.state;
-    const { isOnboardingCompleted } = this.props;
+    const { isOnboardingCompleted, isSocialLoginFlow } = this.props;
     const { t } = this.context;
 
     const needHelpText = t('needHelpLinkText');
@@ -537,9 +539,9 @@ class UnlockPage extends Component {
               onClick={() => this.onForgotPasswordOrLoginWithDiffMethods()}
               marginBottom={6}
             >
-              {isOnboardingCompleted
-                ? t('forgotPassword')
-                : t('useDifferentLoginMethod')}
+              {isSocialLoginFlow && !isOnboardingCompleted
+                ? t('useDifferentLoginMethod')
+                : t('forgotPassword')}
             </Button>
 
             <Text>

--- a/ui/pages/unlock-page/unlock-page.test.js
+++ b/ui/pages/unlock-page/unlock-page.test.js
@@ -6,6 +6,7 @@ import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import { renderWithProvider } from '../../../test/lib/render-helpers';
 import { ONBOARDING_WELCOME_ROUTE } from '../../helpers/constants/routes';
+import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 import UnlockPage from '.';
 
 const mockTryUnlockMetamask = jest.fn(() => {
@@ -35,6 +36,7 @@ jest.mock('@metamask/logo', () => () => {
 
 describe('Unlock Page', () => {
   process.env.METAMASK_BUILD_TYPE = 'main';
+  process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
 
   const mockState = {
     metamask: {},
@@ -97,6 +99,14 @@ describe('Unlock Page', () => {
   });
 
   it('clicks use different login method button', async () => {
+    const mockStateWithUnlock = {
+      metamask: {
+        firstTimeFlowType: FirstTimeFlowType.socialImport,
+        completedOnboarding: false,
+      },
+    };
+    const store = configureMockStore([thunk])(mockStateWithUnlock);
+
     const history = createMemoryHistory({
       initialEntries: [{ pathname: '/unlock' }],
     });
@@ -106,7 +116,7 @@ describe('Unlock Page', () => {
       <Router history={history}>
         <UnlockPage />
       </Router>,
-      mockStore,
+      store,
     );
 
     fireEvent.click(queryByText('Use a different login method'));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR removes the `Use a different login method` button from `Unlock` page if user is not on social-login flow.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34618?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34617

## **Manual testing steps**

1. Create new wallet with SRP
2. Create Password and before completing the onboarding, open an another window from extension
3. User should see the unlock page without the `Use a different Login method` button

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
