### PR TITLE
feat(pr template): make changelog entry mandatory

### DIFF
--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -186,8 +186,15 @@ async function main(): Promise<void> {
         invalidPullRequestTemplateLabel,
       );
 
+      // Skip changelog check if PR has "no-changelog" label
+      const hasNoChangelogLabel = labelable.labels?.some(
+        (label) => label.name === "no-changelog"
+      );
+
       // Require changelog entry
-      if (!hasChangelogEntry(labelable.body)) {
+      if (hasNoChangelogLabel) {
+        console.log(`PR ${labelable.number} has "no-changelog" label. Skipping changelog entry check.`);
+      } else if (!hasChangelogEntry(labelable.body)) {
         const errorMessage = `PR is missing a valid "CHANGELOG entry:" line.`;
         console.log(errorMessage);
 

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -410,8 +410,8 @@ function hasChangelogEntry(body: string): boolean {
     return false;
   }
 
-  // Extract text after the colon
-  const entry = changelogLine.split(":")[1]?.trim() ?? "";
+  // Extract text after the "CHANGELOG entry:" prefix
+  const entry = changelogLine.slice("CHANGELOG entry:".length).trim();
 
   if (entry === "") {
     console.log("Changelog entry is empty");

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -417,8 +417,9 @@ function hasChangelogEntry(body: string): boolean {
     return false;
   }
 
-  // Extract text after the "CHANGELOG entry:" prefix
-  const entry = changelogLine.slice("CHANGELOG entry:".length).trim();
+  // Extract everything after the prefix, tolerating extra spaces after the colon
+  const match = changelogLine.match(/^\s*CHANGELOG entry:\s*(.*)$/);
+  const entry = match?.[1]?.trim() ?? "";
 
   if (entry === "") {
     console.log("Changelog entry is empty");

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -2,9 +2,9 @@ name: Check template and add labels
 
 on:
   issues:
-    types: [opened, edited]
+    types: [opened, edited, labeled, unlabeled, reopened]
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, labeled, unlabeled, reopened]
 
 jobs:
   check-template-and-add-labels:


### PR DESCRIPTION
## **Description**

Some PRs are still created without a changelog entry, which makes generating the changelog less convenient for release engineers. If all changelog entries are properly documented in PR templates, we can fully rely on automatic changelog generation.

[Same PR for Mobile](https://github.com/MetaMask/metamask-mobile/pull/18638)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35339?quickstart=1)

## **Changelog**

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to [this PR](https://github.com/gauthierpetetin-test/repo_test/pull/264) on a test repo
2. Set the changelog entry to an empty string and see the ci fail
3. Set the changelog entry to a valid string and see the ci succeed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
