### PR TITLE
feat: Add multichain account popup menu

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -331,6 +331,10 @@
     "message": "Punycode version: $1",
     "description": "$1 replaced by punycode version of the URL in confirmation request"
   },
+  "addresses": {
+    "message": "Addresses",
+    "description": "Multichain account menu item for linking to addresses page"
+  },
   "advanced": {
     "message": "Advanced"
   },
@@ -4603,6 +4607,10 @@
   "personalAddressDetected": {
     "message": "Personal address detected. Input the token contract address."
   },
+  "pin": {
+    "message": "Pin",
+    "description": "Pin label used in multichain account menu"
+  },
   "pinToTop": {
     "message": "Pin to top"
   },
@@ -4895,6 +4903,10 @@
   },
   "removeSnapDescription": {
     "message": "This action will delete the snap, its data and revoke your given permissions."
+  },
+  "rename": {
+    "message": "Rename",
+    "description": "Multichain account menu item for triggering account rename action modal"
   },
   "replace": {
     "message": "replace"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -331,6 +331,10 @@
     "message": "Punycode version: $1",
     "description": "$1 replaced by punycode version of the URL in confirmation request"
   },
+  "addresses": {
+    "message": "Addresses",
+    "description": "Multichain account menu item for linking to addresses page"
+  },
   "advanced": {
     "message": "Advanced"
   },
@@ -4603,6 +4607,10 @@
   "personalAddressDetected": {
     "message": "Personal address detected. Input the token contract address."
   },
+  "pin": {
+    "message": "Pin",
+    "description": "Pin label used in multichain account menu"
+  },
   "pinToTop": {
     "message": "Pin to top"
   },
@@ -4895,6 +4903,10 @@
   },
   "removeSnapDescription": {
     "message": "This action will delete the snap, its data and revoke your given permissions."
+  },
+  "rename": {
+    "message": "Rename",
+    "description": "Multichain account menu item for triggering account rename action modal"
   },
   "replace": {
     "message": "replace"

--- a/ui/components/multichain-accounts/multichain-account-cell/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-cell/index.scss
@@ -29,5 +29,13 @@
     .multichain-account-cell__account-name {
       color: var(--color-primary-default);
     }
+
+    .multichain-account-cell__end_accessory .mm-box {
+      background: var(--color-primary-muted);
+    }
+
+    .multichain-account-cell__end_accessory .mm-icon {
+      background-color: var(--color-primary-default);
+    }
   }
 }

--- a/ui/components/multichain-accounts/multichain-account-cell/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-cell/index.scss
@@ -30,11 +30,11 @@
       color: var(--color-primary-default);
     }
 
-    .multichain-account-cell__end_accessory .mm-box {
+    .multichain-account-cell__end_accessory .multichain-account-menu-button {
       background: var(--color-primary-muted);
     }
 
-    .multichain-account-cell__end_accessory .mm-icon {
+    .multichain-account-cell__end_accessory .multichain-account-menu-button-icon {
       background-color: var(--color-primary-default);
     }
   }

--- a/ui/components/multichain-accounts/multichain-account-cell/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-cell/index.scss
@@ -30,11 +30,11 @@
       color: var(--color-primary-default);
     }
 
