### PR TITLE
chore: updating MultichainAddressRowList

### DIFF
--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -455,21 +455,6 @@
         ],
         "blockExplorerUrls": []
       },
-      "0x5": {
-        "chainId": "0x5",
-        "name": "Goerli",
-        "nativeCurrency": "ETH",
-        "defaultRpcEndpointIndex": 0,
-        "ticker": "ETH",
-        "rpcEndpoints": [
-          {
-            "type": "custom",
-            "url": "https://goerli.com",
-            "networkClientId": "goerli"
-          }
-        ],
-        "blockExplorerUrls": []
-      },
       "0xaa36a7": {
         "chainId": "0xaa36a7",
         "name": "Sepolia",

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -455,6 +455,21 @@
         ],
         "blockExplorerUrls": []
       },
+      "0x5": {
+        "chainId": "0x5",
+        "name": "Goerli",
+        "nativeCurrency": "ETH",
+        "defaultRpcEndpointIndex": 0,
+        "ticker": "ETH",
+        "rpcEndpoints": [
+          {
+            "type": "custom",
+            "url": "https://goerli.com",
+            "networkClientId": "goerli"
+          }
+        ],
+        "blockExplorerUrls": []
+      },
       "0xaa36a7": {
         "chainId": "0xaa36a7",
         "name": "Sepolia",

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -67,7 +67,8 @@ export const MultichainAddressRow = ({
       display={Display.Flex}
       alignItems={AlignItems.center}
       justifyContent={JustifyContent.spaceBetween}
-      padding={4}
+      paddingTop={4}
+      paddingBottom={4}
       gap={4}
       data-testid="multichain-address-row"
     >

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.stories.tsx
@@ -88,16 +88,16 @@ const createMockState = () => ({
       ),
     },
     multichainNetworkConfigurationsByChainId: {
-      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
-        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      [MultichainNetworks.SOLANA]: {
+        chainId: MultichainNetworks.SOLANA,
         name: 'Solana with a really long name',
-        nativeCurrency: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        nativeCurrency: 'SOL',
         isEvm: false,
       },
       [MultichainNetworks.SOLANA_TESTNET]: {
         chainId: MultichainNetworks.SOLANA_TESTNET,
         name: 'Solana Testnet',
-        nativeCurrency: 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY/slip44:501',
+        nativeCurrency: 'SOL',
         isEvm: false,
       },
     },
@@ -128,7 +128,14 @@ export default meta;
 type Story = StoryObj<typeof MultichainAddressRowsList>;
 
 export const MultipleDifferentAccounts: Story = {
-  args: { accounts: [accounts.ethereum, accounts.solana, accounts.solanaTestnet, accounts.bitcoin] },
+  args: {
+    accounts: [
+      accounts.ethereum,
+      accounts.solana,
+      accounts.solanaTestnet,
+      accounts.bitcoin,
+    ],
+  },
 };
 
 export const SingleEthereumAccount: Story = {

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.stories.tsx
@@ -9,6 +9,7 @@ import {
   MOCK_ACCOUNT_BIP122_P2WPKH,
   MOCK_ACCOUNT_SOLANA_MAINNET,
 } from '../../../../test/data/mock-accounts';
+import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 import { MultichainAddressRowsList } from './multichain-address-rows-list';
 
 const mockStore = configureStore([]);
@@ -22,6 +23,16 @@ const accounts: Record<string, InternalAccount> = {
     scopes: ['eip155:137'],
   },
   solana: { ...MOCK_ACCOUNT_SOLANA_MAINNET, scopes: ['solana:*'] },
+  solanaTestnet: {
+    ...MOCK_ACCOUNT_SOLANA_MAINNET,
+    id: 'solana-testnet-account',
+    address: '9A4AptCThfbuknsbteHgGKXczfJpfjuVA9SLTSGaaLGD',
+    scopes: [MultichainNetworks.SOLANA_TESTNET],
+    metadata: {
+      ...MOCK_ACCOUNT_SOLANA_MAINNET.metadata,
+      name: 'Solana Testnet Account',
+    },
+  },
   bitcoin: { ...MOCK_ACCOUNT_BIP122_P2WPKH, scopes: ['bip122:*'] },
 };
 
@@ -83,6 +94,12 @@ const createMockState = () => ({
         nativeCurrency: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
         isEvm: false,
       },
+      [MultichainNetworks.SOLANA_TESTNET]: {
+        chainId: MultichainNetworks.SOLANA_TESTNET,
+        name: 'Solana Testnet',
+        nativeCurrency: 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY/slip44:501',
+        isEvm: false,
+      },
     },
     internalAccounts: {
       selectedAccount: accounts.ethereum.id,
@@ -111,7 +128,7 @@ export default meta;
 type Story = StoryObj<typeof MultichainAddressRowsList>;
 
 export const MultipleDifferentAccounts: Story = {
-  args: { accounts: [accounts.ethereum, accounts.solana, accounts.bitcoin] },
+  args: { accounts: [accounts.ethereum, accounts.solana, accounts.solanaTestnet, accounts.bitcoin] },
 };
 
 export const SingleEthereumAccount: Story = {

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
@@ -102,6 +102,17 @@ export const MultichainAddressRowsList = ({
     setSearchPattern('');
   };
 
+  const renderedRows = useMemo(() => {
+    return filteredItems.map((item, index) => (
+      <MultichainAddressRow
+        key={`${item.address}-${item.chainId}-${index}`}
+        chainId={item.chainId}
+        networkName={item.networkName}
+        address={item.address}
+      />
+    ));
+  }, [filteredItems]);
+
   return (
     <Box
       display={Display.Flex}
@@ -123,14 +134,7 @@ export const MultichainAddressRowsList = ({
 
       <Box>
         {filteredItems.length > 0 ? (
-          filteredItems.map((item, index) => (
-            <MultichainAddressRow
-              key={`${item.address}-${item.chainId}-${index}`}
-              chainId={item.chainId}
-              networkName={item.networkName}
-              address={item.address}
-            />
-          ))
+          renderedRows
         ) : (
           <Text
             variant={TextVariant.bodyMd}

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
@@ -108,20 +108,18 @@ export const MultichainAddressRowsList = ({
       flexDirection={FlexDirection.Column}
       data-testid="multichain-address-rows-list"
     >
-      <Box padding={4}>
-        <TextFieldSearch
-          size={TextFieldSearchSize.Lg}
-          placeholder={t('searchNetworks')}
-          value={searchPattern}
-          onChange={handleSearchChange}
-          clearButtonOnClick={handleClearSearch}
-          width={BlockSize.Full}
-          borderWidth={0}
-          backgroundColor={BackgroundColor.backgroundMuted}
-          borderRadius={BorderRadius.LG}
-          data-testid="multichain-address-rows-list-search"
-        />
-      </Box>
+      <TextFieldSearch
+        size={TextFieldSearchSize.Lg}
+        placeholder={t('searchNetworks')}
+        value={searchPattern}
+        onChange={handleSearchChange}
+        clearButtonOnClick={handleClearSearch}
+        width={BlockSize.Full}
+        borderWidth={0}
+        backgroundColor={BackgroundColor.backgroundMuted}
+        borderRadius={BorderRadius.LG}
+        data-testid="multichain-address-rows-list-search"
+      />
 
       <Box>
         {filteredItems.length > 0 ? (
@@ -134,15 +132,15 @@ export const MultichainAddressRowsList = ({
             />
           ))
         ) : (
-          <Box padding={6} textAlign={TextAlign.Center}>
-            <Text
-              variant={TextVariant.bodyMd}
-              color={TextColor.textAlternative}
-              data-testid="multichain-address-rows-list-empty-message"
-            >
-              {searchPattern ? t('noNetworksFound') : t('noNetworksAvailable')}
-            </Text>
-          </Box>
+          <Text
+            variant={TextVariant.bodyMd}
+            color={TextColor.textAlternative}
+            textAlign={TextAlign.Center}
+            paddingTop={8}
+            data-testid="multichain-address-rows-list-empty-message"
+          >
+            {searchPattern ? t('noNetworksFound') : t('noNetworksAvailable')}
+          </Text>
         )}
       </Box>
     </Box>

--- a/ui/components/multichain-accounts/multichain-address-rows-list/utils.ts
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/utils.ts
@@ -123,7 +123,7 @@ export const getCompatibleNetworksForAccount = (
     }
   });
 
-  // Filter out test networks to match mobile implementation behavior
+  // Filter out test networks
   return compatibleItems.filter(
     (item) => !CAIP_FORMATTED_EVM_TEST_CHAINS.includes(item.chainId),
   );

--- a/ui/components/multichain-accounts/multichain-address-rows-list/utils.ts
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/utils.ts
@@ -6,7 +6,10 @@ import {
   FEATURED_NETWORK_CHAIN_IDS,
   TEST_NETWORK_IDS,
 } from '../../../../shared/constants/network';
-import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
+import {
+  MultichainNetworks,
+  SOLANA_TEST_CHAINS,
+} from '../../../../shared/constants/multichain/networks';
 
 export type NetworkAddressItem = {
   chainId: string;
@@ -125,6 +128,8 @@ export const getCompatibleNetworksForAccount = (
 
   // Filter out test networks
   return compatibleItems.filter(
-    (item) => !CAIP_FORMATTED_EVM_TEST_CHAINS.includes(item.chainId),
+    (item) =>
+      !CAIP_FORMATTED_EVM_TEST_CHAINS.includes(item.chainId) &&
+      !SOLANA_TEST_CHAINS.includes(item.chainId as CaipChainId),
   );
 };

--- a/ui/components/multichain-accounts/multichain-address-rows-list/utils.ts
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/utils.ts
@@ -1,6 +1,7 @@
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { CaipChainId } from '@metamask/utils';
 import {
+  CAIP_FORMATTED_EVM_TEST_CHAINS,
   CHAIN_IDS,
   FEATURED_NETWORK_CHAIN_IDS,
   TEST_NETWORK_IDS,
@@ -79,11 +80,12 @@ const createNetworkAddressItem = (
 });
 
 /**
- * Gets compatible networks for an InternalAccount based on its scopes
+ * Gets compatible networks for an InternalAccount based on its scopes.
+ * Filters out test networks to match mobile implementation behavior.
  *
  * @param account - InternalAccount object to get compatible networks for
  * @param allNetworks - Record of all network configurations
- * @returns Array of NetworkAddressItem objects
+ * @returns Array of NetworkAddressItem objects, excluding test networks
  */
 export const getCompatibleNetworksForAccount = (
   account: InternalAccount,
@@ -121,5 +123,8 @@ export const getCompatibleNetworksForAccount = (
     }
   });
 
-  return compatibleItems;
+  // Filter out test networks to match mobile implementation behavior
+  return compatibleItems.filter(
+    (item) => !CAIP_FORMATTED_EVM_TEST_CHAINS.includes(item.chainId),
+  );
 };


### PR DESCRIPTION
## **Description**

This PR improves the multichain address rows list component by filtering out test networks and refining the layout for better visual alignment. These changes are part of the [larger `MultichainAccountAddressListPage` implementation](https://github.com/MetaMask/metamask-extension/pull/35191) that displays network addresses for selected accounts.

The key improvements include:
1. Filtering out test networks from the address list
2. Adjusting padding and layout for better visual alignment

These changes ensure that users only see mainnet addresses by default, providing a cleaner and more focused view of their account's network addresses.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35380?quickstart=1)

## **Changelog**

CHANGELOG entry: Improved multichain address list by filtering out test networks and refining layout

## **Related issues**

Part of: https://consensyssoftware.atlassian.net/browse/DSYS-115
[#35191](https://github.com/MetaMask/metamask-extension/pull/35191) - feat: add MultichainAccountAddressListPage component

Related to: https://consensyssoftware.atlassian.net/jira/software/c/projects/DSYS/boards/1888?assignee=6152e94cc7bea40069d6b9c3&selectedIssue=DSYS-115&sprints=6001%2C6002

## **Manual testing steps**

1. Run storybook with `yarn storybook`
2. Navigate to the MultichainAddressRowsList story
3. Verify that test networks (Sepolia, Goerli, etc.) are not displayed in the list
4. Verify that only mainnet addresses are shown
5. Test the search functionality to ensure it still works correctly
6. Verify the empty state message displays properly when no networks match the search

## **Screenshots/Recordings**

### **Before**
- Test networks were visible in the address list
- Padding was inconsistent with extra wrapper Box components
- Empty state had unnecessary padding wrapper

https://github.com/user-attachments/assets/cf03fc83-76c9-40af-8250-890677e0a722

### **After**
- Only mainnet addresses are displayed (test networks filtered out)
- Cleaner padding using direct props on components
- Simplified empty state with better text alignment
- More consistent visual spacing throughout the component

https://github.com/user-attachments/assets/c655cdbb-fccf-45fe-8dbd-59b4b1399b21

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.