### PR TITLE
fix: multichain accounts minor UX bugs cp-13.0.0

### DIFF
--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -374,6 +374,7 @@ export const ImportSrp = () => {
                     flexDirection={FlexDirection.Row}
                     alignItems={AlignItems.center}
                     width={BlockSize.Full}
+                    paddingRight={2}
                   >
                     <TextField
                       id={id}

--- a/ui/pages/multichain-accounts/base-account-details/base-account-details.test.tsx
+++ b/ui/pages/multichain-accounts/base-account-details/base-account-details.test.tsx
@@ -8,7 +8,10 @@ import {
   MOCK_ACCOUNT_EOA,
   MOCK_ACCOUNT_SOLANA_MAINNET,
 } from '../../../../test/data/mock-accounts';
-import { ACCOUNT_DETAILS_QR_CODE_ROUTE } from '../../../helpers/constants/routes';
+import {
+  ACCOUNT_DETAILS_QR_CODE_ROUTE,
+  DEFAULT_ROUTE,
+} from '../../../helpers/constants/routes';
 import { KeyringType } from '../../../../shared/constants/keyring';
 import { BaseAccountDetails } from './base-account-details';
 
@@ -17,12 +20,10 @@ const mockStore = configureMockStore(middleware);
 
 // Mock the useHistory hook
 const mockPush = jest.fn();
-const mockGoBack = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     push: mockPush,
-    goBack: mockGoBack,
   }),
 }));
 
@@ -134,7 +135,6 @@ const createMockState = (
 describe('BaseAccountDetails', () => {
   beforeEach(() => {
     mockPush.mockClear();
-    mockGoBack.mockClear();
   });
 
   describe('Component Rendering', () => {
@@ -216,7 +216,7 @@ describe('BaseAccountDetails', () => {
   });
 
   describe('Navigation', () => {
-    it('should go back when back button is clicked', () => {
+    it('should navigate to default route when back button is clicked', () => {
       const state = createMockState(MOCK_ACCOUNT_EOA.address);
       const store = mockStore(state);
 
@@ -233,7 +233,7 @@ describe('BaseAccountDetails', () => {
       const backButton = screen.getByLabelText('Back');
       fireEvent.click(backButton);
 
-      expect(mockGoBack).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith(DEFAULT_ROUTE);
     });
 
     it('should navigate to QR code route when address row is clicked', () => {

--- a/ui/pages/multichain-accounts/base-account-details/base-account-details.tsx
+++ b/ui/pages/multichain-accounts/base-account-details/base-account-details.tsx
@@ -100,7 +100,7 @@ export const BaseAccountDetails = ({
 
   const handleNavigation = useCallback(() => {
     dispatch(setAccountDetailsAddress(''));
-    history.goBack();
+    history.push(DEFAULT_ROUTE);
   }, [history, dispatch]);
 
   // we can never have a scenario where an account is not associated with a wallet.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR solves 2 issues,

1. Navigation between the screens of wallet details, account details, and QR code. The account details must return to the wallet screen regardless of the wallet details screen to avoid infinite navigation loops.
2. The `ShowHideToggle` in the import SRP screen was glued to the input box, this adds a padding between both components.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34644?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixes navigation between multichain account screens
CHANGELOG entry: Fixes padding between `ShowHideToggle` and `TextField` in `ImportSrp` screen


## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34607

## **Manual testing steps**

Bug 1

1. Navigate Account List > Wallet Detail > Account Detail > QR Code
2. Navigate back until you get back to Wallet view. It should skip the Wallet Detail and Account List

Bug 2

1. Navigate to import SRP
2. Notice the style of `ShowHideToggle` is fixed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Check linked issue: https://github.com/MetaMask/metamask-extension/issues/34607

### **After**

Bug 1

https://github.com/user-attachments/assets/70df1869-bd2b-4f21-a084-f3d96d8454f7

Bug 2

<img width="401" height="598" alt="Screenshot 2025-07-25 at 6 38 48 PM" src="https://github.com/user-attachments/assets/9c4a7ede-4714-4a79-bec1-beea2cb13448" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
