### PR TITLE
fix(v13.0.0): account tree controller clear state

### DIFF
--- a/.yarn/patches/@metamask-account-tree-controller-npm-0.1.0-a0febb78fd.patch
+++ b/.yarn/patches/@metamask-account-tree-controller-npm-0.1.0-a0febb78fd.patch
@@ -1,0 +1,16 @@
+diff --git a/dist/AccountTreeController.cjs b/dist/AccountTreeController.cjs
+index d70e8360f903a99394416604501cfb2bf0909032..8cb12157170c614cc641f19998c82dc9da56b265 100644
+--- a/dist/AccountTreeController.cjs
++++ b/dist/AccountTreeController.cjs
+@@ -127,6 +127,11 @@ class AccountTreeController extends base_controller_1.BaseController {
+             state.accountTree.wallets = wallets;
+         });
+     }
++    clearState() {
++        this.update((state) => {
++            state.accountTree.wallets = {};
++        });
++    }
+ }
+ exports.AccountTreeController = AccountTreeController;
+ _AccountTreeController_reverse = new WeakMap(), _AccountTreeController_rules = new WeakMap(), _AccountTreeController_instances = new WeakSet(), _AccountTreeController_handleAccountAdded = function _AccountTreeController_handleAccountAdded(account) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5371,6 +5371,9 @@ export default class MetamaskController extends EventEmitter {
       // Clear snap state
       await this.snapController.clearState();
 
+      // Clear account tree controller state
+      this.accountWalletController.clearState();
+
       // Currently, the account-order-controller is not in sync with
       // the accounts-controller. To properly persist the hidden state
       // of accounts, we should add a new flag to the account struct

--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
     "@ledgerhq/errors": "^6.21.0",
     "@material-ui/core": "^4.12.4",
     "@metamask/abi-utils": "^2.0.2",
-    "@metamask/account-tree-controller": "^0.1.0",
+    "@metamask/account-tree-controller": "patch:@metamask/account-tree-controller@npm%3A0.1.0#~/.yarn/patches/@metamask-account-tree-controller-npm-0.1.0-a0febb78fd.patch",
     "@metamask/account-watcher": "^4.1.3",
     "@metamask/accounts-controller": "^30.0.0",
     "@metamask/address-book-controller": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5335,7 +5335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^0.1.0":
+"@metamask/account-tree-controller@npm:0.1.0":
   version: 0.1.0
   resolution: "@metamask/account-tree-controller@npm:0.1.0"
   dependencies:
@@ -5350,6 +5350,24 @@ __metadata:
     "@metamask/snaps-controllers": ^12.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/d5e952d9439743335232a010f8e7eda1d54555d91148149cc0cd6ac5559b9b7a6639969580c103a8f27c2012a309cb15c31c48caaf46fa370b0a0bc2a011e491
+  languageName: node
+  linkType: hard
+
+"@metamask/account-tree-controller@patch:@metamask/account-tree-controller@npm%3A0.1.0#~/.yarn/patches/@metamask-account-tree-controller-npm-0.1.0-a0febb78fd.patch":
+  version: 0.1.0
+  resolution: "@metamask/account-tree-controller@patch:@metamask/account-tree-controller@npm%3A0.1.0#~/.yarn/patches/@metamask-account-tree-controller-npm-0.1.0-a0febb78fd.patch::version=0.1.0&hash=3d0f90"
+  dependencies:
+    "@metamask/base-controller": "npm:^8.0.1"
+    "@metamask/snaps-sdk": "npm:^7.1.0"
+    "@metamask/snaps-utils": "npm:^9.4.0"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/accounts-controller": ^30.0.0
+    "@metamask/keyring-controller": ^22.0.0
+    "@metamask/providers": ^22.0.0
+    "@metamask/snaps-controllers": ^12.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/6e20b4c6e4051336f13577dd7fabb670ed97ef579ec62d2c0e4fe43e665a52af094a889855d0f87aeeb0f14e6ba178882ecf9a60ce01a6889918a1a6da8e971f
   languageName: node
   linkType: hard
 
@@ -31916,7 +31934,7 @@ __metadata:
     "@lydell/node-pty": "npm:^1.1.0"
     "@material-ui/core": "npm:^4.12.4"
     "@metamask/abi-utils": "npm:^2.0.2"
-    "@metamask/account-tree-controller": "npm:^0.1.0"
+    "@metamask/account-tree-controller": "patch:@metamask/account-tree-controller@npm%3A0.1.0#~/.yarn/patches/@metamask-account-tree-controller-npm-0.1.0-a0febb78fd.patch"
     "@metamask/account-watcher": "npm:^4.1.3"
     "@metamask/accounts-controller": "npm:^30.0.0"
     "@metamask/address-book-controller": "npm:^6.1.0"


### PR DESCRIPTION
## **Description**

This introduce a patch for the `@metamask/account-tree-controller@0.1.0` package to add a `clearState` method that allow to clear the internal state of this controller during the "forget password" flow.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34670?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a bug where some old wallet data were wrongly kept (on the account list) after resetting the wallet

## **Related issues**

Fixes:

## **Manual testing steps**

1. Import SRP
2. Lock wallet
3. Click Forgot password
4. Restore with SRP
5. You should not see old data from your previous wallet state on the account list.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
