### PR TITLE
chore: refactoring address list to use design system react

### DIFF
--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -1,24 +1,21 @@
 import React from 'react';
 import {
-  AlignItems,
-  BlockSize,
-  BorderRadius,
-  Display,
-  FlexDirection,
-  IconColor,
-  JustifyContent,
-  TextColor,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
-import {
   AvatarNetwork,
   AvatarNetworkSize,
   Box,
   ButtonIcon,
   ButtonIconSize,
+  IconColor,
   IconName,
   Text,
-} from '../../component-library';
+  TextVariant,
+  TextColor,
+  BoxJustifyContent,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  twMerge,
+} from '@metamask/design-system-react';
 import { shortenAddress } from '../../../helpers/utils/util';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { getImageForChainId } from '../../../selectors/multichain';
@@ -63,10 +60,9 @@ export const MultichainAddressRow = ({
 
   return (
     <Box
-      className={`multichain-address-row ${className}`}
-      display={Display.Flex}
-      alignItems={AlignItems.center}
-      justifyContent={JustifyContent.spaceBetween}
+      className={twMerge('w-full flex', className)}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
       padding={4}
       gap={4}
       data-testid="multichain-address-row"
@@ -75,45 +71,42 @@ export const MultichainAddressRow = ({
         size={AvatarNetworkSize.Md}
         name={networkName}
         src={networkImageSrc}
-        borderRadius={BorderRadius.LG}
         data-testid="multichain-address-row-network-icon"
       />
 
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        alignItems={AlignItems.flexStart}
-        // Parent Box with flex: 1 needs minWidth: 0 to allow it to shrink below its content size.
-        // Without that, the flex item would expand the entire row to fit the text content
-        // instead of being constrained by the grid cell.
-        style={{ flex: 1, minWidth: 0 }}
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Start}
+        className="flex-1 min-w-0"
       >
         <Text
-          variant={TextVariant.bodyMdMedium}
-          color={TextColor.textDefault}
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
           data-testid="multichain-address-row-network-name"
-          ellipsis={true}
-          width={BlockSize.Full}
+          ellipsis
+          className="w-full"
         >
           {networkName}
         </Text>
         <Text
-          variant={TextVariant.bodySm}
-          color={TextColor.textAlternative}
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
           data-testid="multichain-address-row-address"
+          className="w-full"
         >
           {truncatedAddress}
         </Text>
       </Box>
 
       {/* Action buttons */}
-      <Box display={Display.Flex} alignItems={AlignItems.center} gap={4}>
+      <Box alignItems={BoxAlignItems.Center} gap={4}>
         <ButtonIcon
           iconName={copied ? IconName.CopySuccess : IconName.Copy}
           size={ButtonIconSize.Md}
           onClick={handleCopyClick}
           ariaLabel="Copy address"
-          color={IconColor.iconDefault}
+          color={IconColor.IconDefault}
           data-testid="multichain-address-row-copy-button"
         />
 
@@ -122,7 +115,7 @@ export const MultichainAddressRow = ({
           size={ButtonIconSize.Md}
           onClick={handleQrClick}
           ariaLabel="Show QR code"
-          color={IconColor.iconDefault}
+          color={IconColor.IconDefault}
           data-testid="multichain-address-row-qr-button"
         />
       </Box>

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
@@ -7,18 +7,15 @@ import {
   BackgroundColor,
   BlockSize,
   BorderRadius,
-  Display,
-  FlexDirection,
-  TextAlign,
-  TextColor,
-  TextVariant,
 } from '../../../helpers/constants/design-system';
 import {
   Box,
+  BoxFlexDirection,
   Text,
-  TextFieldSearch,
-  TextFieldSearchSize,
-} from '../../component-library';
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { TextFieldSearch, TextFieldSearchSize } from '../../component-library';
 import { MultichainAddressRow } from '../multichain-address-row/multichain-address-row';
 import { getMultichainNetworkConfigurationsByChainId } from '../../../selectors/multichain/networks';
 import {
@@ -104,8 +101,7 @@ export const MultichainAddressRowsList = ({
 
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
+      flexDirection={BoxFlexDirection.Column}
       data-testid="multichain-address-rows-list"
     >
       <Box padding={4}>
@@ -134,10 +130,10 @@ export const MultichainAddressRowsList = ({
             />
           ))
         ) : (
-          <Box padding={6} textAlign={TextAlign.Center}>
+          <Box padding={6}>
             <Text
-              variant={TextVariant.bodyMd}
-              color={TextColor.textAlternative}
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
               data-testid="multichain-address-rows-list-empty-message"
             >
               {searchPattern ? t('noNetworksFound') : t('noNetworksAvailable')}

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
@@ -2,12 +2,6 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { CaipChainId } from '@metamask/utils';
-import { useI18nContext } from '../../../hooks/useI18nContext';
-import {
-  BackgroundColor,
-  BlockSize,
-  BorderRadius,
-} from '../../../helpers/constants/design-system';
 import {
   Box,
   BoxFlexDirection,
@@ -15,6 +9,12 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  BackgroundColor,
+  BlockSize,
+  BorderRadius,
+} from '../../../helpers/constants/design-system';
 import { TextFieldSearch, TextFieldSearchSize } from '../../component-library';
 import { MultichainAddressRow } from '../multichain-address-row/multichain-address-row';
 import { getMultichainNetworkConfigurationsByChainId } from '../../../selectors/multichain/networks';


### PR DESCRIPTION
## **Description**

This PR refactors the multichain address list components (`MultichainAddressRow` and `MultichainAddressRowsList`) to use the latest design system libraries from `@metamask/design-system-react`. The changes modernize the component implementations by replacing legacy imports and updating to the current design system conventions, improving code consistency and maintainability across the codebase.

Key improvements:
1. Migrated from local component-library imports to the centralized `@metamask/design-system-react` package
2. Updated all design system prop naming to follow the latest conventions (e.g., `TextVariant.bodyMd` → `TextVariant.BodyMd`)
3. Simplified flexbox layout using Tailwind utility classes with proper text truncation support
4. Improved text truncation handling with `flex-1 min-w-0` pattern for proper ellipsis display

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35192?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/DSYS/boards/1888?assignee=6152e94cc7bea40069d6b9c3&selectedIssue=DSYS-104&sprints=6001%2C6002

## **Manual testing steps**

1. Navigate to `MultichainAddressRow` and `MultichainAddressRowsList` in storybook
2. Ensure the UI looks the same as [current storybook](https://metamask.github.io/metamask-storybook/?path=/story/components-multichainaccounts-multichainaddressrowslist--multiple-different-accounts)

## **Screenshots/Recordings**

### **Before**

- Components using legacy design system imports from local component-library

https://github.com/user-attachments/assets/19700f33-3ff1-418d-94b2-a9474656b5c9



### **After**

- No ui changes, but will inherit future updates

https://github.com/user-attachments/assets/0dd0be9b-eb9b-40af-b063-892a1b7e671e

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.