### PR TITLE
fix: Update spacing between the account avatar and its details rows

### DIFF
--- a/ui/pages/multichain-accounts/base-account-details/base-account-details.tsx
+++ b/ui/pages/multichain-accounts/base-account-details/base-account-details.tsx
@@ -181,7 +181,7 @@ export const BaseAccountDetails = ({
               : AvatarAccountVariant.Jazzicon
           }
           size={AvatarAccountSize.Xl}
-          style={{ margin: '0 auto', marginBottom: '32px' }}
+          style={{ margin: '0 auto', marginBottom: '8px' }}
         />
         <Box className="multichain-account-details__section">
           <AccountDetailsRow


### PR DESCRIPTION
## **Description**
This PR fixes spacing between account avatar and its information rows. The spacing should be `24px` exactly. Given that there is a gap within the flexbox that is holding the elements grid, bottom margin of the avatar is reduced to `8px` so it now has total of `24px` together with the flexbox gap.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34689?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed spacing on multichain account page, between avatar and the rest of account details

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-437

Figma designs: https://www.figma.com/design/G88ChchQ8FINCBI9BBkrAG/BIP-44-Extension?node-id=0-1&p=f&m=dev

## **Manual testing steps**
1. Enable multichain accounts state 1 using feature flag.
2. Go to any account details.
3. Check spacing between the account avatar and the first row with account information.

## **Screenshots/Recordings**
### **Before**
<img width="768" height="1124" alt="image" src="https://github.com/user-attachments/assets/6011a56c-16e5-4061-8a31-00b82ccceef8" />

### **After**
<img width="406" height="606" alt="Screenshot 2025-07-29 at 10 25 05" src="https://github.com/user-attachments/assets/6a16fd45-363a-4a3d-8401-6a45b09fe96a" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.