### PR TITLE
fix: hides bridge button on testnet for unified ui

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -51,6 +51,7 @@ import {
 import { ReceiveModal } from '../../multichain/receive-modal';
 import { setActiveNetworkWithError } from '../../../store/actions';
 import {
+  getMultichainIsTestnet,
   getMultichainNativeCurrency,
   getMultichainNetwork,
 } from '../../../selectors/multichain';
@@ -132,6 +133,8 @@ const CoinButtons = ({
   const nativeToken = isEvmNetwork ? 'ETH' : multichainNativeToken;
 
   const isExternalServicesEnabled = useSelector(getUseExternalServices);
+
+  const isTestnet = useSelector(getMultichainIsTestnet);
 
   const isNonEvmAccountWithoutExternalServices =
     !isExternalServicesEnabled && isNonEvmAccount(account);
@@ -420,7 +423,7 @@ const CoinButtons = ({
         round={!displayNewIconButtons}
       />
       {/* the bridge button is redundant if unified ui is enabled */}
-      {isUnifiedUIEnabled ? null : (
+      {isUnifiedUIEnabled || isTestnet ? null : (
         <IconButton
           className={`${classPrefix}-overview__button`}
           disabled={

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -22,7 +22,6 @@ import {
   getNetworkConfigurationIdByChainId,
   isNonEvmAccount,
   getSwapsDefaultToken,
-  getIsCustomNetwork,
 } from '../../../selectors';
 import Tooltip from '../../ui/tooltip';
 import { setSwapsFromToken } from '../../../ducks/swaps/swaps';
@@ -136,7 +135,6 @@ const CoinButtons = ({
   const isExternalServicesEnabled = useSelector(getUseExternalServices);
 
   const isTestnet = useSelector(getMultichainIsTestnet);
-  const isCustomNetwork = useSelector(getIsCustomNetwork);
 
   const isNonEvmAccountWithoutExternalServices =
     !isExternalServicesEnabled && isNonEvmAccount(account);
@@ -424,8 +422,8 @@ const CoinButtons = ({
         }
         round={!displayNewIconButtons}
       />
-      {/* the bridge button is redundant if unified ui is enabled */}
-      {isUnifiedUIEnabled || isTestnet || isCustomNetwork ? null : (
+      {/* the bridge button is redundant if unified ui is enabled, testnet or non-bridge chain (unsupported) */}
+      {isUnifiedUIEnabled || isTestnet || !isBridgeChain ? null : (
         <IconButton
           className={`${classPrefix}-overview__button`}
           disabled={

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -22,6 +22,7 @@ import {
   getNetworkConfigurationIdByChainId,
   isNonEvmAccount,
   getSwapsDefaultToken,
+  getIsCustomNetwork,
 } from '../../../selectors';
 import Tooltip from '../../ui/tooltip';
 import { setSwapsFromToken } from '../../../ducks/swaps/swaps';
@@ -135,6 +136,7 @@ const CoinButtons = ({
   const isExternalServicesEnabled = useSelector(getUseExternalServices);
 
   const isTestnet = useSelector(getMultichainIsTestnet);
+  const isCustomNetwork = useSelector(getIsCustomNetwork);
 
   const isNonEvmAccountWithoutExternalServices =
     !isExternalServicesEnabled && isNonEvmAccount(account);
@@ -423,7 +425,7 @@ const CoinButtons = ({
         round={!displayNewIconButtons}
       />
       {/* the bridge button is redundant if unified ui is enabled */}
-      {isUnifiedUIEnabled || isTestnet ? null : (
+      {isUnifiedUIEnabled || isTestnet || isCustomNetwork ? null : (
         <IconButton
           className={`${classPrefix}-overview__button`}
           disabled={

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -280,7 +280,7 @@ describe('EthOverview', () => {
       );
     });
 
-    it('should have the Bridge button disabled if chain id is not part of supported chains', () => {
+    it('should not render the Bridge button on testnet chains', () => {
       const mockedFantomStore = {
         ...mockStore,
         metamask: {
@@ -295,12 +295,7 @@ describe('EthOverview', () => {
         mockedStore,
       );
       const bridgeButton = queryByTestId(ETH_OVERVIEW_BRIDGE);
-      expect(bridgeButton).toBeInTheDocument();
-      expect(bridgeButton).toBeDisabled();
-      expect(bridgeButton.parentElement).toHaveAttribute(
-        'data-original-title',
-        'Unavailable on this network',
-      );
+      expect(bridgeButton).not.toBeInTheDocument();
     });
 
     it('should always show the Receive button', () => {

--- a/ui/components/app/wallet-overview/non-evm-overview.test.tsx
+++ b/ui/components/app/wallet-overview/non-evm-overview.test.tsx
@@ -463,7 +463,6 @@ describe('NonEvmOverview', () => {
     const bridgeButton = queryByTestId(BTC_OVERVIEW_BRIDGE);
     expect(sendButton).toBeInTheDocument();
     expect(sendButton).toBeDisabled();
-    expect(bridgeButton).toBeInTheDocument();
-    expect(bridgeButton).toBeDisabled();
+    expect(bridgeButton).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -306,7 +306,7 @@ describe('AssetPage', () => {
     expect(bridgeButton).not.toBeDisabled();
   });
 
-  it('should disable Bridge button if chain id is not supported', async () => {
+  it('should not render Bridge button on testnet chains', async () => {
     const { queryByTestId } = renderWithProvider(
       <AssetPage asset={token} optionsButton={null} />,
       configureMockStore([thunk])({
@@ -317,8 +317,9 @@ describe('AssetPage', () => {
         },
       }),
     );
+    // bridge button is hidden on unified and testnet chains.
     const bridgeButton = queryByTestId('token-overview-bridge');
-    expect(bridgeButton).toBeDisabled();
+    expect(bridgeButton).toBeNull();
   });
 
   it('should render the network name', async () => {

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -48,7 +48,10 @@ import {
 } from '../../../components/component-library';
 import { getIsNativeTokenBuyable } from '../../../ducks/ramps';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
-import { getMultichainIsEvm } from '../../../selectors/multichain';
+import {
+  getMultichainIsEvm,
+  getMultichainIsTestnet,
+} from '../../../selectors/multichain';
 
 ///: BEGIN:ONLY_INCLUDE_IF(multichain)
 import { useHandleSendNonEvm } from '../../../components/app/wallet-overview/hooks/useHandleSendNonEvm';
@@ -213,6 +216,8 @@ const TokenButtons = ({
     ///: END:ONLY_INCLUDE_IF
   ]);
 
+  const isTestnet = useSelector(getMultichainIsTestnet);
+
   const handleBridgeOnClick = useCallback(
     async (isSwap: boolean) => {
       await setCorrectChain();
@@ -339,7 +344,7 @@ const TokenButtons = ({
         disabled={!isSwapsChain}
       />
 
-      {!isUnifiedUIEnabled && (
+      {!isUnifiedUIEnabled && !isTestnet && (
         <IconButton
           className="token-overview__button"
           data-testid="token-overview-bridge"

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -22,6 +22,7 @@ import {
   getNetworkConfigurationIdByChainId,
   getSelectedInternalAccount,
   getSelectedMultichainNetworkConfiguration,
+  getIsCustomNetwork,
 } from '../../../selectors';
 import useBridging from '../../../hooks/bridge/useBridging';
 
@@ -217,6 +218,7 @@ const TokenButtons = ({
   ]);
 
   const isTestnet = useSelector(getMultichainIsTestnet);
+  const isCustomNetwork = useSelector(getIsCustomNetwork);
 
   const handleBridgeOnClick = useCallback(
     async (isSwap: boolean) => {
@@ -344,7 +346,7 @@ const TokenButtons = ({
         disabled={!isSwapsChain}
       />
 
-      {!isUnifiedUIEnabled && !isTestnet && (
+      {!isUnifiedUIEnabled && !isTestnet && !isCustomNetwork && (
         <IconButton
           className="token-overview__button"
           data-testid="token-overview-bridge"

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -22,7 +22,6 @@ import {
   getNetworkConfigurationIdByChainId,
   getSelectedInternalAccount,
   getSelectedMultichainNetworkConfiguration,
-  getIsCustomNetwork,
 } from '../../../selectors';
 import useBridging from '../../../hooks/bridge/useBridging';
 
@@ -218,7 +217,6 @@ const TokenButtons = ({
   ]);
 
   const isTestnet = useSelector(getMultichainIsTestnet);
-  const isCustomNetwork = useSelector(getIsCustomNetwork);
 
   const handleBridgeOnClick = useCallback(
     async (isSwap: boolean) => {
@@ -346,7 +344,7 @@ const TokenButtons = ({
         disabled={!isSwapsChain}
       />
 
-      {!isUnifiedUIEnabled && !isTestnet && !isCustomNetwork && (
+      {!isUnifiedUIEnabled && !isTestnet && isBridgeChain && (
         <IconButton
           className="token-overview__button"
           data-testid="token-overview-bridge"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR hides the bridge button in testnet and custom network circumstances, to keep the look consistent, since the bridge button is no longer needed as the experience is unified between swaps and bridges.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34700?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Navigate to a testnet or custom network.
2. The bridge button should be hidden (only swaps should display)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
