### PR TITLE
style: tell VSCode to end all files with a newline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "files.associations": {
     "app/*.html": "ejs"
   },
+  "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "gitlens.advanced.blame.customArguments": [
     "--ignore-revs-file .git-blame-ignore-revs"


### PR DESCRIPTION
## **Description**

This PR is an excellent example of MetaMask/MetaMask-planning#2676 where we should be skipping most CI steps.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes problem in: #34530
Example of: MetaMask/MetaMask-planning#2676

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->