### PR TITLE
fix: moved pwd-change to background cp-13.1.0

### DIFF
--- a/app/scripts/controllers/onboarding.ts
+++ b/app/scripts/controllers/onboarding.ts
@@ -6,6 +6,7 @@ import {
 } from '@metamask/base-controller';
 import log from 'loglevel';
 import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
+import { getIsSeedlessOnboardingFeatureEnabled } from '../../../shared/modules/environment';
 
 // Unique name for the controller
 const controllerName = 'OnboardingController';
@@ -214,6 +215,11 @@ export default class OnboardingController extends BaseController<
    * @returns true if the user onboarding flow is Social loing flow, otherwise false.
    */
   getIsSocialLoginFlow(): boolean {
+    const isSocialLoginFeatureEnabled = getIsSeedlessOnboardingFeatureEnabled();
+    if (!isSocialLoginFeatureEnabled) {
+      return false;
+    }
+
     const { firstTimeFlowType } = this.state;
     return (
       firstTimeFlowType === FirstTimeFlowType.socialCreate ||

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -96,6 +96,7 @@ describe('MetaMaskController', function () {
   const noop = () => undefined;
 
   beforeAll(async function () {
+    process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
     await ganacheServer.start({ port: 32545 });
   });
 

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -96,7 +96,6 @@ describe('MetaMaskController', function () {
   const noop = () => undefined;
 
   beforeAll(async function () {
-    process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
     await ganacheServer.start({ port: 32545 });
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5153,6 +5153,8 @@ export default class MetamaskController extends EventEmitter {
             keyringEncKey,
           );
         } catch (err) {
+          log.error('error while changing seedless-onboarding password', err);
+          log.error('reverting keyring password change');
           // revert the keyring password change by changing the password back to the old password
           await this.keyringController.changePassword(oldPassword);
           // store the old keyring encryption key in the seedless onboarding controller
@@ -5161,6 +5163,7 @@ export default class MetamaskController extends EventEmitter {
           await this.seedlessOnboardingController.storeKeyringEncryptionKey(
             revertedKeyringEncKey,
           );
+          throw err;
         }
       }
     } catch (error) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3844,10 +3844,7 @@ export default class MetamaskController extends EventEmitter {
       restoreSocialBackupAndGetSeedPhrase:
         this.restoreSocialBackupAndGetSeedPhrase.bind(this),
       syncSeedPhrases: this.syncSeedPhrases.bind(this),
-      socialSyncChangePassword:
-        this.seedlessOnboardingController.changePassword.bind(
-          this.seedlessOnboardingController,
-        ),
+      changePassword: this.changePassword.bind(this),
 
       // KeyringController
       setLocked: this.setLocked.bind(this),
@@ -3857,12 +3854,6 @@ export default class MetamaskController extends EventEmitter {
         this.generateNewMnemonicAndAddToVault.bind(this),
       importMnemonicToVault: this.importMnemonicToVault.bind(this),
       exportAccount: this.exportAccount.bind(this),
-      keyringChangePassword: this.keyringController.changePassword.bind(
-        this.keyringController,
-      ),
-      exportEncryptionKey: this.keyringController.exportEncryptionKey.bind(
-        this.keyringController,
-      ),
 
       // txController
       updateTransaction: txController.updateTransaction.bind(txController),
@@ -5133,6 +5124,49 @@ export default class MetamaskController extends EventEmitter {
         data: seedPhraseAsUint8Array,
         type: SecretType.Mnemonic,
       });
+    }
+  }
+
+  /**
+   * Changes the password for the wallet.
+   *
+   * If the flow is social login flow, it will also change the password for the seedless onboarding controller.
+   *
+   * @param {string} newPassword - The new password.
+   * @param {string} oldPassword - The old password.
+   */
+  async changePassword(newPassword, oldPassword) {
+    const isSocialLoginFlow = this.onboardingController.getIsSocialLoginFlow();
+    try {
+      await this.keyringController.changePassword(newPassword);
+
+      if (isSocialLoginFlow) {
+        let changePasswordSuccess = false;
+        try {
+          await this.seedlessOnboardingController.changePassword(
+            newPassword,
+            oldPassword,
+          );
+          changePasswordSuccess = true;
+        } catch (err) {
+          // revert the keyring password change by changing the password back to the old password
+          await this.keyringController.changePassword(oldPassword);
+        }
+
+        // store the new keyring encryption key in the seedless onboarding controller
+        const keyringEncKey =
+          await this.keyringController.exportEncryptionKey();
+        await this.seedlessOnboardingController.storeKeyringEncryptionKey(
+          keyringEncKey,
+        );
+
+        if (!changePasswordSuccess) {
+          throw new Error('Failed to change password');
+        }
+      }
+    } catch (error) {
+      log.error('error while changing password', error);
+      throw error;
     }
   }
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -315,7 +315,6 @@ function createMockCronjobControllerStorageManager() {
 
 describe('MetaMaskController', () => {
   beforeAll(async () => {
-    process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
     await ganacheServer.start();
   });
 

--- a/test/env.js
+++ b/test/env.js
@@ -16,3 +16,4 @@ process.env.PUSH_NOTIFICATIONS_SERVICE_URL =
 process.env.PORTFOLIO_URL = 'https://portfolio.test';
 process.env.METAMASK_VERSION = 'MOCK_VERSION';
 process.env.TZ = 'UTC';
+process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';

--- a/ui/pages/onboarding-flow/welcome/welcome-login.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome-login.test.tsx
@@ -23,7 +23,6 @@ describe('Welcome login', () => {
   });
 
   it('should display Login Options modal when seedless onboarding feature is enabled', () => {
-    process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
     const mockOnLogin = jest.fn();
 
     const { getByTestId, getByText } = renderWithProvider(

--- a/ui/pages/onboarding-flow/welcome/welcome-login.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome-login.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fireEvent, renderWithProvider } from '../../../../test/jest';
 import WelcomeLogin from './welcome-login';
-import { LOGIN_OPTION, LOGIN_TYPE } from './types';
 
 describe('Welcome login', () => {
   it('should render', () => {
@@ -11,15 +10,11 @@ describe('Welcome login', () => {
     );
     expect(getByTestId('get-started')).toBeInTheDocument();
 
-    const importButton = getByText('Import using Secret Recovery Phrase');
+    const importButton = getByText('I have an existing wallet');
     expect(importButton).toBeInTheDocument();
 
-    fireEvent.click(importButton);
-
-    expect(mockOnLogin).toHaveBeenCalledWith(
-      LOGIN_TYPE.SRP,
-      LOGIN_OPTION.EXISTING,
-    );
+    const createButton = getByText('Create a new wallet');
+    expect(createButton).toBeInTheDocument();
   });
 
   it('should display Login Options modal when seedless onboarding feature is enabled', () => {

--- a/ui/pages/onboarding-flow/welcome/welcome.test.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.test.js
@@ -62,8 +62,6 @@ describe('Welcome Page', () => {
   });
 
   it('should show the error modal when the error thrown in login', async () => {
-    process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
-
     jest
       .spyOn(Actions, 'startOAuthLogin')
       .mockRejectedValue(new Error('login error'));

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -146,6 +146,38 @@ exports[`Security Tab should match snapshot 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="settings-page__security-tab-sub-header"
+    >
+      Password
+    </div>
+    <div
+      class="settings-page__content-padded"
+    >
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <div
+            class="settings-page__content-description"
+          >
+            Choose a strong password to unlock MetaMask app on your device. If you lose this password, you will need your Secret Recovery Phrase to re-import your wallet.
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
+            data-testid="change-password-button"
+          >
+            Change password
+          </button>
+        </div>
+      </div>
+    </div>
     <div>
       <span
         class="settings-page__security-tab-sub-header"

--- a/ui/pages/unlock-page/unlock-page.test.js
+++ b/ui/pages/unlock-page/unlock-page.test.js
@@ -36,7 +36,6 @@ jest.mock('@metamask/logo', () => () => {
 
 describe('Unlock Page', () => {
   process.env.METAMASK_BUILD_TYPE = 'main';
-  process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
 
   const mockState = {
     metamask: {},

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -87,10 +87,6 @@ describe('Actions', () => {
 
   let originalNavigator;
 
-  beforeAll(() => {
-    process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
-  });
-
   beforeEach(async () => {
     // Save original navigator for restoring after tests
     originalNavigator = global.navigator;

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -105,6 +105,7 @@ describe('Actions', () => {
     background.requestAccountsAndChainPermissionsWithId = sinon.stub();
     background.grantPermissions = sinon.stub();
     background.grantPermissionsIncremental = sinon.stub();
+    background.changePassword = sinon.stub();
 
     // Make sure navigator.hid is defined for WebHID tests
     if (!global.navigator) {
@@ -220,13 +221,13 @@ describe('Actions', () => {
       const oldPassword = 'old-password';
       const newPassword = 'new-password';
 
-      const changePasswordStub = background.changePassword.resolves();
+      background.changePassword.resolves();
       setBackgroundConnection(background);
 
       await store.dispatch(actions.changePassword(newPassword, oldPassword));
 
       expect(
-        changePasswordStub.calledOnceWith(newPassword, oldPassword),
+        background.changePassword.calledOnceWith(newPassword, oldPassword),
       ).toStrictEqual(true);
     });
   });

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -224,66 +224,13 @@ describe('Actions', () => {
       const oldPassword = 'old-password';
       const newPassword = 'new-password';
 
-      const socialSyncChangePasswordStub = sinon.stub().resolves();
-      const keyringChangePasswordStub = sinon.stub().resolves();
-      const exportEncryptionKeyStub = sinon.stub().resolves('encryption-key');
-      const storeKeyringEncryptionKeyStub = sinon.stub().resolves();
-
-      background.getApi.returns({
-        socialSyncChangePassword: socialSyncChangePasswordStub,
-        keyringChangePassword: keyringChangePasswordStub,
-        exportEncryptionKey: exportEncryptionKeyStub,
-        storeKeyringEncryptionKey: storeKeyringEncryptionKeyStub,
-      });
-      setBackgroundConnection(background.getApi());
+      const changePasswordStub = background.changePassword.resolves();
+      setBackgroundConnection(background);
 
       await store.dispatch(actions.changePassword(newPassword, oldPassword));
 
       expect(
-        socialSyncChangePasswordStub.calledOnceWith(newPassword, oldPassword),
-      ).toStrictEqual(true);
-      expect(
-        keyringChangePasswordStub.calledOnceWith(newPassword),
-      ).toStrictEqual(true);
-      expect(exportEncryptionKeyStub.callCount).toStrictEqual(1);
-      expect(
-        storeKeyringEncryptionKeyStub.calledOnceWith('encryption-key'),
-      ).toStrictEqual(true);
-    });
-
-    it('should revert the keyring password change if socialSyncChangePassword fails', async () => {
-      const store = mockStore({
-        metamask: {
-          ...defaultState.metamask,
-          firstTimeFlowType: FirstTimeFlowType.socialCreate,
-        },
-      });
-      const oldPassword = 'old-password';
-      const newPassword = 'new-password';
-
-      const socialSyncChangePasswordStub = sinon
-        .stub()
-        .rejects(new Error('error'));
-      const keyringChangePasswordStub = sinon.stub().resolves();
-      const exportEncryptionKeyStub = sinon.stub().resolves('encryption-key');
-      const storeKeyringEncryptionKeyStub = sinon.stub().resolves();
-
-      background.getApi.returns({
-        socialSyncChangePassword: socialSyncChangePasswordStub,
-        keyringChangePassword: keyringChangePasswordStub,
-        exportEncryptionKey: exportEncryptionKeyStub,
-        storeKeyringEncryptionKey: storeKeyringEncryptionKeyStub,
-      });
-
-      await setBackgroundConnection(background.getApi());
-
-      await expect(
-        store.dispatch(actions.changePassword(newPassword, oldPassword)),
-      ).rejects.toThrow('error');
-      expect(keyringChangePasswordStub.callCount).toStrictEqual(2);
-      expect(exportEncryptionKeyStub.callCount).toStrictEqual(1);
-      expect(
-        storeKeyringEncryptionKeyStub.calledOnceWith('encryption-key'),
+        changePasswordStub.calledOnceWith(newPassword, oldPassword),
       ).toStrictEqual(true);
     });
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Previously, for the `password-change` operations, we called `seedless password change` and `keyring password change` separately from the frontend. If any error encountered, we also did the rollback in the frontend (redux actions).
However, that exposed an unexpected issue when user close the browser window or wallet, during the password change operation before it finishes. 

To prevent that unexpected issue, we move the whole password change operations (including the rollback) to the background script, so that even when the wallet/browser window is closed, the operation can continue in the background.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34852?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34890

## **Manual testing steps**

1. Login to wallet is Social login
2. Go to the settings > Security & Privacy > Change Password and change the current password
3. During the password-change loading, close the wallet
4. The operation should not be affected by the wallet close action and user should be able to lock/unlock wallet after that

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
