### PR TITLE
fix: skip metametrics if user has already chosen an option

### DIFF
--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -28,6 +28,7 @@ import {
   getParticipateInMetaMetrics,
   getIsSocialLoginFlow,
   getSocialLoginType,
+  getIsParticipateInMetaMetricsSet,
 } from '../../../selectors';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
@@ -82,6 +83,9 @@ export default function CreatePassword({
   const socialLoginType = useSelector(getSocialLoginType);
 
   const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
+  const isParticipateInMetaMetricsSet = useSelector(
+    getIsParticipateInMetaMetricsSet,
+  );
   const metametricsId = useSelector(getMetaMetricsId);
   const base64MetametricsId = Buffer.from(metametricsId ?? '').toString(
     'base64',
@@ -103,7 +107,11 @@ export default function CreatePassword({
         firstTimeFlowType === FirstTimeFlowType.import ||
         firstTimeFlowType === FirstTimeFlowType.socialImport
       ) {
-        history.replace(ONBOARDING_METAMETRICS);
+        history.replace(
+          isParticipateInMetaMetricsSet
+            ? ONBOARDING_COMPLETION_ROUTE
+            : ONBOARDING_METAMETRICS,
+        );
       } else if (firstTimeFlowType === FirstTimeFlowType.socialCreate) {
         if (isFirefox) {
           history.replace(ONBOARDING_COMPLETION_ROUTE);
@@ -125,6 +133,7 @@ export default function CreatePassword({
     firstTimeFlowType,
     newAccountCreationInProgress,
     secretRecoveryPhrase,
+    isParticipateInMetaMetricsSet,
   ]);
 
   const handleLearnMoreClick = (event) => {

--- a/ui/pages/onboarding-flow/create-password/create-password.test.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.js
@@ -6,6 +6,7 @@ import initializedMockState from '../../../../test/data/mock-send-state.json';
 import {
   ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
   ONBOARDING_METAMETRICS,
+  ONBOARDING_COMPLETION_ROUTE,
 } from '../../../helpers/constants/routes';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import CreatePassword from './create-password';
@@ -46,18 +47,36 @@ describe('Onboarding Create Password', () => {
       );
     });
 
-    it('should route to completion when keyring is present and imported first time flow type', () => {
+    it('should route to metametrics when keyring is present and imported first time flow type', () => {
       const importFirstTimeFlowState = {
         ...initializedMockState,
         metamask: {
           ...initializedMockState.metamask,
           firstTimeFlowType: FirstTimeFlowType.import,
+          participateInMetaMetrics: null,
         },
       };
       const mockStore = configureMockStore()(importFirstTimeFlowState);
 
       renderWithProvider(<CreatePassword />, mockStore);
       expect(mockHistoryReplace).toHaveBeenCalledWith(ONBOARDING_METAMETRICS);
+    });
+
+    it('should redirect to onboarding completion when user has imported SRP and set participating in metametrics', () => {
+      const importFirstTimeFlowState = {
+        ...initializedMockState,
+        metamask: {
+          ...initializedMockState.metamask,
+          firstTimeFlowType: FirstTimeFlowType.import,
+          participateInMetaMetrics: true,
+        },
+      };
+      const mockStore = configureMockStore()(importFirstTimeFlowState);
+      renderWithProvider(<CreatePassword />, mockStore);
+
+      expect(mockHistoryReplace).toHaveBeenCalledWith(
+        ONBOARDING_COMPLETION_ROUTE,
+      );
     });
   });
 


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes the onboarding metametrics page still being displayed even after user has selected an option.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35036?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34928

## **Manual testing steps**

1. Create/Import SRP to the wallet.
2. After creating a password, select metametrics option (Yes or No) in the metametrics page.
3. Before completing the onboarding, open a new tab (via extension icon).
4. After unlocking the wallet, user should not see the metametrics screen again.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
