### PR TITLE
test: Fix console error in onboarding E2E tests

### DIFF
--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -127,7 +127,6 @@ function onboardingFixture() {
           [ETHERSCAN_SUPPORTED_CHAIN_IDS.MEGAETH_TESTNET]: true,
           [ETHERSCAN_SUPPORTED_CHAIN_IDS.MONAD_TESTNET]: true,
         },
-        skipDeepLinkInterstitial: false,
       },
       SelectedNetworkController: {
         domains: {},


### PR DESCRIPTION
## **Description**

The E2E tests using the onboarding fixture would consistently show a background console error about metadata being missing for the `skipDeepLinkInterstitial` property because it was accidentally added to the root of the `PreferencesController` state object rather than in the `preferences` object. It shouldn't really have been in the state fixture at all because the fixture's schema is meant to match migration version 74, which is quite old.

The error was resolved by removing the property.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34627?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

This error was introduced in https://github.com/MetaMask/metamask-extension/pull/33634/

## **Manual testing steps**

1. Start any E2E test that uses the onboarding fixture, and examine the background console during the test. Perhaps easiest by throwing an error in the test and using `yarn test:e2e:single --leave-running --browser chrome [test]`

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
