### PR TITLE
test: add missing tests for `getWalletIdAndNameByAccountAddress` selector

### DIFF
--- a/ui/selectors/multichain-accounts/account-tree.test.ts
+++ b/ui/selectors/multichain-accounts/account-tree.test.ts
@@ -1,5 +1,5 @@
 import mockState from '../../../test/data/mock-state.json';
-import { getAccountTree, getWalletsWithAccounts } from './account-tree';
+import { getAccountTree, getWalletIdAndNameByAccountAddress, getWalletsWithAccounts } from './account-tree';
 import { MultichainAccountsState } from './account-tree.types';
 
 describe('Multichain Accounts Selectors', () => {
@@ -260,6 +260,29 @@ describe('Multichain Accounts Selectors', () => {
           },
         },
       });
+    });
+  });
+
+  describe('getWalletIdAndNameByAccountAddress', () => {
+    it('returns the wallet ID and name for an account', () => {
+      const result = getWalletIdAndNameByAccountAddress(
+        mockState,
+        '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+      );
+
+      expect(result).toStrictEqual({
+        id: '01JKAF3DSGM3AB87EM9N0K41AJ',
+        name: 'Wallet 1',
+      });
+    });
+
+    it('returns null if the account is not found', () => {
+      const result = getWalletIdAndNameByAccountAddress(
+        mockState,
+        '0x1234567890abcdef1234567890abcdef12345678',
+      );
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/ui/selectors/multichain-accounts/account-tree.test.ts
+++ b/ui/selectors/multichain-accounts/account-tree.test.ts
@@ -1,5 +1,9 @@
 import mockState from '../../../test/data/mock-state.json';
-import { getAccountTree, getWalletIdAndNameByAccountAddress, getWalletsWithAccounts } from './account-tree';
+import {
+  getAccountTree,
+  getWalletIdAndNameByAccountAddress,
+  getWalletsWithAccounts,
+} from './account-tree';
 import { MultichainAccountsState } from './account-tree.types';
 
 describe('Multichain Accounts Selectors', () => {


### PR DESCRIPTION
## **Description**

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? The tests for the `getWalletIdAndNameByAccountAddress` were missing.
2. What is the improvement/solution? Improved test coverage.

## **Manual testing steps**

1. Pull down this branch.
2. Run the tests and see that they pass.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
