### PR TITLE
fix: Hide resimulate alert if transaction is wallet initiated

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useResimulationAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useResimulationAlert.test.ts
@@ -5,6 +5,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 
+import { ORIGIN_METAMASK } from '../../../../../../shared/constants/app';
 import { getMockConfirmState } from '../../../../../../test/data/confirmations/helper';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -96,6 +97,16 @@ describe('useResimulationAlert', () => {
       runHook({
         currentConfirmation: notResimulatedConfirmation,
       }),
+    ).toEqual([]);
+  });
+
+  it('returns no alerts if transaction is wallet initiated', () => {
+    const walletInitiatedConfirmation = {
+      ...TRANSACTION_META_MOCK,
+      origin: ORIGIN_METAMASK,
+    };
+    expect(
+      runHook({ currentConfirmation: walletInitiatedConfirmation }),
     ).toEqual([]);
   });
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useResimulationAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useResimulationAlert.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 
+import { ORIGIN_METAMASK } from '../../../../../../shared/constants/app';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -11,11 +12,14 @@ export function useResimulationAlert(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext();
 
-  const isUpdatedAfterSecurityCheck = (currentConfirmation as TransactionMeta)
-    ?.simulationData?.isUpdatedAfterSecurityCheck;
+  const transactionMeta = currentConfirmation as TransactionMeta;
+
+  const isUpdatedAfterSecurityCheck =
+    transactionMeta?.simulationData?.isUpdatedAfterSecurityCheck;
+  const isWalletInitiated = transactionMeta?.origin === ORIGIN_METAMASK;
 
   return useMemo(() => {
-    if (!isUpdatedAfterSecurityCheck) {
+    if (!isUpdatedAfterSecurityCheck || isWalletInitiated) {
       return [];
     }
 
@@ -30,5 +34,5 @@ export function useResimulationAlert(): Alert[] {
         severity: Severity.Danger,
       },
     ];
-  }, [isUpdatedAfterSecurityCheck, t]);
+  }, [isUpdatedAfterSecurityCheck, isWalletInitiated, t]);
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34782?quickstart=1)

This PR fix hiding "Estimate changes changed" alert from wallet initiated transactions.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34737

## **Manual testing steps**

1. Try using send flow as it's seen in the issue
2. "Estimate changes changed" alert shouldn't appear in the confirmation as transaction wallet initiated.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