-    .multichain-account-cell__end_accessory .multichain-account-menu-button {
+    .multichain-account-cell__end_accessory .multichain-account-cell-popover-menu-button {
       background: var(--color-primary-muted);
     }
 
-    .multichain-account-cell__end_accessory .multichain-account-menu-button-icon {
+    .multichain-account-cell__end_accessory .multichain-account-cell-popover-menu-button-icon {
       background-color: var(--color-primary-default);
     }
   }

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.stories.tsx
@@ -65,7 +65,7 @@ export default {
     },
   },
   args: {
-    accountId: '0x1234567890abcdef',
+    accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
     accountName: 'Account 1',
     balance: '$2,400.00',
     selected: false,
@@ -86,7 +86,7 @@ Default.storyName = 'Default';
 
 export const Selected = Template.bind({});
 Selected.args = {
-  accountId: '0x1234567890abcdef',
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
   accountName: 'Selected Account',
   balance: '$2,400.00',
   selected: true,
@@ -94,14 +94,14 @@ Selected.args = {
 
 export const WithoutBalance = Template.bind({});
 WithoutBalance.args = {
-  accountId: '0x2345678901abcdef',
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
   accountName: 'Account 2',
   balance: undefined,
 };
 
 export const WithoutEndAccessory = Template.bind({});
 WithoutEndAccessory.args = {
-  accountId: '0x5678901234abcdef',
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
   accountName: 'Account Without Menu',
   balance: '$2,400.00',
   endAccessory: undefined,
@@ -109,7 +109,7 @@ WithoutEndAccessory.args = {
 
 export const WithLongAccountName = Template.bind({});
 WithLongAccountName.args = {
-  accountId: '0x3456789012abcdef',
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
   accountName:
     'This is a very long account name that might need to be truncated',
   balance: '$2,400.00',
@@ -117,7 +117,7 @@ WithLongAccountName.args = {
 
 export const Clickable = Template.bind({});
 Clickable.args = {
-  accountId: '0x4567890123abcdef',
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
   accountName: 'Clickable Account',
   balance: '$2,400.00',
   onClick: () => console.log('Account cell clicked'),
@@ -125,7 +125,7 @@ Clickable.args = {
 
 export const SelectedAndClickable = Template.bind({});
 SelectedAndClickable.args = {
-  accountId: '0x6789012345abcdef',
+  accountId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
   accountName: 'Selected Clickable Account',
   balance: '$2,400.00',
   selected: true,
@@ -135,14 +135,14 @@ SelectedAndClickable.args = {
 export const MultipleAccounts: StoryFn<typeof MultichainAccountCell> = () => (
   <div style={{ width: '360px', margin: '0 auto' }}>
     <MultichainAccountCell
-      accountId="0x1234567890abcdef"
+      accountId="entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0"
       accountName="Main Account"
       balance="$2,400.00"
       onClick={() => console.log('Main account clicked')}
       endAccessory={<MoreOptionsAccessory />}
     />
     <MultichainAccountCell
-      accountId="0x2345678901abcdef"
+      accountId="entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0"
       accountName="Savings"
       balance="$105,400,720.00"
       onClick={() => console.log('Savings account clicked')}
@@ -150,21 +150,21 @@ export const MultipleAccounts: StoryFn<typeof MultichainAccountCell> = () => (
       selected={true}
     />
     <MultichainAccountCell
-      accountId="0x3456789012abcdef"
+      accountId="entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0"
       accountName="Trading"
       balance="$22,400.00"
       onClick={() => console.log('Trading account clicked')}
       endAccessory={<MoreOptionsAccessory />}
     />
     <MultichainAccountCell
-      accountId="0x3456789012abcdef"
+      accountId="entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0"
       accountName="Second trading account"
       balance="$178,256,100.00"
       onClick={() => console.log('Second trading account clicked')}
       endAccessory={<MoreOptionsAccessory />}
     />
     <MultichainAccountCell
-      accountId="0x3456789012abcdef"
+      accountId="entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0"
       accountName="Second savings account"
       balance="1722.943 ETH"
       onClick={() => console.log('Second savings account clicked')}

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -30,6 +30,7 @@ import {
   getHDEntropyIndex,
 } from '../../../selectors';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { MultichainAccountMenu } from '../multichain-account-menu';
 
 export type MultichainAccountListProps = {
   wallets: AccountTreeWallets;
@@ -103,6 +104,9 @@ export const MultichainAccountList = ({
 
         const groupsItems = Object.entries(walletData.groups || {}).flatMap(
           ([groupId, groupData]) => {
+            // TODO: Implement logic for removable accounts
+            const isRemovable = false;
+
             return [
               <MultichainAccountCell
                 key={`multichain-account-cell-${groupId}`}
@@ -111,6 +115,12 @@ export const MultichainAccountList = ({
                 balance="$ n/a"
                 selected={selectedAccountGroup === groupId}
                 onClick={handleAccountClick}
+                endAccessory={
+                  <MultichainAccountMenu
+                    accountGroupId={groupId as AccountGroupId}
+                    isRemovable={isRemovable}
+                  />
+                }
               />,
             ];
           },

--- a/ui/components/multichain-accounts/multichain-account-menu-items/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-menu-items/index.scss
@@ -1,0 +1,21 @@
+.multichain-account-menu-item {
+  width: 250px;
+
+  &:hover {
+    background: var(--color-background-default-hover);
+  }
+
+  &--with-border {
+    border-bottom: 1px solid var(--color-border-muted);
+  }
+
+  &--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  &--enabled {
+    cursor: pointer;
+    opacity: 1;
+  }
+}

--- a/ui/components/multichain-accounts/multichain-account-menu-items/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-menu-items/index.scss
@@ -1,4 +1,4 @@
-.multichain-account-menu-item {
+.multichain-account-cell-menu-item {
   width: 250px;
 
   &:hover {

--- a/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.stories.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { StoryObj, Meta } from '@storybook/react';
+import { TextColor } from '../../../helpers/constants/design-system';
+import { IconName } from '../../component-library';
+import { MultichainAccountMenuItems } from './multichain-account-menu-items';
+import { MenuItemConfig } from './multichain-account-menu-items.types';
+
+const meta: Meta<typeof MultichainAccountMenuItems> = {
+  title: 'Components/MultichainAccounts/MultichainAccountMenuItems',
+  component: MultichainAccountMenuItems,
+  parameters: {
+    backgrounds: {
+      default: 'light',
+    },
+    docs: {
+      description: {
+        component:
+          'A menu items component for displaying a list of configurable menu options.',
+      },
+    },
+  },
+  argTypes: {
+    menuConfig: {
+      description: 'Configuration array for menu items',
+      control: 'object',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          padding: '20px',
+          maxWidth: '300px',
+          border: '1px solid #eee',
+          borderRadius: '8px',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof MultichainAccountMenuItems>;
+
+const defaultMenuConfig: MenuItemConfig[] = [
+  {
+    textKey: 'accountDetails',
+    iconName: IconName.Details,
+    onClick: () => console.log('Account details clicked'),
+  },
+  {
+    textKey: 'rename',
+    iconName: IconName.Edit,
+    onClick: () => console.log('Rename clicked'),
+  },
+  {
+    textKey: 'pin',
+    iconName: IconName.Pin,
+    onClick: () => console.log('Pin clicked'),
+  },
+];
+
+export const Default: Story = {
+  args: {
+    menuConfig: defaultMenuConfig,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default state of MultichainAccountMenuItems with standard menu options.',
+      },
+    },
+  },
+};
+
+export const WithDisabledItems: Story = {
+  args: {
+    menuConfig: [
+      {
+        textKey: 'accountDetails',
+        iconName: IconName.Details,
+        onClick: () => console.log('Account details clicked'),
+      },
+      {
+        textKey: 'rename',
+        iconName: IconName.Edit,
+        onClick: () => console.log('Rename clicked'),
+        disabled: true,
+      },
+      {
+        textKey: 'pin',
+        iconName: IconName.Pin,
+        onClick: () => console.log('Pin clicked'),
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'MultichainAccountMenuItems with some disabled options. Disabled items have reduced opacity and are non-clickable.',
+      },
+    },
+  },
+};
+
+export const WithCustomTextColor: Story = {
+  args: {
+    menuConfig: [
+      ...defaultMenuConfig,
+      {
+        textKey: 'remove',
+        iconName: IconName.Trash,
+        onClick: () => console.log('Remove clicked'),
+        textColor: TextColor.errorDefault,
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'MultichainAccountMenuItems with a custom text color for certain options, such as using an error color for destructive actions.',
+      },
+    },
+  },
+};

--- a/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.test.tsx
@@ -5,7 +5,7 @@ import { TextColor } from '../../../helpers/constants/design-system';
 import { IconName } from '../../component-library';
 import { MultichainAccountMenuItems } from './multichain-account-menu-items';
 
-const menuItemSelector = '.multichain-account-menu-item';
+const menuItemSelector = '.multichain-account-cell-menu-item';
 
 describe('MultichainAccountMenuItems', () => {
   const mockOnClick = jest.fn();
@@ -45,17 +45,23 @@ describe('MultichainAccountMenuItems', () => {
 
     expect(menuItems).toHaveLength(3);
     expect(menuItems[0]).toHaveClass(
-      'multichain-account-menu-item--with-border',
+      'multichain-account-cell-menu-item--with-border',
     );
-    expect(menuItems[0]).toHaveClass('multichain-account-menu-item--enabled');
+    expect(menuItems[0]).toHaveClass(
+      'multichain-account-cell-menu-item--enabled',
+    );
     expect(menuItems[1]).toHaveClass(
-      'multichain-account-menu-item--with-border',
+      'multichain-account-cell-menu-item--with-border',
     );
-    expect(menuItems[1]).toHaveClass('multichain-account-menu-item--disabled');
+    expect(menuItems[1]).toHaveClass(
+      'multichain-account-cell-menu-item--disabled',
+    );
     expect(menuItems[2]).not.toHaveClass(
-      'multichain-account-menu-item--with-border',
+      'multichain-account-cell-menu-item--with-border',
     );
-    expect(menuItems[2]).toHaveClass('multichain-account-menu-item--enabled');
+    expect(menuItems[2]).toHaveClass(
+      'multichain-account-cell-menu-item--enabled',
+    );
   });
 
   it('triggers onClick handlers when menu items are clicked', () => {

--- a/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import { TextColor } from '../../../helpers/constants/design-system';
+import { IconName } from '../../component-library';
+import { MultichainAccountMenuItems } from './multichain-account-menu-items';
+
+const menuItemSelector = '.multichain-account-menu-item';
+
+describe('MultichainAccountMenuItems', () => {
+  const mockOnClick = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const defaultMenuConfig = [
+    {
+      textKey: 'accountDetails',
+      iconName: IconName.Details,
+      textColor: TextColor.textDefault,
+      onClick: mockOnClick,
+    },
+    {
+      textKey: 'rename',
+      iconName: IconName.Edit,
+      textColor: TextColor.textDefault,
+      onClick: mockOnClick,
+      disabled: true,
+    },
+    {
+      textKey: 'remove',
+      iconName: IconName.Trash,
+      textColor: TextColor.errorDefault,
+      onClick: mockOnClick,
+    },
+  ];
+
+  it('renders all menu items with correct styling', () => {
+    renderWithProvider(
+      <MultichainAccountMenuItems menuConfig={defaultMenuConfig} />,
+    );
+
+    const menuItems = document.querySelectorAll(menuItemSelector);
+
+    expect(menuItems).toHaveLength(3);
+    expect(menuItems[0]).toHaveClass(
+      'multichain-account-menu-item--with-border',
+    );
+    expect(menuItems[0]).toHaveClass('multichain-account-menu-item--enabled');
+    expect(menuItems[1]).toHaveClass(
+      'multichain-account-menu-item--with-border',
+    );
+    expect(menuItems[1]).toHaveClass('multichain-account-menu-item--disabled');
+    expect(menuItems[2]).not.toHaveClass(
+      'multichain-account-menu-item--with-border',
+    );
+    expect(menuItems[2]).toHaveClass('multichain-account-menu-item--enabled');
+  });
+
+  it('triggers onClick handlers when menu items are clicked', () => {
+    renderWithProvider(
+      <MultichainAccountMenuItems menuConfig={defaultMenuConfig} />,
+    );
+
+    const menuItems = document.querySelectorAll(menuItemSelector);
+
+    fireEvent.click(menuItems[0]);
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(menuItems[1]);
+    expect(mockOnClick).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(menuItems[2]);
+    expect(mockOnClick).toHaveBeenCalledTimes(3);
+  });
+});

--- a/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.tsx
@@ -1,0 +1,55 @@
+import React, { useMemo } from 'react';
+import classnames from 'classnames';
+import { Box, Icon, IconSize, Text } from '../../component-library';
+import {
+  AlignItems,
+  Display,
+  FontWeight,
+  JustifyContent,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { MultichainAccountMenuItemsProps } from './multichain-account-menu-items.types';
+
+export const MultichainAccountMenuItems = ({
+  menuConfig,
+}: MultichainAccountMenuItemsProps) => {
+  const t = useI18nContext();
+
+  const menuItems = useMemo(() => {
+    return menuConfig.map((item, index, menuConfigurations) => {
+      const isLast = index === menuConfigurations.length - 1;
+      const isDisabled = Boolean(item.disabled);
+
+      return (
+        <Box
+          key={item.textKey}
+          className={classnames('multichain-account-menu-item', {
+            'multichain-account-menu-item--with-border': !isLast,
+            'multichain-account-menu-item--disabled': isDisabled,
+            'multichain-account-menu-item--enabled': !isDisabled,
+          })}
+          paddingLeft={8}
+          paddingRight={4}
+          paddingTop={3}
+          paddingBottom={3}
+          display={Display.Flex}
+          justifyContent={JustifyContent.spaceBetween}
+          alignItems={AlignItems.center}
+          onClick={item.onClick}
+        >
+          <Text
+            fontWeight={FontWeight.Medium}
+            variant={TextVariant.bodyMdMedium}
+            color={item.textColor}
+          >
+            {t(item.textKey)}
+          </Text>
+          <Icon name={item.iconName} size={IconSize.Md} />
+        </Box>
+      );
+    });
+  }, [menuConfig, t]);
+
+  return <>{menuItems}</>;
+};

--- a/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.tsx
@@ -24,10 +24,10 @@ export const MultichainAccountMenuItems = ({
       return (
         <Box
           key={item.textKey}
-          className={classnames('multichain-account-menu-item', {
-            'multichain-account-menu-item--with-border': !isLast,
-            'multichain-account-menu-item--disabled': isDisabled,
-            'multichain-account-menu-item--enabled': !isDisabled,
+          className={classnames('multichain-account-cell-menu-item', {
+            'multichain-account-cell-menu-item--with-border': !isLast,
+            'multichain-account-cell-menu-item--disabled': isDisabled,
+            'multichain-account-cell-menu-item--enabled': !isDisabled,
           })}
           paddingLeft={8}
           paddingRight={4}

--- a/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.types.ts
+++ b/ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.types.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import { IconName } from '../../component-library';
+import { TextColor } from '../../../helpers/constants/design-system';
+
+export type MultichainAccountMenuItemsProps = {
+  /**
+   * Configuration array for menu items.
+   */
+  menuConfig: MenuItemConfig[];
+};
+
+export type MenuItemConfig = {
+  /**
+   * Translation key for the menu item text.
+   */
+  textKey: string;
+
+  /**
+   * Icon to display for the menu item.
+   */
+  iconName: IconName;
+
+  /**
+   * Function to execute when the menu item is clicked.
+   */
+  onClick: (mouseEvent: React.MouseEvent) => void;
+
+  /**
+   * Optional color for the menu item text.
+   */
+  textColor?: TextColor;
+
+  /**
+   * Whether the menu item is disabled.
+   */
+  disabled?: boolean;
+};

--- a/ui/components/multichain-accounts/multichain-account-menu/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-menu/index.scss
@@ -1,5 +1,20 @@
+.multichain-account-menu-button {
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+}
+
 .multichain-account-menu-item {
   &:hover {
     background: var(--color-background-default-hover);
   }
+}
+
+.multichain-account-menu-popover {
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  cursor: pointer;
+  overflow: hidden;
 }

--- a/ui/components/multichain-accounts/multichain-account-menu/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-menu/index.scss
@@ -4,28 +4,6 @@
   height: 28px;
 }
 
-.multichain-account-menu-item {
-  width: 250px;
-
-  &:hover {
-    background: var(--color-background-default-hover);
-  }
-
-  &--with-border {
-    border-bottom: 1px solid var(--color-border-muted);
-  }
-
-  &--disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
-
-  &--enabled {
-    cursor: pointer;
-    opacity: 1;
-  }
-}
-
 .multichain-account-menu-popover {
   z-index: 10;
   display: flex;

--- a/ui/components/multichain-accounts/multichain-account-menu/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-menu/index.scss
@@ -1,10 +1,10 @@
-.multichain-account-menu-button {
+.multichain-account-cell-popover-menu-button {
   cursor: pointer;
   width: 28px;
   height: 28px;
 }
 
-.multichain-account-menu-popover {
+.multichain-account-cell-popover-menu {
   z-index: 10;
   display: flex;
   flex-direction: column;

--- a/ui/components/multichain-accounts/multichain-account-menu/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-menu/index.scss
@@ -1,0 +1,5 @@
+.multichain-account-menu-item {
+  &:hover {
+    background: var(--color-background-default-hover);
+  }
+}

--- a/ui/components/multichain-accounts/multichain-account-menu/index.scss
+++ b/ui/components/multichain-accounts/multichain-account-menu/index.scss
@@ -5,8 +5,24 @@
 }
 
 .multichain-account-menu-item {
+  width: 250px;
+
   &:hover {
     background: var(--color-background-default-hover);
+  }
+
+  &--with-border {
+    border-bottom: 1px solid var(--color-border-muted);
+  }
+
+  &--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  &--enabled {
+    cursor: pointer;
+    opacity: 1;
   }
 }
 

--- a/ui/components/multichain-accounts/multichain-account-menu/index.ts
+++ b/ui/components/multichain-accounts/multichain-account-menu/index.ts
@@ -1,0 +1,1 @@
+export { MultichainAccountMenu } from './multichain-account-menu';

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.stories.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { StoryObj, Meta } from '@storybook/react';
+import { MultichainAccountMenu } from './multichain-account-menu';
+
+const meta: Meta<typeof MultichainAccountMenu> = {
+  title: 'Components/MultichainAccounts/MultichainAccountMenu',
+  component: MultichainAccountMenu,
+  parameters: {
+    backgrounds: {
+      default: 'light',
+    },
+    docs: {
+      description: {
+        component:
+          'A menu component for multichain accounts that displays a popover when clicked.',
+      },
+    },
+  },
+  argTypes: {
+    isRemovable: {
+      control: 'boolean',
+      description:
+        'Whether the account is removable. When true, a remove option appears in the menu.',
+    },
+    accountGroupId: {
+      control: 'text',
+      description: 'ID of an account group',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{ padding: '50px', display: 'flex', justifyContent: 'center' }}
+      >
+        <div
+          style={{
+            width: '300px',
+            border: '1px solid #ccc',
+            padding: '16px',
+            borderRadius: '8px',
+          }}
+        >
+          <h4 style={{ marginTop: 0, marginBottom: '16px' }}>
+            Account Options
+          </h4>
+          <Story />
+          <p style={{ marginTop: '16px', fontSize: '12px', color: '#666' }}>
+            Click the icon to toggle menu options
+          </p>
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof MultichainAccountMenu>;
+
+export const Default: Story = {
+  args: {
+    accountGroupId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
+    isRemovable: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default state of MultichainAccountMenu with non-removable account. The menu will not include a remove option.',
+      },
+    },
+  },
+};
+
+export const RemovableAccount: Story = {
+  args: {
+    accountGroupId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
+    isRemovable: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'MultichainAccountMenu with a removable account. The menu includes a remove option highlighted in error color.',
+      },
+    },
+  },
+};

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -4,6 +4,12 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import { MultichainAccountMenu } from './multichain-account-menu';
 import type { MultichainAccountMenuProps } from './multichain-account-menu.types';
 
+const popoverOpenSelector = '.mm-popover--open';
+const menuButtonSelector = '.multichain-account-menu-button';
+const menuIconSelector = '.multichain-account-menu-button-icon';
+const menuItemSelector = '.multichain-account-menu-item';
+const errorColorSelector = '.mm-box--color-error-default';
+
 const mockHistoryPush = jest.fn();
 
 jest.mock('react-router-dom', () => ({
@@ -30,26 +36,20 @@ describe('MultichainAccountMenu', () => {
   it('renders the menu button and popover is initially closed', () => {
     renderComponent();
 
-    const menuButton = document.querySelector(
-      '.multichain-account-menu-button',
-    );
+    const menuButton = document.querySelector(menuButtonSelector);
 
     expect(menuButton).toBeInTheDocument();
 
-    const menuIcon = document.querySelector(
-      '.multichain-account-menu-button-icon',
-    );
+    const menuIcon = document.querySelector(menuIconSelector);
 
     expect(menuIcon).toBeInTheDocument();
-    expect(document.querySelector('.mm-popover--open')).not.toBeInTheDocument();
+    expect(document.querySelector(popoverOpenSelector)).not.toBeInTheDocument();
   });
 
   it('opens the popover menu when clicking the menu button', async () => {
     renderComponent();
 
-    const menuButton = document.querySelector(
-      '.multichain-account-menu-button',
-    );
+    const menuButton = document.querySelector(menuButtonSelector);
 
     expect(menuButton).not.toBeNull();
 
@@ -58,19 +58,17 @@ describe('MultichainAccountMenu', () => {
         fireEvent.click(menuButton);
         await waitFor(() => {
           expect(
-            document.querySelector('.mm-popover--open'),
+            document.querySelector(popoverOpenSelector),
           ).toBeInTheDocument();
         });
       });
     }
 
-    const popover = document.querySelector('.mm-popover--open');
+    const popover = document.querySelector(popoverOpenSelector);
 
     expect(popover).toBeInTheDocument();
 
-    const menuItems = document.querySelectorAll(
-      '.multichain-account-menu-item',
-    );
+    const menuItems = document.querySelectorAll(menuItemSelector);
 
     expect(menuItems.length).toBe(5);
   });
@@ -81,9 +79,7 @@ describe('MultichainAccountMenu', () => {
       isRemovable: true,
     });
 
-    const menuButton = document.querySelector(
-      '.multichain-account-menu-button',
-    );
+    const menuButton = document.querySelector(menuButtonSelector);
 
     expect(menuButton).not.toBeNull();
 
@@ -92,19 +88,17 @@ describe('MultichainAccountMenu', () => {
         fireEvent.click(menuButton);
         await waitFor(() => {
           expect(
-            document.querySelector('.mm-popover--open'),
+            document.querySelector(popoverOpenSelector),
           ).toBeInTheDocument();
         });
       });
     }
 
-    const menuItems = document.querySelectorAll(
-      '.multichain-account-menu-item',
-    );
+    const menuItems = document.querySelectorAll(menuItemSelector);
 
     expect(menuItems.length).toBe(6);
 
-    const removeOption = document.querySelector('.mm-box--color-error-default');
+    const removeOption = document.querySelector(errorColorSelector);
 
     expect(removeOption).toBeInTheDocument();
   });
@@ -112,9 +106,7 @@ describe('MultichainAccountMenu', () => {
   it('navigates to account details page when clicking the account details option', async () => {
     renderComponent();
 
-    const menuButton = document.querySelector(
-      '.multichain-account-menu-button',
-    );
+    const menuButton = document.querySelector(menuButtonSelector);
 
     expect(menuButton).not.toBeNull();
 
@@ -123,15 +115,13 @@ describe('MultichainAccountMenu', () => {
         fireEvent.click(menuButton);
         await waitFor(() => {
           expect(
-            document.querySelector('.mm-popover--open'),
+            document.querySelector(popoverOpenSelector),
           ).toBeInTheDocument();
         });
       });
     }
 
-    const accountDetailsOption = document.querySelector(
-      '.multichain-account-menu-item',
-    );
+    const accountDetailsOption = document.querySelector(menuItemSelector);
 
     expect(accountDetailsOption).not.toBeNull();
 
@@ -149,9 +139,7 @@ describe('MultichainAccountMenu', () => {
   it('toggles the popover state when clicking the menu button multiple times', async () => {
     renderComponent();
 
-    const menuButton = document.querySelector(
-      '.multichain-account-menu-button',
-    );
+    const menuButton = document.querySelector(menuButtonSelector);
 
     expect(menuButton).not.toBeNull();
 
@@ -161,7 +149,7 @@ describe('MultichainAccountMenu', () => {
         fireEvent.click(menuButton);
         await waitFor(() => {
           expect(
-            document.querySelector('.mm-popover--open'),
+            document.querySelector(popoverOpenSelector),
           ).toBeInTheDocument();
         });
       });
@@ -171,7 +159,7 @@ describe('MultichainAccountMenu', () => {
         fireEvent.click(menuButton);
         await waitFor(() => {
           expect(
-            document.querySelector('.mm-popover--open'),
+            document.querySelector(popoverOpenSelector),
           ).not.toBeInTheDocument();
         });
       });
@@ -181,7 +169,7 @@ describe('MultichainAccountMenu', () => {
         fireEvent.click(menuButton);
         await waitFor(() => {
           expect(
-            document.querySelector('.mm-popover--open'),
+            document.querySelector(popoverOpenSelector),
           ).toBeInTheDocument();
         });
       });

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -5,9 +5,9 @@ import { MultichainAccountMenu } from './multichain-account-menu';
 import type { MultichainAccountMenuProps } from './multichain-account-menu.types';
 
 const popoverOpenSelector = '.mm-popover--open';
-const menuButtonSelector = '.multichain-account-menu-button';
-const menuIconSelector = '.multichain-account-menu-button-icon';
-const menuItemSelector = '.multichain-account-menu-item';
+const menuButtonSelector = '.multichain-account-cell-popover-menu-button';
+const menuIconSelector = '.multichain-account-cell-popover-menu-button-icon';
+const menuItemSelector = '.multichain-account-cell-menu-item';
 const errorColorSelector = '.mm-box--color-error-default';
 
 const mockHistoryPush = jest.fn();

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { fireEvent, act, waitFor } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import { MultichainAccountMenu } from './multichain-account-menu';
+import type { MultichainAccountMenuProps } from './multichain-account-menu.types';
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
+describe('MultichainAccountMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderComponent = (
+    props: MultichainAccountMenuProps = {
+      accountGroupId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
+      isRemovable: false,
+    },
+  ) => {
+    return renderWithProvider(<MultichainAccountMenu {...props} />);
+  };
+
+  it('renders the menu button and popover is initially closed', () => {
+    renderComponent();
+
+    const menuButton = document.querySelector(
+      '.multichain-account-menu-button',
+    );
+
+    expect(menuButton).toBeInTheDocument();
+
+    const menuIcon = document.querySelector(
+      '.multichain-account-menu-button-icon',
+    );
+
+    expect(menuIcon).toBeInTheDocument();
+    expect(document.querySelector('.mm-popover--open')).not.toBeInTheDocument();
+  });
+
+  it('opens the popover menu when clicking the menu button', async () => {
+    renderComponent();
+
+    const menuButton = document.querySelector(
+      '.multichain-account-menu-button',
+    );
+
+    expect(menuButton).not.toBeNull();
+
+    if (menuButton) {
+      await act(async () => {
+        fireEvent.click(menuButton);
+        await waitFor(() => {
+          expect(
+            document.querySelector('.mm-popover--open'),
+          ).toBeInTheDocument();
+        });
+      });
+    }
+
+    const popover = document.querySelector('.mm-popover--open');
+
+    expect(popover).toBeInTheDocument();
+
+    const menuItems = document.querySelectorAll(
+      '.multichain-account-menu-item',
+    );
+
+    expect(menuItems.length).toBe(5);
+  });
+
+  it('adds the remove option to menu when isRemovable is true', async () => {
+    renderComponent({
+      accountGroupId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
+      isRemovable: true,
+    });
+
+    const menuButton = document.querySelector(
+      '.multichain-account-menu-button',
+    );
+
+    expect(menuButton).not.toBeNull();
+
+    if (menuButton) {
+      await act(async () => {
+        fireEvent.click(menuButton);
+        await waitFor(() => {
+          expect(
+            document.querySelector('.mm-popover--open'),
+          ).toBeInTheDocument();
+        });
+      });
+    }
+
+    const menuItems = document.querySelectorAll(
+      '.multichain-account-menu-item',
+    );
+
+    expect(menuItems.length).toBe(6);
+
+    const removeOption = document.querySelector('.mm-box--color-error-default');
+
+    expect(removeOption).toBeInTheDocument();
+  });
+
+  it('navigates to account details page when clicking the account details option', async () => {
+    renderComponent();
+
+    const menuButton = document.querySelector(
+      '.multichain-account-menu-button',
+    );
+
+    expect(menuButton).not.toBeNull();
+
+    if (menuButton) {
+      await act(async () => {
+        fireEvent.click(menuButton);
+        await waitFor(() => {
+          expect(
+            document.querySelector('.mm-popover--open'),
+          ).toBeInTheDocument();
+        });
+      });
+    }
+
+    const accountDetailsOption = document.querySelector(
+      '.multichain-account-menu-item',
+    );
+
+    expect(accountDetailsOption).not.toBeNull();
+
+    if (accountDetailsOption) {
+      await act(async () => {
+        fireEvent.click(accountDetailsOption);
+      });
+    }
+
+    expect(mockHistoryPush).toHaveBeenCalledWith(
+      '/multichain-account-details/entropy%3A01JKAF3DSGM3AB87EM9N0K41AJ%2Fdefault',
+    );
+  });
+
+  it('toggles the popover state when clicking the menu button multiple times', async () => {
+    renderComponent();
+
+    const menuButton = document.querySelector(
+      '.multichain-account-menu-button',
+    );
+
+    expect(menuButton).not.toBeNull();
+
+    if (menuButton) {
+      // First click - open menu
+      await act(async () => {
+        fireEvent.click(menuButton);
+        await waitFor(() => {
+          expect(
+            document.querySelector('.mm-popover--open'),
+          ).toBeInTheDocument();
+        });
+      });
+
+      // Second click - close menu
+      await act(async () => {
+        fireEvent.click(menuButton);
+        await waitFor(() => {
+          expect(
+            document.querySelector('.mm-popover--open'),
+          ).not.toBeInTheDocument();
+        });
+      });
+
+      // Third click - open menu again
+      await act(async () => {
+        fireEvent.click(menuButton);
+        await waitFor(() => {
+          expect(
+            document.querySelector('.mm-popover--open'),
+          ).toBeInTheDocument();
+        });
+      });
+    }
+  });
+});

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -171,7 +171,6 @@ export const MultichainAccountMenu = ({
         borderRadius={BorderRadius.LG}
         padding={1}
         onClick={togglePopover}
-        style={{ cursor: 'pointer', width: '28px', height: '28px' }}
       >
         <Icon
           className="multichain-account-menu-button-icon"
@@ -179,18 +178,11 @@ export const MultichainAccountMenu = ({
         />
       </Box>
       <Popover
+        className="multichain-account-menu-popover"
         isOpen={isPopoverOpen}
         position={PopoverPosition.LeftStart}
         referenceElement={popoverRef.current}
         matchWidth={false}
-        style={{
-          zIndex: 10,
-          display: 'flex',
-          flexDirection: 'column',
-          padding: 0,
-          cursor: 'pointer',
-          overflow: 'hidden',
-        }}
         borderRadius={BorderRadius.LG}
       >
         {menuItems}

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -198,5 +198,3 @@ export const MultichainAccountMenu = ({
     </>
   );
 };
-
-export default MultichainAccountMenu;

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -117,7 +117,7 @@ export const MultichainAccountMenu = ({
   return (
     <>
       <Box
-        className="multichain-account-menu-button"
+        className="multichain-account-cell-popover-menu-button"
         ref={popoverRef}
         display={Display.Flex}
         alignItems={AlignItems.center}
@@ -128,12 +128,12 @@ export const MultichainAccountMenu = ({
         onClick={togglePopover}
       >
         <Icon
-          className="multichain-account-menu-button-icon"
+          className="multichain-account-cell-popover-menu-button-icon"
           name={IconName.MoreVertical}
         />
       </Box>
       <Popover
-        className="multichain-account-menu-popover"
+        className="multichain-account-cell-popover-menu"
         isOpen={isPopoverOpen}
         position={PopoverPosition.LeftStart}
         referenceElement={popoverRef.current}

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -179,7 +179,7 @@ export const MultichainAccountMenu = ({
       </Box>
       <Popover
         isOpen={isPopoverOpen}
-        position={PopoverPosition.Bottom}
+        position={PopoverPosition.LeftStart}
         referenceElement={popoverRef.current}
         matchWidth={false}
         style={{

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -53,36 +53,31 @@ export const MultichainAccountMenu = ({
     const handleAccountRenameClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account rename click handling
       mouseEvent.stopPropagation();
-      setIsPopoverOpen(false);
-      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+      mouseEvent.preventDefault();
     };
 
     const handleAccountAddressesClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account addresses click handling
       mouseEvent.stopPropagation();
-      setIsPopoverOpen(false);
-      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+      mouseEvent.preventDefault();
     };
 
     const handleAccountPinClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account pin click handling
       mouseEvent.stopPropagation();
-      setIsPopoverOpen(false);
-      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+      mouseEvent.preventDefault();
     };
 
     const handleAccountHideClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account hide click handling
       mouseEvent.stopPropagation();
-      setIsPopoverOpen(false);
-      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+      mouseEvent.preventDefault();
     };
 
     const handleAccountRemoveClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account remove click handling
       mouseEvent.stopPropagation();
-      setIsPopoverOpen(false);
-      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+      mouseEvent.preventDefault();
     };
 
     const baseMenuItems: MenuItemConfig[] = [
@@ -95,21 +90,25 @@ export const MultichainAccountMenu = ({
         textKey: 'rename',
         iconName: IconName.Edit,
         onClick: handleAccountRenameClick,
+        disabled: true,
       },
       {
         textKey: 'addresses',
         iconName: IconName.QrCode,
         onClick: handleAccountAddressesClick,
+        disabled: true,
       },
       {
         textKey: 'pin',
         iconName: IconName.Pin,
         onClick: handleAccountPinClick,
+        disabled: true,
       },
       {
         textKey: 'hide',
         iconName: IconName.EyeSlash,
         onClick: handleAccountHideClick,
+        disabled: true,
       },
     ];
 
@@ -146,7 +145,8 @@ export const MultichainAccountMenu = ({
             ...(isLast
               ? {}
               : { borderBottom: '1px solid var(--color-border-muted)' }),
-            cursor: 'pointer',
+            cursor: item.disabled ? 'not-allowed' : 'pointer',
+            opacity: item.disabled ? 0.5 : 1,
           }}
         >
           <Text

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,0 +1,193 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  Box,
+  Icon,
+  IconName,
+  IconSize,
+  Popover,
+  PopoverPosition,
+  Text,
+} from '../../component-library';
+import {
+  AlignItems,
+  BackgroundColor,
+  BorderRadius,
+  Display,
+  FontWeight,
+  JustifyContent,
+  TextColor,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { ACCOUNT_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
+import {
+  MenuItemConfig,
+  MultichainAccountMenuProps,
+} from './multichain-account-menu.types';
+
+export const MultichainAccountMenu = ({
+  accountGroupId,
+  isRemovable,
+}: MultichainAccountMenuProps) => {
+  const t = useI18nContext();
+  const history = useHistory();
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const togglePopover = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    setIsPopoverOpen(!isPopoverOpen);
+  };
+
+  const menuConfig = useMemo(() => {
+    const handleAccountDetailsClick = () => {
+      // TODO: Implement account details click handling
+      setIsPopoverOpen(false);
+      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+    };
+
+    const handleAccountRenameClick = () => {
+      // TODO: Implement account rename click handling
+      setIsPopoverOpen(false);
+      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+    };
+
+    const handleAccountAddressesClick = () => {
+      // TODO: Implement account addresses click handling
+      setIsPopoverOpen(false);
+      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+    };
+
+    const handleAccountPinClick = () => {
+      // TODO: Implement account pin click handling
+      setIsPopoverOpen(false);
+      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+    };
+
+    const handleAccountHideClick = () => {
+      // TODO: Implement account hide click handling
+      setIsPopoverOpen(false);
+      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+    };
+
+    const handleAccountRemoveClick = () => {
+      // TODO: Implement account remove click handling
+      setIsPopoverOpen(false);
+      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+    };
+
+    const baseMenuItems: MenuItemConfig[] = [
+      {
+        textKey: 'accountDetails',
+        iconName: IconName.Details,
+        onClick: handleAccountDetailsClick,
+      },
+      {
+        textKey: 'rename',
+        iconName: IconName.Edit,
+        onClick: handleAccountRenameClick,
+      },
+      {
+        textKey: 'addresses',
+        iconName: IconName.QrCode,
+        onClick: handleAccountAddressesClick,
+      },
+      {
+        textKey: 'pin',
+        iconName: IconName.Pin,
+        onClick: handleAccountPinClick,
+      },
+      {
+        textKey: 'hide',
+        iconName: IconName.EyeSlash,
+        onClick: handleAccountHideClick,
+      },
+    ];
+
+    if (isRemovable) {
+      baseMenuItems.push({
+        textKey: 'remove',
+        iconName: IconName.Trash,
+        onClick: handleAccountRemoveClick,
+        textColor: TextColor.errorDefault,
+      });
+    }
+
+    return Object.freeze(baseMenuItems);
+  }, [history, isRemovable]);
+
+  const menuItems = useMemo(() => {
+    return menuConfig.map((item, index, menuConfigurations) => {
+      const isLast = index === menuConfigurations.length - 1;
+
+      return (
+        <Box
+          key={item.textKey}
+          className="multichain-account-menu-item"
+          paddingLeft={8}
+          paddingRight={4}
+          paddingTop={3}
+          paddingBottom={3}
+          display={Display.Flex}
+          justifyContent={JustifyContent.spaceBetween}
+          alignItems={AlignItems.center}
+          onClick={item.onClick}
+          style={{
+            width: '250px',
+            ...(isLast
+              ? {}
+              : { borderBottom: '1px solid var(--color-border-muted)' }),
+            cursor: 'pointer',
+          }}
+        >
+          <Text
+            fontWeight={FontWeight.Medium}
+            variant={TextVariant.bodyMdMedium}
+            color={item.textColor}
+          >
+            {t(item.textKey)}
+          </Text>
+          <Icon name={item.iconName} size={IconSize.Md} />
+        </Box>
+      );
+    });
+  }, [menuConfig, t]);
+
+  return (
+    <>
+      <Box
+        ref={popoverRef}
+        display={Display.Flex}
+        alignItems={AlignItems.center}
+        justifyContent={JustifyContent.center}
+        backgroundColor={BackgroundColor.backgroundMuted}
+        borderRadius={BorderRadius.LG}
+        padding={1}
+        onClick={togglePopover}
+        style={{ cursor: 'pointer', width: '28px', height: '28px' }}
+      >
+        <Icon name={IconName.MoreVertical} />
+      </Box>
+      <Popover
+        isOpen={isPopoverOpen}
+        position={PopoverPosition.Bottom}
+        referenceElement={popoverRef.current}
+        matchWidth={false}
+        style={{
+          zIndex: 10,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: 0,
+          cursor: 'pointer',
+          overflow: 'hidden',
+        }}
+        borderRadius={BorderRadius.LG}
+      >
+        {menuItems}
+      </Popover>
+    </>
+  );
+};
+
+export default MultichainAccountMenu;

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -162,6 +162,7 @@ export const MultichainAccountMenu = ({
   return (
     <>
       <Box
+        className="multichain-account-menu-button"
         ref={popoverRef}
         display={Display.Flex}
         alignItems={AlignItems.center}
@@ -172,7 +173,10 @@ export const MultichainAccountMenu = ({
         onClick={togglePopover}
         style={{ cursor: 'pointer', width: '28px', height: '28px' }}
       >
-        <Icon name={IconName.MoreVertical} />
+        <Icon
+          className="multichain-account-menu-button-icon"
+          name={IconName.MoreVertical}
+        />
       </Box>
       <Popover
         isOpen={isPopoverOpen}

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,37 +1,29 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import classnames from 'classnames';
 import {
   Box,
   Icon,
   IconName,
-  IconSize,
   Popover,
   PopoverPosition,
-  Text,
 } from '../../component-library';
 import {
   AlignItems,
   BackgroundColor,
   BorderRadius,
   Display,
-  FontWeight,
   JustifyContent,
   TextColor,
-  TextVariant,
 } from '../../../helpers/constants/design-system';
-import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE } from '../../../helpers/constants/routes';
-import {
-  MenuItemConfig,
-  MultichainAccountMenuProps,
-} from './multichain-account-menu.types';
+import { MultichainAccountMenuItems } from '../multichain-account-menu-items/multichain-account-menu-items';
+import { MenuItemConfig } from '../multichain-account-menu-items/multichain-account-menu-items.types';
+import { MultichainAccountMenuProps } from './multichain-account-menu.types';
 
 export const MultichainAccountMenu = ({
   accountGroupId,
   isRemovable,
 }: MultichainAccountMenuProps) => {
-  const t = useI18nContext();
   const history = useHistory();
   const popoverRef = useRef<HTMLDivElement>(null);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -119,43 +111,8 @@ export const MultichainAccountMenu = ({
       });
     }
 
-    return Object.freeze(baseMenuItems);
+    return baseMenuItems;
   }, [accountGroupId, history, isRemovable]);
-
-  const menuItems = useMemo(() => {
-    return menuConfig.map((item, index, menuConfigurations) => {
-      const isLast = index === menuConfigurations.length - 1;
-      const isDisabled = Boolean(item.disabled);
-
-      return (
-        <Box
-          key={item.textKey}
-          className={classnames('multichain-account-menu-item', {
-            'multichain-account-menu-item--with-border': !isLast,
-            'multichain-account-menu-item--disabled': isDisabled,
-            'multichain-account-menu-item--enabled': !isDisabled,
-          })}
-          paddingLeft={8}
-          paddingRight={4}
-          paddingTop={3}
-          paddingBottom={3}
-          display={Display.Flex}
-          justifyContent={JustifyContent.spaceBetween}
-          alignItems={AlignItems.center}
-          onClick={item.onClick}
-        >
-          <Text
-            fontWeight={FontWeight.Medium}
-            variant={TextVariant.bodyMdMedium}
-            color={item.textColor}
-          >
-            {t(item.textKey)}
-          </Text>
-          <Icon name={item.iconName} size={IconSize.Md} />
-        </Box>
-      );
-    });
-  }, [menuConfig, t]);
 
   return (
     <>
@@ -183,7 +140,7 @@ export const MultichainAccountMenu = ({
         matchWidth={false}
         borderRadius={BorderRadius.LG}
       >
-        {menuItems}
+        <MultichainAccountMenuItems menuConfig={menuConfig} />
       </Popover>
     </>
   );

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -20,10 +20,7 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import {
-  ACCOUNT_LIST_PAGE_ROUTE,
-  MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE,
-} from '../../../helpers/constants/routes';
+import { MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE } from '../../../helpers/constants/routes';
 import {
   MenuItemConfig,
   MultichainAccountMenuProps,

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -20,7 +20,10 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { ACCOUNT_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
+import {
+  ACCOUNT_LIST_PAGE_ROUTE,
+  MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE,
+} from '../../../helpers/constants/routes';
 import {
   MenuItemConfig,
   MultichainAccountMenuProps,
@@ -41,38 +44,43 @@ export const MultichainAccountMenu = ({
   };
 
   const menuConfig = useMemo(() => {
-    const handleAccountDetailsClick = () => {
-      // TODO: Implement account details click handling
-      setIsPopoverOpen(false);
-      history.push(ACCOUNT_LIST_PAGE_ROUTE);
+    const handleAccountDetailsClick = (mouseEvent: React.MouseEvent) => {
+      mouseEvent.stopPropagation();
+      const multichainAccountDetailsPageRoute = `${MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE}/${encodeURIComponent(accountGroupId)}`;
+      history.push(multichainAccountDetailsPageRoute);
     };
 
-    const handleAccountRenameClick = () => {
+    const handleAccountRenameClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account rename click handling
+      mouseEvent.stopPropagation();
       setIsPopoverOpen(false);
       history.push(ACCOUNT_LIST_PAGE_ROUTE);
     };
 
-    const handleAccountAddressesClick = () => {
+    const handleAccountAddressesClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account addresses click handling
+      mouseEvent.stopPropagation();
       setIsPopoverOpen(false);
       history.push(ACCOUNT_LIST_PAGE_ROUTE);
     };
 
-    const handleAccountPinClick = () => {
+    const handleAccountPinClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account pin click handling
+      mouseEvent.stopPropagation();
       setIsPopoverOpen(false);
       history.push(ACCOUNT_LIST_PAGE_ROUTE);
     };
 
-    const handleAccountHideClick = () => {
+    const handleAccountHideClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account hide click handling
+      mouseEvent.stopPropagation();
       setIsPopoverOpen(false);
       history.push(ACCOUNT_LIST_PAGE_ROUTE);
     };
 
-    const handleAccountRemoveClick = () => {
+    const handleAccountRemoveClick = (mouseEvent: React.MouseEvent) => {
       // TODO: Implement account remove click handling
+      mouseEvent.stopPropagation();
       setIsPopoverOpen(false);
       history.push(ACCOUNT_LIST_PAGE_ROUTE);
     };
@@ -115,7 +123,7 @@ export const MultichainAccountMenu = ({
     }
 
     return Object.freeze(baseMenuItems);
-  }, [history, isRemovable]);
+  }, [accountGroupId, history, isRemovable]);
 
   const menuItems = useMemo(() => {
     return menuConfig.map((item, index, menuConfigurations) => {

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import classnames from 'classnames';
 import {
   Box,
   Icon,
@@ -124,11 +125,16 @@ export const MultichainAccountMenu = ({
   const menuItems = useMemo(() => {
     return menuConfig.map((item, index, menuConfigurations) => {
       const isLast = index === menuConfigurations.length - 1;
+      const isDisabled = Boolean(item.disabled);
 
       return (
         <Box
           key={item.textKey}
-          className="multichain-account-menu-item"
+          className={classnames('multichain-account-menu-item', {
+            'multichain-account-menu-item--with-border': !isLast,
+            'multichain-account-menu-item--disabled': isDisabled,
+            'multichain-account-menu-item--enabled': !isDisabled,
+          })}
           paddingLeft={8}
           paddingRight={4}
           paddingTop={3}
@@ -137,14 +143,6 @@ export const MultichainAccountMenu = ({
           justifyContent={JustifyContent.spaceBetween}
           alignItems={AlignItems.center}
           onClick={item.onClick}
-          style={{
-            width: '250px',
-            ...(isLast
-              ? {}
-              : { borderBottom: '1px solid var(--color-border-muted)' }),
-            cursor: item.disabled ? 'not-allowed' : 'pointer',
-            opacity: item.disabled ? 0.5 : 1,
-          }}
         >
           <Text
             fontWeight={FontWeight.Medium}

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
@@ -17,22 +17,27 @@ export type MultichainAccountMenuProps = {
 
 export type MenuItemConfig = {
   /**
-   * Translation key for the menu item text
+   * Translation key for the menu item text.
    */
   textKey: string;
 
   /**
-   * Icon to display for the menu item
+   * Icon to display for the menu item.
    */
   iconName: IconName;
 
   /**
-   * Function to execute when the menu item is clicked
+   * Function to execute when the menu item is clicked.
    */
   onClick: (mouseEvent: React.MouseEvent) => void;
 
   /**
-   * Optional color for the menu item text
+   * Optional color for the menu item text.
    */
   textColor?: TextColor;
+
+  /**
+   * Whether the menu item is disabled.
+   */
+  disabled?: boolean;
 };

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
@@ -1,7 +1,4 @@
 import { AccountGroupId } from '@metamask/account-api';
-import React from 'react';
-import { IconName } from '../../component-library';
-import { TextColor } from '../../../helpers/constants/design-system';
 
 export type MultichainAccountMenuProps = {
   /**
@@ -13,31 +10,4 @@ export type MultichainAccountMenuProps = {
    * Whether the account is removable.
    */
   isRemovable: boolean;
-};
-
-export type MenuItemConfig = {
-  /**
-   * Translation key for the menu item text.
-   */
-  textKey: string;
-
-  /**
-   * Icon to display for the menu item.
-   */
-  iconName: IconName;
-
-  /**
-   * Function to execute when the menu item is clicked.
-   */
-  onClick: (mouseEvent: React.MouseEvent) => void;
-
-  /**
-   * Optional color for the menu item text.
-   */
-  textColor?: TextColor;
-
-  /**
-   * Whether the menu item is disabled.
-   */
-  disabled?: boolean;
 };

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
@@ -1,0 +1,37 @@
+import { AccountGroupId } from '@metamask/account-api';
+import { IconName } from '../../component-library';
+import { TextColor } from '../../../helpers/constants/design-system';
+
+export type MultichainAccountMenuProps = {
+  /**
+   * ID of an account group.
+   */
+  accountGroupId: AccountGroupId;
+
+  /**
+   * Whether the account is removable.
+   */
+  isRemovable: boolean;
+};
+
+export type MenuItemConfig = {
+  /**
+   * Translation key for the menu item text
+   */
+  textKey: string;
+
+  /**
+   * Icon to display for the menu item
+   */
+  iconName: IconName;
+
+  /**
+   * Function to execute when the menu item is clicked
+   */
+  onClick: () => void;
+
+  /**
+   * Optional color for the menu item text
+   */
+  textColor?: TextColor;
+};

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
@@ -1,4 +1,5 @@
 import { AccountGroupId } from '@metamask/account-api';
+import React from 'react';
 import { IconName } from '../../component-library';
 import { TextColor } from '../../../helpers/constants/design-system';
 
@@ -28,7 +29,7 @@ export type MenuItemConfig = {
   /**
    * Function to execute when the menu item is clicked
    */
-  onClick: () => void;
+  onClick: (mouseEvent: React.MouseEvent) => void;
 
   /**
    * Optional color for the menu item text

--- a/ui/components/multichain-accounts/multichain-accounts.scss
+++ b/ui/components/multichain-accounts/multichain-accounts.scss
@@ -1,1 +1,2 @@
 @import "multichain-account-cell";
+@import "multichain-account-menu";

--- a/ui/components/multichain-accounts/multichain-accounts.scss
+++ b/ui/components/multichain-accounts/multichain-accounts.scss
@@ -1,2 +1,3 @@
 @import "multichain-account-cell";
 @import "multichain-account-menu";
+@import "multichain-account-menu-items";

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -42,6 +42,8 @@ export const IMPORT_TOKENS_ROUTE = '/import-tokens';
 export const CONFIRM_IMPORT_TOKEN_ROUTE = '/confirm-import-token';
 export const CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE = '/confirm-add-suggested-token';
 export const ACCOUNT_LIST_PAGE_ROUTE = '/account-list';
+export const MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE =
+  '/multichain-account-details';
 export const NEW_ACCOUNT_ROUTE = '/new-account';
 export const ACCOUNT_DETAILS_ROUTE = '/account-details';
 export const ACCOUNT_DETAILS_QR_CODE_ROUTE = '/account-details/qr-code';
@@ -131,6 +133,11 @@ export const ROUTES = [
   {
     path: ACCOUNT_LIST_PAGE_ROUTE,
     label: 'Account List Page',
+    trackInAnalytics: true,
+  },
+  {
+    path: `${MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE}/:id`,
+    label: 'Account Details Page',
     trackInAnalytics: true,
   },
   {

--- a/ui/pages/multichain-accounts/multichain-account-details-page/index.scss
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/index.scss
@@ -1,0 +1,3 @@
+.multichain-account-details-page-wrapper {
+  max-width: 600px;
+}

--- a/ui/pages/multichain-accounts/multichain-account-details-page/index.ts
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/index.ts
@@ -1,0 +1,1 @@
+export { MultichainAccountDetailsPage } from './multichain-account-details-page';

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.stories.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.stories.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { StoryObj, Meta } from '@storybook/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { MultichainAccountDetailsPage } from './multichain-account-details-page';
+import mockState from '../../../../test/data/mock-state.json';
+import configureStore from '../../../store/store';
+
+const store = configureStore({
+  metamask: {
+    ...mockState.metamask,
+  },
+});
+
+interface WrapperProps {
+  children: React.ReactNode;
+  accountId?: string;
+}
+
+const Wrapper: React.FC<WrapperProps> = ({
+  children,
+  accountId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0',
+}) => (
+  <Provider store={store}>
+    <MemoryRouter
+      initialEntries={[
+        `/multichain-account-details/${encodeURIComponent(accountId)}`,
+      ]}
+    >
+      <Route path="/multichain-account-details/:id">{children}</Route>
+    </MemoryRouter>
+  </Provider>
+);
+
+const meta: Meta<typeof MultichainAccountDetailsPage> = {
+  title: 'Pages/MultichainAccounts/MultichainAccountDetailsPage',
+  component: MultichainAccountDetailsPage,
+  decorators: [
+    (Story) => (
+      <Wrapper>
+        <Story />
+      </Wrapper>
+    ),
+  ],
+  parameters: {
+    backgrounds: {
+      default: 'light',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MultichainAccountDetailsPage>;
+
+export const Default: Story = {};
+
+Default.parameters = {
+  docs: {
+    description: {
+      story:
+        'Default state of the MultichainAccountDetailsPage showing account details for the selected account.',
+    },
+  },
+};

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { useHistory, useParams } from 'react-router-dom';
+import {
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  Text,
+} from '../../../components/component-library';
+import {
+  Content,
+  Header,
+  Page,
+} from '../../../components/multichain/pages/page';
+import {
+  Display,
+  FlexDirection,
+  JustifyContent,
+  TextAlign,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+export const MultichainAccountDetailsPage = () => {
+  const t = useI18nContext();
+  const history = useHistory();
+  const { id } = useParams();
+  const decodedAccountGroupId = decodeURIComponent(id as string);
+
+  return (
+    <Page className="multichain-account-details-page">
+      <Header
+        textProps={{
+          variant: TextVariant.headingSm,
+        }}
+        startAccessory={
+          <ButtonIcon
+            size={ButtonIconSize.Md}
+            ariaLabel={t('back')}
+            iconName={IconName.ArrowLeft}
+            onClick={() => history.goBack()}
+          />
+        }
+      >
+        {t('accountDetails')}
+      </Header>
+      <Content className="account-list-page__content">
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          justifyContent={JustifyContent.center}
+        >
+          <Text textAlign={TextAlign.Center}>
+            Multichain Account Details Page Content ({decodedAccountGroupId})
+          </Text>
+        </Box>
+      </Content>
+    </Page>
+  );
+};

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -29,7 +29,7 @@ export const MultichainAccountDetailsPage = () => {
   const decodedAccountGroupId = decodeURIComponent(id as string);
 
   return (
-    <Page className="multichain-account-details-page">
+    <Page className="multichain-account-details-page-wrapper">
       <Header
         textProps={{
           variant: TextVariant.headingSm,

--- a/ui/pages/pages.scss
+++ b/ui/pages/pages.scss
@@ -30,3 +30,4 @@
 @import 'multi-srp/import-srp/index';
 @import 'multichain-accounts/address-qr-code/address-qr-code';
 @import 'multichain-accounts/base-account-details/base-account-details';
+@import 'multichain-accounts/multichain-account-details-page/index';

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -60,6 +60,7 @@ import {
   ACCOUNT_DETAILS_ROUTE,
   ACCOUNT_DETAILS_QR_CODE_ROUTE,
   ACCOUNT_LIST_PAGE_ROUTE,
+  MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE,
 } from '../../helpers/constants/routes';
 import {
   getProviderConfig,
@@ -289,6 +290,13 @@ const WalletDetails = mmLazy(
   (() =>
     import(
       '../multichain-accounts/wallet-details/index.ts'
+    )) as unknown as DynamicImportType,
+);
+
+const MultichainAccountDetailsPage = mmLazy(
+  (() =>
+    import(
+      '../multichain-accounts/multichain-account-details-page/index.ts'
     )) as unknown as DynamicImportType,
 );
 // End Lazy Routes
@@ -574,6 +582,11 @@ export default function Routes() {
           <Authenticated
             path={ACCOUNT_LIST_PAGE_ROUTE}
             component={AccountList}
+            exact
+          />
+          <Authenticated
+            path={`${MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE}/:id`}
+            component={MultichainAccountDetailsPage}
             exact
           />
           <Authenticated

--- a/ui/pages/routes/utils.js
+++ b/ui/pages/routes/utils.js
@@ -26,6 +26,7 @@ import {
   WALLET_DETAILS_ROUTE,
   ACCOUNT_DETAILS_ROUTE,
   ACCOUNT_DETAILS_QR_CODE_ROUTE,
+  MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE,
 } from '../../helpers/constants/routes';
 
 export function isConfirmTransactionRoute(pathname) {
@@ -182,6 +183,16 @@ export function hideAppHeader(props) {
     }),
   );
   if (isMultichainSend) {
+    return true;
+  }
+
+  const isStateTwoMultichainAccountDetailsPage = Boolean(
+    matchPath(location.pathname, {
+      path: MULTICHAIN_ACCOUNT_DETAILS_PAGE_ROUTE,
+      exact: false,
+    }),
+  );
+  if (isStateTwoMultichainAccountDetailsPage) {
     return true;
   }
 


### PR DESCRIPTION
## **Description**
This PR adds a new component that is used within the multichain account list cell to show popup menu with additional account options.

Notes:
- New multichain account details page is added with some boilerplate code in order to make testing and demo of this component more practical and reasonable. This new details component will be used for new multichain state 2 UI/UX, and is visible only under feature flag. Its code will be reused very soon for finishing it.
- Menu items other than `Account details` are disabled, but still present for demo purposes and increase in development velocity as they're required to wrap up the entire architecture of this component. Soon, we will complete these options as well and remove the disabled states and their temporary UI styling.
- Route changes are made in order to route new `Account details` page.
- Remove button is supposed to be displayed only for certain accounts and this logic is yet to be implemented. Therefore, remove button is not present in the UI still, but it is visible in storybook, for now.
- Cursor is always **pointer** when hovering the menu items and its trigger button, but it's just not visible on the recording for some unknown reason.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35064?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added new multichain account popup menu

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-371

Figma designs: https://www.figma.com/design/G88ChchQ8FINCBI9BBkrAG/BIP-44-Extension?node-id=3057-12602&m=dev

## **Manual testing steps**
1. Enable multichain feature flag for state 2 and go to the account list
2. Click on three dot menu within one of the account cells
3. Notice that popup appears
4. Check popup menu UI elements and behavior
5. Confirm that UI/UX is as expected

## **Screenshots/Recordings**
### **Before**
Popup menu within the multichain account list menu was not available before. Nothing special to show here except maybe the old account list without three dot menu item/icon on each multichain account cell.

<img width="402" height="603" alt="Screenshot 2025-08-14 at 00 12 04" src="https://github.com/user-attachments/assets/a6b2f499-8e16-4eb8-bb62-bd90261236fb" />

### **After**

- Some storybook screenshots
<img width="988" height="680" alt="Screenshot 2025-08-14 at 22 43 56" src="https://github.com/user-attachments/assets/38588d4b-6f4f-4efe-9cdc-e29339d2b804" />
<img width="569" height="378" alt="Screenshot 2025-08-14 at 22 44 19" src="https://github.com/user-attachments/assets/500d520d-2fb7-4d85-a083-ebafcceabafd" />

- Some extension screenshots
<img width="400" height="601" alt="Screenshot 2025-08-14 at 22 54 01" src="https://github.com/user-attachments/assets/300fd9fe-39ce-42f8-9c23-eed9fb8eb278" />
<img width="400" height="601" alt="Screenshot 2025-08-14 at 22 54 15" src="https://github.com/user-attachments/assets/1639eedc-85fe-4a91-88ad-aafdff0079f5" />

- Some real use case demo scenarios from extension

https://github.com/user-attachments/assets/2d8f08ab-eb3a-4e85-adcb-393272121842


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.