### PR TITLE
feat: Add security alerts config option

### DIFF
--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -24,7 +24,11 @@ import {
   handlePPOMError,
   validateRequestWithPPOM,
 } from './ppom-util';
-import { SecurityAlertResponse, UpdateSecurityAlertResponse } from './types';
+import {
+  SecurityAlertResponse,
+  GetSecurityAlertsConfig,
+  UpdateSecurityAlertResponse,
+} from './types';
 
 const CONFIRMATION_METHODS = Object.freeze([
   'eth_sendRawTransaction',
@@ -55,6 +59,7 @@ export type PPOMMiddlewareRequest<
  * @param appStateController
  * @param accountsController - Instance of AccountsController.
  * @param updateSecurityAlertResponse
+ * @param getSecurityAlertsConfig - Optional method to get transaction security alerts parameters.
  * @returns PPOMMiddleware function.
  */
 export function createPPOMMiddleware<
@@ -67,6 +72,7 @@ export function createPPOMMiddleware<
   appStateController: AppStateController,
   accountsController: AccountsController,
   updateSecurityAlertResponse: UpdateSecurityAlertResponse,
+  getSecurityAlertsConfig?: () => GetSecurityAlertsConfig,
 ) {
   return async (
     req: PPOMMiddlewareRequest<Params>,
@@ -120,6 +126,7 @@ export function createPPOMMiddleware<
             securityAlertId,
             chainId: chainId as Hex,
             updateSecurityAlertResponse,
+            getSecurityAlertsConfig: getSecurityAlertsConfig?.(),
           }),
       );
 

--- a/app/scripts/lib/ppom/ppom-util.test.ts
+++ b/app/scripts/lib/ppom/ppom-util.test.ts
@@ -649,10 +649,13 @@ describe('PPOM Utils', () => {
         txParams: TRANSACTION_PARAMS_MOCK_1,
       });
 
+      const getSecurityAlertsConfigMock = jest.fn();
+
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
         ppomController,
         request,
+        getSecurityAlertsConfig: getSecurityAlertsConfigMock,
       });
 
       expect(ppomController.usePPOM).not.toHaveBeenCalled();
@@ -662,6 +665,7 @@ describe('PPOM Utils', () => {
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledWith(
         CHAIN_ID_MOCK,
         request,
+        getSecurityAlertsConfigMock,
       );
     });
 
@@ -676,10 +680,13 @@ describe('PPOM Utils', () => {
         .spyOn(securityAlertAPI, 'validateWithSecurityAlertsAPI')
         .mockRejectedValue(new Error('Test Error'));
 
+      const getSecurityAlertsConfigMock = jest.fn();
+
       await validateRequestWithPPOM({
         ...validateRequestWithPPOMOptionsBase,
         ppomController,
         request,
+        getSecurityAlertsConfig: getSecurityAlertsConfigMock,
       });
 
       expect(ppomController.usePPOM).toHaveBeenCalledTimes(1);
@@ -688,6 +695,7 @@ describe('PPOM Utils', () => {
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledWith(
         CHAIN_ID_MOCK,
         request,
+        getSecurityAlertsConfigMock,
       );
     });
   });

--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -28,7 +28,11 @@ import { AppStateController } from '../../controllers/app-state-controller';
 import { sanitizeMessageRecursively } from '../../../../shared/modules/typed-signature';
 import { parseTypedDataMessage } from '../../../../shared/modules/transaction.utils';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
