### PR TITLE
bump: bitcoin v0.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
     "@metamask/approval-controller": "^7.0.0",
     "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A73.0.2#~/.yarn/patches/@metamask-assets-controllers-npm-73.0.2-d92e4492b2.patch",
     "@metamask/base-controller": "^8.0.0",
-    "@metamask/bitcoin-wallet-snap": "^0.19.0",
+    "@metamask/bitcoin-wallet-snap": "^0.19.3",
     "@metamask/bridge-controller": "^39.1.0",
     "@metamask/bridge-status-controller": "^38.1.0",
     "@metamask/browser-passworder": "^4.3.0",

--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -16,7 +16,7 @@
   "bafkreifvhjdf6ve4jfv6qytqtux5nd4nwnelioeiqx5x2ez5yrgrzk7ypi.ipfs.dweb.link",
   "bafybeidxfmwycgzcp4v2togflpqh2gnibuexjy4m4qqwxp7nh3jx5zlh4y.ipfs.dweb.link",
   "base-mainnet.infura.io",
-  "blockstream.info",
+  "esplora.rivet.link",
   "bridge.api.cx.metamask.io",
   "bridge.dev-api.cx.metamask.io",
   "bsc-dataseed.binance.org",

--- a/test/e2e/flask/btc/mocks/esplora.ts
+++ b/test/e2e/flask/btc/mocks/esplora.ts
@@ -503,7 +503,7 @@ const mockFundingTx = (mockServer: Mockttp, network: string = ESPLORA_URL) =>
 const mockAnyTxs = (mockServer: Mockttp) =>
   mockServer
     .forGet(
-      /^https:\/\/esplora.rivet.link\/(api|testnet\/api)\/scripthash\/[0-9a-f]{64}\/txs$/u,
+      /^https:\/\/esplora.rivet\.link\/esplora\/(api|testnet\/api)\/scripthash\/[0-9a-f]{64}\/txs$/u,
     )
     .thenJson(200, []);
 

--- a/test/e2e/flask/btc/mocks/esplora.ts
+++ b/test/e2e/flask/btc/mocks/esplora.ts
@@ -6,8 +6,8 @@ import {
   SATS_IN_1_BTC,
 } from '../../../constants';
 
-const ESPLORA_URL = 'https://esplora.rivet.link/api';
-const ESPLORA_TESTNET_URL = 'https://esplora.rivet.link/testnet/api';
+const ESPLORA_URL = 'https://esplora.rivet.link/esplora/api';
+const ESPLORA_TESTNET_URL = 'https://esplora.rivet.link/esplora/testnet/api';
 
 const FUNDING_SCRIPT_HASH =
   '538c172f4f5ff9c24693359c4cdc8ee4666565326a789d5e4b2df1db7acb4721';

--- a/test/e2e/flask/btc/mocks/esplora.ts
+++ b/test/e2e/flask/btc/mocks/esplora.ts
@@ -6,8 +6,8 @@ import {
   SATS_IN_1_BTC,
 } from '../../../constants';
 
-const ESPLORA_URL = 'https://blockstream.info/api';
-const ESPLORA_TESTNET_URL = 'https://blockstream.info/testnet/api';
+const ESPLORA_URL = 'https://esplora.rivet.link/api';
+const ESPLORA_TESTNET_URL = 'https://esplora.rivet.link/testnet/api';
 
 const FUNDING_SCRIPT_HASH =
   '538c172f4f5ff9c24693359c4cdc8ee4666565326a789d5e4b2df1db7acb4721';
@@ -503,7 +503,7 @@ const mockFundingTx = (mockServer: Mockttp, network: string = ESPLORA_URL) =>
 const mockAnyTxs = (mockServer: Mockttp) =>
   mockServer
     .forGet(
-      /^https:\/\/blockstream\.info\/(api|testnet\/api)\/scripthash\/[0-9a-f]{64}\/txs$/u,
+      /^https:\/\/esplora.rivet.link\/(api|testnet\/api)\/scripthash\/[0-9a-f]{64}\/txs$/u,
     )
     .thenJson(200, []);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,10 +5596,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bitcoin-wallet-snap@npm:^0.19.0":
-  version: 0.19.0
-  resolution: "@metamask/bitcoin-wallet-snap@npm:0.19.0"
-  checksum: 10/d4dc306ae62ed4ce3a487028d6671125687053760aa75ab8e399f0b8adb32cbfd05bbdde464457d27b76f2b48ca9adbfed161b4f3b9252199d553e59457915bb
+"@metamask/bitcoin-wallet-snap@npm:^0.19.3":
+  version: 0.19.3
+  resolution: "@metamask/bitcoin-wallet-snap@npm:0.19.3"
+  checksum: 10/b6040e600cc862f7350e68dc3d0e86e4e6456aef352b6cbcf29f5de7ffed6bf49f23352d1ac890007c8696896401723e7d72c6bde4b9cdd5446fcc9aa3eaeae3
   languageName: node
   linkType: hard
 
