### PR TITLE
fix: cp-13.2.0 Show error when background is unresponsive

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -25,10 +25,7 @@ import {
   MESSAGE_TYPE,
 } from '../../shared/constants/app';
 import { EXTENSION_MESSAGES } from '../../shared/constants/messages';
-import {
-  BACKGROUND_LIVENESS_REQUEST,
-  BACKGROUND_LIVENESS_RESPONSE,
-} from '../../shared/constants/background-liveness-check';
+import { BACKGROUND_LIVENESS_METHOD } from '../../shared/constants/background-liveness-check';
 import {
   REJECT_NOTIFICATION_CLOSE,
   REJECT_NOTIFICATION_CLOSE_SIG,
@@ -451,22 +448,13 @@ browser.runtime.onConnect.addListener(async (port) => {
   ) {
     return;
   }
-  // Setup listeners to respond immediately to liveness check from UI.
-  const livenessCheckHandler = (event) => {
-    if (
-      event.name === 'background-liveness' &&
-      event.data?.method === BACKGROUND_LIVENESS_REQUEST
-    ) {
-      port.onMessage.removeListener(livenessCheckHandler);
-      port.postMessage({
-        data: {
-          method: BACKGROUND_LIVENESS_RESPONSE,
-        },
-        name: 'background-liveness',
-      });
-    }
-  };
-  port.onMessage.addListener(livenessCheckHandler);
+
+  port.postMessage({
+    data: {
+      method: BACKGROUND_LIVENESS_METHOD,
+    },
+    name: 'background-liveness',
+  });
 
   // Queue up connection attempts here, waiting until after initialization
   try {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -452,12 +452,12 @@ browser.runtime.onConnect.addListener(async (port) => {
     return;
   }
   // Setup listeners to respond immediately to liveness check from UI.
-  const synHandler = (event) => {
+  const livenessCheckHandler = (event) => {
     if (
       event.name === 'background-liveness' &&
       event.data?.method === BACKGROUND_LIVENESS_REQUEST
     ) {
-      port.onMessage.removeListener(synHandler);
+      port.onMessage.removeListener(livenessCheckHandler);
       port.postMessage({
         data: {
           method: BACKGROUND_LIVENESS_RESPONSE,
@@ -466,7 +466,7 @@ browser.runtime.onConnect.addListener(async (port) => {
       });
     }
   };
-  port.onMessage.addListener(synHandler);
+  port.onMessage.addListener(livenessCheckHandler);
 
   // Queue up connection attempts here, waiting until after initialization
   try {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -443,7 +443,7 @@ const corruptionHandler = new CorruptionHandler();
 browser.runtime.onConnect.addListener(async (port) => {
   // Setup listeners to respond immediately to handshake from UI.
   const synHandler = (event) => {
-    if (event.data?.method === 'SYN') {
+    if (event.name === 'handshake' && event.data?.method === 'SYN') {
       port.onMessage.removeListener(synHandler);
       port.postMessage({
         data: {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -26,6 +26,10 @@ import {
 } from '../../shared/constants/app';
 import { EXTENSION_MESSAGES } from '../../shared/constants/messages';
 import {
+  BACKGROUND_LIVENESS_REQUEST,
+  BACKGROUND_LIVENESS_RESPONSE,
+} from '../../shared/constants/background-liveness-check';
+import {
   REJECT_NOTIFICATION_CLOSE,
   REJECT_NOTIFICATION_CLOSE_SIG,
   MetaMetricsEventCategory,
@@ -447,15 +451,18 @@ browser.runtime.onConnect.addListener(async (port) => {
   ) {
     return;
   }
-  // Setup listeners to respond immediately to handshake from UI.
+  // Setup listeners to respond immediately to liveness check from UI.
   const synHandler = (event) => {
-    if (event.name === 'handshake' && event.data?.method === 'SYN') {
+    if (
+      event.name === 'background-liveness' &&
+      event.data?.method === BACKGROUND_LIVENESS_REQUEST
+    ) {
       port.onMessage.removeListener(synHandler);
       port.postMessage({
         data: {
-          method: 'ACK',
+          method: BACKGROUND_LIVENESS_RESPONSE,
         },
-        name: 'handshake',
+        name: 'background-liveness',
       });
     }
   };

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -441,6 +441,12 @@ let connectCaipMultichain;
 
 const corruptionHandler = new CorruptionHandler();
 browser.runtime.onConnect.addListener(async (port) => {
+  if (
+    inTest &&
+    getManifestFlags().testing?.simulateUnresponsiveBackground === true
+  ) {
+    return;
+  }
   // Setup listeners to respond immediately to handshake from UI.
   const synHandler = (event) => {
     if (event.name === 'handshake' && event.data?.method === 'SYN') {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6978,7 +6978,6 @@ export default class MetamaskController extends EventEmitter {
   setupTrustedCommunication(connectionStream, sender) {
     // setup multiplexing
     const mux = setupMultiplex(connectionStream);
-    mux.ignoreStream('background-liveness');
     // connect features
     this.setupControllerConnection(mux.createStream('controller'));
     this.setupProviderConnectionEip1193(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6978,7 +6978,7 @@ export default class MetamaskController extends EventEmitter {
   setupTrustedCommunication(connectionStream, sender) {
     // setup multiplexing
     const mux = setupMultiplex(connectionStream);
-    mux.ignoreStream('handshake');
+    mux.ignoreStream('background-liveness');
     // connect features
     this.setupControllerConnection(mux.createStream('controller'));
     this.setupProviderConnectionEip1193(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6978,6 +6978,7 @@ export default class MetamaskController extends EventEmitter {
   setupTrustedCommunication(connectionStream, sender) {
     // setup multiplexing
     const mux = setupMultiplex(connectionStream);
+    mux.ignoreStream('handshake');
     // connect features
     this.setupControllerConnection(mux.createStream('controller'));
     this.setupProviderConnectionEip1193(

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -358,6 +358,7 @@ function connectSubstreams(connectionStream) {
 
   const controllerSubstream = mx.createStream('controller');
   const providerSubstream = mx.createStream('provider');
+  mx.ignoreStream('handshake');
 
   return {
     controller: controllerSubstream,

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -18,6 +18,7 @@ import browser from 'webextension-polyfill';
 import { StreamProvider } from '@metamask/providers';
 import { createIdRemapMiddleware } from '@metamask/json-rpc-engine';
 import log from 'loglevel';
+import { createDeferredPromise } from '@metamask/utils';
 import launchMetaMaskUi, {
   CriticalStartupErrorHandler,
   connectToBackground,
@@ -38,6 +39,10 @@ import ExtensionPlatform from './platforms/extension';
 import { setupMultiplex } from './lib/stream-utils';
 import { getEnvironmentType, getPlatform } from './lib/util';
 import metaRPCClientFactory from './lib/metaRPCClientFactory';
+
+// This should be long enough that it doesn't trigger when the popup is opened soon after startup.
+// The extension can take a few seconds to start up after a reload.
+const BACKGROUND_CONNECTION_TIMEOUT = 10 * 1000; // 10 Seconds
 
 const PHISHING_WARNING_PAGE_TIMEOUT = 1 * 1000; // 1 Second
 const PHISHING_WARNING_SW_STORAGE_KEY = 'phishing-warning-sw-registered';
@@ -61,6 +66,40 @@ class PhishingWarningPageTimeoutError extends Error {
 }
 
 start().catch(log.error);
+
+/**
+ * Establish that the background connection is working.
+ *
+ * @param {chrome.runtime.Port} extensionPort - The Port object for the background process.
+ */
+async function connectionHandshake(extensionPort) {
+  const { promise: handshake, resolve: handshakeCompleted } =
+    createDeferredPromise();
+  const ackHandler = (event) => {
+    if (event.data?.method === 'ACK') {
+      extensionPort.onMessage.removeListener(ackHandler);
+      handshakeCompleted();
+    }
+  };
+  extensionPort.onMessage.addListener(ackHandler);
+  extensionPort.postMessage({ data: { method: 'SYN' }, name: 'handshake' });
+
+  const timeoutPromise = new Promise((_resolve, reject) => {
+    setTimeout(
+      () => reject(new Error('Background connection unresponsive')),
+      BACKGROUND_CONNECTION_TIMEOUT,
+    );
+  });
+  try {
+    await Promise.race([handshake, timeoutPromise]);
+  } catch (error) {
+    await displayCriticalError(
+      container,
+      CriticalErrorTranslationKey.TroubleStarting,
+      error,
+    );
+  }
+}
 
 async function start() {
   const startTime = performance.now();
@@ -89,6 +128,12 @@ async function start() {
 
   // setup stream to background
   const extensionPort = browser.runtime.connect({ name: windowType });
+
+  // Verify that background connection is active, displaying critical error otherwise.
+  //
+  // Called without `await` intentionally to ensure listeners for other messages are added as
+  // quickly as possible.
+  connectionHandshake(extensionPort);
 
   // Set up error handlers as early as possible to ensure we are ready to
   // handle any errors that occur at any time

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -76,7 +76,7 @@ async function connectionHandshake(extensionPort) {
   const { promise: handshake, resolve: handshakeCompleted } =
     createDeferredPromise();
   const ackHandler = (event) => {
-    if (event.data?.method === 'ACK') {
+    if (event.name === 'handshake' && event.data?.method === 'ACK') {
       extensionPort.onMessage.removeListener(ackHandler);
       handshakeCompleted();
     }

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -313,7 +313,7 @@ function connectSubstreams(connectionStream) {
 
   const controllerSubstream = mx.createStream('controller');
   const providerSubstream = mx.createStream('provider');
-  mx.ignoreStream('handshake');
+  mx.ignoreStream('background-liveness');
 
   return {
     controller: controllerSubstream,

--- a/shared/constants/background-liveness-check.ts
+++ b/shared/constants/background-liveness-check.ts
@@ -1,8 +1,5 @@
 /**
- * Method name for a liveness check from the UI to the background.
+ * This is the method name used for a UI liveness check. This is sent from the background to the UI
+ * automatically upon connection to prove that the connection is active.
  */
-export const BACKGROUND_LIVENESS_REQUEST = 'PING';
-/**
- * Method name for the response from the background to a UI liveness check.
- */
-export const BACKGROUND_LIVENESS_RESPONSE = 'PONG';
+export const BACKGROUND_LIVENESS_METHOD = 'ALIVE';

--- a/shared/constants/background-liveness-check.ts
+++ b/shared/constants/background-liveness-check.ts
@@ -1,0 +1,8 @@
+/**
+ * Method name for a liveness check from the UI to the background.
+ */
+export const BACKGROUND_LIVENESS_REQUEST = 'PING';
+/**
+ * Method name for the response from the background to a UI liveness check.
+ */
+export const BACKGROUND_LIVENESS_RESPONSE = 'PONG';

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -86,7 +86,7 @@ export type ManifestFlags = {
     /**
      * Whether to simulate an unresponsive background by ignoring connections from the UI
      */
-    simulateUnresponsiveBackground: boolean;
+    simulateUnresponsiveBackground?: boolean;
   };
 };
 

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -83,6 +83,10 @@ export type ManifestFlags = {
      * Whether to disable all of the syncing features that get automatically enabled in migrations 158 and 167
      */
     disableSync?: boolean;
+    /**
+     * Whether to simulate an unresponsive background by ignoring connections from the UI
+     */
+    simulateUnresponsiveBackground: boolean;
   };
 };
 

--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -11,6 +11,9 @@ class CriticalErrorPage {
 
   readonly #errorMessage = '.critical-error__details';
 
+  readonly #troubleStartingDescription =
+    'This error could be intermittent, so try restarting the extension.';
+
   constructor(driver: Driver) {
     this.#driver = driver;
   }
@@ -36,7 +39,7 @@ class CriticalErrorPage {
    */
   async validateTroubleStartingDescription(): Promise<void> {
     await this.#driver.waitForSelector({
-      text: 'This error could be intermittent, so try restarting the extension.',
+      text: this.#troubleStartingDescription,
     });
   }
 

--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -1,0 +1,56 @@
+import { Driver } from '../../webdriver/driver';
+
+class CriticalErrorPage {
+  private readonly driver: Driver;
+
+  // Locators
+  private readonly errorPageTitle: object = {
+    text: 'MetaMask had trouble starting.',
+    css: 'h1',
+  };
+
+  private readonly errorMessage = '.critical-error__details';
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  /**
+   * Check that the page has loaded.
+   */
+  async checkPageIsLoaded(): Promise<void> {
+    try {
+      await this.driver.waitForSelector(this.errorPageTitle);
+    } catch (e) {
+      console.log(
+        'Timeout while waiting for critical error page to be loaded',
+        e,
+      );
+      throw e;
+    }
+    console.log('Critical error page is loaded');
+  }
+
+  /**
+   * Validate that the description on the page is for the "trouble starting" scenario.
+   */
+  async validateTroubleStartingDescription(): Promise<void> {
+    await this.driver.waitForSelector({
+      text: 'This error could be intermittent, so try restarting the extension.',
+    });
+  }
+
+  /**
+   * Validate that the given error message is shown.
+   *
+   * @param errorMessage - The error message to check for.
+   */
+  async validateErrorMessage(errorMessage: string): Promise<void> {
+    await this.driver.waitForSelector({
+      text: errorMessage,
+      css: this.errorMessage,
+    });
+  }
+}
+
+export default CriticalErrorPage;

--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -1,18 +1,18 @@
 import { Driver } from '../../webdriver/driver';
 
 class CriticalErrorPage {
-  private readonly driver: Driver;
+  readonly #driver: Driver;
 
   // Locators
-  private readonly errorPageTitle: object = {
+  readonly #errorPageTitle: object = {
     text: 'MetaMask had trouble starting.',
     css: 'h1',
   };
 
-  private readonly errorMessage = '.critical-error__details';
+  readonly #errorMessage = '.critical-error__details';
 
   constructor(driver: Driver) {
-    this.driver = driver;
+    this.#driver = driver;
   }
 
   /**
@@ -20,7 +20,7 @@ class CriticalErrorPage {
    */
   async checkPageIsLoaded(): Promise<void> {
     try {
-      await this.driver.waitForSelector(this.errorPageTitle);
+      await this.#driver.waitForSelector(this.#errorPageTitle);
     } catch (e) {
       console.log(
         'Timeout while waiting for critical error page to be loaded',
@@ -35,7 +35,7 @@ class CriticalErrorPage {
    * Validate that the description on the page is for the "trouble starting" scenario.
    */
   async validateTroubleStartingDescription(): Promise<void> {
-    await this.driver.waitForSelector({
+    await this.#driver.waitForSelector({
       text: 'This error could be intermittent, so try restarting the extension.',
     });
   }
@@ -46,9 +46,9 @@ class CriticalErrorPage {
    * @param errorMessage - The error message to check for.
    */
   async validateErrorMessage(errorMessage: string): Promise<void> {
-    await this.driver.waitForSelector({
+    await this.#driver.waitForSelector({
       text: errorMessage,
-      css: this.errorMessage,
+      css: this.#errorMessage,
     });
   }
 }

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -1,0 +1,35 @@
+import { Suite } from 'mocha';
+import { withFixtures } from '../../helpers';
+import FixtureBuilder from '../../fixture-builder';
+import CriticalErrorPage from '../../page-objects/pages/critical-error-page';
+import { PAGES } from '../../webdriver/driver';
+
+describe('Critical errors', function (this: Suite) {
+  it('shows critical error screen when background is unresponsive', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ignoredConsoleErrors: ['Background connection unresponsive'],
+        manifestFlags: {
+          testing: {
+            simulateUnresponsiveBackground: true,
+          },
+        },
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }) => {
+        await driver.navigate(PAGES.HOME, { waitForControllers: false });
+
+        // Wait until 10 second timer expires
+        await driver.delay(10_000);
+
+        const criticalErrorPage = new CriticalErrorPage(driver);
+        await criticalErrorPage.checkPageIsLoaded();
+        await criticalErrorPage.validateTroubleStartingDescription();
+        await criticalErrorPage.validateErrorMessage(
+          'Background connection unresponsive',
+        );
+      },
+    );
+  });
+});

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -103,8 +103,8 @@ export class CriticalStartupErrorHandler {
       return;
     }
     const { method } = data;
-    // Currently, we only handle ACK, RELOAD_WINDOW, and the state corruption error
-    // message, but we will be adding more in the future.
+    // Currently, we only handle BACKGROUND_LIVENESS_RESPONSE, RELOAD_WINDOW, and the state
+    // corruption error message, but we will be adding more in the future.
     if (method === BACKGROUND_LIVENESS_RESPONSE) {
       if (this.#onLivenessCheckCompleted) {
         this.#onLivenessCheckCompleted();

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -176,11 +176,11 @@ export class CriticalStartupErrorHandler {
    * it minimize abstractions that could cause further issues.
    */
   install() {
+    this.#port.onMessage.addListener(this.#handler);
+
     // Called without `await` intentionally to ensure listeners for other messages are added as
     // quickly as possible.
     this.#startLivenessCheck();
-
-    this.#port.onMessage.addListener(this.#handler);
   }
 
   /**

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -188,7 +188,12 @@ export class CriticalStartupErrorHandler {
    */
   uninstall() {
     this.#port.onMessage.removeListener(this.#handler);
-    this.#onLivenessCheckCompleted = undefined;
+
     clearTimeout(this.#livenessCheckTimeoutId);
+    if (this.#onLivenessCheckCompleted) {
+      // Resolve just to allow any unresolved Promise to be garbage collected.
+      this.#onLivenessCheckCompleted();
+      this.#onLivenessCheckCompleted = undefined;
+    }
   }
 }

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -3,10 +3,7 @@ import { isObject, hasProperty, createDeferredPromise } from '@metamask/utils';
 import log from 'loglevel';
 import { METHOD_DISPLAY_STATE_CORRUPTION_ERROR } from '../../../shared/constants/state-corruption';
 import type { ErrorLike } from '../../../shared/constants/errors';
-import {
-  BACKGROUND_LIVENESS_REQUEST,
-  BACKGROUND_LIVENESS_RESPONSE,
-} from '../../../shared/constants/background-liveness-check';
+import { BACKGROUND_LIVENESS_METHOD } from '../../../shared/constants/background-liveness-check';
 import {
   DISPLAY_GENERAL_STARTUP_ERROR,
   RELOAD_WINDOW,
@@ -59,10 +56,6 @@ export class CriticalStartupErrorHandler {
     // This is called later in `#handle` when the response is received.
     this.#onLivenessCheckCompleted = onLivenessCheckCompleted;
 
-    this.#port.postMessage({
-      data: { method: BACKGROUND_LIVENESS_REQUEST },
-      name: 'background-liveness',
-    });
     const timeoutPromise = new Promise((_resolve, reject) => {
       this.#livenessCheckTimeoutId = setTimeout(
         () => reject(new Error('Background connection unresponsive')),
@@ -103,9 +96,9 @@ export class CriticalStartupErrorHandler {
       return;
     }
     const { method } = data;
-    // Currently, we only handle BACKGROUND_LIVENESS_RESPONSE, RELOAD_WINDOW, and the state
+    // Currently, we only handle BACKGROUND_LIVENESS_METHOD, RELOAD_WINDOW, and the state
     // corruption error message, but we will be adding more in the future.
-    if (method === BACKGROUND_LIVENESS_RESPONSE) {
+    if (method === BACKGROUND_LIVENESS_METHOD) {
       if (this.#onLivenessCheckCompleted) {
         this.#onLivenessCheckCompleted();
       } else {


### PR DESCRIPTION
## **Description**

A handshake process with a timeout has been added to catch the scenario where the background connection is unresponsive.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35332?quickstart=1)

## **Changelog**

CHANGELOG entry: Show error when background unresponsive after update due to Chromium bug

## **Related issues**

Fixes #35327

## **Manual testing steps**

1. Test that the error is not shown during normal operation, particularly just after a reload
2. Comment out the changes to `background.js`, rebuild, then try again and ensure the error is shown after 10 seconds.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Before it would show the loading screen indefinitely when the background connection was unresponsive. I don't have a screenshot because we don't have a reliable reproduction for this problem.

### **After**

<img width="1057" height="495" alt="Screenshot 2025-08-22 at 13 06 18" src="https://github.com/user-attachments/assets/9c245621-01d5-48f1-bfd7-b43c70bf4686" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
