### PR TITLE
feat: better manage automatic labeling of Sentry issues

### DIFF
--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -28,7 +28,6 @@ const knownBots = [
   'metamaskbot',
   'dependabot',
   'github-actions',
-  'sentry-io',
   'devin-ai-integration',
   'runway-github',
 ];
@@ -120,6 +119,20 @@ async function main(): Promise<void> {
         labelable,
         invalidIssueTemplateLabel,
       );
+      process.exit(0); // Stop the process and exit with a success status code
+    }
+
+    if (labelable.author === 'sentry-io') {
+      console.log(
+        `Issue ${labelable?.number} was created through Sentry. Issue's description doesn't need to match issue template in that case. Skip template checks.`,
+      );
+      await removeLabelFromLabelableIfPresent(
+        octokit,
+        labelable,
+        invalidIssueTemplateLabel,
+      );
+      // Add needs triage label to the bug report issue
+      await addNeedsTriageLabelToIssue(octokit, labelable);
       process.exit(0); // Stop the process and exit with a success status code
     }
 

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -155,10 +155,10 @@ async function main(): Promise<void> {
       );
 
       // Add regression label to the bug report issue
-      addRegressionLabelToIssue(octokit, labelable);
+      await addRegressionLabelToIssue(octokit, labelable);
 
       // Add needs triage label to the bug report issue
