### PR TITLE
feat: add  MultichainAccountAddressListPage component

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4850,6 +4850,10 @@
   "received": {
     "message": "Received"
   },
+  "receivingAddress": {
+    "message": "Receiving address",
+    "description": "Page title when viewing addresses for receiving funds"
+  },
   "recipientAddressPlaceholderNew": {
     "message": "Enter public address (0x) or domain name"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4850,6 +4850,10 @@
   "received": {
     "message": "Received"
   },
+  "receivingAddress": {
+    "message": "Receiving address",
+    "description": "Page title when viewing addresses for receiving funds"
+  },
   "recipientAddressPlaceholderNew": {
     "message": "Enter public address (0x) or domain name"
   },

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/index.ts
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/index.ts
@@ -1,0 +1,5 @@
+export { MultichainAccountAddressListPage } from './multichain-account-address-list-page';
+export {
+  AddressListQueryParams,
+  AddressListSource,
+} from './multichain-account-address-list-page.types';

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.stories.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.stories.tsx
@@ -1,0 +1,122 @@
+import React, { ReactNode } from 'react';
+import { StoryObj, Meta } from '@storybook/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { AccountGroupId } from '@metamask/account-api';
+import { MultichainAccountAddressListPage } from './multichain-account-address-list-page';
+import mockState from '../../../../test/data/mock-state.json';
+
+const mockStore = configureStore([]);
+
+interface WrapperProps {
+  children: ReactNode;
+  initialEntries?: string[];
+}
+
+const Wrapper: React.FC<WrapperProps> = ({
+  children,
+  initialEntries = ['/accounts'],
+}) => (
+  <MemoryRouter initialEntries={initialEntries}>
+    <Route path="/multichain-account-address-list/:accountGroupId">
+      {children}
+    </Route>
+  </MemoryRouter>
+);
+
+// Use actual group IDs from mock-state.json
+const MOCK_GROUP_ID = 'entropy:01JKAF3PJ247KAM6C03G5Q0NP8/0' as AccountGroupId;
+const MOCK_WALLET_ID = 'entropy:01JKAF3PJ247KAM6C03G5Q0NP8';
+
+const meta: Meta<typeof MultichainAccountAddressListPage> = {
+  title: 'Pages/MultichainAccounts/MultichainAccountAddressListPage',
+  component: MultichainAccountAddressListPage,
+};
+
+export default meta;
+type Story = StoryObj<typeof MultichainAccountAddressListPage>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => {
+      const store = mockStore(mockState);
+      return (
+        <Provider store={store}>
+          <Wrapper
+            initialEntries={[
+              `/multichain-account-address-list/${encodeURIComponent(
+                MOCK_GROUP_ID,
+              )}`,
+            ]}
+          >
+            <Story />
+          </Wrapper>
+        </Provider>
+      );
+    },
+  ],
+};
+
+export const ReceivingAddress: Story = {
+  decorators: [
+    (Story) => {
+      const store = mockStore(mockState);
+      return (
+        <Provider store={store}>
+          <Wrapper
+            initialEntries={[
+              `/multichain-account-address-list/${encodeURIComponent(
+                MOCK_GROUP_ID,
+              )}?source=receive`,
+            ]}
+          >
+            <Story />
+          </Wrapper>
+        </Provider>
+      );
+    },
+  ],
+};
+
+export const NoAccounts: Story = {
+  decorators: [
+    (Story) => {
+      const store = mockStore({
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          accountTree: {
+            ...mockState.metamask.accountTree,
+            wallets: {
+              ...mockState.metamask.accountTree.wallets,
+              [MOCK_WALLET_ID]: {
+                ...mockState.metamask.accountTree.wallets[MOCK_WALLET_ID],
+                groups: {
+                  [MOCK_GROUP_ID]: {
+                    ...mockState.metamask.accountTree.wallets[MOCK_WALLET_ID]
+                      .groups[MOCK_GROUP_ID],
+                    accounts: [], // No accounts in the group
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      return (
+        <Provider store={store}>
+          <Wrapper
+            initialEntries={[
+              `/multichain-account-address-list/${encodeURIComponent(
+                MOCK_GROUP_ID,
+              )}`,
+            ]}
+          >
+            <Story />
+          </Wrapper>
+        </Provider>
+      );
+    },
+  ],
+};

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.test.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.test.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import { AccountGroupId } from '@metamask/account-api';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import mockState from '../../../../test/data/mock-state.json';
+import configureStore from '../../../store/store';
+import { MultichainAccountAddressListPage } from './multichain-account-address-list-page';
+
+const mockHistoryGoBack = jest.fn();
+const mockUseParams = jest.fn();
+const mockUseLocation = jest.fn();
+const addressRowsListSearchTestId = 'multichain-address-rows-list-search';
+const addressRowsListTestId = 'multichain-address-rows-list';
+const backButtonTestId = 'multichain-account-address-list-page-back-button';
+
+// Use actual group IDs from mock-state.json
+const MOCK_GROUP_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0' as AccountGroupId;
+const MOCK_GROUP_NAME = 'Account 1';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    goBack: mockHistoryGoBack,
+  }),
+  useParams: () => mockUseParams(),
+  useLocation: () => mockUseLocation(),
+}));
+
+describe('MultichainAccountAddressListPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocation.mockReturnValue({ search: '' });
+  });
+
+  it('renders the page with correct components', () => {
+    mockUseParams.mockReturnValue({
+      accountGroupId: MOCK_GROUP_ID,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Check header shows group name from mock state (Account 1)
+    expect(
+      screen.getByText(`${MOCK_GROUP_NAME} / Addresses`),
+    ).toBeInTheDocument();
+
+    // Check back button is present
+    expect(screen.getByTestId(backButtonTestId)).toBeInTheDocument();
+
+    // Check address list component is rendered
+    expect(screen.getByTestId(addressRowsListTestId)).toBeInTheDocument();
+
+    // Verify search field is rendered
+    expect(screen.getByTestId(addressRowsListSearchTestId)).toBeInTheDocument();
+  });
+
+  it('handles back button click', () => {
+    mockUseParams.mockReturnValue({
+      accountGroupId: MOCK_GROUP_ID,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    const backButton = screen.getByTestId(backButtonTestId);
+    fireEvent.click(backButton);
+
+    expect(mockHistoryGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles non-existent account group gracefully', () => {
+    mockUseParams.mockReturnValue({
+      accountGroupId: 'non-existent-group',
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Should show fallback text when group doesn't exist
+    expect(screen.getByText('Account / Addresses')).toBeInTheDocument();
+
+    // Should still render the address list component (even if empty)
+    expect(screen.getByTestId(addressRowsListTestId)).toBeInTheDocument();
+  });
+
+  it('handles encoded account group ID', () => {
+    const encodedGroupId = encodeURIComponent(MOCK_GROUP_ID);
+
+    mockUseParams.mockReturnValue({
+      accountGroupId: encodedGroupId,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Should still render correctly with encoded ID
+    expect(
+      screen.getByText(`${MOCK_GROUP_NAME} / Addresses`),
+    ).toBeInTheDocument();
+
+    // Check address list component is rendered
+    expect(screen.getByTestId(addressRowsListTestId)).toBeInTheDocument();
+  });
+
+  it('shows receiving address title in receive mode', () => {
+    mockUseLocation.mockReturnValue({ search: '?source=receive' });
+    mockUseParams.mockReturnValue({
+      accountGroupId: MOCK_GROUP_ID,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Should show "Receiving address" instead of "Account 1 / Addresses"
+    expect(screen.getByText('Receiving address')).toBeInTheDocument();
+    expect(
+      screen.queryByText(`${MOCK_GROUP_NAME} / Addresses`),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders correctly with multiple accounts in group', () => {
+    // The mock state already has two accounts in the group
+    mockUseParams.mockReturnValue({
+      accountGroupId: MOCK_GROUP_ID,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Check that the page renders correctly
+    expect(
+      screen.getByText(`${MOCK_GROUP_NAME} / Addresses`),
+    ).toBeInTheDocument();
+
+    // The MultichainAddressRowsList component should receive the accounts
+    expect(screen.getByTestId(addressRowsListTestId)).toBeInTheDocument();
+  });
+
+  it('handles special characters in group ID', () => {
+    const specialGroupId =
+      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0' as AccountGroupId;
+    const encodedSpecialGroupId = encodeURIComponent(specialGroupId);
+
+    mockUseParams.mockReturnValue({
+      accountGroupId: encodedSpecialGroupId,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Should decode and handle the special characters correctly
+    expect(
+      screen.getByText(`${MOCK_GROUP_NAME} / Addresses`),
+    ).toBeInTheDocument();
+  });
+
+  it('renders with different query parameters correctly', () => {
+    mockUseLocation.mockReturnValue({ search: '?source=other' });
+    mockUseParams.mockReturnValue({
+      accountGroupId: MOCK_GROUP_ID,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Should show normal title (not receiving address)
+    expect(
+      screen.getByText(`${MOCK_GROUP_NAME} / Addresses`),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Receiving address')).not.toBeInTheDocument();
+  });
+
+  it('handles null account group ID', () => {
+    mockUseParams.mockReturnValue({
+      accountGroupId: null,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Should show fallback text
+    expect(screen.getByText('Account / Addresses')).toBeInTheDocument();
+  });
+
+  it('handles undefined account group ID', () => {
+    mockUseParams.mockReturnValue({
+      accountGroupId: undefined,
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<MultichainAccountAddressListPage />, store);
+
+    // Should show fallback text
+    expect(screen.getByText('Account / Addresses')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import {
+  Box,
+  BoxFlexDirection,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+} from '@metamask/design-system-react';
+import { AccountGroupId } from '@metamask/account-api';
+import {
+  Content,
+  Header,
+  Page,
+} from '../../../components/multichain/pages/page';
+import { TextVariant } from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { MultichainAddressRowsList } from '../../../components/multichain-accounts/multichain-address-rows-list';
+import {
+  getInternalAccountsFromGroupById,
+  getMultichainAccountGroupById,
+} from '../../../selectors/multichain-accounts/account-tree';
+import {
+  AddressListQueryParams,
+  AddressListSource,
+} from './multichain-account-address-list-page.types';
+
+export const MultichainAccountAddressListPage = () => {
+  const t = useI18nContext();
+  const history = useHistory();
+  const location = useLocation();
+  const { accountGroupId } = useParams<{ accountGroupId: string }>();
+
+  const decodedAccountGroupId = accountGroupId
+    ? (decodeURIComponent(accountGroupId) as AccountGroupId)
+    : null;
+
+  const accounts = useSelector((state) =>
+    decodedAccountGroupId
+      ? getInternalAccountsFromGroupById(state, decodedAccountGroupId)
+      : [],
+  );
+
+  const accountGroup = useSelector((state) =>
+    decodedAccountGroupId
+      ? getMultichainAccountGroupById(state, decodedAccountGroupId)
+      : null,
+  );
+
+  const searchParams = new URLSearchParams(location.search);
+  const isReceiveMode =
+    searchParams.get(AddressListQueryParams.Source) ===
+    AddressListSource.Receive;
+
+  const pageTitle = isReceiveMode
+    ? t('receivingAddress')
+    : `${accountGroup?.metadata?.name || t('account')} / ${t('addresses')}`;
+
+  return (
+    <Page className="max-w-[600px]">
+      <Header
+        textProps={{
+          variant: TextVariant.headingSm,
+        }}
+        startAccessory={
+          <ButtonIcon
+            size={ButtonIconSize.Md}
+            ariaLabel={t('back')}
+            iconName={IconName.ArrowLeft}
+            onClick={() => history.goBack()}
+            data-testid="multichain-account-address-list-page-back-button"
+          />
+        }
+      >
+        {pageTitle}
+      </Header>
+      <Content>
+        <Box flexDirection={BoxFlexDirection.Column}>
+          <MultichainAddressRowsList accounts={accounts} />
+        </Box>
+      </Content>
+    </Page>
+  );
+};

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.types.ts
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.types.ts
@@ -1,0 +1,17 @@
+/**
+ * Query parameter names for the multichain account address list page
+ */
+export enum AddressListQueryParams {
+  Source = 'source',
+}
+
+/**
+ * Source values for the multichain account address list page
+ * Used to determine the context/mode of the page
+ */
+export enum AddressListSource {
+  /**
+   * When the page is opened from the receive flow
+   */
+  Receive = 'receive',
+}


### PR DESCRIPTION
## **Description**

This PR adds the `MultichainAccountAddressListPage` component as part of the multichain accounts feature. This page displays a list of addresses for a specific account group and supports two modes:

1. **Regular mode**: Shows account group name and addresses for navigation
2. **Receiving mode**: Shows "Receiving Address" title when accessed from receive flows

The component includes comprehensive TypeScript types, extensive Storybook stories covering edge cases, and full test coverage. This is a foundational UI component that will be integrated with routing and entry points in the larger multichain accounts PR https://github.com/MetaMask/metamask-extension/pull/35191 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35490?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: https://consensyssoftware.atlassian.net/browse/DSYS-115
Part of larger PR: https://github.com/MetaMask/metamask-extension/pull/35490

## **Manual testing steps**

1. Run `yarn storybook` to launch Storybook
2. Navigate to "Pages/MultichainAccounts/MultichainAccountAddressListPage"
3. Test different story variations:
   - Default: Regular page view with account group addresses
   - ReceivingAddress: Page in receiving mode
   - NoAccounts: Empty state when no accounts in group

## **Screenshots/Recordings**

### **Before**

Component did not exist.

### **After**

New multichain account address list page component available in Storybook with comprehensive test coverage and multiple story variations.

https://github.com/user-attachments/assets/d0192efd-5f09-4e87-8f1a-fe52ebe3d1a0

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.