### PR TITLE
refactor: remove useModalNavigation to simplify

### DIFF
--- a/ui/pages/notification-details/notification-details.tsx
+++ b/ui/pages/notification-details/notification-details.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import { TRIGGER_TYPES } from '@metamask/notification-services-controller/notification-services';
@@ -24,18 +24,6 @@ import { getExtractIdentifier } from './utils/utils';
 import { NotificationDetailsHeader } from './notification-details-header/notification-details-header';
 import { NotificationDetailsBody } from './notification-details-body/notification-details-body';
 import { NotificationDetailsFooter } from './notification-details-footer/notification-details-footer';
-
-function useModalNavigation() {
-  const navigate = useNavigate();
-
-  const redirectToNotifications = useCallback(() => {
-    navigate(NOTIFICATIONS_ROUTE);
-  }, [navigate]);
-
-  return {
-    redirectToNotifications,
-  };
-}
 
 function useNotificationByPath() {
   const { pathname } = useLocation();
@@ -73,19 +61,19 @@ function useEffectOnNotificationView(notificationData?: Notification) {
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function NotificationDetails() {
-  const { redirectToNotifications } = useModalNavigation();
+  const navigate = useNavigate();
   const { notification } = useNotificationByPath();
   useEffectOnNotificationView(notification);
 
   // No Notification
   if (!notification) {
-    redirectToNotifications();
+    navigate(NOTIFICATIONS_ROUTE);
     return null;
   }
 
   // Invalid Notification
   if (!hasNotificationComponents(notification.type)) {
-    redirectToNotifications();
+    navigate(NOTIFICATIONS_ROUTE);
     return null;
   }
 
@@ -93,7 +81,9 @@ export default function NotificationDetails() {
 
   return (
     <NotificationsPage>
-      <NotificationDetailsHeader onClickBack={redirectToNotifications}>
+      <NotificationDetailsHeader
+        onClickBack={() => navigate(NOTIFICATIONS_ROUTE)}
+      >
         <ncs.details.title notification={notification} />
       </NotificationDetailsHeader>
       <Content padding={0}>


### PR DESCRIPTION
## **Description**

Removing the `useModalNavigation` hook to simplify the code

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Conversation started in https://github.com/MetaMask/metamask-extension/pull/35009#discussion_r2278141864

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->