-      addNeedsTriageLabelToIssue(octokit, labelable);
+      await addNeedsTriageLabelToIssue(octokit, labelable);
     } else {
       const errorMessage =
         "Issue body does not match any of expected templates ('general-issue.yml' or 'bug-report.yml').\n\nMake sure issue's body includes all section titles.\n\nSections titles are listed here: https://github.com/MetaMask/metamask-extension/blob/main/.github/scripts/shared/template.ts#L14-L37";

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -132,8 +132,10 @@ async function main(): Promise<void> {
         labelable,
         invalidIssueTemplateLabel,
       );
-      // Add needs triage label to the bug report issue
-      await addNeedsTriageLabelToIssue(octokit, labelable);
+      // Add needs triage label ONLY if issue is created (not updated)
+      if (context.payload.action === 'opened') {
+        await addNeedsTriageLabelToIssue(octokit, labelable);
+      }
       // Add area-Sentry label to the bug report issue
       await addAreaSentryLabelToIssue(octokit, labelable);
       process.exit(0); // Stop the process and exit with a success status code
@@ -157,8 +159,10 @@ async function main(): Promise<void> {
       // Add regression label to the bug report issue
       await addRegressionLabelToIssue(octokit, labelable);
 
-      // Add needs triage label to the bug report issue
-      await addNeedsTriageLabelToIssue(octokit, labelable);
+      // Add needs triage label ONLY if issue is created (not updated)
+      if (context.payload.action === 'opened') {
+        await addNeedsTriageLabelToIssue(octokit, labelable);
+      }
     } else {
       const errorMessage =
         "Issue body does not match any of expected templates ('general-issue.yml' or 'bug-report.yml').\n\nMake sure issue's body includes all section titles.\n\nSections titles are listed here: https://github.com/MetaMask/metamask-extension/blob/main/.github/scripts/shared/template.ts#L14-L37";

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -29,6 +29,7 @@ const knownBots = [
   'metamaskbot',
   'dependabot',
   'github-actions',
+  'sentry-io',
   'devin-ai-integration',
   'runway-github',
 ];
@@ -98,8 +99,9 @@ async function main(): Promise<void> {
     labelable.body,
   );
 
-  // If labelable's author is a bot we skip the template checks as bots don't use templates
-  if (knownBots.includes(labelable.author)) {
+  // If labelable's author is a bot we skip the rest of the script, including the template checks as bots don't use templates.
+  // Exception: For issues created the 'sentry-io' bot, we don't skip the rest of the script because there's a specific handling for those issues.
+  if (knownBots.includes(labelable.author) && labelable.author !== 'sentry-io') {
     console.log(
       `${
         labelable.type === LabelableType.PullRequest ? 'PR' : 'Issue'

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -17,6 +17,7 @@ import {
   craftRegressionLabel,
   externalContributorLabel,
   needsTriageLabel,
+  areaSentryLabel,
   flakyTestsLabel,
   invalidIssueTemplateLabel,
   invalidPullRequestTemplateLabel,
@@ -133,6 +134,8 @@ async function main(): Promise<void> {
       );
       // Add needs triage label to the bug report issue
       await addNeedsTriageLabelToIssue(octokit, labelable);
+      // Add area-Sentry label to the bug report issue
+      await addAreaSentryLabelToIssue(octokit, labelable);
       process.exit(0); // Stop the process and exit with a success status code
     }
 
@@ -283,6 +286,13 @@ async function addNeedsTriageLabelToIssue(
   issue: Labelable,
 ): Promise<void> {
   await addLabelToLabelable(octokit, issue, needsTriageLabel);
+}
+// This function adds the "area-Sentry" label to the issue if it doesn't have it
+async function addAreaSentryLabelToIssue(
+  octokit: InstanceType<typeof GitHub>,
+  issue: Labelable,
+): Promise<void> {
+  await addLabelToLabelable(octokit, issue, areaSentryLabel);
 }
 // This function adds the correct regression label to the issue, and removes other ones
 async function addRegressionLabelToIssue(

--- a/.github/scripts/shared/label.ts
+++ b/.github/scripts/shared/label.ts
@@ -33,6 +33,12 @@ export const needsTriageLabel: Label = {
   description: 'Issue needs to be triaged',
 };
 
+export const areaSentryLabel: Label = {
+  name: 'area-sentry',
+  color: '5319E7',
+  description: 'Issue from Sentry',
+};
+
 export const flakyTestsLabel: Label = {
   name: 'flaky tests',
   color: 'BE564E',

--- a/.github/scripts/shared/label.ts
+++ b/.github/scripts/shared/label.ts
@@ -29,7 +29,7 @@ export const externalContributorLabel: Label = {
 
 export const needsTriageLabel: Label = {
   name: 'needs-triage',
-  color: '#68AEE6',
+  color: '68AEE6',
   description: 'Issue needs to be triaged',
 };
 
@@ -113,14 +113,14 @@ export function craftTeamLabel(teamName: string): Label {
     case 'extension-platform':
       return {
         name: `team-${teamName}`,
-        color: '#BFD4F2', // light blue
+        color: 'BFD4F2', // light blue
         description: `Extension Platform team`,
       };
 
     case 'mobile-platform':
       return {
         name: `team-${teamName}`,
-        color: '#76E9D0', // light green
+        color: '76E9D0', // light green
         description: `Mobile Platform team`,
       };
 


### PR DESCRIPTION
## **Description**

We have an Github Action in place to automate the labeling of Github issues, however, it didn't support support issues created through Sentry so far (because they don't respect the same issue template - [example Sentry issue](https://github.com/MetaMask/metamask-extension/issues/34692)).

The initial purpose of this PR was to better manage Sentry issues, by automatically adding "needs-triage" and "area-Sentry" labels upon creation.

In addition, I noticed some small issues that I fixed as part of this same PR:
- Invalid color codes
- Missing awaits
- "needs-triage" label was added upon issue creation and update, while we only need it upon issue creation

These changes were discussed in [metamask-delivery](https://consensys.slack.com/archives/C06GX49NHTP/p1753977768183399?thread_ts=1752558653.156389&cid=C06GX49NHTP) Slack channel.
Once this PR is merged, the same changes will be applied to metamask-mobile repo.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34768?quickstart=1)

## **Changelog**

CHANGELOG entry: nul
CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5476

## **Manual testing steps**

I tested everything on this on this [test repo](https://github.com/gauthierpetetin-test/repo_test) and all works fine. However, it can not be tested by another Github account than mine.

## **Screenshots/Recordings**

None

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