-import { SecurityAlertResponse, UpdateSecurityAlertResponse } from './types';
+import {
+  SecurityAlertResponse,
+  GetSecurityAlertsConfig,
+  UpdateSecurityAlertResponse,
+} from './types';
 import {
   isSecurityAlertsAPIEnabled,
   SecurityAlertsAPIRequest,
@@ -62,12 +66,14 @@ export async function validateRequestWithPPOM({
   securityAlertId,
   chainId,
   updateSecurityAlertResponse: updateSecurityResponse,
+  getSecurityAlertsConfig,
 }: {
   ppomController: PPOMController;
   request: PPOMRequest;
   securityAlertId: string;
   chainId: Hex;
   updateSecurityAlertResponse: UpdateSecurityAlertResponse;
+  getSecurityAlertsConfig?: GetSecurityAlertsConfig;
 }) {
   try {
     const controllerObject = await updateSecurityResponse(
@@ -81,7 +87,12 @@ export async function validateRequestWithPPOM({
     log('Normalized request', normalizedRequest);
 
     const ppomResponse = isSecurityAlertsAPIEnabled()
-      ? await validateWithAPI(ppomController, chainId, normalizedRequest)
+      ? await validateWithAPI(
+          ppomController,
+          chainId,
+          normalizedRequest,
+          getSecurityAlertsConfig,
+        )
       : await validateWithController(
           ppomController,
           normalizedRequest,
@@ -308,9 +319,14 @@ async function validateWithAPI(
   ppomController: PPOMController,
   chainId: string,
   request: SecurityAlertsAPIRequest | PPOMRequest,
+  getSecurityAlertsConfig?: GetSecurityAlertsConfig,
 ): Promise<SecurityAlertResponse> {
   try {
-    const response = await validateWithSecurityAlertsAPI(chainId, request);
+    const response = await validateWithSecurityAlertsAPI(
+      chainId,
+      request,
+      getSecurityAlertsConfig,
+    );
 
     return {
       ...response,

--- a/app/scripts/lib/ppom/security-alerts-api.test.ts
+++ b/app/scripts/lib/ppom/security-alerts-api.test.ts
@@ -95,5 +95,32 @@ describe('Security Alerts API', () => {
       const isEnabled = isSecurityAlertsAPIEnabled();
       expect(isEnabled).toBe(false);
     });
+
+    it('uses getSecurityAlertsConfig', async () => {
+      const newUrl = 'https://proxy.com/validate/0x1';
+      const authorization = 'Bearer token';
+      const getSecurityAlertsConfigMock = (_url: string) => {
+        return Promise.resolve({
+          newUrl,
+          authorization,
+        });
+      };
+
+      await validateWithSecurityAlertsAPI(
+        CHAIN_ID_MOCK,
+        REQUEST_MOCK,
+        getSecurityAlertsConfigMock,
+      );
+
+      // Check for new URL and authorization header.
+      expect(fetchMock).toHaveBeenCalledWith(
+        newUrl,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: authorization,
+          }),
+        }),
+      );
+    });
   });
 });

--- a/app/scripts/lib/ppom/types.ts
+++ b/app/scripts/lib/ppom/types.ts
@@ -20,3 +20,15 @@ export type UpdateSecurityAlertResponse = (
   securityAlertId: string,
   securityAlertResponse: SecurityAlertResponse,
 ) => Promise<TransactionMeta | SignatureRequest>;
+
+/**
+ * Getter for the Security Alerts API configuration. This allows to modify the
+ * URL and authorization header.
+ *
+ * @param url - The URL of the Security Alerts API.
+ * @returns A promise that resolves to the new URL and authorization header.
+ */
+export type GetSecurityAlertsConfig = (url: string) => Promise<{
+  newUrl?: string;
+  authorization?: string;
+}>;

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -22,6 +22,7 @@ import {
 import {
   SecurityAlertResponse,
   UpdateSecurityAlertResponse,
+  GetSecurityAlertsConfig,
 } from '../ppom/types';
 import {
   LOADING_SECURITY_ALERT_RESPONSE,
@@ -61,6 +62,7 @@ type FinalAddTransactionRequest = BaseAddTransactionRequest & {
 
 export type AddTransactionRequest = FinalAddTransactionRequest & {
   waitForSubmit: boolean;
+  getSecurityAlertsConfig?: GetSecurityAlertsConfig;
 };
 
 export type AddDappTransactionRequest = BaseAddTransactionRequest & {
@@ -280,6 +282,7 @@ async function validateSecurity(request: AddTransactionRequest) {
     transactionParams,
     updateSecurityAlertResponse,
     internalAccounts,
+    getSecurityAlertsConfig,
   } = request;
 
   scanAddressForTrustSignals(request);
@@ -331,6 +334,7 @@ async function validateSecurity(request: AddTransactionRequest) {
       securityAlertId,
       chainId,
       updateSecurityAlertResponse,
+      getSecurityAlertsConfig,
     });
 
     const securityAlertResponseLoading: SecurityAlertResponse = {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2005,6 +2005,18 @@ export default class MetamaskController extends EventEmitter {
       controllersByName.SeedlessOnboardingController;
     this.networkOrderController = controllersByName.NetworkOrderController;
 
+    // For now, we return undefined here, which means that the Security Alerts
+    // API falls back to default behavior. In the future, we plan to use this
+    // configuration option for conditional re-routing of API requests.
+    this.getSecurityAlertsConfig = () => {
+      return (_url) => {
+        return Promise.resolve({
+          newUrl: undefined,
+          authorization: undefined,
+        });
+      };
+    };
+
     this.notificationServicesController.init();
     this.snapController.init();
     this.cronjobController.init();
@@ -6698,6 +6710,7 @@ export default class MetamaskController extends EventEmitter {
         this.appStateController.addAddressSecurityAlertResponse.bind(
           this.appStateController,
         ),
+      getSecurityAlertsConfig: this.getSecurityAlertsConfig(),
       ...otherParams,
     };
   }
@@ -7505,6 +7518,7 @@ export default class MetamaskController extends EventEmitter {
         this.appStateController,
         this.accountsController,
         this.updateSecurityAlertResponse.bind(this),
+        this.getSecurityAlertsConfig.bind(this),
       ),
     );
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -579,6 +579,7 @@ describe('MetaMaskController', () => {
           updateSecurityAlertResponse: expect.any(Function),
           getSecurityAlertResponse: expect.any(Function),
           addSecurityAlertResponse: expect.any(Function),
+          getSecurityAlertsConfig: expect.any(Function),
         });
       });
       it('passes through any additional params to the object', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

For MetaMask Transaction Shield, we want to be able to route Security Alerts API requests through a dedicated proxy, if the user is subscribed to Shield. This PR adds a corresponding configuration option to the Security Alerts API, similar to how it was done for the Simulation API in the TransactionController (https://github.com/MetaMask/core/pull/6281).

This option is not used yet. It will later be used once the corresponding backend services are deployed and the new ShieldController and SubscriptionController are being integrated.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35396?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
