### PR TITLE
fix: flaky test `Editing Confirm Transaction goes back from confirm page to edit eth value, baseFee, priorityFee and gas limit - 1559 V2`

### DIFF
--- a/test/e2e/tests/transaction/send-edit.spec.js
+++ b/test/e2e/tests/transaction/send-edit.spec.js
@@ -1,9 +1,12 @@
 const { strict: assert } = require('assert');
+const { loginWithBalanceValidation } =
+  require('../../page-objects/flows/login.flow');
+
 const {
   createInternalTransaction,
 } = require('../../page-objects/flows/transaction');
 
-const { withFixtures, unlockWallet } = require('../../helpers');
+const { withFixtures } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 
 const PREFERENCES_STATE_MOCK = {
@@ -26,7 +29,7 @@ describe('Editing Confirm Transaction', function () {
         title: this.test.fullTitle(),
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         await createInternalTransaction(driver);
 
@@ -110,7 +113,7 @@ describe('Editing Confirm Transaction', function () {
         title: this.test.fullTitle(),
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         await createInternalTransaction(driver);
 

--- a/test/e2e/tests/transaction/send-edit.spec.js
+++ b/test/e2e/tests/transaction/send-edit.spec.js
@@ -1,6 +1,7 @@
 const { strict: assert } = require('assert');
-const { loginWithBalanceValidation } =
-  require('../../page-objects/flows/login.flow');
+const {
+  loginWithBalanceValidation,
+} = require('../../page-objects/flows/login.flow');
 
 const {
   createInternalTransaction,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The send edit specs start a send flow right after login in. The problem is that if we initiate a transaction before the balance has loaded, the `Continue` button is never enabled, no matter how much we wait on the Confirmation screen.
This is a known bug on the wallet side (see [here](https://github.com/MetaMask/metamask-extension/pull/24639)).

To mitigate this on the spec side, we should wait for the balance to load before starting any transaction.

<img width="1673" height="241" alt="Screenshot from 2025-08-05 08-30-20" src="https://github.com/user-attachments/assets/054d54c0-9ea9-42c2-bb27-30ef990fc9e1" />


<img width="1050" height="812" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/2f7bdff3-fac3-45ba-9ead-a3c4cc75f7f5" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34854?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34853

## **Manual testing steps**

1. `yarn test:e2e:single --browser chrome test/e2e/tests/transaction/send-edit.spec.js --leave-running=true`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
