### PR TITLE
build(webpack): fix webpack build paths on windows

### DIFF
--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -22,20 +22,23 @@ export const __HMR_READY__ = Boolean(process.env.__HMR_READY__) || false;
 export const Browsers = ['brave', 'chrome', 'firefox'] as const;
 export type Browser = (typeof Browsers)[number];
 
-const slash = `(?:\\${sep})?`;
+const slash = `\\${sep}`;
 /**
  * Regular expression to match files in any `node_modules` directory
  * Uses a platform-specific path separator: `/` on Unix-like systems and `\` on
  * Windows.
  */
-export const NODE_MODULES_RE = new RegExp(`${slash}node_modules${slash}`, 'u');
+export const NODE_MODULES_RE = new RegExp(
+  `^.*${slash}node_modules${slash}.*$`,
+  'u',
+);
 
 /**
  * Regular expression to match files in the `@lavamoat/snow` node_modules
  * directory.
  */
 export const SNOW_MODULE_RE = new RegExp(
-  `${slash}node_modules${slash}@lavamoat${slash}snow${slash}`,
+  `^.*${slash}node_modules${slash}@lavamoat${slash}snow${slash}.*$`,
   'u',
 );
 
@@ -45,7 +48,7 @@ export const SNOW_MODULE_RE = new RegExp(
  * processed with the CJS loader.
  */
 export const TREZOR_MODULE_RE = new RegExp(
-  `${slash}node_modules${slash}@trezor${slash}`,
+  `^.*${slash}node_modules${slash}@trezor${slash}.*$`,
   'u',
 );
 

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -34,7 +34,20 @@ export const NODE_MODULES_RE = new RegExp(`${slash}node_modules${slash}`, 'u');
  * Regular expression to match files in the `@lavamoat/snow` node_modules
  * directory.
  */
-export const SNOW_MODULE_RE = /^.*\/node_modules\/@lavamoat\/snow\/.*$/u;
+export const SNOW_MODULE_RE = new RegExp(
+  `${slash}node_modules${slash}@lavamoat${slash}snow${slash}`,
+  'u',
+);
+
+/**
+ * Regular expression to match files in the `@trezor` node_modules directory.
+ * This is used to match Trezor libraries that are CJS modules and need to be
+ * processed with the CJS loader.
+ */
+export const TREZOR_MODULE_RE = new RegExp(
+  `${slash}node_modules${slash}@trezor${slash}`,
+  'u',
+);
 
 /**
  * No Operation. A function that does nothing and returns nothing.

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -3,7 +3,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { join, sep } from 'node:path';
+import { join } from 'node:path';
 import { argv, exit } from 'node:process';
 import {
   ProvidePlugin,
@@ -28,6 +28,7 @@ import {
   NODE_MODULES_RE,
   __HMR_READY__,
   SNOW_MODULE_RE,
+  TREZOR_MODULE_RE,
 } from './utils/helpers';
 import { transformManifest } from './utils/plugins/ManifestPlugin/helpers';
 import { parseArgv, getDryRunMessage } from './utils/cli';
@@ -298,10 +299,9 @@ const config = {
               // security team requires that we never process `@lavamoat/snow/**.*`
               SNOW_MODULE_RE,
 
-              // trezor libraries are .js files with CJS exports, they must be
-              // processed with the CJS loader
-              (value: string) =>
-                value.includes(`${sep}node_modules${sep}@trezor${sep}`),
+              // these trezor libraries are .js files with CJS exports, they
+              // must be processed with the CJS loader
+              TREZOR_MODULE_RE,
             ],
             use: npmLoader,
           },

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -3,7 +3,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { argv, exit } from 'node:process';
 import {
   ProvidePlugin,
@@ -298,14 +298,10 @@ const config = {
               // security team requires that we never process `@lavamoat/snow/**.*`
               SNOW_MODULE_RE,
 
-              // these trezor libraries are .js files with CJS exports, they
-              // must be processed with the CJS loader
-              /^.*\/node_modules\/@trezor\/connect\/.*$/u,
-              /^.*\/node_modules\/@trezor\/connect-web\/.*$/u,
-              /^.*\/node_modules\/@trezor\/connect-common\/.*$/u,
-              /^.*\/node_modules\/@trezor\/utils\/.*$/u,
-              /^.*\/node_modules\/@trezor\/websocket-client\/.*$/u,
-              /^.*\/node_modules\/@trezor\/schema-utils\/.*$/u,
+              // trezor libraries are .js files with CJS exports, they must be
+              // processed with the CJS loader
+              (value: string) =>
+                value.includes(`${sep}node_modules${sep}@trezor${sep}`),
             ],
             use: npmLoader,
           },


### PR DESCRIPTION
## **Description**

#33834 broke the webpack build on Windows, this fixes it by using OS-independent path separators

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->