### PR TITLE
fix: adds fromChain to the usecrosschainswaps event tracker hook

### DIFF
--- a/ui/hooks/bridge/useCrossChainSwapsEventTracker.ts
+++ b/ui/hooks/bridge/useCrossChainSwapsEventTracker.ts
@@ -1,6 +1,8 @@
 import { useCallback, useContext } from 'react';
-import { SortOrder } from '@metamask/bridge-controller';
+import { useSelector } from 'react-redux';
+import { SortOrder, formatChainIdToCaip } from '@metamask/bridge-controller';
 import { MetaMetricsContext } from '../../contexts/metametrics';
+import { getFromChain } from '../../ducks/bridge/selectors';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -114,6 +116,7 @@ export type CrossChainSwapsEventProperties = {
  */
 export const useCrossChainSwapsEventTracker = () => {
   const trackEvent = useContext(MetaMetricsContext);
+  const fromChain = useSelector(getFromChain);
 
   const trackCrossChainSwapsEvent = useCallback(
     <EventName extends keyof CrossChainSwapsEventProperties>({
@@ -125,6 +128,10 @@ export const useCrossChainSwapsEventTracker = () => {
       category?: MetaMetricsEventCategory;
       properties: CrossChainSwapsEventProperties[EventName];
     }) => {
+      const chainId = fromChain?.chainId
+        ? formatChainIdToCaip(fromChain.chainId)
+        : undefined;
+
       trackEvent({
         category: category ?? MetaMetricsEventCategory.CrossChainSwaps,
         event,
@@ -132,12 +139,15 @@ export const useCrossChainSwapsEventTracker = () => {
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
           // eslint-disable-next-line @typescript-eslint/naming-convention
           action_type: ActionType.CROSSCHAIN_V1,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          chain_id: chainId,
           ...properties,
         },
         value: 'value' in properties ? (properties.value as never) : undefined,
       });
     },
-    [trackEvent],
+    [trackEvent, fromChain],
   );
 
   return trackCrossChainSwapsEvent;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates the event tracker hook for Unified SwapBridge events to include the correct chainId in multichain scenarios.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34686?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32841

## **Manual testing steps**

1. Not user facing. When navigating to the unified bridge page, sentry should correctly populate the chainId when sending events for the 'Unified SwapBridge' category.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
