### PR TITLE
Remove outdated storybook html addon

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -24,7 +24,6 @@ module.exports = {
     '@storybook/addon-knobs',
     './i18n-party-addon/register.js',
     'storybook-dark-mode',
-    '@whitespace/storybook-addon-html',
     '@storybook/addon-mdx-gfm',
     '@storybook/addon-designs',
   ],

--- a/package.json
+++ b/package.json
@@ -559,7 +559,6 @@
     "@typescript-eslint/parser": "^7.10.0",
     "@viem/anvil": "^0.0.10",
     "@welldone-software/why-did-you-render": "^8.0.3",
-    "@whitespace/storybook-addon-html": "^5.1.6",
     "addons-linter": "^6.28.0",
     "autoprefixer": "^10.4.19",
     "axios": "^1.8.2",


### PR DESCRIPTION
Remove `@whitespace/storybook-addon-html` addon to fix broken Storybook stories and remove an unused dependency.

---
[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1754921075041719?thread_ts=1754921075.041719&cid=C0354T27M5M)

<a href="https://cursor.com/background-agent?bcId=bc-7c726061-3dc1-47af-ba35-2634d4021627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c726061-3dc1-47af-ba35-2634d4021627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

