### PR TITLE
fix: Remove hover state when `SnapUISelector` is disabled

### DIFF
--- a/ui/components/app/snaps/snap-ui-selector/index.scss
+++ b/ui/components/app/snaps/snap-ui-selector/index.scss
@@ -11,7 +11,7 @@
       width: 100%;
     }
 
-    &:hover {
+    &:hover:not([disabled]) {
       background-color: var(--color-background-alternative-hover);
       border-color: var(--color-border-default);
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Disable the hover state when `SnapUISelector` is disabled.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34964?quickstart=1)


## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/32368
