### PR TITLE
Update action button colors and create PR

### DIFF
--- a/ui/components/ui/icon-button/icon-button.scss
+++ b/ui/components/ui/icon-button/icon-button.scss
@@ -4,12 +4,12 @@
   height: auto;
 
   &:hover:not([disabled]) {
-    background-color: var(--color-background-subsection);
+    background-color: var(--color-background-muted-hover);
     transition: background 200ms ease;
   }
 
   &:active:not([disabled]) {
-    background-color: var(--color-background-default-pressed);
+    background-color: var(--color-background-muted-pressed);
   }
 
   &__label {

--- a/ui/components/ui/icon-button/icon-button.tsx
+++ b/ui/components/ui/icon-button/icon-button.tsx
@@ -40,7 +40,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       <ButtonBase
         className={classNames('icon-button', className)}
         onClick={onClick}
-        backgroundColor={BackgroundColor.backgroundSection}
+        backgroundColor={BackgroundColor.backgroundMuted}
         disabled={disabled}
         ref={ref}
         display={Display.InlineFlex}


### PR DESCRIPTION
Update action buttons to use muted background colors to improve hover state visibility in light mode.

The previous color variables used for action buttons (Buy/Sell, Send, Swap, Receive) resulted in hover states being nearly invisible in light mode, addressing the bug reported in #35209. This change updates them to use the correct `background/muted`, `background/muted-hover`, and `background/muted-pressed` colors for better contrast and design system alignment.

---
[Slack Thread](https://consensys.slack.com/archives/C02VD8QG0LT/p1755187202907389?thread_ts=1755187202.907389&cid=C02VD8QG0LT)

<a href="https://cursor.com/background-agent?bcId=bc-d69f447d-fd2c-4948-856a-4ba003d2f329">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d69f447d-fd2c-4948-856a-4ba003d2f329">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