@@ -31996,7 +31996,7 @@ __metadata:
     "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A73.0.2#~/.yarn/patches/@metamask-assets-controllers-npm-73.0.2-d92e4492b2.patch"
     "@metamask/auto-changelog": "npm:^2.1.0"
     "@metamask/base-controller": "npm:^8.0.0"
-    "@metamask/bitcoin-wallet-snap": "npm:^0.19.0"
+    "@metamask/bitcoin-wallet-snap": "npm:^0.19.3"
     "@metamask/bridge-controller": "npm:^39.1.0"
     "@metamask/bridge-status-controller": "npm:^38.1.0"
     "@metamask/browser-passworder": "npm:^4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,10 +5596,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bitcoin-wallet-snap@file:../snap-bitcoin-wallet/packages/snap::locator=metamask-crx%40workspace%3A.":
+"@metamask/bitcoin-wallet-snap@npm:^0.19.3":
   version: 0.19.3
-  resolution: "@metamask/bitcoin-wallet-snap@file:../snap-bitcoin-wallet/packages/snap#../snap-bitcoin-wallet/packages/snap::hash=5170c1&locator=metamask-crx%40workspace%3A."
-  checksum: 10/ec59745acb687d94dbabbeb055f6e5921b4abaa2cd34776f28faf22d5dabd342bc98cbebdf71aa433cd0954f930313fbee256854381c8d2ebc2e2db33a1c567d
+  resolution: "@metamask/bitcoin-wallet-snap@npm:0.19.3"
+  checksum: 10/b6040e600cc862f7350e68dc3d0e86e4e6456aef352b6cbcf29f5de7ffed6bf49f23352d1ac890007c8696896401723e7d72c6bde4b9cdd5446fcc9aa3eaeae3
   languageName: node
   linkType: hard
 
@@ -31996,7 +31996,7 @@ __metadata:
     "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A73.0.2#~/.yarn/patches/@metamask-assets-controllers-npm-73.0.2-d92e4492b2.patch"
     "@metamask/auto-changelog": "npm:^2.1.0"
     "@metamask/base-controller": "npm:^8.0.0"
-    "@metamask/bitcoin-wallet-snap": "file:../snap-bitcoin-wallet/packages/snap"
+    "@metamask/bitcoin-wallet-snap": "npm:^0.19.3"
     "@metamask/bridge-controller": "npm:^39.1.0"
     "@metamask/bridge-status-controller": "npm:^38.1.0"
     "@metamask/browser-passworder": "npm:^4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,10 +5596,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bitcoin-wallet-snap@npm:^0.19.3":
+"@metamask/bitcoin-wallet-snap@file:../snap-bitcoin-wallet/packages/snap::locator=metamask-crx%40workspace%3A.":
   version: 0.19.3
-  resolution: "@metamask/bitcoin-wallet-snap@npm:0.19.3"
-  checksum: 10/b6040e600cc862f7350e68dc3d0e86e4e6456aef352b6cbcf29f5de7ffed6bf49f23352d1ac890007c8696896401723e7d72c6bde4b9cdd5446fcc9aa3eaeae3
+  resolution: "@metamask/bitcoin-wallet-snap@file:../snap-bitcoin-wallet/packages/snap#../snap-bitcoin-wallet/packages/snap::hash=5170c1&locator=metamask-crx%40workspace%3A."
+  checksum: 10/ec59745acb687d94dbabbeb055f6e5921b4abaa2cd34776f28faf22d5dabd342bc98cbebdf71aa433cd0954f930313fbee256854381c8d2ebc2e2db33a1c567d
   languageName: node
   linkType: hard
 
@@ -31996,7 +31996,7 @@ __metadata:
     "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A73.0.2#~/.yarn/patches/@metamask-assets-controllers-npm-73.0.2-d92e4492b2.patch"
     "@metamask/auto-changelog": "npm:^2.1.0"
     "@metamask/base-controller": "npm:^8.0.0"
-    "@metamask/bitcoin-wallet-snap": "npm:^0.19.3"
+    "@metamask/bitcoin-wallet-snap": "file:../snap-bitcoin-wallet/packages/snap"
     "@metamask/bridge-controller": "npm:^39.1.0"
     "@metamask/bridge-status-controller": "npm:^38.1.0"
     "@metamask/browser-passworder": "npm:^4.3.0"


### PR DESCRIPTION
## **Description**

Bump Bitcoin Snap to v0.19.3

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35275?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Bitcoin uses DIN endpoints

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
