### PR TITLE
fix: problem in `yarn start:with-state`

### DIFF
--- a/app/scripts/fixtures/generate-wallet-state.js
+++ b/app/scripts/fixtures/generate-wallet-state.js
@@ -42,7 +42,13 @@ export async function generateWalletState() {
     )
     .withPreferencesController(generatePreferencesControllerState(accounts))
     .withTokensController(generateTokensControllerState(accounts[0]))
-    .withTransactionController(generateTransactionControllerState(accounts[0]));
+    .withTransactionController(generateTransactionControllerState(accounts[0]))
+
+    // Disable backup and sync in this case
+    .withBackupAndSyncSettings({
+      isProfileSyncingEnabled: false,
+      isAccountSyncingEnabled: false,
+    });
 
   return fixtureBuilder.fixture.data;
 }

--- a/app/scripts/migrations/167.ts
+++ b/app/scripts/migrations/167.ts
@@ -49,14 +49,17 @@ function transformState(
     return state;
   }
 
-  if (hasProperty(userStorageControllerState, 'isBackupAndSyncEnabled')) {
-    // Set isBackupAndSyncEnabled to true for all users.
-    userStorageControllerState.isBackupAndSyncEnabled = true;
-  }
+  // If we are using `yarn start:with-state` do not enable syncing
+  if (!process.env.WITH_STATE) {
+    if (hasProperty(userStorageControllerState, 'isBackupAndSyncEnabled')) {
+      // Set isBackupAndSyncEnabled to true for all users.
+      userStorageControllerState.isBackupAndSyncEnabled = true;
+    }
 
-  if (hasProperty(userStorageControllerState, 'isAccountSyncingEnabled')) {
-    // Set isAccountSyncingEnabled to true for all users.
-    userStorageControllerState.isAccountSyncingEnabled = true;
+    if (hasProperty(userStorageControllerState, 'isAccountSyncingEnabled')) {
+      // Set isAccountSyncingEnabled to true for all users.
+      userStorageControllerState.isAccountSyncingEnabled = true;
+    }
   }
 
   return state;


### PR DESCRIPTION
## **Description**

The change to turn backup and sync on by default conflicted with the `yarn start:with-state` command, because it would automatically sync with the remote state of the SRP and overwrite what you just did.

This PR turns off backup and sync if you're using `yarn start:with-state`.

Future plans are to make this work with power user E2E tests.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MetaMask/MetaMask-planning#5451

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->