### PR TITLE
fix: reset `AccountTreeController` state after vault reset - cp-13.0.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5432,6 +5432,20 @@ export default class MetamaskController extends EventEmitter {
         seedPhraseAsUint8Array,
       );
 
+      // We re-created the vault, meaning we only have 1 new HD keyring
+      // now. We re-create the internal list of accounts (which is
+      // not an expensive operation, since we should only have 1 HD
+      // keyring that has one default account.
+      // TODO: Remove this once the `accounts-controller` once only
+      // depends only on keyrings `:stateChange`.
+      await this.accountsController.updateAccounts();
+
+      // And we re-init the account tree controller too, to use the
+      // newly created accounts.
+      // TODO: Remove this once the `accounts-controller` once only
+      // depends only on keyrings `:stateChange`.
+      this.accountTreeController.init();
+
       if (completedOnboarding) {
         await this._addAccountsWithBalance();
 


### PR DESCRIPTION
## **Description**

When using the "forget password flow", the `AccountsController` should re-update its internal list of accounts.

But given that the "default EVM account" remains the same (with the new created keyring) it won't trigger a new `:accountAdded`. This makes the `AccountTreeController` to not re-update it's internal tree state.

While the `AccountsController` should probably trigger an `:accountRemoved` + `:accountAdded` combo even for the default account, this could have an undesired side-effect, and for the moment I think this fix is safer for the moment.

We should still investigate fixing this at the `AccountsController` and probably try to remove the `updateAccounts` method altogher.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34697?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a bug where some old wallet data were wrongly kept (on the account list) after resetting the wallet

## **Related issues**

Fixes:
- https://github.com/MetaMask/metamask-extension/issues/34492

## **Manual testing steps**

1. Import SRP
2. Lock wallet
3. Click Forgot password
4. Restore with SRP
5. You should not see old data from your previous wallet state on the account list.

## **Screenshots/Recordings**

### **Before**

<img width="359" height="590" alt="Screenshot 2025-07-28 at 18 27 13" src="https://github.com/user-attachments/assets/db4d19de-4e5e-489c-a193-bc8c814bf231" />

### **After**

<img width="360" height="539" alt="Screenshot 2025-07-28 at 18 26 46" src="https://github.com/user-attachments/assets/f7be5cd6-a7a3-48e9-8e92-19e96c3d9881" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
