### PR TITLE
perf: Exclude test assets in production

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -584,10 +584,9 @@ async function initialize(backup) {
   // an Offscreen Document message instead. Because it's a singleton class, it's safe to start multiple times.
   if (process.env.IN_TEST && window.navigator?.webdriver) {
     const { getSocketBackgroundToMocha } =
-      // Use `import` to make it easier to exclude this test code from the Browserify build.
-      await import(
-        '../../test/e2e/background-socket/socket-background-to-mocha'
-      );
+      // Use `require` to make it easier to exclude this test code from the Browserify build.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+      require('../../test/e2e/background-socket/socket-background-to-mocha');
     getSocketBackgroundToMocha();
   }
 
@@ -613,11 +612,13 @@ async function initialize(backup) {
   const overrides = inTest
     ? {
         keyrings: {
-          // Use `import` to make it easier to exclude this test code from the Browserify build.
-          trezorBridge: await import('../../test/stub/keyring-bridge')
+          // Use `require` to make it easier to exclude this test code from the Browserify build.
+          // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+          trezorBridge: require('../../test/stub/keyring-bridge')
             .FakeTrezorBridge,
-          // Use `import` to make it easier to exclude this test code from the Browserify build.
-          ledgerBridge: await import('../../test/stub/keyring-bridge')
+          // Use `require` to make it easier to exclude this test code from the Browserify build.
+          // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+          ledgerBridge: require('../../test/stub/keyring-bridge')
             .FakeLedgerBridge,
         },
       }
@@ -772,10 +773,9 @@ async function loadPhishingWarningPage() {
  */
 export async function loadStateFromPersistence(backup) {
   if (process.env.WITH_STATE) {
-    // Use `import` to make it easier to exclude this test code from the Browserify build.
-    const { generateWalletState } = await import(
-      './fixtures/generate-wallet-state'
-    );
+    // Use `require` to make it easier to exclude this test code from the Browserify build.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+    const { generateWalletState } = require('./fixtures/generate-wallet-state');
     const stateOverrides = await generateWalletState();
     firstTimeState = { ...firstTimeState, ...stateOverrides };
   }
@@ -815,9 +815,8 @@ export async function loadStateFromPersistence(backup) {
   const migrator = new Migrator({
     migrations,
     defaultVersion: process.env.WITH_STATE
-      ? // Use `import` to make it easier to exclude this test code from the Browserify build.
-        await import('../../test/e2e/default-fixture')
-          .FIXTURE_STATE_METADATA_VERSION
+      ? // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+        require('../../test/e2e/default-fixture').FIXTURE_STATE_METADATA_VERSION
       : null,
   });
 

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -584,6 +584,7 @@ async function initialize(backup) {
   // an Offscreen Document message instead. Because it's a singleton class, it's safe to start multiple times.
   if (process.env.IN_TEST && window.navigator?.webdriver) {
     const { getSocketBackgroundToMocha } =
+      // Use `require` to make it easier to exclude this test code from the Browserify build.
       // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
       require('../../test/e2e/background-socket/socket-background-to-mocha');
     getSocketBackgroundToMocha();
@@ -611,9 +612,11 @@ async function initialize(backup) {
   const overrides = inTest
     ? {
         keyrings: {
+          // Use `require` to make it easier to exclude this test code from the Browserify build.
           // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
           trezorBridge: require('../../test/stub/keyring-bridge')
             .FakeTrezorBridge,
+          // Use `require` to make it easier to exclude this test code from the Browserify build.
           // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
           ledgerBridge: require('../../test/stub/keyring-bridge')
             .FakeLedgerBridge,
@@ -770,6 +773,7 @@ async function loadPhishingWarningPage() {
  */
 export async function loadStateFromPersistence(backup) {
   if (process.env.WITH_STATE) {
+    // Use `require` to make it easier to exclude this test code from the Browserify build.
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
     const { generateWalletState } = require('./fixtures/generate-wallet-state');
     const stateOverrides = await generateWalletState();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -583,7 +583,9 @@ async function initialize(backup) {
   // In MV3, the Service Worker sees `navigator.webdriver` as `undefined`, so this will trigger from
   // an Offscreen Document message instead. Because it's a singleton class, it's safe to start multiple times.
   if (process.env.IN_TEST && window.navigator?.webdriver) {
-    const { getSocketBackgroundToMocha } = require('../../test/e2e/background-socket/socket-background-to-mocha');
+    const { getSocketBackgroundToMocha } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+      require('../../test/e2e/background-socket/socket-background-to-mocha');
     getSocketBackgroundToMocha();
   }
 
@@ -609,8 +611,12 @@ async function initialize(backup) {
   const overrides = inTest
     ? {
         keyrings: {
-          trezorBridge: require('../../test/stub/keyring-bridge').FakeTrezorBridge,
-          ledgerBridge: require('../../test/stub/keyring-bridge').FakeLedgerBridge,
+          // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+          trezorBridge: require('../../test/stub/keyring-bridge')
+            .FakeTrezorBridge,
+          // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+          ledgerBridge: require('../../test/stub/keyring-bridge')
+            .FakeLedgerBridge,
         },
       }
     : {};
@@ -764,6 +770,7 @@ async function loadPhishingWarningPage() {
  */
 export async function loadStateFromPersistence(backup) {
   if (process.env.WITH_STATE) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
     const { generateWalletState } = require('./fixtures/generate-wallet-state');
     const stateOverrides = await generateWalletState();
     firstTimeState = { ...firstTimeState, ...stateOverrides };
@@ -804,7 +811,8 @@ export async function loadStateFromPersistence(backup) {
   const migrator = new Migrator({
     migrations,
     defaultVersion: process.env.WITH_STATE
-      ? require('../../test/e2e/default-fixture').FIXTURE_STATE_METADATA_VERSION
+      ? // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+        require('../../test/e2e/default-fixture').FIXTURE_STATE_METADATA_VERSION
       : null,
   });
 

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -584,9 +584,10 @@ async function initialize(backup) {
   // an Offscreen Document message instead. Because it's a singleton class, it's safe to start multiple times.
   if (process.env.IN_TEST && window.navigator?.webdriver) {
     const { getSocketBackgroundToMocha } =
-      // Use `require` to make it easier to exclude this test code from the Browserify build.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
-      require('../../test/e2e/background-socket/socket-background-to-mocha');
+      // Use `import` to make it easier to exclude this test code from the Browserify build.
+      await import(
+        '../../test/e2e/background-socket/socket-background-to-mocha'
+      );
     getSocketBackgroundToMocha();
   }
 
@@ -612,13 +613,11 @@ async function initialize(backup) {
   const overrides = inTest
     ? {
         keyrings: {
-          // Use `require` to make it easier to exclude this test code from the Browserify build.
-          // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
-          trezorBridge: require('../../test/stub/keyring-bridge')
+          // Use `import` to make it easier to exclude this test code from the Browserify build.
+          trezorBridge: await import('../../test/stub/keyring-bridge')
             .FakeTrezorBridge,
-          // Use `require` to make it easier to exclude this test code from the Browserify build.
-          // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
-          ledgerBridge: require('../../test/stub/keyring-bridge')
+          // Use `import` to make it easier to exclude this test code from the Browserify build.
+          ledgerBridge: await import('../../test/stub/keyring-bridge')
             .FakeLedgerBridge,
         },
       }
@@ -773,9 +772,10 @@ async function loadPhishingWarningPage() {
  */
 export async function loadStateFromPersistence(backup) {
   if (process.env.WITH_STATE) {
-    // Use `require` to make it easier to exclude this test code from the Browserify build.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
-    const { generateWalletState } = require('./fixtures/generate-wallet-state');
+    // Use `import` to make it easier to exclude this test code from the Browserify build.
+    const { generateWalletState } = await import(
+      './fixtures/generate-wallet-state'
+    );
     const stateOverrides = await generateWalletState();
     firstTimeState = { ...firstTimeState, ...stateOverrides };
   }
@@ -815,8 +815,9 @@ export async function loadStateFromPersistence(backup) {
   const migrator = new Migrator({
     migrations,
     defaultVersion: process.env.WITH_STATE
-      ? // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
-        require('../../test/e2e/default-fixture').FIXTURE_STATE_METADATA_VERSION
+      ? // Use `import` to make it easier to exclude this test code from the Browserify build.
+        await import('../../test/e2e/default-fixture')
+          .FIXTURE_STATE_METADATA_VERSION
       : null,
   });
 

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -40,7 +40,7 @@ export async function createOffscreen() {
 
   let offscreenDocumentLoadedListener;
   const loadPromise = new Promise((resolve) => {
-    offscreenDocumentLoadedListener = async (msg) => {
+    offscreenDocumentLoadedListener = (msg) => {
       if (
         msg.target === OffscreenCommunicationTarget.extensionMain &&
         msg.isBooted
@@ -54,10 +54,9 @@ export async function createOffscreen() {
         // start the SocketBackgroundToMocha.
         if (process.env.IN_TEST && msg.webdriverPresent) {
           const { getSocketBackgroundToMocha } =
-            // Use `import` to make it easier to exclude this test code from the Browserify build.
-            await import(
-              '../../test/e2e/background-socket/socket-background-to-mocha'
-            );
+            // Use `require` to make it easier to exclude this test code from the Browserify build.
+            // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+            require('../../test/e2e/background-socket/socket-background-to-mocha');
           getSocketBackgroundToMocha();
         }
       }

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -3,7 +3,6 @@ import {
   OFFSCREEN_LOAD_TIMEOUT,
   OffscreenCommunicationTarget,
 } from '../../shared/constants/offscreen-communication';
-import { getSocketBackgroundToMocha } from '../../test/e2e/background-socket/socket-background-to-mocha';
 
 /**
  * Returns whether the offscreen document already exists or not.
@@ -54,6 +53,9 @@ export async function createOffscreen() {
         // If the Offscreen Document sees `navigator.webdriver === true` and we are in a test environment,
         // start the SocketBackgroundToMocha.
         if (process.env.IN_TEST && msg.webdriverPresent) {
+          const {
+            getSocketBackgroundToMocha,
+          } = require('../../test/e2e/background-socket/socket-background-to-mocha');
           getSocketBackgroundToMocha();
         }
       }

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -54,6 +54,7 @@ export async function createOffscreen() {
         // start the SocketBackgroundToMocha.
         if (process.env.IN_TEST && msg.webdriverPresent) {
           const { getSocketBackgroundToMocha } =
+            // Use `require` to make it easier to exclude this test code from the Browserify build.
             // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
             require('../../test/e2e/background-socket/socket-background-to-mocha');
           getSocketBackgroundToMocha();

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -40,7 +40,7 @@ export async function createOffscreen() {
 
   let offscreenDocumentLoadedListener;
   const loadPromise = new Promise((resolve) => {
-    offscreenDocumentLoadedListener = (msg) => {
+    offscreenDocumentLoadedListener = async (msg) => {
       if (
         msg.target === OffscreenCommunicationTarget.extensionMain &&
         msg.isBooted
@@ -54,9 +54,10 @@ export async function createOffscreen() {
         // start the SocketBackgroundToMocha.
         if (process.env.IN_TEST && msg.webdriverPresent) {
           const { getSocketBackgroundToMocha } =
-            // Use `require` to make it easier to exclude this test code from the Browserify build.
-            // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
-            require('../../test/e2e/background-socket/socket-background-to-mocha');
+            // Use `import` to make it easier to exclude this test code from the Browserify build.
+            await import(
+              '../../test/e2e/background-socket/socket-background-to-mocha'
+            );
           getSocketBackgroundToMocha();
         }
       }

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -53,9 +53,9 @@ export async function createOffscreen() {
         // If the Offscreen Document sees `navigator.webdriver === true` and we are in a test environment,
         // start the SocketBackgroundToMocha.
         if (process.env.IN_TEST && msg.webdriverPresent) {
-          const {
-            getSocketBackgroundToMocha,
-          } = require('../../test/e2e/background-socket/socket-background-to-mocha');
+          const { getSocketBackgroundToMocha } =
+            // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+            require('../../test/e2e/background-socket/socket-background-to-mocha');
           getSocketBackgroundToMocha();
         }
       }

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -1,9 +1,5 @@
 import { AuthConnection } from '@metamask/seedless-onboarding-controller';
 import { OAuthErrorMessages } from '../../../../shared/modules/error';
-import {
-  MOCK_AUTH_CONNECTION_ID,
-  MOCK_GROUPED_AUTH_CONNECTION_ID,
-} from '../../../../test/e2e/constants';
 import { checkForLastError } from '../../../../shared/modules/browser-runtime.utils';
 import { TraceName, TraceOperation } from '../../../../shared/lib/trace';
 import { BaseLoginHandler } from './base-login-handler';
@@ -273,6 +269,10 @@ export default class OAuthService {
     let groupedAuthConnectionId = '';
 
     if (process.env.IN_TEST) {
+      const {
+        MOCK_AUTH_CONNECTION_ID,
+        MOCK_GROUPED_AUTH_CONNECTION_ID,
+      } = require('../../../../test/e2e/constants');
       authConnectionId = MOCK_AUTH_CONNECTION_ID;
       groupedAuthConnectionId = MOCK_GROUPED_AUTH_CONNECTION_ID;
     } else if (loginHandler.authConnection === AuthConnection.Google) {

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -269,10 +269,9 @@ export default class OAuthService {
     let groupedAuthConnectionId = '';
 
     if (process.env.IN_TEST) {
-      const {
-        MOCK_AUTH_CONNECTION_ID,
-        MOCK_GROUPED_AUTH_CONNECTION_ID,
-      } = require('../../../../test/e2e/constants');
+      const { MOCK_AUTH_CONNECTION_ID, MOCK_GROUPED_AUTH_CONNECTION_ID } =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+        require('../../../../test/e2e/constants');
       authConnectionId = MOCK_AUTH_CONNECTION_ID;
       groupedAuthConnectionId = MOCK_GROUPED_AUTH_CONNECTION_ID;
     } else if (loginHandler.authConnection === AuthConnection.Google) {

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -270,6 +270,7 @@ export default class OAuthService {
 
     if (process.env.IN_TEST) {
       const { MOCK_AUTH_CONNECTION_ID, MOCK_GROUPED_AUTH_CONNECTION_ID } =
+        // Use `require` to make it easier to exclude this test code from the Browserify build.
         // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
         require('../../../../test/e2e/constants');
       authConnectionId = MOCK_AUTH_CONNECTION_ID;

--- a/app/scripts/services/oauth/web-authenticator-factory.ts
+++ b/app/scripts/services/oauth/web-authenticator-factory.ts
@@ -1,5 +1,4 @@
 import browser from 'webextension-polyfill';
-import { mockWebAuthenticator } from '../../../../test/e2e/helpers/seedless-onboarding/mock-web-authenticator';
 import { WebAuthenticator } from './types';
 import { base64urlencode } from './utils';
 
@@ -63,6 +62,7 @@ function getRedirectURL(): string {
 
 export function webAuthenticatorFactory(): WebAuthenticator {
   if (process.env.IN_TEST) {
+    const { mockWebAuthenticator } = require('../../../../test/e2e/helpers/seedless-onboarding/mock-web-authenticator');
     return mockWebAuthenticator();
   }
 

--- a/app/scripts/services/oauth/web-authenticator-factory.ts
+++ b/app/scripts/services/oauth/web-authenticator-factory.ts
@@ -63,6 +63,7 @@ function getRedirectURL(): string {
 export function webAuthenticatorFactory(): WebAuthenticator {
   if (process.env.IN_TEST) {
     const { mockWebAuthenticator } =
+      // Use `require` to make it easier to exclude this test code from the Browserify build.
       // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
       require('../../../../test/e2e/helpers/seedless-onboarding/mock-web-authenticator');
     return mockWebAuthenticator();

--- a/app/scripts/services/oauth/web-authenticator-factory.ts
+++ b/app/scripts/services/oauth/web-authenticator-factory.ts
@@ -62,7 +62,9 @@ function getRedirectURL(): string {
 
 export function webAuthenticatorFactory(): WebAuthenticator {
   if (process.env.IN_TEST) {
-    const { mockWebAuthenticator } = require('../../../../test/e2e/helpers/seedless-onboarding/mock-web-authenticator');
+    const { mockWebAuthenticator } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+      require('../../../../test/e2e/helpers/seedless-onboarding/mock-web-authenticator');
     return mockWebAuthenticator();
   }
 

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -494,7 +494,10 @@ function getIgnoredFiles(target) {
 Please fix builds.yml or specify a compatible set of features.`);
   }
 
-  if (target.includes(BUILD_TARGETS.DEV) || target.includes(BUILD_TARGETS.TEST)) {
+  if (
+    target.includes(BUILD_TARGETS.DEV) ||
+    target.includes(BUILD_TARGETS.TEST)
+  ) {
     return ignoredPaths;
   }
 

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -494,11 +494,11 @@ function getIgnoredFiles(target) {
 Please fix builds.yml or specify a compatible set of features.`);
   }
 
-  if (isDevBuild(target) || isTestBuild(target)) {
+  if (target.includes(BUILD_TARGETS.DEV) || target.includes(BUILD_TARGETS.TEST)) {
     return ignoredPaths;
   }
 
-  // For all production builds exclude test files too.
+  // For all production build tasks exclude test files.
   const testPaths = globby(['./test', './app/scripts/fixtures']);
   return [...ignoredPaths, ...testPaths];
 }

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -459,6 +459,7 @@ testDev: Create an unoptimized, live-reloading build for debugging e2e tests.`,
 /**
  * Gets the files to be ignored by the current build, if any.
  *
+ * @param target - The build target.
  * @returns {string[] | null} The array of files to be ignored by the current
  * build, or `null` if no files are to be ignored.
  */
@@ -493,10 +494,11 @@ function getIgnoredFiles(target) {
 Please fix builds.yml or specify a compatible set of features.`);
   }
 
-  if (!isDevBuild(target)) {
-    const testPaths = globby(['./test', './app/scripts/fixtures']);
-    return [...ignoredPaths, ...testPaths];
+  if (isDevBuild(target)) {
+    return ignoredPaths;
   }
 
-  return ignoredPaths;
+  // For all non-dev builds exclude test files too.
+  const testPaths = globby(['./test', './app/scripts/fixtures']);
+  return [...ignoredPaths, ...testPaths];
 }

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -494,11 +494,11 @@ function getIgnoredFiles(target) {
 Please fix builds.yml or specify a compatible set of features.`);
   }
 
-  if (isDevBuild(target)) {
+  if (isDevBuild(target) || isTestBuild(target)) {
     return ignoredPaths;
   }
 
-  // For all non-dev builds exclude test files too.
+  // For all production builds exclude test files too.
   const testPaths = globby(['./test', './app/scripts/fixtures']);
   return [...ignoredPaths, ...testPaths];
 }

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -188,7 +188,7 @@ async function defineAndRunBuildTasks() {
 
   const browserVersionMap = getBrowserVersionMap(browserPlatforms, version);
 
-  const ignoredFiles = getIgnoredFiles();
+  const ignoredFiles = getIgnoredFiles(entryTask);
 
   const staticTasks = createStaticAssetTasks({
     browserPlatforms,
@@ -462,7 +462,7 @@ testDev: Create an unoptimized, live-reloading build for debugging e2e tests.`,
  * @returns {string[] | null} The array of files to be ignored by the current
  * build, or `null` if no files are to be ignored.
  */
-function getIgnoredFiles() {
+function getIgnoredFiles(target) {
   const buildConfig = loadBuildTypesConfig();
   const cwd = process.cwd();
 
@@ -491,6 +491,11 @@ function getIgnoredFiles() {
     throw new Error(`The following paths are required exclusively by both active and inactive features:
 \t-> ${conflicts.join('\n\t-> ')}
 Please fix builds.yml or specify a compatible set of features.`);
+  }
+
+  if (!isDevBuild(target)) {
+    const testPaths = globby(['./test', './app/scripts/fixtures']);
+    return [...ignoredPaths, ...testPaths];
   }
 
   return ignoredPaths;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reduces the bundle size of the background bundle by ~9% by removing test files that aren't required in production.

We are currently including stubs, fixtures and E2E data in the production builds. The code that brings it in is removed when bundling for production, but the imports remain due to limited tree-shaking in Browserify. This PR ensures that these test files are excluded from the bundle. To do this, I also had to rewrite a couple of the imports.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34690?quickstart=1)
