### PR TITLE
test: Fix test failure when WebDriver is inactive before shutdown

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -534,8 +534,9 @@ class Driver {
         error.message.startsWith('ECONNREFUSED')
       ) {
         console.info('Driver already shut down');
+      } else {
+        throw error;
       }
-      throw error;
     }
   }
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -529,14 +529,10 @@ class Driver {
     try {
       await this.driver.quit();
     } catch (error) {
-      if (
-        typeof error?.message === 'string' &&
-        error.message.startsWith('ECONNREFUSED')
-      ) {
-        console.info('Driver already shut down');
-      } else {
-        throw error;
-      }
+      console.warn(
+        'Failed to quit driver; continuing under assumption that it was already closed. Error:\n',
+        error,
+      );
     }
   }
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -526,7 +526,17 @@ class Driver {
       }
     }
 
-    await this.driver.quit();
+    try {
+      await this.driver.quit();
+    } catch (error) {
+      if (
+        typeof error?.message === 'string' &&
+        error.message.startsWith('ECONNREFUSED')
+      ) {
+        console.info('Driver already shut down');
+      }
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
## **Description**

When an E2E test causes the extension to reset, it can sometimes cause the webdriver to shut down automatically when it loses its connection to the browser. When this happens, the `driver.quit` call throws during the shutdown process. This causes the test to fail, and it leaves later test servers running which causes later tests to fail as well.

The `driver.quit` method has been updated to no longer throw an error when the driver is already shut down.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34748?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Relates to #34739 (in some cases it can prevent the error, in others it just stops it from cascading)

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
