### PR TITLE
test: Speed up test server shutdown by closing connections

### DIFF
--- a/development/lib/create-segment-server.js
+++ b/development/lib/create-segment-server.js
@@ -86,6 +86,9 @@ function createSegmentServer(onRequest, onError = defaultOnError) {
           }
           return resolve();
         });
+        // We need to close all connections to stop the server quickly
+        // Otherwise it takes a few seconds for it to close
+        server.closeAllConnections();
       });
     },
   };

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -412,6 +412,9 @@ async function withFixtures(options, testSuite) {
                   }
                   return resolve();
                 });
+                // We need to close all connections to stop the server quickly
+                // Otherwise it takes a few seconds for it to close
+                dappServer[i].closeAllConnections();
               }),
             );
           }

--- a/test/e2e/phishing-warning-page-server.js
+++ b/test/e2e/phishing-warning-page-server.js
@@ -43,15 +43,18 @@ class PhishingWarningPageServer {
   }
 
   async quit() {
-    await new Promise((resolve, reject) =>
+    await new Promise((resolve, reject) => {
       this._server.close((error) => {
         if (error) {
           reject(error);
         } else {
           resolve();
         }
-      }),
-    );
+      });
+      // We need to close all connections to stop the server quickly
+      // Otherwise it takes a few seconds for it to close
+      this._server.closeAllConnections();
+    });
   }
 }
 

--- a/test/e2e/tests/synchronous-injection/synchronous-injection.spec.ts
+++ b/test/e2e/tests/synchronous-injection/synchronous-injection.spec.ts
@@ -44,6 +44,9 @@ describe('The provider', function () {
         }
         return resolve();
       });
+      // We need to close all connections to stop the server quickly
+      // Otherwise it takes a few seconds for it to close
+      dappServer.closeAllConnections();
     });
   });
 });


### PR DESCRIPTION
Some of the servers used for our E2E tests extend from the Node.js http server, which has a `close` method. This method waits patiently for existing connections to close, rather than terminating them. In one instance we were calling `closeAllConnections` to terminate the server more quickly, but this was not done in most cases.

The `closeAllConenctions` call has been added to all examples I could find of us closing a Node.js http server. This should make them shut down faster, which is what we want in all of these cases.

Note that this doesn't guarantee that HTTP/2 and WebSocket connections are shut down. Confusingly, "all connections" in `closeAllConnections` means "all HTTP connections", and there is no equivalent method for truly closing all connections. We could expand this to track all connections externally and shut them all down to make this more comprehensive, but this seemed inconvenient and probably doesn't impact these cases.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34747?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
