### PR TITLE
Debug storybook view switch error

### DIFF
--- a/ui/components/ui/box/README.mdx
+++ b/ui/components/ui/box/README.mdx
@@ -4,6 +4,8 @@ import { Severity } from '../../../helpers/constants/design-system';
 
 import { BannerAlert } from '../../component-library/banner-alert';
 
+import { DefaultStory, Margin, Padding, ColorStory, BackgroundColorStory, BorderColorStory, BorderRadiusStory, ResponsiveProps, As, Width } from './box.stories';
+
 <BannerAlert
   severity={Severity.Warning}
   title="Deprecated"
@@ -24,7 +26,7 @@ import Box from '.';
 Box is a utility component that can be used for layout or as a base for other UI components.
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--default-story" />
+  <Story of={DefaultStory} />
 </Canvas>
 
 ## Props
@@ -77,7 +79,7 @@ The margin props `margin`, `marginTop`, `marginRight`, `marginBottom`, `marginLe
 Accepted props are: `0, 1, 2, 4, 6, 8, 9, 10, 12, 'auto` or array of these values
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--margin" />
+  <Story of={Margin} />
 </Canvas>
 
 ```jsx
@@ -108,7 +110,7 @@ The padding props work very similarly to margin. The padding props `padding`, `p
 Accepted props are: `0, 1, 2, 4, 6, 8, 9, 10, 12` or array of these values
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--padding" />
+  <Story of={Padding} />
 </Canvas>
 
 ```jsx
@@ -162,7 +164,7 @@ import Box from '../ui/box';
 The `color` prop can be used to set the color of the content in Box component. The `color` prop accepts [responsive props](#responsive-props) in the form of array props. Defaults to `Color.textDefault`.
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--color-story" />
+  <Story of={ColorStory} />
 </Canvas>
 
 Example of importing `TextColor` object with `Box` component
@@ -179,7 +181,7 @@ import Box from '../ui/box';
 Use the `backgroundColor` prop along with the `Color` or `BackgroundColor` object from `ui/helpers/constants/design-system.js` to change background color. The `backgroundColor` prop accepts [responsive props](#responsive-props) in the form of array props.
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--background-color-story" />
+  <Story of={BackgroundColorStory} />
 </Canvas>
 
 Example of importing `BackgroundColor` object with `Box` component
@@ -203,7 +205,7 @@ import Box from '../ui/box';
 Use the `borderColor` prop along with the `Color` or `BorderColor` object from `ui/helpers/constants/design-system.js` to change border color. The `borderColor` prop accepts [responsive props](#responsive-props) in the form of array props.
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--border-color-story" />
+  <Story of={BorderColorStory} />
 </Canvas>
 
 Example of importing `BorderColor` object with `Box` component
@@ -231,7 +233,7 @@ import Box from '../ui/box';
 Use the `borderRadius` prop along with the `BorderRadius` object from `ui/helpers/constants/design-system.js` to change border radius. The `borderRadius` prop accepts [responsive props](#responsive-props) in the form of array props.
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--border-radius-story" />
+  <Story of={BorderRadiusStory} />
 </Canvas>
 
 Example of importing `BorderRadius` object with `Box` component
@@ -272,7 +274,7 @@ The box component provides a responsive props api in the form of array props. Ar
 ```
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--responsive-props" />
+  <Story of={ResponsiveProps} />
 </Canvas>
 
 ```jsx
@@ -318,7 +320,7 @@ import Box from '../ui/box';
 The polymorphic `as` prop allows you to change the root HTML element of the Box component. Defaults to `'div'`
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--as" />
+  <Story of={As} />
 </Canvas>
 
 ```jsx
@@ -345,7 +347,7 @@ Example: [BlockSize.Half, BlockSize.ThreeFourths, BlockSize.OneFifth, BlockSize.
 - BlockSize.ThreeSixths is the width for `large screen size (1280px)` and up
 
 <Canvas>
-  <Story id="components-ui-box-deprecated--width" />
+  <Story of={Width} />
 </Canvas>
 
 ```jsx


### PR DESCRIPTION
Update Storybook MDX files to use `of` syntax instead of `id` to resolve "g.trim is not a function" error.

The error "g.trim is not a function" occurred when switching from docs view to stories view in Storybook. This was caused by the use of deprecated `<Story id="..." />` syntax in MDX documentation files, which is no longer supported in Storybook 7+. Updating to the modern `<Story of={StoryName} />` syntax resolves this compatibility issue.

---

[Open in Web](https://cursor.com/agents?id=bc-9c0e0736-c97d-490f-8f03-8908964b94f3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9c0e0736-c97d-490f-8f03-8908964b94f3)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)