### PR TITLE
feat: get all internal accounts for a given scope (non user facing change)

### DIFF
--- a/ui/selectors/accounts.test.ts
+++ b/ui/selectors/accounts.test.ts
@@ -1,4 +1,10 @@
-import { EthAccountType, EthScope } from '@metamask/keyring-api';
+import {
+  EthAccountType,
+  EthScope,
+  BtcScope,
+  SolScope,
+  CaipChainId,
+} from '@metamask/keyring-api';
 import { ETH_EOA_METHODS } from '../../shared/constants/eth-methods';
 import {
   MOCK_ACCOUNTS,
@@ -13,6 +19,7 @@ import {
   getSelectedInternalAccount,
   getInternalAccounts,
   getInternalAccountsObject,
+  getInternalAccountsByScope,
 } from './accounts';
 
 const MOCK_STATE: AccountsState = {
@@ -149,6 +156,200 @@ describe('Accounts Selectors', () => {
       expect(
         getInternalAccountsObject(mockState as AccountsState),
       ).toStrictEqual(mockState.metamask.internalAccounts.accounts);
+    });
+  });
+
+  describe('getInternalAccountsByScope', () => {
+    it('returns all accounts that have any EVM scope when eip155:0 (wildcard) is requested', () => {
+      const accountWithEthScope = {
+        ...MOCK_ACCOUNT_EOA,
+        id: `${MOCK_ACCOUNT_EOA.id}-evm1`,
+        scopes: ['eip155:1'],
+      };
+      const accountWithPolygonScope = {
+        ...MOCK_ACCOUNT_ERC4337,
+        id: `${MOCK_ACCOUNT_ERC4337.id}-evm137`,
+        scopes: ['eip155:137'],
+      };
+      const nonEvmAccount = {
+        ...MOCK_ACCOUNT_BIP122_P2WPKH,
+        id: `${MOCK_ACCOUNT_BIP122_P2WPKH.id}-btc`,
+      };
+
+      const state: AccountsState = {
+        metamask: {
+          internalAccounts: {
+            selectedAccount: accountWithEthScope.id,
+            accounts: {
+              [accountWithEthScope.id]: accountWithEthScope,
+              [accountWithPolygonScope.id]: accountWithPolygonScope,
+              [nonEvmAccount.id]: nonEvmAccount,
+            },
+          },
+        },
+      } as unknown as AccountsState;
+
+      const result = getInternalAccountsByScope(
+        state,
+        'eip155:0' as CaipChainId,
+      );
+      expect(result).toEqual(
+        expect.arrayContaining([accountWithEthScope, accountWithPolygonScope]),
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns EVM accounts for both EOA and SCA (erc4337) when EVM wildcard scope is requested', () => {
+      const eoaAccount = {
+        ...MOCK_ACCOUNT_EOA,
+        id: `${MOCK_ACCOUNT_EOA.id}-eoa`,
+        scopes: ['eip155:1'],
+      };
+      const scaAccount = {
+        ...MOCK_ACCOUNT_ERC4337,
+        id: `${MOCK_ACCOUNT_ERC4337.id}-sca`,
+        scopes: ['eip155:137'],
+      };
+      const solAccount = {
+        ...MOCK_ACCOUNT_EOA,
+        id: `${MOCK_ACCOUNT_EOA.id}-sol`,
+        scopes: [SolScope.Mainnet],
+      };
+
+      const state: AccountsState = {
+        metamask: {
+          internalAccounts: {
+            selectedAccount: eoaAccount.id,
+            accounts: {
+              [eoaAccount.id]: eoaAccount,
+              [scaAccount.id]: scaAccount,
+              [solAccount.id]: solAccount,
+            },
+          },
+        },
+      } as unknown as AccountsState;
+
+      const result = getInternalAccountsByScope(
+        state,
+        'eip155:0' as CaipChainId,
+      );
+      expect(result).toEqual(expect.arrayContaining([eoaAccount, scaAccount]));
+      expect(result).toHaveLength(2);
+    });
+
+    it('includes accounts with wildcard scope eip155:0 when a specific EVM scope is requested', () => {
+      const wildcardAccount = {
+        ...MOCK_ACCOUNT_EOA,
+        id: `${MOCK_ACCOUNT_EOA.id}-wildcard`,
+        scopes: ['eip155:0'],
+      };
+      const specificChainAccount = {
+        ...MOCK_ACCOUNT_ERC4337,
+        id: `${MOCK_ACCOUNT_ERC4337.id}-evm1`,
+        scopes: ['eip155:1'],
+      };
+
+      const state: AccountsState = {
+        metamask: {
+          internalAccounts: {
+            selectedAccount: wildcardAccount.id,
+            accounts: {
+              [wildcardAccount.id]: wildcardAccount,
+              [specificChainAccount.id]: specificChainAccount,
+            },
+          },
+        },
+      } as unknown as AccountsState;
+
+      const result = getInternalAccountsByScope(
+        state,
+        'eip155:1' as CaipChainId,
+      );
+      expect(result).toEqual(
+        expect.arrayContaining([wildcardAccount, specificChainAccount]),
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it('excludes accounts with a different specific EVM chain when requesting eip155:1 (no wildcard)', () => {
+      const eoaAccount = {
+        ...MOCK_ACCOUNT_EOA,
+        id: `${MOCK_ACCOUNT_EOA.id}-eoa-specific`,
+        scopes: ['eip155:1'],
+      };
+      const scaDifferentChain = {
+        ...MOCK_ACCOUNT_ERC4337,
+        id: `${MOCK_ACCOUNT_ERC4337.id}-sca-diff`,
+        scopes: ['eip155:137'],
+      };
+
+      const state: AccountsState = {
+        metamask: {
+          internalAccounts: {
+            selectedAccount: eoaAccount.id,
+            accounts: {
+              [eoaAccount.id]: eoaAccount,
+              [scaDifferentChain.id]: scaDifferentChain,
+            },
+          },
+        },
+      } as unknown as AccountsState;
+
+      const result = getInternalAccountsByScope(
+        state,
+        'eip155:1' as CaipChainId,
+      );
+      expect(result).toEqual([eoaAccount]);
+    });
+
+    it('returns only accounts with the exact non-EVM scope', () => {
+      const solanaAccount = {
+        ...MOCK_ACCOUNT_EOA,
+        id: `${MOCK_ACCOUNT_EOA.id}-sol1`,
+        scopes: [SolScope.Mainnet],
+      };
+      const anotherSolanaAccount = {
+        ...MOCK_ACCOUNT_ERC4337,
+        id: `${MOCK_ACCOUNT_ERC4337.id}-sol2`,
+        scopes: [SolScope.Mainnet],
+      };
+      const btcAccount = {
+        ...MOCK_ACCOUNT_BIP122_P2WPKH,
+      };
+
+      const state: AccountsState = {
+        metamask: {
+          internalAccounts: {
+            selectedAccount: solanaAccount.id,
+            accounts: {
+              [solanaAccount.id]: solanaAccount,
+              [anotherSolanaAccount.id]: anotherSolanaAccount,
+              [btcAccount.id]: btcAccount,
+            },
+          },
+        },
+      } as unknown as AccountsState;
+
+      const result = getInternalAccountsByScope(
+        state,
+        SolScope.Mainnet as CaipChainId,
+      );
+      expect(result).toEqual(
+        expect.arrayContaining([solanaAccount, anotherSolanaAccount]),
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns an empty array when no accounts match the requested scope', () => {
+      const emptyState = {
+        metamask: { internalAccounts: { selectedAccount: '', accounts: {} } },
+      } as unknown as AccountsState;
+
+      const result = getInternalAccountsByScope(
+        emptyState,
+        BtcScope.Mainnet as CaipChainId,
+      );
+      expect(result).toEqual([]);
     });
   });
 });

--- a/ui/selectors/accounts.ts
+++ b/ui/selectors/accounts.ts
@@ -2,10 +2,13 @@ import {
   EthAccountType,
   BtcAccountType,
   SolAccountType,
+  CaipChainId,
+  EthScope,
 } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { AccountsControllerState } from '@metamask/accounts-controller';
 import { createSelector } from 'reselect';
+import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { createDeepEqualSelector } from '../../shared/modules/selectors/util';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 
@@ -69,3 +72,56 @@ export function hasCreatedSolanaAccount(state: AccountsState) {
   const accounts = getInternalAccounts(state);
   return accounts.some((account) => isSolanaAccount(account));
 }
+
+/**
+ * Returns all internal accounts that declare support for the provided CAIP scope.
+ * The scope should be a CAIP-2 scope string (e.g., 'eip155:0', 'bip122:...').
+ *
+ * @param _state - Redux state (unused; required for selector signature)
+ * @param scope - The CAIP scope string to filter accounts by
+ */
+export const getInternalAccountsByScope = createDeepEqualSelector(
+  [getInternalAccounts, (_state: AccountsState, scope: CaipChainId) => scope],
+  (accounts, scope): InternalAccount[] => {
+    if (!Array.isArray(accounts) || accounts.length === 0) {
+      return [];
+    }
+
+    let namespace: string;
+    let reference: string;
+    try {
+      const parsed = parseCaipChainId(scope);
+      namespace = parsed.namespace;
+      reference = parsed.reference;
+    } catch {
+      return [];
+    }
+
+    if (namespace === KnownCaipNamespace.Eip155) {
+      // If requesting eip155:0 (wildcard), include any account that has any EVM scope
+      if (reference === '0') {
+        return accounts.filter(
+          (account) =>
+            Array.isArray(account.scopes) &&
+            account.scopes.some((s) =>
+              s.startsWith(`${KnownCaipNamespace.Eip155}:`),
+            ),
+        );
+      }
+
+      // For a specific EVM chain, include accounts that either have the exact scope or the wildcard
+      return accounts.filter(
+        (account) =>
+          Array.isArray(account.scopes) &&
+          (account.scopes.includes(scope) ||
+            account.scopes.includes(EthScope.Eoa)),
+      );
+    }
+
+    // Non-EVM: exact scope match only
+    return accounts.filter(
+      (account) =>
+        Array.isArray(account.scopes) && account.scopes.includes(scope),
+    );
+  },
+);


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
Create a selector to get all the possible internal accounts that are valid for a given CAIP scope
the Swaps team needs this to unblock their BIP44 work.
2. What is the improvement/solution?
Add a selector on top of the accounts controller since it already holds all the accounts
filter the accounts based on the passed in scope
tests
This PR has no functional or UI changes and instead will be used by other teams in the future.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35044?quickstart=1)

## **Changelog**


CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-553

## **Manual testing steps**

 This code is not testable in the ui at the moment

please...
1. read the code
2. read the tests
3. verify that all tests are passing

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
