### PR TITLE
chore: Bump main version to 13.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "13.2.0",
+  "version": "13.3.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Version Bump After Release

This PR bumps the main branch version from 13.2.0 to 13.3.0 after cutting the release branch.

### Why this is needed:
- **Nightly builds**: Each nightly build needs to be one minor version ahead of the current release candidate
- **Version conflicts**: Prevents conflicts between nightlies and release candidates
- **Platform alignment**: Maintains version alignment between MetaMask mobile and extension
- **Update systems**: Ensures nightlies are accepted by app stores and browser update systems

### What changed:
- Version bumped from `13.2.0` to `13.3.0`
- Platform: `extension`
- Files updated by `set-semvar-version.sh` script

### Next steps:
This PR should be **manually reviewed and merged by the release manager** to maintain proper version flow.

### Related:
- Release version: 13.2.0
- Release branch: Version-v13.2.0
- Platform: extension
- Test mode: false

---
*This PR was manually created because the `create-platform-release-pr.sh` script is [broken](https://consensys.slack.com/archives/C06GX49NHTP/p1755273426193989).*