### PR TITLE
chore: removing portfolio url from privacy snapshot

### DIFF
--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -69,7 +69,6 @@
   "on-ramp-content.api.cx.metamask.io",
   "on-ramp-content.uat-api.cx.metamask.io",
   "phishing-detection.api.cx.metamask.io",
-  "portfolio.metamask.io",
   "app.metamask.io",
   "price-api.metamask-institutional.io",
   "price.api.cx.metamask.io",


### PR DESCRIPTION
## **Description**

Removes the deprecated `portfolio.metamask.io` domain from the privacy snapshot as a fast follow to [PR #35221](https://github.com/MetaMask/metamask-extension/pull/35221), which migrated all portfolio URLs to `app.metamask.io`. This ensures the privacy snapshot is aligned with the new domain structure.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35338?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (Fast follow to [PR #35221](https://github.com/MetaMask/metamask-extension/pull/35221))

## **Manual testing steps**

1. Build and run the extension
2. Verify that the extension continues to function normally
3. Confirm that no references to `portfolio.metamask.io` remain in the privacy snapshot

## **Screenshots/Recordings**

### **Before**
The privacy-snapshot.json file contained the deprecated `portfolio.metamask.io` entry on line 72.

### **After**
The `portfolio.metamask.io` entry has been removed from the privacy snapshot, maintaining proper JSON formatting.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and screenshots.