### PR TITLE
feat: Add `useSnapNameResolution` hook

### DIFF
--- a/ui/hooks/snaps/useSnapNameResolution.test.ts
+++ b/ui/hooks/snaps/useSnapNameResolution.test.ts
@@ -1,0 +1,228 @@
+import { renderHookWithProvider } from '../../../test/lib/render-helpers';
+import baseMockState from '../../../test/data/mock-state.json';
+import { useSnapNameResolution } from './useSnapNameResolution';
+
+jest.mock('../../store/actions', () => ({
+  ...jest.requireActual('../../store/actions'),
+  handleSnapRequest: jest
+    .fn()
+    .mockImplementation(async ({ snapId, request }) => {
+      if (
+        snapId === 'npm:@metamask/solana-snap' &&
+        request.params.domain.includes('metamask')
+      ) {
+        return {
+          resolvedAddresses: [
+            {
+              resolvedAddress: '7XGrbd3dmdesSR5vAu7siidiZ1YHyizzuPCQAnh2g2Lo',
+              protocol: 'SNS',
+              domainName: 'metamask.sol',
+            },
+          ],
+        };
+      }
+
+      if (
+        snapId === 'npm:@metamask/ens-resolver-snap' &&
+        request.params.domain.includes('metamask')
+      ) {
+        return {
+          resolvedAddresses: [
+            {
+              resolvedAddress: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+              protocol: 'ENS',
+              domainName: 'metamask.eth',
+            },
+          ],
+        };
+      }
+
+      if (
+        snapId === 'npm:social-names-snap' &&
+        request.params.domain.endsWith('.lens')
+      ) {
+        return {
+          resolvedAddresses: [
+            {
+              resolvedAddress: '0x0000000000000000000000000000000000000000',
+              protocol: 'Lens',
+              domainName: 'foo.lens',
+            },
+          ],
+        };
+      }
+
+      if (
+        snapId === 'npm:social-names-snap' &&
+        request.params.domain.startsWith('farcaster:')
+      ) {
+        return {
+          resolvedAddresses: [
+            {
+              resolvedAddress: '0x0000000000000000000000000000000000000000',
+              protocol: 'Farcaster',
+              domainName: 'farcaster:v',
+            },
+          ],
+        };
+      }
+
+      return null;
+    }),
+}));
+
+const mockState = {
+  ...baseMockState,
+  metamask: {
+    ...baseMockState.metamask,
+    snaps: {
+      'npm:@metamask/ens-resolver-snap': {
+        id: 'npm:@metamask/ens-resolver-snap',
+        enabled: true,
+        version: '1.0.0',
+      },
+      'npm:@metamask/solana-snap': {
+        id: 'npm:@metamask/solana-snap',
+        enabled: true,
+        version: '1.0.0',
+      },
+      'npm:social-names-snap': {
+        id: 'npm:social-names-snap',
+        enabled: true,
+        version: '1.0.0',
+      },
+    },
+    subjects: {
+      'npm:@metamask/ens-resolver-snap': {
+        origin: 'npm:@metamask/ens-resolver-snap',
+        permissions: {
+          'endowment:name-lookup': {
+            caveats: null,
+            date: 1718117256761,
+            id: 'MhjpHKQFfGpMzI6YzkPGU',
+            invoker: 'npm:@metamask/ens-resolver-snap',
+            parentCapability: 'endowment:name-lookup',
+          },
+        },
+      },
+      'npm:@metamask/solana-snap': {
+        origin: 'npm:@metamask/solana-snap',
+        permissions: {
+          'endowment:name-lookup': {
+            caveats: [
+              {
+                type: 'chainIds',
+                value: [
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                  'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+                ],
+              },
+            ],
+            date: 1718117256761,
+            id: 'MhjpHKQFfGpMzI6YzkPGA',
+            invoker: 'npm:@metamask/solana-snap',
+            parentCapability: 'endowment:name-lookup',
+          },
+        },
+      },
+      'npm:social-names-snap': {
+        origin: 'npm:social-names-snap',
+        permissions: {
+          'endowment:name-lookup': {
+            caveats: [
+              {
+                type: 'lookupMatchers',
+                value: { tlds: ['lens'], schemes: ['farcaster', 'fc'] },
+              },
+            ],
+            date: 1718117256761,
+            id: 'MhjpHKQFfGpMzI6YzkPGA',
+            invoker: 'npm:social-names-snap',
+            parentCapability: 'endowment:name-lookup',
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('useSnapNameResolution', () => {
+  it('calls name resolution Snaps with the provided input', async () => {
+    const { result, waitForValueToChange } = renderHookWithProvider(
+      () =>
+        useSnapNameResolution({ chainId: 'eip155:1', domain: 'metamask.eth' }),
+      mockState,
+    );
+
+    await waitForValueToChange(() => result.current.results);
+
+    expect(result.current.results).toStrictEqual([
+      {
+        domainName: 'metamask.eth',
+        protocol: 'ENS',
+        resolvedAddress: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+      },
+    ]);
+  });
+
+  it('supports chain ID filtering', async () => {
+    const { result, waitForValueToChange } = renderHookWithProvider(
+      () =>
+        useSnapNameResolution({
+          chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          domain: 'metamask',
+        }),
+      mockState,
+    );
+
+    await waitForValueToChange(() => result.current.results);
+
+    expect(result.current.results).toStrictEqual([
+      {
+        domainName: 'metamask.eth',
+        protocol: 'ENS',
+        resolvedAddress: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+      },
+      {
+        domainName: 'metamask.sol',
+        protocol: 'SNS',
+        resolvedAddress: '7XGrbd3dmdesSR5vAu7siidiZ1YHyizzuPCQAnh2g2Lo',
+      },
+    ]);
+  });
+
+  it('supports scheme filtering', async () => {
+    const { result, waitForValueToChange } = renderHookWithProvider(
+      () =>
+        useSnapNameResolution({ chainId: 'eip155:1', domain: 'farcaster:v' }),
+      mockState,
+    );
+
+    await waitForValueToChange(() => result.current.results);
+
+    expect(result.current.results).toStrictEqual([
+      {
+        domainName: 'farcaster:v',
+        protocol: 'Farcaster',
+        resolvedAddress: '0x0000000000000000000000000000000000000000',
+      },
+    ]);
+  });
+
+  it('supports TLD filtering', async () => {
+    const { result, waitForValueToChange } = renderHookWithProvider(
+      () => useSnapNameResolution({ chainId: 'eip155:1', domain: 'foo.lens' }),
+      mockState,
+    );
+
+    await waitForValueToChange(() => result.current.results);
+
+    expect(result.current.results).toStrictEqual([
+      {
+        domainName: 'foo.lens',
+        protocol: 'Lens',
+        resolvedAddress: '0x0000000000000000000000000000000000000000',
+      },
+    ]);
+  });
+});

--- a/ui/hooks/snaps/useSnapNameResolution.ts
+++ b/ui/hooks/snaps/useSnapNameResolution.ts
@@ -52,7 +52,7 @@ export function useSnapNameResolution({
           return true;
         })
         .map(({ id }) => id),
-    [snaps, chainId],
+    [snaps, chainId, domain],
   );
 
   useEffect(() => {

--- a/ui/hooks/snaps/useSnapNameResolution.ts
+++ b/ui/hooks/snaps/useSnapNameResolution.ts
@@ -34,11 +34,12 @@ export function useSnapNameResolution({
       snaps
         .filter(({ permission }) => {
           const chainIdCaveat = getChainIdsCaveat(permission);
-          const lookupMatchersCaveat = getLookupMatchersCaveat(permission);
 
           if (chainIdCaveat && !chainIdCaveat.includes(chainId)) {
             return false;
           }
+
+          const lookupMatchersCaveat = getLookupMatchersCaveat(permission);
 
           if (lookupMatchersCaveat) {
             const { tlds, schemes } = lookupMatchersCaveat;

--- a/ui/hooks/snaps/useSnapNameResolution.ts
+++ b/ui/hooks/snaps/useSnapNameResolution.ts
@@ -24,10 +24,8 @@ export function useSnapNameResolution({
   chainId: string;
   domain: string;
 }) {
-  const [loading, setLoading] = useState<boolean>(true);
-  const [results, setResults] = useState<AddressResolution[] | undefined>(
-    undefined,
-  );
+  const [loading, setLoading] = useState<boolean>(false);
+  const [results, setResults] = useState<AddressResolution[]>([]);
 
   const snaps = useSelector(getNameLookupSnaps);
 

--- a/ui/hooks/snaps/useSnapNameResolution.ts
+++ b/ui/hooks/snaps/useSnapNameResolution.ts
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  getChainIdsCaveat,
+  getLookupMatchersCaveat,
+} from '@metamask/snaps-rpc-methods';
+import { AddressResolution, DomainLookupResult } from '@metamask/snaps-sdk';
+import { getNameLookupSnaps } from '../../selectors';
+import { handleSnapRequest } from '../../store/actions';
+
+/**
+ * A hook for using Snaps to resolve domain names for a given chain ID.
+ *
+ * @param options - An options bag.
+ * @param options.chainId - A CAIP-2 chain ID.
+ * @param options.domain - The domain to resolve.
+ * @returns The results of the name resolution and a flag to determine if the
+ * results are loading.
+ */
+export function useSnapNameResolution({
+  chainId,
+  domain,
+}: {
+  chainId: string;
+  domain: string;
+}) {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [results, setResults] = useState<AddressResolution[] | undefined>(
+    undefined,
+  );
+
+  const snaps = useSelector(getNameLookupSnaps);
+
+  const filteredSnaps = useMemo(
+    () =>
+      snaps
+        .filter(({ permission }) => {
+          const chainIdCaveat = getChainIdsCaveat(permission);
+          const lookupMatchersCaveat = getLookupMatchersCaveat(permission);
+
+          if (chainIdCaveat && !chainIdCaveat.includes(chainId)) {
+            return false;
+          }
+
+          if (lookupMatchersCaveat) {
+            const { tlds, schemes } = lookupMatchersCaveat;
+            return (
+              tlds?.some((tld) => domain.endsWith(`.${tld}`)) ||
+              schemes?.some((scheme) => domain.startsWith(`${scheme}:`))
+            );
+          }
+
+          return true;
+        })
+        .map(({ id }) => id),
+    [snaps, chainId],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchResolutions() {
+      setLoading(true);
+
+      const responses = await Promise.allSettled(
+        filteredSnaps.map(
+          (id) =>
+            handleSnapRequest({
+              snapId: id,
+              origin: 'metamask',
+              handler: 'onNameLookup',
+              request: {
+                jsonrpc: '2.0',
+                method: ' ',
+                params: {
+                  chainId,
+                  domain,
+                },
+              },
+            }) as Promise<DomainLookupResult>,
+        ),
+      );
+
+      if (!cancelled) {
+        const resolutions = responses
+          .filter(
+            (response) => response.status === 'fulfilled' && response.value,
+          )
+          .flatMap(
+            (response) =>
+              (response as PromiseFulfilledResult<DomainLookupResult>).value
+                .resolvedAddresses,
+          );
+        setResults(resolutions);
+        setLoading(false);
+      }
+    }
+
+    fetchResolutions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filteredSnaps, domain]);
+
+  return { results, loading };
+}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2259,6 +2259,19 @@ export const getNameLookupSnapsIds = createDeepEqualSelector(
   },
 );
 
+export const getNameLookupSnaps = createDeepEqualSelector(
+  getEnabledSnaps,
+  getPermissionSubjects,
+  (snaps, subjects) => {
+    return Object.values(snaps)
+      .filter(({ id }) => subjects[id]?.permissions['endowment:name-lookup'])
+      .map((snap) => ({
+        id: snap.id,
+        permission: subjects[snap.id]?.permissions['endowment:name-lookup'],
+      }));
+  },
+);
+
 export const getSettingsPageSnapsIds = createDeepEqualSelector(
   getSettingsPageSnaps,
   (snaps) => snaps.map((snap) => snap.id),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds a utility hook for using Snaps for name resolution. This is useful for the upcoming send flow revamp that will not use the previous implementation that uses a Redux slice.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35113?quickstart=1)

## **Related issues**

Closes: https://github.com/MetaMask/metamask-extension/issues/35108
