### PR TITLE
fix: wrap long text in `OriginPill` component

### DIFF
--- a/ui/components/ui/origin-pill/index.scss
+++ b/ui/components/ui/origin-pill/index.scss
@@ -1,0 +1,3 @@
+.origin-pill-text {
+  word-break: break-all;
+}

--- a/ui/components/ui/origin-pill/origin-pill.tsx
+++ b/ui/components/ui/origin-pill/origin-pill.tsx
@@ -17,6 +17,7 @@ type OriginPillProps = {
   origin: string;
   dataTestId: string;
   style?: React.CSSProperties;
+  textStyle?: React.CSSProperties;
 };
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -25,6 +26,7 @@ export default function OriginPill({
   origin,
   dataTestId,
   style,
+  textStyle,
 }: OriginPillProps) {
   const subjectMetadata = useSelector(getSubjectMetadata);
 
@@ -57,6 +59,8 @@ export default function OriginPill({
         color={TextColor.textAlternative}
         marginLeft={1}
         data-testid={`${dataTestId}-text`}
+        style={textStyle}
+        className="origin-pill-text"
       >
         {origin}
       </Text>

--- a/ui/components/ui/ui-components.scss
+++ b/ui/components/ui/ui-components.scss
@@ -58,3 +58,4 @@
 @import 'nft-collection-image/index';
 @import 'form-combo-field/index';
 @import 'delineator/index';
+@import 'origin-pill/index';

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
@@ -33,7 +33,7 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
           />
         </div>
         <h6
-          class="mm-box mm-text mm-text--body-sm mm-box--margin-left-1 mm-box--color-text-alternative"
+          class="mm-box mm-text origin-pill-text mm-text--body-sm mm-box--margin-left-1 mm-box--color-text-alternative"
           data-testid="signature-origin-pill-text"
         >
           https://test-dapp.metamask.io

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
@@ -33,7 +33,7 @@ exports[`switch-ethereum-chain confirmation should match snapshot 1`] = `
           />
         </div>
         <h6
-          class="mm-box mm-text mm-text--body-sm mm-box--margin-left-1 mm-box--color-text-alternative"
+          class="mm-box mm-text origin-pill-text mm-text--body-sm mm-box--margin-left-1 mm-box--color-text-alternative"
           data-testid="signature-origin-pill-text"
         >
           https://test-dapp.metamask.io
@@ -145,7 +145,7 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
           />
         </div>
         <h6
-          class="mm-box mm-text mm-text--body-sm mm-box--margin-left-1 mm-box--color-text-alternative"
+          class="mm-box mm-text origin-pill-text mm-text--body-sm mm-box--margin-left-1 mm-box--color-text-alternative"
           data-testid="signature-origin-pill-text"
         >
           https://test-dapp.metamask.io


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR aims to add the `word-break` property to make sure the origin won't go beyond the component boundaries omitting information from the user. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34824?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null
## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5346

## **Manual testing steps**

1. Install the MetaMask browser extension in your browser.
2. Visit [https://rx23.io/poc/metamask/1.html](https://rx23.io/poc/metamask/1.html)
3. Click the interactive buttons.
4. Observe the prompt in MetaMask asking to add a network.
5. Note how the domain is shown as `https://secure.www.cryptogiveaway.eth.2025.portfolio.metamask.io`, hiding the true origin.

## **Screenshots/Recordings**


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="475" height="102" alt="Screenshot from 2025-08-04 09-46-03" src="https://github.com/user-attachments/assets/fca6fcda-c2a1-4fe6-93ae-ad4670a3fb0f" />


<!-- [screenshots/recordings] -->

### **After**

<img width="410" height="617" alt="Screenshot from 2025-08-04 10-06-06" src="https://github.com/user-attachments/assets/bb0d1c87-4408-4e67-8e47-5fd789eb69d5" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
