### PR TITLE
fix: Fix mapping simulation total value for bridge and swap transaction

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -1655,11 +1655,19 @@ describe('Transaction metrics', () => {
       const transactionMetaForSwap = {
         ...mockTransactionMeta,
         type: TransactionType.swap,
+        assetsFiatValues: {
+          sending: '100',
+          receiving: '100',
+        },
       } as TransactionMeta;
 
       const transactionMetaForBridge = {
         ...mockTransactionMeta,
         type: TransactionType.bridge,
+        assetsFiatValues: {
+          sending: '200',
+          receiving: '200',
+        },
       } as TransactionMeta;
 
       await fn(mockTransactionMetricsRequest, {
@@ -1673,6 +1681,8 @@ describe('Transaction metrics', () => {
       expect(propertiesForSwap).toStrictEqual(
         expect.objectContaining({
           transaction_type: 'mm_swap',
+          simulation_sending_assets_total_value: '100',
+          simulation_receiving_assets_total_value: '100',
         }),
       );
 
@@ -1687,6 +1697,8 @@ describe('Transaction metrics', () => {
       expect(propertiesForBridge).toStrictEqual(
         expect.objectContaining({
           transaction_type: 'mm_bridge',
+          simulation_sending_assets_total_value: '200',
+          simulation_receiving_assets_total_value: '200',
         }),
       );
     });

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -1042,7 +1042,10 @@ async function buildEventFragmentProperties({
   );
   Object.assign(properties, snapAndHardwareInfo);
 
-  if (transactionContractMethod === contractMethodNames.APPROVE) {
+  if (
+    transactionContractMethod === contractMethodNames.APPROVE ||
+    getMMSwapOrBridgeType(type as TransactionType)
+  ) {
     properties = {
       ...properties,
       simulation_receiving_assets_total_value:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix mapping `simulation_sending_assets_total_value` and `simulation_receiving_assets_total_value` issue when transaction is either swap or bridge. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35196?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5353

## **Manual testing steps**

No QA needed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="648" height="666" alt="Screenshot 2025-08-19 at 09 35 59" src="https://github.com/user-attachments/assets/5fde2969-2e71-43e6-8d0b-8481b52b07bd" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
