### PR TITLE
fix: add slippage to quote card cp-13.1.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5571,6 +5571,15 @@
   "slideSweepStakeTitle": {
     "message": "Enter the $5000 USDC Giveaway!"
   },
+  "slippage": {
+    "message": "Slippage"
+  },
+  "slippageAuto": {
+    "message": "Auto"
+  },
+  "slippageEditAriaLabel": {
+    "message": "Edit slippage"
+  },
   "smartAccountAccept": {
     "message": "Use smart account"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5571,6 +5571,15 @@
   "slideSweepStakeTitle": {
     "message": "Enter the $5000 USDC Giveaway!"
   },
+  "slippage": {
+    "message": "Slippage"
+  },
+  "slippageAuto": {
+    "message": "Auto"
+  },
+  "slippageEditAriaLabel": {
+    "message": "Edit slippage"
+  },
   "smartAccountAccept": {
     "message": "Use smart account"
   },

--- a/ui/pages/bridge/index.tsx
+++ b/ui/pages/bridge/index.tsx
@@ -140,7 +140,9 @@ const CrossChainSwap = () => {
                 setIsSettingsModalOpen(false);
               }}
             />
-            <PrepareBridgePage />
+            <PrepareBridgePage
+              onOpenSettings={() => setIsSettingsModalOpen(true)}
+            />
           </Route>
           <Route path={CROSS_CHAIN_SWAP_ROUTE + AWAITING_SIGNATURES_ROUTE}>
             <Content>

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -583,7 +583,7 @@ const PrepareBridgePage = ({
 
   return (
     <>
-      <Column className="prepare-bridge-page" gap={8}>
+      <Column className="prepare-bridge-page" gap={isToOrFromSolana ? 2 : 8}>
         <BridgeInputGroup
           header={getFromInputHeader()}
           token={fromToken}
@@ -663,7 +663,7 @@ const PrepareBridgePage = ({
 
         <Column
           height={BlockSize.Full}
-          paddingTop={8}
+          paddingTop={isToOrFromSolana ? 4 : 8}
           backgroundColor={BackgroundColor.backgroundAlternativeSoft}
           style={{
             position: 'relative',

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -177,7 +177,11 @@ export const useEnableMissingNetwork = () => {
   return enableMissingNetwork;
 };
 
-const PrepareBridgePage = () => {
+const PrepareBridgePage = ({
+  onOpenSettings,
+}: {
+  onOpenSettings?: () => void;
+}) => {
   const dispatch = useDispatch();
   const enableMissingNetwork = useEnableMissingNetwork();
 
@@ -906,9 +910,11 @@ const PrepareBridgePage = () => {
               {!wasTxDeclined &&
                 activeQuote &&
                 (isSolanaBridgeEnabled ? (
-                  <MultichainBridgeQuoteCard />
+                  <MultichainBridgeQuoteCard
+                    onOpenSlippageModal={onOpenSettings}
+                  />
                 ) : (
-                  <BridgeQuoteCard />
+                  <BridgeQuoteCard onOpenSlippageModal={onOpenSettings} />
                 ))}
               <Footer padding={0} flexDirection={FlexDirection.Column} gap={2}>
                 <BridgeCTAButton

--- a/ui/pages/bridge/quotes/__snapshots__/bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/bridge-quote-card.test.tsx.snap
@@ -130,6 +130,35 @@ exports[`BridgeQuoteCard should render the recommended quote 1`] = `
       <div
         class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
       >
+        <div
+          class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-alternative-soft"
+            style="white-space: nowrap;"
+          >
+            Slippage
+          </p>
+          <button
+            aria-label="Edit slippage"
+            class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative-soft mm-box--background-color-transparent mm-box--rounded-lg"
+            data-testid="slippage-edit-button"
+          >
+            <span
+              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              style="mask-image: url('./images/icons/edit.svg');"
+            />
+          </button>
+        </div>
+        <p
+          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+        >
+          undefined%
+        </p>
+      </div>
+      <div
+        class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
+      >
         <p
           class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-alternative-soft"
         >
@@ -291,6 +320,35 @@ exports[`BridgeQuoteCard should render the recommended quote while loading new q
             style="mask-image: url('./images/icons/swap-vertical.svg'); cursor: pointer;"
           />
         </div>
+      </div>
+      <div
+        class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
+      >
+        <div
+          class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-alternative-soft"
+            style="white-space: nowrap;"
+          >
+            Slippage
+          </p>
+          <button
+            aria-label="Edit slippage"
+            class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative-soft mm-box--background-color-transparent mm-box--rounded-lg"
+            data-testid="slippage-edit-button"
+          >
+            <span
+              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              style="mask-image: url('./images/icons/edit.svg');"
+            />
+          </button>
+        </div>
+        <p
+          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+        >
+          undefined%
+        </p>
       </div>
       <div
         class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -316,22 +316,20 @@ export const BridgeQuoteCard = ({
                   variant={TextVariant.bodyMdMedium}
                   color={TextColor.textAlternativeSoft}
                 >
-                  {/* // TODO: add translation */}
-                  Slippage
+                  {t('slippage')}
                 </Text>
                 <ButtonIcon
                   iconName={IconName.Edit}
                   size={ButtonIconSize.Sm}
                   color={IconColor.iconAlternativeSoft}
                   onClick={onOpenSlippageModal}
-                  // TODO: add translation
-                  ariaLabel="Edit slippage"
+                  ariaLabel={t('slippageEditAriaLabel')}
                   data-testid="slippage-edit-button"
                 />
               </Row>
               <Text variant={TextVariant.bodyMd}>
                 {slippage === undefined && isSolanaSwap
-                  ? 'Auto' // TODO: add translation
+                  ? t('slippageAuto')
                   : `${slippage}%`}
               </Text>
             </Row>

--- a/ui/pages/bridge/quotes/bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/bridge-quote-card.tsx
@@ -11,6 +11,8 @@ import {
   PopoverPosition,
   IconName,
   ButtonLink,
+  ButtonIcon,
+  ButtonIconSize,
   Icon,
   IconSize,
   AvatarNetwork,
@@ -23,6 +25,8 @@ import {
   getToChain,
   getToToken,
   getValidationErrors,
+  getSlippage,
+  getIsSolanaSwap,
 } from '../../../ducks/bridge/selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { formatCurrencyAmount, formatTokenAmount } from '../utils/quote';
@@ -53,7 +57,11 @@ import { trackUnifiedSwapBridgeEvent } from '../../../ducks/bridge/actions';
 import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
 import { BridgeQuotesModal } from './bridge-quotes-modal';
 
-export const BridgeQuoteCard = () => {
+export const BridgeQuoteCard = ({
+  onOpenSlippageModal,
+}: {
+  onOpenSlippageModal?: () => void;
+}) => {
   const t = useI18nContext();
   const { activeQuote } = useSelector(getBridgeQuotes);
   const currency = useSelector(getCurrentCurrency);
@@ -68,6 +76,8 @@ export const BridgeQuoteCard = () => {
   const fromChain = useSelector(getFromChain);
   const toChain = useSelector(getToChain);
   const locale = useSelector(getIntlLocale);
+  const slippage = useSelector(getSlippage);
+  const isSolanaSwap = useSelector(getIsSolanaSwap);
 
   const [showAllQuotes, setShowAllQuotes] = useState(false);
   const [shouldShowNetworkFeesInGasToken, setShouldShowNetworkFeesInGasToken] =
@@ -297,6 +307,33 @@ export const BridgeQuoteCard = () => {
                   }
                 />
               </Row>
+            </Row>
+
+            <Row justifyContent={JustifyContent.spaceBetween}>
+              <Row gap={1} alignItems={AlignItems.center}>
+                <Text
+                  style={{ whiteSpace: 'nowrap' }}
+                  variant={TextVariant.bodyMdMedium}
+                  color={TextColor.textAlternativeSoft}
+                >
+                  {/* // TODO: add translation */}
+                  Slippage
+                </Text>
+                <ButtonIcon
+                  iconName={IconName.Edit}
+                  size={ButtonIconSize.Sm}
+                  color={IconColor.iconAlternativeSoft}
+                  onClick={onOpenSlippageModal}
+                  // TODO: add translation
+                  ariaLabel="Edit slippage"
+                  data-testid="slippage-edit-button"
+                />
+              </Row>
+              <Text variant={TextVariant.bodyMd}>
+                {slippage === undefined && isSolanaSwap
+                  ? 'Auto' // TODO: add translation
+                  : `${slippage}%`}
+              </Text>
             </Row>
 
             <Row>

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -207,22 +207,20 @@ export const MultichainBridgeQuoteCard = ({
                   variant={TextVariant.bodyMd}
                   color={TextColor.textAlternative}
                 >
-                  {/* // TODO: add translation */}
-                  Slippage
+                  {t('slippage')}
                 </Text>
                 <ButtonIcon
                   iconName={IconName.Edit}
                   size={ButtonIconSize.Sm}
                   color={IconColor.iconAlternative}
                   onClick={onOpenSlippageModal}
-                  // TODO: add translation
-                  ariaLabel="Edit slippage"
+                  ariaLabel={t('slippageEditAriaLabel')}
                   data-testid="slippage-edit-button"
                 />
               </Row>
               <Text variant={TextVariant.bodyMd}>
                 {slippage === undefined && isSolanaSwap
-                  ? 'Auto' // TODO: add translation
+                  ? t('slippageAuto')
                   : `${slippage}%`}
               </Text>
             </Row>

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -13,6 +13,8 @@ import {
   PopoverPosition,
   IconName,
   ButtonLink,
+  ButtonIcon,
+  ButtonIconSize,
   Icon,
   IconSize,
   AvatarNetwork,
@@ -25,6 +27,8 @@ import {
   getIsBridgeTx,
   getToToken,
   getFromToken,
+  getSlippage,
+  getIsSolanaSwap,
 } from '../../../ducks/bridge/selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { formatCurrencyAmount, formatTokenAmount } from '../utils/quote';
@@ -32,6 +36,7 @@ import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
   BackgroundColor,
   FontStyle,
+  IconColor,
   JustifyContent,
   TextColor,
   TextVariant,
@@ -48,7 +53,11 @@ import { getIntlLocale } from '../../../ducks/locale/locale';
 import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
 import { BridgeQuotesModal } from './bridge-quotes-modal';
 
-export const MultichainBridgeQuoteCard = () => {
+export const MultichainBridgeQuoteCard = ({
+  onOpenSlippageModal,
+}: {
+  onOpenSlippageModal?: () => void;
+}) => {
   const t = useI18nContext();
   const { activeQuote } = useSelector(getBridgeQuotes);
   const currency = useSelector(getCurrentCurrency);
@@ -62,6 +71,8 @@ export const MultichainBridgeQuoteCard = () => {
   );
   const fromToken = useSelector(getFromToken);
   const toToken = useSelector(getToToken);
+  const slippage = useSelector(getSlippage);
+  const isSolanaSwap = useSelector(getIsSolanaSwap);
   const dispatch = useDispatch();
 
   const [showAllQuotes, setShowAllQuotes] = useState(false);
@@ -187,6 +198,33 @@ export const MultichainBridgeQuoteCard = () => {
                   )}
                 </Text>
               )}
+            </Row>
+
+            {/* Slippage */}
+            <Row justifyContent={JustifyContent.spaceBetween}>
+              <Row gap={1}>
+                <Text
+                  variant={TextVariant.bodyMd}
+                  color={TextColor.textAlternative}
+                >
+                  {/* // TODO: add translation */}
+                  Slippage
+                </Text>
+                <ButtonIcon
+                  iconName={IconName.Edit}
+                  size={ButtonIconSize.Sm}
+                  color={IconColor.iconAlternative}
+                  onClick={onOpenSlippageModal}
+                  // TODO: add translation
+                  ariaLabel="Edit slippage"
+                  data-testid="slippage-edit-button"
+                />
+              </Row>
+              <Text variant={TextVariant.bodyMd}>
+                {slippage === undefined && isSolanaSwap
+                  ? 'Auto' // TODO: add translation
+                  : `${slippage}%`}
+              </Text>
             </Row>
 
             {/* Time */}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

> there is an edge case in the latest slippage defaulting logic in which the user’s selected custom slippage can get reset without them knowing:
> 1. user enters swap flow
> 2. user selects a custom slippage
> 3. they switch the inputs using the “switch” button
> 4. the ui resets the custom slippage to the smart default without the user’s knowledge
> 5. this could result in the tx executing with an unintended slippage, which the user may not expect

The solution for this is to add the slippage in the quote card and make it easily editable by adding an edit button. The user is informed of the slippage being changed to a new default, and then they can make the decision to edit slippage or keep the new default. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34916?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: adds slippage information in the quote card for swap transactions.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34914

## **Manual testing steps**

1. Go to the swaps page.
2. See that you can view and edit the slippage from within the quote card.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="398" height="493" alt="Screenshot 2025-08-06 at 4 11 38 PM" src="https://github.com/user-attachments/assets/a3e8a718-0289-4717-acd0-19e3e6ad1a06" />

<!-- [screenshots/recordings] -->

### **After**

<img width="397" height="526" alt="Screenshot 2025-08-06 at 4 10 52 PM" src="https://github.com/user-attachments/assets/a9948f00-b1e3-49e5-a78f-2a45fdb5c52a" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
