### PR TITLE
test: Optimize test server shutdown

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -9,6 +9,7 @@ module.exports = {
   globals: {
     document: 'readonly',
     window: 'readonly',
+    AggregateError: 'readonly',
   },
 
   rules: {

--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -9,6 +9,9 @@ module.exports = {
   globals: {
     document: 'readonly',
     window: 'readonly',
+    // Our ESLint config is stuck at ES2017 because Browserify doesn't support the spread operator.
+    // We can remove this global after we've migrated away from Browserify and updated our ESLint
+    // config to at least ES2021.
     AggregateError: 'readonly',
   },
 

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -447,8 +447,6 @@ async function withFixtures(options, testSuite) {
           'Failed to shut down test servers',
         );
       }
-
-      await new Promise((resolve) => setTimeout(resolve, 2000));
     }
   }
 }

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -445,6 +445,8 @@ async function withFixtures(options, testSuite) {
           'Failed to shut down test servers',
         );
       }
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
     }
   }
 }

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -440,9 +440,10 @@ async function withFixtures(options, testSuite) {
         // A test error may get overridden here by the shutdown error, but this is OK because a
         // shutdown error indicates a bug in our test tooling that might invalidate later tests.
         // eslint-disable-next-line no-unsafe-finally
-        throw new Error('Failed to shut down test servers', {
-          cause: failures[0].reason,
-        });
+        throw new AggregateError(
+          failures.map((failure) => failure.reason),
+          'Failed to shut down test servers',
+        );
       }
     }
   }

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -418,7 +418,7 @@ async function withFixtures(options, testSuite) {
         }
       }
       if (phishingPageServer.isRunning()) {
-        shutdownTasks.push(await phishingPageServer.quit());
+        shutdownTasks.push(phishingPageServer.quit());
       }
 
       shutdownTasks.push(


### PR DESCRIPTION
## **Description**

The `withFixtures` helper function has been updated to shut down test servers in parallel rather than one-at-a-time. Any shutdown errors are logged, then the first error is re-thrown.

Potentially this could obscure the underlying test error (if there was one), but this seems like an acceptable tradeoff for ensuring bugs in the shutdown code are discovered and prioritized.

This change has two main benefits:
* It ensures we attempt to shut down _all_ servers, even when one shutdown attempt fails
* It speeds up the shutdown process

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34707?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
