### PR TITLE
ci(next semver version): rely on package.json when crafting next semver version

### DIFF
--- a/.github/scripts/get-next-semver-version.sh
+++ b/.github/scripts/get-next-semver-version.sh
@@ -9,20 +9,7 @@ then
   exit 0
 fi
 
-# Pattern for Version-vX.Y.Z branches
-VERSION_BRANCHES_VERSION_V=$(git branch -r | grep -o 'Version-v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
-# Default pattern for release/x.y.z branches
-VERSION_BRANCHES_RELEASE=$(git branch -r | grep -o 'release/[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
+# Get the version from package.json
+VERSION_PACKAGE=$(node -p "require('../../package.json').version")
 
-
-# Get the highest version from tags
-VERSION_TAGS=$(git tag | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
-
-# Compare versions and keep the highest one
-HIGHEST_VERSION=$(printf "%s\n%s\n%s" "$VERSION_BRANCHES_VERSION_V" "$VERSION_BRANCHES_RELEASE" "$VERSION_TAGS" | sort --version-sort | tail -n 1)
-echo "HIGHEST_VERSION=${HIGHEST_VERSION}, VERSION_BRANCHES_VERSION_V=${VERSION_BRANCHES_VERSION_V}, VERSION_BRANCHES_RELEASE=${VERSION_BRANCHES_RELEASE}, VERSION_TAGS=${VERSION_TAGS}"
-
-# Increment the minor version of the highest version found and reset the patch version to 0
-NEXT_VERSION=$(echo "$HIGHEST_VERSION" | awk -F. -v OFS=. '{$2++; $3=0; print}')
-
-echo "NEXT_SEMVER_VERSION=${NEXT_VERSION}" >> "$GITHUB_ENV"
+echo "NEXT_SEMVER_VERSION=${VERSION_PACKAGE}" >> "$GITHUB_ENV"

--- a/.github/scripts/get-next-semver-version.sh
+++ b/.github/scripts/get-next-semver-version.sh
@@ -10,6 +10,6 @@ then
 fi
 
 # Get the version from package.json
-VERSION_PACKAGE=$(node -p "require('../../package.json').version")
+VERSION_PACKAGE=$(node -p "require(process.env.GITHUB_WORKSPACE + '/package.json').version")
 
 echo "NEXT_SEMVER_VERSION=${VERSION_PACKAGE}" >> "$GITHUB_ENV"

--- a/.github/scripts/get-next-semver-version.sh
+++ b/.github/scripts/get-next-semver-version.sh
@@ -18,12 +18,9 @@ VERSION_BRANCHES_RELEASE=$(git branch -r | grep -o 'release/[0-9]*\.[0-9]*\.[0-9
 # Get the highest version from tags
 VERSION_TAGS=$(git tag | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
 
-# Get the version from package.json
-VERSION_PACKAGE=$(node -p "require('../../package.json').version")
-
 # Compare versions and keep the highest one
-HIGHEST_VERSION=$(printf "%s\n%s\n%s\n%s" "$VERSION_BRANCHES_VERSION_V" "$VERSION_BRANCHES_RELEASE" "$VERSION_TAGS" "$VERSION_PACKAGE" | sort --version-sort | tail -n 1)
-echo "HIGHEST_VERSION=${HIGHEST_VERSION}, VERSION_BRANCHES_VERSION_V=${VERSION_BRANCHES_VERSION_V}, VERSION_BRANCHES_RELEASE=${VERSION_BRANCHES_RELEASE}, VERSION_TAGS=${VERSION_TAGS}, VERSION_PACKAGE=${VERSION_PACKAGE}"
+HIGHEST_VERSION=$(printf "%s\n%s\n%s" "$VERSION_BRANCHES_VERSION_V" "$VERSION_BRANCHES_RELEASE" "$VERSION_TAGS" | sort --version-sort | tail -n 1)
+echo "HIGHEST_VERSION=${HIGHEST_VERSION}, VERSION_BRANCHES_VERSION_V=${VERSION_BRANCHES_VERSION_V}, VERSION_BRANCHES_RELEASE=${VERSION_BRANCHES_RELEASE}, VERSION_TAGS=${VERSION_TAGS}"
 
 # Increment the minor version of the highest version found and reset the patch version to 0
 NEXT_VERSION=$(echo "$HIGHEST_VERSION" | awk -F. -v OFS=. '{$2++; $3=0; print}')

--- a/development/get-next-semver-version.sh
+++ b/development/get-next-semver-version.sh
@@ -9,16 +9,7 @@ then
   exit 0
 fi
 
-# Get the highest version from release branches
-VERSION_BRANCHES=$(git branch -r | grep -o 'Version-v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
+# Get the version from package.json
+VERSION_PACKAGE=$(node -p "require('../package.json').version")
 
-# Get the highest version from tags
-VERSION_TAGS=$(git tag | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
-
-# Compare versions and keep the highest one
-HIGHEST_VERSION=$(printf "%s\n%s" "$VERSION_BRANCHES" "$VERSION_TAGS" | sort --version-sort | tail -n 1)
-
-# Increment the minor version of the highest version found and reset the patch version to 0
-NEXT_VERSION=$(echo "$HIGHEST_VERSION" | awk -F. -v OFS=. '{$2++; $3=0; print}')
-
-echo "NEXT_SEMVER_VERSION=${NEXT_VERSION}" >> "$GITHUB_ENV"
+echo "NEXT_SEMVER_VERSION=${VERSION_PACKAGE}" >> "$GITHUB_ENV"

--- a/development/get-next-semver-version.sh
+++ b/development/get-next-semver-version.sh
@@ -15,11 +15,8 @@ VERSION_BRANCHES=$(git branch -r | grep -o 'Version-v[0-9]*\.[0-9]*\.[0-9]*' | g
 # Get the highest version from tags
 VERSION_TAGS=$(git tag | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
 
-# Get the version from package.json
-VERSION_PACKAGE=$(node -p "require('./package.json').version")
-
 # Compare versions and keep the highest one
-HIGHEST_VERSION=$(printf "%s\n%s\n%s" "$VERSION_BRANCHES" "$VERSION_TAGS" "$VERSION_PACKAGE" | sort --version-sort | tail -n 1)
+HIGHEST_VERSION=$(printf "%s\n%s" "$VERSION_BRANCHES" "$VERSION_TAGS" | sort --version-sort | tail -n 1)
 
 # Increment the minor version of the highest version found and reset the patch version to 0
 NEXT_VERSION=$(echo "$HIGHEST_VERSION" | awk -F. -v OFS=. '{$2++; $3=0; print}')

--- a/development/get-next-semver-version.sh
+++ b/development/get-next-semver-version.sh
@@ -10,6 +10,6 @@ then
 fi
 
 # Get the version from package.json
-VERSION_PACKAGE=$(node -p "require('../package.json').version")
+VERSION_PACKAGE=$(node -p "require(process.env.GITHUB_WORKSPACE + '/package.json').version")
 
 echo "NEXT_SEMVER_VERSION=${VERSION_PACKAGE}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## **Description**

package.json can no longer be used to craft next semver version with our new process, as it's now bumped to the next version number by a version bump PR such as this one: https://github.com/MetaMask/metamask-extension/pull/34840

We need to stop relying on package.json when crafting next semver version otherwise, the automatic labeling of PRs and linked issues gets inaccurate.

Same PR for Mobile: https://github.com/MetaMask/metamask-mobile/pull/17822

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34855?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
