### PR TITLE
Remove portfolio.metamask.io from privacy snapshot

### DIFF
--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -69,7 +69,6 @@
   "on-ramp-content.api.cx.metamask.io",
   "on-ramp-content.uat-api.cx.metamask.io",
   "phishing-detection.api.cx.metamask.io",
-  "portfolio.metamask.io",
   "price-api.metamask-institutional.io",
   "price.api.cx.metamask.io",
   "proxy.api.cx.metamask.io",


### PR DESCRIPTION
Remove `portfolio.metamask.io` from `privacy-snapshot.json` as a fast follow to the portfolio link removal discussed in #35221.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0796d1d-ab09-4a84-bf61-0f7e7dc1098c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0796d1d-ab09-4a84-bf61-0f7e7dc1098c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

