### PR TITLE
Update color docs and remove outdated examples

### DIFF
--- a/.storybook/3.COLORS.stories.mdx
+++ b/.storybook/3.COLORS.stories.mdx
@@ -9,7 +9,7 @@ Color is used to express style and communicate meaning.
 
 ## Design tokens
 
-We are importing design tokens as CSS variables from [@metamask/design-tokens](https://github.com/MetaMask/design-tokens) repo to help consolidate colors and enable theming across all MetaMask products.
+We are importing design tokens as CSS variables from [@metamask/design-tokens](https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-tokens) repo to help consolidate colors and enable theming across all MetaMask products.
 
 ### Token tiers
 
@@ -32,122 +32,18 @@ We follow a 3 tiered system for color design tokens and css variables.
 
 These colors **SHOULD NOT** be used in your styles directly. They are used as a reference for the [theme colors](#theme-colors-tier-2). Brand colors should just keep track of every color used in our app.
 
-#### Example of brand color css variables
-
-```css
-/** !!!DO NOT USE BRAND COLORS DIRECTLY IN YOUR CODE!!! */
-var(--brand-colors-white)
-var(--brand-colors-black)
-var(--brand-colors-grey-grey800)
-```
-
 ### **Theme colors** (tier 2)
 
-Theme colors are color agnostic, semantically neutral and theme compatible design tokens that you can use in your code and styles. Please refer to the description of each token for it's intended purpose in [@metamask/design-tokens](https://github.com/MetaMask/design-tokens/blob/main/src/figma/tokens.json#L329-L554).
-
-#### Example of theme color css variables
-
-```css
-/** Backgrounds */
-var(--color-background-default)
-var(--color-background-default-hover)
-var(--color-background-default-pressed)
-var(--color-background-alternative)
-var(--color-background-alternative-hover)
-var(--color-background-alternative-pressed)
-var(--color-background-hover)
-var(--color-background-pressed)
-
-/** Text */
-var(--color-text-default)
-var(--color-text-alternative)
-var(--color-text-muted)
-
-/** Icons */
-var(--color-icon-default)
-var(--color-icon-alternative)
-var(--color-icon-muted)
-
-/** Borders */
-var(--color-border-default)
-var(--color-border-muted)
-
-/** Overlays */
-var(--color-overlay-default)
-var(--color-overlay-alternative)
-var(--color-overlay-inverse)
-
-/** User Actions */
-var(--color-primary-default)
-var(--color-primary-default-hover)
-var(--color-primary-default-pressed)
-var(--color-primary-alternative)
-var(--color-primary-muted)
-var(--color-primary-inverse)
-
-/** States */
-/** Error */
-var(--color-error-default)
-var(--color-error-default-hover)
-var(--color-error-default-pressed)
-var(--color-error-alternative)
-var(--color-error-default-hover)
-var(--color-error-default-pressed)
-var(--color-error-muted)
-var(--color-error-inverse)
-
-/** Warning */
-var(--color-warning-default)
-var(--color-warning-default-hover)
-var(--color-warning-default-pressed)
-var(--color-warning-muted)
-var(--color-warning-inverse)
-
-/** Success */
-var(--color-success-default)
-var(--color-success-default-hover)
-var(--color-success-default-pressed)
-var(--color-success-muted)
-var(--color-success-inverse)
-
-/** Info */
-var(--color-info-default)
-var(--color-info-muted)
-var(--color-info-inverse)
-```
+Theme colors are color agnostic, semantically neutral and theme compatible design tokens that you can use in your code and styles. For detailed information about each token and its intended purpose, please refer to the [MMDS Color documentation](https://metamask.github.io/metamask-design-system/?path=/docs/design-tokens-color-introduction--docs).
 
 ### **Component colors** (tier 3)
 
 Another level of abstraction is component tier colors that you can define at the top of your styles and use at the component specific level.
 
-```scss
-.button {
-  --color-background-primary: var(--color-primary-default);
-  --color-text-primary: var(--color-primary-inverse);
-  --color-border-primary: var(--color-primary-default);
-
-  --color-background-primary-hover: var(--color-primary-default-hover);
-  --color-border-primary-hover: var(--color-primary-default-hover);
-
-  .btn-primary {
-    background-color: var(--color-background-primary);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-border-primary);
-
-    &:hover {
-      background-color: var(--color-background-primary-hover);
-      border: 1px solid var(--color-border-primary-hover);
-    }
-
-    /** btn-primary css continued... */
-  }
-}
-```
-
 ## Takeaways
 
 - Do not use static HEX values in your code. Use the [theme colors](#theme-colors-tier-2). If one does not exist for your use case ask the designer or [create an issue](https://github.com/MetaMask/metamask-extension/issues/new) and tag it with a `design-system` label.
-- Make sure the design token you are using is for it's intended purpose. Please refer to the description of each token in [@metamask/design-tokens](https://github.com/MetaMask/design-tokens/blob/main/src/figma/tokens.json#L329-L554).
+- Make sure the design token you are using is for its intended purpose. Please refer to the [MMDS Color documentation](https://metamask.github.io/metamask-design-system/?path=/docs/design-tokens-color-introduction--docs) for detailed token descriptions.
 
 ### ❌ Don't do this
 
@@ -191,7 +87,8 @@ Do use component tiered and [theme colors](#theme-colors-tier-2) in your styles 
 
 ## References
 
-- [@metamask/design-tokens](https://github.com/MetaMask/design-tokens)
+- [@metamask/design-tokens](https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-tokens)
+- [MMDS Color documentation](https://metamask.github.io/metamask-design-system/?path=/docs/design-tokens-color-introduction--docs)
 - [Figma brand colors library](https://www.figma.com/file/cBAUPFMnbv6tHR1J8KvBI2/Brand-Colors?node-id=0%3A1) (internal use only)
 - [Figma theme colors library](https://www.figma.com/file/kdFzEC7xzSNw7cXteqgzDW/Light-Theme-Colors?node-id=0%3A1) (internal use only)
 - [Figma dark theme colors library](https://www.figma.com/file/rLKsoqpjyoKauYnFDcBIbO/Dark-Theme-Colors?node-id=0%3A1) (internal use only)


### PR DESCRIPTION
Update Storybook color documentation to fix broken links, remove outdated code examples, and point to the official MMDS design token documentation.

---
[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1755867600914669?thread_ts=1755867600.914669&cid=C0354T27M5M)

<a href="https://cursor.com/background-agent?bcId=bc-cbeba94f-4d91-4345-99bc-512dcb4b208c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbeba94f-4d91-4345-99bc-512dcb4b208c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

