### PR TITLE
fix: update address QR code navigation to prevent infinite loop of navigation cherry-pick cp-13.0.0

### DIFF
--- a/ui/pages/multichain-accounts/address-qr-code/address-qr-code.test.tsx
+++ b/ui/pages/multichain-accounts/address-qr-code/address-qr-code.test.tsx
@@ -4,10 +4,7 @@ import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import {
-  ACCOUNT_DETAILS_ROUTE,
-  ACCOUNT_DETAILS_QR_CODE_ROUTE,
-} from '../../../helpers/constants/routes';
+import { ACCOUNT_DETAILS_QR_CODE_ROUTE } from '../../../helpers/constants/routes';
 import { openBlockExplorer } from '../../../components/multichain/menu-items/view-explorer-menu-item';
 import { getMultichainAccountUrl } from '../../../helpers/utils/multichain/blockExplorer';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
@@ -33,11 +30,11 @@ jest.mock('../../../hooks/useMultichainSelector', () => ({
 }));
 
 // Mock React Router
-const mockHistoryPush = jest.fn();
+const mockHistoryGoBack = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
-    push: mockHistoryPush,
+    goBack: mockHistoryGoBack,
   }),
 }));
 
@@ -168,9 +165,7 @@ describe('AddressQRCode', () => {
       const backButton = screen.getByLabelText('Back');
       fireEvent.click(backButton);
 
-      expect(mockHistoryPush).toHaveBeenCalledWith(
-        `${ACCOUNT_DETAILS_ROUTE}/${mockAccount.address}`,
-      );
+      expect(mockHistoryGoBack).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/ui/pages/multichain-accounts/address-qr-code/address-qr-code.tsx
+++ b/ui/pages/multichain-accounts/address-qr-code/address-qr-code.tsx
@@ -16,7 +16,6 @@ import {
   ButtonSecondarySize,
   IconName,
 } from '../../../components/component-library';
-import { ACCOUNT_DETAILS_ROUTE } from '../../../helpers/constants/routes';
 import {
   BackgroundColor,
   TextVariant,
@@ -79,7 +78,7 @@ export const AddressQRCode = () => {
             ariaLabel="Back"
             iconName={IconName.ArrowLeft}
             size={ButtonIconSize.Sm}
-            onClick={() => history.push(`${ACCOUNT_DETAILS_ROUTE}/${address}`)}
+            onClick={() => history.goBack()}
           />
         }
       >


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request,
also include relevant motivation and context. Have in mind the following
questions:
1. What is the reason for the change? The `AddressQRCode` component currently uses a `history.push` call to navigate to its respective account details page. This is erroneous because account details uses `history.goBack` which just picks the page it came from which is `AddressQRCode`.
2. What is the improvement/solution? Use `history.goBack` in the `AddressQRCode` component.

Cherry-pick from: https://github.com/MetaMask/metamask-extension/pull/34381

Fixes: https://github.com/MetaMask/metamask-extension/issues/34607

## **Manual testing steps**

1. Build from this branch.
2. Navigate to an account's address qr code page, navigate back to the
account details page, hit back again.
3. Observe that the navigation leads you back to the home page.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/e238f5fc-4dc4-4901-b137-984b06d85130

### **After**

https://github.com/user-attachments/assets/da2e140e-9455-4612-93ef-66ec730e4dc1

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask
Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [x] I’ve applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.