### PR TITLE
ci: cache the anvil binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,13 @@ jobs:
           skip-allow-scripts: true
           yarn-custom-url: ${{ vars.YARN_URL }}
 
+      # Need to cache `.metamask` folder for the anvil binary
+      - name: Cache .metamask folder
+        uses: actions/cache/save@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('yarn.lock') }}
+
   lint-workflows:
     name: Lint workflows
     uses: metamask/github-tools/.github/workflows/lint-workflows.yml@1299bb1de0c6974ae6d0a32c7e8897fe168239ac
@@ -186,6 +193,7 @@ jobs:
   run-benchmarks:
     uses: ./.github/workflows/run-benchmarks.yml
     needs:
+      - prep-deps
       - build-test-browserify
       - build-test-webpack
 

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .metamask
-          key: .metamask-fail-${{ hashFiles('yarn.lock') }}
+          key: .metamask-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: false
 
       - name: Install anvil if cache missed

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -31,8 +31,16 @@ jobs:
           skip-allow-scripts: true
           yarn-custom-url: ${{ vars.YARN_URL }}
 
-      # not installed by checkout-and-setup when cache is restored
-      - name: Install anvil
+      - name: Restore .metamask folder
+        id: restore-metamask
+        uses: actions/cache/restore@v4
+        with:
+          path: .metamask
+          key: .metamask-fail-${{ hashFiles('yarn.lock') }}
+          fail-on-cache-miss: false
+
+      - name: Install anvil if cache missed
+        if: ${{ steps.restore-metamask.outputs.cache-hit != 'true'}}
         run: yarn mm-foundryup
 
       - name: Download artifact '${{ env.ARTIFACT_NAME }}'

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -68,8 +68,16 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
-      # not installed by checkout-and-setup when cache is restored
-      - name: Install anvil
+      - name: Restore .metamask folder
+        id: restore-metamask
+        uses: actions/cache/restore@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('yarn.lock') }}
+          fail-on-cache-miss: false
+
+      - name: Install anvil if cache missed
+        if: ${{ steps.restore-metamask.outputs.cache-hit != 'true'}}
         run: yarn mm-foundryup
 
       - name: Download build artifact

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "webpack": "tsx ./development/webpack/launch.ts",
     "webpack:clearcache": "./development/clear-webpack-cache.js",
-    "foundryup": "npx mm-foundryup",
+    "foundryup": "yarn mm-foundryup",
     "postinstall": "yarn webpack:clearcache && yarn foundryup",
     "env:e2e": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' yarn",
     "start": "yarn build:dev dev --apply-lavamoat=false --snow=false",
@@ -465,7 +465,7 @@
     "@metamask/eslint-plugin-design-tokens": "^1.1.0",
     "@metamask/eth-json-rpc-provider": "^4.1.6",
     "@metamask/forwarder": "^1.1.0",
-    "@metamask/foundryup": "^1.0.0",
+    "@metamask/foundryup": "^1.0.1",
     "@metamask/phishing-warning": "^5.0.0",
     "@metamask/preferences-controller": "^17.0.0",
     "@metamask/superstruct": "^3.2.1",

--- a/test/e2e/seeder/anvil.ts
+++ b/test/e2e/seeder/anvil.ts
@@ -1,6 +1,10 @@
-import { delimiter, join } from 'path';
 import { execSync } from 'child_process';
-import { createAnvil, Anvil as AnvilType } from '@viem/anvil';
+import { delimiter, join } from 'path';
+import {
+  Anvil as AnvilType,
+  createAnvil,
+  CreateAnvilOptions,
+} from '@viem/anvil';
 import { createAnvilClients } from './anvil-clients';
 
 type Hardfork =
@@ -54,7 +58,7 @@ export class Anvil {
       noMining?: boolean;
     } = {},
   ): Promise<void> {
-    const options = { ...defaultOptions, ...opts };
+    const options: CreateAnvilOptions = { ...defaultOptions, ...opts };
 
     // Set blockTime if noMining is disabled, as those 2 options are incompatible
     if (!opts?.noMining && !opts?.blockTime) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6287,9 +6287,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/foundryup@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/foundryup@npm:1.0.0"
+"@metamask/foundryup@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@metamask/foundryup@npm:1.0.1"
   dependencies:
     minipass: "npm:^7.1.2"
     tar: "npm:^7.4.3"
@@ -6298,7 +6298,7 @@ __metadata:
     yargs-parser: "npm:^21.1.1"
   bin:
     mm-foundryup: ./dist/cli.mjs
-  checksum: 10/20296930936a87525331ae9244a144cbd272a61cb658a367194ad7101379633daeb4a5294a6843b013aa14198d7b8bf99ee754ec2c4729880097b486e3754587
+  checksum: 10/57305fd670e078164ef5d437df6f8fe76955430a4a18f591b3f1e3efbed63bccdadafeac2ce186cf1ccfcd25fb3601fdae3e7b8d41947c01aecc459bc835af87
   languageName: node
   linkType: hard
 
@@ -32184,7 +32184,7 @@ __metadata:
     "@metamask/eth-trezor-keyring": "npm:^9.0.0"
     "@metamask/etherscan-link": "npm:^3.0.0"
     "@metamask/forwarder": "npm:^1.1.0"
-    "@metamask/foundryup": "npm:^1.0.0"
+    "@metamask/foundryup": "npm:^1.0.1"
     "@metamask/gas-fee-controller": "npm:^23.0.0"
     "@metamask/institutional-wallet-snap": "npm:1.3.1"
     "@metamask/jazzicon": "npm:^2.0.0"


### PR DESCRIPTION
## **Description**

- Update `@metamask/foundryup` to `1.0.1` to fix a symlinks problem with containers on CI
- Cache the `.metamask` folder to cache the anvil binary

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MetaMask/metamask-planning#5448

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->