### PR TITLE
fix: cp-13.2.0 show active dapp network

### DIFF
--- a/ui/components/multichain/connected-site-popover/connected-site-popover.test.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.test.tsx
@@ -6,11 +6,11 @@ import { renderWithProvider } from '../../../../test/jest';
 import { ConnectedSitePopover } from './connected-site-popover';
 
 const props = {
+  referenceElement: { current: document.createElement('div') },
   isOpen: true,
   isConnected: true,
   onClick: jest.fn(),
   onClose: jest.fn(),
-  connectedOrigin: 'https://metamask.github.io',
 };
 
 const render = () => {

--- a/ui/components/multichain/connected-site-popover/connected-site-popover.test.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.test.tsx
@@ -18,6 +18,26 @@ const render = () => {
     metamask: {
       ...mockState.metamask,
       completedOnboarding: true,
+      // Add domains mapping for the test dapp
+      domains: {
+        'https://metamask.github.io': 'goerli-test-client',
+      },
+      // Add network configuration
+      networkConfigurationsByChainId: {
+        ...mockState.metamask.networkConfigurationsByChainId,
+        '0x5': {
+          chainId: '0x5',
+          name: 'Goerli',
+          nativeCurrency: 'ETH',
+          rpcEndpoints: [
+            {
+              type: 'custom',
+              url: 'https://goerli.test',
+              networkClientId: 'goerli-test-client',
+            },
+          ],
+        },
+      },
       // Add multichain network state
       selectedMultichainNetworkChainId: 'eip155:5',
       isEvmSelected: true,


### PR DESCRIPTION
This PR ensures that changing the global network should not affect the dapp connected active network


## **Related issues**

Fixes: 
[#34931](https://github.com/MetaMask/metamask-extension/issues/34931)
[#35369](https://github.com/MetaMask/metamask-extension/issues/35369)

## **Manual testing steps**

1. connect MM to a dapp
2. add a new network from additional network to popular network in MM, check the portfolio view network is updated but dapp stays on same network


## **Screenshots/Recordings**


### **Before**

NA
### **After**

https://github.com/user-attachments/assets/0d255fad-eeb6-4570-bac9-8e3c78ba96cf



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
