### PR TITLE
fix: Allow Snap confirmations during chain switching

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js
@@ -230,7 +230,11 @@ export async function switchChain(
           autoApprove,
           metadata,
         });
-      } else if (hasApprovalRequestsForOrigin?.() && !isAddFlow && !autoApprove) {
+      } else if (
+        hasApprovalRequestsForOrigin?.() &&
+        !isAddFlow &&
+        !autoApprove
+      ) {
         await requestUserApproval({
           origin,
           type: ApprovalType.SwitchEthereumChain,

--- a/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js
@@ -6,6 +6,7 @@ import {
   getPermittedEthChainIds,
 } from '@metamask/chain-agnostic-permission';
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
+import { isSnapId } from '@metamask/snaps-utils';
 import {
   isPrefixedFormattedHexString,
   isSafeChainId,
@@ -229,7 +230,7 @@ export async function switchChain(
           autoApprove,
           metadata,
         });
-      } else if (hasApprovalRequestsForOrigin?.() && !isAddFlow) {
+      } else if (hasApprovalRequestsForOrigin?.() && !isAddFlow && !autoApprove) {
         await requestUserApproval({
           origin,
           type: ApprovalType.SwitchEthereumChain,
@@ -246,7 +247,9 @@ export async function switchChain(
       });
     }
 
-    rejectApprovalRequestsForOrigin?.();
+    if (!isSnapId(origin)) {
+      rejectApprovalRequestsForOrigin?.();
+    }
 
     await setActiveNetwork(networkClientId);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes two issues with using `wallet_switchEthereumChain` in Snaps when displaying an approval. First of all, Snaps are intended to automatically switch the chain, but this behavior was different when an approval was on screen. Secondly, all confirmations are currently cancelled before the chain switch triggers. Both of these behaviors have been disabled/corrected.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35107?quickstart=1)

## **Manual testing steps**

This Snap should work.

```ts
import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
import { Text } from '@metamask/snaps-sdk/jsx';

export const onRpcRequest: OnRpcRequestHandler = async ({
  origin,
  request,
}) => {
  switch (request.method) {
    case 'hello': {
      const selectedChain = await ethereum.request({
        method: 'eth_chainId',
        params: [],
      });

      const newChain = selectedChain === '0x1' ? '0xaa36a7' : '0x1';

      const interfaceId = await snap.request({
        method: 'snap_createInterface',
        params: {
          context: {},
          ui: Text({
            children: `Hello world, switching to: ${newChain}`,
          }),
        },
      });

      const dialog = snap.request({
        method: 'snap_dialog',
        params: {
          id: interfaceId,
        },
      });

      await ethereum.request({
        method: 'wallet_switchEthereumChain',
        params: [
          {
            chainId: newChain,
          },
        ],
      });

      await dialog;

      return;
    }
    default:
      throw new Error('Method not found.');
  }
};


```