### PR TITLE
feat: Add the selection process for multichain accounts

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3689,6 +3689,11 @@ export default class MetamaskController extends EventEmitter {
         this.accountsController.setAccountName(account.id, label);
       },
 
+      // AccountTreeController
+      setSelectedMultichainAccount: (accountGroupId) => {
+        this.accountTreeController.setSelectedAccountGroup(accountGroupId);
+      },
+
       // AssetsContractController
       getTokenStandardAndDetails: this.getTokenStandardAndDetails.bind(this),
       getTokenSymbol: this.getTokenSymbol.bind(this),

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -549,7 +549,7 @@
                 "07c2cfec-36c9-46c4-8115-3836d3ac9047"
               ],
               "metadata": {
-                "name": "Default",
+                "name": "Account 1",
                 "entropy": {
                   "groupIndex": 0
                 },
@@ -574,7 +574,7 @@
               "type": "multichain-account",
               "accounts": ["784225f4-d30b-4e77-a900-c8bbce735b88"],
               "metadata": {
-                "name": "Default",
+                "name": "Account 2",
                 "hidden": false,
                 "pinned": false,
                 "entropy": {
@@ -599,7 +599,7 @@
               "type": "single-account",
               "accounts": ["15e69915-2a1a-4019-93b3-916e11fd432f"],
               "metadata": {
-                "name": "Default",
+                "name": "Ledger Account 1",
                 "hidden": false,
                 "pinned": false
               }
@@ -621,7 +621,7 @@
               "type": "single-account",
               "accounts": ["694225f4-d30b-4e77-a900-c8bbce735b42"],
               "metadata": {
-                "name": "Default",
+                "name": "Another Snap Account 1",
                 "hidden": false,
                 "pinned": false
               }
@@ -643,7 +643,7 @@
               "type": "single-account",
               "accounts": ["c3deeb99-ba0d-4a4e-a0aa-033fc1f79ae3"],
               "metadata": {
-                "name": "Default",
+                "name": "Snap Account 1",
                 "hidden": false,
                 "pinned": false
               }

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MultichainAccountCell } from './multichain-account-cell';
+import {
+  MultichainAccountCell,
+  MultichainAccountCellProps,
+} from './multichain-account-cell';
 
 describe('MultichainAccountCell', () => {
-  const defaultProps = {
-    accountId: '0x1234567890abcdef',
+  const defaultProps: MultichainAccountCellProps = {
+    accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
     accountName: 'Test Account',
     balance: '$2,400.00',
     endAccessory: <span data-testid="end-accessory">More</span>,
@@ -14,7 +17,7 @@ describe('MultichainAccountCell', () => {
     render(<MultichainAccountCell {...defaultProps} />);
 
     const cellElement = screen.getByTestId(
-      'multichain-account-cell-0x1234567890abcdef',
+      `multichain-account-cell-${defaultProps.accountId}`,
     );
     expect(cellElement).toBeInTheDocument();
 
@@ -24,7 +27,7 @@ describe('MultichainAccountCell', () => {
 
     expect(
       screen.queryByTestId(
-        'multichain-account-cell-0x1234567890abcdef-selected-icon',
+        `multichain-account-cell-${defaultProps.accountId}-selected-icon`,
       ),
     ).not.toBeInTheDocument();
   });
@@ -34,7 +37,7 @@ describe('MultichainAccountCell', () => {
 
     expect(
       screen.getByTestId(
-        'multichain-account-cell-0x1234567890abcdef-selected-icon',
+        `multichain-account-cell-${defaultProps.accountId}-selected-icon`,
       ),
     ).toBeInTheDocument();
 
@@ -54,7 +57,7 @@ describe('MultichainAccountCell', () => {
     render(<MultichainAccountCell {...defaultProps} onClick={handleClick} />);
 
     const cellElement = screen.getByTestId(
-      'multichain-account-cell-0x1234567890abcdef',
+      `multichain-account-cell-${defaultProps.accountId}`,
     );
 
     expect(cellElement.style.cursor).toBe('pointer');
@@ -66,7 +69,7 @@ describe('MultichainAccountCell', () => {
   it('renders correctly without optional props', () => {
     render(
       <MultichainAccountCell
-        accountId="0xabc123"
+        accountId={defaultProps.accountId}
         accountName="Minimal Account"
         balance="$100"
       />,
@@ -81,7 +84,9 @@ describe('MultichainAccountCell', () => {
     expect(endAccessoryContainer).toBeInTheDocument();
     expect(endAccessoryContainer?.children.length).toBe(0);
 
-    const cellElement = screen.getByTestId('multichain-account-cell-0xabc123');
+    const cellElement = screen.getByTestId(
+      `multichain-account-cell-${defaultProps.accountId}`,
+    );
     expect(cellElement.style.cursor).toBe('default');
   });
 
@@ -89,7 +94,7 @@ describe('MultichainAccountCell', () => {
     const handleClick = jest.fn();
     render(
       <MultichainAccountCell
-        accountId="0xfull789"
+        accountId={defaultProps.accountId}
         accountName="Complete Account"
         balance="$1,234.56"
         onClick={handleClick}
@@ -102,7 +107,9 @@ describe('MultichainAccountCell', () => {
     expect(screen.getByText('$1,234.56')).toBeInTheDocument();
     expect(screen.getByTestId('end-accessory')).toBeInTheDocument();
     expect(
-      screen.getByTestId('multichain-account-cell-0xfull789-selected-icon'),
+      screen.getByTestId(
+        `multichain-account-cell-${defaultProps.accountId}-selected-icon`,
+      ),
     ).toBeInTheDocument();
 
     const avatarContainer = document.querySelector(
@@ -110,7 +117,9 @@ describe('MultichainAccountCell', () => {
     );
     expect(avatarContainer).toHaveClass('mm-box--border-color-primary-default');
 
-    const cellElement = screen.getByTestId('multichain-account-cell-0xfull789');
+    const cellElement = screen.getByTestId(
+      `multichain-account-cell-${defaultProps.accountId}`,
+    );
     expect(cellElement.style.cursor).toBe('pointer');
 
     fireEvent.click(cellElement);

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -37,11 +37,7 @@ export const MultichainAccountCell = ({
   endAccessory,
   selected = false,
 }: MultichainAccountCellProps) => {
-  const handleClick = () => {
-    if (onClick) {
-      onClick(accountId);
-    }
-  };
+  const handleClick = () => onClick?.(accountId);
 
   return (
     <Box

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AccountGroupId } from '@metamask/account-api';
 import {
   AvatarAccount,
   AvatarAccountSize,
@@ -20,9 +21,9 @@ import {
 } from '../../../helpers/constants/design-system';
 
 export type MultichainAccountCellProps = {
-  accountId: string;
+  accountId: AccountGroupId;
   accountName: string;
-  onClick?: () => void;
+  onClick?: (accountGroupId: AccountGroupId) => void;
   balance: string;
   endAccessory?: React.ReactNode;
   selected?: boolean;
@@ -36,6 +37,12 @@ export const MultichainAccountCell = ({
   endAccessory,
   selected = false,
 }: MultichainAccountCellProps) => {
+  const handleClick = () => {
+    if (onClick) {
+      onClick(accountId);
+    }
+  };
+
   return (
     <Box
       backgroundColor={BackgroundColor.backgroundDefault}
@@ -46,7 +53,7 @@ export const MultichainAccountCell = ({
         cursor: onClick ? 'pointer' : 'default',
       }}
       padding={4}
-      onClick={onClick}
+      onClick={handleClick}
       className="multichain-account-cell"
       data-testid={`multichain-account-cell-${accountId}`}
       key={`multichain-account-cell-${accountId}`}

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.stories.tsx
@@ -1,78 +1,27 @@
 import { StoryObj, Meta } from '@storybook/react';
+import { Provider } from 'react-redux';
 import {
   MultichainAccountList,
   type MultichainAccountListProps,
 } from './multichain-account-list';
 import { AccountGroupId } from '@metamask/account-api';
 import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
-import { AccountWalletMetadata } from '@metamask/account-tree-controller';
+import React from 'react';
+import mockState from '../../../../test/data/mock-state.json';
+import configureStore from '../../../store/store';
 
-const mockWallets: AccountTreeWallets = {
-  'entropy:01K1100EDPEV57BY4136X5CBEJ': {
-    id: 'entropy:01K1100EDPEV57BY4136X5CBEJ',
-    groups: {
-      'entropy:01K1100EDPEV57BY4136X5CBEJ/0': {
-        id: 'entropy:01K1100EDPEV57BY4136X5CBEJ/0',
-        accounts: [
-          '09956ce0-ab75-4716-9dad-0ed0b1d58eaf',
-          '784f976c-8c14-4eee-90c1-75f7071edb49',
-        ],
-        metadata: {
-          name: 'Account 1',
-        },
-      },
-      'entropy:01K1100EDPEV57BY4136X5CBEJ/1': {
-        id: 'entropy:01K1100EDPEV57BY4136X5CBEJ/1',
-        accounts: ['b392b97b-13a2-4c70-a6ae-cd781a3f7048'],
-        metadata: {
-          name: 'Account 2',
-        },
-      },
-    },
-    metadata: {
-      name: 'Wallet 1',
-      type: 'entropy',
-      entropy: {
-        id: '01K1100EDPEV57BY4136X5CBEJ',
-        index: 0,
-      },
-    } as AccountWalletMetadata,
-  },
-  'snap:npm:@metamask/bitcoin-wallet-snap': {
-    id: 'snap:npm:@metamask/bitcoin-wallet-snap',
-    groups: {
-      'snap:npm:@metamask/bitcoin-wallet-snap/bc1qfp0kcnpgmp0t96nsawtl2n0vm2jdrcrvv3cvjr':
-        {
-          id: 'snap:npm:@metamask/bitcoin-wallet-snap/bc1qfp0kcnpgmp0t96nsawtl2n0vm2jdrcrvv3cvjr',
-          accounts: ['26f57559-e378-4c3d-b523-9398155ced41'],
-          metadata: {
-            name: 'Bitcoin Account 1',
-          },
-        },
-      'snap:npm:@metamask/bitcoin-wallet-snap/bc1qf6devcwfq2d5nup8j6w2c27jp8ddtpkqx3y0lt':
-        {
-          id: 'snap:npm:@metamask/bitcoin-wallet-snap/bc1qf6devcwfq2d5nup8j6w2c27jp8ddtpkqx3y0lt',
-          accounts: ['6f1f5ae7-e971-462d-9fa3-b4d789881bbd'],
-          metadata: {
-            name: 'Bitcoin Account 3',
-          },
-        },
-    },
-    metadata: {
-      name: 'Bitcoin',
-      type: 'snap',
-      snap: {
-        id: 'npm:@metamask/bitcoin-wallet-snap',
-      },
-    } as AccountWalletMetadata,
-  },
-};
+const mockSelectedAccountGroup = mockState.metamask.accountTree
+  .selectedAccountGroup as AccountGroupId;
 
 const defaultArgs: MultichainAccountListProps = {
-  wallets: mockWallets,
-  selectedAccountGroup:
-    'entropy:01K1100EDPEV57BY4136X5CBEJ/0' as AccountGroupId,
+  wallets: mockState.metamask.accountTree
+    .wallets as unknown as AccountTreeWallets,
+  selectedAccountGroup: mockSelectedAccountGroup,
 };
+
+const store = configureStore({
+  metamask: mockState.metamask,
+});
 
 const meta: Meta<typeof MultichainAccountList> = {
   title: 'Components/MultichainAccounts/MultichainAccountList',
@@ -82,6 +31,13 @@ const meta: Meta<typeof MultichainAccountList> = {
       default: 'light',
     },
   },
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <Story />
+      </Provider>
+    ),
+  ],
 };
 
 export default meta;

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -10,10 +10,23 @@ import { AccountTreeWallets } from '../../../selectors/multichain-accounts/accou
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import configureStore from '../../../store/store';
 import mockDefaultState from '../../../../test/data/mock-state.json';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import {
   MultichainAccountList,
   MultichainAccountListProps,
 } from './multichain-account-list';
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+  return {
+    ...original,
+    useHistory: () => ({
+      push: mockHistoryPush,
+    }),
+  };
+});
 
 jest.mock('../../../store/actions', () => {
   const actualActions = jest.requireActual('../../../store/actions');
@@ -164,6 +177,7 @@ describe('MultichainAccountList', () => {
     expect(mockSetSelectedMultichainAccount).toHaveBeenCalledWith(
       walletTwoGroupId,
     );
+    expect(mockHistoryPush).toHaveBeenCalledWith(DEFAULT_ROUTE);
   });
 
   it('updates selected account when selectedAccountGroup changes', () => {

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import {
   AccountGroupType,
   AccountWalletType,
@@ -7,11 +7,31 @@ import {
   toDefaultAccountGroupId,
 } from '@metamask/account-api';
 import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import configureStore from '../../../store/store';
+import mockDefaultState from '../../../../test/data/mock-state.json';
 import {
   MultichainAccountList,
   MultichainAccountListProps,
 } from './multichain-account-list';
 
+jest.mock('../../../store/actions', () => {
+  const actualActions = jest.requireActual('../../../store/actions');
+  const mockSetSelectedMultichainAccount = jest.fn().mockImplementation(() => {
+    return async function () {
+      await Promise.resolve();
+    };
+  });
+
+  return {
+    ...actualActions,
+    setSelectedMultichainAccount: mockSetSelectedMultichainAccount,
+  };
+});
+
+const mockSetSelectedMultichainAccount = jest.requireMock(
+  '../../../store/actions',
+).setSelectedMultichainAccount;
 const mockWalletOneEntropySource = '01JKAF3DSGM3AB87EM9N0K41AJ';
 const mockWalletTwoEntropySource = '01JKAF3PJ247KAM6C03G5Q0NP8';
 
@@ -86,8 +106,17 @@ describe('MultichainAccountList', () => {
   };
 
   const renderComponent = (props = {}) => {
-    return render(<MultichainAccountList {...defaultProps} {...props} />);
+    const store = configureStore(mockDefaultState);
+
+    return renderWithProvider(
+      <MultichainAccountList {...defaultProps} {...props} />,
+      store,
+    );
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('renders wallet headers and account cells correctly', () => {
     renderComponent();
@@ -111,9 +140,10 @@ describe('MultichainAccountList', () => {
     expect(screen.getByText('Account 1 from wallet 2')).toBeInTheDocument();
   });
 
-  it('marks only the selected account with a check icon', () => {
+  it('marks only the selected account with a check icon and dispatches action on click', () => {
     renderComponent();
 
+    // Check that the correct account is initially selected
     const selectedAccountIcon = screen.getByTestId(
       `multichain-account-cell-${walletOneGroupId}-selected-icon`,
     );
@@ -123,6 +153,17 @@ describe('MultichainAccountList', () => {
         `multichain-account-cell-${walletTwoGroupId}-selected-icon`,
       ),
     ).not.toBeInTheDocument();
+
+    // Find and click the second account cell (wallet two)
+    const accountCell = screen.getByTestId(
+      `multichain-account-cell-${walletTwoGroupId}`,
+    );
+    accountCell.click();
+
+    // Verify that the action was dispatched with the correct account group ID
+    expect(mockSetSelectedMultichainAccount).toHaveBeenCalledWith(
+      walletTwoGroupId,
+    );
   });
 
   it('updates selected account when selectedAccountGroup changes', () => {

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { AccountGroupId } from '@metamask/account-api';
+import { useDispatch } from 'react-redux';
 import { Box, Text } from '../../component-library';
 
 import {
@@ -12,6 +13,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { MultichainAccountCell } from '../multichain-account-cell';
 import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+import { setSelectedMultichainAccount } from '../../../store/actions';
 
 export type MultichainAccountListProps = {
   wallets: AccountTreeWallets;
@@ -22,6 +24,12 @@ export const MultichainAccountList = ({
   wallets,
   selectedAccountGroup,
 }: MultichainAccountListProps) => {
+  const dispatch = useDispatch();
+
+  const handleAccountClick = (accountGroupId: AccountGroupId) => {
+    dispatch(setSelectedMultichainAccount(accountGroupId));
+  };
+
   const walletTree = useMemo(() => {
     return Object.entries(wallets).reduce(
       (walletsAccumulator, [walletId, walletData]) => {
@@ -54,10 +62,11 @@ export const MultichainAccountList = ({
             return [
               <MultichainAccountCell
                 key={`multichain-account-cell-${groupId}`}
-                accountId={groupId}
+                accountId={groupId as AccountGroupId}
                 accountName={groupData.metadata.name}
                 balance="$ n/a"
                 selected={selectedAccountGroup === groupId}
+                onClick={handleAccountClick}
               />,
             ];
           },

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -48,33 +48,33 @@ export const MultichainAccountList = ({
   );
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
 
-  const handleAccountClick = (accountGroupId: AccountGroupId) => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Navigation,
-      event: MetaMetricsEventName.NavAccountSwitched,
-      properties: {
-        location: 'Main Menu',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        hd_entropy_index: hdEntropyIndex,
-      },
-    });
-    endTrace({
-      name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[
-        defaultHomeActiveTabName
-      ],
-    });
-    trace({
-      name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[
-        defaultHomeActiveTabName
-      ],
-    });
-
-    dispatch(setSelectedMultichainAccount(accountGroupId));
-    history.push(DEFAULT_ROUTE);
-  };
-
   const walletTree = useMemo(() => {
+    const handleAccountClick = (accountGroupId: AccountGroupId) => {
+      trackEvent({
+        category: MetaMetricsEventCategory.Navigation,
+        event: MetaMetricsEventName.NavAccountSwitched,
+        properties: {
+          location: 'Main Menu',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          hd_entropy_index: hdEntropyIndex,
+        },
+      });
+      endTrace({
+        name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[
+          defaultHomeActiveTabName
+        ],
+      });
+      trace({
+        name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[
+          defaultHomeActiveTabName
+        ],
+      });
+
+      dispatch(setSelectedMultichainAccount(accountGroupId));
+      history.push(DEFAULT_ROUTE);
+    };
+
     return Object.entries(wallets).reduce(
       (walletsAccumulator, [walletId, walletData]) => {
         const walletName = walletData.metadata?.name;
@@ -120,7 +120,15 @@ export const MultichainAccountList = ({
       },
       [] as React.ReactNode[],
     );
-  }, [wallets, selectedAccountGroup]);
+  }, [
+    wallets,
+    trackEvent,
+    hdEntropyIndex,
+    defaultHomeActiveTabName,
+    dispatch,
+    history,
+    selectedAccountGroup,
+  ]);
 
   return <>{walletTree}</>;
 };

--- a/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
+++ b/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
@@ -29,6 +29,7 @@ exports[`AccountPicker renders properly 1`] = `
           </div>
           <span
             class="mm-box mm-text multichain-account-picker__label mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-default"
+            style="font-weight: medium;"
           >
             Account 1
           </span>

--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -18,6 +18,7 @@ import {
   BorderRadius,
   Display,
   FlexDirection,
+  FontWeight,
   IconColor,
   Size,
   TextColor,
@@ -25,7 +26,10 @@ import {
 } from '../../../helpers/constants/design-system';
 import { shortenAddress } from '../../../helpers/utils/util';
 import { trace, TraceName } from '../../../../shared/lib/trace';
-import { getUseBlockie } from '../../../selectors';
+import {
+  getIsMultichainAccountsState2Enabled,
+  getUseBlockie,
+} from '../../../selectors';
 
 const AccountMenuStyle = { height: 'auto' };
 
@@ -49,6 +53,9 @@ export const AccountPicker = ({
   const shortenedAddress = address
     ? shortenAddress(toChecksumHexAddress(address))
     : '';
+  const isMultichainAccountsState2Enabled = useSelector(
+    getIsMultichainAccountsState2Enabled,
+  );
 
   return (
     <Box
@@ -106,12 +113,21 @@ export const AccountPicker = ({
           <Text
             as="span"
             ellipsis
-            variant={TextVariant.bodyMdMedium}
+            variant={
+              isMultichainAccountsState2Enabled
+                ? TextVariant.bodyLgMedium
+                : TextVariant.bodyMdMedium
+            }
             {...labelProps}
             className={classnames(
               'multichain-account-picker__label',
               labelProps.className ?? '',
             )}
+            style={{
+              fontWeight: isMultichainAccountsState2Enabled
+                ? 600
+                : FontWeight.Medium,
+            }}
           >
             {name}
             {showAddress ? (

--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -124,6 +124,7 @@ export const AccountPicker = ({
               labelProps.className ?? '',
             )}
             style={{
+              ...labelProps.style,
               fontWeight: isMultichainAccountsState2Enabled
                 ? 600
                 : FontWeight.Medium,

--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
@@ -57,6 +57,22 @@ export const AccountPicker = ({
     getIsMultichainAccountsState2Enabled,
   );
 
+  const accountNameStyling = useMemo(
+    () => ({
+      ...labelProps.style,
+      fontWeight: isMultichainAccountsState2Enabled ? 600 : FontWeight.Medium,
+    }),
+    [isMultichainAccountsState2Enabled, labelProps.style],
+  );
+
+  const accountNameFontVariant = useMemo(
+    () =>
+      isMultichainAccountsState2Enabled
+        ? TextVariant.bodyLgMedium
+        : TextVariant.bodyMdMedium,
+    [isMultichainAccountsState2Enabled],
+  );
+
   return (
     <Box
       display={Display.Flex}
@@ -113,22 +129,13 @@ export const AccountPicker = ({
           <Text
             as="span"
             ellipsis
-            variant={
-              isMultichainAccountsState2Enabled
-                ? TextVariant.bodyLgMedium
-                : TextVariant.bodyMdMedium
-            }
+            variant={accountNameFontVariant}
             {...labelProps}
             className={classnames(
               'multichain-account-picker__label',
               labelProps.className ?? '',
             )}
-            style={{
-              ...labelProps.style,
-              fontWeight: isMultichainAccountsState2Enabled
-                ? 600
-                : FontWeight.Medium,
-            }}
+            style={accountNameStyling}
           >
             {name}
             {showAddress ? (

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -161,6 +161,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                 >
                   <span
                     class="mm-box mm-text multichain-account-picker__label mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-default"
+                    style="font-weight: medium;"
                   >
                     Test Account
                   </span>

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -204,15 +204,17 @@ export const AppHeaderUnlockedContent = ({
 
     return (
       <>
-        <AvatarAccount
-          variant={
-            useBlockie
-              ? AvatarAccountVariant.Blockies
-              : AvatarAccountVariant.Jazzicon
-          }
-          address={internalAccount.address}
-          size={AvatarAccountSize.Md}
-        />
+        {!isMultichainAccountsState2Enabled && (
+          <AvatarAccount
+            variant={
+              useBlockie
+                ? AvatarAccountVariant.Blockies
+                : AvatarAccountVariant.Jazzicon
+            }
+            address={internalAccount.address}
+            size={AvatarAccountSize.Md}
+          />
+        )}
         {internalAccount && (
           <Text
             as="div"
@@ -240,7 +242,7 @@ export const AppHeaderUnlockedContent = ({
               paddingLeft={2}
               paddingRight={2}
             />
-            <>{CopyButton}</>
+            <>{!isMultichainAccountsState2Enabled && CopyButton}</>
           </Text>
         )}
       </>

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -110,7 +110,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                   </div>
                   <span
                     class="mm-box mm-text multichain-account-picker__label multichain-send-page__account-picker__label mm-text--body-md-medium mm-text--ellipsis mm-box--padding-inline-start-1 mm-box--color-text-default"
-                    style="flex-grow: 1; text-align: start;"
+                    style="font-weight: medium;"
                   >
                     Test Account
                     <p

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -110,7 +110,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                   </div>
                   <span
                     class="mm-box mm-text multichain-account-picker__label multichain-send-page__account-picker__label mm-text--body-md-medium mm-text--ellipsis mm-box--padding-inline-start-1 mm-box--color-text-default"
-                    style="font-weight: medium;"
+                    style="flex-grow: 1; text-align: start; font-weight: medium;"
                   >
                     Test Account
                     <p

--- a/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`SendPageAccountPicker render renders correctly 1`] = `
             </div>
             <span
               class="mm-box mm-text multichain-account-picker__label multichain-send-page__account-picker__label mm-text--body-md-medium mm-text--ellipsis mm-box--padding-inline-start-1 mm-box--color-text-default"
-              style="font-weight: medium;"
+              style="flex-grow: 1; text-align: start; font-weight: medium;"
             >
               Test Account
               <p

--- a/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`SendPageAccountPicker render renders correctly 1`] = `
             </div>
             <span
               class="mm-box mm-text multichain-account-picker__label multichain-send-page__account-picker__label mm-text--body-md-medium mm-text--ellipsis mm-box--padding-inline-start-1 mm-box--color-text-default"
-              style="flex-grow: 1; text-align: start;"
+              style="font-weight: medium;"
             >
               Test Account
               <p

--- a/ui/pages/multichain-accounts/account-list/account-list.stories.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.stories.tsx
@@ -3,146 +3,25 @@ import { StoryObj, Meta } from '@storybook/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { AccountList } from './account-list';
-import { configureStore } from '@reduxjs/toolkit';
+import mockState from '../../../../test/data/mock-state.json';
+import configureStore from '../../../store/store';
 
-const mockAccountTree = {
-  wallets: {
-    'entropy:01K1100EDPEV57BY4136X5CBEJ': {
-      id: 'entropy:01K1100EDPEV57BY4136X5CBEJ',
-      groups: {
-        'entropy:01K1100EDPEV57BY4136X5CBEJ/0': {
-          id: 'entropy:01K1100EDPEV57BY4136X5CBEJ/0',
-          accounts: [
-            '09956ce0-ab75-4716-9dad-0ed0b1d58eaf',
-            '784f976c-8c14-4eee-90c1-75f7071edb49',
-          ],
-          metadata: {
-            name: 'Account 1',
-          },
-        },
-        'entropy:01K1100EDPEV57BY4136X5CBEJ/1': {
-          id: 'entropy:01K1100EDPEV57BY4136X5CBEJ/1',
-          accounts: ['b392b97b-13a2-4c70-a6ae-cd781a3f7048'],
-          metadata: {
-            name: 'Account 2',
-          },
-        },
-        'entropy:01K1100EDPEV57BY4136X5CBEJ/2': {
-          id: 'entropy:01K1100EDPEV57BY4136X5CBEJ/2',
-          accounts: ['de8c7954-3575-42f3-9db7-b7da669a9b56'],
-          metadata: {
-            name: 'Account 3',
-          },
-        },
-      },
-      metadata: {
-        name: 'Wallet 1',
-        type: 'entropy',
-        entropy: {
-          id: '01K1100EDPEV57BY4136X5CBEJ',
-          index: 0,
-        },
-      },
-    },
-    'snap:npm:@metamask/bitcoin-wallet-snap': {
-      id: 'snap:npm:@metamask/bitcoin-wallet-snap',
-      groups: {
-        'snap:npm:@metamask/bitcoin-wallet-snap/bc1qfp0kcnpgmp0t96nsawtl2n0vm2jdrcrvv3cvjr':
-          {
-            id: 'snap:npm:@metamask/bitcoin-wallet-snap/bc1qfp0kcnpgmp0t96nsawtl2n0vm2jdrcrvv3cvjr',
-            accounts: ['26f57559-e378-4c3d-b523-9398155ced41'],
-            metadata: {
-              name: 'Bitcoin Account 1',
-            },
-          },
-        'snap:npm:@metamask/bitcoin-wallet-snap/bc1qf6devcwfq2d5nup8j6w2c27jp8ddtpkqx3y0lt':
-          {
-            id: 'snap:npm:@metamask/bitcoin-wallet-snap/bc1qf6devcwfq2d5nup8j6w2c27jp8ddtpkqx3y0lt',
-            accounts: ['6f1f5ae7-e971-462d-9fa3-b4d789881bbd'],
-            metadata: {
-              name: 'Bitcoin Account 3',
-            },
-          },
-      },
-      metadata: {
-        name: 'Bitcoin',
-        type: 'snap',
-        snap: {
-          id: 'npm:@metamask/bitcoin-wallet-snap',
-        },
-      },
-    },
-    'snap:npm:@metamask/snap-simple-keyring-snap': {
-      id: 'snap:npm:@metamask/snap-simple-keyring-snap',
-      groups: {
-        'snap:npm:@metamask/snap-simple-keyring-snap/0x6de4728d5d625ee2c583f6ed589654e2155674f2':
-          {
-            id: 'snap:npm:@metamask/snap-simple-keyring-snap/0x6de4728d5d625ee2c583f6ed589654e2155674f2',
-            accounts: ['afb3d49c-61e1-4cd2-9fbf-749842c303f7'],
-            metadata: {
-              name: 'SSK Account',
-            },
-          },
-      },
-      metadata: {
-        name: 'MetaMask Simple Snap Keyring',
-        type: 'snap',
-        snap: {
-          id: 'npm:@metamask/snap-simple-keyring-snap',
-        },
-      },
-    },
-    'entropy:01K1FTF5X0KT76Q2XCPVZ75QE3': {
-      id: 'entropy:01K1FTF5X0KT76Q2XCPVZ75QE3',
-      groups: {
-        'entropy:01K1FTF5X0KT76Q2XCPVZ75QE3/0': {
-          id: 'entropy:01K1FTF5X0KT76Q2XCPVZ75QE3/0',
-          accounts: [
-            'fc6c40ef-5394-46cb-a700-b874693b84bf',
-            'e25fb335-4018-4406-8681-e619538ceccc',
-          ],
-          metadata: {
-            name: 'Account From Wallet 2',
-          },
-        },
-      },
-      metadata: {
-        name: 'Wallet 2',
-        type: 'entropy',
-        entropy: {
-          id: '01K1FTF5X0KT76Q2XCPVZ75QE3',
-          index: 1,
-        },
-      },
-    },
+const store = configureStore({
+  metamask: {
+    ...mockState.metamask,
   },
-  selectedAccountGroup: 'entropy:01K1100EDPEV57BY4136X5CBEJ/0',
-};
-
-const createMockStore = (accountTree = mockAccountTree) => {
-  return configureStore({
-    reducer: {
-      metamask: () => ({
-        accountTree,
-      }),
-    },
-  });
-};
-
-type Store = ReturnType<typeof createMockStore>;
+});
 
 interface WrapperProps {
   children: ReactNode;
-  store?: Store;
   initialEntries?: string[];
 }
 
 const Wrapper: React.FC<WrapperProps> = ({
   children,
-  store,
   initialEntries = ['/accounts'],
 }) => (
-  <Provider store={store || createMockStore()}>
+  <Provider store={store}>
     <MemoryRouter initialEntries={initialEntries}>
       <Route path="*">{children}</Route>
     </MemoryRouter>
@@ -153,8 +32,8 @@ const meta: Meta<typeof AccountList> = {
   title: 'Pages/MultichainAccounts/AccountList',
   component: AccountList,
   decorators: [
-    (Story, context) => (
-      <Wrapper store={context.parameters.store}>
+    (Story) => (
+      <Wrapper>
         <Story />
       </Wrapper>
     ),
@@ -169,11 +48,7 @@ const meta: Meta<typeof AccountList> = {
 export default meta;
 type Story = StoryObj<typeof AccountList>;
 
-export const Default: Story = {
-  parameters: {
-    store: createMockStore(),
-  },
-};
+export const Default: Story = {};
 
 Default.parameters = {
   docs: {

--- a/ui/selectors/multichain-accounts/account-tree.test.ts
+++ b/ui/selectors/multichain-accounts/account-tree.test.ts
@@ -90,7 +90,7 @@ describe('Multichain Accounts Selectors', () => {
                 },
               ],
               metadata: {
-                name: 'Default',
+                name: 'Account 1',
                 entropy: {
                   groupIndex: 0,
                 },
@@ -143,7 +143,7 @@ describe('Multichain Accounts Selectors', () => {
                 },
               ],
               metadata: {
-                name: 'Default',
+                name: 'Account 2',
                 entropy: {
                   groupIndex: 0,
                 },
@@ -195,7 +195,7 @@ describe('Multichain Accounts Selectors', () => {
                   },
                 ],
                 metadata: {
-                  name: 'Default',
+                  name: 'Another Snap Account 1',
                   pinned: false,
                   hidden: false,
                 },
@@ -244,7 +244,7 @@ describe('Multichain Accounts Selectors', () => {
                   },
                 ],
                 metadata: {
-                  name: 'Default',
+                  name: 'Ledger Account 1',
                   pinned: false,
                   hidden: false,
                 },
@@ -297,7 +297,7 @@ describe('Multichain Accounts Selectors', () => {
                 },
               ],
               metadata: {
-                name: 'Default',
+                name: 'Snap Account 1',
                 pinned: false,
                 hidden: false,
               },

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -1354,6 +1354,38 @@ describe('Actions', () => {
         ),
       ).toBe(true);
     });
+
+    it('handles gracefully when setSelectedMultichainAccount throws', async () => {
+      const store = mockStore({
+        activeTab: {},
+        metamask: {
+          alertEnabledness: {},
+          accountTree: {},
+        },
+      });
+
+      const setSelectedMultichainAccountSpy = sinon
+        .stub()
+        .rejects(new Error('error'));
+
+      background.getApi.returns({
+        setSelectedMultichainAccount: setSelectedMultichainAccountSpy,
+      });
+
+      setBackgroundConnection(background.getApi());
+
+      const expectedActions = [
+        { type: 'SHOW_LOADING_INDICATION', payload: undefined },
+        { type: 'HIDE_LOADING_INDICATION' },
+      ];
+
+      await store.dispatch(
+        actions.setSelectedMultichainAccount(
+          'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
+        ),
+      );
+      expect(store.getActions()).toStrictEqual(expectedActions);
+    });
   });
 
   describe('#addToken', () => {

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -1321,6 +1321,41 @@ describe('Actions', () => {
     });
   });
 
+  describe('#setSelectedMultichainAccount', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('#setSelectedMultichainAccount', async () => {
+      const store = mockStore({
+        activeTab: {},
+        metamask: {
+          accountTree: {},
+        },
+      });
+
+      const setSelectedMultichainAccountSpy = sinon.stub().resolves();
+
+      background.getApi.returns({
+        setSelectedMultichainAccount: setSelectedMultichainAccountSpy,
+      });
+
+      setBackgroundConnection(background.getApi());
+
+      await store.dispatch(
+        actions.setSelectedMultichainAccount(
+          'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
+        ),
+      );
+      expect(setSelectedMultichainAccountSpy.callCount).toStrictEqual(1);
+      expect(
+        setSelectedMultichainAccountSpy.calledWith(
+          'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
+        ),
+      ).toBe(true);
+    });
+  });
+
   describe('#addToken', () => {
     afterEach(() => {
       sinon.restore();

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2218,6 +2218,9 @@ export function setSelectedMultichainAccount(
       await submitRequestToBackground('setSelectedMultichainAccount', [
         accountGroupId,
       ]);
+      // Forcing update of the state speeds up the UI update process
+      // and makes UX better
+      await forceUpdateMetamaskState(dispatch);
     } catch (error) {
       logErrorWithMessage(error);
     } finally {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -60,6 +60,7 @@ import { HandlerType } from '@metamask/snaps-utils';
 import { BACKUPANDSYNC_FEATURES } from '@metamask/profile-sync-controller/user-storage';
 import { isInternalAccountInPermittedAccountIds } from '@metamask/chain-agnostic-permission';
 import { AuthConnection } from '@metamask/seedless-onboarding-controller';
+import { AccountGroupId } from '@metamask/account-api';
 import { captureException } from '../../shared/lib/sentry';
 import { switchDirection } from '../../shared/lib/switch-direction';
 import {
@@ -2200,6 +2201,29 @@ export function lockMetamask(): ThunkAction<
 async function _setSelectedInternalAccount(accountId: string): Promise<void> {
   log.debug(`background.setSelectedInternalAccount`);
   await submitRequestToBackground('setSelectedInternalAccount', [accountId]);
+}
+
+/**
+ * Update the selected multichain account.
+ *
+ * @param accountGroupId - ID of an account group representing the multichain account.
+ */
+export function setSelectedMultichainAccount(
+  accountGroupId: AccountGroupId,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async (dispatch, _getState) => {
+    log.debug(`background.setSelectedMultichainAccount`);
+    try {
+      dispatch(showLoadingIndication());
+      await submitRequestToBackground('setSelectedMultichainAccount', [
+        accountGroupId,
+      ]);
+    } catch (error) {
+      logErrorWithMessage(error);
+    } finally {
+      dispatch(hideLoadingIndication());
+    }
+  };
 }
 
 /**


### PR DESCRIPTION
## **Description**
This PR adds functionality for selecting multichain accounts. Changes added enable users to switch between multichain accounts.

Notes: 
- Updates added to the Account Picker and App Header are because the new multichain designs (enabled in state 2) does not use the same designs, so having account avatar and ethereum address would not make sense. It is requested by designers ([check figma](https://www.figma.com/design/G88ChchQ8FINCBI9BBkrAG/BIP-44-Extension?node-id=0-1&p=f&m=dev)). Feature flag checks are temporary.
- Related storybook files are updated and refactored to handle mock store by using shared mocked state.
- Code ownership related changes:
-- `Wallet UX`: Account Picker and Header changes under feature flag. Test snapshots.
-- `Confirmations`: Test snapshots because of the Account Picker changes.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/34989?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added account switching functionality for the multichain accounts

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-427

Designs on Figma: https://www.figma.com/design/G88ChchQ8FINCBI9BBkrAG/BIP-44-Extension?node-id=0-1&p=f&m=dev

## **Manual testing steps**
1. Start MetaMask extension under multichain accounts feature flag turned on for state 2.
2. Open the extension and click on the Account name in the top left corner on the main screen.
3. Try changing selected accounts by clicking on some of them displayed on the multichain accounts list page.
4. Verify that UX/UI around switching accounts is functional and working as expected.

## **Screenshots/Recordings**

### **Before**
Selection for multichain accounts was not available before this PR. Nothing important to show here.

Showing only recording of the UX/UI when feature flag is disabled, so we make sure that previous UI/UX is not affected:

https://github.com/user-attachments/assets/3314eefe-c0b2-470f-aa67-dbce0b963812

### **After**
<img width="399" height="602" alt="Screenshot 2025-08-11 at 12 16 45" src="https://github.com/user-attachments/assets/36c8a419-dfaf-485f-bce1-274ca1f874b4" />

https://github.com/user-attachments/assets/90b05c18-a5c5-408c-8671-1a918bcf8aeb

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.