### PR TITLE
chore: adding getInternalAccountsFromGroupById selector

### DIFF
--- a/ui/selectors/multichain-accounts/account-tree.ts
+++ b/ui/selectors/multichain-accounts/account-tree.ts
@@ -716,7 +716,7 @@ export const getMultichainAccountsByWalletId = createSelector(
  * @param groupId - The ID of the account group.
  * @returns Array of internal accounts in the specified group, or empty array if not found.
  */
-export const getInternalAccountsFromGroupById = createDeepEqualSelector(
+export const getInternalAccountsFromGroupById = createSelector(
   getAccountTree,
   getInternalAccountsObject,
   (_, groupId: AccountGroupId) => groupId,

--- a/ui/selectors/multichain-accounts/account-tree.ts
+++ b/ui/selectors/multichain-accounts/account-tree.ts
@@ -41,11 +41,10 @@ import { getSanitizedChainId, extractWalletIdFromGroupId } from './utils';
  * @param state - Redux state.
  * @param state.metamask - MetaMask state object.
  * @param state.metamask.accountTree - Account tree state object.
- * @returns Account tree state, or default empty state if not available.
+ * @returns Account tree state.
  */
 export const getAccountTree = createDeepEqualSelector(
-  (state: MultichainAccountsState) =>
-    state.metamask.accountTree ?? { wallets: {}, selectedAccountGroup: null },
+  (state: MultichainAccountsState) => state.metamask.accountTree,
   (accountTree: AccountTreeState): AccountTreeState => accountTree,
 );
 
@@ -617,7 +616,7 @@ export const getInternalAccountByGroupAndCaip = createDeepEqualSelector(
  */
 export const getSelectedAccountGroup = createDeepEqualSelector(
   getAccountTree,
-  (accountTree: AccountTreeState) => accountTree?.selectedAccountGroup ?? null,
+  (accountTree: AccountTreeState) => accountTree.selectedAccountGroup,
 );
 
 /**


### PR DESCRIPTION
## **Description**

This PR adds a new Redux selector `getInternalAccountsFromGroupById` to retrieve all internal accounts associated with a specific account group. This selector is part of the larger PR to add `MultichainAccountAddressListPage` https://github.com/MetaMask/metamask-extension/pull/35191

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35381?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of a larger PR https://github.com/MetaMask/metamask-extension/pull/35191
Related to: [DSYS-115](https://consensyssoftware.atlassian.net/browse/DSYS-115)

## **Manual testing steps**

Since this is a selector addition with comprehensive unit tests, manual testing can be verified through the test suite:

1. Run `yarn test ui/selectors/multichain-accounts/account-tree.test.ts`
2. Verify all 47 tests pass, including the 9 new tests for `getInternalAccountsFromGroupById`
3. The selector can be used in components by:
   - Importing `getInternalAccountsFromGroupById` from `ui/selectors/multichain-accounts/account-tree`
   - Calling it with state and a group ID to retrieve the internal accounts for that group

## **Screenshots/Recordings**

### **Before**

N/A - This is a new selector addition

### **After**

N/A - This is a new selector addition

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[DSYS-115]: https://consensyssoftware.atlassian.net/browse/DSYS-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