### PR TITLE
chore: update phishing-warning@5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -467,7 +467,7 @@
     "@metamask/eth-json-rpc-provider": "^4.1.6",
     "@metamask/forwarder": "^1.1.0",
     "@metamask/foundryup": "^1.0.1",
-    "@metamask/phishing-warning": "^5.0.0",
+    "@metamask/phishing-warning": "^5.0.1",
     "@metamask/preferences-controller": "^17.0.0",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/test-bundler": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6926,9 +6926,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/phishing-warning@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@metamask/phishing-warning@npm:5.0.0"
+"@metamask/phishing-warning@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@metamask/phishing-warning@npm:5.0.1"
   dependencies:
     "@metamask/design-tokens": "npm:^7.1.0"
     "@metamask/object-multiplex": "npm:^2.0.0"
@@ -6937,7 +6937,7 @@ __metadata:
     punycode: "npm:^2.3.1"
     readable-stream: "npm:^3.6.2"
     ses: "npm:^1.1.0"
-  checksum: 10/446e72dad36729afb5830f88ccfa4e49ce9f89f64a3edc61f7b2548b17c39a5aaf9e537773fc990a5e2fc59fa973d860b6bf1d2d1c7601138553e7fb8aff5dbf
+  checksum: 10/fdcb5c7398b68adbcd15876c39516c7cf93b810d08e85dc60ee459dab7ee83a41d4248a2332c772a562dc3652f34eed0eb1af982ad486f81a70089e1ec520e31
   languageName: node
   linkType: hard
 
@@ -32062,7 +32062,7 @@ __metadata:
     "@metamask/permission-controller": "npm:^11.0.6"
     "@metamask/permission-log-controller": "npm:^4.0.0"
     "@metamask/phishing-controller": "npm:^13.1.0"
-    "@metamask/phishing-warning": "npm:^5.0.0"
+    "@metamask/phishing-warning": "npm:^5.0.1"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/ppom-validator": "npm:0.36.0"
     "@metamask/preferences-controller": "npm:^17.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a visual display bug in very long URLs of the `phishing-warning` page.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35179?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

Changelog from phishing-warning: https://github.com/MetaMask/phishing-warning/pull/200/files

## **Related issues**

Fixes: https://github.com/MetaMask/eth-phishing-detect/issues/160813

## **Manual testing steps**

1. Go to this page: https://inquirer.pro/WwwNmYPh?utm_creative=New+Sales+ad&utm_campaign=PE%2FJaime+Bayly%2Fvideo&utm_source=fb&utm_placement=Facebook_Desktop_Feed&campaign_id=120225787927560429&adset_id=120225787927600429&ad_id=120225787927570429&adset_name=New+Sales+ad+set&emaill=2314&pixel=1196785042230272&token=EAAXD16w6QbcBO8nLerQHz1NZBeZCtvZAFFhmzyJgRpNodqxr5SZCoJulRExMrvIX1apQNEtTLWtWlqxnelsx4IsICMqE4qdZBZAA9w0k4N4IsqvkZCNQJbHDKSSHss3FVKDcOt8fMScpOtqXz4iUV9GUQlYIgwdSkC8SsRAHBM7nsPkZC6hZCxiOF5Qs7MgVF9gZDZD&domain=inquirer.pro&media_type=video&utm_medium=paid&utm_id=120225787927560429&utm_content=120225787927570429&utm_term=120225787927600429&fbclid=IwY2xjawKdsvZleHRuA2FlbQEwAGFkaWQBqyC3nhg0DQEeIx3vp7TpFC-QWZnFEnzvwC77gv5PCmoQKzlWuPeM23hmHyNknQ-kWu1Pz5c_aem_J0Y-lN4gpjbPlMTDYRZeJQ
2. Before vs after changes shown in screenshots below

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

`phishing-warning@5.0.0`

<img width="1832" height="1442" alt="image" src="https://github.com/user-attachments/assets/b2f5b36d-d33b-40db-97b5-a8e1a3d26c8a" />


<!-- [screenshots/recordings] -->

### **After**

`phishing-warning@5.0.1`

<img width="1832" height="1442" alt="image" src="https://github.com/user-attachments/assets/b01b917b-fc31-459c-95fd-9389a8c9079d" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
