### PR TITLE
test: remove unnecessary balance-check race in test

### DIFF
--- a/test/e2e/tests/privacy/onboarding-infura-call-privacy.spec.ts
+++ b/test/e2e/tests/privacy/onboarding-infura-call-privacy.spec.ts
@@ -116,7 +116,6 @@ describe('MetaMask onboarding', function () {
         await onboardingCompletePage.completeOnboarding();
         const homePage = new HomePage(driver);
         await homePage.check_pageIsLoaded();
-        await homePage.check_expectedBalanceIsDisplayed('0');
 
         // network requests happen here
         for (const mockedEndpoint of mockedEndpoints) {
@@ -166,7 +165,6 @@ describe('MetaMask onboarding', function () {
         await onboardingCompletePage.completeOnboarding();
         const homePage = new HomePage(driver);
         await homePage.check_pageIsLoaded();
-        await homePage.check_expectedBalanceIsDisplayed('0');
 
         // requests happen here
         for (const mockedEndpoint of mockedEndpoints) {


### PR DESCRIPTION
Fixes flaky test by removing an unnecessary balance-check that was racing against API calls in the background, causing the test to sometimes fail.

<!--

## **Description**


Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34793?quickstart=1)

## **Changelog**



CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->