### PR TITLE
fix: usd values in simulation metrics

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Info renders info section for approve request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-12"
+              aria-describedby="tippy-tooltip-13"
               class=""
               data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
               data-tooltipped=""
@@ -126,7 +126,7 @@ exports[`Info renders info section for approve request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-9"
+              aria-describedby="tippy-tooltip-10"
               class=""
               data-original-title="This is the address that will be able to withdraw your NFTs."
               data-tooltipped=""
@@ -189,7 +189,7 @@ exports[`Info renders info section for approve request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-10"
+              aria-describedby="tippy-tooltip-11"
               class=""
               data-original-title="This is the site asking for your confirmation."
               data-tooltipped=""
@@ -241,7 +241,7 @@ exports[`Info renders info section for approve request 1`] = `
             </p>
             <div>
               <div
-                aria-describedby="tippy-tooltip-11"
+                aria-describedby="tippy-tooltip-12"
                 class=""
                 data-original-title="Amount paid to process the transaction on network."
                 data-tooltipped=""
@@ -829,7 +829,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-13"
+              aria-describedby="tippy-tooltip-14"
               class=""
               data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
               data-tooltipped=""
@@ -932,7 +932,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-14"
+              aria-describedby="tippy-tooltip-15"
               class=""
               data-original-title="This is the address that will be able to withdraw your NFTs."
               data-tooltipped=""
@@ -995,7 +995,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-15"
+              aria-describedby="tippy-tooltip-16"
               class=""
               data-original-title="This is the site asking for your confirmation."
               data-tooltipped=""
@@ -1047,7 +1047,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
             </p>
             <div>
               <div
-                aria-describedby="tippy-tooltip-16"
+                aria-describedby="tippy-tooltip-17"
                 class=""
                 data-original-title="Amount paid to process the transaction on network."
                 data-tooltipped=""

--- a/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.test.tsx
@@ -61,6 +61,7 @@ const BALANCE_CHANGE_ERC20_MOCK: ApprovalBalanceChange = {
   isAllApproval: false,
   isUnlimitedApproval: false,
   nestedTransactionIndex: 0,
+  usdAmount: null,
 };
 
 const BALANCE_CHANGE_ERC721_MOCK: ApprovalBalanceChange = {
@@ -76,6 +77,7 @@ const BALANCE_CHANGE_ERC721_MOCK: ApprovalBalanceChange = {
   isAllApproval: false,
   isUnlimitedApproval: false,
   nestedTransactionIndex: 0,
+  usdAmount: null,
 };
 
 const BALANCE_CHANGE_ERC1155_MOCK: ApprovalBalanceChange = {
@@ -91,6 +93,7 @@ const BALANCE_CHANGE_ERC1155_MOCK: ApprovalBalanceChange = {
   isAllApproval: false,
   isUnlimitedApproval: false,
   nestedTransactionIndex: 0,
+  usdAmount: null,
 };
 
 function render(transaction?: Confirmation) {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.test.ts
@@ -47,6 +47,7 @@ const BALANCE_CHANGE_MOCK: BalanceChange = {
   amount: new BigNumber('123.56'),
   fiatAmount: 12.34,
   isApproval: false,
+  usdAmount: 12.34,
 };
 
 async function runHook({

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
@@ -205,6 +205,7 @@ describe('SimulationDetails', () => {
             },
             amount: new BigNumber(123),
             fiatAmount: 456,
+            usdAmount: 789,
           },
         ],
       },

--- a/ui/pages/confirmations/components/simulation-details/types.ts
+++ b/ui/pages/confirmations/components/simulation-details/types.ts
@@ -70,4 +70,7 @@ export type BalanceChange = Readonly<{
 
   /** Callback to support editing the value. */
   onEdit?: () => void;
+
+  /** The amount of USD that corresponds to the asset amount. */
+  usdAmount: FiatAmount;
 }>;

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -200,9 +200,14 @@ export const useBalanceChanges = ({
   const erc20UsdRates = useAsyncResultOrThrow(
     async () =>
       fiatCurrency === CURRENCY_USD
-        ? (erc20FiatRates.value as ContractExchangeRates)
-        : fetchTokenExchangeRates(CURRENCY_USD, erc20TokenAddresses, chainId),
-    [JSON.stringify(erc20TokenAddresses), chainId],
+        ? (erc20FiatRates.value ?? {})
+        : fetchTokenFiatRates(CURRENCY_USD, erc20TokenAddresses, chainId),
+    [
+      JSON.stringify(erc20TokenAddresses),
+      chainId,
+      fiatCurrency,
+      erc20FiatRates.value,
+    ],
   );
 
   if (

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -11,7 +11,11 @@ import { ContractExchangeRates } from '@metamask/assets-controllers';
 import { useAsyncResultOrThrow } from '../../../../hooks/useAsync';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
-import { selectConversionRateByChainId } from '../../../../selectors';
+import {
+  // eslint-disable-next-line no-restricted-syntax
+  getUSDConversionRateByChainId,
+  selectConversionRateByChainId,
+} from '../../../../selectors';
 import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
 import { ERC20_DEFAULT_DECIMALS, fetchErc20Decimals } from '../../utils/token';
 
@@ -23,6 +27,7 @@ import {
 } from './types';
 
 const NATIVE_DECIMALS = 18;
+const CURRENCY_USD = 'usd';
 
 // See https://github.com/MikeMcl/bignumber.js/issues/11#issuecomment-23053776
 function convertNumberToStringWithPrecisionWarning(value: number): string {
@@ -96,6 +101,7 @@ async function fetchTokenFiatRates(
 function getNativeBalanceChange(
   nativeBalanceChange: SimulationBalanceChange | undefined,
   nativeFiatRate: number | undefined,
+  nativeUsdRate: number | undefined,
   chainId: Hex,
 ): BalanceChange | undefined {
   if (!nativeBalanceChange) {
@@ -109,13 +115,13 @@ function getNativeBalanceChange(
 
   const amount = getAssetAmount(nativeBalanceChange, NATIVE_DECIMALS);
 
-  const fiatAmount = nativeFiatRate
-    ? amount
-        .times(convertNumberToStringWithPrecisionWarning(nativeFiatRate))
-        .toNumber()
-    : FIAT_UNAVAILABLE;
+  const [fiatAmount, usdAmount] = [nativeFiatRate, nativeUsdRate].map((rate) =>
+    rate
+      ? amount.times(convertNumberToStringWithPrecisionWarning(rate)).toNumber()
+      : FIAT_UNAVAILABLE,
+  );
 
-  return { asset, amount, fiatAmount };
+  return { asset, amount, fiatAmount, usdAmount };
 }
 
 // Compiles the balance changes for token assets
@@ -123,6 +129,7 @@ function getTokenBalanceChanges(
   tokenBalanceChanges: SimulationTokenBalanceChange[],
   erc20Decimals: Record<Hex, number>,
   erc20FiatRates: Partial<Record<Hex, number>>,
+  erc20UsdRates: Partial<Record<Hex, number>>,
   chainId: Hex,
 ): BalanceChange[] {
   return tokenBalanceChanges.map((tokenBc) => {
@@ -138,16 +145,20 @@ function getTokenBalanceChanges(
       asset.standard === TokenStandard.ERC20
         ? (erc20Decimals[asset.address] ?? ERC20_DEFAULT_DECIMALS)
         : 0;
+
     const amount = getAssetAmount(tokenBc, decimals);
-
     const fiatRate = erc20FiatRates[tokenBc.address.toLowerCase() as Hex];
-    const fiatAmount = fiatRate
-      ? amount
-          .times(convertNumberToStringWithPrecisionWarning(fiatRate))
-          .toNumber()
-      : FIAT_UNAVAILABLE;
+    const usdRate = erc20UsdRates[tokenBc.address.toLowerCase() as Hex];
 
-    return { asset, amount, fiatAmount };
+    const [fiatAmount, usdAmount] = [fiatRate, usdRate].map((rate) =>
+      rate
+        ? amount
+            .times(convertNumberToStringWithPrecisionWarning(rate))
+            .toNumber()
+        : FIAT_UNAVAILABLE,
+    );
+
+    return { asset, amount, fiatAmount, usdAmount };
   });
 }
 
@@ -163,6 +174,10 @@ export const useBalanceChanges = ({
 
   const nativeFiatRate = useSelector((state) =>
     selectConversionRateByChainId(state, chainId),
+  );
+
+  const nativeUsdRate = useSelector((state) =>
+    getUSDConversionRateByChainId(chainId)(state),
   );
 
   const { nativeBalanceChange, tokenBalanceChanges = [] } =
@@ -182,13 +197,27 @@ export const useBalanceChanges = ({
     [JSON.stringify(erc20TokenAddresses), chainId, fiatCurrency],
   );
 
-  if (erc20Decimals.pending || erc20FiatRates.pending || !simulationData) {
+  const erc20UsdRates = useAsyncResultOrThrow(
+    async () =>
+      fiatCurrency === CURRENCY_USD
+        ? (erc20FiatRates.value as ContractExchangeRates)
+        : fetchTokenExchangeRates(CURRENCY_USD, erc20TokenAddresses, chainId),
+    [JSON.stringify(erc20TokenAddresses), chainId],
+  );
+
+  if (
+    erc20Decimals.pending ||
+    erc20FiatRates.pending ||
+    erc20UsdRates.pending ||
+    !simulationData
+  ) {
     return { pending: true, value: [] };
   }
 
   const nativeChange = getNativeBalanceChange(
     nativeBalanceChange,
     nativeFiatRate,
+    nativeUsdRate,
     chainId,
   );
 
@@ -196,6 +225,7 @@ export const useBalanceChanges = ({
     tokenBalanceChanges,
     erc20Decimals.value,
     erc20FiatRates.value,
+    erc20UsdRates.value,
     chainId,
   );
 
@@ -203,5 +233,6 @@ export const useBalanceChanges = ({
     ...(nativeChange ? [nativeChange] : []),
     ...tokenChanges,
   ];
+
   return { pending: false, value: balanceChanges };
 };

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.test.ts
@@ -491,12 +491,12 @@ describe('useSimulationMetrics', () => {
         const balanceChange1 = {
           ...BALANCE_CHANGE_MOCK,
           amount: new BigNumber(isNegative ? -1 : 1),
-          fiatAmount: 1.23,
+          usdAmount: 1.23,
         };
 
         const balanceChange2 = {
           ...balanceChange1,
-          fiatAmount: 1.23,
+          usdAmount: 1.23,
         };
 
         expectUpdateTransactionEventFragmentCalled(

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
@@ -224,7 +224,7 @@ function getProperties(
     ),
   );
 
-  const fiatAmounts = changes.map((change) => change.fiatAmount);
+  const fiatAmounts = changes.map((change) => change.usdAmount);
   const totalFiat = calculateTotalFiat(fiatAmounts);
   const totalValue = totalFiat ? Math.abs(totalFiat) : undefined;
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.test.ts
@@ -72,6 +72,7 @@ const MOCK_APPROVAL_BALANCE_CHANGE: ApprovalBalanceChange = {
   isAllApproval: false,
   isUnlimitedApproval: false,
   nestedTransactionIndex: 0,
+  usdAmount: null,
 };
 
 const createMockNestedTransaction = (


### PR DESCRIPTION
## **Description**

Use only USD values in simulation metrics, rather than selected currency.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34645?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5387](https://github.com/MetaMask/MetaMask-planning/issues/5387)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
