### PR TITLE
fix: fix ui not loading in old browsers due to use `Promise.withResolvers` cp-13.2.0

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -6,6 +6,7 @@ import browser from 'webextension-polyfill';
 import { isInternalAccountInPermittedAccountIds } from '@metamask/chain-agnostic-permission';
 
 import { captureException } from '../shared/lib/sentry';
+import { withResolvers } from '../shared/lib/promise-with-resolvers';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../app/scripts/lib/util';
@@ -53,7 +54,7 @@ log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn', false);
 /**
  * @type {PromiseWithResolvers<ReturnType<typeof configureStore>>}
  */
-const reduxStore = Promise.withResolvers();
+const reduxStore = withResolvers();
 
 /**
  * Method to update backgroundConnection object use by UI


### PR DESCRIPTION
## **Description**

`Promise.withResolvers` is not supported in very old versions of Chrome and Firefox, we used to polyfill it, but the polyfill was silently failing due to `lavamoat` protections, but our tests were still passing because we only test on new versions of browsers.

We fixed this by switching all uses of this API to our own local helper function, `withResolvers`, that implements the same API, _the same day_ the PR introducing a new usage was also merged, but I had failed to realize I had used the unsupported API in the new PR.

Fixes the `Promise.withResolvers` usage issue introduced by https://github.com/MetaMask/metamask-extension/pull/33211 by using this fix for `Promise.withResolvers` introduced the same day: https://github.com/MetaMask/metamask-extension/pull/34255

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35175?quickstart=1)

## **Changelog**

CHANGELOG entry: fix ui not loading in old browsers due to use `Promise.withResolvers`

<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

-->