### PR TITLE
ci: fix PRs from external contributors

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -72,6 +72,8 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-vault-decryption:
+    # This if statement is equivalent to IS_FORK
+    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
     with:
       test-suite-name: test-e2e-chrome-vault-decryption

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -52,6 +52,9 @@ jobs:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.
       BRANCH: ${{ github.head_ref || github.ref_name }}
+      # For a `pull_request` event, the fork is `github.event.pull_request.head.repo.fork`.
+      # For a `push` event, the fork is `github.event.repository.fork`.
+      IS_FORK: ${{ github.event.pull_request.head.repo.fork || github.event.repository.fork }}
       # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
       # For a `push` event, the head commit hash is `github.sha`.
       HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/test/e2e/tests/notifications/notification-items.spec.ts
+++ b/test/e2e/tests/notifications/notification-items.spec.ts
@@ -19,6 +19,9 @@ import {
 
 describe('Notification List - View Items and Details', function () {
   it('find each notification type we support, and navigates to their details page', async function () {
+    if (process.env.IS_FORK) {
+      this.skip();
+    }
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/notifications/notification-items.spec.ts
+++ b/test/e2e/tests/notifications/notification-items.spec.ts
@@ -19,7 +19,7 @@ import {
 
 describe('Notification List - View Items and Details', function () {
   it('find each notification type we support, and navigates to their details page', async function () {
-    if (process.env.IS_FORK) {
+    if (process.env.IS_FORK === 'true') {
       this.skip();
     }
     await withFixtures(


### PR DESCRIPTION
## **Description**

This PR is specifically coming from a fork so we can test forks.

- Do not run `test-e2e-chrome-vault-decryption` from forks
- Do not run `test/e2e/tests/notifications/notification-items.spec.ts` from forks

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #35265
Fixes: #35266

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->