### PR TITLE
chore: Disable transaction resubmit (same is done in mobile)

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.test.ts
@@ -182,4 +182,10 @@ describe('Transaction Controller Init', () => {
 
     expect(isSimulationEnabled?.()).toBe(true);
   });
+
+  it('always disables pending transaction resubmit', () => {
+    const pendingTransactions = testConstructorOption('pendingTransactions');
+
+    expect(pendingTransactions?.isResubmitEnabled?.()).toBe(false);
+  });
 });

--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -8,11 +8,7 @@ import {
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller/dist/types';
 import { Hex } from '@metamask/utils';
-import {
-  getChainSupportsSmartTransactions,
-  getIsSmartTransaction,
-  getSmartTransactionsPreferenceEnabled,
-} from '../../../../shared/modules/selectors';
+import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
 import {
   SmartTransactionHookMessenger,
   publishSmartTransactionHook,
@@ -107,13 +103,7 @@ export const TransactionControllerInit: ControllerInitFunction<
       preferencesController().state.useTransactionSimulations,
     messenger: controllerMessenger,
     pendingTransactions: {
-      isResubmitEnabled: () => {
-        const uiState = getUIState(getFlatState());
-        return !(
-          getSmartTransactionsPreferenceEnabled(uiState) &&
-          getChainSupportsSmartTransactions(uiState)
-        );
-      },
+      isResubmitEnabled: () => false,
     },
     publicKeyEIP7702: process.env.EIP_7702_PUBLIC_KEY as Hex | undefined,
     testGasFeeFlows: Boolean(process.env.TEST_GAS_FEE_FLOWS === 'true'),


### PR DESCRIPTION
## **Description**

Disable transaction resubmit in the extension, since it can lead to transactions being submitted to both Sentinel and as a regular transaction. This was already [done in mobile](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts#L117)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore: Disable transaction resubmit

## **Related issues**

Fixes:

## **Manual testing steps**

Set the global chain to chain A via the UI, then trigger a transaction on a different chain from a dApp. It should never be submitted to Sentinel and as a regular transaction again at the same time, only to one of them.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
