### PR TITLE
fix: flaky test `Developer Options - Sentry gives option to cause a page crash and offer contact support option with consenting to share data`

### DIFF
--- a/test/e2e/tests/metrics/developer-options-sentry.spec.ts
+++ b/test/e2e/tests/metrics/developer-options-sentry.spec.ts
@@ -49,7 +49,7 @@ describe('Developer Options - Sentry', function (this: Suite) {
         title: this.test?.fullTitle(),
         testSpecificMock: mockSentryError,
         ignoredConsoleErrors: [
-          'Error#1: Unable to find value of key "developerOptions" for locale "en"',
+          'Unable to find value of key "developerOptions" for locale "en"',
           'React will try to recreate this component tree from scratch using the error boundary you provided, Index.',
         ],
       },
@@ -76,7 +76,7 @@ describe('Developer Options - Sentry', function (this: Suite) {
           .build(),
         title: this.test?.fullTitle(),
         ignoredConsoleErrors: [
-          'Error#1: Unable to find value of key "developerOptions" for locale "en"',
+          'Unable to find value of key "developerOptions" for locale "en"',
           'React will try to recreate this component tree from scratch using the error boundary you provided, Index.',
         ],
       },
@@ -99,7 +99,7 @@ describe('Developer Options - Sentry', function (this: Suite) {
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         ignoredConsoleErrors: [
-          'Error#1: Unable to find value of key "developerOptions" for locale "en"',
+          'Unable to find value of key "developerOptions" for locale "en"',
           'React will try to recreate this component tree from scratch using the error boundary you provided, Index.',
         ],
       },

--- a/test/e2e/tests/metrics/developer-options-sentry.spec.ts
+++ b/test/e2e/tests/metrics/developer-options-sentry.spec.ts
@@ -50,7 +50,6 @@ describe('Developer Options - Sentry', function (this: Suite) {
         testSpecificMock: mockSentryError,
         ignoredConsoleErrors: [
           'Unable to find value of key "developerOptions" for locale "en"',
-          'React will try to recreate this component tree from scratch using the error boundary you provided, Index.',
         ],
       },
       async ({ driver }: { driver: Driver }) => {
@@ -77,7 +76,6 @@ describe('Developer Options - Sentry', function (this: Suite) {
         title: this.test?.fullTitle(),
         ignoredConsoleErrors: [
           'Unable to find value of key "developerOptions" for locale "en"',
-          'React will try to recreate this component tree from scratch using the error boundary you provided, Index.',
         ],
       },
       async ({ driver }: { driver: Driver }) => {
@@ -100,7 +98,6 @@ describe('Developer Options - Sentry', function (this: Suite) {
         title: this.test?.fullTitle(),
         ignoredConsoleErrors: [
           'Unable to find value of key "developerOptions" for locale "en"',
-          'React will try to recreate this component tree from scratch using the error boundary you provided, Index.',
         ],
       },
       async ({ driver }: { driver: Driver }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

For this spec, we added an expected error in the ignore console error list. However, sometimes instead of this error:
`Error: Unable to find value of key "developerOptio…kipeoacjioc/js-u.137417f4d9c18f57fdfe.js:62821:13, Unable to find value of key "developerOptions" for locale "en", true`

<img width="1681" height="147" alt="Screenshot from 2025-08-05 16-29-43" src="https://github.com/user-attachments/assets/cad5598b-8937-4995-a7a7-b2f232fcc937" />

we get this error (see duplicated key `Error: Error`):
`Error: Error: Unable to find value of key "developerOptio…kipeoacjioc/js-u.137417f4d9c18f57fdfe.js:62821:13, Unable to find value of key "developerOptions" for locale "en", true`

<img width="1681" height="147" alt="Screenshot from 2025-08-05 16-29-57" src="https://github.com/user-attachments/assets/a243a72e-0009-47fd-aa3a-c280e1232970" />


this makes that the error is not ignored, so the test fails. This is an issue on the app side, so I've added a bug ticket [here](https://github.com/MetaMask/metamask-extension/issues/34867). For stabilizing the spec, I've updated the error text to match both cases.

Extra note: when debugging this, there was a layer of confusion on top of that which was that in reality, the first error was ignored, not because of the `Error: Unable...`, text as it didn't started with `Error#1: Unable...` as in the ignore list, but rather because a warning was present in the same trace, which was included in the first error but not in the second type of error, causing the first one to be ignored and not fail, but not in the second case.

The warning is now removed from the ignored console errors, to avoid confusion.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34866?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34859

## **Manual testing steps**

1. `yarn test:e2e:single --browser chrome test/e2e/tests/metrics/developer-options-sentry.spec.ts --leave-running=true`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
