### PR TITLE
feat: Add support for gas sponsorship on extension

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4432,6 +4432,9 @@
   "padlock": {
     "message": "Padlock"
   },
+  "paidByMetaMask": {
+    "message": "Paid by MetaMask"
+  },
   "participateInMetaMetrics": {
     "message": "Participate in MetaMetrics"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4432,6 +4432,9 @@
   "padlock": {
     "message": "Padlock"
   },
+  "paidByMetaMask": {
+    "message": "Paid by MetaMask"
+  },
   "participateInMetaMetrics": {
     "message": "Participate in MetaMetrics"
   },

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.test.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.test.ts
@@ -337,6 +337,30 @@ describe('Delegation 7702 Publish Hook', () => {
     expect(submitRelayTransactionMock).toHaveBeenCalledTimes(1);
   });
 
+  it('submits request to relay for sponsored flow without gas fee tokens', async () => {
+    isAtomicBatchSupportedMock.mockResolvedValueOnce([
+      {
+        chainId: TRANSACTION_META_MOCK.chainId,
+        delegationAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        isSupported: true,
+        upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+      },
+    ]);
+
+    await hookClass.getHook()(
+      {
+        ...TRANSACTION_META_MOCK,
+        isGasFeeSponsored: true,
+      },
+      SIGNED_TX_MOCK,
+    );
+
+    expect(submitRelayTransactionMock).toHaveBeenCalledTimes(1);
+    expect(signDelegationControllerMock).toHaveBeenCalledTimes(1);
+    const signArgs = signDelegationControllerMock.mock.calls[0][0];
+    expect(signArgs.delegation.caveats).toHaveLength(2);
+  });
+
   it('signs delegation for gasless 7702 swap without gas fee tokens', async () => {
     isAtomicBatchSupportedMock.mockResolvedValueOnce([
       {

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
@@ -116,20 +116,27 @@ export class Delegation7702PublishHook {
 
     const isGaslessSwap = transactionMeta.isGasFeeIncluded;
 
-    if ((!selectedGasFeeToken || !gasFeeTokens?.length) && !isGaslessSwap) {
+    const isSponsored = Boolean(transactionMeta.isGasFeeSponsored);
+
+    if (
+      (!selectedGasFeeToken || !gasFeeTokens?.length) &&
+      !isGaslessSwap &&
+      !isSponsored
+    ) {
       log('Skipping as no selected gas fee token');
       return EMPTY_RESULT;
     }
 
-    const gasFeeToken = isGaslessSwap
-      ? undefined
-      : gasFeeTokens?.find(
-          (token) =>
-            token.tokenAddress.toLowerCase() ===
-            selectedGasFeeToken?.toLowerCase(),
-        );
+    const gasFeeToken =
+      isGaslessSwap || isSponsored
+        ? undefined
+        : gasFeeTokens?.find(
+            (token) =>
+              token.tokenAddress.toLowerCase() ===
+              selectedGasFeeToken?.toLowerCase(),
+          );
 
-    if (!gasFeeToken && !isGaslessSwap) {
+    if (!gasFeeToken && !isGaslessSwap && !isSponsored) {
       throw new Error('Selected gas fee token not found');
     }
 
@@ -137,7 +144,8 @@ export class Delegation7702PublishHook {
       parseInt(transactionMeta.chainId, 16),
     );
     const delegationManagerAddress = delegationEnvironment.DelegationManager;
-    const includeTransfer = !isGaslessSwap;
+    const includeTransfer =
+      !isGaslessSwap && !transactionMeta.isGasFeeSponsored;
 
     if (includeTransfer && (!gasFeeToken || gasFeeToken === undefined)) {
       throw new Error('Gas fee token not found');

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -51,6 +51,9 @@ class TransactionConfirmation extends Confirmation {
   private readonly gasFeeFiatText: RawLocator =
     '[data-testid="native-currency"]';
 
+  private readonly paidByMetaMaskNotice: RawLocator =
+    '[data-testid="paid-by-meta-mask"]';
+
   private readonly gasFeeText: RawLocator = '[data-testid="first-gas-field"]';
 
   private readonly gasFeeTokenArrow: RawLocator =
@@ -131,6 +134,13 @@ class TransactionConfirmation extends Confirmation {
     await this.driver.findElement({
       css: this.gasFeeTokenFeeText,
       text: amountFiat,
+    });
+  }
+
+  async checkPaidByMetaMask() {
+    await this.driver.findElement({
+      css: this.paidByMetaMaskNotice,
+      text: tEn('paidByMetaMask') as string,
     });
   }
 

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
@@ -1,0 +1,242 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { Suite } from 'mocha';
+import { MockttpServer } from 'mockttp';
+import { RelayStatus } from '../../../../../app/scripts/lib/transaction/transaction-relay';
+import { TX_SENTINEL_URL } from '../../../../../shared/constants/transaction';
+import { DEFAULT_FIXTURE_ACCOUNT } from '../../../constants';
+import FixtureBuilder from '../../../fixture-builder';
+import {
+  WINDOW_TITLES,
+  convertETHToHexGwei,
+  withFixtures,
+} from '../../../helpers';
+import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
+import { createDappTransaction } from '../../../page-objects/flows/transaction';
+import TransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/transaction-confirmation';
+import ActivityListPage from '../../../page-objects/pages/home/activity-list';
+import HomePage from '../../../page-objects/pages/home/homepage';
+import { mockEip7702FeatureFlag } from '../helpers';
+
+const UUID = '1234-5678';
+const TRANSACTION_HASH =
+  '0xf25183af3bf64af01e9210201a2ede3c1dcd6d16091283152d13265242939fc4';
+
+describe('Gas Fee Tokens - EIP-7702 - Sponsored', function (this: Suite) {
+  it('confirms transaction if successful', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
+          .withPermissionControllerConnectedToTestDapp()
+          .withPreferencesControllerSmartTransactionsOptedOut()
+          .build(),
+        manifestFlags: {
+          testing: { disableSmartTransactionsOverride: true },
+        },
+        localNodeOptions: {
+          loadState:
+            './test/e2e/seeder/network-states/eip7702-state/withUpgradedAccount.json',
+        },
+        testSpecificMock: (mockServer: MockttpServer) => {
+          mockSimulationResponse(mockServer);
+          mockEip7702FeatureFlag(mockServer);
+          mockTransactionRelayNetworks(mockServer);
+          mockTransactionRelaySubmit(mockServer);
+          mockTransactionRelayStatus(mockServer);
+          mockSmartTransactionFeatureFlags(mockServer);
+        },
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver, localNodes }) => {
+        await localNodes?.[0]?.setAccountBalance(
+          DEFAULT_FIXTURE_ACCOUNT,
+          convertETHToHexGwei(1),
+        );
+        await loginWithBalanceValidation(driver, localNodes?.[0]);
+
+        await createDappTransaction(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const transactionConfirmation = new TransactionConfirmation(driver);
+        await transactionConfirmation.checkPaidByMetaMask();
+
+        await transactionConfirmation.clickAdvancedDetailsButton();
+
+        await transactionConfirmation.checkPaidByMetaMask();
+        await transactionConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
+
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+
+        const homepage = new HomePage(driver);
+        await homepage.goToActivityList();
+
+        const activityListPage = new ActivityListPage(driver);
+        await activityListPage.checkConfirmedTxNumberDisplayedInActivity(1);
+      },
+    );
+  });
+
+  it('fails transaction if error', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
+          .withPermissionControllerConnectedToTestDapp()
+          .withNetworkControllerOnMainnet()
+          .build(),
+        localNodeOptions: {
+          loadState:
+            './test/e2e/seeder/network-states/eip7702-state/withUpgradedAccount.json',
+        },
+        testSpecificMock: (mockServer: MockttpServer) => {
+          mockSimulationResponse(mockServer);
+          mockEip7702FeatureFlag(mockServer);
+          mockTransactionRelayNetworks(mockServer);
+          mockTransactionRelaySubmit(mockServer);
+          mockTransactionRelayStatus(mockServer, { success: false });
+          mockSmartTransactionFeatureFlags(mockServer);
+        },
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver, localNodes }) => {
+        await localNodes?.[0]?.setAccountBalance(
+          DEFAULT_FIXTURE_ACCOUNT,
+          convertETHToHexGwei(1),
+        );
+        await loginWithBalanceValidation(driver, localNodes?.[0]);
+        await createDappTransaction(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const transactionConfirmation = new TransactionConfirmation(driver);
+
+        await transactionConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
+
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+
+        const homepage = new HomePage(driver);
+        await homepage.goToActivityList();
+
+        const activityListPage = new ActivityListPage(driver);
+        await activityListPage.checkFailedTxNumberDisplayedInActivity(1);
+      },
+    );
+  });
+});
+
+async function mockSimulationResponse(mockServer: MockttpServer) {
+  await mockServer
+    .forPost(TX_SENTINEL_URL)
+    .withBodyIncluding('simulateTransactions')
+    .thenCallback(() => {
+      return {
+        ok: true,
+        statusCode: 200,
+        json: {
+          jsonrpc: '2.0',
+          result: {
+            transactions: [
+              {
+                return:
+                  '0x0000000000000000000000000000000000000000000000000000000000000000',
+                status: '0x1',
+                gasUsed: '0x5de2',
+                gasLimit: '0x5f34',
+                fees: [
+                  {
+                    maxFeePerGas: '0xf19b9f48d',
+                    maxPriorityFeePerGas: '0x9febc9',
+                    balanceNeeded: '0x59d9d3b865ed8',
+                    currentBalance: '0x77f9fd8d99e7e0',
+                    error: '',
+                    tokenFees: [],
+                  },
+                ],
+                stateDiff: {},
+                feeEstimate: 972988071597550,
+                baseFeePerGas: 40482817574,
+              },
+            ],
+            blockNumber: '0x1293669',
+            id: 'faaab4c5-edf5-4077-ac75-8d26278ca2c5',
+            sponsorship: { isSponsored: true },
+          },
+        },
+      };
+    });
+}
+
+async function mockTransactionRelayNetworks(mockServer: MockttpServer) {
+  await mockServer
+    .forGet(`${TX_SENTINEL_URL}/networks`)
+    .always()
+    .thenCallback(() => {
+      return {
+        ok: true,
+        statusCode: 200,
+        json: {
+          '1': {
+            network: 'ethereum-mainnet',
+            confirmations: true,
+            relayTransactions: true,
+            sendBundle: true,
+          },
+        },
+      };
+    });
+}
+
+async function mockTransactionRelaySubmit(mockServer: MockttpServer) {
+  await mockServer
+    .forPost(TX_SENTINEL_URL)
+    .withBodyIncluding('eth_sendRelayTransaction')
+    .thenCallback(() => {
+      return {
+        ok: true,
+        statusCode: 200,
+        json: {
+          jsonrpc: '2.0',
+          result: {
+            uuid: UUID,
+          },
+        },
+      };
+    });
+}
+
+async function mockTransactionRelayStatus(
+  mockServer: MockttpServer,
+  { success }: { success?: boolean } = { success: true },
+) {
+  await mockServer
+    .forGet(`${TX_SENTINEL_URL}/smart-transactions/${UUID}`)
+    .thenCallback(() => {
+      return {
+        ok: true,
+        statusCode: 200,
+        json: {
+          transactions: [
+            {
+              hash: TRANSACTION_HASH,
+              status: success ? RelayStatus.Success : 'FAILED',
+            },
+          ],
+        },
+      };
+    });
+}
+
+async function mockSmartTransactionFeatureFlags(mockServer: MockttpServer) {
+  await mockServer
+    .forGet('https://bridge.api.cx.metamask.io/featureFlags')
+    .thenCallback(() => {
+      return {
+        ok: true,
+        statusCode: 200,
+        json: {},
+      };
+    });
+}

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -47,8 +47,7 @@ export const EditGasFeesRow = ({
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
-
-  const { chainId, simulationData } = transactionMeta;
+  const { chainId, isGasFeeSponsored, simulationData } = transactionMeta;
   const gasFeeToken = useSelectedGasFeeToken();
   const showFiat = useShowFiat(chainId);
   const fiatValue = gasFeeToken ? gasFeeToken.amountFiat : fiatFee;
@@ -83,50 +82,61 @@ export const EditGasFeesRow = ({
             textAlign={TextAlign.Center}
             gap={1}
           >
-            {!gasFeeToken && (
+            {isGasFeeSponsored && (
+              <Text
+                color={TextColor.textDefault}
+                data-testid="paid-by-meta-mask"
+              >
+                {t('paidByMetaMask')}
+              </Text>
+            )}
+            {!gasFeeToken && !isGasFeeSponsored && (
               <EditGasIconButton
                 supportsEIP1559={supportsEIP1559}
                 setShowCustomizeGasPopover={setShowCustomizeGasPopover}
               />
             )}
-            {showFiat && !showAdvancedDetails ? (
+            {showFiat && !showAdvancedDetails && !isGasFeeSponsored && (
               <FiatValue
                 fullValue={fiatFeeWith18SignificantDigits}
                 roundedValue={fiatValue}
               />
-            ) : (
+            )}
+            {!(showFiat && !showAdvancedDetails) && !isGasFeeSponsored && (
               <TokenValue roundedValue={tokenValue} />
             )}
-            <SelectedGasFeeToken />
+            {!isGasFeeSponsored && <SelectedGasFeeToken />}
           </Box>
         )}
       </ConfirmInfoAlertRow>
-      <Box
-        display={Display.Flex}
-        justifyContent={JustifyContent.spaceBetween}
-        paddingInline={2}
-      >
-        <Box style={{ marginTop: gasFeeToken ? -8 : 0 }}>
-          <Text
-            data-testid="gas-fee-token-fee"
-            variant={TextVariant.bodySm}
-            color={TextColor.textAlternative}
-            paddingBottom={gasFeeToken ? 2 : 0}
-          >
-            {gasFeeToken
-              ? t('confirmGasFeeTokenMetaMaskFee', [metamaskFeeFiat])
-              : ' '}
-          </Text>
+      {!isGasFeeSponsored && (
+        <Box
+          display={Display.Flex}
+          justifyContent={JustifyContent.spaceBetween}
+          paddingInline={2}
+        >
+          <Box style={{ marginTop: gasFeeToken ? -8 : 0 }}>
+            <Text
+              data-testid="gas-fee-token-fee"
+              variant={TextVariant.bodySm}
+              color={TextColor.textAlternative}
+              paddingBottom={gasFeeToken ? 2 : 0}
+            >
+              {gasFeeToken
+                ? t('confirmGasFeeTokenMetaMaskFee', [metamaskFeeFiat])
+                : ' '}
+            </Text>
+          </Box>
+          {showAdvancedDetails && (
+            <FiatValue
+              fullValue={fiatFeeWith18SignificantDigits}
+              roundedValue={fiatValue}
+              variant={TextVariant.bodySm}
+              color={TextColor.textAlternative}
+            />
+          )}
         </Box>
-        {showAdvancedDetails && (
-          <FiatValue
-            fullValue={fiatFeeWith18SignificantDigits}
-            roundedValue={fiatValue}
-            variant={TextVariant.bodySm}
-            color={TextColor.textAlternative}
-          />
-        )}
-      </Box>
+      )}
     </Box>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
@@ -68,51 +68,57 @@ export const GasFeesDetails = ({
         supportsEIP1559={supportsEIP1559}
         setShowCustomizeGasPopover={setShowCustomizeGasPopover}
       />
-      {showAdvancedDetails && hasLayer1GasFee && (
-        <>
-          <GasFeesRow
-            data-testid="gas-fee-details-l1"
-            label={t('l1Fee')}
-            tooltipText={t('l1FeeTooltip')}
-            fiatFee={l1FeeFiat}
-            fiatFeeWith18SignificantDigits={l1FeeFiatWith18SignificantDigits}
-            nativeFee={l1FeeNative}
-          />
-          <GasFeesRow
-            data-testid="gas-fee-details-l2"
-            label={t('l2Fee')}
-            tooltipText={t('l2FeeTooltip')}
-            fiatFee={l2FeeFiat}
-            fiatFeeWith18SignificantDigits={l2FeeFiatWith18SignificantDigits}
-            nativeFee={l2FeeNative}
-          />
-        </>
-      )}
-      {supportsEIP1559 && !transactionMeta.selectedGasFeeToken && (
-        <ConfirmInfoAlertRow
-          alertKey={RowAlertKey.Speed}
-          data-testid="gas-fee-details-speed"
-          label={t('speed')}
-          ownerId={transactionMeta.id}
-        >
-          <Box display={Display.Flex} alignItems={AlignItems.center}>
-            <GasTiming
-              maxFeePerGas={maxFeePerGas}
-              maxPriorityFeePerGas={maxPriorityFeePerGas}
+      {showAdvancedDetails &&
+        hasLayer1GasFee &&
+        !transactionMeta.isGasFeeSponsored && (
+          <>
+            <GasFeesRow
+              data-testid="gas-fee-details-l1"
+              label={t('l1Fee')}
+              tooltipText={t('l1FeeTooltip')}
+              fiatFee={l1FeeFiat}
+              fiatFeeWith18SignificantDigits={l1FeeFiatWith18SignificantDigits}
+              nativeFee={l1FeeNative}
             />
-          </Box>
-        </ConfirmInfoAlertRow>
-      )}
-      {showAdvancedDetails && !transactionMeta.selectedGasFeeToken && (
-        <GasFeesRow
-          data-testid="gas-fee-details-max-fee"
-          label={t('maxFee')}
-          tooltipText={t('maxFeeTooltip')}
-          fiatFee={maxFeeFiat}
-          fiatFeeWith18SignificantDigits={maxFeeFiatWith18SignificantDigits}
-          nativeFee={maxFeeNative}
-        />
-      )}
+            <GasFeesRow
+              data-testid="gas-fee-details-l2"
+              label={t('l2Fee')}
+              tooltipText={t('l2FeeTooltip')}
+              fiatFee={l2FeeFiat}
+              fiatFeeWith18SignificantDigits={l2FeeFiatWith18SignificantDigits}
+              nativeFee={l2FeeNative}
+            />
+          </>
+        )}
+      {supportsEIP1559 &&
+        !transactionMeta.selectedGasFeeToken &&
+        !transactionMeta.isGasFeeSponsored && (
+          <ConfirmInfoAlertRow
+            alertKey={RowAlertKey.Speed}
+            data-testid="gas-fee-details-speed"
+            label={t('speed')}
+            ownerId={transactionMeta.id}
+          >
+            <Box display={Display.Flex} alignItems={AlignItems.center}>
+              <GasTiming
+                maxFeePerGas={maxFeePerGas}
+                maxPriorityFeePerGas={maxPriorityFeePerGas}
+              />
+            </Box>
+          </ConfirmInfoAlertRow>
+        )}
+      {showAdvancedDetails &&
+        !transactionMeta.selectedGasFeeToken &&
+        !transactionMeta.isGasFeeSponsored && (
+          <GasFeesRow
+            data-testid="gas-fee-details-max-fee"
+            label={t('maxFee')}
+            tooltipText={t('maxFeeTooltip')}
+            fiatFee={maxFeeFiat}
+            fiatFeeWith18SignificantDigits={maxFeeFiatWith18SignificantDigits}
+            nativeFee={maxFeeNative}
+          />
+        )}
     </>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.stories.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.stories.tsx
@@ -2,13 +2,13 @@ import { Meta } from '@storybook/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import mockState from '../../../../../../../../test/data/mock-state.json';
+import { getMockContractInteractionConfirmState } from '../../../../../../../../test/data/confirmations/helper';
 import configureStore from '../../../../../../../store/store';
 import { ConfirmContextProvider } from '../../../../../context/confirm';
 import { GasFeesRow } from './gas-fees-row';
 
 function getStore() {
-  return configureStore(mockState);
+  return configureStore(getMockContractInteractionConfirmState());
 }
 
 const Story = {
@@ -23,7 +23,7 @@ const Story = {
             padding: 30,
           }}
         >
-          {story()}
+          <ConfirmContextProvider>{story()}</ConfirmContextProvider>
         </div>
       </Provider>
     ),
@@ -33,15 +33,13 @@ const Story = {
 export default Story;
 
 export const DefaultStory = () => (
-  <ConfirmContextProvider>
-    <GasFeesRow
-      label="Some kind of fee"
-      tooltipText="Tooltip text"
-      fiatFee="$1"
-      fiatFeeWith18SignificantDigits="0.001234"
-      nativeFee="0.0001 ETH"
-    />
-  </ConfirmContextProvider>
+  <GasFeesRow
+    label="Some kind of fee"
+    tooltipText="Tooltip text"
+    fiatFee="$1"
+    fiatFeeWith18SignificantDigits="0.001234"
+    nativeFee="0.0001 ETH"
+  />
 );
 
 DefaultStory.storyName = 'Default';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

If the gas is sponsored, and the account has been upgraded to smart account, certain transactions might be sponsored, which means the usual transfer transaction with the gas costs doesn't need to be included in the encoded delegation.

The gas fees UI is also conditionally updated to show "Free" (see screenshot below).

Related to this core PR: https://github.com/MetaMask/core/pull/6244

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34905?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5494

https://github.com/MetaMask/MetaMask-planning/issues/6015

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="567" height="771" alt="Screenshot 2025-10-14 at 10 39 24" src="https://github.com/user-attachments/assets/dd7bbde0-f6bf-403f-8b47-b4e9ac243d3d" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds sponsored gas (paymaster) support for EIP-7702 flows, showing “Paid by MetaMask” in confirmations and adjusting publish logic/UI accordingly, with tests and e2e coverage.
> 
> - **EIP-7702 Sponsored Gas Support**
>   - **Publish Hook (`delegation-7702-publish.ts`)**: Treat `isGasFeeSponsored` like gasless — skip gas-fee-token requirement/transfer, adjust caveats/executions, and avoid errors when no token is selected.
>   - **Tests**:
>     - Unit: Add sponsored-flow test; validate delegation caveats/signing and relay submission.
>     - E2E: New spec to verify sponsored success/failure and presence of "Paid by MetaMask" notice.
> - **Confirmations UI**
>   - **Gas Fees Row/Details**: When sponsored, display `paidByMetaMask`, hide edit button, token selection, L1/L2/max fee, and fiat/token fee values where applicable.
>   - **i18n**: Add `paidByMetaMask` string (en, en_GB).
>   - **Page Objects**: Add `checkPaidByMetaMask()` using `data-testid="paid-by-meta-mask"`.
> - **Storybook**
>   - Update GasFeesRow stories to use confirmation context and new mock state helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fe00733c3cd9f357f7b79156edcf357a66121cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->