### PR TITLE
build(webpack): silence swc sourcemap messages on Windows

### DIFF
--- a/development/webpack/utils/loaders/swcLoader.ts
+++ b/development/webpack/utils/loaders/swcLoader.ts
@@ -1,3 +1,4 @@
+import { sep } from 'node:path';
 import type { LoaderContext } from 'webpack';
 import { type JSONSchema7 } from 'schema-utils/declarations/validate';
 import { validate } from 'schema-utils';
@@ -188,7 +189,7 @@ export default function swcLoader(this: Context, src: string, srcMap?: string) {
       // for debugging.
       // [0]: https://github.com/trezor/trezor-suite/issues/20298
       // [1]: https://github.com/swc-project/swc/issues/9416
-      this.resourcePath.includes('/node_modules/') ? false : srcMap,
+      this.resourcePath.includes(`${sep}node_modules${sep}`) ? false : srcMap,
     sourceFileName: this.resourcePath,
     sourceMaps: this.sourceMap,
     swcrc: false,


### PR DESCRIPTION
## **Description**

Silences meaningless errors during the webpack build like
`ERROR  failed to read input source map: failed to find input source map file "getWeakRandomId.js.map" `

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->