### PR TITLE
test: add power user persona E2E test

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -773,10 +773,14 @@ async function loadPhishingWarningPage() {
  */
 export async function loadStateFromPersistence(backup) {
   if (process.env.WITH_STATE) {
+    const withState = JSON.parse(process.env.WITH_STATE);
+
     // Use `require` to make it easier to exclude this test code from the Browserify build.
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
     const { generateWalletState } = require('./fixtures/generate-wallet-state');
-    const stateOverrides = await generateWalletState();
+    const fixtureBuilder = await generateWalletState(withState, false);
+
+    const stateOverrides = fixtureBuilder.fixture.data;
     firstTimeState = { ...firstTimeState, ...stateOverrides };
   }
 

--- a/app/scripts/fixtures/generate-wallet-state.js
+++ b/app/scripts/fixtures/generate-wallet-state.js
@@ -47,13 +47,7 @@ export async function generateWalletState(withState, fromTest) {
     )
     .withPreferencesController(generatePreferencesControllerState(accounts))
     .withTokensController(generateTokensControllerState(accounts[0]))
-    .withTransactionController(generateTransactionControllerState(accounts[0]))
-
-    // Disable backup and sync in this case
-    .withBackupAndSyncSettings({
-      isProfileSyncingEnabled: false,
-      isAccountSyncingEnabled: false,
-    });
+    .withTransactionController(generateTransactionControllerState(accounts[0]));
 
   return fixtureBuilder;
 }

--- a/app/scripts/fixtures/generate-wallet-state.js
+++ b/app/scripts/fixtures/generate-wallet-state.js
@@ -2,32 +2,37 @@ import { Messenger } from '@metamask/base-controller';
 import { KeyringController } from '@metamask/keyring-controller';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { UI_NOTIFICATIONS } from '../../../shared/notifications';
+import { WALLET_PASSWORD } from '../../../test/e2e/constants';
 import { E2E_SRP, defaultFixture } from '../../../test/e2e/default-fixture';
 import FixtureBuilder from '../../../test/e2e/fixture-builder';
 import { encryptorFactory } from '../lib/encryptor-factory';
+import { withAddressBook } from './with-address-book';
 import { FIXTURES_APP_STATE } from './with-app-state';
+import { withConfirmedTransactions } from './with-confirmed-transactions';
+import { FIXTURES_ERC20_TOKENS } from './with-erc20-tokens';
 import { FIXTURES_NETWORKS } from './with-networks';
 import { FIXTURES_PREFERENCES } from './with-preferences';
-import { FIXTURES_ERC20_TOKENS } from './with-erc20-tokens';
-import { withAddressBook } from './with-address-book';
-import { withConfirmedTransactions } from './with-confirmed-transactions';
 import { withUnreadNotifications } from './with-unread-notifications';
 
-const FIXTURES_CONFIG = process.env.WITH_STATE
-  ? JSON.parse(process.env.WITH_STATE)
-  : {};
+let FIXTURES_CONFIG = {};
 
 /**
  * Generates the wallet state based on the fixtures set in the environment variable.
  *
- * @returns {Promise<object>} The generated wallet state.
+ * @param {object} withState - The fixture configuration state
+ * @param {boolean} fromTest - Whether this is being called from a test
+ * @returns {Promise<FixtureBuilder>} The generated FixtureBuilder object
  */
-export async function generateWalletState() {
+export async function generateWalletState(withState, fromTest) {
   const fixtureBuilder = new FixtureBuilder({ inputChainId: '0xaa36a7' });
+
+  if (withState) {
+    FIXTURES_CONFIG = withState;
+  }
 
   const { vault, accounts } = await generateVaultAndAccount(
     process.env.TEST_SRP || E2E_SRP,
-    process.env.PASSWORD,
+    fromTest ? WALLET_PASSWORD : process.env.PASSWORD,
   );
 
   fixtureBuilder
@@ -50,7 +55,7 @@ export async function generateWalletState() {
       isAccountSyncingEnabled: false,
     });
 
-  return fixtureBuilder.fixture.data;
+  return fixtureBuilder;
 }
 
 /**
@@ -58,7 +63,7 @@ export async function generateWalletState() {
  *
  * @param {string} encodedSeedPhrase - The encoded seed phrase.
  * @param {string} password - The password for the vault.
- * @returns {Promise<{vault: object, account: string}>} The generated vault and account.
+ * @returns {Promise<{vault: object, accounts: Array<string>}>} The generated vault and account.
  */
 async function generateVaultAndAccount(encodedSeedPhrase, password) {
   const messenger = new Messenger();
@@ -115,7 +120,7 @@ function generateKeyringControllerState(vault) {
 /**
  * Generates the state for the AccountsController.
  *
- * @param {string} accounts - The account addresses.
+ * @param {Array<string>} accounts - The account addresses.
  * @returns {object} The generated AccountsController state.
  */
 function generateAccountsControllerState(accounts) {
@@ -246,7 +251,7 @@ function generateNetworkControllerState() {
 /**
  * Generates the state for the PreferencesController.
  *
- * @param {string} accounts - The account addresses.
+ * @param {Array<string>} accounts - The account addresses.
  * @returns {object} The generated PreferencesController state.
  */
 function generatePreferencesControllerState(accounts) {

--- a/app/scripts/migrations/167.ts
+++ b/app/scripts/migrations/167.ts
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash';
 import { hasProperty, isObject } from '@metamask/utils';
+import { getManifestFlags } from '../../../shared/lib/manifestFlags';
 
 type VersionedData = {
   meta: { version: number };
@@ -49,17 +50,22 @@ function transformState(
     return state;
   }
 
-  // If we are using `yarn start:with-state` or we're running a test, do not enable syncing
-  if (!process.env.WITH_STATE && !process.env.IN_TEST) {
-    if (hasProperty(userStorageControllerState, 'isBackupAndSyncEnabled')) {
-      // Set isBackupAndSyncEnabled to true for all users.
-      userStorageControllerState.isBackupAndSyncEnabled = true;
-    }
+  if (hasProperty(userStorageControllerState, 'isBackupAndSyncEnabled')) {
+    // Set isBackupAndSyncEnabled to true for all users.
+    userStorageControllerState.isBackupAndSyncEnabled = true;
+  }
 
-    if (hasProperty(userStorageControllerState, 'isAccountSyncingEnabled')) {
-      // Set isAccountSyncingEnabled to true for all users.
-      userStorageControllerState.isAccountSyncingEnabled = true;
-    }
+  if (hasProperty(userStorageControllerState, 'isAccountSyncingEnabled')) {
+    // Set isAccountSyncingEnabled to true for all users.
+    userStorageControllerState.isAccountSyncingEnabled = true;
+  }
+
+  // If we are using `yarn start:with-state` or running an E2E test with generateWalletState, disable all syncing
+  if (process.env.WITH_STATE || getManifestFlags().testing?.disableSync) {
+    userStorageControllerState.isBackupAndSyncEnabled = false;
+    userStorageControllerState.isAccountSyncingEnabled = false;
+    userStorageControllerState.isProfileSyncingEnabled = false;
+    userStorageControllerState.isContactSyncingEnabled = false;
   }
 
   return state;

--- a/app/scripts/migrations/167.ts
+++ b/app/scripts/migrations/167.ts
@@ -49,8 +49,8 @@ function transformState(
     return state;
   }
 
-  // If we are using `yarn start:with-state` do not enable syncing
-  if (!process.env.WITH_STATE) {
+  // If we are using `yarn start:with-state` or we're running a test, do not enable syncing
+  if (!process.env.WITH_STATE && !process.env.IN_TEST) {
     if (hasProperty(userStorageControllerState, 'isBackupAndSyncEnabled')) {
       // Set isBackupAndSyncEnabled to true for all users.
       userStorageControllerState.isBackupAndSyncEnabled = true;

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -79,6 +79,10 @@ export type ManifestFlags = {
      * The public key used to verify deep links
      */
     deepLinkPublicKey?: string;
+    /**
+     * Whether to disable all of the syncing features that get automatically enabled in migrations 158 and 167
+     */
+    disableSync?: boolean;
   };
 };
 

--- a/test/e2e/power-user/power-user.spec.ts
+++ b/test/e2e/power-user/power-user.spec.ts
@@ -1,6 +1,8 @@
 import { generateWalletState } from '../../../app/scripts/fixtures/generate-wallet-state';
 import { withFixtures } from '../helpers';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
+import AccountListPage from '../page-objects/pages/account-list-page';
+import HeaderNavbar from '../page-objects/pages/header-navbar';
 import { Driver } from '../webdriver/driver';
 
 const withState = {
@@ -14,7 +16,7 @@ const withState = {
 };
 
 describe('Power user persona', function () {
-  it('loads and unlocks the wallet', async function () {
+  it('loads the requested number of accounts', async function () {
     await withFixtures(
       {
         title: this.test?.fullTitle(),
@@ -25,6 +27,18 @@ describe('Power user persona', function () {
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithBalanceValidation(driver);
+
+        // Confirm the number of accounts in the account list
+        new HeaderNavbar(driver).openAccountMenu();
+        const accountListPage = new AccountListPage(driver);
+        await accountListPage.checkNumberOfAvailableAccounts(
+          withState.withAccounts,
+        );
+
+        // Confirm that the last account is displayed in the account list
+        await accountListPage.checkAccountDisplayedInAccountList(
+          `Account ${withState.withAccounts}`,
+        );
       },
     );
   });

--- a/test/e2e/power-user/power-user.spec.ts
+++ b/test/e2e/power-user/power-user.spec.ts
@@ -1,0 +1,28 @@
+import { generateWalletState } from '../../../app/scripts/fixtures/generate-wallet-state';
+import { withFixtures } from '../helpers';
+import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
+import { Driver } from '../webdriver/driver';
+
+const withState = {
+  withAccounts: 30,
+  withConfirmedTransactions: 40,
+  withContacts: 40,
+  withErc20Tokens: true,
+  withNetworks: true,
+  withPreferences: true,
+  withUnreadNotifications: 15,
+};
+
+describe('Power user persona', function () {
+  it('loads and unlocks the wallet', async function () {
+    await withFixtures(
+      {
+        title: this.test?.fullTitle(),
+        fixtures: (await generateWalletState(withState, true)).build(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithBalanceValidation(driver);
+      },
+    );
+  });
+});

--- a/test/e2e/power-user/power-user.spec.ts
+++ b/test/e2e/power-user/power-user.spec.ts
@@ -19,6 +19,9 @@ describe('Power user persona', function () {
       {
         title: this.test?.fullTitle(),
         fixtures: (await generateWalletState(withState, true)).build(),
+        manifestFlags: {
+          testing: { disableSync: true },
+        },
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithBalanceValidation(driver);

--- a/test/e2e/set-manifest-flags.ts
+++ b/test/e2e/set-manifest-flags.ts
@@ -60,7 +60,10 @@ export async function setManifestFlags(flags: ManifestFlags = {}) {
     delete manifest.key;
   }
 
-  fs.writeFileSync(`${folder}/manifest.json`, JSON.stringify(manifest));
+  fs.writeFileSync(
+    `${folder}/manifest.json`,
+    JSON.stringify(manifest, null, 2),
+  );
 }
 
 export function getManifestVersion(): number {


### PR DESCRIPTION
## **Description**

Puts the hooks in so that `generateWalletState`, previously only called from `yarn start:with-state`, can also be called from an E2E test's fixtures.

Adds the E2E test `Power user persona loads the requested number of accounts`, mostly to make sure the hooks are working.

In future PRs, will link benchmarks up to this.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: MetaMask/MetaMask-planning#5383

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->